### PR TITLE
chore: update rust version to 1.92

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-rust = "1.83"
+rust = "1.92"
 node = "22"
 
 [env]


### PR DESCRIPTION
Fixing the following error
```
[build] $ cargo build --workspace
error: rustc 1.83.0 is not supported by the following package:
  napi-build@2.3.1 requires rustc 1.88
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.83.0

[build] ERROR task failed
```