### PR TITLE
feat: unify ox content lsp and i18n tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Rust
 /target
+**/target/
 **/*.rs.bk
 Cargo.lock
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ ox-content-i18n validate "Hello {$name}"
 
 ### Editor Tooling
 
-Ox Content now ships an authoring-oriented Markdown language server:
+Ox Content now ships a unified authoring and i18n language server:
 
 ```bash
 cargo run -p ox_content_lsp --bin ox-content-lsp
@@ -138,6 +138,7 @@ Supported features include:
 
 - fast Markdown snippet completion
 - frontmatter schema completion and diagnostics
+- i18n key completion, hover, go-to-definition, diagnostics, and inlay hints for JS/TS
 - table / code fence / callout insertion commands
 - preview HTML generation for editor UIs
 - `.mdc` authoring support

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - **Built-in SSG** - Static site generation with theming, search, and OG images
 - **API Docs Generation** - Generate docs from JSDoc/TypeScript (like `cargo doc`)
 - **i18n** - ICU MessageFormat 2 parser, dictionary management, static checker, and LSP
+- **Editor Tooling** - Markdown/MDC LSP plus VS Code, Zed, and Neovim integrations
 
 ## Quick Start
 
@@ -119,6 +120,28 @@ ox-content-i18n check --dict-dir content/i18n --src src
 ox-content-i18n validate "Hello {$name}"
 ```
 
+### Editor Tooling
+
+Ox Content now ships an authoring-oriented Markdown language server:
+
+```bash
+cargo run -p ox_content_lsp --bin ox-content-lsp
+```
+
+You can wire it into:
+
+- VS Code via [npm/vscode-ox-content](./npm/vscode-ox-content)
+- Zed via [editors/zed](./editors/zed)
+- Neovim via [editors/neovim](./editors/neovim)
+
+Supported features include:
+
+- fast Markdown snippet completion
+- frontmatter schema completion and diagnostics
+- table / code fence / callout insertion commands
+- preview HTML generation for editor UIs
+- `.mdc` authoring support
+
 **[Read the full documentation →](https://ubugeeei.github.io/ox-content/)**
 
 ## Performance
@@ -167,6 +190,7 @@ vp install             # Install JS dependencies through Vite+
 vp run build:napi      # Build NAPI bindings
 vp run build:npm       # Build npm packages
 vp run build:wasm      # Build publish-ready @ox-content/wasm package
+cargo check -p ox_content_lsp
 vp run test            # Run tests
 ```
 

--- a/crates/ox_content_lsp/Cargo.toml
+++ b/crates/ox_content_lsp/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "ox_content_lsp"
+version.workspace = true
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Unified LSP server for Ox Content authoring"
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "ox-content-lsp"
+path = "src/main.rs"
+
+[dependencies]
+ox_content_allocator = { workspace = true }
+ox_content_ast = { workspace = true }
+ox_content_i18n = { workspace = true }
+ox_content_i18n_checker = { workspace = true }
+ox_content_parser = { workspace = true }
+ox_content_renderer = { workspace = true }
+oxc_span = { workspace = true }
+tower-lsp = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }

--- a/crates/ox_content_lsp/src/backend.rs
+++ b/crates/ox_content_lsp/src/backend.rs
@@ -1,0 +1,113 @@
+mod commands;
+mod diagnostics;
+mod handlers;
+mod snippets;
+
+use tower_lsp::lsp_types::{Diagnostic, Url};
+use tower_lsp::Client;
+
+use crate::config::{InitializationOptions, ResolvedConfig};
+use crate::document::{is_markdown_path, TextDocumentState};
+use crate::frontmatter::{self, FrontmatterSchema};
+use crate::state::LspState;
+
+pub struct Backend {
+    pub(super) client: Client,
+    pub(super) state: LspState,
+}
+
+impl Backend {
+    pub fn new(client: Client) -> Self {
+        Self { client, state: LspState::new() }
+    }
+
+    pub(super) async fn on_change(&self, uri: &Url, text: String) {
+        if uri.to_file_path().ok().is_some_and(|path| !is_markdown_path(&path)) {
+            return;
+        }
+
+        self.state.upsert_document(uri.clone(), text).await;
+        self.publish_diagnostics_for(uri).await;
+    }
+
+    pub(super) async fn publish_diagnostics_for(&self, uri: &Url) {
+        let Some(document) = self.state.document(uri).await else {
+            return;
+        };
+
+        let diagnostics = self.diagnostics(&document).await;
+        self.client.publish_diagnostics(uri.clone(), diagnostics, None).await;
+    }
+
+    async fn diagnostics(&self, document: &TextDocumentState) -> Vec<Diagnostic> {
+        let config = self.resolved_config().await;
+        let frontmatter = frontmatter::parse_frontmatter(document);
+        let mut diagnostics = frontmatter
+            .block
+            .as_ref()
+            .map_or_else(Vec::new, |block| self.frontmatter_diagnostics(block, &config));
+        diagnostics
+            .extend(diagnostics::markdown_parse_diagnostics(document, frontmatter.block.as_ref()));
+        diagnostics
+    }
+
+    fn frontmatter_diagnostics(
+        &self,
+        block: &frontmatter::FrontmatterBlock,
+        config: &ResolvedConfig,
+    ) -> Vec<Diagnostic> {
+        let mut diagnostics = block.diagnostics.clone();
+        match self.load_schema(config) {
+            Ok(Some(schema)) => {
+                diagnostics.extend(frontmatter::validate_frontmatter(block, &schema))
+            }
+            Ok(None) => {}
+            Err(message) => diagnostics.push(Diagnostic {
+                range: block.block_range,
+                severity: Some(tower_lsp::lsp_types::DiagnosticSeverity::ERROR),
+                source: Some("ox-content".to_string()),
+                message,
+                ..Default::default()
+            }),
+        }
+        diagnostics
+    }
+
+    pub(super) async fn resolved_config(&self) -> ResolvedConfig {
+        let root = self.state.root().await;
+        let init = self.state.init_options().await;
+        ResolvedConfig::load(root.as_deref(), &init)
+    }
+
+    pub(super) fn load_schema(
+        &self,
+        config: &ResolvedConfig,
+    ) -> std::result::Result<Option<FrontmatterSchema>, String> {
+        let Some(path) = &config.frontmatter_schema else {
+            return Ok(None);
+        };
+        if !path.exists() {
+            return Err(format!(
+                "Configured frontmatter schema does not exist: {}",
+                path.display()
+            ));
+        }
+        frontmatter::load_schema(path).map(Some)
+    }
+
+    pub(super) async fn init_from_params(&self, params: &tower_lsp::lsp_types::InitializeParams) {
+        let root = params.root_uri.as_ref().and_then(|uri| uri.to_file_path().ok()).or_else(|| {
+            params.workspace_folders.as_ref().and_then(|folders| {
+                folders.first().and_then(|folder| folder.uri.to_file_path().ok())
+            })
+        });
+        let init_options = params
+            .initialization_options
+            .clone()
+            .and_then(|value| serde_json::from_value::<InitializationOptions>(value).ok())
+            .unwrap_or_default();
+
+        self.state.set_root(root).await;
+        self.state.set_init_options(init_options).await;
+    }
+}

--- a/crates/ox_content_lsp/src/backend.rs
+++ b/crates/ox_content_lsp/src/backend.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod diagnostics;
+mod features;
 mod handlers;
 mod snippets;
 
@@ -9,25 +10,59 @@ use tower_lsp::Client;
 use crate::config::{InitializationOptions, ResolvedConfig};
 use crate::document::{is_markdown_path, TextDocumentState};
 use crate::frontmatter::{self, FrontmatterSchema};
+use crate::i18n::{self, I18nState};
 use crate::state::LspState;
 
 pub struct Backend {
     pub(super) client: Client,
+    pub(super) i18n_state: I18nState,
     pub(super) state: LspState,
 }
 
 impl Backend {
     pub fn new(client: Client) -> Self {
-        Self { client, state: LspState::new() }
+        Self { client, i18n_state: I18nState::new(), state: LspState::new() }
     }
 
     pub(super) async fn on_change(&self, uri: &Url, text: String) {
-        if uri.to_file_path().ok().is_some_and(|path| !is_markdown_path(&path)) {
+        let Some(path) = uri.to_file_path().ok() else {
             return;
+        };
+
+        if is_markdown_path(&path) {
+            self.state.upsert_document(uri.clone(), text.clone()).await;
+            self.publish_diagnostics_for(uri).await;
         }
 
-        self.state.upsert_document(uri.clone(), text).await;
-        self.publish_diagnostics_for(uri).await;
+        let path_str = path.to_string_lossy().to_string();
+        if i18n::is_i18n_source_path(&path) {
+            self.i18n_state.update_file_keys(&path_str, &text).await;
+            self.publish_i18n_diagnostics().await;
+        } else if i18n::is_i18n_dictionary_path(&path) {
+            self.i18n_state.reload_dictionaries().await;
+            self.publish_i18n_diagnostics().await;
+        }
+    }
+
+    pub(super) async fn open_document(&self, uri: &Url, text: String) {
+        if uri.to_file_path().ok().is_some_and(|path| i18n::is_i18n_source_path(&path)) {
+            self.i18n_state.add_open_uri(uri.clone()).await;
+        }
+        self.on_change(uri, text).await;
+    }
+
+    pub(super) async fn close_document(&self, uri: &Url) {
+        self.state.remove_document(uri).await;
+
+        if let Ok(path) = uri.to_file_path() {
+            let path_str = path.to_string_lossy().to_string();
+            if i18n::is_i18n_source_path(&path) {
+                self.i18n_state.remove_file(&path_str).await;
+                self.publish_i18n_diagnostics().await;
+            }
+        }
+
+        self.client.publish_diagnostics(uri.clone(), Vec::new(), None).await;
     }
 
     pub(super) async fn publish_diagnostics_for(&self, uri: &Url) {
@@ -49,6 +84,53 @@ impl Backend {
         diagnostics
             .extend(diagnostics::markdown_parse_diagnostics(document, frontmatter.block.as_ref()));
         diagnostics
+    }
+
+    pub(super) async fn publish_i18n_diagnostics(&self) {
+        let checker_diags = self.i18n_state.check_diagnostics().await;
+        for uri in &self.i18n_state.get_open_uris().await {
+            let Ok(path) = uri.to_file_path() else {
+                continue;
+            };
+            let path_str = path.to_string_lossy().to_string();
+            let usages = self.i18n_state.get_file_key_usages(&path_str).await;
+            let mut diagnostics = Vec::new();
+
+            for usage in &usages {
+                for diag in &checker_diags {
+                    if diag.key.as_deref() == Some(&usage.key) {
+                        diagnostics.push(Diagnostic {
+                            range: tower_lsp::lsp_types::Range {
+                                start: tower_lsp::lsp_types::Position {
+                                    line: usage.line - 1,
+                                    character: usage.column - 1,
+                                },
+                                end: tower_lsp::lsp_types::Position {
+                                    line: usage.line - 1,
+                                    character: usage.end_column - 1,
+                                },
+                            },
+                            severity: Some(match diag.severity {
+                                ox_content_i18n::checker::Severity::Error => {
+                                    tower_lsp::lsp_types::DiagnosticSeverity::ERROR
+                                }
+                                ox_content_i18n::checker::Severity::Warning => {
+                                    tower_lsp::lsp_types::DiagnosticSeverity::WARNING
+                                }
+                                ox_content_i18n::checker::Severity::Info => {
+                                    tower_lsp::lsp_types::DiagnosticSeverity::INFORMATION
+                                }
+                            }),
+                            source: Some("ox-content-i18n".to_string()),
+                            message: diag.message.clone(),
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+
+            self.client.publish_diagnostics(uri.clone(), diagnostics, None).await;
+        }
     }
 
     fn frontmatter_diagnostics(
@@ -107,7 +189,8 @@ impl Backend {
             .and_then(|value| serde_json::from_value::<InitializationOptions>(value).ok())
             .unwrap_or_default();
 
-        self.state.set_root(root).await;
+        self.state.set_root(root.clone()).await;
+        self.i18n_state.set_root(root).await;
         self.state.set_init_options(init_options).await;
     }
 }

--- a/crates/ox_content_lsp/src/backend.rs
+++ b/crates/ox_content_lsp/src/backend.rs
@@ -80,7 +80,7 @@ impl Backend {
         let mut diagnostics = frontmatter
             .block
             .as_ref()
-            .map_or_else(Vec::new, |block| self.frontmatter_diagnostics(block, &config));
+            .map_or_else(Vec::new, |block| Self::frontmatter_diagnostics(block, &config));
         diagnostics
             .extend(diagnostics::markdown_parse_diagnostics(document, frontmatter.block.as_ref()));
         diagnostics
@@ -134,14 +134,13 @@ impl Backend {
     }
 
     fn frontmatter_diagnostics(
-        &self,
         block: &frontmatter::FrontmatterBlock,
         config: &ResolvedConfig,
     ) -> Vec<Diagnostic> {
         let mut diagnostics = block.diagnostics.clone();
-        match self.load_schema(config) {
+        match Self::load_schema(config) {
             Ok(Some(schema)) => {
-                diagnostics.extend(frontmatter::validate_frontmatter(block, &schema))
+                diagnostics.extend(frontmatter::validate_frontmatter(block, &schema));
             }
             Ok(None) => {}
             Err(message) => diagnostics.push(Diagnostic {
@@ -162,7 +161,6 @@ impl Backend {
     }
 
     pub(super) fn load_schema(
-        &self,
         config: &ResolvedConfig,
     ) -> std::result::Result<Option<FrontmatterSchema>, String> {
         let Some(path) = &config.frontmatter_schema else {

--- a/crates/ox_content_lsp/src/backend/commands.rs
+++ b/crates/ox_content_lsp/src/backend/commands.rs
@@ -1,0 +1,106 @@
+use std::collections::HashMap;
+
+use tower_lsp::jsonrpc::{Error, ErrorCode, Result};
+use tower_lsp::lsp_types::{
+    CodeAction, CodeActionKind, CodeActionOrCommand, Command, Position, Range, TextEdit, Url,
+    WorkspaceEdit,
+};
+
+use crate::preview;
+
+use super::Backend;
+
+pub(super) const COMMAND_INSERT_TABLE: &str = "oxContent.insertTable";
+pub(super) const COMMAND_INSERT_CODE_FENCE: &str = "oxContent.insertCodeFence";
+pub(super) const COMMAND_INSERT_CALLOUT: &str = "oxContent.insertCallout";
+pub(super) const COMMAND_PREVIEW_HTML: &str = "oxContent.previewHtml";
+
+#[derive(serde::Deserialize)]
+struct EditCommandPayload {
+    uri: String,
+    position: Position,
+}
+
+impl Backend {
+    pub(super) async fn insert_template(
+        &self,
+        command: &str,
+        arguments: Vec<serde_json::Value>,
+    ) -> Result<Option<serde_json::Value>> {
+        let Some(payload) = arguments.first() else {
+            return Ok(None);
+        };
+        let payload: EditCommandPayload = serde_json::from_value(payload.clone())
+            .map_err(|_| Error::invalid_params("Invalid command payload"))?;
+        let uri =
+            Url::parse(&payload.uri).map_err(|_| Error::invalid_params("Invalid document URI"))?;
+        let snippet = match command {
+            COMMAND_INSERT_TABLE => "| Column | Column |\n| --- | --- |\n| Value | Value |\n",
+            COMMAND_INSERT_CODE_FENCE => "```ts\nconst value = true;\n```\n",
+            COMMAND_INSERT_CALLOUT => "> [!NOTE]\n> Add your note here.\n",
+            _ => return Ok(None),
+        };
+
+        let mut changes = HashMap::new();
+        changes.insert(
+            uri,
+            vec![TextEdit {
+                range: Range { start: payload.position, end: payload.position },
+                new_text: snippet.to_string(),
+            }],
+        );
+
+        self.client
+            .apply_edit(WorkspaceEdit { changes: Some(changes), ..Default::default() })
+            .await?;
+        Ok(None)
+    }
+
+    pub(super) async fn preview_html(
+        &self,
+        arguments: Vec<serde_json::Value>,
+    ) -> Result<Option<serde_json::Value>> {
+        let Some(argument) = arguments.first().and_then(serde_json::Value::as_str) else {
+            return Err(Error::invalid_params("Missing preview URI"));
+        };
+        let uri = Url::parse(argument).map_err(|_| Error::invalid_params("Invalid preview URI"))?;
+        let Some(document) = self.state.document(&uri).await else {
+            return Ok(None);
+        };
+
+        let payload = preview::render_preview(document.text()).map_err(|error| Error {
+            code: ErrorCode::InternalError,
+            message: error.to_string().into(),
+            data: None,
+        })?;
+
+        serde_json::to_value(payload).map(Some).map_err(|_| Error::internal_error())
+    }
+}
+
+pub(super) fn insert_actions(uri: &Url, position: Position) -> Vec<CodeActionOrCommand> {
+    [
+        ("Insert table", COMMAND_INSERT_TABLE),
+        ("Insert code fence", COMMAND_INSERT_CODE_FENCE),
+        ("Insert callout", COMMAND_INSERT_CALLOUT),
+    ]
+    .into_iter()
+    .map(|(title, command)| code_action(title, command, uri, position))
+    .collect()
+}
+
+fn code_action(title: &str, command: &str, uri: &Url, position: Position) -> CodeActionOrCommand {
+    CodeActionOrCommand::CodeAction(CodeAction {
+        title: title.to_string(),
+        kind: Some(CodeActionKind::REFACTOR_REWRITE),
+        command: Some(Command {
+            title: title.to_string(),
+            command: command.to_string(),
+            arguments: Some(vec![serde_json::json!({
+                "uri": uri.to_string(),
+                "position": position,
+            })]),
+        }),
+        ..Default::default()
+    })
+}

--- a/crates/ox_content_lsp/src/backend/diagnostics.rs
+++ b/crates/ox_content_lsp/src/backend/diagnostics.rs
@@ -9,12 +9,15 @@ pub(super) fn markdown_parse_diagnostics(
     document: &TextDocumentState,
     block: Option<&FrontmatterBlock>,
 ) -> Vec<Diagnostic> {
-    let (source, offset) = block.map_or((document.text(), 0), |block| {
-        (
-            &document.text()[block.content_start_offset..block.content_end_offset],
-            block.content_start_offset,
-        )
-    });
+    let (source, offset) = block.map_or_else(
+        || (document.text(), 0),
+        |block| {
+            (
+                &document.text()[block.content_start_offset..block.content_end_offset],
+                block.content_start_offset,
+            )
+        },
+    );
 
     let allocator = Allocator::new();
     let parser = Parser::with_options(&allocator, source, ParserOptions::gfm());

--- a/crates/ox_content_lsp/src/backend/diagnostics.rs
+++ b/crates/ox_content_lsp/src/backend/diagnostics.rs
@@ -1,0 +1,45 @@
+use ox_content_allocator::Allocator;
+use ox_content_parser::{ParseError, Parser, ParserOptions};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
+
+use crate::document::TextDocumentState;
+use crate::frontmatter::FrontmatterBlock;
+
+pub(super) fn markdown_parse_diagnostics(
+    document: &TextDocumentState,
+    block: Option<&FrontmatterBlock>,
+) -> Vec<Diagnostic> {
+    let (source, offset) = block.map_or((document.text(), 0), |block| {
+        (
+            &document.text()[block.content_start_offset..block.content_end_offset],
+            block.content_start_offset,
+        )
+    });
+
+    let allocator = Allocator::new();
+    let parser = Parser::with_options(&allocator, source, ParserOptions::gfm());
+    let diagnostics = match parser.parse() {
+        Ok(_) => Vec::new(),
+        Err(error) => vec![parse_error_to_diagnostic(document, offset, error)],
+    };
+
+    diagnostics
+}
+
+fn parse_error_to_diagnostic(
+    document: &TextDocumentState,
+    base_offset: usize,
+    error: ParseError,
+) -> Diagnostic {
+    let span = error.span();
+    let start = base_offset + span.start as usize;
+    let end = (base_offset + span.end as usize).max(start + 1).min(document.text().len());
+
+    Diagnostic {
+        range: document.range_from_offsets(start, end),
+        severity: Some(DiagnosticSeverity::ERROR),
+        source: Some("ox-content".to_string()),
+        message: error.to_string(),
+        ..Default::default()
+    }
+}

--- a/crates/ox_content_lsp/src/backend/features.rs
+++ b/crates/ox_content_lsp/src/backend/features.rs
@@ -1,0 +1,181 @@
+use tower_lsp::lsp_types::*;
+
+use crate::document::is_markdown_path;
+use crate::frontmatter;
+use crate::i18n;
+use crate::preview;
+
+use super::snippets::markdown_snippet_items;
+use super::Backend;
+
+impl Backend {
+    pub(super) async fn completion_response(
+        &self,
+        uri: &Url,
+        position: Position,
+    ) -> Option<CompletionResponse> {
+        let Ok(path) = uri.to_file_path() else {
+            return None;
+        };
+
+        if i18n::is_i18n_source_path(&path) {
+            let items = self
+                .i18n_state
+                .all_dictionary_keys()
+                .await
+                .into_iter()
+                .map(|key| CompletionItem {
+                    label: key,
+                    kind: Some(CompletionItemKind::TEXT),
+                    detail: Some("i18n translation key".to_string()),
+                    ..Default::default()
+                })
+                .collect::<Vec<_>>();
+            return (!items.is_empty()).then_some(CompletionResponse::Array(items));
+        }
+
+        if !is_markdown_path(&path) {
+            return None;
+        }
+
+        let document = self.state.document(uri).await?;
+        let config = self.resolved_config().await;
+        let frontmatter = frontmatter::parse_frontmatter(&document);
+        let mut items = frontmatter
+            .block
+            .as_ref()
+            .and_then(|block| {
+                self.load_schema(&config).ok().flatten().and_then(|schema| {
+                    frontmatter::completion_items(&document, position, block, &schema)
+                })
+            })
+            .unwrap_or_default();
+        items.extend(markdown_snippet_items(&document, position));
+        (!items.is_empty()).then_some(CompletionResponse::Array(items))
+    }
+
+    pub(super) async fn hover_response(&self, uri: &Url, position: Position) -> Option<Hover> {
+        let Ok(path) = uri.to_file_path() else {
+            return None;
+        };
+
+        if i18n::is_i18n_source_path(&path) {
+            let path_str = path.to_string_lossy().to_string();
+            let usages = self.i18n_state.get_file_key_usages(&path_str).await;
+            let key = i18n::key_at_position(&usages, position)?;
+            let translations = self.i18n_state.translations_for_key(&key).await;
+            if translations.is_empty() {
+                return None;
+            }
+
+            let mut value =
+                format!("**`{key}`**\n\n| Locale | Translation |\n|--------|-------------|\n");
+            for (locale, translation) in &translations {
+                value.push_str(&format!("| `{locale}` | {translation} |\n"));
+            }
+
+            return Some(Hover {
+                contents: HoverContents::Markup(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value,
+                }),
+                range: None,
+            });
+        }
+
+        if !is_markdown_path(&path) {
+            return None;
+        }
+
+        let document = self.state.document(uri).await?;
+        let config = self.resolved_config().await;
+        let block = frontmatter::parse_frontmatter(&document).block?;
+        let schema = self.load_schema(&config).ok().flatten()?;
+        frontmatter::hover(&block, position, &schema)
+    }
+
+    pub(super) async fn goto_definition_response(
+        &self,
+        uri: &Url,
+        position: Position,
+    ) -> Option<GotoDefinitionResponse> {
+        let Ok(path) = uri.to_file_path() else {
+            return None;
+        };
+        if !i18n::is_i18n_source_path(&path) {
+            return None;
+        }
+
+        let path_str = path.to_string_lossy().to_string();
+        let usages = self.i18n_state.get_file_key_usages(&path_str).await;
+        let key = i18n::key_at_position(&usages, position)?;
+        let dict_file = self.i18n_state.find_key_definition(&key).await?;
+        let target_uri = Url::from_file_path(&dict_file).ok()?;
+        let line = i18n::find_key_line_in_file(&dict_file, &key).unwrap_or(0);
+
+        Some(GotoDefinitionResponse::Scalar(Location {
+            uri: target_uri,
+            range: Range {
+                start: Position { line, character: 0 },
+                end: Position { line, character: 0 },
+            },
+        }))
+    }
+
+    pub(super) async fn inlay_hints(&self, uri: &Url) -> Option<Vec<InlayHint>> {
+        let Ok(path) = uri.to_file_path() else {
+            return None;
+        };
+        if !i18n::is_i18n_source_path(&path) {
+            return None;
+        }
+
+        let path_str = path.to_string_lossy().to_string();
+        let usages = self.i18n_state.get_file_key_usages(&path_str).await;
+        if usages.is_empty() {
+            return None;
+        }
+
+        let mut hints = Vec::new();
+        for usage in &usages {
+            if let Some(translation) = self.i18n_state.default_translation(&usage.key).await {
+                let label = if translation.len() > 40 {
+                    format!(" {}...", &translation[..37])
+                } else {
+                    format!(" {translation}")
+                };
+
+                hints.push(InlayHint {
+                    position: Position { line: usage.line - 1, character: usage.end_column - 1 },
+                    label: InlayHintLabel::String(label),
+                    kind: Some(InlayHintKind::PARAMETER),
+                    text_edits: None,
+                    tooltip: None,
+                    padding_left: Some(true),
+                    padding_right: None,
+                    data: None,
+                });
+            }
+        }
+
+        Some(hints)
+    }
+
+    pub(super) async fn document_symbols_response(
+        &self,
+        uri: &Url,
+    ) -> Option<DocumentSymbolResponse> {
+        let Ok(path) = uri.to_file_path() else {
+            return None;
+        };
+        if !is_markdown_path(&path) {
+            return None;
+        }
+
+        let document = self.state.document(uri).await?;
+        match preview::document_symbols(document.text(), &document) {
+            Ok(symbols) if !symbols.is_empty() => Some(DocumentSymbolResponse::Nested(symbols)),
+            _ => None,
+        }
+    }
+}

--- a/crates/ox_content_lsp/src/backend/features.rs
+++ b/crates/ox_content_lsp/src/backend/features.rs
@@ -45,7 +45,7 @@ impl Backend {
             .block
             .as_ref()
             .and_then(|block| {
-                self.load_schema(&config).ok().flatten().and_then(|schema| {
+                Self::load_schema(&config).ok().flatten().and_then(|schema| {
                     frontmatter::completion_items(&document, position, block, &schema)
                 })
             })
@@ -90,7 +90,7 @@ impl Backend {
         let document = self.state.document(uri).await?;
         let config = self.resolved_config().await;
         let block = frontmatter::parse_frontmatter(&document).block?;
-        let schema = self.load_schema(&config).ok().flatten()?;
+        let schema = Self::load_schema(&config).ok().flatten()?;
         frontmatter::hover(&block, position, &schema)
     }
 

--- a/crates/ox_content_lsp/src/backend/handlers.rs
+++ b/crates/ox_content_lsp/src/backend/handlers.rs
@@ -1,0 +1,148 @@
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::*;
+use tower_lsp::LanguageServer;
+
+use crate::frontmatter;
+use crate::preview;
+
+use super::commands::{
+    insert_actions, COMMAND_INSERT_CALLOUT, COMMAND_INSERT_CODE_FENCE, COMMAND_INSERT_TABLE,
+    COMMAND_PREVIEW_HTML,
+};
+use super::snippets::markdown_snippet_items;
+use super::Backend;
+
+#[tower_lsp::async_trait]
+impl LanguageServer for Backend {
+    async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
+        self.init_from_params(&params).await;
+        Ok(InitializeResult {
+            capabilities: ServerCapabilities {
+                text_document_sync: Some(TextDocumentSyncCapability::Kind(
+                    TextDocumentSyncKind::FULL,
+                )),
+                completion_provider: Some(CompletionOptions {
+                    trigger_characters: Some(vec![
+                        "#".into(),
+                        "-".into(),
+                        "[".into(),
+                        "`".into(),
+                        "!".into(),
+                        ">".into(),
+                        "|".into(),
+                        ":".into(),
+                    ]),
+                    ..Default::default()
+                }),
+                hover_provider: Some(HoverProviderCapability::Simple(true)),
+                document_symbol_provider: Some(OneOf::Left(true)),
+                code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
+                execute_command_provider: Some(ExecuteCommandOptions {
+                    commands: vec![
+                        COMMAND_INSERT_TABLE.into(),
+                        COMMAND_INSERT_CODE_FENCE.into(),
+                        COMMAND_INSERT_CALLOUT.into(),
+                        COMMAND_PREVIEW_HTML.into(),
+                    ],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            server_info: Some(ServerInfo {
+                name: "ox-content-lsp".to_string(),
+                version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            }),
+            ..Default::default()
+        })
+    }
+
+    async fn initialized(&self, _: InitializedParams) {
+        self.client.log_message(MessageType::INFO, "ox-content LSP initialized").await;
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        self.on_change(&params.text_document.uri, params.text_document.text).await;
+    }
+
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        if let Some(change) = params.content_changes.first() {
+            self.on_change(&params.text_document.uri, change.text.clone()).await;
+        }
+    }
+
+    async fn did_close(&self, params: DidCloseTextDocumentParams) {
+        self.state.remove_document(&params.text_document.uri).await;
+        self.client.publish_diagnostics(params.text_document.uri, Vec::new(), None).await;
+    }
+
+    async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
+        let uri = &params.text_document_position.text_document.uri;
+        let position = params.text_document_position.position;
+        let Some(document) = self.state.document(uri).await else {
+            return Ok(None);
+        };
+        let config = self.resolved_config().await;
+        let frontmatter = frontmatter::parse_frontmatter(&document);
+        let mut items = frontmatter
+            .block
+            .as_ref()
+            .and_then(|block| {
+                self.load_schema(&config).ok().flatten().and_then(|schema| {
+                    frontmatter::completion_items(&document, position, block, &schema)
+                })
+            })
+            .unwrap_or_default();
+        items.extend(markdown_snippet_items(&document, position));
+        Ok((!items.is_empty()).then_some(CompletionResponse::Array(items)))
+    }
+
+    async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
+        let uri = &params.text_document_position_params.text_document.uri;
+        let position = params.text_document_position_params.position;
+        let Some(document) = self.state.document(uri).await else {
+            return Ok(None);
+        };
+        let config = self.resolved_config().await;
+        let Some(block) = frontmatter::parse_frontmatter(&document).block else {
+            return Ok(None);
+        };
+        let Ok(Some(schema)) = self.load_schema(&config) else {
+            return Ok(None);
+        };
+        Ok(frontmatter::hover(&block, position, &schema))
+    }
+
+    async fn document_symbol(
+        &self,
+        params: DocumentSymbolParams,
+    ) -> Result<Option<DocumentSymbolResponse>> {
+        let Some(document) = self.state.document(&params.text_document.uri).await else {
+            return Ok(None);
+        };
+        match preview::document_symbols(document.text(), &document) {
+            Ok(symbols) if !symbols.is_empty() => Ok(Some(DocumentSymbolResponse::Nested(symbols))),
+            _ => Ok(None),
+        }
+    }
+
+    async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
+        Ok(Some(insert_actions(&params.text_document.uri, params.range.start)))
+    }
+
+    async fn execute_command(
+        &self,
+        params: ExecuteCommandParams,
+    ) -> Result<Option<serde_json::Value>> {
+        match params.command.as_str() {
+            COMMAND_INSERT_TABLE | COMMAND_INSERT_CODE_FENCE | COMMAND_INSERT_CALLOUT => {
+                self.insert_template(&params.command, params.arguments).await
+            }
+            COMMAND_PREVIEW_HTML => self.preview_html(params.arguments).await,
+            _ => Ok(None),
+        }
+    }
+}

--- a/crates/ox_content_lsp/src/backend/handlers.rs
+++ b/crates/ox_content_lsp/src/backend/handlers.rs
@@ -2,14 +2,12 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::LanguageServer;
 
-use crate::frontmatter;
-use crate::preview;
+use crate::document::is_markdown_path;
 
 use super::commands::{
     insert_actions, COMMAND_INSERT_CALLOUT, COMMAND_INSERT_CODE_FENCE, COMMAND_INSERT_TABLE,
     COMMAND_PREVIEW_HTML,
 };
-use super::snippets::markdown_snippet_items;
 use super::Backend;
 
 #[tower_lsp::async_trait]
@@ -23,6 +21,8 @@ impl LanguageServer for Backend {
                 )),
                 completion_provider: Some(CompletionOptions {
                     trigger_characters: Some(vec![
+                        "\"".into(),
+                        "'".into(),
                         "#".into(),
                         "-".into(),
                         "[".into(),
@@ -35,6 +35,8 @@ impl LanguageServer for Backend {
                     ..Default::default()
                 }),
                 hover_provider: Some(HoverProviderCapability::Simple(true)),
+                definition_provider: Some(OneOf::Left(true)),
+                inlay_hint_provider: Some(OneOf::Left(true)),
                 document_symbol_provider: Some(OneOf::Left(true)),
                 code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
                 execute_command_provider: Some(ExecuteCommandOptions {
@@ -65,7 +67,7 @@ impl LanguageServer for Backend {
     }
 
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
-        self.on_change(&params.text_document.uri, params.text_document.text).await;
+        self.open_document(&params.text_document.uri, params.text_document.text).await;
     }
 
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
@@ -75,61 +77,55 @@ impl LanguageServer for Backend {
     }
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
-        self.state.remove_document(&params.text_document.uri).await;
-        self.client.publish_diagnostics(params.text_document.uri, Vec::new(), None).await;
+        self.close_document(&params.text_document.uri).await;
     }
 
     async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
-        let uri = &params.text_document_position.text_document.uri;
-        let position = params.text_document_position.position;
-        let Some(document) = self.state.document(uri).await else {
-            return Ok(None);
-        };
-        let config = self.resolved_config().await;
-        let frontmatter = frontmatter::parse_frontmatter(&document);
-        let mut items = frontmatter
-            .block
-            .as_ref()
-            .and_then(|block| {
-                self.load_schema(&config).ok().flatten().and_then(|schema| {
-                    frontmatter::completion_items(&document, position, block, &schema)
-                })
-            })
-            .unwrap_or_default();
-        items.extend(markdown_snippet_items(&document, position));
-        Ok((!items.is_empty()).then_some(CompletionResponse::Array(items)))
+        Ok(self
+            .completion_response(
+                &params.text_document_position.text_document.uri,
+                params.text_document_position.position,
+            )
+            .await)
     }
 
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
-        let uri = &params.text_document_position_params.text_document.uri;
-        let position = params.text_document_position_params.position;
-        let Some(document) = self.state.document(uri).await else {
-            return Ok(None);
-        };
-        let config = self.resolved_config().await;
-        let Some(block) = frontmatter::parse_frontmatter(&document).block else {
-            return Ok(None);
-        };
-        let Ok(Some(schema)) = self.load_schema(&config) else {
-            return Ok(None);
-        };
-        Ok(frontmatter::hover(&block, position, &schema))
+        Ok(self
+            .hover_response(
+                &params.text_document_position_params.text_document.uri,
+                params.text_document_position_params.position,
+            )
+            .await)
+    }
+
+    async fn goto_definition(
+        &self,
+        params: GotoDefinitionParams,
+    ) -> Result<Option<GotoDefinitionResponse>> {
+        Ok(self
+            .goto_definition_response(
+                &params.text_document_position_params.text_document.uri,
+                params.text_document_position_params.position,
+            )
+            .await)
+    }
+
+    async fn inlay_hint(&self, params: InlayHintParams) -> Result<Option<Vec<InlayHint>>> {
+        Ok(self.inlay_hints(&params.text_document.uri).await)
     }
 
     async fn document_symbol(
         &self,
         params: DocumentSymbolParams,
     ) -> Result<Option<DocumentSymbolResponse>> {
-        let Some(document) = self.state.document(&params.text_document.uri).await else {
-            return Ok(None);
-        };
-        match preview::document_symbols(document.text(), &document) {
-            Ok(symbols) if !symbols.is_empty() => Ok(Some(DocumentSymbolResponse::Nested(symbols))),
-            _ => Ok(None),
-        }
+        Ok(self.document_symbols_response(&params.text_document.uri).await)
     }
 
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
+        if params.text_document.uri.to_file_path().ok().is_some_and(|path| !is_markdown_path(&path))
+        {
+            return Ok(None);
+        }
         Ok(Some(insert_actions(&params.text_document.uri, params.range.start)))
     }
 

--- a/crates/ox_content_lsp/src/backend/handlers.rs
+++ b/crates/ox_content_lsp/src/backend/handlers.rs
@@ -54,7 +54,6 @@ impl LanguageServer for Backend {
                 name: "ox-content-lsp".to_string(),
                 version: Some(env!("CARGO_PKG_VERSION").to_string()),
             }),
-            ..Default::default()
         })
     }
 

--- a/crates/ox_content_lsp/src/backend/snippets.rs
+++ b/crates/ox_content_lsp/src/backend/snippets.rs
@@ -1,0 +1,54 @@
+use tower_lsp::lsp_types::{
+    CompletionItem, CompletionItemKind, CompletionTextEdit, InsertTextFormat, Position, TextEdit,
+};
+
+use crate::document::TextDocumentState;
+
+pub(super) fn markdown_snippet_items(
+    document: &TextDocumentState,
+    position: Position,
+) -> Vec<CompletionItem> {
+    let line = document.line_text(position.line);
+    let prefix = line[..document
+        .position_to_offset(position)
+        .saturating_sub(document.line_start_offset(position.line as usize))
+        .min(line.len())]
+        .trim();
+
+    if !prefix.is_empty() && !prefix.chars().all(|ch| ch.is_ascii_alphanumeric()) {
+        return Vec::new();
+    }
+
+    let replace = document.word_range_at(position, |ch| ch.is_ascii_alphanumeric());
+    [
+        ("h1", "Page heading", "# ${1:Title}\n\n$0"),
+        ("h2", "Section heading", "## ${1:Section}\n\n$0"),
+        ("quote", "Blockquote", "> ${1:Quoted text}\n\n$0"),
+        ("list", "Bullet list", "- ${1:First item}\n- ${2:Second item}\n$0"),
+        ("task", "Task list", "- [ ] ${1:Open item}\n- [x] ${2:Done item}\n$0"),
+        ("link", "Markdown link", "[${1:label}](${2:https://example.com})$0"),
+        ("image", "Markdown image", "![${1:alt text}](${2:/path/to/image.png})$0"),
+        ("code", "TypeScript code fence", "```ts\n${1:const value = true}\n```\n$0"),
+        (
+            "table",
+            "Simple table",
+            "| ${1:Column} | ${2:Column} |\n| --- | --- |\n| ${3:Value} | ${4:Value} |\n$0",
+        ),
+    ]
+    .into_iter()
+    .enumerate()
+    .map(|(index, (label, detail, insert_text))| CompletionItem {
+        label: label.to_string(),
+        kind: Some(CompletionItemKind::SNIPPET),
+        detail: Some(detail.to_string()),
+        insert_text: Some(insert_text.to_string()),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        sort_text: Some(format!("9{index:02}")),
+        text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+            range: replace,
+            new_text: insert_text.to_string(),
+        })),
+        ..Default::default()
+    })
+    .collect()
+}

--- a/crates/ox_content_lsp/src/backend/snippets.rs
+++ b/crates/ox_content_lsp/src/backend/snippets.rs
@@ -4,6 +4,7 @@ use tower_lsp::lsp_types::{
 
 use crate::document::TextDocumentState;
 
+#[allow(clippy::literal_string_with_formatting_args)]
 pub(super) fn markdown_snippet_items(
     document: &TextDocumentState,
     position: Position,

--- a/crates/ox_content_lsp/src/config.rs
+++ b/crates/ox_content_lsp/src/config.rs
@@ -1,0 +1,89 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+const DEFAULT_CONFIG_NAMES: &[&str] = &[".ox-content.json", "ox-content.json"];
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct InitializationOptions {
+    #[serde(rename = "configPath")]
+    pub config_path: Option<String>,
+    #[serde(rename = "frontmatterSchema")]
+    pub frontmatter_schema: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+struct WorkspaceConfigFile {
+    frontmatter: FrontmatterConfigFile,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+struct FrontmatterConfigFile {
+    schema: Option<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ResolvedConfig {
+    pub frontmatter_schema: Option<PathBuf>,
+}
+
+impl ResolvedConfig {
+    #[must_use]
+    pub fn load(root: Option<&Path>, init: &InitializationOptions) -> Self {
+        let root = root.map(Path::to_path_buf);
+        let frontmatter_schema = init
+            .frontmatter_schema
+            .as_ref()
+            .map(|value| resolve_path(root.as_deref(), value))
+            .or_else(|| {
+                load_workspace_file(root.as_deref(), init.config_path.as_deref()).and_then(
+                    |(path, config)| {
+                        config.frontmatter.schema.map(|value| resolve_path(path.parent(), &value))
+                    },
+                )
+            })
+            .or_else(|| {
+                env::var("OX_CONTENT_FRONTMATTER_SCHEMA")
+                    .ok()
+                    .map(|value| resolve_path(root.as_deref(), &value))
+            });
+
+        Self { frontmatter_schema }
+    }
+}
+
+fn load_workspace_file(
+    root: Option<&Path>,
+    config_override: Option<&str>,
+) -> Option<(PathBuf, WorkspaceConfigFile)> {
+    let config_path = if let Some(config_override) = config_override {
+        Some(resolve_path(root, config_override))
+    } else {
+        root.and_then(|root| {
+            DEFAULT_CONFIG_NAMES
+                .iter()
+                .map(|name| root.join(name))
+                .find(|candidate| candidate.exists())
+        })
+    }?;
+
+    let content = fs::read_to_string(&config_path).ok()?;
+    let config = serde_json::from_str::<WorkspaceConfigFile>(&content).ok()?;
+    Some((config_path, config))
+}
+
+fn resolve_path(base: Option<&Path>, value: &str) -> PathBuf {
+    let candidate = PathBuf::from(value);
+    if candidate.is_absolute() {
+        candidate
+    } else if let Some(base) = base {
+        base.join(candidate)
+    } else {
+        candidate
+    }
+}

--- a/crates/ox_content_lsp/src/document.rs
+++ b/crates/ox_content_lsp/src/document.rs
@@ -1,0 +1,139 @@
+use std::path::Path;
+
+use tower_lsp::lsp_types::{Position, Range};
+
+#[derive(Clone, Debug)]
+pub struct TextDocumentState {
+    text: String,
+    line_offsets: Vec<usize>,
+}
+
+impl TextDocumentState {
+    #[must_use]
+    pub fn new(text: String) -> Self {
+        let mut line_offsets = vec![0];
+        for (index, ch) in text.char_indices() {
+            if ch == '\n' {
+                line_offsets.push(index + 1);
+            }
+        }
+        Self { text, line_offsets }
+    }
+
+    #[must_use]
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    #[must_use]
+    pub fn line_count(&self) -> usize {
+        self.line_offsets.len()
+    }
+
+    #[must_use]
+    pub fn line_start_offset(&self, line: usize) -> usize {
+        self.line_offsets.get(line).copied().unwrap_or(self.text.len())
+    }
+
+    #[must_use]
+    pub fn line_end_offset(&self, line: usize) -> usize {
+        if line + 1 < self.line_offsets.len() {
+            self.line_offsets[line + 1]
+        } else {
+            self.text.len()
+        }
+    }
+
+    #[must_use]
+    pub fn line_text(&self, line: u32) -> &str {
+        let line = line as usize;
+        if line >= self.line_offsets.len() {
+            return "";
+        }
+        let start = self.line_start_offset(line);
+        let end = self.line_end_offset(line);
+        &self.text[start..end]
+    }
+
+    #[must_use]
+    pub fn position_to_offset(&self, position: Position) -> usize {
+        if self.line_offsets.is_empty() {
+            return 0;
+        }
+
+        let line = (position.line as usize).min(self.line_offsets.len().saturating_sub(1));
+        let start = self.line_start_offset(line);
+        let end = self.line_end_offset(line);
+        let line_text = &self.text[start..end];
+
+        let mut utf16_offset = 0usize;
+        let mut byte_offset = start;
+
+        for (index, ch) in line_text.char_indices() {
+            let width = ch.len_utf16();
+            if utf16_offset + width > position.character as usize {
+                return start + index;
+            }
+            utf16_offset += width;
+            byte_offset = start + index + ch.len_utf8();
+        }
+
+        byte_offset.min(self.text.len())
+    }
+
+    #[must_use]
+    pub fn offset_to_position(&self, offset: usize) -> Position {
+        let clamped = offset.min(self.text.len());
+        let line_index = self
+            .line_offsets
+            .partition_point(|line_offset| *line_offset <= clamped)
+            .saturating_sub(1);
+
+        let start = self.line_start_offset(line_index);
+        let character = self.text[start..clamped].encode_utf16().count() as u32;
+
+        Position { line: line_index as u32, character }
+    }
+
+    #[must_use]
+    pub fn range_from_offsets(&self, start: usize, end: usize) -> Range {
+        Range { start: self.offset_to_position(start), end: self.offset_to_position(end) }
+    }
+
+    #[must_use]
+    pub fn word_range_at(&self, position: Position, predicate: fn(char) -> bool) -> Range {
+        let offset = self.position_to_offset(position);
+        let line_start = self.line_start_offset(position.line as usize);
+        let line_end = self.line_end_offset(position.line as usize);
+        let line_text = &self.text[line_start..line_end];
+        let local_offset = offset.saturating_sub(line_start).min(line_text.len());
+
+        let mut start = local_offset;
+        for (index, ch) in line_text[..local_offset].char_indices().rev() {
+            if predicate(ch) {
+                start = index;
+            } else {
+                break;
+            }
+        }
+
+        let mut end = local_offset;
+        for (index, ch) in line_text[local_offset..].char_indices() {
+            if predicate(ch) {
+                end = local_offset + index + ch.len_utf8();
+            } else {
+                break;
+            }
+        }
+
+        self.range_from_offsets(line_start + start, line_start + end)
+    }
+}
+
+#[must_use]
+pub fn is_markdown_path(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some("md" | "markdown" | "mdown" | "mdc")
+    )
+}

--- a/crates/ox_content_lsp/src/frontmatter.rs
+++ b/crates/ox_content_lsp/src/frontmatter.rs
@@ -1,0 +1,12 @@
+mod complete;
+mod parse;
+mod schema;
+mod types;
+mod utils;
+mod validate;
+
+pub use complete::{completion_items, hover};
+pub use parse::parse_frontmatter;
+pub use schema::load_schema;
+pub use types::{FrontmatterBlock, FrontmatterDocument, FrontmatterSchema, TopLevelKey};
+pub use validate::validate_frontmatter;

--- a/crates/ox_content_lsp/src/frontmatter/complete.rs
+++ b/crates/ox_content_lsp/src/frontmatter/complete.rs
@@ -197,6 +197,7 @@ fn property_snippet(name: &str, property: &FrontmatterSchema) -> String {
     format!("{name}: {}", default_value_snippet(property))
 }
 
+#[allow(clippy::literal_string_with_formatting_args)]
 fn default_value_snippet(property: &FrontmatterSchema) -> String {
     if let Some(default) = &property.default {
         return display_value(default);

--- a/crates/ox_content_lsp/src/frontmatter/complete.rs
+++ b/crates/ox_content_lsp/src/frontmatter/complete.rs
@@ -1,0 +1,215 @@
+use std::collections::HashSet;
+
+use tower_lsp::lsp_types::{
+    CompletionItem, CompletionItemKind, Documentation, Hover, HoverContents, InsertTextFormat,
+    MarkupContent, MarkupKind, Position,
+};
+
+use crate::document::TextDocumentState;
+use crate::frontmatter::utils::{contains_position, display_value};
+use crate::frontmatter::{FrontmatterBlock, FrontmatterSchema};
+
+pub fn completion_items(
+    document: &TextDocumentState,
+    position: Position,
+    block: &FrontmatterBlock,
+    schema: &FrontmatterSchema,
+) -> Option<Vec<CompletionItem>> {
+    if !contains_position(&block.block_range, position) {
+        return None;
+    }
+
+    let line = crate::frontmatter::utils::strip_line_breaks(document.line_text(position.line));
+    let line_start = document.line_start_offset(position.line as usize);
+    let cursor_offset = document.position_to_offset(position);
+    let cursor_in_line = cursor_offset.saturating_sub(line_start).min(line.len());
+    let prefix = &line[..cursor_in_line];
+    let colon_index = line.find(':');
+
+    if colon_index.is_none() || cursor_in_line <= colon_index.unwrap_or(0) {
+        return Some(property_items(document, position, block, schema));
+    }
+
+    value_items(document, position, prefix, line, schema)
+}
+
+pub fn hover(
+    block: &FrontmatterBlock,
+    position: Position,
+    schema: &FrontmatterSchema,
+) -> Option<Hover> {
+    let key =
+        block.top_level_keys.iter().find(|entry| contains_position(&entry.key_range, position))?;
+    let property = schema.property(&key.name)?;
+    let mut lines = vec![format!("**{}**", key.name), format!("Type: `{}`", property.kind_label())];
+
+    if let Some(description) = &property.description {
+        lines.extend([String::new(), description.clone()]);
+    }
+    if !property.enum_values.is_empty() {
+        lines.extend([
+            String::new(),
+            format!(
+                "Allowed values: {}",
+                property.enum_values.iter().map(display_value).collect::<Vec<_>>().join(", ")
+            ),
+        ]);
+    }
+    if let Some(default) = &property.default {
+        lines.extend([String::new(), format!("Default: `{}`", display_value(default))]);
+    }
+
+    Some(Hover {
+        contents: HoverContents::Markup(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: lines.join("\n"),
+        }),
+        range: Some(key.key_range),
+    })
+}
+
+fn property_items(
+    document: &TextDocumentState,
+    position: Position,
+    block: &FrontmatterBlock,
+    schema: &FrontmatterSchema,
+) -> Vec<CompletionItem> {
+    let existing: HashSet<&str> =
+        block.top_level_keys.iter().map(|key| key.name.as_str()).collect();
+    let replace = document.word_range_at(position, |ch| {
+        ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '"'
+    });
+
+    schema
+        .properties
+        .iter()
+        .map(|(name, property)| CompletionItem {
+            label: name.clone(),
+            kind: Some(CompletionItemKind::PROPERTY),
+            detail: Some(property.kind_label()),
+            documentation: property.description.as_ref().map(|description| {
+                Documentation::MarkupContent(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: description.clone(),
+                })
+            }),
+            insert_text: Some(property_snippet(name, property)),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            sort_text: Some(if existing.contains(name.as_str()) {
+                format!("1{name}")
+            } else {
+                format!("0{name}")
+            }),
+            text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(
+                tower_lsp::lsp_types::TextEdit {
+                    range: replace,
+                    new_text: property_snippet(name, property),
+                },
+            )),
+            ..Default::default()
+        })
+        .collect()
+}
+
+fn value_items(
+    document: &TextDocumentState,
+    position: Position,
+    prefix: &str,
+    line: &str,
+    schema: &FrontmatterSchema,
+) -> Option<Vec<CompletionItem>> {
+    let key = line[..line.find(':')?].trim().trim_matches('"').trim_matches('\'');
+    let property = schema.property(key)?;
+    let replace = document.word_range_at(position, |ch| {
+        ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '"' || ch == '\''
+    });
+    let mut items = enum_or_default_items(property, replace);
+
+    if items.is_empty() && prefix.trim_end().ends_with(':') {
+        items.push(CompletionItem {
+            label: property.kind_label(),
+            kind: Some(CompletionItemKind::VALUE),
+            insert_text: Some(default_value_snippet(property)),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            detail: property.description.clone(),
+            ..Default::default()
+        });
+    }
+
+    Some(items)
+}
+
+fn enum_or_default_items(
+    property: &FrontmatterSchema,
+    range: tower_lsp::lsp_types::Range,
+) -> Vec<CompletionItem> {
+    let mut items = property
+        .enum_values
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            completion_value(display_value(value), property.kind_label(), range, index)
+        })
+        .collect::<Vec<_>>();
+
+    if items.is_empty() && property.type_name.as_deref() == Some("boolean") {
+        items.extend(["true", "false"].into_iter().enumerate().map(|(index, value)| {
+            completion_value(value.to_string(), "boolean".to_string(), range, index)
+        }));
+    } else if items.is_empty() {
+        if let Some(default) = &property.default {
+            items.push(CompletionItem {
+                label: display_value(default),
+                kind: Some(CompletionItemKind::VALUE),
+                detail: Some("default".to_string()),
+                insert_text: Some(display_value(default)),
+                text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(
+                    tower_lsp::lsp_types::TextEdit { range, new_text: display_value(default) },
+                )),
+                ..Default::default()
+            });
+        }
+    }
+
+    items
+}
+
+fn completion_value(
+    text: String,
+    detail: String,
+    range: tower_lsp::lsp_types::Range,
+    index: usize,
+) -> CompletionItem {
+    CompletionItem {
+        label: text.clone(),
+        kind: Some(CompletionItemKind::VALUE),
+        detail: Some(detail),
+        insert_text: Some(text.clone()),
+        sort_text: Some(format!("0{index:02}")),
+        text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(
+            tower_lsp::lsp_types::TextEdit { range, new_text: text },
+        )),
+        ..Default::default()
+    }
+}
+
+fn property_snippet(name: &str, property: &FrontmatterSchema) -> String {
+    format!("{name}: {}", default_value_snippet(property))
+}
+
+fn default_value_snippet(property: &FrontmatterSchema) -> String {
+    if let Some(default) = &property.default {
+        return display_value(default);
+    }
+    if let Some(first) = property.enum_values.first() {
+        return display_value(first);
+    }
+
+    match property.type_name.as_deref() {
+        Some("boolean") => "${1:true}".to_string(),
+        Some("number") | Some("integer") => "${1:0}".to_string(),
+        Some("array") => "[${1}]".to_string(),
+        Some("object") => "{ ${1:key}: ${2:value} }".to_string(),
+        _ => "\"${1:value}\"".to_string(),
+    }
+}

--- a/crates/ox_content_lsp/src/frontmatter/parse.rs
+++ b/crates/ox_content_lsp/src/frontmatter/parse.rs
@@ -1,0 +1,125 @@
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+
+use crate::document::TextDocumentState;
+use crate::frontmatter::utils::{strip_line_breaks, yaml_error_range};
+use crate::frontmatter::{FrontmatterBlock, FrontmatterDocument, TopLevelKey};
+
+pub fn parse_frontmatter(document: &TextDocumentState) -> FrontmatterDocument {
+    if strip_line_breaks(document.line_text(0)) != "---" {
+        return FrontmatterDocument { block: None };
+    }
+
+    let Some(closing_line) = find_closing_line(document) else {
+        return FrontmatterDocument { block: Some(unterminated_block(document)) };
+    };
+
+    let content_start_offset = document.line_end_offset(0).min(document.text().len());
+    let content_end_offset = document.line_start_offset(closing_line);
+    let raw = document.text()[content_start_offset..content_end_offset].to_string();
+    let top_level_keys = collect_top_level_keys(document, content_start_offset, &raw);
+    let (value, diagnostics) = parse_yaml(document, content_start_offset, &raw);
+
+    FrontmatterDocument {
+        block: Some(FrontmatterBlock {
+            block_range: document.range_from_offsets(0, document.line_end_offset(closing_line)),
+            content_range: document.range_from_offsets(content_start_offset, content_end_offset),
+            content_start_offset,
+            content_end_offset,
+            value,
+            diagnostics,
+            top_level_keys,
+        }),
+    }
+}
+
+fn find_closing_line(document: &TextDocumentState) -> Option<usize> {
+    (1..document.line_count())
+        .find(|line| matches!(strip_line_breaks(document.line_text(*line as u32)), "---" | "..."))
+}
+
+fn unterminated_block(document: &TextDocumentState) -> FrontmatterBlock {
+    let range = Range {
+        start: Position { line: 0, character: 0 },
+        end: Position { line: 0, character: 3 },
+    };
+
+    FrontmatterBlock {
+        block_range: Range {
+            start: range.start,
+            end: document.offset_to_position(document.text().len()),
+        },
+        content_range: Range {
+            start: Position { line: 1, character: 0 },
+            end: document.offset_to_position(document.text().len()),
+        },
+        content_start_offset: document.line_start_offset(1.min(document.line_count())),
+        content_end_offset: document.text().len(),
+        value: None,
+        diagnostics: vec![Diagnostic {
+            range,
+            severity: Some(DiagnosticSeverity::ERROR),
+            source: Some("ox-content".to_string()),
+            message: "Unterminated frontmatter block".to_string(),
+            ..Default::default()
+        }],
+        top_level_keys: Vec::new(),
+    }
+}
+
+fn parse_yaml(
+    document: &TextDocumentState,
+    content_start_offset: usize,
+    raw: &str,
+) -> (Option<serde_json::Value>, Vec<Diagnostic>) {
+    match serde_yaml::from_str::<serde_yaml::Value>(raw) {
+        Ok(parsed) => (serde_json::to_value(parsed).ok(), Vec::new()),
+        Err(error) => (
+            None,
+            vec![Diagnostic {
+                range: yaml_error_range(document, content_start_offset, raw, &error),
+                severity: Some(DiagnosticSeverity::ERROR),
+                source: Some("ox-content".to_string()),
+                message: format!("Invalid YAML frontmatter: {error}"),
+                ..Default::default()
+            }],
+        ),
+    }
+}
+
+fn collect_top_level_keys(
+    document: &TextDocumentState,
+    content_start_offset: usize,
+    raw: &str,
+) -> Vec<TopLevelKey> {
+    let mut entries = Vec::new();
+    let mut line_offset = 0usize;
+
+    for line in raw.lines() {
+        let trimmed = strip_line_breaks(line);
+        let indent = trimmed
+            .chars()
+            .take_while(|ch| *ch == ' ' || *ch == '\t')
+            .map(char::len_utf8)
+            .sum::<usize>();
+        let candidate = trimmed.trim();
+
+        if !candidate.is_empty() && !candidate.starts_with('#') && indent == 0 {
+            if let Some(colon_index) = trimmed.find(':') {
+                let raw_key = trimmed[indent..colon_index].trim();
+                if !raw_key.is_empty() {
+                    let name = raw_key.trim_matches('"').trim_matches('\'').to_string();
+                    let start = content_start_offset + line_offset + indent;
+                    let end = content_start_offset + line_offset + colon_index;
+                    entries.push(TopLevelKey {
+                        name,
+                        key_range: document.range_from_offsets(start, end),
+                    });
+                }
+            }
+        }
+
+        line_offset += line.len() + 1;
+    }
+
+    entries
+}

--- a/crates/ox_content_lsp/src/frontmatter/schema.rs
+++ b/crates/ox_content_lsp/src/frontmatter/schema.rs
@@ -5,14 +5,14 @@ use crate::frontmatter::FrontmatterSchema;
 
 pub fn load_schema(path: &Path) -> Result<FrontmatterSchema, String> {
     let content = fs::read_to_string(path)
-        .map_err(|error| format!("Failed to read schema {path:?}: {error}"))?;
+        .map_err(|error| format!("Failed to read schema {}: {error}", path.display()))?;
     let extension = path.extension().and_then(|value| value.to_str()).unwrap_or_default();
 
     if matches!(extension, "yaml" | "yml") {
         serde_yaml::from_str::<FrontmatterSchema>(&content)
-            .map_err(|error| format!("Failed to parse schema {path:?}: {error}"))
+            .map_err(|error| format!("Failed to parse schema {}: {error}", path.display()))
     } else {
         serde_json::from_str::<FrontmatterSchema>(&content)
-            .map_err(|error| format!("Failed to parse schema {path:?}: {error}"))
+            .map_err(|error| format!("Failed to parse schema {}: {error}", path.display()))
     }
 }

--- a/crates/ox_content_lsp/src/frontmatter/schema.rs
+++ b/crates/ox_content_lsp/src/frontmatter/schema.rs
@@ -1,0 +1,18 @@
+use std::fs;
+use std::path::Path;
+
+use crate::frontmatter::FrontmatterSchema;
+
+pub fn load_schema(path: &Path) -> Result<FrontmatterSchema, String> {
+    let content = fs::read_to_string(path)
+        .map_err(|error| format!("Failed to read schema {path:?}: {error}"))?;
+    let extension = path.extension().and_then(|value| value.to_str()).unwrap_or_default();
+
+    if matches!(extension, "yaml" | "yml") {
+        serde_yaml::from_str::<FrontmatterSchema>(&content)
+            .map_err(|error| format!("Failed to parse schema {path:?}: {error}"))
+    } else {
+        serde_json::from_str::<FrontmatterSchema>(&content)
+            .map_err(|error| format!("Failed to parse schema {path:?}: {error}"))
+    }
+}

--- a/crates/ox_content_lsp/src/frontmatter/types.rs
+++ b/crates/ox_content_lsp/src/frontmatter/types.rs
@@ -1,0 +1,61 @@
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+use serde_json::Value;
+use tower_lsp::lsp_types::{Diagnostic, Range};
+
+#[derive(Clone, Debug)]
+pub struct FrontmatterDocument {
+    pub block: Option<FrontmatterBlock>,
+}
+
+#[derive(Clone, Debug)]
+pub struct FrontmatterBlock {
+    pub block_range: Range,
+    pub content_range: Range,
+    pub content_start_offset: usize,
+    pub content_end_offset: usize,
+    pub value: Option<Value>,
+    pub diagnostics: Vec<Diagnostic>,
+    pub top_level_keys: Vec<TopLevelKey>,
+}
+
+#[derive(Clone, Debug)]
+pub struct TopLevelKey {
+    pub name: String,
+    pub key_range: Range,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct FrontmatterSchema {
+    pub description: Option<String>,
+    #[serde(rename = "type")]
+    pub type_name: Option<String>,
+    pub properties: BTreeMap<String, FrontmatterSchema>,
+    pub required: Vec<String>,
+    #[serde(rename = "enum")]
+    pub enum_values: Vec<Value>,
+    pub default: Option<Value>,
+    pub items: Option<Box<FrontmatterSchema>>,
+    #[serde(rename = "additionalProperties")]
+    pub additional_properties: Option<bool>,
+}
+
+impl FrontmatterSchema {
+    #[must_use]
+    pub fn property(&self, name: &str) -> Option<&Self> {
+        self.properties.get(name)
+    }
+
+    #[must_use]
+    pub fn kind_label(&self) -> String {
+        self.type_name.clone().unwrap_or_else(|| {
+            if self.properties.is_empty() {
+                "value".to_string()
+            } else {
+                "object".to_string()
+            }
+        })
+    }
+}

--- a/crates/ox_content_lsp/src/frontmatter/utils.rs
+++ b/crates/ox_content_lsp/src/frontmatter/utils.rs
@@ -1,0 +1,108 @@
+use serde_json::Value;
+use tower_lsp::lsp_types::{Position, Range};
+
+use crate::document::TextDocumentState;
+use crate::frontmatter::{FrontmatterBlock, FrontmatterSchema};
+
+pub fn contains_position(range: &Range, position: Position) -> bool {
+    (position.line > range.start.line
+        || (position.line == range.start.line && position.character >= range.start.character))
+        && (position.line < range.end.line
+            || (position.line == range.end.line && position.character <= range.end.character))
+}
+
+pub fn strip_line_breaks(line: &str) -> &str {
+    line.trim_end_matches(['\r', '\n'])
+}
+
+pub fn yaml_error_range(
+    document: &TextDocumentState,
+    content_start_offset: usize,
+    raw: &str,
+    error: &serde_yaml::Error,
+) -> Range {
+    let Some(location) = error.location() else {
+        return document.range_from_offsets(content_start_offset, content_start_offset);
+    };
+
+    let raw_offset = raw_offset_from_line_col(raw, location.line(), location.column());
+    let start = content_start_offset + raw_offset;
+    document.range_from_offsets(start, (start + 1).min(document.text().len()))
+}
+
+fn raw_offset_from_line_col(raw: &str, line: usize, column: usize) -> usize {
+    let mut current_line = 1usize;
+    let mut current_column = 1usize;
+    let mut offset = 0usize;
+
+    for ch in raw.chars() {
+        if current_line == line && current_column == column {
+            return offset;
+        }
+
+        offset += ch.len_utf8();
+        if ch == '\n' {
+            current_line += 1;
+            current_column = 1;
+        } else {
+            current_column += 1;
+        }
+    }
+
+    offset
+}
+
+pub fn display_value(value: &Value) -> String {
+    match value {
+        Value::String(value) => format!("\"{value}\""),
+        _ => value.to_string(),
+    }
+}
+
+pub fn effective_type(schema: &FrontmatterSchema) -> Option<&str> {
+    schema.type_name.as_deref().or_else(|| {
+        if schema.properties.is_empty() {
+            None
+        } else {
+            Some("object")
+        }
+    })
+}
+
+pub fn matches_type(type_name: &str, value: &Value) -> bool {
+    match type_name {
+        "string" => value.is_string(),
+        "boolean" => value.is_boolean(),
+        "number" => value.is_number(),
+        "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
+        "array" => value.is_array(),
+        "object" => value.is_object(),
+        "null" => value.is_null(),
+        _ => true,
+    }
+}
+
+pub fn value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(number) if number.is_i64() || number.is_u64() => "integer",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+pub fn range_for_path(block: &FrontmatterBlock, path: &[String]) -> Range {
+    path.first().map_or(block.content_range, |name| range_for_named_key(block, name))
+}
+
+pub fn range_for_named_key(block: &FrontmatterBlock, name: &str) -> Range {
+    block
+        .top_level_keys
+        .iter()
+        .find(|entry| entry.name == name)
+        .map(|entry| entry.key_range)
+        .unwrap_or(block.content_range)
+}

--- a/crates/ox_content_lsp/src/frontmatter/utils.rs
+++ b/crates/ox_content_lsp/src/frontmatter/utils.rs
@@ -60,7 +60,7 @@ pub fn display_value(value: &Value) -> String {
 }
 
 pub fn effective_type(schema: &FrontmatterSchema) -> Option<&str> {
-    schema.type_name.as_deref().or_else(|| {
+    schema.type_name.as_deref().or({
         if schema.properties.is_empty() {
             None
         } else {
@@ -103,6 +103,5 @@ pub fn range_for_named_key(block: &FrontmatterBlock, name: &str) -> Range {
         .top_level_keys
         .iter()
         .find(|entry| entry.name == name)
-        .map(|entry| entry.key_range)
-        .unwrap_or(block.content_range)
+        .map_or(block.content_range, |entry| entry.key_range)
 }

--- a/crates/ox_content_lsp/src/frontmatter/validate.rs
+++ b/crates/ox_content_lsp/src/frontmatter/validate.rs
@@ -1,0 +1,126 @@
+use serde_json::Value;
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
+
+use crate::frontmatter::utils::{
+    display_value, effective_type, matches_type, range_for_named_key, range_for_path, value_kind,
+};
+use crate::frontmatter::{FrontmatterBlock, FrontmatterSchema};
+
+pub fn validate_frontmatter(
+    block: &FrontmatterBlock,
+    schema: &FrontmatterSchema,
+) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    let Some(value) = &block.value else {
+        return diagnostics;
+    };
+
+    validate_value(schema, value, &mut Vec::new(), block, &mut diagnostics);
+    diagnostics
+}
+
+fn validate_value(
+    schema: &FrontmatterSchema,
+    value: &Value,
+    path: &mut Vec<String>,
+    block: &FrontmatterBlock,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if let Some(type_name) = effective_type(schema) {
+        if !matches_type(type_name, value) {
+            diagnostics.push(Diagnostic {
+                range: range_for_path(block, path),
+                severity: Some(DiagnosticSeverity::ERROR),
+                source: Some("ox-content".to_string()),
+                message: format!("Expected `{type_name}` but found `{}`", value_kind(value)),
+                ..Default::default()
+            });
+            return;
+        }
+    }
+
+    validate_enum(schema, value, path, block, diagnostics);
+    validate_object(schema, value, path, block, diagnostics);
+    validate_array(schema, value, path, block, diagnostics);
+}
+
+fn validate_enum(
+    schema: &FrontmatterSchema,
+    value: &Value,
+    path: &[String],
+    block: &FrontmatterBlock,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if schema.enum_values.is_empty()
+        || schema.enum_values.iter().any(|candidate| candidate == value)
+    {
+        return;
+    }
+
+    diagnostics.push(Diagnostic {
+        range: range_for_path(block, path),
+        severity: Some(DiagnosticSeverity::ERROR),
+        source: Some("ox-content".to_string()),
+        message: format!(
+            "Expected one of {}",
+            schema.enum_values.iter().map(display_value).collect::<Vec<_>>().join(", ")
+        ),
+        ..Default::default()
+    });
+}
+
+fn validate_object(
+    schema: &FrontmatterSchema,
+    value: &Value,
+    path: &mut Vec<String>,
+    block: &FrontmatterBlock,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Value::Object(map) = value else {
+        return;
+    };
+
+    for required in &schema.required {
+        if !map.contains_key(required) {
+            diagnostics.push(Diagnostic {
+                range: block.content_range,
+                severity: Some(DiagnosticSeverity::WARNING),
+                source: Some("ox-content".to_string()),
+                message: format!("Missing required frontmatter field `{required}`"),
+                ..Default::default()
+            });
+        }
+    }
+
+    for (key, child) in map {
+        if let Some(child_schema) = schema.properties.get(key) {
+            path.push(key.clone());
+            validate_value(child_schema, child, path, block, diagnostics);
+            path.pop();
+        } else if schema.additional_properties == Some(false) {
+            diagnostics.push(Diagnostic {
+                range: range_for_named_key(block, key),
+                severity: Some(DiagnosticSeverity::WARNING),
+                source: Some("ox-content".to_string()),
+                message: format!("Unknown frontmatter field `{key}`"),
+                ..Default::default()
+            });
+        }
+    }
+}
+
+fn validate_array(
+    schema: &FrontmatterSchema,
+    value: &Value,
+    path: &mut Vec<String>,
+    block: &FrontmatterBlock,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let (Some(item_schema), Value::Array(items)) = (&schema.items, value) else {
+        return;
+    };
+
+    for item in items {
+        validate_value(item_schema, item, path, block, diagnostics);
+    }
+}

--- a/crates/ox_content_lsp/src/i18n.rs
+++ b/crates/ox_content_lsp/src/i18n.rs
@@ -1,0 +1,7 @@
+mod document;
+mod state;
+
+pub use document::{
+    find_key_line_in_file, is_i18n_dictionary_path, is_i18n_source_path, key_at_position,
+};
+pub use state::I18nState;

--- a/crates/ox_content_lsp/src/i18n/document.rs
+++ b/crates/ox_content_lsp/src/i18n/document.rs
@@ -1,0 +1,48 @@
+use std::path::Path;
+
+use ox_content_i18n_checker::key_collector::KeyUsage;
+use tower_lsp::lsp_types::Position;
+
+const DICT_SEGMENT_POSIX: &str = "/content/i18n/";
+const DICT_SEGMENT_WINDOWS: &str = "\\content\\i18n\\";
+
+#[must_use]
+pub fn is_i18n_source_path(path: &Path) -> bool {
+    matches!(path.extension().and_then(|ext| ext.to_str()), Some("ts" | "tsx" | "js" | "jsx"))
+}
+
+#[must_use]
+pub fn is_i18n_dictionary_path(path: &Path) -> bool {
+    let path_str = path.to_string_lossy();
+    let in_dict_dir =
+        path_str.contains(DICT_SEGMENT_POSIX) || path_str.contains(DICT_SEGMENT_WINDOWS);
+
+    in_dict_dir
+        && matches!(path.extension().and_then(|ext| ext.to_str()), Some("json" | "yaml" | "yml"))
+}
+
+pub fn key_at_position(usages: &[KeyUsage], position: Position) -> Option<String> {
+    let cursor_line = position.line + 1;
+    let cursor_col = position.character + 1;
+
+    usages
+        .iter()
+        .find(|usage| {
+            usage.line == cursor_line
+                && cursor_col >= usage.column
+                && cursor_col <= usage.end_column
+        })
+        .map(|usage| usage.key.clone())
+}
+
+pub fn find_key_line_in_file(file_path: &str, key: &str) -> Option<u32> {
+    let content = std::fs::read_to_string(file_path).ok()?;
+    let leaf_key = key.rsplit('.').next().unwrap_or(key);
+
+    content.lines().enumerate().find_map(|(index, line)| {
+        let trimmed = line.trim();
+        (trimmed.starts_with(&format!("\"{leaf_key}\""))
+            || trimmed.starts_with(&format!("{leaf_key}:")))
+        .then_some(index as u32)
+    })
+}

--- a/crates/ox_content_lsp/src/i18n/state.rs
+++ b/crates/ox_content_lsp/src/i18n/state.rs
@@ -1,0 +1,178 @@
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+use tower_lsp::lsp_types::Url;
+
+use ox_content_i18n::dictionary::{self, DictionarySet};
+use ox_content_i18n_checker::key_collector::{KeyCollector, KeyUsage};
+use oxc_span::SourceType;
+
+#[derive(Clone)]
+pub struct I18nState {
+    inner: Arc<RwLock<Inner>>,
+}
+
+#[derive(Default)]
+struct Inner {
+    dict_dir: Option<PathBuf>,
+    dict_set: DictionarySet,
+    file_keys: HashMap<String, Vec<KeyUsage>>,
+    all_keys: HashSet<String>,
+    open_uris: Vec<Url>,
+}
+
+impl I18nState {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { inner: Arc::new(RwLock::new(Inner::default())) }
+    }
+
+    pub async fn set_root(&self, root: Option<PathBuf>) {
+        let (dict_dir, dict_set) = load_dicts(root.as_deref());
+        let mut inner = self.inner.write().await;
+        inner.dict_dir = dict_dir;
+        inner.dict_set = dict_set;
+    }
+
+    pub async fn reload_dictionaries(&self) {
+        let mut inner = self.inner.write().await;
+        let (dict_dir, dict_set) = load_dicts(inner.dict_dir.as_deref().and_then(Path::parent));
+        inner.dict_dir = dict_dir;
+        inner.dict_set = dict_set;
+    }
+
+    pub async fn update_file_keys(&self, file_path: &str, source: &str) {
+        let collector = KeyCollector::new();
+        let source_type = SourceType::from_path(Path::new(file_path)).unwrap_or_default();
+        let usages = collector.collect_source(source, file_path, source_type).unwrap_or_default();
+
+        let mut inner = self.inner.write().await;
+        inner.file_keys.insert(file_path.to_string(), usages);
+        rebuild_all_keys(&mut inner);
+    }
+
+    pub async fn remove_file(&self, file_path: &str) {
+        let mut inner = self.inner.write().await;
+        inner.file_keys.remove(file_path);
+        inner.open_uris.retain(|uri| {
+            uri.to_file_path().map_or(true, |path| path.to_string_lossy() != file_path)
+        });
+        rebuild_all_keys(&mut inner);
+    }
+
+    pub async fn add_open_uri(&self, uri: Url) {
+        let mut inner = self.inner.write().await;
+        if !inner.open_uris.contains(&uri) {
+            inner.open_uris.push(uri);
+        }
+    }
+
+    pub async fn get_open_uris(&self) -> Vec<Url> {
+        let inner = self.inner.read().await;
+        inner.open_uris.clone()
+    }
+
+    pub async fn all_dictionary_keys(&self) -> Vec<String> {
+        let inner = self.inner.read().await;
+        let mut keys = HashSet::new();
+        for locale in inner.dict_set.locales() {
+            if let Some(dict) = inner.dict_set.get(locale) {
+                keys.extend(dict.keys().map(std::string::ToString::to_string));
+            }
+        }
+        let mut sorted: Vec<String> = keys.into_iter().collect();
+        sorted.sort();
+        sorted
+    }
+
+    pub async fn translations_for_key(&self, key: &str) -> Vec<(String, String)> {
+        let inner = self.inner.read().await;
+        let mut translations = Vec::new();
+        for locale in inner.dict_set.locales() {
+            if let Some(dict) = inner.dict_set.get(locale) {
+                if let Some(value) = dict.get(key) {
+                    translations.push((locale.to_string(), value.to_string()));
+                }
+            }
+        }
+        translations
+    }
+
+    pub async fn default_translation(&self, key: &str) -> Option<String> {
+        let inner = self.inner.read().await;
+        if let Some(locale) =
+            inner.dict_set.default_locale().map(|locale| locale.as_str().to_string())
+        {
+            if let Some(dict) = inner.dict_set.get(&locale) {
+                if let Some(value) = dict.get(key) {
+                    return Some(value.to_string());
+                }
+            }
+        }
+
+        let fallback = inner
+            .dict_set
+            .locales()
+            .find_map(|locale| inner.dict_set.get(locale).and_then(|dict| dict.get(key)))
+            .map(std::string::ToString::to_string);
+
+        fallback
+    }
+
+    pub async fn find_key_definition(&self, key: &str) -> Option<String> {
+        let inner = self.inner.read().await;
+        let dict_dir = inner.dict_dir.as_ref()?;
+        let namespace = key.split('.').next().unwrap_or(key);
+
+        for locale in inner.dict_set.locales() {
+            if inner.dict_set.get(locale).and_then(|dict| dict.get(key)).is_none() {
+                continue;
+            }
+
+            for ext in ["json", "yaml", "yml"] {
+                let candidate = dict_dir.join(locale).join(format!("{namespace}.{ext}"));
+                if candidate.exists() {
+                    return Some(candidate.to_string_lossy().to_string());
+                }
+            }
+        }
+        None
+    }
+
+    pub async fn check_diagnostics(&self) -> Vec<ox_content_i18n::checker::Diagnostic> {
+        let inner = self.inner.read().await;
+        ox_content_i18n::checker::check_all(&inner.all_keys, &inner.dict_set)
+    }
+
+    pub async fn get_file_key_usages(&self, file_path: &str) -> Vec<KeyUsage> {
+        let inner = self.inner.read().await;
+        inner.file_keys.get(file_path).cloned().unwrap_or_default()
+    }
+}
+
+impl Default for I18nState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn load_dicts(root: Option<&Path>) -> (Option<PathBuf>, DictionarySet) {
+    let Some(root) = root else {
+        return (None, DictionarySet::new());
+    };
+
+    let dict_dir = root.join("content/i18n");
+    let dict_set = if dict_dir.exists() {
+        dictionary::load_from_dir(&dict_dir).unwrap_or_default()
+    } else {
+        DictionarySet::new()
+    };
+
+    (Some(dict_dir), dict_set)
+}
+
+fn rebuild_all_keys(inner: &mut Inner) {
+    inner.all_keys = inner.file_keys.values().flatten().map(|usage| usage.key.clone()).collect();
+}

--- a/crates/ox_content_lsp/src/i18n/state.rs
+++ b/crates/ox_content_lsp/src/i18n/state.rs
@@ -51,6 +51,7 @@ impl I18nState {
         let mut inner = self.inner.write().await;
         inner.file_keys.insert(file_path.to_string(), usages);
         rebuild_all_keys(&mut inner);
+        drop(inner);
     }
 
     pub async fn remove_file(&self, file_path: &str) {
@@ -60,6 +61,7 @@ impl I18nState {
             uri.to_file_path().map_or(true, |path| path.to_string_lossy() != file_path)
         });
         rebuild_all_keys(&mut inner);
+        drop(inner);
     }
 
     pub async fn add_open_uri(&self, uri: Url) {
@@ -123,14 +125,17 @@ impl I18nState {
 
     pub async fn find_key_definition(&self, key: &str) -> Option<String> {
         let inner = self.inner.read().await;
-        let dict_dir = inner.dict_dir.as_ref()?;
+        let dict_dir = inner.dict_dir.clone()?;
+        let locales: Vec<String> = inner
+            .dict_set
+            .locales()
+            .filter(|locale| inner.dict_set.get(locale).and_then(|dict| dict.get(key)).is_some())
+            .map(String::from)
+            .collect();
+        drop(inner);
         let namespace = key.split('.').next().unwrap_or(key);
 
-        for locale in inner.dict_set.locales() {
-            if inner.dict_set.get(locale).and_then(|dict| dict.get(key)).is_none() {
-                continue;
-            }
-
+        for locale in &locales {
             for ext in ["json", "yaml", "yml"] {
                 let candidate = dict_dir.join(locale).join(format!("{namespace}.{ext}"));
                 if candidate.exists() {

--- a/crates/ox_content_lsp/src/main.rs
+++ b/crates/ox_content_lsp/src/main.rs
@@ -1,0 +1,29 @@
+//! # ox-content-lsp
+//!
+//! Unified Language Server Protocol server for Ox Content authoring.
+//!
+//! Provides:
+//! - schema-aware frontmatter completion and diagnostics
+//! - fast Markdown snippet completions
+//! - editor-triggered insertion commands
+//! - preview HTML generation via `workspace/executeCommand`
+//! - heading symbols for document outline navigation
+
+mod backend;
+mod config;
+mod document;
+mod frontmatter;
+mod preview;
+mod state;
+
+use tower_lsp::{LspService, Server};
+
+#[tokio::main]
+async fn main() {
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+
+    let (service, socket) = LspService::new(backend::Backend::new);
+
+    Server::new(stdin, stdout, socket).serve(service).await;
+}

--- a/crates/ox_content_lsp/src/main.rs
+++ b/crates/ox_content_lsp/src/main.rs
@@ -13,6 +13,7 @@ mod backend;
 mod config;
 mod document;
 mod frontmatter;
+mod i18n;
 mod preview;
 mod state;
 

--- a/crates/ox_content_lsp/src/preview.rs
+++ b/crates/ox_content_lsp/src/preview.rs
@@ -1,0 +1,7 @@
+mod html;
+mod render;
+mod symbols;
+mod text;
+
+pub use render::render_preview;
+pub use symbols::document_symbols;

--- a/crates/ox_content_lsp/src/preview/html.rs
+++ b/crates/ox_content_lsp/src/preview/html.rs
@@ -1,0 +1,89 @@
+pub fn wrap_preview_html(title: &str, body: &str) -> String {
+    format!(
+        r#"<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+    <style>
+      :root {{
+        color-scheme: light dark;
+        --bg: #f6f8fb;
+        --surface: #ffffff;
+        --text: #0f172a;
+        --muted: #475569;
+        --border: #dbe2ea;
+        --accent: #0f766e;
+        --code-bg: #0f172a;
+        --code-text: #e2e8f0;
+      }}
+      @media (prefers-color-scheme: dark) {{
+        :root {{
+          --bg: #0b1120;
+          --surface: #111827;
+          --text: #e5edf5;
+          --muted: #94a3b8;
+          --border: #243042;
+          --accent: #34d399;
+          --code-bg: #020617;
+          --code-text: #dbeafe;
+        }}
+      }}
+      * {{ box-sizing: border-box; }}
+      body {{
+        margin: 0;
+        padding: 32px 20px 64px;
+        background:
+          radial-gradient(circle at top left, color-mix(in srgb, var(--accent) 12%, transparent), transparent 40%),
+          var(--bg);
+        color: var(--text);
+        font: 16px/1.7 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }}
+      main {{
+        max-width: 880px;
+        margin: 0 auto;
+        background: color-mix(in srgb, var(--surface) 94%, transparent);
+        border: 1px solid var(--border);
+        border-radius: 20px;
+        padding: 40px;
+        backdrop-filter: blur(12px);
+        box-shadow: 0 20px 60px rgba(15, 23, 42, 0.12);
+      }}
+      h1, h2, h3, h4, h5, h6 {{ line-height: 1.2; margin: 1.8em 0 0.7em; }}
+      h1:first-child {{ margin-top: 0; }}
+      p, ul, ol, blockquote, pre, table {{ margin: 1rem 0; }}
+      a {{ color: var(--accent); }}
+      code {{
+        padding: 0.18em 0.4em;
+        border-radius: 0.45em;
+        background: color-mix(in srgb, var(--accent) 10%, var(--surface));
+        font: 0.92em/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+      }}
+      pre {{
+        overflow-x: auto;
+        padding: 16px 18px;
+        border-radius: 16px;
+        background: var(--code-bg);
+        color: var(--code-text);
+      }}
+      pre code {{ padding: 0; background: transparent; color: inherit; }}
+      blockquote {{
+        margin-inline: 0;
+        padding: 14px 18px;
+        border-left: 4px solid var(--accent);
+        border-radius: 0 14px 14px 0;
+        background: color-mix(in srgb, var(--accent) 10%, var(--surface));
+      }}
+      table {{ width: 100%; border-collapse: collapse; }}
+      th, td {{ padding: 10px 12px; border: 1px solid var(--border); text-align: left; }}
+      img {{ max-width: 100%; height: auto; }}
+      hr {{ border: 0; border-top: 1px solid var(--border); margin: 2rem 0; }}
+    </style>
+  </head>
+  <body>
+    <main>{body}</main>
+  </body>
+</html>"#
+    )
+}

--- a/crates/ox_content_lsp/src/preview/render.rs
+++ b/crates/ox_content_lsp/src/preview/render.rs
@@ -1,0 +1,34 @@
+use ox_content_allocator::Allocator;
+use ox_content_parser::{ParseError, Parser, ParserOptions};
+use ox_content_renderer::HtmlRenderer;
+use serde::Serialize;
+
+use crate::document::TextDocumentState;
+use crate::frontmatter::parse_frontmatter;
+use crate::preview::html::wrap_preview_html;
+use crate::preview::text::preview_title;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PreviewPayload {
+    pub html: String,
+    pub title: String,
+}
+
+pub fn render_preview(source: &str) -> Result<PreviewPayload, ParseError> {
+    let document = TextDocumentState::new(source.to_string());
+    let frontmatter = parse_frontmatter(&document);
+    let block = frontmatter.block;
+    let content = block
+        .as_ref()
+        .map_or(source, |block| &source[block.content_start_offset..block.content_end_offset]);
+
+    let allocator = Allocator::new();
+    let parser = Parser::with_options(&allocator, content, ParserOptions::gfm());
+    let ast = parser.parse()?;
+    let mut renderer = HtmlRenderer::new();
+    let body = renderer.render(&ast);
+    let title = preview_title(block.as_ref(), &ast.children)
+        .unwrap_or_else(|| "Ox Content Preview".to_string());
+
+    Ok(PreviewPayload { title: title.clone(), html: wrap_preview_html(&title, &body) })
+}

--- a/crates/ox_content_lsp/src/preview/symbols.rs
+++ b/crates/ox_content_lsp/src/preview/symbols.rs
@@ -1,7 +1,7 @@
 use ox_content_allocator::Allocator;
 use ox_content_ast::Node;
 use ox_content_parser::{ParseError, Parser, ParserOptions};
-use tower_lsp::lsp_types::{DocumentSymbol, Range, SymbolKind};
+use tower_lsp::lsp_types::{DocumentSymbol, SymbolKind};
 
 use crate::document::TextDocumentState;
 use crate::frontmatter::parse_frontmatter;
@@ -35,10 +35,10 @@ fn collect_symbols(
     for node in nodes {
         match node {
             Node::Heading(heading) => {
-                symbols.push(symbol_for_heading(heading, document, base_offset))
+                symbols.push(symbol_for_heading(heading, document, base_offset));
             }
             Node::BlockQuote(block) => {
-                collect_symbols(&block.children, document, base_offset, symbols)
+                collect_symbols(&block.children, document, base_offset, symbols);
             }
             Node::List(list) => {
                 for item in &list.children {
@@ -65,7 +65,7 @@ fn symbol_for_heading(
         detail: Some(format!("h{}", heading.depth)),
         kind: SymbolKind::STRING,
         range,
-        selection_range: Range { start: range.start, end: range.end },
+        selection_range: range,
         tags: None,
         deprecated: None,
         children: None,

--- a/crates/ox_content_lsp/src/preview/symbols.rs
+++ b/crates/ox_content_lsp/src/preview/symbols.rs
@@ -1,0 +1,73 @@
+use ox_content_allocator::Allocator;
+use ox_content_ast::Node;
+use ox_content_parser::{ParseError, Parser, ParserOptions};
+use tower_lsp::lsp_types::{DocumentSymbol, Range, SymbolKind};
+
+use crate::document::TextDocumentState;
+use crate::frontmatter::parse_frontmatter;
+use crate::preview::text::heading_text;
+
+pub fn document_symbols(
+    source: &str,
+    document: &TextDocumentState,
+) -> Result<Vec<DocumentSymbol>, ParseError> {
+    let frontmatter = parse_frontmatter(document);
+    let (content, base_offset) = if let Some(block) = frontmatter.block {
+        (&source[block.content_start_offset..block.content_end_offset], block.content_start_offset)
+    } else {
+        (source, 0)
+    };
+
+    let allocator = Allocator::new();
+    let parser = Parser::with_options(&allocator, content, ParserOptions::gfm());
+    let ast = parser.parse()?;
+    let mut symbols = Vec::new();
+    collect_symbols(&ast.children, document, base_offset, &mut symbols);
+    Ok(symbols)
+}
+
+fn collect_symbols(
+    nodes: &[Node<'_>],
+    document: &TextDocumentState,
+    base_offset: usize,
+    symbols: &mut Vec<DocumentSymbol>,
+) {
+    for node in nodes {
+        match node {
+            Node::Heading(heading) => {
+                symbols.push(symbol_for_heading(heading, document, base_offset))
+            }
+            Node::BlockQuote(block) => {
+                collect_symbols(&block.children, document, base_offset, symbols)
+            }
+            Node::List(list) => {
+                for item in &list.children {
+                    collect_symbols(&item.children, document, base_offset, symbols);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn symbol_for_heading(
+    heading: &ox_content_ast::Heading<'_>,
+    document: &TextDocumentState,
+    base_offset: usize,
+) -> DocumentSymbol {
+    let start = base_offset + heading.span.start as usize;
+    let end = base_offset + heading.span.end as usize;
+    let range = document.range_from_offsets(start, end);
+
+    #[allow(deprecated)]
+    DocumentSymbol {
+        name: heading_text(heading),
+        detail: Some(format!("h{}", heading.depth)),
+        kind: SymbolKind::STRING,
+        range,
+        selection_range: Range { start: range.start, end: range.end },
+        tags: None,
+        deprecated: None,
+        children: None,
+    }
+}

--- a/crates/ox_content_lsp/src/preview/text.rs
+++ b/crates/ox_content_lsp/src/preview/text.rs
@@ -1,0 +1,55 @@
+use ox_content_ast::{Heading, Node};
+
+use crate::frontmatter::FrontmatterBlock;
+
+pub fn preview_title(block: Option<&FrontmatterBlock>, nodes: &[Node<'_>]) -> Option<String> {
+    if let Some(title) = block
+        .and_then(|block| block.value.as_ref())
+        .and_then(|value| value.as_object())
+        .and_then(|value| value.get("title"))
+        .and_then(serde_json::Value::as_str)
+    {
+        return Some(title.to_string());
+    }
+
+    nodes.iter().find_map(|node| match node {
+        Node::Heading(heading) if heading.depth == 1 => Some(heading_text(heading)),
+        _ => None,
+    })
+}
+
+pub fn heading_text(heading: &Heading<'_>) -> String {
+    let mut text = String::new();
+    for child in &heading.children {
+        collect_text(child, &mut text);
+    }
+    text
+}
+
+fn collect_text(node: &Node<'_>, text: &mut String) {
+    match node {
+        Node::Text(value) => text.push_str(value.value),
+        Node::InlineCode(value) => text.push_str(value.value),
+        Node::Emphasis(value) => {
+            for child in &value.children {
+                collect_text(child, text);
+            }
+        }
+        Node::Strong(value) => {
+            for child in &value.children {
+                collect_text(child, text);
+            }
+        }
+        Node::Delete(value) => {
+            for child in &value.children {
+                collect_text(child, text);
+            }
+        }
+        Node::Link(value) => {
+            for child in &value.children {
+                collect_text(child, text);
+            }
+        }
+        _ => {}
+    }
+}

--- a/crates/ox_content_lsp/src/state.rs
+++ b/crates/ox_content_lsp/src/state.rs
@@ -1,0 +1,69 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+use tower_lsp::lsp_types::Url;
+
+use crate::config::InitializationOptions;
+use crate::document::TextDocumentState;
+
+#[derive(Clone)]
+pub struct LspState {
+    inner: Arc<RwLock<Inner>>,
+}
+
+#[derive(Default)]
+struct Inner {
+    documents: HashMap<Url, TextDocumentState>,
+    root: Option<PathBuf>,
+    init_options: InitializationOptions,
+}
+
+impl LspState {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { inner: Arc::new(RwLock::new(Inner::default())) }
+    }
+
+    pub async fn set_root(&self, root: Option<PathBuf>) {
+        let mut inner = self.inner.write().await;
+        inner.root = root;
+    }
+
+    pub async fn set_init_options(&self, init_options: InitializationOptions) {
+        let mut inner = self.inner.write().await;
+        inner.init_options = init_options;
+    }
+
+    pub async fn root(&self) -> Option<PathBuf> {
+        let inner = self.inner.read().await;
+        inner.root.clone()
+    }
+
+    pub async fn init_options(&self) -> InitializationOptions {
+        let inner = self.inner.read().await;
+        inner.init_options.clone()
+    }
+
+    pub async fn upsert_document(&self, uri: Url, text: String) {
+        let mut inner = self.inner.write().await;
+        inner.documents.insert(uri, TextDocumentState::new(text));
+    }
+
+    pub async fn remove_document(&self, uri: &Url) {
+        let mut inner = self.inner.write().await;
+        inner.documents.remove(uri);
+    }
+
+    pub async fn document(&self, uri: &Url) -> Option<TextDocumentState> {
+        let inner = self.inner.read().await;
+        inner.documents.get(uri).cloned()
+    }
+}
+
+impl Default for LspState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/docs/content/development-setup.md
+++ b/docs/content/development-setup.md
@@ -103,13 +103,18 @@ ox-content/
 │   ├── ox_content_search/      # Full-text search engine
 │   ├── ox_content_napi/        # Node.js N-API bindings
 │   ├── ox_content_wasm/        # WebAssembly bindings
-│   └── ox_content_og_image/    # OG image generation
+│   ├── ox_content_og_image/    # OG image generation
+│   └── ox_content_lsp/         # Unified language server
 ├── npm/                    # npm packages
 │   ├── vite-plugin-ox-content/       # @ox-content/vite-plugin
 │   ├── vite-plugin-ox-content-vue/   # @ox-content/vite-plugin-vue
 │   ├── vite-plugin-ox-content-react/ # @ox-content/vite-plugin-react
 │   ├── vite-plugin-ox-content-svelte/# @ox-content/vite-plugin-svelte
-│   └── unplugin-ox-content/          # @ox-content/unplugin
+│   ├── unplugin-ox-content/          # @ox-content/unplugin
+│   └── vscode-ox-content/            # VS Code extension
+├── editors/                # Editor integrations
+│   ├── zed/                # Zed extension
+│   └── neovim/             # Neovim plugin
 ├── examples/               # Usage examples
 ├── docs/                   # Documentation site
 └── .github/workflows/      # CI/CD

--- a/editors/neovim/README.md
+++ b/editors/neovim/README.md
@@ -1,0 +1,25 @@
+# Ox Content for Neovim
+
+Neovim integration for Ox Content authoring.
+
+Example with `lazy.nvim`:
+
+```lua
+{
+  dir = "/absolute/path/to/ox-content/editors/neovim",
+  config = function()
+    require("ox-content").setup({
+      frontmatter_schema = "./content/frontmatter.schema.json",
+    })
+  end,
+}
+```
+
+Commands:
+
+- `:OxContentInsertTable`
+- `:OxContentInsertCodeFence`
+- `:OxContentInsertCallout`
+- `:OxContentPreview`
+
+The plugin maps `*.mdc` to `markdown`, starts `ox-content-lsp`, and uses the LSP server for insertion commands and preview rendering.

--- a/editors/neovim/README.md
+++ b/editors/neovim/README.md
@@ -1,6 +1,6 @@
 # Ox Content for Neovim
 
-Neovim integration for Ox Content authoring.
+Neovim integration for Ox Content authoring and i18n workflows.
 
 Example with `lazy.nvim`:
 
@@ -22,4 +22,4 @@ Commands:
 - `:OxContentInsertCallout`
 - `:OxContentPreview`
 
-The plugin maps `*.mdc` to `markdown`, starts `ox-content-lsp`, and uses the LSP server for insertion commands and preview rendering.
+The plugin maps `*.mdc` to `markdown`, starts `ox-content-lsp` for Markdown and JS/TS/JSON/YAML buffers, and uses the same server for insertion commands, preview rendering, and i18n key intelligence.

--- a/editors/neovim/lua/ox-content/client.lua
+++ b/editors/neovim/lua/ox-content/client.lua
@@ -1,0 +1,144 @@
+local config = require("ox-content.config")
+local util = require("ox-content.util")
+
+local M = {}
+
+local function resolve_root(bufnr)
+  local name = vim.api.nvim_buf_get_name(bufnr)
+  if name == "" then
+    return vim.fn.getcwd()
+  end
+
+  local markers = { ".ox-content.json", "ox-content.json", "package.json", ".git" }
+  local root = vim.fs.root(name, markers)
+  return root or vim.fs.dirname(name) or vim.fn.getcwd()
+end
+
+local function server_binary_name()
+  if util.is_windows() then
+    return "ox-content-lsp.exe"
+  end
+  return "ox-content-lsp"
+end
+
+local function resolve_cmd(bufnr)
+  local user_cmd = config.get().cmd
+  if type(user_cmd) == "table" and #user_cmd > 0 then
+    return vim.deepcopy(user_cmd)
+  end
+
+  if type(user_cmd) == "string" and user_cmd ~= "" then
+    return { user_cmd }
+  end
+
+  local executable = vim.fn.exepath(server_binary_name())
+  if executable ~= "" then
+    return { executable }
+  end
+
+  local root = resolve_root(bufnr)
+  local binary_name = server_binary_name()
+  local local_binaries = {
+    vim.fs.joinpath(root, "target", "debug", binary_name),
+    vim.fs.joinpath(root, "target", "release", binary_name),
+  }
+
+  for _, candidate in ipairs(local_binaries) do
+    if vim.uv.fs_stat(candidate) then
+      return { candidate }
+    end
+  end
+
+  return {
+    "cargo",
+    "run",
+    "-p",
+    "ox_content_lsp",
+    "--bin",
+    "ox-content-lsp",
+  }
+end
+
+local function resolve_init_options(bufnr)
+  local schema = config.get().frontmatter_schema
+  if type(schema) ~= "string" or schema == "" then
+    return {}
+  end
+
+  if vim.startswith(schema, "/") or schema:match("^%a:[/\\]") then
+    return { frontmatterSchema = schema }
+  end
+
+  return { frontmatterSchema = vim.fs.joinpath(resolve_root(bufnr), schema) }
+end
+
+local function position_from_cursor()
+  local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+  local line = vim.api.nvim_get_current_line()
+  return { line = row - 1, character = vim.str_utfindex(line, col) }
+end
+
+function M.current_buffer_uri(bufnr)
+  return vim.uri_from_bufnr(bufnr)
+end
+
+function M.get(bufnr)
+  local clients = vim.lsp.get_clients({ bufnr = bufnr, name = config.server_name })
+  return clients[1]
+end
+
+function M.start(bufnr)
+  if M.get(bufnr) then
+    return
+  end
+
+  local client_id = vim.lsp.start({
+    name = config.server_name,
+    cmd = resolve_cmd(bufnr),
+    root_dir = resolve_root(bufnr),
+    init_options = resolve_init_options(bufnr),
+  }, { bufnr = bufnr })
+
+  if client_id and vim.lsp.completion and vim.lsp.completion.enable then
+    pcall(vim.lsp.completion.enable, true, client_id, bufnr, { autotrigger = true })
+  end
+end
+
+function M.request_command(bufnr, command, arguments, callback)
+  local client = M.get(bufnr)
+  if not client then
+    M.start(bufnr)
+    client = M.get(bufnr)
+  end
+
+  if not client then
+    util.notify("Ox Content language server is not running", vim.log.levels.ERROR)
+    return
+  end
+
+  client:request("workspace/executeCommand", {
+    command = command,
+    arguments = arguments,
+  }, function(err, result)
+    if err then
+      util.notify(err.message or ("Command failed: " .. command), vim.log.levels.ERROR)
+      return
+    end
+
+    if callback then
+      callback(result)
+    end
+  end, bufnr)
+end
+
+function M.insert(command)
+  local bufnr = vim.api.nvim_get_current_buf()
+  M.request_command(bufnr, command, {
+    {
+      uri = M.current_buffer_uri(bufnr),
+      position = position_from_cursor(),
+    },
+  })
+end
+
+return M

--- a/editors/neovim/lua/ox-content/config.lua
+++ b/editors/neovim/lua/ox-content/config.lua
@@ -1,0 +1,27 @@
+local M = {}
+
+local defaults = {
+  cmd = nil,
+  frontmatter_schema = nil,
+  auto_start = true,
+}
+
+local state = vim.deepcopy(defaults)
+
+M.server_name = "ox-content-lsp"
+M.commands = {
+  insert_table = "oxContent.insertTable",
+  insert_code_fence = "oxContent.insertCodeFence",
+  insert_callout = "oxContent.insertCallout",
+  preview_html = "oxContent.previewHtml",
+}
+
+function M.setup(opts)
+  state = vim.tbl_deep_extend("force", {}, defaults, opts or {})
+end
+
+function M.get()
+  return state
+end
+
+return M

--- a/editors/neovim/lua/ox-content/init.lua
+++ b/editors/neovim/lua/ox-content/init.lua
@@ -1,0 +1,69 @@
+local client = require("ox-content.client")
+local config = require("ox-content.config")
+local preview = require("ox-content.preview")
+
+local M = {}
+local augroup = nil
+local commands_defined = false
+
+local function define_commands()
+  if commands_defined then
+    return
+  end
+
+  vim.api.nvim_create_user_command("OxContentInsertTable", function()
+    client.insert(config.commands.insert_table)
+  end, { force = true })
+
+  vim.api.nvim_create_user_command("OxContentInsertCodeFence", function()
+    client.insert(config.commands.insert_code_fence)
+  end, { force = true })
+
+  vim.api.nvim_create_user_command("OxContentInsertCallout", function()
+    client.insert(config.commands.insert_callout)
+  end, { force = true })
+
+  vim.api.nvim_create_user_command("OxContentPreview", function()
+    preview.open()
+  end, { force = true })
+
+  commands_defined = true
+end
+
+function M.setup(opts)
+  config.setup(opts)
+
+  vim.filetype.add({
+    extension = {
+      mdc = "markdown",
+    },
+  })
+
+  if augroup then
+    vim.api.nvim_del_augroup_by_id(augroup)
+  end
+
+  augroup = vim.api.nvim_create_augroup("OxContentMarkdown", { clear = true })
+
+  if config.get().auto_start then
+    vim.api.nvim_create_autocmd("FileType", {
+      group = augroup,
+      pattern = "markdown",
+      callback = function(args)
+        client.start(args.buf)
+      end,
+    })
+  end
+
+  define_commands()
+end
+
+function M.start(bufnr)
+  client.start(bufnr or vim.api.nvim_get_current_buf())
+end
+
+function M.preview()
+  preview.open()
+end
+
+return M

--- a/editors/neovim/lua/ox-content/init.lua
+++ b/editors/neovim/lua/ox-content/init.lua
@@ -48,7 +48,15 @@ function M.setup(opts)
   if config.get().auto_start then
     vim.api.nvim_create_autocmd("FileType", {
       group = augroup,
-      pattern = "markdown",
+      pattern = {
+        "markdown",
+        "javascript",
+        "javascriptreact",
+        "typescript",
+        "typescriptreact",
+        "json",
+        "yaml",
+      },
       callback = function(args)
         client.start(args.buf)
       end,

--- a/editors/neovim/lua/ox-content/preview.lua
+++ b/editors/neovim/lua/ox-content/preview.lua
@@ -1,0 +1,41 @@
+local client = require("ox-content.client")
+local config = require("ox-content.config")
+local util = require("ox-content.util")
+
+local M = {}
+
+local function open_path(path)
+  if vim.ui and vim.ui.open then
+    vim.ui.open(path)
+    return
+  end
+
+  local command
+  if vim.fn.has("mac") == 1 then
+    command = { "open", path }
+  elseif util.is_windows() then
+    command = { "cmd", "/c", "start", "", path }
+  else
+    command = { "xdg-open", path }
+  end
+
+  vim.fn.jobstart(command, { detach = true })
+end
+
+function M.open()
+  local bufnr = vim.api.nvim_get_current_buf()
+  client.request_command(bufnr, config.commands.preview_html, {
+    client.current_buffer_uri(bufnr),
+  }, function(result)
+    if type(result) ~= "table" or type(result.html) ~= "string" then
+      util.notify("Preview payload was empty", vim.log.levels.ERROR)
+      return
+    end
+
+    local file = vim.fn.tempname() .. ".html"
+    vim.fn.writefile(vim.split(result.html, "\n", { plain = true }), file)
+    open_path(file)
+  end)
+end
+
+return M

--- a/editors/neovim/lua/ox-content/util.lua
+++ b/editors/neovim/lua/ox-content/util.lua
@@ -1,0 +1,11 @@
+local M = {}
+
+function M.notify(message, level)
+  vim.notify(message, level or vim.log.levels.INFO, { title = "ox-content" })
+end
+
+function M.is_windows()
+  return vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1
+end
+
+return M

--- a/editors/neovim/plugin/ox-content.lua
+++ b/editors/neovim/plugin/ox-content.lua
@@ -1,0 +1,5 @@
+if vim.g.ox_content_auto_setup == false then
+  return
+end
+
+require("ox-content").setup()

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ox-content-zed"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+serde_json = "1"
+zed_extension_api = "0.7.0"
+
+[workspace]

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -1,6 +1,6 @@
 # Ox Content for Zed
 
-This extension wires Zed buffers to `ox-content-lsp`.
+This extension wires Zed Markdown, JavaScript, TypeScript, JSON, and YAML buffers to `ox-content-lsp`.
 
 Recommended Zed settings:
 
@@ -22,4 +22,4 @@ Recommended Zed settings:
 }
 ```
 
-Once `.mdc` is associated with `Markdown`, you get Zed's native Markdown preview/highlighting together with Ox Content frontmatter completion and diagnostics from the language server.
+Once `.mdc` is associated with `Markdown`, you get Zed's native Markdown preview/highlighting together with Ox Content frontmatter completion and diagnostics, plus i18n key intelligence in JS/TS.

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -1,0 +1,25 @@
+# Ox Content for Zed
+
+This extension wires Zed buffers to `ox-content-lsp`.
+
+Recommended Zed settings:
+
+```json
+{
+  "file_types": {
+    "Markdown": ["md", "markdown", "mdc"]
+  },
+  "lsp": {
+    "ox-content-lsp": {
+      "binary": {
+        "path": "/absolute/path/to/ox-content-lsp"
+      },
+      "initialization_options": {
+        "frontmatterSchema": "./content/frontmatter.schema.json"
+      }
+    }
+  }
+}
+```
+
+Once `.mdc` is associated with `Markdown`, you get Zed's native Markdown preview/highlighting together with Ox Content frontmatter completion and diagnostics from the language server.

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -8,7 +8,12 @@ repository = "https://github.com/ubugeeei/ox-content"
 
 [language_servers.ox-content-lsp]
 name = "ox-content-lsp"
-languages = ["Markdown"]
+languages = ["Markdown", "JavaScript", "TypeScript", "TSX", "JSON", "YAML"]
 
 [language_servers.ox-content-lsp.language_ids]
 Markdown = "markdown"
+JavaScript = "javascript"
+TypeScript = "typescript"
+TSX = "typescriptreact"
+JSON = "json"
+YAML = "yaml"

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,0 +1,14 @@
+id = "ox-content"
+name = "Ox Content"
+version = "0.1.0"
+schema_version = 1
+authors = ["ubugeeei"]
+description = "Ox Content authoring support for Zed"
+repository = "https://github.com/ubugeeei/ox-content"
+
+[language_servers.ox-content-lsp]
+name = "ox-content-lsp"
+languages = ["Markdown"]
+
+[language_servers.ox-content-lsp.language_ids]
+Markdown = "markdown"

--- a/editors/zed/src/lib.rs
+++ b/editors/zed/src/lib.rs
@@ -1,0 +1,50 @@
+use zed_extension_api as zed;
+
+use zed::settings::LspSettings;
+use zed::{Command, Extension, LanguageServerId, Result, Worktree};
+
+struct OxContentZedExtension;
+
+impl Extension for OxContentZedExtension {
+    fn new() -> Self {
+        Self
+    }
+
+    fn language_server_command(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &Worktree,
+    ) -> Result<Command> {
+        let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
+        let binary = settings.binary;
+
+        let command = binary
+            .as_ref()
+            .and_then(|binary| binary.path.clone())
+            .unwrap_or_else(|| "ox-content-lsp".to_string());
+        let args = binary.as_ref().and_then(|binary| binary.arguments.clone()).unwrap_or_default();
+        let env = binary.and_then(|binary| binary.env).unwrap_or_default().into_iter().collect();
+
+        Ok(Command { command, args, env })
+    }
+
+    fn language_server_initialization_options(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
+        Ok(settings.initialization_options)
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
+        Ok(settings.settings)
+    }
+}
+
+zed::register_extension!(OxContentZedExtension);

--- a/npm/vscode-ox-content/README.md
+++ b/npm/vscode-ox-content/README.md
@@ -1,0 +1,11 @@
+# VS Code Ox Content
+
+VS Code support for Ox Content authoring.
+
+Features:
+
+- Ox Content LSP client
+- frontmatter schema completion and diagnostics
+- command palette actions for table/code fence/callout insertion
+- Ox Content HTML preview
+- `.mdc` files associated with Markdown

--- a/npm/vscode-ox-content/README.md
+++ b/npm/vscode-ox-content/README.md
@@ -1,11 +1,12 @@
 # VS Code Ox Content
 
-VS Code support for Ox Content authoring.
+VS Code support for Ox Content authoring and i18n workflows.
 
 Features:
 
 - Ox Content LSP client
 - frontmatter schema completion and diagnostics
+- i18n key completion, hover, definition, diagnostics, and inlay hints for JS/TS
 - command palette actions for table/code fence/callout insertion
 - Ox Content HTML preview
 - `.mdc` files associated with Markdown

--- a/npm/vscode-ox-content/package.json
+++ b/npm/vscode-ox-content/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-ox-content",
   "version": "0.1.0",
   "private": true,
-  "description": "VS Code extension for Ox Content authoring",
+  "description": "VS Code extension for Ox Content authoring and i18n workflows",
   "license": "MIT",
   "main": "./dist/extension.js",
   "engines": {
@@ -15,6 +15,12 @@
   ],
   "activationEvents": [
     "onLanguage:markdown",
+    "onLanguage:javascript",
+    "onLanguage:javascriptreact",
+    "onLanguage:typescript",
+    "onLanguage:typescriptreact",
+    "onLanguage:json",
+    "onLanguage:yaml",
     "onCommand:oxContent.insertTable",
     "onCommand:oxContent.insertCodeFence",
     "onCommand:oxContent.insertCallout",

--- a/npm/vscode-ox-content/package.json
+++ b/npm/vscode-ox-content/package.json
@@ -1,0 +1,93 @@
+{
+  "name": "vscode-ox-content",
+  "version": "0.1.0",
+  "private": true,
+  "description": "VS Code extension for Ox Content authoring",
+  "license": "MIT",
+  "main": "./dist/extension.js",
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "categories": [
+    "Formatters",
+    "Programming Languages",
+    "Snippets"
+  ],
+  "activationEvents": [
+    "onLanguage:markdown",
+    "onCommand:oxContent.insertTable",
+    "onCommand:oxContent.insertCodeFence",
+    "onCommand:oxContent.insertCallout",
+    "onCommand:oxContent.openPreview"
+  ],
+  "files": [
+    "dist",
+    "snippets",
+    "README.md"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "oxContent.insertTable",
+        "title": "Ox Content: Insert Table",
+        "category": "Ox Content"
+      },
+      {
+        "command": "oxContent.insertCodeFence",
+        "title": "Ox Content: Insert Code Fence",
+        "category": "Ox Content"
+      },
+      {
+        "command": "oxContent.insertCallout",
+        "title": "Ox Content: Insert Callout",
+        "category": "Ox Content"
+      },
+      {
+        "command": "oxContent.openPreview",
+        "title": "Ox Content: Open Preview",
+        "category": "Ox Content"
+      }
+    ],
+    "configuration": {
+      "title": "Ox Content",
+      "properties": {
+        "oxContent.server.path": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Absolute or workspace-relative path to `ox-content-lsp`. When empty, the extension looks in `target/debug`, `target/release`, then falls back to `cargo run`."
+        },
+        "oxContent.frontmatter.schema": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Optional absolute or workspace-relative path to the frontmatter schema file used for Markdown and `.mdc` frontmatter completion and diagnostics."
+        },
+        "oxContent.preview.autoRefresh": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically refresh the Ox Content preview when the document changes."
+        }
+      }
+    },
+    "configurationDefaults": {
+      "files.associations": {
+        "*.mdc": "markdown"
+      }
+    },
+    "snippets": [
+      {
+        "language": "markdown",
+        "path": "./snippets/markdown.json"
+      }
+    ]
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@types/vscode": "^1.90.0",
+    "typescript": "catalog:",
+    "vscode-languageclient": "^9.0.1"
+  }
+}

--- a/npm/vscode-ox-content/snippets/markdown.json
+++ b/npm/vscode-ox-content/snippets/markdown.json
@@ -1,0 +1,37 @@
+{
+  "Ox Content Heading 1": {
+    "prefix": "h1",
+    "body": ["# ${1:Title}", "", "$0"],
+    "description": "Insert a page heading"
+  },
+  "Ox Content Heading 2": {
+    "prefix": "h2",
+    "body": ["## ${1:Section}", "", "$0"],
+    "description": "Insert a section heading"
+  },
+  "Ox Content Quote": {
+    "prefix": "quote",
+    "body": ["> ${1:Quoted text}", "", "$0"],
+    "description": "Insert a blockquote"
+  },
+  "Ox Content Task List": {
+    "prefix": "task",
+    "body": ["- [ ] ${1:Open item}", "- [x] ${2:Done item}", "$0"],
+    "description": "Insert a task list"
+  },
+  "Ox Content Code Fence": {
+    "prefix": "code",
+    "body": ["```ts", "${1:const value = true}", "```", "$0"],
+    "description": "Insert a code fence"
+  },
+  "Ox Content Table": {
+    "prefix": "table",
+    "body": [
+      "| ${1:Column} | ${2:Column} |",
+      "| --- | --- |",
+      "| ${3:Value} | ${4:Value} |",
+      "$0"
+    ],
+    "description": "Insert a Markdown table"
+  }
+}

--- a/npm/vscode-ox-content/src/client.ts
+++ b/npm/vscode-ox-content/src/client.ts
@@ -1,16 +1,11 @@
 import * as vscode from "vscode";
-import {
-  LanguageClient,
-  type LanguageClientOptions,
-} from "vscode-languageclient/node";
+import { LanguageClient, type LanguageClientOptions } from "vscode-languageclient/node";
 
 import { resolveInitializationOptions, resolveServerOptions } from "./config";
 
 let client: LanguageClient | undefined;
 
-export async function startClient(
-  context: vscode.ExtensionContext,
-): Promise<LanguageClient> {
+export async function startClient(context: vscode.ExtensionContext): Promise<LanguageClient> {
   if (client) {
     return client;
   }
@@ -43,9 +38,7 @@ export async function startClient(
   return client;
 }
 
-export async function restartClient(
-  context: vscode.ExtensionContext,
-): Promise<LanguageClient> {
+export async function restartClient(context: vscode.ExtensionContext): Promise<LanguageClient> {
   await stopClient();
   return startClient(context);
 }

--- a/npm/vscode-ox-content/src/client.ts
+++ b/npm/vscode-ox-content/src/client.ts
@@ -1,0 +1,67 @@
+import * as vscode from "vscode";
+import {
+  LanguageClient,
+  type LanguageClientOptions,
+} from "vscode-languageclient/node";
+
+import { resolveInitializationOptions, resolveServerOptions } from "./config";
+
+let client: LanguageClient | undefined;
+
+export async function startClient(
+  context: vscode.ExtensionContext,
+): Promise<LanguageClient> {
+  if (client) {
+    return client;
+  }
+
+  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  const clientOptions: LanguageClientOptions = {
+    documentSelector: [
+      { language: "markdown", scheme: "file" },
+      { language: "markdown", scheme: "untitled" },
+    ],
+    initializationOptions: resolveInitializationOptions(workspaceRoot),
+    synchronize: { configurationSection: "oxContent" },
+  };
+
+  client = new LanguageClient(
+    "oxContent",
+    "Ox Content",
+    resolveServerOptions(context, workspaceRoot),
+    clientOptions,
+  );
+
+  await client.start();
+  context.subscriptions.push({ dispose: () => void client?.stop() });
+  return client;
+}
+
+export async function restartClient(
+  context: vscode.ExtensionContext,
+): Promise<LanguageClient> {
+  await stopClient();
+  return startClient(context);
+}
+
+export async function stopClient(): Promise<void> {
+  const current = client;
+  client = undefined;
+  if (current) {
+    await current.stop();
+  }
+}
+
+export async function sendServerCommand<T = unknown>(
+  command: string,
+  args: unknown[],
+): Promise<T | undefined> {
+  if (!client) {
+    throw new Error("Ox Content language client is not running.");
+  }
+
+  return client.sendRequest<T | undefined>("workspace/executeCommand", {
+    command,
+    arguments: args,
+  });
+}

--- a/npm/vscode-ox-content/src/client.ts
+++ b/npm/vscode-ox-content/src/client.ts
@@ -20,6 +20,12 @@ export async function startClient(
     documentSelector: [
       { language: "markdown", scheme: "file" },
       { language: "markdown", scheme: "untitled" },
+      { language: "javascript", scheme: "file" },
+      { language: "javascriptreact", scheme: "file" },
+      { language: "typescript", scheme: "file" },
+      { language: "typescriptreact", scheme: "file" },
+      { language: "json", scheme: "file" },
+      { language: "yaml", scheme: "file" },
     ],
     initializationOptions: resolveInitializationOptions(workspaceRoot),
     synchronize: { configurationSection: "oxContent" },

--- a/npm/vscode-ox-content/src/commands.ts
+++ b/npm/vscode-ox-content/src/commands.ts
@@ -1,0 +1,31 @@
+import * as vscode from "vscode";
+
+import {
+  COMMAND_INSERT_CALLOUT,
+  COMMAND_INSERT_CODE_FENCE,
+  COMMAND_INSERT_TABLE,
+} from "./constants";
+import { sendServerCommand } from "./client";
+
+export async function runInsertCommand(command: string): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.document.languageId !== "markdown") {
+    void vscode.window.showInformationMessage("Open a Markdown or .mdc document first.");
+    return;
+  }
+
+  await sendServerCommand(command, [
+    {
+      uri: editor.document.uri.toString(),
+      position: editor.selection.active,
+    },
+  ]);
+}
+
+export function insertionCommands(): Array<[string, () => Promise<void>]> {
+  return [
+    [COMMAND_INSERT_TABLE, () => runInsertCommand(COMMAND_INSERT_TABLE)],
+    [COMMAND_INSERT_CODE_FENCE, () => runInsertCommand(COMMAND_INSERT_CODE_FENCE)],
+    [COMMAND_INSERT_CALLOUT, () => runInsertCommand(COMMAND_INSERT_CALLOUT)],
+  ];
+}

--- a/npm/vscode-ox-content/src/config.ts
+++ b/npm/vscode-ox-content/src/config.ts
@@ -31,23 +31,16 @@ export function resolveServerOptions(
   };
 }
 
-export function resolveInitializationOptions(
-  workspaceRoot?: string,
-): Record<string, string> {
+export function resolveInitializationOptions(workspaceRoot?: string): Record<string, string> {
   const schemaSetting = getConfig().get<string>("frontmatter.schema", "").trim();
-  return schemaSetting
-    ? { frontmatterSchema: resolveFilePath(schemaSetting, workspaceRoot) }
-    : {};
+  return schemaSetting ? { frontmatterSchema: resolveFilePath(schemaSetting, workspaceRoot) } : {};
 }
 
 function findLocalServerBinary(
   context: vscode.ExtensionContext,
   workspaceRoot?: string,
 ): string | undefined {
-  const binaryName =
-    process.platform === "win32"
-      ? "ox-content-lsp.exe"
-      : "ox-content-lsp";
+  const binaryName = process.platform === "win32" ? "ox-content-lsp.exe" : "ox-content-lsp";
   const candidates = [
     workspaceRoot ? path.join(workspaceRoot, "target", "debug", binaryName) : undefined,
     workspaceRoot ? path.join(workspaceRoot, "target", "release", binaryName) : undefined,

--- a/npm/vscode-ox-content/src/config.ts
+++ b/npm/vscode-ox-content/src/config.ts
@@ -1,0 +1,66 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as vscode from "vscode";
+import type { ServerOptions } from "vscode-languageclient/node";
+
+export function getConfig(): vscode.WorkspaceConfiguration {
+  return vscode.workspace.getConfiguration("oxContent");
+}
+
+export function resolveServerOptions(
+  context: vscode.ExtensionContext,
+  workspaceRoot?: string,
+): ServerOptions {
+  const configuredPath = getConfig().get<string>("server.path", "").trim();
+  const resolvedConfiguredPath = configuredPath
+    ? resolveFilePath(configuredPath, workspaceRoot)
+    : undefined;
+
+  if (resolvedConfiguredPath && fs.existsSync(resolvedConfiguredPath)) {
+    return { command: resolvedConfiguredPath, args: [] };
+  }
+
+  const localBinary = findLocalServerBinary(context, workspaceRoot);
+  if (localBinary) {
+    return { command: localBinary, args: [] };
+  }
+
+  return {
+    command: "cargo",
+    args: ["run", "-p", "ox_content_lsp", "--bin", "ox-content-lsp"],
+  };
+}
+
+export function resolveInitializationOptions(
+  workspaceRoot?: string,
+): Record<string, string> {
+  const schemaSetting = getConfig().get<string>("frontmatter.schema", "").trim();
+  return schemaSetting
+    ? { frontmatterSchema: resolveFilePath(schemaSetting, workspaceRoot) }
+    : {};
+}
+
+function findLocalServerBinary(
+  context: vscode.ExtensionContext,
+  workspaceRoot?: string,
+): string | undefined {
+  const binaryName =
+    process.platform === "win32"
+      ? "ox-content-lsp.exe"
+      : "ox-content-lsp";
+  const candidates = [
+    workspaceRoot ? path.join(workspaceRoot, "target", "debug", binaryName) : undefined,
+    workspaceRoot ? path.join(workspaceRoot, "target", "release", binaryName) : undefined,
+    path.join(context.extensionPath, "bin", binaryName),
+  ].filter((value): value is string => Boolean(value));
+
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function resolveFilePath(value: string, workspaceRoot?: string): string {
+  if (path.isAbsolute(value)) {
+    return value;
+  }
+
+  return workspaceRoot ? path.join(workspaceRoot, value) : value;
+}

--- a/npm/vscode-ox-content/src/constants.ts
+++ b/npm/vscode-ox-content/src/constants.ts
@@ -1,0 +1,5 @@
+export const COMMAND_INSERT_TABLE = "oxContent.insertTable";
+export const COMMAND_INSERT_CODE_FENCE = "oxContent.insertCodeFence";
+export const COMMAND_INSERT_CALLOUT = "oxContent.insertCallout";
+export const COMMAND_OPEN_PREVIEW = "oxContent.openPreview";
+export const SERVER_COMMAND_PREVIEW_HTML = "oxContent.previewHtml";

--- a/npm/vscode-ox-content/src/extension.ts
+++ b/npm/vscode-ox-content/src/extension.ts
@@ -1,0 +1,45 @@
+import * as vscode from "vscode";
+
+import {
+  COMMAND_INSERT_CALLOUT,
+  COMMAND_INSERT_CODE_FENCE,
+  COMMAND_INSERT_TABLE,
+  COMMAND_OPEN_PREVIEW,
+} from "./constants";
+import { insertionCommands } from "./commands";
+import { restartClient, startClient, stopClient } from "./client";
+import { openPreview, refreshAllPreviews, schedulePreviewRefresh } from "./preview";
+
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  await startClient(context);
+
+  context.subscriptions.push(
+    ...insertionCommands().map(([command, handler]) =>
+      vscode.commands.registerCommand(command, handler),
+    ),
+    vscode.commands.registerCommand(COMMAND_OPEN_PREVIEW, async () => {
+      await openPreview(context);
+    }),
+    vscode.workspace.onDidChangeTextDocument((event) => {
+      schedulePreviewRefresh(event.document);
+    }),
+    vscode.workspace.onDidSaveTextDocument((document) => {
+      schedulePreviewRefresh(document);
+    }),
+    vscode.workspace.onDidCloseTextDocument((document) => {
+      schedulePreviewRefresh(document, true);
+    }),
+    vscode.workspace.onDidChangeConfiguration(async (event) => {
+      if (!event.affectsConfiguration("oxContent")) {
+        return;
+      }
+
+      await restartClient(context);
+      await refreshAllPreviews();
+    }),
+  );
+}
+
+export async function deactivate(): Promise<void> {
+  await stopClient();
+}

--- a/npm/vscode-ox-content/src/extension.ts
+++ b/npm/vscode-ox-content/src/extension.ts
@@ -1,11 +1,6 @@
 import * as vscode from "vscode";
 
-import {
-  COMMAND_INSERT_CALLOUT,
-  COMMAND_INSERT_CODE_FENCE,
-  COMMAND_INSERT_TABLE,
-  COMMAND_OPEN_PREVIEW,
-} from "./constants";
+import { COMMAND_OPEN_PREVIEW } from "./constants";
 import { insertionCommands } from "./commands";
 import { restartClient, startClient, stopClient } from "./client";
 import { openPreview, refreshAllPreviews, schedulePreviewRefresh } from "./preview";

--- a/npm/vscode-ox-content/src/preview.ts
+++ b/npm/vscode-ox-content/src/preview.ts
@@ -1,0 +1,137 @@
+import * as path from "node:path";
+import * as vscode from "vscode";
+
+import { getConfig } from "./config";
+import { SERVER_COMMAND_PREVIEW_HTML } from "./constants";
+import { sendServerCommand } from "./client";
+import type { PreviewEntry, PreviewPayload } from "./types";
+
+const previewEntries = new Map<string, PreviewEntry>();
+const refreshTimers = new Map<string, NodeJS.Timeout>();
+
+export async function openPreview(
+  context: vscode.ExtensionContext,
+): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.document.languageId !== "markdown") {
+    void vscode.window.showInformationMessage("Open a Markdown or .mdc document first.");
+    return;
+  }
+
+  const documentUri = editor.document.uri.toString();
+  const existing = previewEntries.get(documentUri);
+  if (existing) {
+    existing.panel.reveal(vscode.ViewColumn.Beside, true);
+    await updatePreview(existing.panel, editor.document);
+    return;
+  }
+
+  const panel = vscode.window.createWebviewPanel(
+    "oxContentPreview",
+    "Ox Content Preview",
+    { viewColumn: vscode.ViewColumn.Beside, preserveFocus: true },
+    { enableFindWidget: true, enableScripts: false, retainContextWhenHidden: true },
+  );
+
+  previewEntries.set(documentUri, { documentUri, panel });
+  panel.onDidDispose(() => disposePreview(documentUri), null, context.subscriptions);
+  await updatePreview(panel, editor.document);
+}
+
+export function schedulePreviewRefresh(
+  document: vscode.TextDocument,
+  dispose = false,
+): void {
+  const key = document.uri.toString();
+  if (dispose) {
+    disposePreview(key);
+    return;
+  }
+
+  if (!getConfig().get<boolean>("preview.autoRefresh", true) || document.languageId !== "markdown") {
+    return;
+  }
+
+  const entry = previewEntries.get(key);
+  if (!entry) {
+    return;
+  }
+
+  clearTimer(key);
+  refreshTimers.set(
+    key,
+    setTimeout(() => {
+      void updatePreview(entry.panel, document);
+    }, 150),
+  );
+}
+
+export async function refreshAllPreviews(): Promise<void> {
+  for (const entry of previewEntries.values()) {
+    const document = await vscode.workspace.openTextDocument(vscode.Uri.parse(entry.documentUri));
+    await updatePreview(entry.panel, document);
+  }
+}
+
+async function updatePreview(
+  panel: vscode.WebviewPanel,
+  document: vscode.TextDocument,
+): Promise<void> {
+  try {
+    const payload = await sendServerCommand<PreviewPayload>(SERVER_COMMAND_PREVIEW_HTML, [
+      document.uri.toString(),
+    ]);
+    if (!payload) {
+      panel.webview.html = errorHtml("Preview payload was empty.");
+      return;
+    }
+
+    panel.title = payload.title || `${path.basename(document.fileName) || "Untitled"} Preview`;
+    panel.webview.html = payload.html;
+  } catch (error) {
+    panel.webview.html = errorHtml(
+      error instanceof Error ? error.message : "Failed to render preview.",
+    );
+  }
+}
+
+function disposePreview(key: string): void {
+  previewEntries.delete(key);
+  clearTimer(key);
+}
+
+function clearTimer(key: string): void {
+  const timer = refreshTimers.get(key);
+  if (timer) {
+    clearTimeout(timer);
+  }
+  refreshTimers.delete(key);
+}
+
+function errorHtml(message: string): string {
+  const escaped = message
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body { margin: 0; padding: 24px; font: 14px/1.6 ui-sans-serif, system-ui, sans-serif; background: #0f172a; color: #e2e8f0; }
+      .card { max-width: 720px; margin: 0 auto; padding: 20px 22px; border-radius: 16px; border: 1px solid #334155; background: #111827; }
+      h1 { margin-top: 0; font-size: 1rem; }
+      code { color: #fda4af; }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Ox Content Preview</h1>
+      <p>${escaped}</p>
+      <p>Make sure <code>ox-content-lsp</code> is available or set <code>oxContent.server.path</code>.</p>
+    </div>
+  </body>
+</html>`;
+}

--- a/npm/vscode-ox-content/src/preview.ts
+++ b/npm/vscode-ox-content/src/preview.ts
@@ -9,9 +9,7 @@ import type { PreviewEntry, PreviewPayload } from "./types";
 const previewEntries = new Map<string, PreviewEntry>();
 const refreshTimers = new Map<string, NodeJS.Timeout>();
 
-export async function openPreview(
-  context: vscode.ExtensionContext,
-): Promise<void> {
+export async function openPreview(context: vscode.ExtensionContext): Promise<void> {
   const editor = vscode.window.activeTextEditor;
   if (!editor || editor.document.languageId !== "markdown") {
     void vscode.window.showInformationMessage("Open a Markdown or .mdc document first.");
@@ -38,17 +36,17 @@ export async function openPreview(
   await updatePreview(panel, editor.document);
 }
 
-export function schedulePreviewRefresh(
-  document: vscode.TextDocument,
-  dispose = false,
-): void {
+export function schedulePreviewRefresh(document: vscode.TextDocument, dispose = false): void {
   const key = document.uri.toString();
   if (dispose) {
     disposePreview(key);
     return;
   }
 
-  if (!getConfig().get<boolean>("preview.autoRefresh", true) || document.languageId !== "markdown") {
+  if (
+    !getConfig().get<boolean>("preview.autoRefresh", true) ||
+    document.languageId !== "markdown"
+  ) {
     return;
   }
 
@@ -109,10 +107,7 @@ function clearTimer(key: string): void {
 }
 
 function errorHtml(message: string): string {
-  const escaped = message
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
+  const escaped = message.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 
   return `<!doctype html>
 <html lang="en">

--- a/npm/vscode-ox-content/src/types.ts
+++ b/npm/vscode-ox-content/src/types.ts
@@ -1,0 +1,11 @@
+import * as vscode from "vscode";
+
+export type PreviewPayload = {
+  html: string;
+  title: string;
+};
+
+export type PreviewEntry = {
+  documentUri: string;
+  panel: vscode.WebviewPanel;
+};

--- a/npm/vscode-ox-content/tsconfig.json
+++ b/npm/vscode-ox-content/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "moduleResolution": "node",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "sourceMap": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "types": ["node", "vscode"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/npm/vscode-ox-content/vite.config.ts
+++ b/npm/vscode-ox-content/vite.config.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -755,6 +755,21 @@ importers:
         specifier: 'catalog:'
         version: 3.5.26(typescript@5.9.3)
 
+  npm/vscode-ox-content:
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.3
+      '@types/vscode':
+        specifier: ^1.90.0
+        version: 1.116.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vscode-languageclient:
+        specifier: ^9.0.1
+        version: 9.0.1
+
 packages:
 
   '@algolia/abtesting@1.12.2':
@@ -3029,6 +3044,9 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/vscode@1.116.0':
+    resolution: {integrity: sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA==}
+
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
 
@@ -3549,6 +3567,9 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
     peerDependencies:
@@ -3618,6 +3639,9 @@ packages:
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5061,6 +5085,10 @@ packages:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -6234,6 +6262,10 @@ packages:
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
+
+  vscode-languageclient@9.0.1:
+    resolution: {integrity: sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==}
+    engines: {vscode: ^1.82.0}
 
   vscode-languageserver-protocol@3.17.5:
     resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
@@ -8404,6 +8436,8 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/vscode@1.116.0': {}
+
   '@types/web-bluetooth@0.0.21': {}
 
   '@types/yauzl@2.10.3':
@@ -9125,6 +9159,8 @@ snapshots:
 
   bail@2.0.2: {}
 
+  balanced-match@1.0.2: {}
+
   bare-events@2.8.2: {}
 
   bare-fs@4.5.3:
@@ -9188,6 +9224,10 @@ snapshots:
       type-fest: 4.41.0
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
+
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
 
   braces@3.0.3:
     dependencies:
@@ -10821,6 +10861,10 @@ snapshots:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
   minipass@7.1.2: {}
 
   minisearch@7.2.0: {}
@@ -12390,6 +12434,12 @@ snapshots:
       - yaml
 
   vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageclient@9.0.1:
+    dependencies:
+      minimatch: 5.1.9
+      semver: 7.7.3
+      vscode-languageserver-protocol: 3.17.5
 
   vscode-languageserver-protocol@3.17.5:
     dependencies:


### PR DESCRIPTION
## Summary
- rename the shared authoring server from `ox_content_markdown_lsp` / `ox-content-markdown-lsp` to `ox_content_lsp` / `ox-content-lsp`
- merge the existing i18n LSP capabilities into the shared server so Markdown and JS/TS authoring use one LSP entrypoint
- update the VS Code, Zed, and Neovim integrations to target the unified server and attach it to the relevant authoring buffers

## Why
The previous server name was too Markdown-specific for its actual role, and the i18n workflow still lived behind a separate LSP. That split made editor setup heavier, duplicated integration work, and forced users to think about two servers for one content workflow.

## User Impact
- editor setup now points to a single `ox-content-lsp` binary
- Markdown and `.mdc` frontmatter completion, diagnostics, snippets, insert commands, and preview still work as before
- JS/TS files now get i18n key completion, hover, go-to-definition, diagnostics, and inlay hints from the same server
- dictionary edits in `content/i18n` can refresh diagnostics without switching to another language server

## Root Cause
We had already introduced a shared authoring-focused LSP, but it was still named as if it only served Markdown, while the older i18n LSP remained separate. The naming and architecture had drifted away from the actual product shape.

## Validation
- `cargo check --workspace`
- `pnpm --filter ./npm/vscode-ox-content build`
- `cargo check --manifest-path editors/zed/Cargo.toml`
- `nvim --headless -u NONE '+set rtp+=/Users/nishimura/Code/github.com/ubugeeei/ox-content/editors/neovim' '+lua require("ox-content").setup({ frontmatter_schema = "./content/frontmatter.schema.json" })' +qa`
