### PR TITLE
chore: add md4x to benchmarks

### DIFF
--- a/benchmarks/bundle-size/package.json
+++ b/benchmarks/bundle-size/package.json
@@ -14,6 +14,7 @@
     "markdown-it": "^14.1.0",
     "marked": "^15.0.0",
     "md4w": "^0.2.7",
+    "md4x": "^0.0.25",
     "micromark": "^4.0.1",
     "remark-html": "^16.0.1",
     "remark-parse": "^11.0.0",

--- a/benchmarks/bundle-size/parse-benchmark.mjs
+++ b/benchmarks/bundle-size/parse-benchmark.mjs
@@ -188,6 +188,7 @@ async function runBenchmarks() {
   const { Lexer: MarkedLexer } = await import("marked");
   const MarkdownIt = (await import("markdown-it")).default;
   const { init: initMd4w, mdToHtml, mdToJSON } = await import("md4w");
+  const { parseAST: md4xParseAST, renderToHtml: md4xRenderToHtml } = await import("md4x/napi");
   const { micromark } = await import("micromark");
   const { unified } = await import("unified");
   const remarkParse = (await import("remark-parse")).default;
@@ -227,6 +228,7 @@ async function runBenchmarks() {
   parsers.push(
     { name: "marked", fn: (input) => MarkedLexer.lex(input) },
     { name: "md4w (md4c)", fn: (input) => mdToJSON(input) },
+    { name: "md4x (napi)", fn: (input) => md4xParseAST(input) },
     { name: "markdown-it", fn: (input) => md.parse(input, {}) },
     { name: "remark", fn: (input) => remarkParseProcessor.parse(input) },
   );
@@ -244,6 +246,7 @@ async function runBenchmarks() {
   renderers.push(
     { name: "marked", fn: (input) => marked(input) },
     { name: "md4w (md4c)", fn: (input) => mdToHtml(input) },
+    { name: "md4x (napi)", fn: (input) => md4xRenderToHtml(input) },
     { name: "markdown-it", fn: (input) => md.render(input) },
     { name: "micromark", fn: (input) => micromark(input) },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       md4w:
         specifier: ^0.2.7
         version: 0.2.7
+      md4x:
+        specifier: ^0.0.25
+        version: 0.0.25
       micromark:
         specifier: ^4.0.1
         version: 4.0.2
@@ -5242,6 +5245,10 @@ packages:
 
   md4w@0.2.7:
     resolution: {integrity: sha512-lFM7vwk3d4MzkV2mija7aPkK6OjKXZDQsH2beX+e2cvccBoqc6RraheMtAO0Wcr/gjj5L+WS5zhb+06AmuGZrg==}
+
+  md4x@0.0.25:
+    resolution: {integrity: sha512-GrexawUhrKcwl7o2hkgs7Ut0PqI/meOCevmaRB1ueKo2y1Fh2nIl8e6KKawYGm9eXJP3u6BzVs4rzZOc2+w3hA==}
+    hasBin: true
 
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
@@ -11143,6 +11150,8 @@ snapshots:
 
   md4w@0.2.7: {}
 
+  md4x@0.0.25: {}
+
   mdast-util-definitions@6.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -13000,7 +13009,7 @@ snapshots:
     dependencies:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       postcss: 8.5.8
       rolldown: 1.0.0-rc.9
       tinyglobby: 0.2.15


### PR DESCRIPTION
This PR adds [unjs/md4x](https://github.com/unjs/md4x) napi to the benchmarks./


## Results

```
Parse/Render Speed Benchmark
============================

Using @ox-content/napi (Native)

Using Bun.markdown (Bun 1.3.11)


## SMALL (0.5 KB)

### Parse Only

| Library          |    ops/sec |  avg time |  throughput |   ratio |
|------------------|------------|-----------|-------------|---------|
| @ox-content/napi |     251151 |    0.00ms | 119.04 MB/s |   1.00x |
| md4x (napi)      |      89074 |    0.01ms |  42.22 MB/s |   2.82x |
| md4w (md4c)      |      38085 |    0.03ms |  18.05 MB/s |   6.59x |
| marked           |      26773 |    0.04ms |  12.69 MB/s |   9.38x |
| markdown-it      |      22210 |    0.05ms |  10.53 MB/s |  11.31x |
| remark           |       4242 |    0.24ms |   2.01 MB/s |  59.21x |

### Parse + Render

| Library           |    ops/sec |  avg time |  throughput |   ratio |
|-------------------|------------|-----------|-------------|---------|
| Bun.markdown.html |     281823 |    0.00ms | 133.58 MB/s |   1.00x |
| md4x (napi)       |     246053 |    0.00ms | 116.62 MB/s |   1.15x |
| @ox-content/napi  |     220264 |    0.00ms | 104.40 MB/s |   1.28x |
| md4w (md4c)       |     108254 |    0.01ms |  51.31 MB/s |   2.60x |
| markdown-it       |      36996 |    0.03ms |  17.54 MB/s |   7.62x |
| marked            |      30697 |    0.03ms |  14.55 MB/s |   9.18x |
| micromark         |       4726 |    0.21ms |   2.24 MB/s |  59.63x |
| remark            |       3991 |    0.25ms |   1.89 MB/s |  70.62x |

## MEDIUM (4.9 KB)

### Parse Only

| Library          |    ops/sec |  avg time |  throughput |   ratio |
|------------------|------------|-----------|-------------|---------|
| @ox-content/napi |      25572 |    0.04ms | 121.64 MB/s |   1.00x |
| md4x (napi)      |      11165 |    0.09ms |  53.11 MB/s |   2.29x |
| md4w (md4c)      |       8801 |    0.11ms |  41.86 MB/s |   2.91x |
| markdown-it      |       6717 |    0.15ms |  31.95 MB/s |   3.81x |
| marked           |       4238 |    0.24ms |  20.16 MB/s |   6.03x |
| remark           |        579 |    1.73ms |   2.76 MB/s |  44.14x |

### Parse + Render

| Library           |    ops/sec |  avg time |  throughput |   ratio |
|-------------------|------------|-----------|-------------|---------|
| Bun.markdown.html |      39377 |    0.03ms | 187.31 MB/s |   1.00x |
| md4x (napi)       |      31511 |    0.03ms | 149.90 MB/s |   1.25x |
| @ox-content/napi  |      30161 |    0.03ms | 143.48 MB/s |   1.31x |
| md4w (md4c)       |      20333 |    0.05ms |  96.72 MB/s |   1.94x |
| markdown-it       |       5849 |    0.17ms |  27.82 MB/s |   6.73x |
| marked            |       3911 |    0.26ms |  18.61 MB/s |  10.07x |
| micromark         |        602 |    1.66ms |   2.87 MB/s |  65.36x |
| remark            |        503 |    1.99ms |   2.39 MB/s |  78.30x |

## LARGE (48.7 KB)

### Parse Only

| Library          |    ops/sec |  avg time |  throughput |   ratio |
|------------------|------------|-----------|-------------|---------|
| @ox-content/napi |       2771 |    0.36ms | 131.84 MB/s |   1.00x |
| md4x (napi)      |       1120 |    0.89ms |  53.28 MB/s |   2.47x |
| md4w (md4c)      |       1018 |    0.98ms |  48.46 MB/s |   2.72x |
| markdown-it      |        780 |    1.28ms |  37.12 MB/s |   3.55x |
| marked           |        471 |    2.12ms |  22.41 MB/s |   5.88x |
| remark           |         43 |   23.12ms |   2.06 MB/s |  64.06x |

### Parse + Render

| Library           |    ops/sec |  avg time |  throughput |   ratio |
|-------------------|------------|-----------|-------------|---------|
| md4x (napi)       |       3668 |    0.27ms | 174.57 MB/s |   1.00x |
| Bun.markdown.html |       3553 |    0.28ms | 169.09 MB/s |   1.03x |
| @ox-content/napi  |       2916 |    0.34ms | 138.75 MB/s |   1.26x |
| md4w (md4c)       |       2529 |    0.40ms | 120.35 MB/s |   1.45x |
| markdown-it       |        731 |    1.37ms |  34.77 MB/s |   5.02x |
| marked            |        439 |    2.28ms |  20.87 MB/s |   8.36x |
| micromark         |         45 |   22.04ms |   2.16 MB/s |  80.84x |
| remark            |         35 |   28.27ms |   1.68 MB/s | 103.69x |

### Parse + Render (Async/Worker Thread)

| Library                  |    ops/sec |  avg time |  throughput |   ratio |
|--------------------------|------------|-----------|-------------|---------|
| @ox-content/napi (async) |       2660 |    0.38ms | 126.60 MB/s |   1.00x |


*Higher ops/sec and throughput = better.*
```