### PR TITLE
chore: unify vp lifecycle commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,18 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  lint-rust:
-    name: Lint (Rust)
+  check:
+    name: Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: true
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -24,45 +31,11 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Check formatting
-        run: cargo fmt --all -- --check
+      - name: Check
+        run: vp check
 
-      - name: Run clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
-
-  check-ts:
-    name: Check (JS/TS)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
-        with:
-          node-version-file: ".node-version"
-          cache: true
-          run-install: true
-
-      - name: Check (Vite+)
-        run: vp run check:ts
-
-  test-rust:
-    name: Test (Rust)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-
-      - name: Run tests
-        run: cargo test --workspace
-
-  test-ts:
-    name: Test (TypeScript)
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -79,15 +52,12 @@ jobs:
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
-
-      - name: Build NAPI
-        run: vp run build:napi
 
       - name: Install Playwright browsers
         run: vp exec --filter @ox-content/vite-plugin -- playwright install --with-deps chromium
 
       - name: Run tests
-        run: vp run test:ts
+        run: vp run test
 
   build:
     name: Build
@@ -111,8 +81,5 @@ jobs:
       - name: Install Chromium for mermaid-cli
         run: vp exec --filter @ox-content/vite-plugin -- puppeteer browsers install chrome-headless-shell
 
-      - name: Build documentation site
-        run: vp run dev-build
-
-      - name: Check JS/TS
-        run: vp run check:ts
+      - name: Build
+        run: vp build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,17 +41,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Build Rust documentation
-        run: cargo doc --workspace --no-deps
-
       - name: Install Chromium for mermaid-cli
         run: vp exec --filter @ox-content/vite-plugin -- puppeteer browsers install chrome-headless-shell
 
-      - name: Build documentation site
-        run: vp run dev-build
-
-      - name: Build playground
-        working-directory: examples/playground
+      - name: Build
         run: vp build
 
       - name: Prepare deployment directory

--- a/README.md
+++ b/README.md
@@ -188,11 +188,10 @@ The script now compares against `md4w (md4c)` by default and will include `Bun.m
 ```bash
 nix develop           # Enter the pinned dev shell
 vp install             # Install JS dependencies through Vite+
-vp run build:napi      # Build NAPI bindings
-vp run build:npm       # Build npm packages
-vp run build:wasm      # Build publish-ready @ox-content/wasm package
-cargo check -p ox_content_lsp
-vp run test            # Run tests
+vp fmt                 # Format Rust and JS/TS sources
+vp check               # Check Rust and JS/TS sources
+vp dev                 # Start the docs and playground dev servers
+vp build               # Build Rust, npm packages, docs, and playground
 ```
 
 The dev shell is pinned in `flake.nix`, the workspace task graph lives in `vite.config.ts`, and `.node-version` is kept for CI / non-Nix Node setup.

--- a/npm/vscode-ox-content/package.json
+++ b/npm/vscode-ox-content/package.json
@@ -3,34 +3,28 @@
   "version": "0.1.0",
   "private": true,
   "description": "VS Code extension for Ox Content authoring and i18n workflows",
-  "license": "MIT",
-  "main": "./dist/extension.js",
-  "engines": {
-    "vscode": "^1.90.0"
-  },
   "categories": [
     "Formatters",
     "Programming Languages",
     "Snippets"
   ],
-  "activationEvents": [
-    "onLanguage:markdown",
-    "onLanguage:javascript",
-    "onLanguage:javascriptreact",
-    "onLanguage:typescript",
-    "onLanguage:typescriptreact",
-    "onLanguage:json",
-    "onLanguage:yaml",
-    "onCommand:oxContent.insertTable",
-    "onCommand:oxContent.insertCodeFence",
-    "onCommand:oxContent.insertCallout",
-    "onCommand:oxContent.openPreview"
-  ],
+  "license": "MIT",
   "files": [
     "dist",
     "snippets",
     "README.md"
   ],
+  "main": "./dist/extension.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@types/vscode": "^1.90.0",
+    "typescript": "catalog:",
+    "vscode-languageclient": "^9.0.1"
+  },
   "contributes": {
     "commands": [
       {
@@ -86,14 +80,20 @@
       }
     ]
   },
-  "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist"
-  },
-  "devDependencies": {
-    "@types/node": "catalog:",
-    "@types/vscode": "^1.90.0",
-    "typescript": "catalog:",
-    "vscode-languageclient": "^9.0.1"
+  "activationEvents": [
+    "onCommand:oxContent.insertCallout",
+    "onCommand:oxContent.insertCodeFence",
+    "onCommand:oxContent.insertTable",
+    "onCommand:oxContent.openPreview",
+    "onLanguage:javascript",
+    "onLanguage:javascriptreact",
+    "onLanguage:json",
+    "onLanguage:markdown",
+    "onLanguage:typescript",
+    "onLanguage:typescriptreact",
+    "onLanguage:yaml"
+  ],
+  "engines": {
+    "vscode": "^1.90.0"
   }
 }

--- a/npm/vscode-ox-content/snippets/markdown.json
+++ b/npm/vscode-ox-content/snippets/markdown.json
@@ -26,12 +26,7 @@
   },
   "Ox Content Table": {
     "prefix": "table",
-    "body": [
-      "| ${1:Column} | ${2:Column} |",
-      "| --- | --- |",
-      "| ${3:Value} | ${4:Value} |",
-      "$0"
-    ],
+    "body": ["| ${1:Column} | ${2:Column} |", "| --- | --- |", "| ${3:Value} | ${4:Value} |", "$0"],
     "description": "Insert a Markdown table"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ox-content",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "devDependencies": {
     "typescript": "catalog:",
     "vite-plus": "catalog:"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,41 @@
+import { spawnSync } from "node:child_process";
 import { defineConfig } from "vite-plus";
+
+const lifecycleEnvName = "OX_CONTENT_VP_LIFECYCLE";
+
+const lifecycleTasks: Record<string, string> = {
+  build: "build",
+  check: "check",
+  dev: "dev",
+  fmt: "fmt",
+};
+
+// Vite+ direct commands bypass run.tasks, so root lifecycle commands delegate into the task graph.
+const delegateLifecycleCommand = () => {
+  if (process.env[lifecycleEnvName]) {
+    return;
+  }
+
+  const [, , command, ...args] = process.argv;
+  const taskName = command ? lifecycleTasks[command] : undefined;
+
+  if (!taskName || args.length > 0) {
+    return;
+  }
+
+  const result = spawnSync("vp", ["run", taskName], {
+    env: { ...process.env, [lifecycleEnvName]: "1" },
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  process.exit(result.status ?? 1);
+};
+
+delegateLifecycleCommand();
 
 const task = (
   command: string,
@@ -27,9 +64,11 @@ const uncachedTask = (
   } = {},
 ) => task(command, { ...options, cache: false });
 
+const vpBuiltin = (command: string) => `${lifecycleEnvName}=1 ${command}`;
+
 export default defineConfig({
   fmt: {
-    ignorePatterns: ["crates/ox_content_ssg/templates/*.html"],
+    ignorePatterns: ["crates/ox_content_napi/index.d.ts", "crates/ox_content_ssg/templates/*.html"],
   },
   lint: {
     options: {
@@ -46,12 +85,20 @@ export default defineConfig({
       tasks: true,
     },
     tasks: {
-      build: noopTask(["build:rust", "build:npm"]),
+      build: noopTask(["build:docs", "build:playground", "doc:cargo"]),
       "build:rust": task("cargo build --workspace"),
       "build:rust-release": task("cargo build --workspace --release"),
-      "build:napi": task("vp run --filter ./crates/ox_content_napi build"),
+      "build:napi": task("vp run --filter ./crates/ox_content_napi build", {
+        dependsOn: ["build:rust"],
+      }),
       "build:npm": task("vp run --filter './npm/*' build", {
         dependsOn: ["build:napi"],
+      }),
+      "build:docs": task("vp run --filter ./docs build", {
+        dependsOn: ["build:npm"],
+      }),
+      "build:playground": task("vp run --filter ./examples/playground build", {
+        dependsOn: ["build:npm"],
       }),
       "build:wasm": task("node --experimental-strip-types scripts/build-wasm-package.ts"),
 
@@ -72,31 +119,35 @@ export default defineConfig({
         },
       ),
 
-      check: noopTask(["check:rust", "check:ts"]),
-      "check:rust": task("cargo check --workspace"),
+      check: noopTask(["fmt:rust-check", "lint:rust", "check:ts"]),
+      "check:rust": task("cargo check --workspace --all-targets"),
 
-      clippy: task("cargo clippy --workspace --all-targets -- -D warnings"),
+      clippy: task("cargo clippy --workspace --all-targets -- -D warnings", {
+        dependsOn: ["check:rust"],
+      }),
 
       fmt: noopTask(["fmt:rust", "fmt:ts"]),
       "fmt:rust": task("cargo fmt --all"),
-      "fmt:check": noopTask(["fmt:rust-check", "check:ts"]),
+      "fmt:check": noopTask(["fmt:rust-check", "fmt:ts-check"]),
       "fmt:rust-check": task("cargo fmt --all -- --check"),
-      "fmt:ts": task('vp fmt "npm/*/src" scripts'),
-      "fmt:ts-check": noopTask(["check:ts"]),
+      "fmt:ts": task(vpBuiltin("vp fmt")),
+      "fmt:ts-check": task(vpBuiltin("vp fmt --check")),
 
       lint: noopTask(["lint:rust", "check:ts"]),
-      "lint:rust": task("cargo clippy --workspace --all-targets -- -D warnings"),
+      "lint:rust": task("cargo clippy --workspace --all-targets -- -D warnings", {
+        dependsOn: ["check:rust"],
+      }),
       "lint:ts": noopTask(["check:ts"]),
-      "check:ts": task(
-        'vp check vite.config.ts scripts && vp exec --filter "./npm/*" -- vp check src vite.config.ts',
-      ),
+      "check:ts": task(vpBuiltin("vp check")),
 
       bench: noopTask(["bench:rust", "bench:parse", "bench:bundle"], { cache: false }),
       "bench:rust": uncachedTask("cargo bench --workspace"),
       "bench:parse": uncachedTask("vp run --filter ./benchmarks/bundle-size benchmark:parse"),
       "bench:bundle": uncachedTask("vp run --filter ./benchmarks/bundle-size benchmark"),
 
-      "doc:cargo": task("cargo doc --workspace --no-deps"),
+      "doc:cargo": task("cargo doc --workspace --no-deps", {
+        dependsOn: ["build:napi"],
+      }),
       "doc:cargo-open": uncachedTask("cargo doc --workspace --no-deps --open"),
       clean: uncachedTask("cargo clean"),
       "napi-prepublish": uncachedTask("napi prepublish", {
@@ -136,9 +187,7 @@ export default defineConfig({
           dependsOn: ["build:npm"],
         },
       ),
-      "dev-build": task("vp run --filter ./docs build", {
-        dependsOn: ["build:npm"],
-      }),
+      "dev-build": noopTask(["build:docs"]),
       "dev-preview": uncachedTask("vp run --filter ./docs preview"),
 
       install: uncachedTask("vp install"),


### PR DESCRIPTION
## Summary
- Route root `vp check`, `vp fmt`, `vp dev`, and `vp build` through the workspace task graph.
- Include Rust formatting, checking, clippy, docs, and build steps under those lifecycle commands.
- Update CI, deploy, and development docs to use the unified entry points.

## Validation
- `vp fmt`
- `vp check`
- `vp build`
- `vp dev` startup check for docs and playground, then stopped the local servers

## Notes
- `vp check` still reports the existing triple-slash reference warning in `npm/vite-plugin-ox-content/src/og-image/index.ts`, but exits successfully.
- `vp build` still reports the existing Cargo documentation filename collision warning for `ox_content_i18n`.