### PR TITLE
docs: publish md4x benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,31 +149,33 @@ Supported features include:
 
 Ox Content is positioned both as a document generator and as a high-performance Markdown toolkit. The numbers below focus on the Markdown engine side.
 
-Latest local benchmark sweep on 2026-04-22 with Node `v24.15.0` on Apple M5 Pro. The tables below show median results from 7 local runs of the benchmark harness for the large 48.7 KB case.
+Latest local benchmark sweep on 2026-04-24 with Node `v24.15.0` on Apple M5 Pro. The tables below show median results from 7 local runs of the benchmark harness for the large 48.7 KB case.
 
 ### Parse Only (48.7 KB)
 
 | Library            | ops/sec | avg time |  throughput |
 | ------------------ | ------: | -------: | ----------: |
-| `@ox-content/napi` |    2933 |  0.34 ms | 139.55 MB/s |
-| `md4w (md4c)`      |    1054 |  0.95 ms |  50.16 MB/s |
-| `markdown-it`      |     807 |  1.24 ms |  38.42 MB/s |
-| `marked`           |     512 |  1.95 ms |  24.36 MB/s |
-| `remark`           |      42 | 23.89 ms |   1.99 MB/s |
+| `@ox-content/napi` |    2337 |  0.43 ms | 111.20 MB/s |
+| `md4x (napi)`      |     958 |  1.04 ms |  45.56 MB/s |
+| `md4w (md4c)`      |     884 |  1.13 ms |  42.06 MB/s |
+| `markdown-it`      |     631 |  1.58 ms |  30.04 MB/s |
+| `marked`           |     385 |  2.60 ms |  18.33 MB/s |
+| `remark`           |      33 | 29.97 ms |   1.59 MB/s |
 
 ### Parse + Render (48.7 KB)
 
 | Library             | ops/sec | avg time |  throughput |
 | ------------------- | ------: | -------: | ----------: |
-| `@ox-content/napi`  |    3273 |  0.31 ms | 155.73 MB/s |
-| `Bun.markdown.html` |    2848 |  0.35 ms | 135.52 MB/s |
-| `md4w (md4c)`       |    2608 |  0.38 ms | 124.13 MB/s |
-| `markdown-it`       |     787 |  1.27 ms |  37.44 MB/s |
-| `marked`            |     489 |  2.04 ms |  23.28 MB/s |
-| `micromark`         |      44 | 22.62 ms |   2.10 MB/s |
-| `remark`            |      36 | 28.16 ms |   1.69 MB/s |
+| `Bun.markdown.html` |    3376 |  0.30 ms | 160.67 MB/s |
+| `md4x (napi)`       |    3167 |  0.32 ms | 150.73 MB/s |
+| `@ox-content/napi`  |    2599 |  0.38 ms | 123.66 MB/s |
+| `md4w (md4c)`       |    2253 |  0.44 ms | 107.21 MB/s |
+| `markdown-it`       |     628 |  1.59 ms |  29.91 MB/s |
+| `marked`            |     381 |  2.62 ms |  18.15 MB/s |
+| `micromark`         |      36 | 28.16 ms |   1.69 MB/s |
+| `remark`            |      29 | 34.97 ms |   1.36 MB/s |
 
-In this latest local release-build sweep, Ox Content came out on top for both parse-only and parse+render in the large 48.7 KB case while still serving as the native core for the full documentation pipeline.
+In this latest local release-build sweep, Ox Content stays ahead for parse-only throughput. The parse+render comparison now includes `md4x (napi)`, where Bun and md4x lead the table and Ox Content remains close behind while still serving as the native core for the full documentation pipeline.
 
 Run the benchmark with:
 
@@ -181,7 +183,7 @@ Run the benchmark with:
 node benchmarks/bundle-size/parse-benchmark.mjs
 ```
 
-The script now compares against `md4w (md4c)` by default and will include `Bun.markdown.html` automatically when `bun` is installed.
+The script now compares against `md4w (md4c)` and `md4x (napi)` by default and will include `Bun.markdown.html` automatically when `bun` is installed.
 
 ## Development
 

--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -507,19 +507,20 @@ The Vite plugin supports HMR for Markdown files:
 
 ### Parse and Render Speed
 
-Latest local benchmark sweep on 2026-04-22 with Node `v24.15.0` on Apple M5 Pro. The tables below show median results from 7 local runs of the benchmark harness for the large 48.7 KB case.
+Latest local benchmark sweep on 2026-04-24 with Node `v24.15.0` on Apple M5 Pro. The tables below show median results from 7 local runs of the benchmark harness for the large 48.7 KB case.
 
 | Library             | Parse Only (48.7 KB) | Parse + Render (48.7 KB) |
 | ------------------- | -------------------: | -----------------------: |
-| `@ox-content/napi`  |         2933 ops/sec |             3273 ops/sec |
-| `Bun.markdown.html` |                    - |             2848 ops/sec |
-| `md4w (md4c)`       |         1054 ops/sec |             2608 ops/sec |
-| `markdown-it`       |          807 ops/sec |              787 ops/sec |
-| `marked`            |          512 ops/sec |              489 ops/sec |
-| `micromark`         |                    - |               44 ops/sec |
-| `remark`            |           42 ops/sec |               36 ops/sec |
+| `Bun.markdown.html` |                    - |             3376 ops/sec |
+| `md4x (napi)`       |          958 ops/sec |             3167 ops/sec |
+| `@ox-content/napi`  |         2337 ops/sec |             2599 ops/sec |
+| `md4w (md4c)`       |          884 ops/sec |             2253 ops/sec |
+| `markdown-it`       |          631 ops/sec |              628 ops/sec |
+| `marked`            |          385 ops/sec |              381 ops/sec |
+| `micromark`         |                    - |               36 ops/sec |
+| `remark`            |           33 ops/sec |               29 ops/sec |
 
-This benchmark uses `node benchmarks/bundle-size/parse-benchmark.mjs`. The comparison set now includes `md4w (md4c)` by default, and `Bun.markdown.html` is measured automatically when `bun` is available on the host.
+This benchmark uses `node benchmarks/bundle-size/parse-benchmark.mjs`. The comparison set now includes `md4w (md4c)` and `md4x (napi)` by default, and `Bun.markdown.html` is measured automatically when `bun` is available on the host.
 
 ## Security Considerations
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -90,31 +90,33 @@ Under the hood, Ox Content is not only a docs theme. It also exposes the Markdow
 
 Ox Content is positioned both as a document generator and as a high-performance Markdown toolkit. The numbers below focus on the Markdown engine side.
 
-Latest local benchmark sweep on 2026-04-22 with Node `v24.15.0` on Apple M5 Pro. The tables below show median results from 7 local runs of the benchmark harness for the large 48.7 KB case.
+Latest local benchmark sweep on 2026-04-24 with Node `v24.15.0` on Apple M5 Pro. The tables below show median results from 7 local runs of the benchmark harness for the large 48.7 KB case.
 
 ### Parse Only (48.7 KB)
 
 | Library            | ops/sec | avg time |  throughput |
 | ------------------ | ------: | -------: | ----------: |
-| `@ox-content/napi` |    2933 |  0.34 ms | 139.55 MB/s |
-| `md4w (md4c)`      |    1054 |  0.95 ms |  50.16 MB/s |
-| `markdown-it`      |     807 |  1.24 ms |  38.42 MB/s |
-| `marked`           |     512 |  1.95 ms |  24.36 MB/s |
-| `remark`           |      42 | 23.89 ms |   1.99 MB/s |
+| `@ox-content/napi` |    2337 |  0.43 ms | 111.20 MB/s |
+| `md4x (napi)`      |     958 |  1.04 ms |  45.56 MB/s |
+| `md4w (md4c)`      |     884 |  1.13 ms |  42.06 MB/s |
+| `markdown-it`      |     631 |  1.58 ms |  30.04 MB/s |
+| `marked`           |     385 |  2.60 ms |  18.33 MB/s |
+| `remark`           |      33 | 29.97 ms |   1.59 MB/s |
 
 ### Parse + Render (48.7 KB)
 
 | Library             | ops/sec | avg time |  throughput |
 | ------------------- | ------: | -------: | ----------: |
-| `@ox-content/napi`  |    3273 |  0.31 ms | 155.73 MB/s |
-| `Bun.markdown.html` |    2848 |  0.35 ms | 135.52 MB/s |
-| `md4w (md4c)`       |    2608 |  0.38 ms | 124.13 MB/s |
-| `markdown-it`       |     787 |  1.27 ms |  37.44 MB/s |
-| `marked`            |     489 |  2.04 ms |  23.28 MB/s |
-| `micromark`         |      44 | 22.62 ms |   2.10 MB/s |
-| `remark`            |      36 | 28.16 ms |   1.69 MB/s |
+| `Bun.markdown.html` |    3376 |  0.30 ms | 160.67 MB/s |
+| `md4x (napi)`       |    3167 |  0.32 ms | 150.73 MB/s |
+| `@ox-content/napi`  |    2599 |  0.38 ms | 123.66 MB/s |
+| `md4w (md4c)`       |    2253 |  0.44 ms | 107.21 MB/s |
+| `markdown-it`       |     628 |  1.59 ms |  29.91 MB/s |
+| `marked`            |     381 |  2.62 ms |  18.15 MB/s |
+| `micromark`         |      36 | 28.16 ms |   1.69 MB/s |
+| `remark`            |      29 | 34.97 ms |   1.36 MB/s |
 
-In this latest local release-build sweep, Ox Content came out on top for both parse-only and parse+render in the large 48.7 KB case while still serving as the native core for the full documentation pipeline.
+In this latest local release-build sweep, Ox Content stays ahead for parse-only throughput. The parse+render comparison now includes `md4x (napi)`, where Bun and md4x lead the table and Ox Content remains close behind while still serving as the native core for the full documentation pipeline.
 
 Reproduce with:
 
@@ -122,4 +124,4 @@ Reproduce with:
 node benchmarks/bundle-size/parse-benchmark.mjs
 ```
 
-The benchmark includes `md4w (md4c)` by default and adds `Bun.markdown.html` automatically when `bun` is available.
+The benchmark includes `md4w (md4c)` and `md4x (napi)` by default and adds `Bun.markdown.html` automatically when `bun` is available.

--- a/docs/content/packages/napi.md
+++ b/docs/content/packages/napi.md
@@ -213,29 +213,31 @@ const doc = extractSearchContent(markdown, "hello", "/hello", { gfm: true });
 
 Ox Content is positioned both as a document generator and as a high-performance Markdown toolkit. The numbers below focus on the Markdown engine side.
 
-Latest local benchmark sweep on 2026-04-22 with Node `v24.15.0` on Apple M5 Pro. The tables below show median results from 7 local runs of the benchmark harness for the large 48.7 KB case.
+Latest local benchmark sweep on 2026-04-24 with Node `v24.15.0` on Apple M5 Pro. The tables below show median results from 7 local runs of the benchmark harness for the large 48.7 KB case.
 
 ### Parse Only (48.7 KB)
 
 | Library            | ops/sec | avg time |  throughput |
 | ------------------ | ------: | -------: | ----------: |
-| `@ox-content/napi` |    2933 |  0.34 ms | 139.55 MB/s |
-| `md4w (md4c)`      |    1054 |  0.95 ms |  50.16 MB/s |
-| `markdown-it`      |     807 |  1.24 ms |  38.42 MB/s |
-| `marked`           |     512 |  1.95 ms |  24.36 MB/s |
-| `remark`           |      42 | 23.89 ms |   1.99 MB/s |
+| `@ox-content/napi` |    2337 |  0.43 ms | 111.20 MB/s |
+| `md4x (napi)`      |     958 |  1.04 ms |  45.56 MB/s |
+| `md4w (md4c)`      |     884 |  1.13 ms |  42.06 MB/s |
+| `markdown-it`      |     631 |  1.58 ms |  30.04 MB/s |
+| `marked`           |     385 |  2.60 ms |  18.33 MB/s |
+| `remark`           |      33 | 29.97 ms |   1.59 MB/s |
 
 ### Parse + Render (48.7 KB)
 
 | Library             | ops/sec | avg time |  throughput |
 | ------------------- | ------: | -------: | ----------: |
-| `@ox-content/napi`  |    3273 |  0.31 ms | 155.73 MB/s |
-| `Bun.markdown.html` |    2848 |  0.35 ms | 135.52 MB/s |
-| `md4w (md4c)`       |    2608 |  0.38 ms | 124.13 MB/s |
-| `markdown-it`       |     787 |  1.27 ms |  37.44 MB/s |
-| `marked`            |     489 |  2.04 ms |  23.28 MB/s |
-| `micromark`         |      44 | 22.62 ms |   2.10 MB/s |
-| `remark`            |      36 | 28.16 ms |   1.69 MB/s |
+| `Bun.markdown.html` |    3376 |  0.30 ms | 160.67 MB/s |
+| `md4x (napi)`       |    3167 |  0.32 ms | 150.73 MB/s |
+| `@ox-content/napi`  |    2599 |  0.38 ms | 123.66 MB/s |
+| `md4w (md4c)`       |    2253 |  0.44 ms | 107.21 MB/s |
+| `markdown-it`       |     628 |  1.59 ms |  29.91 MB/s |
+| `marked`            |     381 |  2.62 ms |  18.15 MB/s |
+| `micromark`         |      36 | 28.16 ms |   1.69 MB/s |
+| `remark`            |      29 | 34.97 ms |   1.36 MB/s |
 
 Reproduce with:
 
@@ -243,6 +245,6 @@ Reproduce with:
 node benchmarks/bundle-size/parse-benchmark.mjs
 ```
 
-In this latest local release-build sweep, Ox Content came out on top for both parse-only and parse+render in the large 48.7 KB case while still serving as the native core for the full documentation pipeline.
+In this latest local release-build sweep, Ox Content stays ahead for parse-only throughput. The parse+render comparison now includes `md4x (napi)`, where Bun and md4x lead the table and Ox Content remains close behind while still serving as the native core for the full documentation pipeline.
 
-The benchmark includes `md4w (md4c)` by default and adds `Bun.markdown.html` automatically when `bun` is available.
+The benchmark includes `md4w (md4c)` and `md4x (napi)` by default and adds `Bun.markdown.html` automatically when `bun` is available.


### PR DESCRIPTION
## Summary
- Add md4x benchmark results to the README performance table.
- Update the docs home page, NAPI package page, and architecture performance table with the latest 7-run median sweep.
- Adjust the benchmark summary text now that md4x and Bun lead parse+render while Ox Content remains ahead for parse-only.

## Validation
- `vp run build:napi`
- `node benchmarks/bundle-size/parse-benchmark.mjs`
- 7-run median benchmark collection for the large 48.7 KB case
- `vp fmt README.md docs/content/index.md docs/content/architecture.md docs/content/packages/napi.md --check`