### PR TITLE
perf: speed up markdown render benchmark

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -156,38 +156,60 @@ impl<'a> Parser<'a> {
         }
 
         let start = self.position;
+        let line = self.remaining().lines().next().unwrap_or("");
+        let trimmed = line.trim_start();
+        let first = trimmed.as_bytes().first().copied();
 
         // Try to parse different block types
-        if self.try_parse_heading() {
-            return self.parse_heading(start);
+        match first {
+            Some(b'#') if self.try_parse_heading() => return self.parse_heading(start),
+            Some(b'-' | b'*') => {
+                if self.try_parse_thematic_break() {
+                    return self.parse_thematic_break(start);
+                }
+                if self.try_parse_list() {
+                    return self.parse_list(start);
+                }
+            }
+            Some(b'_') if self.try_parse_thematic_break() => {
+                return self.parse_thematic_break(start);
+            }
+            Some(b'>') => return self.parse_block_quote(start),
+            Some(b'`' | b'~') if self.try_parse_fenced_code() => {
+                return self.parse_fenced_code(start);
+            }
+            Some(b'<') if self.try_parse_html_block() => return self.parse_html_block(start),
+            Some(b'+' | b'0'..=b'9') if self.try_parse_list() => {
+                return self.parse_list(start);
+            }
+            _ => {}
         }
 
-        if self.try_parse_thematic_break() {
-            return self.parse_thematic_break(start);
-        }
-
-        if self.try_parse_block_quote() {
-            return self.parse_block_quote(start);
-        }
-
-        if self.try_parse_fenced_code() {
-            return self.parse_fenced_code(start);
-        }
-
-        if self.try_parse_html_block() {
-            return self.parse_html_block(start);
-        }
-
-        if self.options.tables && self.try_parse_table() {
+        if self.options.tables && line.contains('|') && self.try_parse_table() {
             return self.parse_table(start);
-        }
-
-        if self.try_parse_list() {
-            return self.parse_list(start);
         }
 
         // Default: parse as paragraph
         self.parse_paragraph(start)
+    }
+
+    fn line_starts_block(&self) -> bool {
+        let line = self.remaining().lines().next().unwrap_or("");
+        let trimmed = line.trim_start();
+        let first = trimmed.as_bytes().first().copied();
+
+        let starts_block = match first {
+            Some(b'#') => self.try_parse_heading(),
+            Some(b'-' | b'*') => self.try_parse_thematic_break() || self.try_parse_list(),
+            Some(b'_') => self.try_parse_thematic_break(),
+            Some(b'>') => self.try_parse_block_quote(),
+            Some(b'`' | b'~') => self.try_parse_fenced_code(),
+            Some(b'<') => self.try_parse_html_block(),
+            Some(b'+' | b'0'..=b'9') => self.try_parse_list(),
+            _ => false,
+        };
+
+        starts_block || (self.options.tables && line.contains('|') && self.try_parse_table())
     }
 
     fn try_parse_html_block(&self) -> bool {
@@ -913,14 +935,7 @@ impl<'a> Parser<'a> {
             self.position = line_start;
 
             // Check for block-level element that would end paragraph
-            if self.try_parse_heading()
-                || self.try_parse_thematic_break()
-                || self.try_parse_block_quote()
-                || self.try_parse_fenced_code()
-                || self.try_parse_html_block()
-                || (self.options.tables && self.try_parse_table())
-                || self.try_parse_list()
-            {
+            if self.line_starts_block() {
                 break;
             }
 

--- a/crates/ox_content_renderer/src/html.rs
+++ b/crates/ox_content_renderer/src/html.rs
@@ -533,6 +533,18 @@ fn normalize_code_block_info(lang: Option<&str>, meta: Option<&str>) -> Normaliz
     NormalizedCodeBlockInfo { language, meta: meta_parts.join(" ") }
 }
 
+fn normalize_code_block_language(lang: Option<&str>) -> Option<&str> {
+    let raw_lang = lang.map(str::trim).filter(|value| !value.is_empty())?;
+    let (language, _) = split_code_block_language_token(raw_lang);
+    let language = language.trim();
+
+    if language.is_empty() {
+        None
+    } else {
+        Some(language)
+    }
+}
+
 fn apply_annotation_numbers(
     lines: &mut [CodeLineRenderState],
     line_numbers: &[usize],
@@ -1208,6 +1220,19 @@ impl<'a> Visit<'a> for HtmlRenderer {
     }
 
     fn visit_code_block(&mut self, code_block: &CodeBlock<'a>) {
+        if !self.options.code_annotations {
+            self.write("<pre><code");
+            if let Some(lang) = normalize_code_block_language(code_block.lang) {
+                self.write(" class=\"language-");
+                self.write_escaped(lang);
+                self.write("\"");
+            }
+            self.write(">");
+            self.write_escaped(code_block.value);
+            self.write("</code></pre>\n");
+            return;
+        }
+
         let state = self.build_code_block_state(code_block);
         let block_classes = state.block_classes();
 
@@ -1302,8 +1327,12 @@ impl<'a> Visit<'a> for HtmlRenderer {
 
     fn visit_link(&mut self, link: &Link<'a>) {
         self.write("<a href=\"");
-        let url = self.convert_md_url(link.url);
-        self.write_url_escaped(&url);
+        if self.options.convert_md_links {
+            let url = self.convert_md_url(link.url);
+            self.write_url_escaped(&url);
+        } else {
+            self.write_url_escaped(link.url);
+        }
         self.write("\"");
         // Add target="_blank" for external links (http:// or https://)
         if link.url.starts_with("http://") || link.url.starts_with("https://") {


### PR DESCRIPTION
## Summary
- dispatch block parsing from the current line marker to avoid unnecessary parser probes
- fast-path standard code block HTML rendering when annotations are disabled
- skip markdown-link conversion work unless that option is enabled

## Benchmarks
`node benchmarks/bundle-size/parse-benchmark.mjs` (7-run median, LARGE Parse + Render):
- `@ox-content/napi`: 3199 ops/sec
- `md4x (napi)`: 2836 ops/sec
- `Bun.markdown.html`: 3004 ops/sec

## Validation
- `cargo test -p ox_content_parser -p ox_content_renderer`
- `vp run build:napi`
- `vp fmt --check`
- `vp check` (passes with existing triple-slash warning)
- `vp build` (passes with existing build warnings)
