### PR TITLE
feat: add pull request benchmark comments

### DIFF
--- a/.github/scripts/comment-pr-benchmark.mjs
+++ b/.github/scripts/comment-pr-benchmark.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const COMMENT_MARKER = "<!-- ox-content-benchmark-report -->";
+
+const token = requiredEnv("GITHUB_TOKEN");
+const [owner, repo] = requiredEnv("GITHUB_REPOSITORY").split("/");
+const event = JSON.parse(readFileSync(requiredEnv("GITHUB_EVENT_PATH"), "utf8"));
+const issueNumber = event.pull_request?.number ?? event.number;
+
+if (!owner || !repo) {
+  throw new Error("GITHUB_REPOSITORY must be in owner/repo format");
+}
+if (!issueNumber) {
+  throw new Error("Pull request number was not found in the event payload");
+}
+
+const body = readFileSync(requiredEnv("COMMENT_PATH"), "utf8");
+const comments = await listComments(owner, repo, issueNumber);
+const previous = comments.find((comment) => {
+  return comment.user?.type === "Bot" && comment.body?.includes(COMMENT_MARKER);
+});
+
+if (previous) {
+  await request(`/repos/${owner}/${repo}/issues/comments/${previous.id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ body }),
+  });
+} else {
+  await request(`/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
+    method: "POST",
+    body: JSON.stringify({ body }),
+  });
+}
+
+/**
+ * @param {string} owner
+ * @param {string} repo
+ * @param {number} issueNumber
+ * @returns {Promise<unknown[]>}
+ */
+async function listComments(owner, repo, issueNumber) {
+  const comments = [];
+
+  for (let page = 1; ; page++) {
+    const pageComments = await request(
+      `/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
+    );
+    comments.push(...pageComments);
+    if (pageComments.length < 100) {
+      return comments;
+    }
+  }
+}
+
+/**
+ * @param {string} path
+ * @param {RequestInit} init
+ * @returns {Promise<any>}
+ */
+async function request(path, init = {}) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  if (!response.ok) {
+    const responseBody = await response.text();
+    throw new Error(`GitHub API request failed: ${response.status} ${responseBody}`);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  return response.json();
+}
+
+/**
+ * @param {string} name
+ * @returns {string}
+ */
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+
+  return value;
+}

--- a/.github/scripts/compare-pr-benchmark.mjs
+++ b/.github/scripts/compare-pr-benchmark.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { appendFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const runnerTemp = requiredEnv("RUNNER_TEMP");
+const commentPath = join(runnerTemp, "benchmark-comment.md");
+
+run("node", [
+  "benchmarks/bundle-size/compare-pr-benchmark.mjs",
+  "--base",
+  join(runnerTemp, "benchmark-base.json"),
+  "--head",
+  join(runnerTemp, "benchmark-head.json"),
+  "--base-bundle",
+  join(runnerTemp, "bundle-base.json"),
+  "--head-bundle",
+  join(runnerTemp, "bundle-head.json"),
+  "--output",
+  commentPath,
+  "--base-sha",
+  requiredEnv("BASE_SHA"),
+  "--head-sha",
+  requiredEnv("HEAD_SHA"),
+]);
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${readFileSync(commentPath, "utf8")}\n`);
+}
+
+/**
+ * @param {string} name
+ * @returns {string}
+ */
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+
+  return value;
+}
+
+/**
+ * @param {string} command
+ * @param {string[]} args
+ */
+function run(command, args) {
+  const result = spawnSync(command, args, { stdio: "inherit" });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}

--- a/.github/scripts/run-pr-benchmark.mjs
+++ b/.github/scripts/run-pr-benchmark.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { copyFileSync, mkdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+const options = parseOptions(process.argv.slice(2));
+const checkoutRoot = process.cwd();
+const sourceRoot = resolve(options.source ?? requiredEnv("GITHUB_WORKSPACE"));
+
+for (const file of [
+  "benchmarks/bundle-size/parse-benchmark.mjs",
+  "benchmarks/bundle-size/parse-benchmark-bun.mjs",
+  "benchmarks/bundle-size/measure.mjs",
+]) {
+  const from = join(sourceRoot, file);
+  const to = join(checkoutRoot, file);
+  mkdirSync(dirname(to), { recursive: true });
+  copyFileSync(from, to);
+}
+
+run("vp", ["install"]);
+run("vp", ["run", "build:npm"]);
+run("node", [
+  "benchmarks/bundle-size/parse-benchmark.mjs",
+  "--runs",
+  "3",
+  "--json",
+  options.runtimeJson,
+]);
+run("node", ["benchmarks/bundle-size/measure.mjs", "--skip-install", "--json", options.bundleJson]);
+
+/**
+ * @param {string[]} args
+ * @returns {{ source: string | null; runtimeJson: string; bundleJson: string }}
+ */
+function parseOptions(args) {
+  const parsed = {
+    source: null,
+    runtimeJson: null,
+    bundleJson: null,
+  };
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === "--source") {
+      parsed.source = readOptionValue(args, ++index, "--source");
+      continue;
+    }
+    if (arg === "--runtime-json") {
+      parsed.runtimeJson = readOptionValue(args, ++index, "--runtime-json");
+      continue;
+    }
+    if (arg === "--bundle-json") {
+      parsed.bundleJson = readOptionValue(args, ++index, "--bundle-json");
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!parsed.runtimeJson) {
+    throw new Error("--runtime-json is required");
+  }
+  if (!parsed.bundleJson) {
+    throw new Error("--bundle-json is required");
+  }
+
+  return parsed;
+}
+
+/**
+ * @param {string[]} args
+ * @param {number} index
+ * @param {string} optionName
+ * @returns {string}
+ */
+function readOptionValue(args, index, optionName) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${optionName} requires a value`);
+  }
+
+  return value;
+}
+
+/**
+ * @param {string} name
+ * @returns {string}
+ */
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+
+  return value;
+}
+
+/**
+ * @param {string} command
+ * @param {string[]} args
+ */
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: checkoutRoot,
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,71 @@
+name: Benchmark
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: /tmp/ox-content-cargo-target
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout base
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .benchmark/base
+
+      - name: Checkout head
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: .benchmark/head
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Benchmark base
+        working-directory: .benchmark/base
+        run: node "$GITHUB_WORKSPACE/.github/scripts/run-pr-benchmark.mjs" --source "$GITHUB_WORKSPACE" --runtime-json "$RUNNER_TEMP/benchmark-base.json" --bundle-json "$RUNNER_TEMP/bundle-base.json"
+
+      - name: Benchmark head
+        working-directory: .benchmark/head
+        run: node "$GITHUB_WORKSPACE/.github/scripts/run-pr-benchmark.mjs" --source "$GITHUB_WORKSPACE" --runtime-json "$RUNNER_TEMP/benchmark-head.json" --bundle-json "$RUNNER_TEMP/bundle-head.json"
+
+      - name: Compare benchmarks
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        working-directory: .benchmark/head
+        run: node "$GITHUB_WORKSPACE/.github/scripts/compare-pr-benchmark.mjs"
+
+      - name: Comment on pull request
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          COMMENT_PATH: ${{ runner.temp }}/benchmark-comment.md
+        run: node "$GITHUB_WORKSPACE/.github/scripts/comment-pr-benchmark.mjs"

--- a/benchmarks/bundle-size/compare-pr-benchmark.mjs
+++ b/benchmarks/bundle-size/compare-pr-benchmark.mjs
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const COMMENT_MARKER = "<!-- ox-content-benchmark-report -->";
+const TARGET_NAMES = new Set(["@ox-content/napi", "@ox-content/napi (async)"]);
+const COMMENT_SIZE_NAMES = new Set(["large"]);
+const NOISE_THRESHOLD_PERCENT = 5;
+const BUNDLE_APP_ORDER = [
+  "ox-content (bare)",
+  "ox-content (default)",
+  "ox-content + Vue",
+  "VitePress (bare)",
+  "VitePress (default)",
+  "Astro",
+  "Astro + Vue",
+];
+
+const SUITE_LABELS = {
+  parseOnly: "Parse only",
+  parseAndRender: "Parse + render",
+  parseAndRenderAsync: "Parse + render async",
+};
+
+const SIZE_ORDER = ["small", "medium", "large"];
+const SUITE_ORDER = ["parseOnly", "parseAndRender", "parseAndRenderAsync"];
+
+const options = parseOptions(process.argv.slice(2));
+const body = buildComment(options);
+
+if (options.outputPath) {
+  writeFileSync(options.outputPath, body);
+}
+
+console.log(body);
+
+function parseOptions(args) {
+  const parsed = {
+    basePath: null,
+    headPath: null,
+    baseBundlePath: null,
+    headBundlePath: null,
+    outputPath: null,
+    baseSha: null,
+    headSha: null,
+  };
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === "--base") {
+      parsed.basePath = readOptionValue(args, ++index, "--base");
+      continue;
+    }
+    if (arg === "--head") {
+      parsed.headPath = readOptionValue(args, ++index, "--head");
+      continue;
+    }
+    if (arg === "--base-bundle") {
+      parsed.baseBundlePath = readOptionValue(args, ++index, "--base-bundle");
+      continue;
+    }
+    if (arg === "--head-bundle") {
+      parsed.headBundlePath = readOptionValue(args, ++index, "--head-bundle");
+      continue;
+    }
+    if (arg === "--output") {
+      parsed.outputPath = readOptionValue(args, ++index, "--output");
+      continue;
+    }
+    if (arg === "--base-sha") {
+      parsed.baseSha = readOptionValue(args, ++index, "--base-sha");
+      continue;
+    }
+    if (arg === "--head-sha") {
+      parsed.headSha = readOptionValue(args, ++index, "--head-sha");
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!parsed.basePath || !parsed.headPath) {
+    throw new Error("--base and --head are required");
+  }
+  if (Boolean(parsed.baseBundlePath) !== Boolean(parsed.headBundlePath)) {
+    throw new Error("--base-bundle and --head-bundle must be used together");
+  }
+
+  return parsed;
+}
+
+function readOptionValue(args, index, optionName) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${optionName} requires a value`);
+  }
+
+  return value;
+}
+
+function printUsage() {
+  console.log(`Usage: node compare-pr-benchmark.mjs --base <path> --head <path> [--output <path>]
+
+Options:
+  --base <path>      Base benchmark JSON
+  --head <path>      Head benchmark JSON
+  --base-bundle <path> Base bundle size JSON
+  --head-bundle <path> Head bundle size JSON
+  --output <path>    Write the Markdown comment to a file
+  --base-sha <sha>   Base commit SHA for the heading
+  --head-sha <sha>   Head commit SHA for the heading
+  -h, --help         Show this help message`);
+}
+
+function buildComment({ basePath, headPath, baseBundlePath, headBundlePath, baseSha, headSha }) {
+  const base = readJson(basePath);
+  const head = readJson(headPath);
+  const runtimeRows = compareRuntimeReports(base, head);
+  const bundleRows =
+    baseBundlePath && headBundlePath
+      ? compareBundleReports(readJson(baseBundlePath), readJson(headBundlePath))
+      : [];
+  const summary = summarizeRows(runtimeRows, bundleRows);
+  const compareText =
+    baseSha && headSha
+      ? `Comparing base \`${shortSha(baseSha)}\` to head \`${shortSha(headSha)}\`.`
+      : "Comparing base to head.";
+
+  const lines = [
+    COMMENT_MARKER,
+    "## Benchmark report",
+    "",
+    `${summary} ${compareText}`,
+    "",
+    "### Runtime",
+    "",
+    "| Suite | Size | Target | Base ops/sec | Head ops/sec | Delta |",
+    "| --- | --- | --- | ---: | ---: | ---: |",
+  ];
+
+  if (runtimeRows.length === 0) {
+    lines.push("| n/a | n/a | n/a | n/a | n/a | n/a |");
+  } else {
+    for (const row of runtimeRows) {
+      lines.push(
+        `| ${row.suiteLabel} | ${row.sizeName} | ${row.targetName} | ${formatOps(row.baseOps)} | ${formatOps(row.headOps)} | ${formatDelta(row.deltaPercent)} |`,
+      );
+    }
+  }
+
+  lines.push(
+    "",
+    `Values are from the large parse/render benchmark. Higher ops/sec is better; changes within +/-${NOISE_THRESHOLD_PERCENT}% are treated as noise.`,
+    "",
+  );
+
+  if (baseBundlePath && headBundlePath) {
+    lines.push(
+      "### Bundle Size",
+      "",
+      "| App | Base gzip | Head gzip | Delta | Base requests | Head requests | Base files | Head files |",
+      "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    );
+
+    if (bundleRows.length === 0) {
+      lines.push("| n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |");
+    } else {
+      for (const row of bundleRows) {
+        lines.push(
+          `| ${String(row.name)} | ${formatBytes(row.baseGzipped)} | ${formatBytes(row.headGzipped)} | ${formatDelta(row.deltaPercent)} | ${formatNumber(row.baseRequests)} | ${formatNumber(row.headRequests)} | ${formatNumber(row.baseFiles)} | ${formatNumber(row.headFiles)} |`,
+        );
+      }
+    }
+
+    lines.push(
+      "",
+      "Bundle size uses gzipped JS/CSS/HTML/JSON assets. Requests estimate index.html plus referenced local initial assets. Lower is better.",
+      "",
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function compareRuntimeReports(base, head) {
+  const baseRows = new Map(collectRows(base).map((row) => [row.key, row]));
+  const headRows = new Map(collectRows(head).map((row) => [row.key, row]));
+  const keys = [...new Set([...baseRows.keys(), ...headRows.keys()])];
+
+  return keys.sort(compareKeys).map((key) => {
+    const baseRow = baseRows.get(key);
+    const headRow = headRows.get(key);
+    const baseOps = baseRow?.opsPerSec ?? null;
+    const headOps = headRow?.opsPerSec ?? null;
+    return {
+      key,
+      suiteKey: headRow?.suiteKey ?? baseRow?.suiteKey ?? "unknown",
+      suiteLabel: SUITE_LABELS[headRow?.suiteKey ?? baseRow?.suiteKey] ?? "Unknown",
+      sizeName: headRow?.sizeName ?? baseRow?.sizeName ?? "unknown",
+      targetName: headRow?.targetName ?? baseRow?.targetName ?? "unknown",
+      baseOps,
+      headOps,
+      deltaPercent: percentChange(baseOps, headOps),
+    };
+  });
+}
+
+function compareBundleReports(base, head) {
+  const baseRows = new Map(collectBundleRows(base).map((row) => [row.name, row]));
+  const headRows = new Map(collectBundleRows(head).map((row) => [row.name, row]));
+  const names = [...new Set([...baseRows.keys(), ...headRows.keys()])];
+
+  return names.sort(compareBundleNames).map((name) => {
+    const baseRow = baseRows.get(name);
+    const headRow = headRows.get(name);
+    const baseGzipped = baseRow?.gzipped ?? null;
+    const headGzipped = headRow?.gzipped ?? null;
+
+    return {
+      name,
+      baseGzipped,
+      headGzipped,
+      baseRequests: baseRow?.requests ?? null,
+      headRequests: headRow?.requests ?? null,
+      baseFiles: baseRow?.files ?? null,
+      headFiles: headRow?.files ?? null,
+      deltaPercent: percentChange(baseGzipped, headGzipped),
+    };
+  });
+}
+
+function collectBundleRows(report) {
+  return (report.results ?? [])
+    .filter((result) => !result.error)
+    .map((result) => ({
+      name: String(result.name),
+      gzipped: Number(result.gzipped),
+      requests: Number(result.requests),
+      files: Number(result.files),
+    }));
+}
+
+function collectRows(report) {
+  const rows = [];
+
+  for (const [sizeName, sizeReport] of Object.entries(report.sizes ?? {})) {
+    for (const [suiteKey, results] of Object.entries(sizeReport.suites ?? {})) {
+      for (const result of results) {
+        if (!TARGET_NAMES.has(result.name) || result.error) {
+          continue;
+        }
+        if (!COMMENT_SIZE_NAMES.has(sizeName)) {
+          continue;
+        }
+
+        rows.push({
+          key: `${sizeName}:${suiteKey}:${result.name}`,
+          sizeName,
+          suiteKey,
+          targetName: result.name,
+          opsPerSec: result.opsPerSec,
+        });
+      }
+    }
+  }
+
+  return rows;
+}
+
+function compareKeys(left, right) {
+  const [leftSize, leftSuite, leftName] = left.split(":");
+  const [rightSize, rightSuite, rightName] = right.split(":");
+  const sizeDiff = orderIndex(SIZE_ORDER, leftSize) - orderIndex(SIZE_ORDER, rightSize);
+  if (sizeDiff !== 0) {
+    return sizeDiff;
+  }
+
+  const suiteDiff = orderIndex(SUITE_ORDER, leftSuite) - orderIndex(SUITE_ORDER, rightSuite);
+  if (suiteDiff !== 0) {
+    return suiteDiff;
+  }
+
+  return leftName.localeCompare(rightName);
+}
+
+function compareBundleNames(left, right) {
+  const appDiff = orderIndex(BUNDLE_APP_ORDER, left) - orderIndex(BUNDLE_APP_ORDER, right);
+  if (appDiff !== 0) {
+    return appDiff;
+  }
+
+  return left.localeCompare(right);
+}
+
+function orderIndex(order, value) {
+  const index = order.indexOf(value);
+  return index === -1 ? order.length : index;
+}
+
+function percentChange(baseValue, headValue) {
+  if (!Number.isFinite(baseValue) || !Number.isFinite(headValue) || baseValue <= 0) {
+    return null;
+  }
+
+  return ((headValue - baseValue) / baseValue) * 100;
+}
+
+function summarizeRows(runtimeRows, bundleRows) {
+  const runtimeCount = runtimeRows.filter((row) => row.deltaPercent !== null).length;
+  const bundleCount = bundleRows.filter((row) => row.deltaPercent !== null).length;
+
+  if (runtimeCount === 0 && bundleCount === 0) {
+    return "No comparable benchmark rows were found.";
+  }
+
+  const parts = [];
+  if (runtimeCount > 0) {
+    parts.push(`${runtimeCount} runtime row${runtimeCount === 1 ? "" : "s"}`);
+  }
+  if (bundleCount > 0) {
+    parts.push(`${bundleCount} bundle row${bundleCount === 1 ? "" : "s"}`);
+  }
+
+  return `${parts.join(" and ")} compared.`;
+}
+
+function formatOps(value) {
+  return formatNumber(value);
+}
+
+function formatNumber(value) {
+  if (!Number.isFinite(value)) {
+    return "n/a";
+  }
+
+  return Math.round(value).toLocaleString("en-US");
+}
+
+function formatBytes(value) {
+  if (!Number.isFinite(value)) {
+    return "n/a";
+  }
+  if (value < 1024) {
+    return `${value} B`;
+  }
+  if (value < 1024 * 1024) {
+    return `${(value / 1024).toFixed(1)} KB`;
+  }
+
+  return `${(value / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function formatDelta(value) {
+  if (!Number.isFinite(value)) {
+    return "n/a";
+  }
+
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(2)}%`;
+}
+
+function shortSha(value) {
+  return value.slice(0, 7);
+}

--- a/benchmarks/bundle-size/measure.mjs
+++ b/benchmarks/bundle-size/measure.mjs
@@ -1,11 +1,12 @@
 import { execSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { gzipSizeSync } from "gzip-size";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const WORKSPACE_ROOT = join(__dirname, "..", "..");
+const options = parseOptions(process.argv.slice(2));
 
 /**
  * Get total size of a directory
@@ -43,6 +44,228 @@ function getDirSize(dir) {
 
   walk(dir);
   return { total, gzipped, files };
+}
+
+/**
+ * Estimate the initial request count for the root document and its local assets.
+ * @param {string} distDir
+ * @returns {number}
+ */
+function getInitialRequestCount(distDir) {
+  const indexPath = join(distDir, "index.html");
+  if (!existsSync(indexPath)) {
+    return 0;
+  }
+
+  const resources = new Set();
+  collectHtmlResourceUrls(readFileSync(indexPath, "utf8"), resources);
+  collectCssResourceUrls(distDir, resources);
+
+  return 1 + resources.size;
+}
+
+/**
+ * @param {string} html
+ * @param {Set<string>} resources
+ */
+function collectHtmlResourceUrls(html, resources) {
+  const tagPattern = /<([a-zA-Z][\w:-]*)\b[^>]*>/g;
+  for (const match of html.matchAll(tagPattern)) {
+    const tagName = match[1].toLowerCase();
+    const attrs = parseAttributes(match[0]);
+
+    if (tagName === "script") {
+      addResource(resources, attrs.get("src"));
+    }
+
+    if (tagName === "link" && isInitialLink(attrs)) {
+      addResource(resources, attrs.get("href"));
+    }
+
+    if (tagName === "img" || tagName === "source") {
+      addResource(resources, attrs.get("src"));
+      addSrcsetResources(resources, attrs.get("srcset"));
+    }
+
+    addResource(resources, attrs.get("component-url"));
+    addResource(resources, attrs.get("renderer-url"));
+    addResource(resources, attrs.get("before-hydration-url"));
+  }
+}
+
+/**
+ * @param {string} tag
+ * @returns {Map<string, string>}
+ */
+function parseAttributes(tag) {
+  const attrs = new Map();
+  const attrPattern = /([:\w-]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+  for (const match of tag.matchAll(attrPattern)) {
+    const [, name, doubleQuoted, singleQuoted, unquoted] = match;
+    const value = doubleQuoted ?? singleQuoted ?? unquoted;
+    if (value !== undefined) {
+      attrs.set(name.toLowerCase(), value);
+    }
+  }
+
+  return attrs;
+}
+
+/**
+ * @param {Map<string, string>} attrs
+ * @returns {boolean}
+ */
+function isInitialLink(attrs) {
+  const href = attrs.get("href");
+  if (!href) {
+    return false;
+  }
+
+  const rel = attrs.get("rel")?.toLowerCase() ?? "";
+  const rels = new Set(rel.split(/\s+/).filter(Boolean));
+  return (
+    rels.has("stylesheet") ||
+    rels.has("preload") ||
+    rels.has("modulepreload") ||
+    rels.has("icon") ||
+    rels.has("apple-touch-icon") ||
+    rels.has("manifest")
+  );
+}
+
+/**
+ * @param {Set<string>} resources
+ * @param {string | undefined} srcset
+ */
+function addSrcsetResources(resources, srcset) {
+  if (!srcset) {
+    return;
+  }
+
+  for (const candidate of srcset.split(",")) {
+    const url = candidate.trim().split(/\s+/)[0];
+    addResource(resources, url);
+  }
+}
+
+/**
+ * @param {string} distDir
+ * @param {Set<string>} resources
+ */
+function collectCssResourceUrls(distDir, resources) {
+  const visitedCss = new Set();
+  const cssQueue = [...resources].filter(isCssPath);
+
+  while (cssQueue.length > 0) {
+    const cssPath = cssQueue.shift();
+    if (!cssPath || visitedCss.has(cssPath)) {
+      continue;
+    }
+
+    visitedCss.add(cssPath);
+    const fullPath = join(distDir, cssPath);
+    if (!isInsideDir(fullPath, distDir) || !existsSync(fullPath)) {
+      continue;
+    }
+
+    const css = readFileSync(fullPath, "utf8");
+    const discovered = extractCssUrls(css);
+    for (const url of discovered) {
+      const added = addResource(resources, url, `/${cssPath}`);
+      const resourcePath = normalizeLocalUrl(url, `/${cssPath}`);
+      if (added && resourcePath && isCssPath(resourcePath)) {
+        cssQueue.push(resourcePath);
+      }
+    }
+  }
+}
+
+/**
+ * @param {string} css
+ * @returns {string[]}
+ */
+function extractCssUrls(css) {
+  const urls = [];
+  const urlPattern = /url\(\s*(?:"([^"]+)"|'([^']+)'|([^'")]+))\s*\)/g;
+  for (const match of css.matchAll(urlPattern)) {
+    urls.push(match[1] ?? match[2] ?? match[3]);
+  }
+
+  const importPattern = /@import\s+(?:url\(\s*)?(?:"([^"]+)"|'([^']+)'|([^'")\s;]+))/g;
+  for (const match of css.matchAll(importPattern)) {
+    urls.push(match[1] ?? match[2] ?? match[3]);
+  }
+
+  return urls;
+}
+
+/**
+ * @param {Set<string>} resources
+ * @param {string | undefined} rawUrl
+ * @param {string} basePath
+ * @returns {boolean}
+ */
+function addResource(resources, rawUrl, basePath = "/index.html") {
+  const resourcePath = normalizeLocalUrl(rawUrl, basePath);
+  if (!resourcePath) {
+    return false;
+  }
+
+  const previousSize = resources.size;
+  resources.add(resourcePath);
+  return resources.size !== previousSize;
+}
+
+/**
+ * @param {string | undefined} rawUrl
+ * @param {string} basePath
+ * @returns {string | null}
+ */
+function normalizeLocalUrl(rawUrl, basePath) {
+  const value = rawUrl?.trim();
+  if (!value || value.startsWith("#") || value.startsWith("//")) {
+    return null;
+  }
+  if (/^(?:data|blob|mailto|tel|javascript):/i.test(value)) {
+    return null;
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(value, `https://benchmark.local${basePath}`);
+  } catch {
+    return null;
+  }
+
+  if (parsed.origin !== "https://benchmark.local") {
+    return null;
+  }
+
+  const pathname = decodeURIComponent(parsed.pathname).replace(/^\/+/, "");
+  if (!pathname || pathname.endsWith("/")) {
+    return null;
+  }
+
+  return pathname;
+}
+
+/**
+ * @param {string} path
+ * @returns {boolean}
+ */
+function isCssPath(path) {
+  return /\.css$/i.test(path);
+}
+
+/**
+ * @param {string} filePath
+ * @param {string} dir
+ * @returns {boolean}
+ */
+function isInsideDir(filePath, dir) {
+  const resolvedFilePath = resolve(filePath);
+  const resolvedDir = resolve(dir);
+  return resolvedFilePath === resolvedDir || resolvedFilePath.startsWith(`${resolvedDir}/`);
 }
 
 /**
@@ -110,14 +333,91 @@ const apps = [
   },
 ];
 
-async function main() {
-  const skipBuild = process.argv.includes("--skip-build");
+/**
+ * @param {string[]} args
+ * @returns {{ jsonPath: string | null; skipBuild: boolean; skipInstall: boolean }}
+ */
+function parseOptions(args) {
+  const parsed = {
+    jsonPath: null,
+    skipBuild: false,
+    skipInstall: false,
+  };
 
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === "--json") {
+      parsed.jsonPath = readOptionValue(args, ++index, "--json");
+      continue;
+    }
+    if (arg.startsWith("--json=")) {
+      parsed.jsonPath = readInlineOptionValue(arg, "--json");
+      continue;
+    }
+    if (arg === "--skip-build") {
+      parsed.skipBuild = true;
+      continue;
+    }
+    if (arg === "--skip-install") {
+      parsed.skipInstall = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return parsed;
+}
+
+/**
+ * @param {string[]} args
+ * @param {number} index
+ * @param {string} optionName
+ * @returns {string}
+ */
+function readOptionValue(args, index, optionName) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${optionName} requires a file path`);
+  }
+
+  return value;
+}
+
+/**
+ * @param {string} arg
+ * @param {string} optionName
+ * @returns {string}
+ */
+function readInlineOptionValue(arg, optionName) {
+  const value = arg.slice(`${optionName}=`.length);
+  if (!value) {
+    throw new Error(`${optionName} requires a file path`);
+  }
+
+  return value;
+}
+
+function printUsage() {
+  console.log(`Usage: node measure.mjs [--json <path>] [--skip-build] [--skip-install]
+
+Options:
+  --json <path>    Write benchmark results as JSON
+  --skip-build     Measure existing build outputs without rebuilding
+  --skip-install   Skip workspace install before building
+  -h, --help       Show this help message`);
+}
+
+async function main() {
   console.log("Bundle Size Benchmark");
   console.log("=====================\n");
 
   // Install dependencies
-  if (!skipBuild) {
+  if (!options.skipBuild && !options.skipInstall) {
     console.log("Installing workspace dependencies...\n");
     try {
       const installCmd = existsSync(join(WORKSPACE_ROOT, "node_modules/.bin/vp"))
@@ -137,7 +437,7 @@ async function main() {
   for (const app of apps) {
     console.log(`Building ${app.name}...`);
 
-    if (!skipBuild) {
+    if (!options.skipBuild) {
       try {
         execSync(app.buildCmd, { cwd: app.dir, stdio: "pipe" });
       } catch (e) {
@@ -147,6 +447,7 @@ async function main() {
           total: -1,
           gzipped: -1,
           files: 0,
+          requests: 0,
           error: true,
         });
         continue;
@@ -154,7 +455,10 @@ async function main() {
     }
 
     const distPath = join(app.dir, app.distDir);
-    const size = getDirSize(distPath);
+    const size = {
+      ...getDirSize(distPath),
+      requests: getInitialRequestCount(distPath),
+    };
 
     results.push({
       name: app.name,
@@ -163,6 +467,7 @@ async function main() {
 
     console.log(`  Total: ${formatBytes(size.total)}`);
     console.log(`  Gzipped: ${formatBytes(size.gzipped)}`);
+    console.log(`  Requests: ${size.requests}`);
     console.log(`  Files: ${size.files}\n`);
   }
 
@@ -188,18 +493,19 @@ async function main() {
   const totalWidth = 10;
   const gzippedWidth = 10;
   const ratioWidth = 9;
+  const requestsWidth = 8;
   const filesWidth = 5;
 
   // Print markdown table
-  const header = `| ${"Framework".padEnd(nameWidth)} | ${"Total".padEnd(totalWidth)} | ${"Gzipped".padEnd(gzippedWidth)} | ${"Ratio".padEnd(ratioWidth)} | ${"Files".padEnd(filesWidth)} |`;
-  const separator = `|${"-".repeat(nameWidth + 2)}|${"-".repeat(totalWidth + 2)}|${"-".repeat(gzippedWidth + 2)}|${"-".repeat(ratioWidth + 2)}|${"-".repeat(filesWidth + 2)}|`;
+  const header = `| ${"Framework".padEnd(nameWidth)} | ${"Total".padEnd(totalWidth)} | ${"Gzipped".padEnd(gzippedWidth)} | ${"Ratio".padEnd(ratioWidth)} | ${"Requests".padEnd(requestsWidth)} | ${"Files".padEnd(filesWidth)} |`;
+  const separator = `|${"-".repeat(nameWidth + 2)}|${"-".repeat(totalWidth + 2)}|${"-".repeat(gzippedWidth + 2)}|${"-".repeat(ratioWidth + 2)}|${"-".repeat(requestsWidth + 2)}|${"-".repeat(filesWidth + 2)}|`;
   console.log(header);
   console.log(separator);
 
   for (const result of results) {
     if (result.error) {
       console.log(
-        `| ${result.name.padEnd(nameWidth)} | ${"Error".padEnd(totalWidth)} | ${"-".padEnd(gzippedWidth)} | ${"-".padEnd(ratioWidth)} | ${"-".padEnd(filesWidth)} |`,
+        `| ${result.name.padEnd(nameWidth)} | ${"Error".padEnd(totalWidth)} | ${"-".padEnd(gzippedWidth)} | ${"-".padEnd(ratioWidth)} | ${"-".padEnd(requestsWidth)} | ${"-".padEnd(filesWidth)} |`,
       );
       continue;
     }
@@ -208,15 +514,29 @@ async function main() {
     const total = formatBytes(result.total).padEnd(totalWidth);
     const gzipped = formatBytes(result.gzipped).padEnd(gzippedWidth);
     const ratio = ((result.gzipped / baseline).toFixed(2) + "x").padEnd(ratioWidth);
+    const requests = String(result.requests).padEnd(requestsWidth);
     const files = String(result.files).padEnd(filesWidth);
-    console.log(`| ${name} | ${total} | ${gzipped} | ${ratio} | ${files} |`);
+    console.log(`| ${name} | ${total} | ${gzipped} | ${ratio} | ${requests} | ${files} |`);
   }
 
   console.log("\n\nNotes:");
   console.log("- All frameworks built with production settings");
   console.log("- Gzipped size calculated for JS/CSS/HTML files");
+  console.log("- Requests include index.html plus referenced local initial assets");
   console.log("- Same markdown content used across all frameworks");
   console.log("- Ratio is relative to the smallest bundle");
+
+  const report = {
+    name: "Bundle Size Benchmark",
+    generatedAt: new Date().toISOString(),
+    baseline,
+    results,
+  };
+
+  if (options.jsonPath) {
+    writeFileSync(options.jsonPath, `${JSON.stringify(report, null, 2)}\n`);
+    console.log(`\nWrote bundle size JSON to ${options.jsonPath}`);
+  }
 }
 
 main().catch(console.error);

--- a/benchmarks/bundle-size/parse-benchmark.mjs
+++ b/benchmarks/bundle-size/parse-benchmark.mjs
@@ -4,12 +4,20 @@
  */
 
 import { spawnSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
 import { performance } from "node:perf_hooks";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BUN_BENCHMARK_SCRIPT = join(__dirname, "parse-benchmark-bun.mjs");
+const options = parseOptions(process.argv.slice(2));
+
+/**
+ * @typedef {Object} BenchmarkOptions
+ * @property {string | null} jsonPath
+ * @property {number} runs
+ */
 
 // Sample markdown content for benchmarking
 const sampleMarkdown = `
@@ -57,7 +65,61 @@ const sizes = {
 /**
  * Benchmark a sync function
  */
-function benchmark(name, fn, input, iterations = 100) {
+function benchmark(name, fn, input, iterations = 100, runs = 1) {
+  const samples = [];
+
+  for (let run = 0; run < runs; run++) {
+    samples.push(benchmarkOnce(fn, input, iterations));
+  }
+
+  return {
+    name,
+    ...medianSample(samples),
+    samples,
+  };
+}
+
+/**
+ * @param {string[]} args
+ * @returns {BenchmarkOptions}
+ */
+function parseOptions(args) {
+  /** @type {BenchmarkOptions} */
+  const parsed = {
+    jsonPath: null,
+    runs: 1,
+  };
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === "--json") {
+      parsed.jsonPath = readOptionValue(args, ++index, "--json");
+      continue;
+    }
+    if (arg.startsWith("--json=")) {
+      parsed.jsonPath = readInlineOptionValue(arg, "--json");
+      continue;
+    }
+    if (arg === "--runs") {
+      parsed.runs = readPositiveIntegerOption(args, ++index, "--runs");
+      continue;
+    }
+    if (arg.startsWith("--runs=")) {
+      parsed.runs = readPositiveIntegerInlineOption(arg, "--runs");
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return parsed;
+}
+
+function benchmarkOnce(fn, input, iterations) {
   // Warmup
   for (let i = 0; i < 5; i++) {
     fn(input);
@@ -73,7 +135,6 @@ function benchmark(name, fn, input, iterations = 100) {
   const opsPerSec = 1000 / avgMs;
 
   return {
-    name,
     opsPerSec,
     avgMs,
     throughputMBs: (input.length / 1024 / 1024) * opsPerSec,
@@ -81,9 +142,94 @@ function benchmark(name, fn, input, iterations = 100) {
 }
 
 /**
+ * @param {string[]} args
+ * @param {number} index
+ * @param {string} optionName
+ * @returns {string}
+ */
+function readOptionValue(args, index, optionName) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${optionName} requires a file path`);
+  }
+
+  return value;
+}
+
+/**
+ * @param {string[]} args
+ * @param {number} index
+ * @param {string} optionName
+ * @returns {number}
+ */
+function readPositiveIntegerOption(args, index, optionName) {
+  return parsePositiveInteger(readOptionValue(args, index, optionName), optionName);
+}
+
+/**
+ * @param {string} arg
+ * @param {string} optionName
+ * @returns {string}
+ */
+function readInlineOptionValue(arg, optionName) {
+  const value = arg.slice(`${optionName}=`.length);
+  if (!value) {
+    throw new Error(`${optionName} requires a file path`);
+  }
+
+  return value;
+}
+
+/**
+ * @param {string} arg
+ * @param {string} optionName
+ * @returns {number}
+ */
+function readPositiveIntegerInlineOption(arg, optionName) {
+  return parsePositiveInteger(readInlineOptionValue(arg, optionName), optionName);
+}
+
+function parsePositiveInteger(value, optionName) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || String(parsed) !== value) {
+    throw new Error(`${optionName} requires a positive integer`);
+  }
+
+  return parsed;
+}
+
+function medianSample(samples) {
+  const sorted = [...samples].sort((a, b) => a.opsPerSec - b.opsPerSec);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+function printUsage() {
+  console.log(`Usage: node parse-benchmark.mjs [--json <path>] [--runs <count>]
+
+Options:
+  --json <path>  Write benchmark results as JSON
+  --runs <count> Use the median result from repeated runs
+  -h, --help     Show this help message`);
+}
+
+/**
  * Benchmark an async function
  */
 async function benchmarkAsync(name, fn, input, iterations = 100) {
+  const samples = [];
+
+  for (let run = 0; run < options.runs; run++) {
+    samples.push(await benchmarkAsyncOnce(fn, input, iterations));
+  }
+
+  return {
+    name,
+    ...medianSample(samples),
+    samples,
+  };
+}
+
+async function benchmarkAsyncOnce(fn, input, iterations) {
   // Warmup
   for (let i = 0; i < 5; i++) {
     await fn(input);
@@ -99,7 +245,6 @@ async function benchmarkAsync(name, fn, input, iterations = 100) {
   const opsPerSec = 1000 / avgMs;
 
   return {
-    name,
     opsPerSec,
     avgMs,
     throughputMBs: (input.length / 1024 / 1024) * opsPerSec,
@@ -182,6 +327,16 @@ function loadBunMarkdownBenchmarks() {
 async function runBenchmarks() {
   console.log("Parse/Render Speed Benchmark");
   console.log("============================\n");
+  if (options.runs > 1) {
+    console.log(`Using median of ${options.runs} runs\n`);
+  }
+
+  const report = {
+    name: "Parse/Render Speed Benchmark",
+    generatedAt: new Date().toISOString(),
+    runs: options.runs,
+    sizes: {},
+  };
 
   // Import libraries
   const { marked } = await import("marked");
@@ -270,25 +425,27 @@ async function runBenchmarks() {
     console.log(`\n## ${sizeName.toUpperCase()} (${sizeKB} KB)`);
 
     const iterations = sizeName === "large" ? 20 : sizeName === "medium" ? 50 : 100;
+    const suites = {};
 
     // Parse only benchmark
     const parseResults = [];
     for (const parser of parsers) {
       try {
-        const result = benchmark(parser.name, parser.fn, content, iterations);
+        const result = benchmark(parser.name, parser.fn, content, iterations, options.runs);
         parseResults.push(result);
       } catch {
         parseResults.push({ name: parser.name, error: true });
       }
     }
     parseResults.sort((a, b) => (b.opsPerSec || 0) - (a.opsPerSec || 0));
+    suites.parseOnly = parseResults;
     printTable("Parse Only", parseResults);
 
     // Parse + Render benchmark
     const renderResults = [];
     for (const renderer of renderers) {
       try {
-        const result = benchmark(renderer.name, renderer.fn, content, iterations);
+        const result = benchmark(renderer.name, renderer.fn, content, iterations, options.runs);
         renderResults.push(result);
       } catch {
         renderResults.push({ name: renderer.name, error: true });
@@ -298,6 +455,7 @@ async function runBenchmarks() {
       renderResults.push(bunMarkdown.render[sizeName]);
     }
     renderResults.sort((a, b) => (b.opsPerSec || 0) - (a.opsPerSec || 0));
+    suites.parseAndRender = renderResults;
     printTable("Parse + Render", renderResults);
 
     // Async benchmark (only for large)
@@ -312,11 +470,32 @@ async function runBenchmarks() {
         }
       }
       asyncResults.sort((a, b) => (b.opsPerSec || 0) - (a.opsPerSec || 0));
+      suites.parseAndRenderAsync = asyncResults;
       printTable("Parse + Render (Async/Worker Thread)", asyncResults);
     }
+
+    report.sizes[sizeName] = {
+      bytes: content.length,
+      sizeKB: Number(sizeKB),
+      iterations,
+      runs: options.runs,
+      suites,
+    };
   }
 
   console.log("\n\n*Higher ops/sec and throughput = better.*");
+
+  return report;
 }
 
-runBenchmarks().catch(console.error);
+runBenchmarks()
+  .then((report) => {
+    if (options.jsonPath) {
+      writeFileSync(options.jsonPath, `${JSON.stringify(report, null, 2)}\n`);
+      console.log(`\nWrote benchmark JSON to ${options.jsonPath}`);
+    }
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
## Summary

- add a pull request benchmark workflow that checks out base and head separately
- keep workflow YAML as orchestration only by moving benchmark execution, comparison summary, and PR comment update logic into repository scripts
- emit JSON from the parse/render and bundle-size benchmark harnesses
- use median-of-3 runtime runs and update a stable PR comment with large-case runtime, bundle-size, and request-count deltas

## Validation

- vp check
- node --check .github/scripts/run-pr-benchmark.mjs
- node --check .github/scripts/compare-pr-benchmark.mjs
- node --check .github/scripts/comment-pr-benchmark.mjs
- RUNNER_TEMP=/tmp BASE_SHA=1111111111111111111111111111111111111111 HEAD_SHA=2222222222222222222222222222222222222222 node .github/scripts/compare-pr-benchmark.mjs
- vp run build:npm
- node benchmarks/bundle-size/parse-benchmark.mjs --runs 3 --json /tmp/ox-benchmark-napi-runs.json
- node benchmarks/bundle-size/measure.mjs --skip-install --json /tmp/ox-bundle-size.json