### PR TITLE
feat: parse source docs with ox_jsdoc_binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,9 @@ oxc_parser = "0.44"
 oxc_ast = "0.44"
 oxc_span = "0.44"
 
+# JSDoc parser
+ox_jsdoc_binary = { path = "crates/ox_jsdoc_binary" }
+
 # Testing
 criterion = "0.5"
 insta = "1"

--- a/crates/ox_content_docs/Cargo.toml
+++ b/crates/ox_content_docs/Cargo.toml
@@ -28,3 +28,4 @@ oxc_allocator = { workspace = true }
 oxc_parser = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_span = { workspace = true }
+ox_jsdoc_binary = { workspace = true }

--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -1,5 +1,8 @@
 //! Documentation extraction from source code using OXC parser.
 
+use ox_jsdoc_binary::decoder::nodes::comment_ast::LazyJsdocTag;
+use ox_jsdoc_binary::decoder::LazySourceFile;
+use ox_jsdoc_binary::parser::{parse_to_bytes, ParseOptions};
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
     BindingPatternKind, Class, Comment, Declaration, ExportDefaultDeclarationKind, Expression,
@@ -59,6 +62,10 @@ pub struct DocItem {
     pub params: Vec<ParamDoc>,
     /// Return type (for functions/methods).
     pub return_type: Option<String>,
+    /// Return description from JSDoc @returns tag.
+    pub return_description: Option<String>,
+    /// Code examples from JSDoc @example tags.
+    pub examples: Vec<String>,
     /// Child items (for classes, modules, etc.).
     pub children: Vec<DocItem>,
     /// JSDoc tags.
@@ -87,6 +94,50 @@ pub struct DocTag {
     pub tag: String,
     /// Tag value.
     pub value: String,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedParamTag {
+    name: String,
+    type_annotation: Option<String>,
+    optional: bool,
+    default_value: Option<String>,
+    description: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedReturnTag {
+    type_annotation: Option<String>,
+    description: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedJsdoc {
+    raw: String,
+    doc: String,
+    tags: Vec<DocTag>,
+    param_tags: Vec<ParsedParamTag>,
+    return_tag: Option<ParsedReturnTag>,
+    examples: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedJsdocBody {
+    doc: String,
+    tags: Vec<DocTag>,
+    param_tags: Vec<ParsedParamTag>,
+    return_tag: Option<ParsedReturnTag>,
+    examples: Vec<String>,
+}
+
+impl ParsedJsdoc {
+    fn doc_option(&self) -> Option<String> {
+        (!self.doc.is_empty()).then(|| self.doc.clone())
+    }
+
+    fn return_description(&self) -> Option<String> {
+        self.return_tag.as_ref().and_then(|tag| tag.description.clone())
+    }
 }
 
 /// Kind of documentation item.
@@ -256,64 +307,97 @@ impl<'a> DocVisitor<'a> {
         (start_line, end_line)
     }
 
-    fn extract_jsdoc(&self, attached_to: u32) -> Option<(String, String, Vec<DocTag>)> {
+    fn extract_jsdoc(&self, attached_to: u32) -> Option<ParsedJsdoc> {
         let comment =
             self.comments.iter().rev().find(|comment| {
                 comment.attached_to == attached_to && comment.is_jsdoc(self.source)
             })?;
 
+        let full_raw = comment.span.source_text(self.source);
         let mut raw = comment.content_span().source_text(self.source).to_string();
         if raw.starts_with('*') {
             raw.remove(0);
         }
         let raw = raw.trim_matches('\n').to_string();
-        let (doc, tags) = Self::parse_jsdoc(&raw);
-        Some((raw, doc, tags))
+
+        let body = Self::parse_jsdoc(full_raw)?;
+
+        Some(ParsedJsdoc {
+            raw,
+            doc: body.doc,
+            tags: body.tags,
+            param_tags: body.param_tags,
+            return_tag: body.return_tag,
+            examples: body.examples,
+        })
     }
 
-    /// Parse JSDoc comment into description and tags.
-    fn parse_jsdoc(comment: &str) -> (String, Vec<DocTag>) {
-        let mut description_lines = Vec::new();
+    /// Parse JSDoc comment into description and tags with ox_jsdoc_binary.
+    fn parse_jsdoc(comment: &str) -> Option<ParsedJsdocBody> {
+        let result = parse_to_bytes(
+            comment,
+            ParseOptions { compat_mode: true, fence_aware: true, ..ParseOptions::default() },
+        );
+        let source_file = LazySourceFile::new(&result.binary_bytes).ok()?;
+        let root = source_file.asts().next().flatten()?;
+
+        let doc = root.description().unwrap_or_default().trim().to_string();
         let mut tags = Vec::new();
-        let mut current_tag: Option<(String, Vec<String>)> = None;
+        let mut param_tags = Vec::new();
+        let mut return_tag = None;
+        let mut examples = Vec::new();
 
-        let lines: Vec<String> = comment
-            .lines()
-            .map(|line| {
-                let trimmed = line.trim_start();
-                let trimmed = trimmed.strip_prefix('*').unwrap_or(trimmed);
-                trimmed.strip_prefix(' ').unwrap_or(trimmed).trim_end().to_string()
-            })
-            .collect();
+        for tag in root.tags() {
+            let tag_name = tag.tag().value().to_string();
+            let value = tag.raw_body().unwrap_or_default().trim().to_string();
 
-        for line in lines {
-            let trimmed = line.trim_start();
-            if let Some(without_at) = trimmed.strip_prefix('@') {
-                // Save previous tag if any
-                if let Some((tag, value_lines)) = current_tag.take() {
-                    tags.push(DocTag { tag, value: value_lines.join("\n").trim().to_string() });
-                }
-
-                let split_at = without_at
-                    .char_indices()
-                    .find_map(|(index, ch)| ch.is_whitespace().then_some(index))
-                    .unwrap_or(without_at.len());
-                let tag_name = without_at[..split_at].to_string();
-                let tag_value = without_at[split_at..].trim_start().to_string();
-                current_tag = Some((tag_name, vec![tag_value]));
-            } else if let Some((_, ref mut value_lines)) = current_tag {
-                value_lines.push(line);
-            } else {
-                description_lines.push(line);
+            if let Some(param_tag) = Self::parse_param_tag(tag) {
+                param_tags.push(param_tag);
             }
+            if return_tag.is_none() {
+                return_tag = Self::parse_return_tag(tag);
+            }
+            if tag_name == "example" {
+                let example = tag
+                    .description()
+                    .or_else(|| tag.raw_body())
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string);
+                if let Some(example) = example {
+                    examples.push(example);
+                }
+            }
+
+            tags.push(DocTag { tag: tag_name, value });
         }
 
-        // Save last tag if any
-        if let Some((tag, value_lines)) = current_tag {
-            tags.push(DocTag { tag, value: value_lines.join("\n").trim().to_string() });
+        Some(ParsedJsdocBody { doc, tags, param_tags, return_tag, examples })
+    }
+
+    fn parse_param_tag(tag: LazyJsdocTag<'_>) -> Option<ParsedParamTag> {
+        if tag.tag().value() != "param" {
+            return None;
         }
 
-        (description_lines.join("\n").trim().to_string(), tags)
+        Some(ParsedParamTag {
+            name: tag.name()?.raw().trim_start_matches("...").to_string(),
+            type_annotation: tag.raw_type().map(|raw_type| raw_type.raw().to_string()),
+            optional: tag.optional(),
+            default_value: tag.default_value().map(str::to_string),
+            description: tag.description().map(str::to_string),
+        })
+    }
+
+    fn parse_return_tag(tag: LazyJsdocTag<'_>) -> Option<ParsedReturnTag> {
+        if tag.tag().value() != "returns" && tag.tag().value() != "return" {
+            return None;
+        }
+
+        Some(ParsedReturnTag {
+            type_annotation: tag.raw_type().map(|raw_type| raw_type.raw().to_string()),
+            description: tag.description().map(str::to_string),
+        })
     }
 
     fn format_type_parameter_declaration<T>(
@@ -616,61 +700,107 @@ impl<'a> DocVisitor<'a> {
     fn extract_params_from_formals(
         &self,
         params: &oxc_ast::ast::FormalParameters<'a>,
-        tags: &[DocTag],
+        parsed_tags: &[ParsedParamTag],
     ) -> Vec<ParamDoc> {
         params
             .items
             .iter()
             .map(|param| {
-                let name = match &param.pattern.kind {
-                    BindingPatternKind::BindingIdentifier(id) => id.name.to_string(),
-                    _ => "param".to_string(),
-                };
+                let name = Self::binding_pattern_name(&param.pattern).unwrap_or_else(|| {
+                    parsed_tags
+                        .iter()
+                        .find(|tag| {
+                            !params.items.iter().any(|item| {
+                                Self::binding_pattern_name(&item.pattern).as_deref()
+                                    == Some(tag.name.as_str())
+                            })
+                        })
+                        .map_or_else(|| "param".to_string(), |tag| tag.name.clone())
+                });
 
                 let type_annotation = param
                     .pattern
                     .type_annotation
                     .as_ref()
-                    .map(|t| self.format_ts_type(&t.type_annotation));
+                    .map(|t| self.format_ts_type(&t.type_annotation))
+                    .or_else(|| self.assignment_pattern_type_annotation(&param.pattern));
 
-                let description =
-                    tags.iter().find(|t| t.tag == "param" && t.value.starts_with(&name)).map(|t| {
-                        t.value
-                            .trim_start_matches(&name)
-                            .trim_start_matches(" - ")
-                            .trim()
-                            .to_string()
-                    });
+                let default_value = self.assignment_pattern_default_value(&param.pattern);
+                let tag = parsed_tags.iter().find(|tag| tag.name == name);
 
                 ParamDoc {
                     name,
-                    type_annotation,
-                    optional: param.pattern.optional,
-                    default_value: None,
-                    description,
+                    type_annotation: tag
+                        .and_then(|tag| tag.type_annotation.clone())
+                        .or(type_annotation),
+                    optional: param.pattern.optional
+                        || default_value.is_some()
+                        || tag.is_some_and(|tag| tag.optional),
+                    default_value: tag.and_then(|tag| tag.default_value.clone()).or(default_value),
+                    description: tag.and_then(|tag| tag.description.clone()),
                 }
             })
             .collect()
     }
 
+    fn binding_pattern_name(pattern: &oxc_ast::ast::BindingPattern<'a>) -> Option<String> {
+        match &pattern.kind {
+            BindingPatternKind::BindingIdentifier(id) => Some(id.name.to_string()),
+            BindingPatternKind::AssignmentPattern(assign) => {
+                Self::binding_pattern_name(&assign.left)
+            }
+            _ => None,
+        }
+    }
+
+    fn assignment_pattern_default_value(
+        &self,
+        pattern: &oxc_ast::ast::BindingPattern<'a>,
+    ) -> Option<String> {
+        match &pattern.kind {
+            BindingPatternKind::AssignmentPattern(assign) => {
+                Some(self.slice(assign.right.span().start, assign.right.span().end))
+            }
+            _ => None,
+        }
+    }
+
+    fn assignment_pattern_type_annotation(
+        &self,
+        pattern: &oxc_ast::ast::BindingPattern<'a>,
+    ) -> Option<String> {
+        match &pattern.kind {
+            BindingPatternKind::AssignmentPattern(assign) => assign
+                .left
+                .type_annotation
+                .as_ref()
+                .map(|t| self.format_ts_type(&t.type_annotation)),
+            _ => None,
+        }
+    }
+
     /// Extract parameters from a function.
-    fn extract_params(&self, func: &Function, tags: &[DocTag]) -> Vec<ParamDoc> {
-        self.extract_params_from_formals(&func.params, tags)
+    fn extract_params(&self, func: &Function, param_tags: &[ParsedParamTag]) -> Vec<ParamDoc> {
+        self.extract_params_from_formals(&func.params, param_tags)
     }
 
     fn extract_return_type_from_annotation(
         &self,
         return_type: Option<&oxc_allocator::Box<'a, oxc_ast::ast::TSTypeAnnotation<'a>>>,
-        tags: &[DocTag],
+        return_tag: Option<&ParsedReturnTag>,
     ) -> Option<String> {
-        return_type.map(|r| self.format_ts_type(&r.type_annotation)).or_else(|| {
-            tags.iter().find(|t| t.tag == "returns" || t.tag == "return").map(|t| t.value.clone())
-        })
+        return_type
+            .map(|r| self.format_ts_type(&r.type_annotation))
+            .or_else(|| return_tag.and_then(|tag| tag.type_annotation.clone()))
     }
 
     /// Extract return type from tags.
-    fn extract_return_type(&self, func: &Function, tags: &[DocTag]) -> Option<String> {
-        self.extract_return_type_from_annotation(func.return_type.as_ref(), tags)
+    fn extract_return_type(
+        &self,
+        func: &Function,
+        return_tag: Option<&ParsedReturnTag>,
+    ) -> Option<String> {
+        self.extract_return_type_from_annotation(func.return_type.as_ref(), return_tag)
     }
 
     /// Create a DocItem from a function.
@@ -681,31 +811,36 @@ impl<'a> DocVisitor<'a> {
         attached_to: u32,
     ) -> Option<DocItem> {
         let name = func.id.as_ref()?.name.to_string();
-        let (jsdoc, doc, tags) = self.extract_jsdoc(attached_to)?;
-        if !self.include_private && Self::has_private_tag(&tags) {
+        let jsdoc = self.extract_jsdoc(attached_to)?;
+        if !self.include_private && Self::has_private_tag(&jsdoc.tags) {
             return None;
         }
         let (line, end_line) = self.span_lines(attached_to, func.span.end);
+        let params = self.extract_params(func, &jsdoc.param_tags);
+        let return_type = self.extract_return_type(func, jsdoc.return_tag.as_ref());
+        let return_description = jsdoc.return_description();
 
         Some(DocItem {
             name,
             kind: DocItemKind::Function,
-            doc: if doc.is_empty() { None } else { Some(doc) },
+            doc: jsdoc.doc_option(),
             source_path: self.file_path.to_string(),
             line,
             end_line,
             column: self.column_number(attached_to),
-            jsdoc: Some(jsdoc),
+            jsdoc: Some(jsdoc.raw),
             exported,
             signature: Some(self.format_function_signature(
                 func,
                 func.id.as_ref()?.name.as_str(),
                 exported,
             )),
-            params: self.extract_params(func, &tags),
-            return_type: self.extract_return_type(func, &tags),
+            params,
+            return_type,
+            return_description,
+            examples: jsdoc.examples,
             children: Vec::new(),
-            tags,
+            tags: jsdoc.tags,
         })
     }
 
@@ -717,8 +852,8 @@ impl<'a> DocVisitor<'a> {
         exported: bool,
         attached_to: u32,
     ) -> Option<DocItem> {
-        let (jsdoc, doc, tags) = self.extract_jsdoc(attached_to)?;
-        if !self.include_private && Self::has_private_tag(&tags) {
+        let jsdoc = self.extract_jsdoc(attached_to)?;
+        if !self.include_private && Self::has_private_tag(&jsdoc.tags) {
             return None;
         }
         let (line, end_line) = self.span_lines(attached_to, class.span.end);
@@ -741,26 +876,28 @@ impl<'a> DocVisitor<'a> {
                         oxc_ast::ast::MethodDefinitionKind::Method => DocItemKind::Method,
                     };
 
-                    let Some((method_jsdoc, method_doc, method_tags)) =
-                        self.extract_jsdoc(method.span.start)
-                    else {
+                    let Some(method_jsdoc) = self.extract_jsdoc(method.span.start) else {
                         continue;
                     };
-                    if !self.include_private && Self::has_private_tag(&method_tags) {
+                    if !self.include_private && Self::has_private_tag(&method_jsdoc.tags) {
                         continue;
                     }
                     let (method_line, method_end_line) =
                         self.span_lines(method.span.start, method.span.end);
+                    let params = self.extract_params(&method.value, &method_jsdoc.param_tags);
+                    let return_type =
+                        self.extract_return_type(&method.value, method_jsdoc.return_tag.as_ref());
+                    let return_description = method_jsdoc.return_description();
 
                     children.push(DocItem {
                         name: method_name,
                         kind,
-                        doc: if method_doc.is_empty() { None } else { Some(method_doc) },
+                        doc: method_jsdoc.doc_option(),
                         source_path: self.file_path.to_string(),
                         line: method_line,
                         end_line: method_end_line,
                         column: self.column_number(method.span.start),
-                        jsdoc: Some(method_jsdoc),
+                        jsdoc: Some(method_jsdoc.raw),
                         exported: false,
                         signature: Some(self.format_assigned_function_signature(
                             "",
@@ -769,10 +906,12 @@ impl<'a> DocVisitor<'a> {
                             &method.value.params,
                             method.value.return_type.as_ref(),
                         )),
-                        params: self.extract_params(&method.value, &method_tags),
-                        return_type: self.extract_return_type(&method.value, &method_tags),
+                        params,
+                        return_type,
+                        return_description,
+                        examples: method_jsdoc.examples,
                         children: Vec::new(),
-                        tags: method_tags,
+                        tags: method_jsdoc.tags,
                     });
                 }
                 oxc_ast::ast::ClassElement::PropertyDefinition(prop) => {
@@ -781,12 +920,10 @@ impl<'a> DocVisitor<'a> {
                         _ => continue,
                     };
 
-                    let Some((prop_jsdoc, prop_doc, prop_tags)) =
-                        self.extract_jsdoc(prop.span.start)
-                    else {
+                    let Some(prop_jsdoc) = self.extract_jsdoc(prop.span.start) else {
                         continue;
                     };
-                    if !self.include_private && Self::has_private_tag(&prop_tags) {
+                    if !self.include_private && Self::has_private_tag(&prop_jsdoc.tags) {
                         continue;
                     }
                     let (prop_line, prop_end_line) =
@@ -800,18 +937,20 @@ impl<'a> DocVisitor<'a> {
                     children.push(DocItem {
                         name: prop_name,
                         kind: DocItemKind::Property,
-                        doc: if prop_doc.is_empty() { None } else { Some(prop_doc) },
+                        doc: prop_jsdoc.doc_option(),
                         source_path: self.file_path.to_string(),
                         line: prop_line,
                         end_line: prop_end_line,
                         column: self.column_number(prop.span.start),
-                        jsdoc: Some(prop_jsdoc),
+                        jsdoc: Some(prop_jsdoc.raw),
                         exported: false,
                         signature: type_annotation,
                         params: Vec::new(),
                         return_type: None,
+                        return_description: None,
+                        examples: prop_jsdoc.examples,
                         children: Vec::new(),
-                        tags: prop_tags,
+                        tags: prop_jsdoc.tags,
                     });
                 }
                 _ => {}
@@ -821,18 +960,20 @@ impl<'a> DocVisitor<'a> {
         Some(DocItem {
             name: name.to_string(),
             kind: DocItemKind::Class,
-            doc: if doc.is_empty() { None } else { Some(doc) },
+            doc: jsdoc.doc_option(),
             source_path: self.file_path.to_string(),
             line,
             end_line,
             column: self.column_number(attached_to),
-            jsdoc: Some(jsdoc),
+            jsdoc: Some(jsdoc.raw),
             exported,
             signature: Some(self.format_class_signature(class, name, exported)),
             params: Vec::new(),
             return_type: None,
+            return_description: None,
+            examples: jsdoc.examples,
             children,
-            tags,
+            tags: jsdoc.tags,
         })
     }
 }
@@ -907,10 +1048,10 @@ impl<'a> DocVisitor<'a> {
                 }
             }
             Declaration::VariableDeclaration(var_decl) => {
-                let Some((jsdoc, doc, tags)) = self.extract_jsdoc(attached_to) else {
+                let Some(jsdoc) = self.extract_jsdoc(attached_to) else {
                     return;
                 };
-                if !self.include_private && Self::has_private_tag(&tags) {
+                if !self.include_private && Self::has_private_tag(&jsdoc.tags) {
                     return;
                 }
                 let (line, end_line) = self.span_lines(attached_to, var_decl.span.end);
@@ -925,15 +1066,21 @@ impl<'a> DocVisitor<'a> {
 
                         match initializer {
                             Expression::ArrowFunctionExpression(arrow) => {
+                                let params = self
+                                    .extract_params_from_formals(&arrow.params, &jsdoc.param_tags);
+                                let return_type = self.extract_return_type_from_annotation(
+                                    arrow.return_type.as_ref(),
+                                    jsdoc.return_tag.as_ref(),
+                                );
                                 self.items.push(DocItem {
                                     name: name.clone(),
                                     kind: DocItemKind::Function,
-                                    doc: if doc.is_empty() { None } else { Some(doc.clone()) },
+                                    doc: jsdoc.doc_option(),
                                     source_path: self.file_path.to_string(),
                                     line,
                                     end_line,
                                     column: self.column_number(attached_to),
-                                    jsdoc: Some(jsdoc.clone()),
+                                    jsdoc: Some(jsdoc.raw.clone()),
                                     exported,
                                     signature: Some(self.format_assigned_function_signature(
                                         &name,
@@ -942,25 +1089,27 @@ impl<'a> DocVisitor<'a> {
                                         &arrow.params,
                                         arrow.return_type.as_ref(),
                                     )),
-                                    params: self.extract_params_from_formals(&arrow.params, &tags),
-                                    return_type: self.extract_return_type_from_annotation(
-                                        arrow.return_type.as_ref(),
-                                        &tags,
-                                    ),
+                                    params,
+                                    return_type,
+                                    return_description: jsdoc.return_description(),
+                                    examples: jsdoc.examples.clone(),
                                     children: Vec::new(),
-                                    tags: tags.clone(),
+                                    tags: jsdoc.tags.clone(),
                                 });
                             }
                             Expression::FunctionExpression(func_expr) => {
+                                let params = self.extract_params(func_expr, &jsdoc.param_tags);
+                                let return_type =
+                                    self.extract_return_type(func_expr, jsdoc.return_tag.as_ref());
                                 self.items.push(DocItem {
                                     name: name.clone(),
                                     kind: DocItemKind::Function,
-                                    doc: if doc.is_empty() { None } else { Some(doc.clone()) },
+                                    doc: jsdoc.doc_option(),
                                     source_path: self.file_path.to_string(),
                                     line,
                                     end_line,
                                     column: self.column_number(attached_to),
-                                    jsdoc: Some(jsdoc.clone()),
+                                    jsdoc: Some(jsdoc.raw.clone()),
                                     exported,
                                     signature: Some(self.format_assigned_function_signature(
                                         &name,
@@ -969,10 +1118,12 @@ impl<'a> DocVisitor<'a> {
                                         &func_expr.params,
                                         func_expr.return_type.as_ref(),
                                     )),
-                                    params: self.extract_params(func_expr, &tags),
-                                    return_type: self.extract_return_type(func_expr, &tags),
+                                    params,
+                                    return_type,
+                                    return_description: jsdoc.return_description(),
+                                    examples: jsdoc.examples.clone(),
                                     children: Vec::new(),
-                                    tags: tags.clone(),
+                                    tags: jsdoc.tags.clone(),
                                 });
                             }
                             _ => {}
@@ -981,10 +1132,10 @@ impl<'a> DocVisitor<'a> {
                 }
             }
             Declaration::TSTypeAliasDeclaration(type_alias) => {
-                let Some((jsdoc, doc, tags)) = self.extract_jsdoc(attached_to) else {
+                let Some(jsdoc) = self.extract_jsdoc(attached_to) else {
                     return;
                 };
-                if !self.include_private && Self::has_private_tag(&tags) {
+                if !self.include_private && Self::has_private_tag(&jsdoc.tags) {
                     return;
                 }
                 let (line, end_line) = self.span_lines(attached_to, type_alias.span.end);
@@ -992,25 +1143,27 @@ impl<'a> DocVisitor<'a> {
                 self.items.push(DocItem {
                     name: type_alias.id.name.to_string(),
                     kind: DocItemKind::Type,
-                    doc: if doc.is_empty() { None } else { Some(doc) },
+                    doc: jsdoc.doc_option(),
                     source_path: self.file_path.to_string(),
                     line,
                     end_line,
                     column: self.column_number(attached_to),
-                    jsdoc: Some(jsdoc),
+                    jsdoc: Some(jsdoc.raw),
                     exported,
                     signature: Some(self.format_type_alias_signature(type_alias, exported)),
                     params: Vec::new(),
                     return_type: None,
+                    return_description: None,
+                    examples: jsdoc.examples,
                     children: Vec::new(),
-                    tags,
+                    tags: jsdoc.tags,
                 });
             }
             Declaration::TSInterfaceDeclaration(interface) => {
-                let Some((jsdoc, doc, tags)) = self.extract_jsdoc(attached_to) else {
+                let Some(jsdoc) = self.extract_jsdoc(attached_to) else {
                     return;
                 };
-                if !self.include_private && Self::has_private_tag(&tags) {
+                if !self.include_private && Self::has_private_tag(&jsdoc.tags) {
                     return;
                 }
                 let (line, end_line) = self.span_lines(attached_to, interface.span.end);
@@ -1028,12 +1181,10 @@ impl<'a> DocVisitor<'a> {
                                 _ => continue,
                             };
 
-                            let Some((prop_jsdoc, prop_doc, prop_tags)) =
-                                self.extract_jsdoc(prop.span.start)
-                            else {
+                            let Some(prop_jsdoc) = self.extract_jsdoc(prop.span.start) else {
                                 continue;
                             };
-                            if !self.include_private && Self::has_private_tag(&prop_tags) {
+                            if !self.include_private && Self::has_private_tag(&prop_jsdoc.tags) {
                                 continue;
                             }
                             let (prop_line, prop_end_line) =
@@ -1047,18 +1198,20 @@ impl<'a> DocVisitor<'a> {
                             children.push(DocItem {
                                 name: prop_name,
                                 kind: DocItemKind::Property,
-                                doc: if prop_doc.is_empty() { None } else { Some(prop_doc) },
+                                doc: prop_jsdoc.doc_option(),
                                 source_path: self.file_path.to_string(),
                                 line: prop_line,
                                 end_line: prop_end_line,
                                 column: self.column_number(prop.span.start),
-                                jsdoc: Some(prop_jsdoc),
+                                jsdoc: Some(prop_jsdoc.raw),
                                 exported: false,
                                 signature: type_annotation,
                                 params: Vec::new(),
                                 return_type: None,
+                                return_description: None,
+                                examples: prop_jsdoc.examples,
                                 children: Vec::new(),
-                                tags: prop_tags,
+                                tags: prop_jsdoc.tags,
                             });
                         }
                         TSSignature::TSMethodSignature(method) => {
@@ -1069,26 +1222,33 @@ impl<'a> DocVisitor<'a> {
                                 _ => continue,
                             };
 
-                            let Some((method_jsdoc, method_doc, method_tags)) =
-                                self.extract_jsdoc(method.span.start)
-                            else {
+                            let Some(method_jsdoc) = self.extract_jsdoc(method.span.start) else {
                                 continue;
                             };
-                            if !self.include_private && Self::has_private_tag(&method_tags) {
+                            if !self.include_private && Self::has_private_tag(&method_jsdoc.tags) {
                                 continue;
                             }
                             let (method_line, method_end_line) =
                                 self.span_lines(method.span.start, method.span.end);
+                            let params = self.extract_params_from_formals(
+                                &method.params,
+                                &method_jsdoc.param_tags,
+                            );
+                            let return_type = self.extract_return_type_from_annotation(
+                                method.return_type.as_ref(),
+                                method_jsdoc.return_tag.as_ref(),
+                            );
+                            let return_description = method_jsdoc.return_description();
 
                             children.push(DocItem {
                                 name: method_name.clone(),
                                 kind: DocItemKind::Method,
-                                doc: if method_doc.is_empty() { None } else { Some(method_doc) },
+                                doc: method_jsdoc.doc_option(),
                                 source_path: self.file_path.to_string(),
                                 line: method_line,
                                 end_line: method_end_line,
                                 column: self.column_number(method.span.start),
-                                jsdoc: Some(method_jsdoc),
+                                jsdoc: Some(method_jsdoc.raw),
                                 exported: false,
                                 signature: Some(self.format_assigned_function_signature(
                                     &method_name,
@@ -1097,14 +1257,12 @@ impl<'a> DocVisitor<'a> {
                                     &method.params,
                                     method.return_type.as_ref(),
                                 )),
-                                params: self
-                                    .extract_params_from_formals(&method.params, &method_tags),
-                                return_type: self.extract_return_type_from_annotation(
-                                    method.return_type.as_ref(),
-                                    &method_tags,
-                                ),
+                                params,
+                                return_type,
+                                return_description,
+                                examples: method_jsdoc.examples,
                                 children: Vec::new(),
-                                tags: method_tags,
+                                tags: method_jsdoc.tags,
                             });
                         }
                         _ => {}
@@ -1114,25 +1272,27 @@ impl<'a> DocVisitor<'a> {
                 self.items.push(DocItem {
                     name: interface.id.name.to_string(),
                     kind: DocItemKind::Interface,
-                    doc: if doc.is_empty() { None } else { Some(doc) },
+                    doc: jsdoc.doc_option(),
                     source_path: self.file_path.to_string(),
                     line,
                     end_line,
                     column: self.column_number(attached_to),
-                    jsdoc: Some(jsdoc),
+                    jsdoc: Some(jsdoc.raw),
                     exported,
                     signature: Some(self.format_interface_signature(interface, exported)),
                     params: Vec::new(),
                     return_type: None,
+                    return_description: None,
+                    examples: jsdoc.examples,
                     children,
-                    tags,
+                    tags: jsdoc.tags,
                 });
             }
             Declaration::TSEnumDeclaration(enum_decl) => {
-                let Some((jsdoc, doc, tags)) = self.extract_jsdoc(attached_to) else {
+                let Some(jsdoc) = self.extract_jsdoc(attached_to) else {
                     return;
                 };
-                if !self.include_private && Self::has_private_tag(&tags) {
+                if !self.include_private && Self::has_private_tag(&jsdoc.tags) {
                     return;
                 }
                 let (line, end_line) = self.span_lines(attached_to, enum_decl.span.end);
@@ -1160,6 +1320,8 @@ impl<'a> DocVisitor<'a> {
                             signature: None,
                             params: Vec::new(),
                             return_type: None,
+                            return_description: None,
+                            examples: Vec::new(),
                             children: Vec::new(),
                             tags: Vec::new(),
                         }
@@ -1169,18 +1331,20 @@ impl<'a> DocVisitor<'a> {
                 self.items.push(DocItem {
                     name: enum_decl.id.name.to_string(),
                     kind: DocItemKind::Enum,
-                    doc: if doc.is_empty() { None } else { Some(doc) },
+                    doc: jsdoc.doc_option(),
                     source_path: self.file_path.to_string(),
                     line,
                     end_line,
                     column: self.column_number(attached_to),
-                    jsdoc: Some(jsdoc),
+                    jsdoc: Some(jsdoc.raw),
                     exported,
                     signature: None,
                     params: Vec::new(),
                     return_type: None,
+                    return_description: None,
+                    examples: jsdoc.examples,
                     children,
-                    tags,
+                    tags: jsdoc.tags,
                 });
             }
             _ => {}
@@ -1238,5 +1402,48 @@ export interface User {
         assert_eq!(items[0].name, "User");
         assert_eq!(items[0].kind, DocItemKind::Interface);
         assert_eq!(items[0].children.len(), 2);
+    }
+
+    #[test]
+    fn test_extract_structured_jsdoc_metadata() {
+        let source = r#"
+/**
+ * Formats a value.
+ *
+ * @param {number} value - Input value.
+ * @param {"short" | "long"} [mode="short"] - Format mode.
+ * @returns {string} Rendered label.
+ * @example
+ * ```ts
+ * const snippet = "@param not-a-real-tag";
+ * formatValue(1, "short");
+ * ```
+ * @since 2.4.0
+ */
+export function formatValue(value: number, mode: "short" | "long" = "short"): string {
+    return mode === "short" ? String(value) : `value: ${value}`;
+}
+"#;
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "test.ts", SourceType::ts()).unwrap();
+        let item = &items[0];
+
+        assert_eq!(item.doc.as_deref(), Some("Formats a value."));
+        assert_eq!(item.return_type.as_deref(), Some("string"));
+        assert_eq!(item.return_description.as_deref(), Some("Rendered label."));
+        assert_eq!(item.examples.len(), 1);
+        assert!(item.examples[0].contains("@param not-a-real-tag"));
+        assert!(item.tags.iter().any(|tag| tag.tag == "since" && tag.value == "2.4.0"));
+
+        assert_eq!(item.params.len(), 2);
+        assert_eq!(item.params[0].name, "value");
+        assert_eq!(item.params[0].type_annotation.as_deref(), Some("number"));
+        assert_eq!(item.params[0].description.as_deref(), Some("Input value."));
+        assert_eq!(item.params[1].name, "mode");
+        assert_eq!(item.params[1].type_annotation.as_deref(), Some(r#""short" | "long""#));
+        assert_eq!(item.params[1].default_value.as_deref(), Some(r#""short""#));
+        assert_eq!(item.params[1].description.as_deref(), Some("Format mode."));
+        assert!(item.params[1].optional);
     }
 }

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -329,6 +329,8 @@ export interface JsSourceDocItem {
   signature?: string
   params: Array<JsSourceDocParam>
   returnType?: string
+  returnDescription?: string
+  examples: Array<string>
   tags: Array<JsSourceDocTag>
 }
 

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -106,6 +106,8 @@ pub struct JsSourceDocItem {
     pub signature: Option<String>,
     pub params: Vec<JsSourceDocParam>,
     pub return_type: Option<String>,
+    pub return_description: Option<String>,
+    pub examples: Vec<String>,
     pub tags: Vec<JsSourceDocTag>,
 }
 
@@ -289,6 +291,8 @@ fn map_doc_item(item: DocItem) -> JsSourceDocItem {
         signature: item.signature,
         params: item.params.into_iter().map(map_param_doc).collect(),
         return_type: item.return_type,
+        return_description: item.return_description,
+        examples: item.examples,
         tags: item.tags.into_iter().map(map_doc_tag).collect(),
     }
 }

--- a/crates/ox_jsdoc_binary/Cargo.toml
+++ b/crates/ox_jsdoc_binary/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ox_jsdoc_binary"
+version = "0.0.0"
+edition = "2024"
+rust-version = "1.92.0"
+license = "MIT"
+publish = false
+description = "Binary AST format and lazy decoder for ox_jsdoc (parser-integrated, approach c-1)"
+
+[dependencies]
+memchr = "2"
+oxc_allocator = "=0.123.0"
+oxc_span = "=0.123.0"
+rustc-hash = "2"
+smallvec = { version = "1.15.1", features = ["union"] }

--- a/crates/ox_jsdoc_binary/src/decoder/error.rs
+++ b/crates/ox_jsdoc_binary/src/decoder/error.rs
@@ -1,0 +1,115 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Errors raised by the lazy decoder.
+
+use core::fmt;
+
+use crate::format::kind::UnknownKind;
+
+/// Errors that can occur while decoding a Binary AST byte stream.
+///
+/// The lazy decoder validates only the Header eagerly; per-node and
+/// per-string failures surface here as decoding proceeds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecodeError {
+    /// The input slice is shorter than the 40-byte Header.
+    TooShort {
+        /// Actual byte length of the input slice.
+        actual: usize,
+        /// Minimum length required (always 40 for this variant).
+        required: usize,
+    },
+    /// The buffer's major version disagrees with the decoder's supported
+    /// major version. Different majors are intentionally incompatible — see
+    /// `format.md` "Header" version-rules table.
+    IncompatibleMajor {
+        /// Major version stored in the buffer's Header byte 0.
+        buffer_major: u8,
+        /// Major version this decoder was compiled against.
+        decoder_major: u8,
+    },
+    /// The Node Data type tag is the reserved `0b11` value. Phase 1 decoders
+    /// must reject this; later phases may assign meaning to it.
+    UnsupportedTypeTag {
+        /// Index of the offending node record.
+        node_index: u32,
+        /// Raw 2-bit tag value (always `0b11` today).
+        tag: u32,
+    },
+    /// The Kind byte does not correspond to any defined node kind.
+    UnknownKind {
+        /// Index of the offending node record.
+        node_index: u32,
+        /// Raw Kind byte that failed to decode.
+        kind_byte: u8,
+    },
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DecodeError::TooShort { actual, required } => {
+                write!(f, "input is too short: got {actual} bytes, need at least {required}")
+            }
+            DecodeError::IncompatibleMajor { buffer_major, decoder_major } => write!(
+                f,
+                "incompatible major version: buffer is v{buffer_major}, decoder supports v{decoder_major}"
+            ),
+            DecodeError::UnsupportedTypeTag { node_index, tag } => {
+                write!(f, "node[{node_index}] uses reserved Node Data type tag 0b{tag:02b}")
+            }
+            DecodeError::UnknownKind { node_index, kind_byte } => {
+                write!(f, "node[{node_index}] has unknown Kind 0x{kind_byte:02X}")
+            }
+        }
+    }
+}
+
+impl From<UnknownKind> for DecodeError {
+    fn from(err: UnknownKind) -> Self {
+        DecodeError::UnknownKind { node_index: 0, kind_byte: err.0 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_too_short() {
+        let err = DecodeError::TooShort { actual: 8, required: 40 };
+        assert_eq!(err.to_string(), "input is too short: got 8 bytes, need at least 40");
+    }
+
+    #[test]
+    fn display_incompatible_major() {
+        let err = DecodeError::IncompatibleMajor { buffer_major: 2, decoder_major: 1 };
+        assert_eq!(
+            err.to_string(),
+            "incompatible major version: buffer is v2, decoder supports v1"
+        );
+    }
+
+    #[test]
+    fn display_unsupported_type_tag() {
+        let err = DecodeError::UnsupportedTypeTag { node_index: 17, tag: 0b11 };
+        assert_eq!(err.to_string(), "node[17] uses reserved Node Data type tag 0b11");
+    }
+
+    #[test]
+    fn display_unknown_kind() {
+        let err = DecodeError::UnknownKind { node_index: 5, kind_byte: 0x40 };
+        assert_eq!(err.to_string(), "node[5] has unknown Kind 0x40");
+    }
+
+    #[test]
+    fn from_unknown_kind_preserves_byte() {
+        let conv: DecodeError = UnknownKind(0x42).into();
+        match conv {
+            DecodeError::UnknownKind { kind_byte, .. } => assert_eq!(kind_byte, 0x42),
+            _ => panic!("expected UnknownKind variant"),
+        }
+    }
+}

--- a/crates/ox_jsdoc_binary/src/decoder/helpers.rs
+++ b/crates/ox_jsdoc_binary/src/decoder/helpers.rs
@@ -1,0 +1,207 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Common helpers shared by lazy node implementations.
+//!
+//! See `design/007-binary-ast/rust-impl.md#helper-functions-shared-parts-for-reading-binary-ast`.
+
+use crate::format::node_record::{
+    NEXT_SIBLING_OFFSET, NODE_DATA_OFFSET, NODE_RECORD_SIZE, PARENT_INDEX_OFFSET, PAYLOAD_MASK,
+    TYPE_TAG_SHIFT, TypeTag,
+};
+use crate::format::string_field::{STRING_FIELD_SIZE, StringField};
+
+use super::source_file::LazySourceFile;
+
+/// Read a little-endian `u32` at `offset` from `bytes`.
+///
+/// The buffer is expected to be at least `offset + 4` bytes long; the
+/// caller (via the lazy decoder) guarantees this through Header validation.
+#[inline]
+#[must_use]
+pub fn read_u32(bytes: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap())
+}
+
+/// Read a little-endian `u16` at `offset` from `bytes`.
+#[inline]
+#[must_use]
+pub fn read_u16(bytes: &[u8], offset: usize) -> u16 {
+    u16::from_le_bytes(bytes[offset..offset + 2].try_into().unwrap())
+}
+
+/// Resolve the Extended Data byte offset for the node at `node_index`.
+///
+/// The node must use Extended type Node Data (`0b10`); calling this on a
+/// Children/String/Reserved node debug-asserts in development builds.
+#[inline]
+#[must_use]
+pub fn ext_offset(sf: &LazySourceFile<'_>, node_index: u32) -> u32 {
+    let nd = read_node_data(sf, node_index);
+    let tag = TypeTag::from_u32((nd >> TYPE_TAG_SHIFT) & 0b11)
+        .expect("Node Data type tag bits cover 0..=3 by construction");
+    debug_assert_eq!(tag, TypeTag::Extended, "ext_offset called on a non-Extended node ({tag:?})");
+    sf.extended_data_offset + (nd & PAYLOAD_MASK)
+}
+
+/// Read the raw 32-bit Node Data field for the given node.
+#[inline]
+#[must_use]
+pub fn read_node_data(sf: &LazySourceFile<'_>, node_index: u32) -> u32 {
+    let off = sf.nodes_offset as usize + node_index as usize * NODE_RECORD_SIZE + NODE_DATA_OFFSET;
+    read_u32(sf.bytes(), off)
+}
+
+/// Read the `next_sibling` field for the given node.
+#[inline]
+#[must_use]
+pub fn read_next_sibling(sf: &LazySourceFile<'_>, node_index: u32) -> u32 {
+    let off =
+        sf.nodes_offset as usize + node_index as usize * NODE_RECORD_SIZE + NEXT_SIBLING_OFFSET;
+    read_u32(sf.bytes(), off)
+}
+
+/// Read the `parent_index` field for the given node.
+#[inline]
+#[must_use]
+pub fn read_parent_index(sf: &LazySourceFile<'_>, node_index: u32) -> u32 {
+    let off =
+        sf.nodes_offset as usize + node_index as usize * NODE_RECORD_SIZE + PARENT_INDEX_OFFSET;
+    read_u32(sf.bytes(), off)
+}
+
+/// Return the first child of `parent_index` (= `parent_index + 1` if it
+/// exists and its `parent_index` field equals `parent_index`).
+///
+/// Returns `None` when the parent has no child.
+#[inline]
+#[must_use]
+pub fn first_child(sf: &LazySourceFile<'_>, parent_index: u32) -> Option<u32> {
+    let candidate = parent_index + 1;
+    if candidate >= sf.node_count {
+        return None;
+    }
+    if read_parent_index(sf, candidate) == parent_index { Some(candidate) } else { None }
+}
+
+/// Read a [`StringField`] (6 bytes, little-endian) from `bytes` at
+/// `offset`. Used by lazy nodes when reading a string slot from inside
+/// their Extended Data record.
+#[inline]
+#[must_use]
+pub fn read_string_field(bytes: &[u8], offset: usize) -> StringField {
+    StringField::read_le(&bytes[offset..offset + STRING_FIELD_SIZE])
+}
+
+/// Read NodeList metadata `(head_index: u32, count: u16)` from a parent's
+/// Extended Data block, returning `(head, count_as_u32)`.
+///
+/// `ext_byte_offset` is the absolute byte offset of the parent's ED record
+/// in the buffer (resolved via [`ext_offset`]). `slot_offset` is the per-Kind
+/// byte offset of the list slot inside the ED block.
+#[inline]
+#[must_use]
+pub fn read_list_metadata(
+    sf: &LazySourceFile<'_>,
+    ext_byte_offset: usize,
+    slot_offset: usize,
+) -> (u32, u32) {
+    let bytes = sf.bytes();
+    let head = read_u32(bytes, ext_byte_offset + slot_offset);
+    let count = read_u16(bytes, ext_byte_offset + slot_offset + 4) as u32;
+    (head, count)
+}
+
+/// Resolve the 30-bit String payload of a String-type or StringInline-type
+/// node into its underlying string. `None` when the writer used the
+/// [`crate::format::node_record::STRING_PAYLOAD_NONE_SENTINEL`] sentinel
+/// (only meaningful for `TypeTag::String`).
+///
+/// Used by string-leaf Kinds whose Node Data carries either a
+/// `TypeTag::String` payload (legacy String Offsets table indirection) or
+/// a `TypeTag::StringInline` payload (Path B-leaf inline `(offset, length)`
+/// pack). Dispatches on the tag.
+#[inline]
+#[must_use]
+pub fn string_payload<'a>(sf: &LazySourceFile<'a>, node_index: u32) -> Option<&'a str> {
+    let nd = read_node_data(sf, node_index);
+    let tag = (nd >> TYPE_TAG_SHIFT) & 0b11;
+    let payload = nd & PAYLOAD_MASK;
+    if tag == TypeTag::StringInline as u32 {
+        let (offset, length) = crate::format::node_record::unpack_string_inline(payload);
+        return Some(sf.get_inline_string(offset, length));
+    }
+    debug_assert_eq!(
+        TypeTag::from_u32(tag),
+        Ok(TypeTag::String),
+        "string_payload called on a non-String/StringInline node"
+    );
+    sf.get_string(payload)
+}
+
+/// Resolve the leading [`StringField`] of an Extended-type node whose
+/// Extended Data record begins with a 6-byte StringField slot
+/// (Pattern 3 TypeNodes such as `TypeKeyValue.key`,
+/// `TypeMethodSignature.name`, `TypeSymbol.value`, …).
+///
+/// Returns the empty string when the slot equals [`StringField::NONE`].
+#[inline]
+#[must_use]
+pub fn ext_string_leaf<'a>(sf: &LazySourceFile<'a>, node_index: u32) -> &'a str {
+    let ext = ext_offset(sf, node_index) as usize;
+    let field = read_string_field(sf.bytes(), ext);
+    sf.get_string_by_field(field).unwrap_or("")
+}
+
+/// Read the Children bitmask from the 30-bit Node Data payload of a
+/// Children-type node.
+#[inline]
+#[must_use]
+pub fn children_bitmask_payload(sf: &LazySourceFile<'_>, node_index: u32) -> u32 {
+    let nd = read_node_data(sf, node_index);
+    debug_assert_eq!(
+        TypeTag::from_u32((nd >> TYPE_TAG_SHIFT) & 0b11),
+        Ok(TypeTag::Children),
+        "children_bitmask_payload called on a non-Children node"
+    );
+    nd & PAYLOAD_MASK
+}
+
+/// Find the `visitor_index`-th set bit in `bitmask` and return the
+/// corresponding child node index relative to `parent_index`.
+///
+/// Children are placed contiguously starting at `parent_index + 1` in DFS
+/// pre-order. The `visitor_index`-th set bit denotes the slot the parent
+/// promised in its visitor key list; we walk `next_sibling` links between
+/// emitted children to reach that slot.
+///
+/// Returns `None` when the requested visitor slot's bit is unset (the
+/// caller's getter then yields `None` for an `Option`-typed field) or when
+/// a sibling chain is truncated.
+#[inline]
+#[must_use]
+pub fn child_at_visitor_index(
+    sf: &LazySourceFile<'_>,
+    parent_index: u32,
+    bitmask: u8,
+    visitor_index: u8,
+) -> Option<u32> {
+    if (bitmask & (1u8 << visitor_index)) == 0 {
+        return None;
+    }
+    // Count the number of set bits below `visitor_index` to know how many
+    // siblings to walk past.
+    let mask_below = (1u8 << visitor_index).wrapping_sub(1);
+    let skip = (bitmask & mask_below).count_ones();
+
+    let mut child = parent_index + 1;
+    for _ in 0..skip {
+        let next = read_next_sibling(sf, child);
+        if next == 0 {
+            return None; // truncated sibling chain
+        }
+        child = next;
+    }
+    Some(child)
+}

--- a/crates/ox_jsdoc_binary/src/decoder/mod.rs
+++ b/crates/ox_jsdoc_binary/src/decoder/mod.rs
@@ -1,0 +1,32 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Rust-side lazy decoder.
+//!
+//! See `design/007-binary-ast/rust-impl.md#rust-side-lazy-decoder` and
+//! `js-decoder.md` (the JS counterpart) for the design rationale.
+//!
+//! The decoder is **stateless** with respect to the input bytes: every
+//! lazy node struct is `Copy` and just remembers `(source_file, node_index)`.
+//! Reads happen on demand from the underlying `&[u8]`.
+//!
+//! Module layout:
+//!
+//! - [`error`]: [`error::DecodeError`] enum.
+//! - [`source_file`]: [`source_file::LazySourceFile`] (decoder root).
+//! - [`helpers`]: shared low-level read helpers.
+//! - [`nodes`]: lazy node structs (15 comment AST + 45 TypeNode = 60).
+//! - [`visitor`]: [`visitor::LazyJsdocVisitor`] depth-first walker.
+
+pub mod error;
+pub mod helpers;
+pub mod nodes;
+pub mod source_file;
+pub mod text;
+pub mod visitor;
+
+pub use error::DecodeError;
+pub use nodes::{LazyNode, NodeListIter};
+pub use source_file::LazySourceFile;
+pub use visitor::LazyJsdocVisitor;

--- a/crates/ox_jsdoc_binary/src/decoder/nodes/comment_ast.rs
+++ b/crates/ox_jsdoc_binary/src/decoder/nodes/comment_ast.rs
@@ -1,0 +1,613 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Lazy structs for the 15 comment AST kinds (`0x01 - 0x0F`).
+//!
+//! Every struct is a `Copy` value type wrapping
+//! `(source_file, node_index, root_index)` (16 bytes on 64-bit targets).
+//! All string fields read inline [`crate::format::string_field::StringField`]
+//! slots from Extended Data — there is no longer a String Offsets table to
+//! consult.
+
+use std::borrow::Cow;
+
+use crate::format::kind::Kind;
+use crate::format::node_record::{KIND_OFFSET, NODE_RECORD_SIZE};
+use crate::format::string_field::STRING_FIELD_SIZE;
+use crate::writer::nodes::comment_ast::{
+    JSDOC_BLOCK_BASIC_SIZE, JSDOC_BLOCK_COMPAT_SIZE, JSDOC_BLOCK_DESC_LINES_SLOT,
+    JSDOC_BLOCK_HAS_DESCRIPTION_RAW_SPAN_BIT, JSDOC_BLOCK_INLINE_TAGS_SLOT, JSDOC_BLOCK_TAGS_SLOT,
+    JSDOC_TAG_BASIC_SIZE, JSDOC_TAG_COMPAT_SIZE, JSDOC_TAG_DESC_LINES_SLOT,
+    JSDOC_TAG_HAS_DESCRIPTION_RAW_SPAN_BIT, JSDOC_TAG_INLINE_TAGS_SLOT, JSDOC_TAG_TYPE_LINES_SLOT,
+};
+
+use super::super::helpers::{
+    child_at_visitor_index, ext_offset, read_list_metadata, read_string_field, string_payload,
+};
+use super::super::source_file::LazySourceFile;
+use super::super::text::parsed_preserving_whitespace;
+use super::type_node::LazyTypeNode;
+use super::{LazyNode, NodeListIter};
+
+/// Generate a lazy comment AST struct + its `LazyNode` impl in one go.
+macro_rules! define_lazy_comment_node {
+    ($name:ident, $kind:expr, $doc:expr) => {
+        #[doc = $doc]
+        #[derive(Debug, Clone, Copy)]
+        pub struct $name<'a> {
+            source_file: &'a LazySourceFile<'a>,
+            node_index: u32,
+            root_index: u32,
+        }
+
+        impl<'a> LazyNode<'a> for $name<'a> {
+            const KIND: Kind = $kind;
+
+            #[inline]
+            fn from_index(
+                source_file: &'a LazySourceFile<'a>,
+                node_index: u32,
+                root_index: u32,
+            ) -> Self {
+                $name { source_file, node_index, root_index }
+            }
+
+            #[inline]
+            fn source_file(&self) -> &'a LazySourceFile<'a> {
+                self.source_file
+            }
+
+            #[inline]
+            fn node_index(&self) -> u32 {
+                self.node_index
+            }
+
+            #[inline]
+            fn root_index(&self) -> u32 {
+                self.root_index
+            }
+        }
+    };
+}
+
+/// Read an Optional `StringField` slot at `field_offset` inside a node's
+/// Extended Data record. Returns `None` when the slot equals
+/// [`crate::format::string_field::StringField::NONE`].
+#[inline]
+fn resolve_string_field_slot<'a>(
+    sf: &LazySourceFile<'a>,
+    ext_byte: usize,
+    field_offset: usize,
+) -> Option<&'a str> {
+    let field = read_string_field(sf.bytes(), ext_byte + field_offset);
+    sf.get_string_by_field(field)
+}
+
+/// Read a Required `StringField` slot at `field_offset` inside a node's
+/// Extended Data record. Returns `""` if the slot is mistakenly the NONE
+/// sentinel (defensive — the writer never emits NONE for a Required slot).
+#[inline]
+fn ext_string<'a>(sf: &LazySourceFile<'a>, node_index: u32, field_offset: usize) -> &'a str {
+    let ext = ext_offset(sf, node_index) as usize;
+    let field = read_string_field(sf.bytes(), ext + field_offset);
+    sf.get_string_by_field(field).unwrap_or("")
+}
+
+// ---------------------------------------------------------------------------
+// 0x01 LazyJsdocBlock
+// ---------------------------------------------------------------------------
+define_lazy_comment_node!(
+    LazyJsdocBlock,
+    Kind::JsdocBlock,
+    "Lazy view of a `JsdocBlock` (Kind 0x01, root node)."
+);
+
+impl<'a> LazyJsdocBlock<'a> {
+    /// Children bitmask (`bit0=descLines`, `bit1=tags`, `bit2=inlineTags`).
+    /// Retained in Extended Data byte 0 for the visitor framework even
+    /// though the lazy decoder now reads list head/count from the per-list
+    /// metadata slots (bytes 50-67).
+    #[inline]
+    #[allow(dead_code)]
+    fn children_bitmask(&self) -> u8 {
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        self.source_file.bytes()[ext]
+    }
+
+    /// Description string (None when absent).
+    pub fn description(&self) -> Option<&'a str> {
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        resolve_string_field_slot(self.source_file, ext, 2)
+    }
+
+    /// Source-preserving delimiter strings stored in Extended Data.
+    pub fn delimiter(&self) -> &'a str {
+        ext_string(self.source_file, self.node_index, 8)
+    }
+    /// `post_delimiter`.
+    pub fn post_delimiter(&self) -> &'a str {
+        ext_string(self.source_file, self.node_index, 14)
+    }
+    /// `terminal` source string (`"*/"`).
+    pub fn terminal(&self) -> &'a str {
+        ext_string(self.source_file, self.node_index, 20)
+    }
+    /// `line_end` source string.
+    pub fn line_end(&self) -> &'a str {
+        ext_string(self.source_file, self.node_index, 26)
+    }
+    /// `initial` source string.
+    pub fn initial(&self) -> &'a str {
+        ext_string(self.source_file, self.node_index, 32)
+    }
+    /// `delimiter_line_break` source string.
+    pub fn delimiter_line_break(&self) -> &'a str {
+        ext_string(self.source_file, self.node_index, 38)
+    }
+    /// `preterminal_line_break` source string.
+    pub fn preterminal_line_break(&self) -> &'a str {
+        ext_string(self.source_file, self.node_index, 44)
+    }
+
+    /// Top-level description lines.
+    pub fn description_lines(&self) -> NodeListIter<'a, LazyJsdocDescriptionLine<'a>> {
+        self.list_at(JSDOC_BLOCK_DESC_LINES_SLOT)
+    }
+    /// Block tags.
+    pub fn tags(&self) -> NodeListIter<'a, LazyJsdocTag<'a>> {
+        self.list_at(JSDOC_BLOCK_TAGS_SLOT)
+    }
+    /// Inline tags found in the top-level description.
+    pub fn inline_tags(&self) -> NodeListIter<'a, LazyJsdocInlineTag<'a>> {
+        self.list_at(JSDOC_BLOCK_INLINE_TAGS_SLOT)
+    }
+
+    // -- compat-mode-only line metadata (Extended Data byte 70+) ------------
+
+    /// 0-based line index of the closing `*/` line. Returns `None` when the
+    /// buffer was not written in compat mode.
+    pub fn end_line(&self) -> Option<u32> {
+        if !self.source_file.compat_mode {
+            return None;
+        }
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        // Compat tail starts at byte 68 (basic ED size). end_line is the
+        // first u32 after a 2-byte alignment padding → byte 70.
+        Some(super::super::helpers::read_u32(self.source_file.bytes(), ext + 70))
+    }
+
+    /// Raw description slice (with `*` prefix and blank lines intact).
+    /// Returns `None` when the buffer was not parsed with
+    /// `preserve_whitespace = true` (the per-node
+    /// `has_description_raw_span` Common Data bit is clear), or when the
+    /// block has no description.
+    ///
+    /// Phase 5 layout: the span sits at the **last 8 bytes** of the ED
+    /// record (offset = compat ? 90 : 68 = the basic / compat ED size).
+    /// See `design/008-oxlint-oxfmt-support/README.md` §4.2 / §4.3.
+    pub fn description_raw(&self) -> Option<&'a str> {
+        if (self.common_data() & JSDOC_BLOCK_HAS_DESCRIPTION_RAW_SPAN_BIT) == 0 {
+            return None;
+        }
+        let span_off = if self.source_file.compat_mode {
+            JSDOC_BLOCK_COMPAT_SIZE
+        } else {
+            JSDOC_BLOCK_BASIC_SIZE
+        };
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        let bytes = self.source_file.bytes();
+        let start = super::super::helpers::read_u32(bytes, ext + span_off);
+        let end = super::super::helpers::read_u32(bytes, ext + span_off + 4);
+        self.source_file.slice_source_text(self.root_index, start, end)
+    }
+
+    /// Description text. When `preserve_whitespace` is `true`, blank lines
+    /// and indentation past the `* ` prefix are preserved (algorithm in
+    /// [`super::super::text::parsed_preserving_whitespace`]). When `false`,
+    /// returns the compact view ([`Self::description`]). Returns `None`
+    /// when no description is present, or when `preserve_whitespace = true`
+    /// is requested on a buffer that wasn't parsed with the matching
+    /// `preserve_whitespace = true` parse option.
+    pub fn description_text(&self, preserve_whitespace: bool) -> Option<Cow<'a, str>> {
+        if preserve_whitespace {
+            self.description_raw().map(|raw| Cow::Owned(parsed_preserving_whitespace(raw)))
+        } else {
+            self.description().map(Cow::Borrowed)
+        }
+    }
+
+    /// Helper: read the per-list `(head, count)` metadata at `slot_offset`
+    /// inside this block's Extended Data record and produce an iterator.
+    #[inline]
+    fn list_at<T: LazyNode<'a>>(&self, slot_offset: usize) -> NodeListIter<'a, T> {
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        let (head, count) = read_list_metadata(self.source_file, ext, slot_offset);
+        NodeListIter::new(self.source_file, head, count, self.root_index)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 0x02 LazyJsdocDescriptionLine
+// ---------------------------------------------------------------------------
+define_lazy_comment_node!(
+    LazyJsdocDescriptionLine,
+    Kind::JsdocDescriptionLine,
+    "Lazy view of a `JsdocDescriptionLine` (Kind 0x02)."
+);
+
+impl<'a> LazyJsdocDescriptionLine<'a> {
+    /// Description content. Basic mode reads it from the String-payload
+    /// (Node Data); compat mode reads from byte 0-5 of the Extended Data
+    /// record.
+    pub fn description(&self) -> &'a str {
+        if self.source_file.compat_mode {
+            ext_string(self.source_file, self.node_index, 0)
+        } else {
+            string_payload(self.source_file, self.node_index).unwrap_or("")
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 0x03 LazyJsdocTag
+// ---------------------------------------------------------------------------
+define_lazy_comment_node!(LazyJsdocTag, Kind::JsdocTag, "Lazy view of a `JsdocTag` (Kind 0x03).");
+
+impl<'a> LazyJsdocTag<'a> {
+    /// Whether the tag was written with bracket syntax such as `[id]`.
+    #[inline]
+    pub fn optional(&self) -> bool {
+        (self.common_data() & 0b0000_0001) != 0
+    }
+
+    /// `default_value` from `[id=foo]` syntax.
+    pub fn default_value(&self) -> Option<&'a str> {
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        resolve_string_field_slot(self.source_file, ext, 2)
+    }
+    /// Joined description text.
+    pub fn description(&self) -> Option<&'a str> {
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        resolve_string_field_slot(self.source_file, ext, 8)
+    }
+    /// Raw description slice (with `*` prefix and blank lines intact).
+    /// Returns `None` when the buffer was not parsed with
+    /// `preserve_whitespace = true` (the per-node
+    /// `has_description_raw_span` Common Data bit is clear), or when the
+    /// tag has no description.
+    ///
+    /// Phase 5 layout: the span sits at the **last 8 bytes** of the ED
+    /// record (offset = compat ? 80 : 38 = the basic / compat ED size).
+    /// See `design/008-oxlint-oxfmt-support/README.md` §4.2 / §4.3.
+    pub fn description_raw(&self) -> Option<&'a str> {
+        if (self.common_data() & JSDOC_TAG_HAS_DESCRIPTION_RAW_SPAN_BIT) == 0 {
+            return None;
+        }
+        let span_off =
+            if self.source_file.compat_mode { JSDOC_TAG_COMPAT_SIZE } else { JSDOC_TAG_BASIC_SIZE };
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        let bytes = self.source_file.bytes();
+        let start = super::super::helpers::read_u32(bytes, ext + span_off);
+        let end = super::super::helpers::read_u32(bytes, ext + span_off + 4);
+        self.source_file.slice_source_text(self.root_index, start, end)
+    }
+    /// Description text. Identical contract to
+    /// [`LazyJsdocBlock::description_text`].
+    pub fn description_text(&self, preserve_whitespace: bool) -> Option<Cow<'a, str>> {
+        if preserve_whitespace {
+            self.description_raw().map(|raw| Cow::Owned(parsed_preserving_whitespace(raw)))
+        } else {
+            self.description().map(Cow::Borrowed)
+        }
+    }
+    /// Raw body when the tag uses the `Raw` body variant.
+    pub fn raw_body(&self) -> Option<&'a str> {
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        resolve_string_field_slot(self.source_file, ext, 14)
+    }
+
+    #[inline]
+    fn children_bitmask(&self) -> u8 {
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        self.source_file.bytes()[ext]
+    }
+
+    /// Tag name child (`@name`). Always present.
+    pub fn tag(&self) -> LazyJsdocTagName<'a> {
+        let bitmask = self.children_bitmask();
+        let idx = child_at_visitor_index(self.source_file, self.node_index, bitmask, 0)
+            .expect("JsdocTag.tag is required");
+        LazyJsdocTagName::from_index(self.source_file, idx, self.root_index)
+    }
+    /// Raw `{...}` type source.
+    pub fn raw_type(&self) -> Option<LazyJsdocTypeSource<'a>> {
+        let bitmask = self.children_bitmask();
+        child_at_visitor_index(self.source_file, self.node_index, bitmask, 1)
+            .map(|idx| LazyJsdocTypeSource::from_index(self.source_file, idx, self.root_index))
+    }
+    /// Tag-name value (e.g. `id` in `@param id`).
+    pub fn name(&self) -> Option<LazyJsdocTagNameValue<'a>> {
+        let bitmask = self.children_bitmask();
+        child_at_visitor_index(self.source_file, self.node_index, bitmask, 2)
+            .map(|idx| LazyJsdocTagNameValue::from_index(self.source_file, idx, self.root_index))
+    }
+    /// `parsedType` child (any TypeNode variant).
+    pub fn parsed_type(&self) -> Option<LazyTypeNode<'a>> {
+        let bitmask = self.children_bitmask();
+        let idx = child_at_visitor_index(self.source_file, self.node_index, bitmask, 3)?;
+        LazyTypeNode::from_index(self.source_file, idx, self.root_index)
+    }
+    /// `body` child (one of `JsdocGenericTagBody` / `JsdocBorrowsTagBody` /
+    /// `JsdocRawTagBody`). The variant is determined from the child's Kind
+    /// byte; returns `None` when bit4 of the Children bitmask is unset or
+    /// the child is not one of the three body kinds.
+    pub fn body(&self) -> Option<LazyJsdocTagBody<'a>> {
+        let bitmask = self.children_bitmask();
+        let idx = child_at_visitor_index(self.source_file, self.node_index, bitmask, 4)?;
+        let kind_byte = self.source_file.bytes()[self.source_file.nodes_offset as usize
+            + idx as usize * NODE_RECORD_SIZE
+            + KIND_OFFSET];
+        let kind = Kind::from_u8(kind_byte).ok()?;
+        match kind {
+            Kind::JsdocGenericTagBody => Some(LazyJsdocTagBody::Generic(
+                LazyJsdocGenericTagBody::from_index(self.source_file, idx, self.root_index),
+            )),
+            Kind::JsdocBorrowsTagBody => Some(LazyJsdocTagBody::Borrows(
+                LazyJsdocBorrowsTagBody::from_index(self.source_file, idx, self.root_index),
+            )),
+            Kind::JsdocRawTagBody => Some(LazyJsdocTagBody::Raw(LazyJsdocRawTagBody::from_index(
+                self.source_file,
+                idx,
+                self.root_index,
+            ))),
+            _ => None,
+        }
+    }
+
+    /// Source-preserving description lines.
+    pub fn description_lines(&self) -> NodeListIter<'a, LazyJsdocDescriptionLine<'a>> {
+        self.list_at(JSDOC_TAG_DESC_LINES_SLOT)
+    }
+    /// Source-preserving type lines.
+    pub fn type_lines(&self) -> NodeListIter<'a, LazyJsdocTypeLine<'a>> {
+        self.list_at(JSDOC_TAG_TYPE_LINES_SLOT)
+    }
+    /// Inline tags found in this tag's description.
+    pub fn inline_tags(&self) -> NodeListIter<'a, LazyJsdocInlineTag<'a>> {
+        self.list_at(JSDOC_TAG_INLINE_TAGS_SLOT)
+    }
+
+    #[inline]
+    fn list_at<T: LazyNode<'a>>(&self, slot_offset: usize) -> NodeListIter<'a, T> {
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        let (head, count) = read_list_metadata(self.source_file, ext, slot_offset);
+        NodeListIter::new(self.source_file, head, count, self.root_index)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 0x04-0x06, 0x0B, 0x0D-0x0F: Extended-type string-leaf nodes (6-byte ED)
+// ---------------------------------------------------------------------------
+
+macro_rules! define_string_leaf {
+    ($name:ident, $kind:expr, $accessor:ident, $doc:expr) => {
+        define_lazy_comment_node!($name, $kind, $doc);
+        impl<'a> $name<'a> {
+            #[doc = concat!("Resolve the underlying string value of this `", stringify!($name), "`.")]
+            pub fn $accessor(&self) -> &'a str {
+                string_payload(self.source_file, self.node_index).unwrap_or("")
+            }
+        }
+    };
+}
+
+define_string_leaf!(
+    LazyJsdocTagName,
+    Kind::JsdocTagName,
+    value,
+    "Lazy view of a `JsdocTagName` leaf (Kind 0x04)."
+);
+define_string_leaf!(
+    LazyJsdocTagNameValue,
+    Kind::JsdocTagNameValue,
+    raw,
+    "Lazy view of a `JsdocTagNameValue` leaf (Kind 0x05)."
+);
+define_string_leaf!(
+    LazyJsdocTypeSource,
+    Kind::JsdocTypeSource,
+    raw,
+    "Lazy view of a `JsdocTypeSource` leaf (Kind 0x06)."
+);
+define_string_leaf!(
+    LazyJsdocRawTagBody,
+    Kind::JsdocRawTagBody,
+    raw,
+    "Lazy view of a `JsdocRawTagBody` leaf (Kind 0x0B)."
+);
+define_string_leaf!(
+    LazyJsdocNamepathSource,
+    Kind::JsdocNamepathSource,
+    raw,
+    "Lazy view of a `JsdocNamepathSource` leaf (Kind 0x0D)."
+);
+define_string_leaf!(
+    LazyJsdocIdentifier,
+    Kind::JsdocIdentifier,
+    name,
+    "Lazy view of a `JsdocIdentifier` leaf (Kind 0x0E)."
+);
+define_string_leaf!(
+    LazyJsdocText,
+    Kind::JsdocText,
+    value,
+    "Lazy view of a `JsdocText` leaf (Kind 0x0F)."
+);
+
+// ---------------------------------------------------------------------------
+// 0x07 LazyJsdocTypeLine (Extended)
+// ---------------------------------------------------------------------------
+define_lazy_comment_node!(
+    LazyJsdocTypeLine,
+    Kind::JsdocTypeLine,
+    "Lazy view of a `JsdocTypeLine` (Kind 0x07)."
+);
+
+impl<'a> LazyJsdocTypeLine<'a> {
+    /// Raw `{...}` line content. Basic mode reads it from the
+    /// String-payload (Node Data); compat mode reads from byte 0-5 of the
+    /// Extended Data record.
+    pub fn raw_type(&self) -> &'a str {
+        if self.source_file.compat_mode {
+            ext_string(self.source_file, self.node_index, 0)
+        } else {
+            string_payload(self.source_file, self.node_index).unwrap_or("")
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 0x08 LazyJsdocInlineTag
+// ---------------------------------------------------------------------------
+define_lazy_comment_node!(
+    LazyJsdocInlineTag,
+    Kind::JsdocInlineTag,
+    "Lazy view of a `JsdocInlineTag` (Kind 0x08)."
+);
+
+impl<'a> LazyJsdocInlineTag<'a> {
+    /// Inline tag format (`bits[0:2]` of Common Data).
+    #[inline]
+    pub fn format(&self) -> u8 {
+        self.common_data() & 0b0000_0111
+    }
+    /// Optional name path or URL portion.
+    pub fn namepath_or_url(&self) -> Option<&'a str> {
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        resolve_string_field_slot(self.source_file, ext, 0)
+    }
+    /// Optional display text portion.
+    pub fn text(&self) -> Option<&'a str> {
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        resolve_string_field_slot(self.source_file, ext, STRING_FIELD_SIZE)
+    }
+    /// Raw body text fallback.
+    pub fn raw_body(&self) -> Option<&'a str> {
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        resolve_string_field_slot(self.source_file, ext, 2 * STRING_FIELD_SIZE)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 0x09 LazyJsdocGenericTagBody
+// ---------------------------------------------------------------------------
+define_lazy_comment_node!(
+    LazyJsdocGenericTagBody,
+    Kind::JsdocGenericTagBody,
+    "Lazy view of a `JsdocGenericTagBody` (Kind 0x09)."
+);
+
+impl<'a> LazyJsdocGenericTagBody<'a> {
+    /// `true` when the tag separator was `-`.
+    #[inline]
+    pub fn has_dash_separator(&self) -> bool {
+        (self.common_data() & 0b0000_0001) != 0
+    }
+    /// `description` string after the dash separator.
+    pub fn description(&self) -> Option<&'a str> {
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        resolve_string_field_slot(self.source_file, ext, 2)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 0x0A LazyJsdocBorrowsTagBody
+// ---------------------------------------------------------------------------
+define_lazy_comment_node!(
+    LazyJsdocBorrowsTagBody,
+    Kind::JsdocBorrowsTagBody,
+    "Lazy view of a `JsdocBorrowsTagBody` (Kind 0x0A)."
+);
+
+// ---------------------------------------------------------------------------
+// 0x0C LazyJsdocParameterName
+// ---------------------------------------------------------------------------
+define_lazy_comment_node!(
+    LazyJsdocParameterName,
+    Kind::JsdocParameterName,
+    "Lazy view of a `JsdocParameterName` (Kind 0x0C)."
+);
+
+impl<'a> LazyJsdocParameterName<'a> {
+    /// `true` when the parameter was wrapped in brackets (`[id]`).
+    #[inline]
+    pub fn optional(&self) -> bool {
+        (self.common_data() & 0b0000_0001) != 0
+    }
+    /// The path text (required, byte 0-5).
+    pub fn path(&self) -> &'a str {
+        ext_string(self.source_file, self.node_index, 0)
+    }
+    /// Default value from `[id=foo]` syntax (Optional, byte 6-11).
+    pub fn default_value(&self) -> Option<&'a str> {
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        resolve_string_field_slot(self.source_file, ext, STRING_FIELD_SIZE)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Variant wrappers
+// ---------------------------------------------------------------------------
+
+/// Body of a `JsdocTag` — one of three variants distinguished by the child Kind.
+#[derive(Debug, Clone, Copy)]
+pub enum LazyJsdocTagBody<'a> {
+    /// Generic body (`@param {T} name - desc`).
+    Generic(LazyJsdocGenericTagBody<'a>),
+    /// Borrows body (`@borrows from as to`).
+    Borrows(LazyJsdocBorrowsTagBody<'a>),
+    /// Raw text body.
+    Raw(LazyJsdocRawTagBody<'a>),
+}
+
+/// Tag value — first non-type token after the tag name.
+#[derive(Debug, Clone, Copy)]
+pub enum LazyJsdocTagValue<'a> {
+    /// Parameter-style name (e.g. `[id=foo]`).
+    Parameter(LazyJsdocParameterName<'a>),
+    /// Namepath token.
+    Namepath(LazyJsdocNamepathSource<'a>),
+    /// Bare identifier.
+    Identifier(LazyJsdocIdentifier<'a>),
+    /// Raw text fallback.
+    Raw(LazyJsdocText<'a>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::size_of;
+
+    #[test]
+    fn lazy_comment_structs_are_compact() {
+        macro_rules! assert_size {
+            ($t:ty) => {
+                assert!(size_of::<$t>() <= 16, concat!(stringify!($t), " exceeds 16 bytes"));
+            };
+        }
+        assert_size!(LazyJsdocBlock<'static>);
+        assert_size!(LazyJsdocDescriptionLine<'static>);
+        assert_size!(LazyJsdocTag<'static>);
+        assert_size!(LazyJsdocTagName<'static>);
+        assert_size!(LazyJsdocText<'static>);
+        assert_size!(LazyJsdocInlineTag<'static>);
+        assert_size!(LazyJsdocParameterName<'static>);
+    }
+
+    #[test]
+    fn variant_wrappers_fit_in_24_bytes() {
+        assert!(size_of::<LazyJsdocTagBody<'static>>() <= 24);
+        assert!(size_of::<LazyJsdocTagValue<'static>>() <= 24);
+    }
+}

--- a/crates/ox_jsdoc_binary/src/decoder/nodes/mod.rs
+++ b/crates/ox_jsdoc_binary/src/decoder/nodes/mod.rs
@@ -1,0 +1,207 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Lazy node structs (60 in total) and the [`LazyNode`] trait.
+//!
+//! Per `design/007-binary-ast/rust-impl.md#lazy-nodes-are-stack-value-types-no-box-allocation`,
+//! every lazy node is a `#[derive(Copy, Clone)]` struct of at most ~32 bytes
+//! that holds a slice into the buffer plus its `node_index`. Eliminating
+//! the per-traversal `Box::new` is the main reason the Rust walker is
+//! ~10x faster than the typed-AST baseline in earlier ox-jsdoc benchmarks.
+
+pub mod comment_ast;
+pub mod type_node;
+
+use core::marker::PhantomData;
+
+use crate::format::kind::Kind;
+use crate::format::node_record::{
+    COMMON_DATA_MASK, END_OFFSET, KIND_OFFSET, NODE_RECORD_SIZE, PARENT_INDEX_OFFSET, POS_OFFSET,
+};
+
+use super::helpers::read_u32;
+use super::source_file::LazySourceFile;
+
+/// Common interface implemented by every lazy node struct.
+///
+/// `KIND` enables compile-time `from_index` validation (`debug_assert!` on
+/// the byte at `nodes_offset + node_index * 24`). The accessor methods give
+/// generic helpers (e.g. [`NodeListIter`]) a uniform way to construct child
+/// instances.
+pub trait LazyNode<'a>: Copy + Clone + Sized {
+    /// The Kind value this struct represents.
+    const KIND: Kind;
+
+    /// Construct a lazy node from `(source_file, node_index, root_index)`.
+    ///
+    /// `root_index` is the index of the [`crate::decoder::source_file::LazySourceFile::asts`]
+    /// entry that contains this node, propagated from parent to child so
+    /// that [`Self::range`] can compute absolute positions in O(1).
+    ///
+    /// Implementations must `debug_assert!` that the Kind byte at
+    /// `nodes_offset + node_index * 24` equals `Self::KIND`.
+    fn from_index(source_file: &'a LazySourceFile<'a>, node_index: u32, root_index: u32) -> Self;
+
+    /// Borrow the [`LazySourceFile`] this node came from.
+    fn source_file(&self) -> &'a LazySourceFile<'a>;
+
+    /// The index of this node within the Nodes section.
+    fn node_index(&self) -> u32;
+
+    /// The root this node belongs to.
+    fn root_index(&self) -> u32;
+
+    // ----- default-method getters shared by every Lazy* struct -----
+
+    /// Byte offset of this node's record within the Nodes section.
+    #[inline]
+    fn byte_offset(&self) -> usize {
+        self.source_file().nodes_offset as usize + self.node_index() as usize * NODE_RECORD_SIZE
+    }
+
+    /// Read the `Kind` byte and decode it via [`Kind::from_u8`].
+    #[inline]
+    fn kind(&self) -> Kind {
+        let byte = self.source_file().bytes()[self.byte_offset() + KIND_OFFSET];
+        Kind::from_u8(byte).expect("encoder must only emit defined Kinds")
+    }
+
+    /// Read the 6-bit Common Data byte (upper 2 bits masked off).
+    #[inline]
+    fn common_data(&self) -> u8 {
+        self.source_file().bytes()[self.byte_offset() + 1] & COMMON_DATA_MASK
+    }
+
+    /// `Pos` field — UTF-16 code unit offset *relative to the root's
+    /// sourceText*.
+    #[inline]
+    fn pos(&self) -> u32 {
+        read_u32(self.source_file().bytes(), self.byte_offset() + POS_OFFSET)
+    }
+
+    /// `End` field (relative to the root's sourceText).
+    #[inline]
+    fn end(&self) -> u32 {
+        read_u32(self.source_file().bytes(), self.byte_offset() + END_OFFSET)
+    }
+
+    /// `[absolute_pos, absolute_end]` — `Pos`/`End` plus the root's
+    /// `base_offset`. Use this when feeding ranges into ESLint reports.
+    #[inline]
+    fn range(&self) -> [u32; 2] {
+        let base = self.source_file().get_root_base_offset(self.root_index());
+        [base + self.pos(), base + self.end()]
+    }
+
+    /// Index of this node's parent. `0` means the parent is the
+    /// [`crate::format::root_index::PARSE_FAILURE_SENTINEL`] (i.e. this
+    /// node is a root).
+    #[inline]
+    fn parent_index(&self) -> u32 {
+        read_u32(self.source_file().bytes(), self.byte_offset() + PARENT_INDEX_OFFSET)
+    }
+}
+
+/// Iterator yielded by lazy "NodeList" getters.
+///
+/// Stored as a tiny value-type struct so that calling `.tags()` on a parent
+/// allocates nothing — the iterator itself sits on the stack and walks
+/// `next_sibling` links on each `next()` call.
+///
+/// As of the NodeList-elimination format change, the iterator carries an
+/// explicit `remaining` count read from the parent's Extended Data block
+/// (slot layout: `head: u32` + `count: u16`). The Kind 0x7F wrapper that
+/// previously delimited each list is no longer emitted; the iterator stops
+/// once `remaining` reaches zero.
+#[derive(Debug, Clone, Copy)]
+pub struct NodeListIter<'a, T> {
+    source_file: &'a LazySourceFile<'a>,
+    /// Current position in the Nodes section. `0` indicates an empty or
+    /// fully-consumed iterator.
+    current_index: u32,
+    /// Number of elements left to yield. Decremented on every `next()`;
+    /// reaching zero ends iteration even if `current_index` still points at
+    /// a sibling chain (which it can, when the parent has multiple lists
+    /// laid out back-to-back).
+    remaining: u32,
+    /// Root index propagated to every yielded child.
+    root_index: u32,
+    _marker: PhantomData<T>,
+}
+
+impl<'a, T: LazyNode<'a>> NodeListIter<'a, T> {
+    /// Create a new iterator over `count` elements starting at `head_index`.
+    /// Either `head_index = 0` or `count = 0` produces an immediately-empty
+    /// iterator.
+    #[inline]
+    #[must_use]
+    pub const fn new(
+        source_file: &'a LazySourceFile<'a>,
+        head_index: u32,
+        count: u32,
+        root_index: u32,
+    ) -> Self {
+        let (current, remaining) =
+            if head_index == 0 || count == 0 { (0, 0) } else { (head_index, count) };
+        NodeListIter {
+            source_file,
+            current_index: current,
+            remaining,
+            root_index,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Whether the iterator has been fully consumed.
+    #[inline]
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.remaining == 0
+    }
+
+    /// Number of elements still to yield.
+    #[inline]
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.remaining as usize
+    }
+}
+
+impl<'a, T: LazyNode<'a>> Iterator for NodeListIter<'a, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        let item = T::from_index(self.source_file, self.current_index, self.root_index);
+        self.current_index =
+            super::helpers::read_next_sibling(self.source_file, self.current_index);
+        self.remaining -= 1;
+        Some(item)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = self.remaining as usize;
+        (n, Some(n))
+    }
+}
+
+impl<'a, T: LazyNode<'a>> ExactSizeIterator for NodeListIter<'a, T> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::size_of;
+
+    /// `NodeListIter` is one of the values that crosses every traversal
+    /// boundary, so it must stay tiny enough to pass through registers on
+    /// every supported target.
+    #[test]
+    fn node_list_iter_is_compact() {
+        // ptr (8) + u32 (4) + u32 (4) + PhantomData (0) = 16
+        assert!(size_of::<NodeListIter<'static, ()>>() <= 24);
+    }
+}

--- a/crates/ox_jsdoc_binary/src/decoder/nodes/type_node.rs
+++ b/crates/ox_jsdoc_binary/src/decoder/nodes/type_node.rs
@@ -1,0 +1,960 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Lazy structs for the 45 TypeNode kinds (`0x80 - 0xAC`).
+//!
+//! Each struct mirrors the comment-AST style in
+//! [`super::comment_ast`]: a `Copy` value type holding
+//! `(source_file, node_index, root_index)` plus per-Kind getters.
+//!
+//! In addition to the per-Kind structs, this module exposes the
+//! [`LazyTypeNode`] enum for callers (such as `JsdocTag.parsed_type`) that
+//! receive a TypeNode of unknown variant.
+
+use crate::format::kind::Kind;
+use crate::format::string_field::STRING_FIELD_SIZE;
+use crate::writer::nodes::type_node::TYPE_LIST_PARENT_SLOT;
+
+use super::super::helpers::{
+    child_at_visitor_index, children_bitmask_payload, ext_offset, ext_string_leaf, first_child,
+    read_list_metadata, read_next_sibling, read_string_field, read_u16, string_payload,
+};
+use super::super::source_file::LazySourceFile;
+use super::LazyNode;
+
+/// Generate a lazy TypeNode struct + its `LazyNode` impl in one go.
+macro_rules! define_lazy_type_node {
+    ($name:ident, $kind:expr, $doc:expr) => {
+        #[doc = $doc]
+        #[derive(Debug, Clone, Copy)]
+        pub struct $name<'a> {
+            source_file: &'a LazySourceFile<'a>,
+            node_index: u32,
+            root_index: u32,
+        }
+
+        impl<'a> LazyNode<'a> for $name<'a> {
+            const KIND: Kind = $kind;
+
+            #[inline]
+            fn from_index(
+                source_file: &'a LazySourceFile<'a>,
+                node_index: u32,
+                root_index: u32,
+            ) -> Self {
+                $name { source_file, node_index, root_index }
+            }
+
+            #[inline]
+            fn source_file(&self) -> &'a LazySourceFile<'a> {
+                self.source_file
+            }
+
+            #[inline]
+            fn node_index(&self) -> u32 {
+                self.node_index
+            }
+
+            #[inline]
+            fn root_index(&self) -> u32 {
+                self.root_index
+            }
+        }
+    };
+}
+
+// ===========================================================================
+// Pattern 1 — String only (5 kinds)
+// ===========================================================================
+
+define_lazy_type_node!(LazyTypeName, Kind::TypeName, "Lazy view of `TypeName` (Kind 0x80).");
+impl<'a> LazyTypeName<'a> {
+    /// Identifier name string.
+    pub fn value(&self) -> &'a str {
+        string_payload(self.source_file, self.node_index).unwrap_or("")
+    }
+}
+
+define_lazy_type_node!(LazyTypeNumber, Kind::TypeNumber, "Lazy view of `TypeNumber` (Kind 0x81).");
+impl<'a> LazyTypeNumber<'a> {
+    /// Numeric literal as written in the source.
+    pub fn value(&self) -> &'a str {
+        string_payload(self.source_file, self.node_index).unwrap_or("")
+    }
+}
+
+define_lazy_type_node!(
+    LazyTypeStringValue,
+    Kind::TypeStringValue,
+    "Lazy view of `TypeStringValue` (Kind 0x82)."
+);
+impl<'a> LazyTypeStringValue<'a> {
+    /// Quote style (None=0 / Single=1 / Double=2).
+    #[inline]
+    pub fn quote(&self) -> u8 {
+        self.common_data() & 0b11
+    }
+    /// String literal value.
+    pub fn value(&self) -> &'a str {
+        string_payload(self.source_file, self.node_index).unwrap_or("")
+    }
+}
+
+define_lazy_type_node!(
+    LazyTypeProperty,
+    Kind::TypeProperty,
+    "Lazy view of `TypeProperty` (Kind 0xA3)."
+);
+impl<'a> LazyTypeProperty<'a> {
+    /// Quote style (3-state).
+    #[inline]
+    pub fn quote(&self) -> u8 {
+        self.common_data() & 0b11
+    }
+    /// Property name string.
+    pub fn value(&self) -> &'a str {
+        string_payload(self.source_file, self.node_index).unwrap_or("")
+    }
+}
+
+define_lazy_type_node!(
+    LazyTypeSpecialNamePath,
+    Kind::TypeSpecialNamePath,
+    "Lazy view of `TypeSpecialNamePath` (Kind 0x8F)."
+);
+impl<'a> LazyTypeSpecialNamePath<'a> {
+    /// Special path category (3 variants).
+    #[inline]
+    pub fn special_type(&self) -> u8 {
+        self.common_data() & 0b11
+    }
+    /// Quote style (3-state).
+    #[inline]
+    pub fn quote(&self) -> u8 {
+        (self.common_data() >> 2) & 0b11
+    }
+    /// Path string.
+    pub fn value(&self) -> &'a str {
+        string_payload(self.source_file, self.node_index).unwrap_or("")
+    }
+}
+
+// ===========================================================================
+// Pattern 2 — Children only (29 kinds)
+//
+// Most of these wrap zero or more child TypeNodes accessed via
+// `child_at_visitor_index`. Phase 1.1b ships the structs + the most
+// useful getters (`element` / `elements` / `left` / `right` / etc.); the
+// long tail of trivial accessors can be filled in during Phase 1.2a as
+// the parser starts emitting them.
+// ===========================================================================
+
+/// Iterator yielding [`LazyTypeNode`] values walked through `next_sibling`.
+///
+/// Separate from the generic [`NodeListIter`] because `LazyTypeNode` is a
+/// sum type and can't implement [`LazyNode`] (each variant has its own
+/// `Kind`). Carries an explicit `remaining` count read from the parent's
+/// Extended Data list-metadata slot.
+#[derive(Debug, Clone, Copy)]
+pub struct LazyTypeNodeListIter<'a> {
+    source_file: &'a LazySourceFile<'a>,
+    current_index: u32,
+    remaining: u32,
+    root_index: u32,
+}
+
+impl<'a> LazyTypeNodeListIter<'a> {
+    /// Create a fresh iterator over `count` elements starting at
+    /// `head_index`. Either `head_index = 0` or `count = 0` produces an
+    /// immediately-empty iterator.
+    #[inline]
+    #[must_use]
+    pub const fn new(
+        source_file: &'a LazySourceFile<'a>,
+        head_index: u32,
+        count: u32,
+        root_index: u32,
+    ) -> Self {
+        let (current, remaining) =
+            if head_index == 0 || count == 0 { (0, 0) } else { (head_index, count) };
+        LazyTypeNodeListIter { source_file, current_index: current, remaining, root_index }
+    }
+
+    /// Whether the iterator has been fully consumed.
+    #[inline]
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.remaining == 0
+    }
+
+    /// Number of elements still to yield.
+    #[inline]
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.remaining as usize
+    }
+}
+
+impl<'a> Iterator for LazyTypeNodeListIter<'a> {
+    type Item = LazyTypeNode<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.remaining > 0 {
+            let item =
+                LazyTypeNode::from_index(self.source_file, self.current_index, self.root_index);
+            self.current_index = read_next_sibling(self.source_file, self.current_index);
+            self.remaining -= 1;
+            if let Some(node) = item {
+                return Some(node);
+            }
+            // Skip non-TypeNode siblings (shouldn't happen with valid buffers).
+        }
+        None
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = self.remaining as usize;
+        (n, Some(n))
+    }
+}
+
+/// Helper: build a [`LazyTypeNodeListIter`] over the elements registered in
+/// the parent's Extended Data list-metadata slot at
+/// [`TYPE_LIST_PARENT_SLOT`].
+fn nodelist_at<'a>(
+    sf: &'a LazySourceFile<'a>,
+    parent_index: u32,
+    root_index: u32,
+) -> LazyTypeNodeListIter<'a> {
+    let ext = ext_offset(sf, parent_index) as usize;
+    let (head, count) = read_list_metadata(sf, ext, TYPE_LIST_PARENT_SLOT);
+    LazyTypeNodeListIter::new(sf, head, count, root_index)
+}
+
+/// Helper: get the n-th direct child as a TypeNode.
+fn child_type_node<'a>(
+    sf: &'a LazySourceFile<'a>,
+    parent_index: u32,
+    visitor_index: u8,
+    root_index: u32,
+) -> Option<LazyTypeNode<'a>> {
+    let bitmask = children_bitmask_payload(sf, parent_index) as u8;
+    let idx = child_at_visitor_index(sf, parent_index, bitmask, visitor_index)?;
+    LazyTypeNode::from_index(sf, idx, root_index)
+}
+
+define_lazy_type_node!(LazyTypeUnion, Kind::TypeUnion, "Lazy view of `TypeUnion` (Kind 0x87).");
+impl<'a> LazyTypeUnion<'a> {
+    /// Union elements.
+    pub fn elements(&self) -> LazyTypeNodeListIter<'a> {
+        nodelist_at(self.source_file, self.node_index, self.root_index)
+    }
+}
+
+define_lazy_type_node!(
+    LazyTypeIntersection,
+    Kind::TypeIntersection,
+    "Lazy view of `TypeIntersection` (Kind 0x88)."
+);
+impl<'a> LazyTypeIntersection<'a> {
+    /// Intersection elements.
+    pub fn elements(&self) -> LazyTypeNodeListIter<'a> {
+        nodelist_at(self.source_file, self.node_index, self.root_index)
+    }
+}
+
+define_lazy_type_node!(
+    LazyTypeGeneric,
+    Kind::TypeGeneric,
+    "Lazy view of `TypeGeneric` (Kind 0x89)."
+);
+impl<'a> LazyTypeGeneric<'a> {
+    /// Bracket style (Angle=0 / Square=1).
+    #[inline]
+    pub fn brackets(&self) -> u8 {
+        self.common_data() & 1
+    }
+    /// Whether the generic was written with a leading `.` (Closure form).
+    #[inline]
+    pub fn dot(&self) -> bool {
+        (self.common_data() & 0b10) != 0
+    }
+    /// Left-hand side type (the parent's first direct child).
+    pub fn left(&self) -> Option<LazyTypeNode<'a>> {
+        let idx = first_child(self.source_file, self.node_index)?;
+        LazyTypeNode::from_index(self.source_file, idx, self.root_index)
+    }
+    /// Generic argument elements (registered in the parent's ED block).
+    pub fn elements(&self) -> LazyTypeNodeListIter<'a> {
+        nodelist_at(self.source_file, self.node_index, self.root_index)
+    }
+}
+
+define_lazy_type_node!(
+    LazyTypeFunction,
+    Kind::TypeFunction,
+    "Lazy view of `TypeFunction` (Kind 0x8A)."
+);
+impl<'a> LazyTypeFunction<'a> {
+    /// Constructor flag.
+    #[inline]
+    pub fn constructor(&self) -> bool {
+        (self.common_data() & 0b001) != 0
+    }
+    /// Arrow-form flag.
+    #[inline]
+    pub fn arrow(&self) -> bool {
+        (self.common_data() & 0b010) != 0
+    }
+    /// Whether parameters were enclosed in parentheses.
+    #[inline]
+    pub fn parenthesis(&self) -> bool {
+        (self.common_data() & 0b100) != 0
+    }
+    /// Parameter list child.
+    pub fn parameters(&self) -> Option<LazyTypeParameterList<'a>> {
+        let bitmask = children_bitmask_payload(self.source_file, self.node_index) as u8;
+        let idx = child_at_visitor_index(self.source_file, self.node_index, bitmask, 0)?;
+        Some(LazyTypeParameterList::from_index(self.source_file, idx, self.root_index))
+    }
+    /// Return type child.
+    pub fn return_type(&self) -> Option<LazyTypeNode<'a>> {
+        child_type_node(self.source_file, self.node_index, 1, self.root_index)
+    }
+    /// Type-parameter list child.
+    pub fn type_parameters(&self) -> Option<LazyTypeParameterList<'a>> {
+        let bitmask = children_bitmask_payload(self.source_file, self.node_index) as u8;
+        let idx = child_at_visitor_index(self.source_file, self.node_index, bitmask, 2)?;
+        Some(LazyTypeParameterList::from_index(self.source_file, idx, self.root_index))
+    }
+}
+
+define_lazy_type_node!(LazyTypeObject, Kind::TypeObject, "Lazy view of `TypeObject` (Kind 0x8B).");
+impl<'a> LazyTypeObject<'a> {
+    /// Field separator style (`bits[0:2]`).
+    #[inline]
+    pub fn separator(&self) -> u8 {
+        self.common_data() & 0b111
+    }
+    /// Field elements.
+    pub fn elements(&self) -> LazyTypeNodeListIter<'a> {
+        nodelist_at(self.source_file, self.node_index, self.root_index)
+    }
+}
+
+define_lazy_type_node!(LazyTypeTuple, Kind::TypeTuple, "Lazy view of `TypeTuple` (Kind 0x8C).");
+impl<'a> LazyTypeTuple<'a> {
+    /// Tuple elements.
+    pub fn elements(&self) -> LazyTypeNodeListIter<'a> {
+        nodelist_at(self.source_file, self.node_index, self.root_index)
+    }
+}
+
+define_lazy_type_node!(
+    LazyTypeParenthesis,
+    Kind::TypeParenthesis,
+    "Lazy view of `TypeParenthesis` (Kind 0x8D)."
+);
+impl<'a> LazyTypeParenthesis<'a> {
+    /// Wrapped type.
+    pub fn element(&self) -> Option<LazyTypeNode<'a>> {
+        child_type_node(self.source_file, self.node_index, 0, self.root_index)
+    }
+}
+
+define_lazy_type_node!(
+    LazyTypeNamePath,
+    Kind::TypeNamePath,
+    "Lazy view of `TypeNamePath` (Kind 0x8E)."
+);
+impl<'a> LazyTypeNamePath<'a> {
+    /// Path connector category (`bits[0:1]`).
+    #[inline]
+    pub fn path_type(&self) -> u8 {
+        self.common_data() & 0b11
+    }
+    /// Left-hand side.
+    pub fn left(&self) -> Option<LazyTypeNode<'a>> {
+        child_type_node(self.source_file, self.node_index, 0, self.root_index)
+    }
+    /// Right-hand side.
+    pub fn right(&self) -> Option<LazyTypeNode<'a>> {
+        child_type_node(self.source_file, self.node_index, 1, self.root_index)
+    }
+}
+
+/// Macro for the simple "1-child + position" modifier types
+/// (`Nullable` / `NotNullable` / `Optional` / `Variadic`).
+macro_rules! define_modifier_type {
+    ($name:ident, $kind:expr, $doc:expr) => {
+        define_lazy_type_node!($name, $kind, $doc);
+        impl<'a> $name<'a> {
+            /// Modifier position (Prefix=0 / Suffix=1).
+            #[inline]
+            pub fn position(&self) -> u8 {
+                self.common_data() & 1
+            }
+            /// Wrapped type.
+            pub fn element(&self) -> Option<LazyTypeNode<'a>> {
+                child_type_node(self.source_file, self.node_index, 0, self.root_index)
+            }
+        }
+    };
+}
+define_modifier_type!(
+    LazyTypeNullable,
+    Kind::TypeNullable,
+    "Lazy view of `TypeNullable` (Kind 0x90)."
+);
+define_modifier_type!(
+    LazyTypeNotNullable,
+    Kind::TypeNotNullable,
+    "Lazy view of `TypeNotNullable` (Kind 0x91)."
+);
+define_modifier_type!(
+    LazyTypeOptional,
+    Kind::TypeOptional,
+    "Lazy view of `TypeOptional` (Kind 0x92)."
+);
+
+define_lazy_type_node!(
+    LazyTypeVariadic,
+    Kind::TypeVariadic,
+    "Lazy view of `TypeVariadic` (Kind 0x93)."
+);
+impl<'a> LazyTypeVariadic<'a> {
+    /// Modifier position.
+    #[inline]
+    pub fn position(&self) -> u8 {
+        self.common_data() & 1
+    }
+    /// Whether the variadic was written with `[]` brackets.
+    #[inline]
+    pub fn square_brackets(&self) -> bool {
+        (self.common_data() & 0b10) != 0
+    }
+    /// Wrapped type.
+    pub fn element(&self) -> Option<LazyTypeNode<'a>> {
+        child_type_node(self.source_file, self.node_index, 0, self.root_index)
+    }
+}
+
+define_lazy_type_node!(
+    LazyTypeConditional,
+    Kind::TypeConditional,
+    "Lazy view of `TypeConditional` (Kind 0x94)."
+);
+impl<'a> LazyTypeConditional<'a> {
+    /// `T` in `T extends U ? X : Y`.
+    pub fn check_type(&self) -> Option<LazyTypeNode<'a>> {
+        child_type_node(self.source_file, self.node_index, 0, self.root_index)
+    }
+    /// `U`.
+    pub fn extends_type(&self) -> Option<LazyTypeNode<'a>> {
+        child_type_node(self.source_file, self.node_index, 1, self.root_index)
+    }
+    /// `X` (true branch).
+    pub fn true_type(&self) -> Option<LazyTypeNode<'a>> {
+        child_type_node(self.source_file, self.node_index, 2, self.root_index)
+    }
+    /// `Y` (false branch).
+    pub fn false_type(&self) -> Option<LazyTypeNode<'a>> {
+        child_type_node(self.source_file, self.node_index, 3, self.root_index)
+    }
+}
+
+/// Macro for "1 child = element" types.
+macro_rules! define_single_child_type {
+    ($name:ident, $kind:expr, $doc:expr) => {
+        define_lazy_type_node!($name, $kind, $doc);
+        impl<'a> $name<'a> {
+            /// Wrapped child type.
+            pub fn element(&self) -> Option<LazyTypeNode<'a>> {
+                child_type_node(self.source_file, self.node_index, 0, self.root_index)
+            }
+        }
+    };
+}
+define_single_child_type!(LazyTypeInfer, Kind::TypeInfer, "Lazy view of `TypeInfer` (Kind 0x95).");
+define_single_child_type!(LazyTypeKeyOf, Kind::TypeKeyOf, "Lazy view of `TypeKeyOf` (Kind 0x96).");
+define_single_child_type!(
+    LazyTypeTypeOf,
+    Kind::TypeTypeOf,
+    "Lazy view of `TypeTypeOf` (Kind 0x97)."
+);
+define_single_child_type!(
+    LazyTypeImport,
+    Kind::TypeImport,
+    "Lazy view of `TypeImport` (Kind 0x98)."
+);
+define_single_child_type!(
+    LazyTypeAssertsPlain,
+    Kind::TypeAssertsPlain,
+    "Lazy view of `TypeAssertsPlain` (Kind 0x9B)."
+);
+define_single_child_type!(
+    LazyTypeReadonlyArray,
+    Kind::TypeReadonlyArray,
+    "Lazy view of `TypeReadonlyArray` (Kind 0x9C)."
+);
+define_single_child_type!(
+    LazyTypeIndexedAccessIndex,
+    Kind::TypeIndexedAccessIndex,
+    "Lazy view of `TypeIndexedAccessIndex` (Kind 0xAA)."
+);
+define_single_child_type!(
+    LazyTypeReadonlyProperty,
+    Kind::TypeReadonlyProperty,
+    "Lazy view of `TypeReadonlyProperty` (Kind 0xAC)."
+);
+
+/// Macro for the "left + right" 2-child types (Predicate / Asserts).
+macro_rules! define_left_right_type {
+    ($name:ident, $kind:expr, $doc:expr) => {
+        define_lazy_type_node!($name, $kind, $doc);
+        impl<'a> $name<'a> {
+            /// Left-hand operand.
+            pub fn left(&self) -> Option<LazyTypeNode<'a>> {
+                child_type_node(self.source_file, self.node_index, 0, self.root_index)
+            }
+            /// Right-hand operand.
+            pub fn right(&self) -> Option<LazyTypeNode<'a>> {
+                child_type_node(self.source_file, self.node_index, 1, self.root_index)
+            }
+        }
+    };
+}
+define_left_right_type!(
+    LazyTypePredicate,
+    Kind::TypePredicate,
+    "Lazy view of `TypePredicate` (Kind 0x99)."
+);
+define_left_right_type!(
+    LazyTypeAsserts,
+    Kind::TypeAsserts,
+    "Lazy view of `TypeAsserts` (Kind 0x9A)."
+);
+
+define_lazy_type_node!(
+    LazyTypeObjectField,
+    Kind::TypeObjectField,
+    "Lazy view of `TypeObjectField` (Kind 0xA0)."
+);
+impl<'a> LazyTypeObjectField<'a> {
+    /// `?` modifier flag.
+    #[inline]
+    pub fn optional(&self) -> bool {
+        (self.common_data() & 0b0001) != 0
+    }
+    /// `readonly` modifier flag.
+    #[inline]
+    pub fn readonly(&self) -> bool {
+        (self.common_data() & 0b0010) != 0
+    }
+    /// Quote style for the field key (3-state).
+    #[inline]
+    pub fn quote(&self) -> u8 {
+        (self.common_data() >> 2) & 0b11
+    }
+    /// Field key.
+    pub fn key(&self) -> Option<LazyTypeNode<'a>> {
+        child_type_node(self.source_file, self.node_index, 0, self.root_index)
+    }
+    /// Field value type.
+    pub fn right(&self) -> Option<LazyTypeNode<'a>> {
+        child_type_node(self.source_file, self.node_index, 1, self.root_index)
+    }
+}
+
+define_lazy_type_node!(
+    LazyTypeJsdocObjectField,
+    Kind::TypeJsdocObjectField,
+    "Lazy view of `TypeJsdocObjectField` (Kind 0xA1)."
+);
+impl<'a> LazyTypeJsdocObjectField<'a> {
+    /// Field key.
+    pub fn key(&self) -> Option<LazyTypeNode<'a>> {
+        child_type_node(self.source_file, self.node_index, 0, self.root_index)
+    }
+    /// Field value type.
+    pub fn right(&self) -> Option<LazyTypeNode<'a>> {
+        child_type_node(self.source_file, self.node_index, 1, self.root_index)
+    }
+}
+
+/// Macro for the call-style signature types (CallSignature / ConstructorSignature).
+macro_rules! define_signature_type {
+    ($name:ident, $kind:expr, $doc:expr) => {
+        define_lazy_type_node!($name, $kind, $doc);
+        impl<'a> $name<'a> {
+            /// Parameter list.
+            pub fn parameters(&self) -> Option<LazyTypeParameterList<'a>> {
+                let bitmask = children_bitmask_payload(self.source_file, self.node_index) as u8;
+                let idx = child_at_visitor_index(self.source_file, self.node_index, bitmask, 0)?;
+                Some(LazyTypeParameterList::from_index(self.source_file, idx, self.root_index))
+            }
+            /// Return type.
+            pub fn return_type(&self) -> Option<LazyTypeNode<'a>> {
+                child_type_node(self.source_file, self.node_index, 1, self.root_index)
+            }
+            /// Type-parameter list.
+            pub fn type_parameters(&self) -> Option<LazyTypeParameterList<'a>> {
+                let bitmask = children_bitmask_payload(self.source_file, self.node_index) as u8;
+                let idx = child_at_visitor_index(self.source_file, self.node_index, bitmask, 2)?;
+                Some(LazyTypeParameterList::from_index(self.source_file, idx, self.root_index))
+            }
+        }
+    };
+}
+define_signature_type!(
+    LazyTypeCallSignature,
+    Kind::TypeCallSignature,
+    "Lazy view of `TypeCallSignature` (Kind 0xA7)."
+);
+define_signature_type!(
+    LazyTypeConstructorSignature,
+    Kind::TypeConstructorSignature,
+    "Lazy view of `TypeConstructorSignature` (Kind 0xA8)."
+);
+
+define_lazy_type_node!(
+    LazyTypeTypeParameter,
+    Kind::TypeTypeParameter,
+    "Lazy view of `TypeTypeParameter` (Kind 0xA6)."
+);
+impl<'a> LazyTypeTypeParameter<'a> {
+    /// Type-parameter children.
+    pub fn elements(&self) -> LazyTypeNodeListIter<'a> {
+        nodelist_at(self.source_file, self.node_index, self.root_index)
+    }
+}
+
+define_lazy_type_node!(
+    LazyTypeParameterList,
+    Kind::TypeParameterList,
+    "Lazy view of `TypeParameterList` (Kind 0xAB)."
+);
+impl<'a> LazyTypeParameterList<'a> {
+    /// Parameter elements.
+    pub fn elements(&self) -> LazyTypeNodeListIter<'a> {
+        nodelist_at(self.source_file, self.node_index, self.root_index)
+    }
+}
+
+// ===========================================================================
+// Pattern 3 — Mixed string + children (6 kinds)
+// ===========================================================================
+
+define_lazy_type_node!(
+    LazyTypeKeyValue,
+    Kind::TypeKeyValue,
+    "Lazy view of `TypeKeyValue` (Kind 0xA2)."
+);
+impl<'a> LazyTypeKeyValue<'a> {
+    /// `?` modifier flag.
+    #[inline]
+    pub fn optional(&self) -> bool {
+        (self.common_data() & 0b01) != 0
+    }
+    /// `...` variadic flag.
+    #[inline]
+    pub fn variadic(&self) -> bool {
+        (self.common_data() & 0b10) != 0
+    }
+    /// Key string from Extended Data byte 0-5.
+    pub fn key(&self) -> &'a str {
+        ext_string_leaf(self.source_file, self.node_index)
+    }
+    /// Value type (first child if present).
+    pub fn right(&self) -> Option<LazyTypeNode<'a>> {
+        // Pattern 3 children are NOT gated by a Children bitmask in
+        // Extended Data; they sit directly under the parent index.
+        let child = first_child(self.source_file, self.node_index)?;
+        LazyTypeNode::from_index(self.source_file, child, self.root_index)
+    }
+}
+
+define_lazy_type_node!(
+    LazyTypeIndexSignature,
+    Kind::TypeIndexSignature,
+    "Lazy view of `TypeIndexSignature` (Kind 0xA4)."
+);
+impl<'a> LazyTypeIndexSignature<'a> {
+    /// Key string.
+    pub fn key(&self) -> &'a str {
+        ext_string_leaf(self.source_file, self.node_index)
+    }
+    /// Value type (`right`).
+    pub fn right(&self) -> Option<LazyTypeNode<'a>> {
+        let child = first_child(self.source_file, self.node_index)?;
+        LazyTypeNode::from_index(self.source_file, child, self.root_index)
+    }
+}
+
+define_lazy_type_node!(
+    LazyTypeMappedType,
+    Kind::TypeMappedType,
+    "Lazy view of `TypeMappedType` (Kind 0xA5)."
+);
+impl<'a> LazyTypeMappedType<'a> {
+    /// Key string.
+    pub fn key(&self) -> &'a str {
+        ext_string_leaf(self.source_file, self.node_index)
+    }
+    /// Value type (`right`).
+    pub fn right(&self) -> Option<LazyTypeNode<'a>> {
+        let child = first_child(self.source_file, self.node_index)?;
+        LazyTypeNode::from_index(self.source_file, child, self.root_index)
+    }
+}
+
+define_lazy_type_node!(
+    LazyTypeMethodSignature,
+    Kind::TypeMethodSignature,
+    "Lazy view of `TypeMethodSignature` (Kind 0xA9)."
+);
+impl<'a> LazyTypeMethodSignature<'a> {
+    /// Quote style for the method name (3-state).
+    #[inline]
+    pub fn quote(&self) -> u8 {
+        self.common_data() & 0b11
+    }
+    /// `true` when the parameter NodeList was emitted.
+    #[inline]
+    pub fn has_parameters(&self) -> bool {
+        (self.common_data() & 0b0100) != 0
+    }
+    /// `true` when the type-parameter NodeList was emitted.
+    #[inline]
+    pub fn has_type_parameters(&self) -> bool {
+        (self.common_data() & 0b1000) != 0
+    }
+    /// Method name string.
+    pub fn name(&self) -> &'a str {
+        ext_string_leaf(self.source_file, self.node_index)
+    }
+}
+
+define_lazy_type_node!(
+    LazyTypeTemplateLiteral,
+    Kind::TypeTemplateLiteral,
+    "Lazy view of `TypeTemplateLiteral` (Kind 0x9D)."
+);
+impl<'a> LazyTypeTemplateLiteral<'a> {
+    /// Number of literal segments.
+    pub fn literal_count(&self) -> u16 {
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        read_u16(self.source_file.bytes(), ext)
+    }
+    /// Get the n-th literal segment (panics when `index >= literal_count`).
+    pub fn literal(&self, index: u16) -> &'a str {
+        let ext = ext_offset(self.source_file, self.node_index) as usize;
+        let field = read_string_field(
+            self.source_file.bytes(),
+            ext + 2 + index as usize * STRING_FIELD_SIZE,
+        );
+        self.source_file.get_string_by_field(field).unwrap_or("")
+    }
+}
+
+define_lazy_type_node!(LazyTypeSymbol, Kind::TypeSymbol, "Lazy view of `TypeSymbol` (Kind 0x9F).");
+impl<'a> LazyTypeSymbol<'a> {
+    /// Whether the call carries an element argument.
+    #[inline]
+    pub fn has_element(&self) -> bool {
+        (self.common_data() & 1) != 0
+    }
+    /// `Symbol(...)` callee text.
+    pub fn value(&self) -> &'a str {
+        ext_string_leaf(self.source_file, self.node_index)
+    }
+    /// Element argument when `has_element` is `true`.
+    pub fn element(&self) -> Option<LazyTypeNode<'a>> {
+        if !self.has_element() {
+            return None;
+        }
+        let child = first_child(self.source_file, self.node_index)?;
+        LazyTypeNode::from_index(self.source_file, child, self.root_index)
+    }
+}
+
+// ===========================================================================
+// Others — pure leaves (no payload)
+// ===========================================================================
+define_lazy_type_node!(LazyTypeNull, Kind::TypeNull, "Lazy view of `TypeNull` leaf (Kind 0x83).");
+define_lazy_type_node!(
+    LazyTypeUndefined,
+    Kind::TypeUndefined,
+    "Lazy view of `TypeUndefined` leaf (Kind 0x84)."
+);
+define_lazy_type_node!(LazyTypeAny, Kind::TypeAny, "Lazy view of `TypeAny` leaf (Kind 0x85).");
+define_lazy_type_node!(
+    LazyTypeUnknown,
+    Kind::TypeUnknown,
+    "Lazy view of `TypeUnknown` leaf (Kind 0x86)."
+);
+define_lazy_type_node!(
+    LazyTypeUniqueSymbol,
+    Kind::TypeUniqueSymbol,
+    "Lazy view of `TypeUniqueSymbol` leaf (Kind 0x9E)."
+);
+
+// ===========================================================================
+// Sum type for any TypeNode variant
+// ===========================================================================
+
+/// Wrapper enum produced when the parent node only knows it has *some*
+/// TypeNode child.
+#[derive(Debug, Clone, Copy)]
+#[allow(missing_docs)]
+pub enum LazyTypeNode<'a> {
+    Name(LazyTypeName<'a>),
+    Number(LazyTypeNumber<'a>),
+    StringValue(LazyTypeStringValue<'a>),
+    Property(LazyTypeProperty<'a>),
+    SpecialNamePath(LazyTypeSpecialNamePath<'a>),
+    Union(LazyTypeUnion<'a>),
+    Intersection(LazyTypeIntersection<'a>),
+    Generic(LazyTypeGeneric<'a>),
+    Function(LazyTypeFunction<'a>),
+    Object(LazyTypeObject<'a>),
+    Tuple(LazyTypeTuple<'a>),
+    Parenthesis(LazyTypeParenthesis<'a>),
+    NamePath(LazyTypeNamePath<'a>),
+    Nullable(LazyTypeNullable<'a>),
+    NotNullable(LazyTypeNotNullable<'a>),
+    Optional(LazyTypeOptional<'a>),
+    Variadic(LazyTypeVariadic<'a>),
+    Conditional(LazyTypeConditional<'a>),
+    Infer(LazyTypeInfer<'a>),
+    KeyOf(LazyTypeKeyOf<'a>),
+    TypeOf(LazyTypeTypeOf<'a>),
+    Import(LazyTypeImport<'a>),
+    Predicate(LazyTypePredicate<'a>),
+    Asserts(LazyTypeAsserts<'a>),
+    AssertsPlain(LazyTypeAssertsPlain<'a>),
+    ReadonlyArray(LazyTypeReadonlyArray<'a>),
+    ObjectField(LazyTypeObjectField<'a>),
+    JsdocObjectField(LazyTypeJsdocObjectField<'a>),
+    IndexedAccessIndex(LazyTypeIndexedAccessIndex<'a>),
+    CallSignature(LazyTypeCallSignature<'a>),
+    ConstructorSignature(LazyTypeConstructorSignature<'a>),
+    TypeParameter(LazyTypeTypeParameter<'a>),
+    ParameterList(LazyTypeParameterList<'a>),
+    ReadonlyProperty(LazyTypeReadonlyProperty<'a>),
+    KeyValue(LazyTypeKeyValue<'a>),
+    IndexSignature(LazyTypeIndexSignature<'a>),
+    MappedType(LazyTypeMappedType<'a>),
+    MethodSignature(LazyTypeMethodSignature<'a>),
+    TemplateLiteral(LazyTypeTemplateLiteral<'a>),
+    Symbol(LazyTypeSymbol<'a>),
+    Null(LazyTypeNull<'a>),
+    Undefined(LazyTypeUndefined<'a>),
+    Any(LazyTypeAny<'a>),
+    Unknown(LazyTypeUnknown<'a>),
+    UniqueSymbol(LazyTypeUniqueSymbol<'a>),
+}
+
+impl<'a> LazyTypeNode<'a> {
+    /// Construct the appropriate variant by reading the node's Kind byte.
+    pub fn from_index(
+        source_file: &'a LazySourceFile<'a>,
+        node_index: u32,
+        root_index: u32,
+    ) -> Option<Self> {
+        let kind_byte = source_file.bytes()[source_file.nodes_offset as usize
+            + node_index as usize * crate::format::node_record::NODE_RECORD_SIZE];
+        let kind = Kind::from_u8(kind_byte).ok()?;
+        if !crate::format::kind::is_type_node(kind_byte) {
+            return None;
+        }
+        // Macro to map each TypeNode Kind to its variant constructor.
+        macro_rules! dispatch {
+            ($($kind:ident => $variant:ident($struct:ty)),* $(,)?) => {
+                match kind {
+                    $(
+                        Kind::$kind => Some(LazyTypeNode::$variant(
+                            <$struct>::from_index(source_file, node_index, root_index),
+                        )),
+                    )*
+                    _ => None,
+                }
+            };
+        }
+        dispatch! {
+            TypeName => Name(LazyTypeName<'a>),
+            TypeNumber => Number(LazyTypeNumber<'a>),
+            TypeStringValue => StringValue(LazyTypeStringValue<'a>),
+            TypeProperty => Property(LazyTypeProperty<'a>),
+            TypeSpecialNamePath => SpecialNamePath(LazyTypeSpecialNamePath<'a>),
+            TypeUnion => Union(LazyTypeUnion<'a>),
+            TypeIntersection => Intersection(LazyTypeIntersection<'a>),
+            TypeGeneric => Generic(LazyTypeGeneric<'a>),
+            TypeFunction => Function(LazyTypeFunction<'a>),
+            TypeObject => Object(LazyTypeObject<'a>),
+            TypeTuple => Tuple(LazyTypeTuple<'a>),
+            TypeParenthesis => Parenthesis(LazyTypeParenthesis<'a>),
+            TypeNamePath => NamePath(LazyTypeNamePath<'a>),
+            TypeNullable => Nullable(LazyTypeNullable<'a>),
+            TypeNotNullable => NotNullable(LazyTypeNotNullable<'a>),
+            TypeOptional => Optional(LazyTypeOptional<'a>),
+            TypeVariadic => Variadic(LazyTypeVariadic<'a>),
+            TypeConditional => Conditional(LazyTypeConditional<'a>),
+            TypeInfer => Infer(LazyTypeInfer<'a>),
+            TypeKeyOf => KeyOf(LazyTypeKeyOf<'a>),
+            TypeTypeOf => TypeOf(LazyTypeTypeOf<'a>),
+            TypeImport => Import(LazyTypeImport<'a>),
+            TypePredicate => Predicate(LazyTypePredicate<'a>),
+            TypeAsserts => Asserts(LazyTypeAsserts<'a>),
+            TypeAssertsPlain => AssertsPlain(LazyTypeAssertsPlain<'a>),
+            TypeReadonlyArray => ReadonlyArray(LazyTypeReadonlyArray<'a>),
+            TypeObjectField => ObjectField(LazyTypeObjectField<'a>),
+            TypeJsdocObjectField => JsdocObjectField(LazyTypeJsdocObjectField<'a>),
+            TypeIndexedAccessIndex => IndexedAccessIndex(LazyTypeIndexedAccessIndex<'a>),
+            TypeCallSignature => CallSignature(LazyTypeCallSignature<'a>),
+            TypeConstructorSignature => ConstructorSignature(LazyTypeConstructorSignature<'a>),
+            TypeTypeParameter => TypeParameter(LazyTypeTypeParameter<'a>),
+            TypeParameterList => ParameterList(LazyTypeParameterList<'a>),
+            TypeReadonlyProperty => ReadonlyProperty(LazyTypeReadonlyProperty<'a>),
+            TypeKeyValue => KeyValue(LazyTypeKeyValue<'a>),
+            TypeIndexSignature => IndexSignature(LazyTypeIndexSignature<'a>),
+            TypeMappedType => MappedType(LazyTypeMappedType<'a>),
+            TypeMethodSignature => MethodSignature(LazyTypeMethodSignature<'a>),
+            TypeTemplateLiteral => TemplateLiteral(LazyTypeTemplateLiteral<'a>),
+            TypeSymbol => Symbol(LazyTypeSymbol<'a>),
+            TypeNull => Null(LazyTypeNull<'a>),
+            TypeUndefined => Undefined(LazyTypeUndefined<'a>),
+            TypeAny => Any(LazyTypeAny<'a>),
+            TypeUnknown => Unknown(LazyTypeUnknown<'a>),
+            TypeUniqueSymbol => UniqueSymbol(LazyTypeUniqueSymbol<'a>),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::size_of;
+
+    #[test]
+    fn type_node_lazy_structs_fit_in_16_bytes() {
+        macro_rules! assert_size {
+            ($t:ty) => {
+                assert!(size_of::<$t>() <= 16, concat!(stringify!($t), " > 16 bytes"));
+            };
+        }
+        assert_size!(LazyTypeName<'static>);
+        assert_size!(LazyTypeFunction<'static>);
+        assert_size!(LazyTypeKeyValue<'static>);
+        assert_size!(LazyTypeNull<'static>);
+        assert_size!(LazyTypeMethodSignature<'static>);
+        assert_size!(LazyTypeTemplateLiteral<'static>);
+    }
+
+    #[test]
+    fn lazy_type_node_sum_fits_in_24_bytes() {
+        assert!(size_of::<LazyTypeNode<'static>>() <= 24);
+    }
+}

--- a/crates/ox_jsdoc_binary/src/decoder/source_file.rs
+++ b/crates/ox_jsdoc_binary/src/decoder/source_file.rs
@@ -1,0 +1,295 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! [`LazySourceFile`] — root of the lazy decoder.
+//!
+//! See `design/007-binary-ast/rust-impl.md#lazysourcefile-root-of-the-decoder`.
+//!
+//! The struct caches the Header offsets/counts at construction so every
+//! lazy node can reach the String table or Root array in O(1) without
+//! re-parsing the Header.
+
+use crate::format::header::{
+    self, COMPAT_MODE_BIT, DIAGNOSTICS_OFFSET_FIELD, EXTENDED_DATA_OFFSET_FIELD, FLAGS_OFFSET,
+    HEADER_SIZE, NODE_COUNT_FIELD, NODES_OFFSET_FIELD, ROOT_ARRAY_OFFSET_FIELD, ROOT_COUNT_FIELD,
+    STRING_DATA_OFFSET_FIELD, STRING_OFFSETS_OFFSET_FIELD,
+};
+use crate::format::node_record::STRING_PAYLOAD_NONE_SENTINEL;
+use crate::format::root_index::{
+    BASE_OFFSET_FIELD, NODE_INDEX_OFFSET, ROOT_INDEX_ENTRY_SIZE, SOURCE_OFFSET_FIELD,
+};
+use crate::format::string_field::StringField;
+use crate::format::string_table::STRING_OFFSET_ENTRY_SIZE;
+
+use super::error::DecodeError;
+use super::helpers::read_u32;
+use super::nodes::LazyNode;
+use super::nodes::comment_ast::LazyJsdocBlock;
+
+/// Lazy decoder root. Holds the underlying byte slice plus all Header-derived
+/// offsets/counts.
+///
+/// `#[derive(Copy, Clone)]` so that lazy node structs can store
+/// `&'a LazySourceFile<'a>` (already a stack value) and pass it around by
+/// value without cost.
+#[derive(Debug, Clone, Copy)]
+pub struct LazySourceFile<'a> {
+    pub(crate) bytes: &'a [u8],
+    /// Whether the buffer's `compat_mode` flag bit is set.
+    pub compat_mode: bool,
+    /// Byte offset of the Root index array within `bytes`.
+    pub root_array_offset: u32,
+    /// Byte offset of the String Offsets section. Indexed by
+    /// `StringIndex` for string-leaf nodes and the diagnostics section's
+    /// `message_index`.
+    pub string_offsets_offset: u32,
+    /// Byte offset of the String Data section. Both string-leaf
+    /// (offsets-table indirection) and Extended Data
+    /// [`crate::format::string_field::StringField`] slots resolve into
+    /// this section's raw UTF-8 bytes.
+    pub string_data_offset: u32,
+    /// Byte offset of the Extended Data section.
+    pub extended_data_offset: u32,
+    /// Byte offset of the Diagnostics section.
+    pub diagnostics_offset: u32,
+    /// Byte offset of the Nodes section.
+    pub nodes_offset: u32,
+    /// Total node count (including the `node[0]` sentinel).
+    pub node_count: u32,
+    /// Number of roots N stored in this batch buffer.
+    pub root_count: u32,
+}
+
+impl<'a> LazySourceFile<'a> {
+    /// Parse the 40-byte Header from `bytes` and construct a [`LazySourceFile`].
+    ///
+    /// Returns [`DecodeError::TooShort`] when the slice cannot fit a Header,
+    /// and [`DecodeError::IncompatibleMajor`] when the buffer's major version
+    /// disagrees with [`crate::format::header::SUPPORTED_MAJOR`]. Decoders
+    /// silently accept buffers with a newer minor version (forward
+    /// compatibility) — Phase 1.1a is the first version, so the only valid
+    /// value is `0`.
+    pub fn new(bytes: &'a [u8]) -> Result<Self, DecodeError> {
+        if bytes.len() < HEADER_SIZE {
+            return Err(DecodeError::TooShort { actual: bytes.len(), required: HEADER_SIZE });
+        }
+        let version_byte = bytes[0];
+        let major = header::major(version_byte);
+        if major != header::SUPPORTED_MAJOR {
+            return Err(DecodeError::IncompatibleMajor {
+                buffer_major: major,
+                decoder_major: header::SUPPORTED_MAJOR,
+            });
+        }
+        let flags = bytes[FLAGS_OFFSET];
+        Ok(LazySourceFile {
+            bytes,
+            compat_mode: (flags & COMPAT_MODE_BIT) != 0,
+            root_array_offset: read_u32(bytes, ROOT_ARRAY_OFFSET_FIELD),
+            string_offsets_offset: read_u32(bytes, STRING_OFFSETS_OFFSET_FIELD),
+            string_data_offset: read_u32(bytes, STRING_DATA_OFFSET_FIELD),
+            extended_data_offset: read_u32(bytes, EXTENDED_DATA_OFFSET_FIELD),
+            diagnostics_offset: read_u32(bytes, DIAGNOSTICS_OFFSET_FIELD),
+            nodes_offset: read_u32(bytes, NODES_OFFSET_FIELD),
+            node_count: read_u32(bytes, NODE_COUNT_FIELD),
+            root_count: read_u32(bytes, ROOT_COUNT_FIELD),
+        })
+    }
+
+    /// Borrow the underlying byte slice. Useful for advanced consumers that
+    /// need raw access (e.g. exporting the buffer over IPC).
+    #[inline]
+    #[must_use]
+    pub const fn bytes(&self) -> &'a [u8] {
+        self.bytes
+    }
+
+    /// Resolve the string at `idx` (None when `idx` is the
+    /// [`STRING_PAYLOAD_NONE_SENTINEL`] (`0x3FFF_FFFF`)). Used by
+    /// string-leaf nodes (`TypeTag::String` payload) and the diagnostics
+    /// section.
+    ///
+    /// Performs a zero-copy slice from String Data via the offsets table.
+    #[must_use]
+    pub fn get_string(&self, idx: u32) -> Option<&'a str> {
+        if idx == STRING_PAYLOAD_NONE_SENTINEL {
+            return None;
+        }
+        let so_offset =
+            self.string_offsets_offset as usize + idx as usize * STRING_OFFSET_ENTRY_SIZE;
+        let start = read_u32(self.bytes, so_offset) as usize;
+        let end = read_u32(self.bytes, so_offset + 4) as usize;
+        let sd_offset = self.string_data_offset as usize;
+        let slice = &self.bytes[sd_offset + start..sd_offset + end];
+        // SAFETY: Phase 1 writers only accept `&str` inputs and feed them
+        // verbatim into String Data, so the slice is guaranteed UTF-8.
+        Some(unsafe { core::str::from_utf8_unchecked(slice) })
+    }
+
+    /// Resolve a Path B-leaf inline `(offset, length)` pair into the
+    /// underlying string slice. Always returns a valid `&str` (no NONE
+    /// sentinel for inline payloads — encoders only emit StringInline when
+    /// the string is real and short).
+    #[inline]
+    #[must_use]
+    pub fn get_inline_string(&self, offset: u32, length: u8) -> &'a str {
+        let sd_offset = self.string_data_offset as usize;
+        let start = sd_offset + offset as usize;
+        let end = start + length as usize;
+        let slice = &self.bytes[start..end];
+        // SAFETY: writers only accept `&str` inputs and feed them
+        // verbatim into String Data, so the slice is guaranteed UTF-8.
+        unsafe { core::str::from_utf8_unchecked(slice) }
+    }
+
+    /// Resolve a [`StringField`] into the underlying string (`None` when
+    /// the field equals [`StringField::NONE`]).
+    ///
+    /// Performs a zero-copy slice from String Data; the returned `&str`
+    /// borrows directly from the buffer. Used by Extended Data string
+    /// slots which embed `(offset, length)` directly without going
+    /// through the offsets table.
+    #[inline]
+    #[must_use]
+    pub fn get_string_by_field(&self, field: StringField) -> Option<&'a str> {
+        if field.is_none() {
+            return None;
+        }
+        let sd_offset = self.string_data_offset as usize;
+        let start = sd_offset + field.offset as usize;
+        let end = start + field.length as usize;
+        let slice = &self.bytes[start..end];
+        // SAFETY: writers only accept `&str` inputs and feed them
+        // verbatim into String Data, so the slice is guaranteed UTF-8.
+        Some(unsafe { core::str::from_utf8_unchecked(slice) })
+    }
+
+    /// Required-string variant of [`Self::get_string_by_field`]. Panics on
+    /// the [`StringField::NONE`] sentinel — callers must guarantee the
+    /// field is non-NONE (used for required-by-spec slots like
+    /// `JsdocBlock.delimiter`).
+    #[inline]
+    #[must_use]
+    pub fn get_required_string_by_field(&self, field: StringField) -> &'a str {
+        debug_assert!(
+            !field.is_none(),
+            "get_required_string_by_field called with StringField::NONE"
+        );
+        let sd_offset = self.string_data_offset as usize;
+        let start = sd_offset + field.offset as usize;
+        let end = start + field.length as usize;
+        let slice = &self.bytes[start..end];
+        // SAFETY: see `get_string_by_field`.
+        unsafe { core::str::from_utf8_unchecked(slice) }
+    }
+
+    /// Get the `base_offset` (original-file absolute byte position) for
+    /// root index `root_index`. Used by lazy nodes when computing the
+    /// `range` getter.
+    #[must_use]
+    pub fn get_root_base_offset(&self, root_index: u32) -> u32 {
+        let off = self.root_array_offset as usize
+            + root_index as usize * ROOT_INDEX_ENTRY_SIZE
+            + BASE_OFFSET_FIELD;
+        read_u32(self.bytes, off)
+    }
+
+    /// Get the `source_offset_in_data` (byte offset where this root's
+    /// source text starts inside the String Data section) for root index
+    /// `root_index`. Used by `description_raw` getters that need to slice
+    /// the source text by `(start, end)` byte offsets.
+    #[must_use]
+    pub fn get_root_source_offset_in_data(&self, root_index: u32) -> u32 {
+        let off = self.root_array_offset as usize
+            + root_index as usize * ROOT_INDEX_ENTRY_SIZE
+            + SOURCE_OFFSET_FIELD;
+        read_u32(self.bytes, off)
+    }
+
+    /// Slice the source text region for `root_index` at the given
+    /// `(start, end)` source-text-relative UTF-8 byte offsets. Returns
+    /// `None` for the `(0, 0)` sentinel, for `start > end`, or when the
+    /// slice would extend past `bytes`.
+    ///
+    /// Used by `description_raw` getters on `LazyJsdocBlock` /
+    /// `LazyJsdocTag` (compat-mode wire field per
+    /// `design/008-oxlint-oxfmt-support/README.md` §4.3).
+    #[must_use]
+    pub fn slice_source_text(&self, root_index: u32, start: u32, end: u32) -> Option<&'a str> {
+        if start == 0 && end == 0 {
+            return None;
+        }
+        if start > end {
+            return None;
+        }
+        let source_offset = self.get_root_source_offset_in_data(root_index) as usize;
+        let sd_offset = self.string_data_offset as usize;
+        let abs_start = sd_offset + source_offset + start as usize;
+        let abs_end = sd_offset + source_offset + end as usize;
+        if abs_end > self.bytes.len() {
+            return None;
+        }
+        let slice = &self.bytes[abs_start..abs_end];
+        // SAFETY: writers only feed `&str` source text into String Data,
+        // so the slice is guaranteed UTF-8.
+        Some(unsafe { core::str::from_utf8_unchecked(slice) })
+    }
+
+    /// Iterate over the AST root for each entry in the Root index array.
+    ///
+    /// Yields `None` for entries whose `node_index = 0` (parse failure
+    /// sentinel) and `Some(LazyJsdocBlock)` for successful parses.
+    pub fn asts(&'a self) -> AstsIter<'a> {
+        AstsIter { source_file: self, cursor: 0 }
+    }
+}
+
+/// Iterator returned by [`LazySourceFile::asts`].
+#[derive(Debug)]
+pub struct AstsIter<'a> {
+    source_file: &'a LazySourceFile<'a>,
+    cursor: u32,
+}
+
+impl<'a> Iterator for AstsIter<'a> {
+    type Item = Option<LazyJsdocBlock<'a>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cursor >= self.source_file.root_count {
+            return None;
+        }
+        let root_index = self.cursor;
+        let off = self.source_file.root_array_offset as usize
+            + root_index as usize * ROOT_INDEX_ENTRY_SIZE
+            + NODE_INDEX_OFFSET;
+        let node_index = read_u32(self.source_file.bytes, off);
+        self.cursor += 1;
+        if node_index == 0 {
+            // Parse failure sentinel.
+            Some(None)
+        } else {
+            Some(Some(LazyJsdocBlock::from_index(self.source_file, node_index, root_index)))
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = (self.source_file.root_count - self.cursor) as usize;
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for AstsIter<'_> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::size_of;
+
+    #[test]
+    fn lazy_source_file_is_compact() {
+        // Concrete size depends on the field layout, but it must comfortably
+        // fit in 64 bytes so it can sit on the stack with no heap pressure.
+        assert!(size_of::<LazySourceFile<'static>>() <= 64);
+    }
+}

--- a/crates/ox_jsdoc_binary/src/decoder/text.rs
+++ b/crates/ox_jsdoc_binary/src/decoder/text.rs
@@ -1,0 +1,38 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Description text post-processing helpers (decoder side).
+//!
+//! Mirrors `ox_jsdoc::parser::text::parsed_preserving_whitespace` byte-for-byte
+//! so the binary AST decoder can produce the same preserve-whitespace output
+//! as the typed AST `description_text(true)` method without taking a
+//! cross-crate dependency. See `design/008-oxlint-oxfmt-support/README.md`
+//! §3 for the algorithm + §4.3 for the JS API contract this method backs.
+
+/// Reflow a raw description slice into preserve-whitespace form. See
+/// `crates/ox_jsdoc/src/parser/text.rs` for the canonical implementation
+/// + per-line behavior (markdown emphasis exemption, indented code block
+/// preservation, blank-line preservation).
+#[must_use]
+pub fn parsed_preserving_whitespace(raw: &str) -> String {
+    if !raw.contains('\n') {
+        return raw.trim().to_string();
+    }
+    let mut result = String::with_capacity(raw.len());
+    for (i, line) in raw.lines().enumerate() {
+        if i > 0 {
+            result.push('\n');
+        }
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix('*') {
+            let is_emphasis = rest.starts_with(|ch: char| ch.is_alphanumeric() || ch == '_');
+            if !is_emphasis {
+                result.push_str(rest.strip_prefix(' ').unwrap_or(rest));
+                continue;
+            }
+        }
+        result.push_str(trimmed);
+    }
+    result
+}

--- a/crates/ox_jsdoc_binary/src/decoder/visitor.rs
+++ b/crates/ox_jsdoc_binary/src/decoder/visitor.rs
@@ -1,0 +1,860 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! `LazyJsdocVisitor` — depth-first walker over the lazy decoder.
+//!
+//! See `design/007-binary-ast/rust-impl.md#lazy-visitor-trait-code-generation`.
+//!
+//! Each lazy node kind exposes two methods:
+//!
+//! - `visit_xxx(&mut self, node)` — the override hook. The default
+//!   implementation forwards to `visit_xxx_default(node)` for container
+//!   nodes (or is a no-op for leaves), so an empty trait impl already
+//!   walks the entire tree.
+//! - `visit_xxx_default(&mut self, node)` (container nodes only) —
+//!   recursively walks every accessor-exposed child via the corresponding
+//!   `visit_*` method. Override `visit_xxx` and call this from inside it to
+//!   mix custom logic with the default traversal.
+//!
+//! Two helpers dispatch sum-typed children:
+//!
+//! - [`LazyJsdocVisitor::visit_type_node`] — match on a [`LazyTypeNode`] and
+//!   forward to the variant-specific `visit_type_*` method.
+//! - [`LazyJsdocVisitor::visit_tag_body`] — match on a [`LazyJsdocTagBody`].
+//!
+//! Phase 4 will replace this hand-written file with a code-generated
+//! version derived from the same schema that emits the writer/decoder.
+
+use super::nodes::comment_ast::{
+    LazyJsdocBlock, LazyJsdocBorrowsTagBody, LazyJsdocDescriptionLine, LazyJsdocGenericTagBody,
+    LazyJsdocIdentifier, LazyJsdocInlineTag, LazyJsdocNamepathSource, LazyJsdocParameterName,
+    LazyJsdocRawTagBody, LazyJsdocTag, LazyJsdocTagBody, LazyJsdocTagName, LazyJsdocTagNameValue,
+    LazyJsdocText, LazyJsdocTypeLine, LazyJsdocTypeSource,
+};
+use super::nodes::type_node::{
+    LazyTypeAny, LazyTypeAsserts, LazyTypeAssertsPlain, LazyTypeCallSignature, LazyTypeConditional,
+    LazyTypeConstructorSignature, LazyTypeFunction, LazyTypeGeneric, LazyTypeImport,
+    LazyTypeIndexSignature, LazyTypeIndexedAccessIndex, LazyTypeInfer, LazyTypeIntersection,
+    LazyTypeJsdocObjectField, LazyTypeKeyOf, LazyTypeKeyValue, LazyTypeMappedType,
+    LazyTypeMethodSignature, LazyTypeName, LazyTypeNamePath, LazyTypeNode, LazyTypeNotNullable,
+    LazyTypeNull, LazyTypeNullable, LazyTypeNumber, LazyTypeObject, LazyTypeObjectField,
+    LazyTypeOptional, LazyTypeParameterList, LazyTypeParenthesis, LazyTypePredicate,
+    LazyTypeProperty, LazyTypeReadonlyArray, LazyTypeReadonlyProperty, LazyTypeSpecialNamePath,
+    LazyTypeStringValue, LazyTypeSymbol, LazyTypeTemplateLiteral, LazyTypeTuple, LazyTypeTypeOf,
+    LazyTypeTypeParameter, LazyTypeUndefined, LazyTypeUnion, LazyTypeUniqueSymbol, LazyTypeUnknown,
+    LazyTypeVariadic,
+};
+
+/// Hand-written depth-first visitor over the lazy decoder. The default
+/// implementations together produce a complete pre-order walk; users can
+/// hook any subset of the methods to inject custom behaviour.
+///
+/// See the module-level docs for the `visit_xxx` / `visit_xxx_default`
+/// pattern.
+pub trait LazyJsdocVisitor<'a> {
+    // =====================================================================
+    // Comment AST
+    // =====================================================================
+
+    /// Visit a `JsdocBlock`. Default: walk every accessor-exposed child.
+    fn visit_block(&mut self, block: LazyJsdocBlock<'a>) {
+        self.visit_block_default(block);
+    }
+
+    /// Default `JsdocBlock` traversal — descriptionLines → tags → inlineTags.
+    fn visit_block_default(&mut self, block: LazyJsdocBlock<'a>) {
+        for line in block.description_lines() {
+            self.visit_description_line(line);
+        }
+        for tag in block.tags() {
+            self.visit_tag(tag);
+        }
+        for inline in block.inline_tags() {
+            self.visit_inline_tag(inline);
+        }
+    }
+
+    /// Visit a `JsdocDescriptionLine` leaf.
+    fn visit_description_line(&mut self, _node: LazyJsdocDescriptionLine<'a>) {}
+
+    /// Visit a `JsdocTag`. Default: walk every accessor-exposed child.
+    fn visit_tag(&mut self, tag: LazyJsdocTag<'a>) {
+        self.visit_tag_default(tag);
+    }
+
+    /// Default `JsdocTag` traversal in visitor-bit order
+    /// (tag → rawType → name → parsedType → body → typeLines →
+    /// descriptionLines → inlineTags).
+    fn visit_tag_default(&mut self, tag: LazyJsdocTag<'a>) {
+        self.visit_tag_name(tag.tag());
+        if let Some(rt) = tag.raw_type() {
+            self.visit_type_source(rt);
+        }
+        if let Some(name) = tag.name() {
+            self.visit_tag_name_value(name);
+        }
+        if let Some(pt) = tag.parsed_type() {
+            self.visit_type_node(pt);
+        }
+        if let Some(body) = tag.body() {
+            self.visit_tag_body(body);
+        }
+        for line in tag.type_lines() {
+            self.visit_type_line(line);
+        }
+        for line in tag.description_lines() {
+            self.visit_description_line(line);
+        }
+        for inline in tag.inline_tags() {
+            self.visit_inline_tag(inline);
+        }
+    }
+
+    /// Dispatch a `JsdocTagBody` sum to the variant-specific method.
+    fn visit_tag_body(&mut self, body: LazyJsdocTagBody<'a>) {
+        match body {
+            LazyJsdocTagBody::Generic(b) => self.visit_generic_tag_body(b),
+            LazyJsdocTagBody::Borrows(b) => self.visit_borrows_tag_body(b),
+            LazyJsdocTagBody::Raw(b) => self.visit_raw_tag_body(b),
+        }
+    }
+
+    /// Visit a `JsdocTagName` leaf.
+    fn visit_tag_name(&mut self, _node: LazyJsdocTagName<'a>) {}
+    /// Visit a `JsdocTagNameValue` leaf.
+    fn visit_tag_name_value(&mut self, _node: LazyJsdocTagNameValue<'a>) {}
+    /// Visit a `JsdocTypeSource` leaf.
+    fn visit_type_source(&mut self, _node: LazyJsdocTypeSource<'a>) {}
+    /// Visit a `JsdocTypeLine` leaf.
+    fn visit_type_line(&mut self, _node: LazyJsdocTypeLine<'a>) {}
+    /// Visit a `JsdocInlineTag` leaf.
+    fn visit_inline_tag(&mut self, _node: LazyJsdocInlineTag<'a>) {}
+    /// Visit a `JsdocGenericTagBody`. Currently a leaf — child accessors
+    /// (description tag-list etc.) land in Phase 1.2a.
+    fn visit_generic_tag_body(&mut self, _node: LazyJsdocGenericTagBody<'a>) {}
+    /// Visit a `JsdocBorrowsTagBody`. Currently a leaf — `source`/`target`
+    /// child accessors land in Phase 1.2a.
+    fn visit_borrows_tag_body(&mut self, _node: LazyJsdocBorrowsTagBody<'a>) {}
+    /// Visit a `JsdocRawTagBody` leaf.
+    fn visit_raw_tag_body(&mut self, _node: LazyJsdocRawTagBody<'a>) {}
+    /// Visit a `JsdocParameterName` leaf.
+    fn visit_parameter_name(&mut self, _node: LazyJsdocParameterName<'a>) {}
+    /// Visit a `JsdocNamepathSource` leaf.
+    fn visit_namepath_source(&mut self, _node: LazyJsdocNamepathSource<'a>) {}
+    /// Visit a `JsdocIdentifier` leaf.
+    fn visit_identifier(&mut self, _node: LazyJsdocIdentifier<'a>) {}
+    /// Visit a `JsdocText` leaf.
+    fn visit_text(&mut self, _node: LazyJsdocText<'a>) {}
+
+    // =====================================================================
+    // TypeNode dispatch
+    // =====================================================================
+
+    /// Dispatch a `LazyTypeNode` sum to the variant-specific method.
+    fn visit_type_node(&mut self, node: LazyTypeNode<'a>) {
+        match node {
+            LazyTypeNode::Name(n) => self.visit_type_name(n),
+            LazyTypeNode::Number(n) => self.visit_type_number(n),
+            LazyTypeNode::StringValue(n) => self.visit_type_string_value(n),
+            LazyTypeNode::Property(n) => self.visit_type_property(n),
+            LazyTypeNode::SpecialNamePath(n) => self.visit_type_special_name_path(n),
+            LazyTypeNode::Union(n) => self.visit_type_union(n),
+            LazyTypeNode::Intersection(n) => self.visit_type_intersection(n),
+            LazyTypeNode::Generic(n) => self.visit_type_generic(n),
+            LazyTypeNode::Function(n) => self.visit_type_function(n),
+            LazyTypeNode::Object(n) => self.visit_type_object(n),
+            LazyTypeNode::Tuple(n) => self.visit_type_tuple(n),
+            LazyTypeNode::Parenthesis(n) => self.visit_type_parenthesis(n),
+            LazyTypeNode::NamePath(n) => self.visit_type_name_path(n),
+            LazyTypeNode::Nullable(n) => self.visit_type_nullable(n),
+            LazyTypeNode::NotNullable(n) => self.visit_type_not_nullable(n),
+            LazyTypeNode::Optional(n) => self.visit_type_optional(n),
+            LazyTypeNode::Variadic(n) => self.visit_type_variadic(n),
+            LazyTypeNode::Conditional(n) => self.visit_type_conditional(n),
+            LazyTypeNode::Infer(n) => self.visit_type_infer(n),
+            LazyTypeNode::KeyOf(n) => self.visit_type_key_of(n),
+            LazyTypeNode::TypeOf(n) => self.visit_type_type_of(n),
+            LazyTypeNode::Import(n) => self.visit_type_import(n),
+            LazyTypeNode::Predicate(n) => self.visit_type_predicate(n),
+            LazyTypeNode::Asserts(n) => self.visit_type_asserts(n),
+            LazyTypeNode::AssertsPlain(n) => self.visit_type_asserts_plain(n),
+            LazyTypeNode::ReadonlyArray(n) => self.visit_type_readonly_array(n),
+            LazyTypeNode::ObjectField(n) => self.visit_type_object_field(n),
+            LazyTypeNode::JsdocObjectField(n) => self.visit_type_jsdoc_object_field(n),
+            LazyTypeNode::IndexedAccessIndex(n) => self.visit_type_indexed_access_index(n),
+            LazyTypeNode::CallSignature(n) => self.visit_type_call_signature(n),
+            LazyTypeNode::ConstructorSignature(n) => self.visit_type_constructor_signature(n),
+            LazyTypeNode::TypeParameter(n) => self.visit_type_type_parameter(n),
+            LazyTypeNode::ParameterList(n) => self.visit_type_parameter_list(n),
+            LazyTypeNode::ReadonlyProperty(n) => self.visit_type_readonly_property(n),
+            LazyTypeNode::KeyValue(n) => self.visit_type_key_value(n),
+            LazyTypeNode::IndexSignature(n) => self.visit_type_index_signature(n),
+            LazyTypeNode::MappedType(n) => self.visit_type_mapped_type(n),
+            LazyTypeNode::MethodSignature(n) => self.visit_type_method_signature(n),
+            LazyTypeNode::TemplateLiteral(n) => self.visit_type_template_literal(n),
+            LazyTypeNode::Symbol(n) => self.visit_type_symbol(n),
+            LazyTypeNode::Null(n) => self.visit_type_null(n),
+            LazyTypeNode::Undefined(n) => self.visit_type_undefined(n),
+            LazyTypeNode::Any(n) => self.visit_type_any(n),
+            LazyTypeNode::Unknown(n) => self.visit_type_unknown(n),
+            LazyTypeNode::UniqueSymbol(n) => self.visit_type_unique_symbol(n),
+        }
+    }
+
+    // =====================================================================
+    // TypeNode — Pattern 1 (string-only leaves)
+    // =====================================================================
+
+    /// Visit a `TypeName` leaf.
+    fn visit_type_name(&mut self, _node: LazyTypeName<'a>) {}
+    /// Visit a `TypeNumber` leaf.
+    fn visit_type_number(&mut self, _node: LazyTypeNumber<'a>) {}
+    /// Visit a `TypeStringValue` leaf.
+    fn visit_type_string_value(&mut self, _node: LazyTypeStringValue<'a>) {}
+    /// Visit a `TypeProperty` leaf.
+    fn visit_type_property(&mut self, _node: LazyTypeProperty<'a>) {}
+    /// Visit a `TypeSpecialNamePath` leaf.
+    fn visit_type_special_name_path(&mut self, _node: LazyTypeSpecialNamePath<'a>) {}
+
+    // =====================================================================
+    // TypeNode — Pattern 2 (children-only containers)
+    // =====================================================================
+
+    /// Visit a `TypeUnion`. Default: walk `elements`.
+    fn visit_type_union(&mut self, node: LazyTypeUnion<'a>) {
+        self.visit_type_union_default(node);
+    }
+    /// Default `TypeUnion` traversal.
+    fn visit_type_union_default(&mut self, node: LazyTypeUnion<'a>) {
+        for el in node.elements() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeIntersection`. Default: walk `elements`.
+    fn visit_type_intersection(&mut self, node: LazyTypeIntersection<'a>) {
+        self.visit_type_intersection_default(node);
+    }
+    /// Default `TypeIntersection` traversal.
+    fn visit_type_intersection_default(&mut self, node: LazyTypeIntersection<'a>) {
+        for el in node.elements() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeGeneric`. Default: walk `left` then `elements`.
+    fn visit_type_generic(&mut self, node: LazyTypeGeneric<'a>) {
+        self.visit_type_generic_default(node);
+    }
+    /// Default `TypeGeneric` traversal.
+    fn visit_type_generic_default(&mut self, node: LazyTypeGeneric<'a>) {
+        if let Some(l) = node.left() {
+            self.visit_type_node(l);
+        }
+        for el in node.elements() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeFunction`. Default: walk
+    /// `parameters` → `return_type` → `type_parameters`.
+    fn visit_type_function(&mut self, node: LazyTypeFunction<'a>) {
+        self.visit_type_function_default(node);
+    }
+    /// Default `TypeFunction` traversal.
+    fn visit_type_function_default(&mut self, node: LazyTypeFunction<'a>) {
+        if let Some(params) = node.parameters() {
+            self.visit_type_parameter_list(params);
+        }
+        if let Some(ret) = node.return_type() {
+            self.visit_type_node(ret);
+        }
+        if let Some(tp) = node.type_parameters() {
+            self.visit_type_parameter_list(tp);
+        }
+    }
+
+    /// Visit a `TypeObject`. Default: walk `elements`.
+    fn visit_type_object(&mut self, node: LazyTypeObject<'a>) {
+        self.visit_type_object_default(node);
+    }
+    /// Default `TypeObject` traversal.
+    fn visit_type_object_default(&mut self, node: LazyTypeObject<'a>) {
+        for el in node.elements() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeTuple`. Default: walk `elements`.
+    fn visit_type_tuple(&mut self, node: LazyTypeTuple<'a>) {
+        self.visit_type_tuple_default(node);
+    }
+    /// Default `TypeTuple` traversal.
+    fn visit_type_tuple_default(&mut self, node: LazyTypeTuple<'a>) {
+        for el in node.elements() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeParenthesis`. Default: walk `element`.
+    fn visit_type_parenthesis(&mut self, node: LazyTypeParenthesis<'a>) {
+        self.visit_type_parenthesis_default(node);
+    }
+    /// Default `TypeParenthesis` traversal.
+    fn visit_type_parenthesis_default(&mut self, node: LazyTypeParenthesis<'a>) {
+        if let Some(el) = node.element() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeNamePath`. Default: walk `left` then `right`.
+    fn visit_type_name_path(&mut self, node: LazyTypeNamePath<'a>) {
+        self.visit_type_name_path_default(node);
+    }
+    /// Default `TypeNamePath` traversal.
+    fn visit_type_name_path_default(&mut self, node: LazyTypeNamePath<'a>) {
+        if let Some(l) = node.left() {
+            self.visit_type_node(l);
+        }
+        if let Some(r) = node.right() {
+            self.visit_type_node(r);
+        }
+    }
+
+    /// Visit a `TypeNullable`. Default: walk `element`.
+    fn visit_type_nullable(&mut self, node: LazyTypeNullable<'a>) {
+        self.visit_type_nullable_default(node);
+    }
+    /// Default `TypeNullable` traversal.
+    fn visit_type_nullable_default(&mut self, node: LazyTypeNullable<'a>) {
+        if let Some(el) = node.element() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeNotNullable`. Default: walk `element`.
+    fn visit_type_not_nullable(&mut self, node: LazyTypeNotNullable<'a>) {
+        self.visit_type_not_nullable_default(node);
+    }
+    /// Default `TypeNotNullable` traversal.
+    fn visit_type_not_nullable_default(&mut self, node: LazyTypeNotNullable<'a>) {
+        if let Some(el) = node.element() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeOptional`. Default: walk `element`.
+    fn visit_type_optional(&mut self, node: LazyTypeOptional<'a>) {
+        self.visit_type_optional_default(node);
+    }
+    /// Default `TypeOptional` traversal.
+    fn visit_type_optional_default(&mut self, node: LazyTypeOptional<'a>) {
+        if let Some(el) = node.element() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeVariadic`. Default: walk `element`.
+    fn visit_type_variadic(&mut self, node: LazyTypeVariadic<'a>) {
+        self.visit_type_variadic_default(node);
+    }
+    /// Default `TypeVariadic` traversal.
+    fn visit_type_variadic_default(&mut self, node: LazyTypeVariadic<'a>) {
+        if let Some(el) = node.element() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeConditional`. Default: walk
+    /// check → extends → true → false.
+    fn visit_type_conditional(&mut self, node: LazyTypeConditional<'a>) {
+        self.visit_type_conditional_default(node);
+    }
+    /// Default `TypeConditional` traversal.
+    fn visit_type_conditional_default(&mut self, node: LazyTypeConditional<'a>) {
+        if let Some(t) = node.check_type() {
+            self.visit_type_node(t);
+        }
+        if let Some(t) = node.extends_type() {
+            self.visit_type_node(t);
+        }
+        if let Some(t) = node.true_type() {
+            self.visit_type_node(t);
+        }
+        if let Some(t) = node.false_type() {
+            self.visit_type_node(t);
+        }
+    }
+
+    /// Visit a `TypeInfer`. Default: walk `element`.
+    fn visit_type_infer(&mut self, node: LazyTypeInfer<'a>) {
+        self.visit_type_infer_default(node);
+    }
+    /// Default `TypeInfer` traversal.
+    fn visit_type_infer_default(&mut self, node: LazyTypeInfer<'a>) {
+        if let Some(el) = node.element() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeKeyOf`. Default: walk `element`.
+    fn visit_type_key_of(&mut self, node: LazyTypeKeyOf<'a>) {
+        self.visit_type_key_of_default(node);
+    }
+    /// Default `TypeKeyOf` traversal.
+    fn visit_type_key_of_default(&mut self, node: LazyTypeKeyOf<'a>) {
+        if let Some(el) = node.element() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeTypeOf`. Default: walk `element`.
+    fn visit_type_type_of(&mut self, node: LazyTypeTypeOf<'a>) {
+        self.visit_type_type_of_default(node);
+    }
+    /// Default `TypeTypeOf` traversal.
+    fn visit_type_type_of_default(&mut self, node: LazyTypeTypeOf<'a>) {
+        if let Some(el) = node.element() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeImport`. Default: walk `element`.
+    fn visit_type_import(&mut self, node: LazyTypeImport<'a>) {
+        self.visit_type_import_default(node);
+    }
+    /// Default `TypeImport` traversal.
+    fn visit_type_import_default(&mut self, node: LazyTypeImport<'a>) {
+        if let Some(el) = node.element() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypePredicate`. Default: walk `left` then `right`.
+    fn visit_type_predicate(&mut self, node: LazyTypePredicate<'a>) {
+        self.visit_type_predicate_default(node);
+    }
+    /// Default `TypePredicate` traversal.
+    fn visit_type_predicate_default(&mut self, node: LazyTypePredicate<'a>) {
+        if let Some(l) = node.left() {
+            self.visit_type_node(l);
+        }
+        if let Some(r) = node.right() {
+            self.visit_type_node(r);
+        }
+    }
+
+    /// Visit a `TypeAsserts`. Default: walk `left` then `right`.
+    fn visit_type_asserts(&mut self, node: LazyTypeAsserts<'a>) {
+        self.visit_type_asserts_default(node);
+    }
+    /// Default `TypeAsserts` traversal.
+    fn visit_type_asserts_default(&mut self, node: LazyTypeAsserts<'a>) {
+        if let Some(l) = node.left() {
+            self.visit_type_node(l);
+        }
+        if let Some(r) = node.right() {
+            self.visit_type_node(r);
+        }
+    }
+
+    /// Visit a `TypeAssertsPlain`. Default: walk `element`.
+    fn visit_type_asserts_plain(&mut self, node: LazyTypeAssertsPlain<'a>) {
+        self.visit_type_asserts_plain_default(node);
+    }
+    /// Default `TypeAssertsPlain` traversal.
+    fn visit_type_asserts_plain_default(&mut self, node: LazyTypeAssertsPlain<'a>) {
+        if let Some(el) = node.element() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeReadonlyArray`. Default: walk `element`.
+    fn visit_type_readonly_array(&mut self, node: LazyTypeReadonlyArray<'a>) {
+        self.visit_type_readonly_array_default(node);
+    }
+    /// Default `TypeReadonlyArray` traversal.
+    fn visit_type_readonly_array_default(&mut self, node: LazyTypeReadonlyArray<'a>) {
+        if let Some(el) = node.element() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeObjectField`. Default: walk `key` then `right`.
+    fn visit_type_object_field(&mut self, node: LazyTypeObjectField<'a>) {
+        self.visit_type_object_field_default(node);
+    }
+    /// Default `TypeObjectField` traversal.
+    fn visit_type_object_field_default(&mut self, node: LazyTypeObjectField<'a>) {
+        if let Some(k) = node.key() {
+            self.visit_type_node(k);
+        }
+        if let Some(r) = node.right() {
+            self.visit_type_node(r);
+        }
+    }
+
+    /// Visit a `TypeJsdocObjectField`. Default: walk `key` then `right`.
+    fn visit_type_jsdoc_object_field(&mut self, node: LazyTypeJsdocObjectField<'a>) {
+        self.visit_type_jsdoc_object_field_default(node);
+    }
+    /// Default `TypeJsdocObjectField` traversal.
+    fn visit_type_jsdoc_object_field_default(&mut self, node: LazyTypeJsdocObjectField<'a>) {
+        if let Some(k) = node.key() {
+            self.visit_type_node(k);
+        }
+        if let Some(r) = node.right() {
+            self.visit_type_node(r);
+        }
+    }
+
+    /// Visit a `TypeIndexedAccessIndex`. Default: walk `element`.
+    fn visit_type_indexed_access_index(&mut self, node: LazyTypeIndexedAccessIndex<'a>) {
+        self.visit_type_indexed_access_index_default(node);
+    }
+    /// Default `TypeIndexedAccessIndex` traversal.
+    fn visit_type_indexed_access_index_default(&mut self, node: LazyTypeIndexedAccessIndex<'a>) {
+        if let Some(el) = node.element() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeCallSignature`. Default: walk
+    /// parameters → return_type → type_parameters.
+    fn visit_type_call_signature(&mut self, node: LazyTypeCallSignature<'a>) {
+        self.visit_type_call_signature_default(node);
+    }
+    /// Default `TypeCallSignature` traversal.
+    fn visit_type_call_signature_default(&mut self, node: LazyTypeCallSignature<'a>) {
+        if let Some(params) = node.parameters() {
+            self.visit_type_parameter_list(params);
+        }
+        if let Some(ret) = node.return_type() {
+            self.visit_type_node(ret);
+        }
+        if let Some(tp) = node.type_parameters() {
+            self.visit_type_parameter_list(tp);
+        }
+    }
+
+    /// Visit a `TypeConstructorSignature`. Default: walk
+    /// parameters → return_type → type_parameters.
+    fn visit_type_constructor_signature(&mut self, node: LazyTypeConstructorSignature<'a>) {
+        self.visit_type_constructor_signature_default(node);
+    }
+    /// Default `TypeConstructorSignature` traversal.
+    fn visit_type_constructor_signature_default(&mut self, node: LazyTypeConstructorSignature<'a>) {
+        if let Some(params) = node.parameters() {
+            self.visit_type_parameter_list(params);
+        }
+        if let Some(ret) = node.return_type() {
+            self.visit_type_node(ret);
+        }
+        if let Some(tp) = node.type_parameters() {
+            self.visit_type_parameter_list(tp);
+        }
+    }
+
+    /// Visit a `TypeTypeParameter`. Default: walk `elements`.
+    fn visit_type_type_parameter(&mut self, node: LazyTypeTypeParameter<'a>) {
+        self.visit_type_type_parameter_default(node);
+    }
+    /// Default `TypeTypeParameter` traversal.
+    fn visit_type_type_parameter_default(&mut self, node: LazyTypeTypeParameter<'a>) {
+        for el in node.elements() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeParameterList`. Default: walk `elements`.
+    fn visit_type_parameter_list(&mut self, node: LazyTypeParameterList<'a>) {
+        self.visit_type_parameter_list_default(node);
+    }
+    /// Default `TypeParameterList` traversal.
+    fn visit_type_parameter_list_default(&mut self, node: LazyTypeParameterList<'a>) {
+        for el in node.elements() {
+            self.visit_type_node(el);
+        }
+    }
+
+    /// Visit a `TypeReadonlyProperty`. Default: walk `element`.
+    fn visit_type_readonly_property(&mut self, node: LazyTypeReadonlyProperty<'a>) {
+        self.visit_type_readonly_property_default(node);
+    }
+    /// Default `TypeReadonlyProperty` traversal.
+    fn visit_type_readonly_property_default(&mut self, node: LazyTypeReadonlyProperty<'a>) {
+        if let Some(el) = node.element() {
+            self.visit_type_node(el);
+        }
+    }
+
+    // =====================================================================
+    // TypeNode — Pattern 3 (mixed string + children)
+    // =====================================================================
+
+    /// Visit a `TypeKeyValue`. Default: walk `right`.
+    fn visit_type_key_value(&mut self, node: LazyTypeKeyValue<'a>) {
+        self.visit_type_key_value_default(node);
+    }
+    /// Default `TypeKeyValue` traversal.
+    fn visit_type_key_value_default(&mut self, node: LazyTypeKeyValue<'a>) {
+        if let Some(r) = node.right() {
+            self.visit_type_node(r);
+        }
+    }
+
+    /// Visit a `TypeIndexSignature`. Default: walk `right`.
+    fn visit_type_index_signature(&mut self, node: LazyTypeIndexSignature<'a>) {
+        self.visit_type_index_signature_default(node);
+    }
+    /// Default `TypeIndexSignature` traversal.
+    fn visit_type_index_signature_default(&mut self, node: LazyTypeIndexSignature<'a>) {
+        if let Some(r) = node.right() {
+            self.visit_type_node(r);
+        }
+    }
+
+    /// Visit a `TypeMappedType`. Default: walk `right`.
+    fn visit_type_mapped_type(&mut self, node: LazyTypeMappedType<'a>) {
+        self.visit_type_mapped_type_default(node);
+    }
+    /// Default `TypeMappedType` traversal.
+    fn visit_type_mapped_type_default(&mut self, node: LazyTypeMappedType<'a>) {
+        if let Some(r) = node.right() {
+            self.visit_type_node(r);
+        }
+    }
+
+    /// Visit a `TypeMethodSignature`. Currently a leaf — child accessors
+    /// (`parameters` / `return_type` / `type_parameters`) land in Phase 1.2a
+    /// alongside the parser's MethodSignature emission.
+    fn visit_type_method_signature(&mut self, _node: LazyTypeMethodSignature<'a>) {}
+
+    /// Visit a `TypeTemplateLiteral` leaf (literals live in Extended Data,
+    /// not as child nodes).
+    fn visit_type_template_literal(&mut self, _node: LazyTypeTemplateLiteral<'a>) {}
+
+    /// Visit a `TypeSymbol`. Default: walk `element` when `has_element`.
+    fn visit_type_symbol(&mut self, node: LazyTypeSymbol<'a>) {
+        self.visit_type_symbol_default(node);
+    }
+    /// Default `TypeSymbol` traversal.
+    fn visit_type_symbol_default(&mut self, node: LazyTypeSymbol<'a>) {
+        if let Some(el) = node.element() {
+            self.visit_type_node(el);
+        }
+    }
+
+    // =====================================================================
+    // TypeNode — Others (pure leaves, no payload)
+    // =====================================================================
+
+    /// Visit a `TypeNull` leaf.
+    fn visit_type_null(&mut self, _node: LazyTypeNull<'a>) {}
+    /// Visit a `TypeUndefined` leaf.
+    fn visit_type_undefined(&mut self, _node: LazyTypeUndefined<'a>) {}
+    /// Visit a `TypeAny` leaf.
+    fn visit_type_any(&mut self, _node: LazyTypeAny<'a>) {}
+    /// Visit a `TypeUnknown` leaf.
+    fn visit_type_unknown(&mut self, _node: LazyTypeUnknown<'a>) {}
+    /// Visit a `TypeUniqueSymbol` leaf.
+    fn visit_type_unique_symbol(&mut self, _node: LazyTypeUniqueSymbol<'a>) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decoder::source_file::LazySourceFile;
+    use crate::format::kind::Kind;
+    use crate::writer::BinaryWriter;
+    use crate::writer::nodes::comment_ast::{
+        JSDOC_BLOCK_TAGS_SLOT, write_jsdoc_block, write_jsdoc_tag, write_jsdoc_tag_name,
+        write_jsdoc_tag_name_value,
+    };
+    use crate::writer::nodes::type_node::TYPE_LIST_PARENT_SLOT;
+    use crate::writer::nodes::type_node::write_type_name;
+    use oxc_allocator::Allocator;
+    use oxc_span::Span;
+    use std::collections::HashMap;
+
+    /// Visitor that counts every visited node bucketed by Kind.
+    struct CountVisitor {
+        counts: HashMap<Kind, usize>,
+    }
+
+    impl CountVisitor {
+        fn bump(&mut self, kind: Kind) {
+            *self.counts.entry(kind).or_insert(0) += 1;
+        }
+    }
+
+    impl<'a> LazyJsdocVisitor<'a> for CountVisitor {
+        fn visit_block(&mut self, b: LazyJsdocBlock<'a>) {
+            self.bump(Kind::JsdocBlock);
+            self.visit_block_default(b);
+        }
+        fn visit_tag(&mut self, t: LazyJsdocTag<'a>) {
+            self.bump(Kind::JsdocTag);
+            self.visit_tag_default(t);
+        }
+        fn visit_tag_name(&mut self, _n: LazyJsdocTagName<'a>) {
+            self.bump(Kind::JsdocTagName);
+        }
+        fn visit_tag_name_value(&mut self, _n: LazyJsdocTagNameValue<'a>) {
+            self.bump(Kind::JsdocTagNameValue);
+        }
+        fn visit_type_name(&mut self, _n: LazyTypeName<'a>) {
+            self.bump(Kind::TypeName);
+        }
+    }
+
+    /// Build a `/** @param {string} id */` buffer with the new no-NodeList
+    /// hierarchy: block → tag (direct child) → tag-name + parsedType +
+    /// tag-name-value. The block's `tags` list metadata slot is patched to
+    /// `(head=tag_index, count=1)` once the tag has been emitted.
+    fn build_single_tag_buffer<'a>(arena: &'a Allocator) -> Vec<u8> {
+        let mut writer = BinaryWriter::new(arena);
+        let _ = writer.append_source_text("/** @param {string} id */");
+
+        let empty = writer.intern_string("");
+        let star = writer.intern_string("*");
+        let space = writer.intern_string(" ");
+        let close = writer.intern_string("*/");
+        let nl = writer.intern_string("\n");
+        let tag_name_str = writer.intern_string_payload("param");
+        let type_name_str = writer.intern_string_payload("string");
+        let param_name_str = writer.intern_string_payload("id");
+
+        let (block, block_ext) = write_jsdoc_block(
+            &mut writer,
+            Span::new(0, 25),
+            0,
+            None,
+            star,
+            space,
+            close,
+            nl,
+            empty,
+            nl,
+            empty,
+            0b010, // bit1 = tags
+            None,  // description_raw_span — Phase 5 opt-in, off here
+        );
+        let mut tags_list = writer.begin_node_list_at(block_ext, JSDOC_BLOCK_TAGS_SLOT);
+        // Tag children bitmask: bit0 (tag) + bit2 (name) + bit3 (parsedType) = 0b1101.
+        let (tag, _tag_ext) = write_jsdoc_tag(
+            &mut writer,
+            Span::new(4, 23),
+            block.as_u32(),
+            false,
+            None,
+            None,
+            None,
+            0b0000_1101,
+            None, // description_raw_span — Phase 5 opt-in, off here
+        );
+        writer.record_list_child(&mut tags_list, tag.as_u32());
+        writer.finalize_node_list(tags_list);
+        // Children of tag are emitted in visitor-bit order:
+        // bit0 (JsdocTagName), then bit2 (JsdocTagNameValue), then bit3 (TypeName).
+        let _ = write_jsdoc_tag_name(&mut writer, Span::new(4, 9), tag.as_u32(), tag_name_str);
+        let _ = write_jsdoc_tag_name_value(
+            &mut writer,
+            Span::new(20, 22),
+            tag.as_u32(),
+            param_name_str,
+        );
+        let _ = write_type_name(&mut writer, Span::new(11, 17), tag.as_u32(), type_name_str);
+
+        writer.push_root(block.as_u32(), 0, 0);
+        writer.finish()
+    }
+
+    #[test]
+    fn visitor_walks_block_and_children() {
+        let arena = Allocator::default();
+        let bytes = build_single_tag_buffer(&arena);
+        let sf = LazySourceFile::new(&bytes).unwrap();
+
+        let mut v = CountVisitor { counts: HashMap::new() };
+        for opt in sf.asts() {
+            if let Some(block) = opt {
+                v.visit_block(block);
+            }
+        }
+
+        assert_eq!(v.counts.get(&Kind::JsdocBlock).copied(), Some(1));
+        assert_eq!(v.counts.get(&Kind::JsdocTag).copied(), Some(1));
+        assert_eq!(v.counts.get(&Kind::JsdocTagName).copied(), Some(1));
+        assert_eq!(v.counts.get(&Kind::JsdocTagNameValue).copied(), Some(1));
+        // The TypeName is reached via `tag.parsed_type()` which feeds into
+        // `visit_type_node` → `visit_type_name`.
+        assert_eq!(v.counts.get(&Kind::TypeName).copied(), Some(1));
+    }
+
+    /// Empty visitor — verifies that `LazyJsdocVisitor` is implementable
+    /// with zero overrides and traverses cleanly without panicking.
+    struct NoopVisitor;
+    impl<'a> LazyJsdocVisitor<'a> for NoopVisitor {}
+
+    #[test]
+    fn empty_visitor_traverses_without_panic() {
+        let arena = Allocator::default();
+        let bytes = build_single_tag_buffer(&arena);
+        let sf = LazySourceFile::new(&bytes).unwrap();
+
+        let mut v = NoopVisitor;
+        for opt in sf.asts() {
+            if let Some(block) = opt {
+                v.visit_block(block);
+            }
+        }
+    }
+
+    /// Visitor that records every TypeNode variant it visits; verifies the
+    /// `visit_type_node` dispatch wires each variant to its method.
+    #[test]
+    fn visit_type_node_dispatches_each_variant() {
+        let arena = Allocator::default();
+        let mut writer = BinaryWriter::new(&arena);
+        let s = writer.intern_string_payload("Foo");
+        // Build a TypeUnion with 2 TypeName children. Elements are direct
+        // children of the union; their (head, count) is patched into the
+        // union's ED list-metadata slot.
+        use crate::writer::nodes::type_node::{write_type_name, write_type_union};
+        let (union_idx, union_ext) = write_type_union(&mut writer, Span::new(0, 10), 0);
+        let union = union_idx.as_u32();
+        let mut list = writer.begin_node_list_at(union_ext, TYPE_LIST_PARENT_SLOT);
+        let n1 = write_type_name(&mut writer, Span::new(0, 3), union, s);
+        writer.record_list_child(&mut list, n1.as_u32());
+        let n2 = write_type_name(&mut writer, Span::new(4, 7), union, s);
+        writer.record_list_child(&mut list, n2.as_u32());
+        writer.finalize_node_list(list);
+        writer.push_root(union, 0, 0);
+
+        let bytes = writer.finish();
+        let sf = LazySourceFile::new(&bytes).unwrap();
+        use crate::decoder::nodes::type_node::LazyTypeNode;
+
+        struct TypeVisitor {
+            saw_union: bool,
+            type_name_count: usize,
+        }
+        impl<'a> LazyJsdocVisitor<'a> for TypeVisitor {
+            fn visit_type_union(&mut self, n: LazyTypeUnion<'a>) {
+                self.saw_union = true;
+                self.visit_type_union_default(n);
+            }
+            fn visit_type_name(&mut self, _n: LazyTypeName<'a>) {
+                self.type_name_count += 1;
+            }
+        }
+        let mut v = TypeVisitor { saw_union: false, type_name_count: 0 };
+        let root = LazyTypeNode::from_index(&sf, union, 0).expect("union root");
+        v.visit_type_node(root);
+
+        assert!(v.saw_union);
+        assert_eq!(v.type_name_count, 2);
+    }
+}

--- a/crates/ox_jsdoc_binary/src/format/diagnostics.rs
+++ b/crates/ox_jsdoc_binary/src/format/diagnostics.rs
@@ -1,0 +1,68 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Diagnostics section constants.
+//!
+//! See `design/007-binary-ast/format.md#diagnostics-section-4--8m-bytes` for
+//! the full layout.
+//!
+//! ```text
+//! byte 0-3      : M (u32)            -- diagnostic count
+//! per entry (8 bytes, sorted ascending by root_index):
+//!   byte 0-3    : root_index    (u32) -- index into the root array
+//!   byte 4-7    : message_index (u32) -- String Offsets index for the message
+//! ```
+
+/// Size in bytes of the diagnostic count header at the start of the section.
+pub const COUNT_HEADER_SIZE: usize = 4;
+
+/// Size of one diagnostic entry in bytes (`u32 root_index` + `u32 message_index`).
+pub const DIAGNOSTIC_ENTRY_SIZE: usize = 8;
+
+/// Byte offset of `root_index` within a diagnostic entry.
+pub const ROOT_INDEX_OFFSET: usize = 0;
+/// Byte offset of `message_index` within a diagnostic entry.
+pub const MESSAGE_INDEX_OFFSET: usize = 4;
+
+/// Compute the total Diagnostics-section size for `m` entries.
+#[inline]
+#[must_use]
+pub const fn section_size(m: usize) -> usize {
+    COUNT_HEADER_SIZE + DIAGNOSTIC_ENTRY_SIZE * m
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entry_size_is_8() {
+        assert_eq!(DIAGNOSTIC_ENTRY_SIZE, 8);
+    }
+
+    #[test]
+    fn entry_field_offsets_partition_8_bytes() {
+        let layout: &[(usize, usize)] = &[(ROOT_INDEX_OFFSET, 4), (MESSAGE_INDEX_OFFSET, 4)];
+        let mut cursor = 0usize;
+        for (offset, size) in layout {
+            assert_eq!(*offset, cursor);
+            cursor += size;
+        }
+        assert_eq!(cursor, DIAGNOSTIC_ENTRY_SIZE);
+    }
+
+    #[test]
+    fn section_size_for_zero_entries_is_just_count_header() {
+        assert_eq!(section_size(0), COUNT_HEADER_SIZE);
+    }
+
+    #[test]
+    fn section_size_examples() {
+        // Spec example: M=2 -> 4 + 16 = 20 bytes
+        assert_eq!(section_size(2), 20);
+        // M=10 -> 84 bytes; M=100 -> 804 bytes
+        assert_eq!(section_size(10), 84);
+        assert_eq!(section_size(100), 804);
+    }
+}

--- a/crates/ox_jsdoc_binary/src/format/extended_data.rs
+++ b/crates/ox_jsdoc_binary/src/format/extended_data.rs
@@ -1,0 +1,51 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Extended Data section constants.
+//!
+//! See `design/007-binary-ast/format.md#extended-data-section` for the full
+//! specification. Per-Kind layouts (e.g. `JsdocBlock` 18 / 40 bytes,
+//! `JsdocTag` 8 / 22 bytes) live in the per-Kind layout helpers shipped in
+//! later sub-phases (Phase 1.1a writer / 1.1b decoder).
+
+/// Alignment requirement for each Extended Data record start (8 bytes).
+///
+/// The encoder inserts zero-fill padding before each new record so that
+/// every offset reserved in the 30-bit Node Data payload is divisible by
+/// [`EXTENDED_DATA_ALIGNMENT`]. This guarantees that u32 fields can be read
+/// without unaligned-access penalties on every supported target.
+pub const EXTENDED_DATA_ALIGNMENT: usize = 8;
+
+/// Maximum byte offset that fits in the 30-bit Node Data payload
+/// (`2^30 - 1`). Cross-checked against
+/// [`super::node_record::PAYLOAD_MAX`].
+pub const EXTENDED_DATA_MAX_OFFSET: u32 = (1u32 << 30) - 1;
+
+/// Size of one **NodeList metadata** slot stored inline inside a parent's
+/// Extended Data block. Layout: `head_index: u32` followed by `count: u16`.
+///
+/// Parents with one or more variable-length child lists (`JsdocBlock.tags`,
+/// `TypeUnion.elements`, …) reserve `LIST_METADATA_SIZE` bytes per list at
+/// known per-Kind offsets. The writer patches `(head_index, count)` after
+/// the last child of each list is emitted; the decoder reads the head and
+/// walks `next_sibling` exactly `count` times. This replaces the Kind 0x7F
+/// `NodeList` wrapper that previously sat between the parent and its
+/// children.
+pub const LIST_METADATA_SIZE: usize = 4 + 2;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::format::node_record::PAYLOAD_MAX;
+
+    #[test]
+    fn alignment_is_8_bytes() {
+        assert_eq!(EXTENDED_DATA_ALIGNMENT, 8);
+    }
+
+    #[test]
+    fn max_offset_matches_node_data_payload_max() {
+        assert_eq!(EXTENDED_DATA_MAX_OFFSET, PAYLOAD_MAX);
+    }
+}

--- a/crates/ox_jsdoc_binary/src/format/header.rs
+++ b/crates/ox_jsdoc_binary/src/format/header.rs
@@ -1,0 +1,235 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Header section (40 bytes, fixed).
+//!
+//! See `design/007-binary-ast/format.md#header-40-bytes` for the full layout.
+//!
+//! ```text
+//! byte 0       : version (upper 4-bit major + lower 4-bit minor)
+//! byte 1       : flags   (bit0=compat_mode, bit1-7=reserved)
+//! byte 2-3     : reserved (zero-fill)
+//! byte 4-7     : root_array_offset    (u32)
+//! byte 8-11    : string_offsets_offset(u32)
+//! byte 12-15   : string_data_offset   (u32)
+//! byte 16-19   : extended_data_offset (u32)
+//! byte 20-23   : diagnostics_offset   (u32)
+//! byte 24-27   : nodes_offset         (u32)
+//! byte 28-31   : node_count           (u32)
+//! byte 32-35   : source_text_length   (u32)
+//! byte 36-39   : root_count           (u32)
+//! ```
+//!
+//! All multi-byte integers are little-endian (per the format conventions).
+
+/// Header size in bytes (fixed).
+pub const HEADER_SIZE: usize = 40;
+
+// ---------------------------------------------------------------------------
+// Field byte offsets within the header.
+// ---------------------------------------------------------------------------
+
+/// Offset of the version byte (`bits[7:4]` major, `bits[3:0]` minor).
+pub const VERSION_OFFSET: usize = 0;
+/// Offset of the flag byte.
+pub const FLAGS_OFFSET: usize = 1;
+/// Offset of the 2-byte reserved region (capability flags etc.).
+pub const RESERVED_OFFSET: usize = 2;
+/// Offset of the root index array start (u32).
+pub const ROOT_ARRAY_OFFSET_FIELD: usize = 4;
+/// Offset of the String Offsets section start (u32).
+pub const STRING_OFFSETS_OFFSET_FIELD: usize = 8;
+/// Offset of the String Data section start (u32).
+pub const STRING_DATA_OFFSET_FIELD: usize = 12;
+/// Offset of the Extended Data section start (u32).
+pub const EXTENDED_DATA_OFFSET_FIELD: usize = 16;
+/// Offset of the Diagnostics section start (u32).
+pub const DIAGNOSTICS_OFFSET_FIELD: usize = 20;
+/// Offset of the Nodes section start (u32).
+pub const NODES_OFFSET_FIELD: usize = 24;
+/// Offset of the total node count (u32).
+pub const NODE_COUNT_FIELD: usize = 28;
+/// Offset of the total source text length in UTF-8 bytes (u32).
+pub const SOURCE_TEXT_LENGTH_FIELD: usize = 32;
+/// Offset of the batch root count N (u32).
+pub const ROOT_COUNT_FIELD: usize = 36;
+
+// ---------------------------------------------------------------------------
+// Protocol version (4-bit major + 4-bit minor packed into byte 0).
+// ---------------------------------------------------------------------------
+
+/// Major version supported by this implementation.
+pub const SUPPORTED_MAJOR: u8 = 1;
+/// Minor version supported by this implementation.
+pub const SUPPORTED_MINOR: u8 = 0;
+
+/// Bit shift for extracting the major version from byte 0.
+pub const MAJOR_SHIFT: u8 = 4;
+/// Bit mask for extracting the minor version from byte 0.
+pub const MINOR_MASK: u8 = 0x0F;
+
+/// Pack the (major, minor) tuple into the single version byte.
+#[inline]
+#[must_use]
+pub const fn pack_version(major: u8, minor: u8) -> u8 {
+    (major << MAJOR_SHIFT) | (minor & MINOR_MASK)
+}
+
+/// Extract the major version number from byte 0.
+#[inline]
+#[must_use]
+pub const fn major(version_byte: u8) -> u8 {
+    version_byte >> MAJOR_SHIFT
+}
+
+/// Extract the minor version number from byte 0.
+#[inline]
+#[must_use]
+pub const fn minor(version_byte: u8) -> u8 {
+    version_byte & MINOR_MASK
+}
+
+/// The version byte that this implementation writes (`SUPPORTED_MAJOR.SUPPORTED_MINOR`).
+pub const SUPPORTED_VERSION_BYTE: u8 = pack_version(SUPPORTED_MAJOR, SUPPORTED_MINOR);
+
+// ---------------------------------------------------------------------------
+// Flag bit definitions (byte 1).
+// ---------------------------------------------------------------------------
+
+/// `bit0` of the flag byte: when set, the buffer carries jsdoccomment-compat
+/// extension data on `JsdocBlock` / `JsdocTag` / `JsdocDescriptionLine` /
+/// `JsdocTypeLine` (see `design/007-binary-ast/encoding.md`).
+pub const COMPAT_MODE_BIT: u8 = 0b0000_0001;
+
+/// Mask for the reserved flag bits (bit1..=bit7). Decoders must ignore bits
+/// they do not understand.
+pub const FLAGS_RESERVED_MASK: u8 = 0b1111_1110;
+
+// ---------------------------------------------------------------------------
+// Header struct (in-memory representation, populated by the writer).
+// ---------------------------------------------------------------------------
+
+/// In-memory representation of the binary Header.
+///
+/// This struct is only used while constructing or inspecting a buffer; the
+/// on-wire representation is the 40-byte little-endian byte sequence
+/// described at the top of this module. The struct itself does **not** have a
+/// guaranteed `repr(C)` layout because individual fields are written through
+/// the offset constants rather than via direct struct copy.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct Header {
+    /// Packed major+minor version byte.
+    pub version: u8,
+    /// Flag byte (`bit0=compat_mode`, others reserved).
+    pub flags: u8,
+    /// Byte offset of the root index array (Header end if N=0).
+    pub root_array_offset: u32,
+    /// Byte offset of the String Offsets section.
+    pub string_offsets_offset: u32,
+    /// Byte offset of the String Data section.
+    pub string_data_offset: u32,
+    /// Byte offset of the Extended Data section.
+    pub extended_data_offset: u32,
+    /// Byte offset of the Diagnostics section.
+    pub diagnostics_offset: u32,
+    /// Byte offset of the Nodes section.
+    pub nodes_offset: u32,
+    /// Number of node records (including the `node[0]` sentinel).
+    pub node_count: u32,
+    /// Total length of the concatenated source texts in UTF-8 bytes.
+    pub source_text_length: u32,
+    /// Number of roots N in this buffer (1 for the single-comment case).
+    pub root_count: u32,
+}
+
+impl Header {
+    /// Returns whether the `compat_mode` flag bit is set.
+    #[inline]
+    #[must_use]
+    pub const fn compat_mode(&self) -> bool {
+        (self.flags & COMPAT_MODE_BIT) != 0
+    }
+
+    /// Returns the major version stored in `self.version`.
+    #[inline]
+    #[must_use]
+    pub const fn major(&self) -> u8 {
+        major(self.version)
+    }
+
+    /// Returns the minor version stored in `self.version`.
+    #[inline]
+    #[must_use]
+    pub const fn minor(&self) -> u8 {
+        minor(self.version)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_size_is_40_bytes() {
+        // The on-wire size is fixed at 40 bytes regardless of struct padding.
+        // This test pins the *layout constant*, not `size_of::<Header>()`.
+        assert_eq!(HEADER_SIZE, 40);
+    }
+
+    #[test]
+    fn header_field_offsets_cover_40_bytes_without_overlap() {
+        // Each field must lie inside the 40-byte header, and the order of
+        // offsets must match the spec.
+        let offsets: &[(usize, usize)] = &[
+            (VERSION_OFFSET, 1),
+            (FLAGS_OFFSET, 1),
+            (RESERVED_OFFSET, 2),
+            (ROOT_ARRAY_OFFSET_FIELD, 4),
+            (STRING_OFFSETS_OFFSET_FIELD, 4),
+            (STRING_DATA_OFFSET_FIELD, 4),
+            (EXTENDED_DATA_OFFSET_FIELD, 4),
+            (DIAGNOSTICS_OFFSET_FIELD, 4),
+            (NODES_OFFSET_FIELD, 4),
+            (NODE_COUNT_FIELD, 4),
+            (SOURCE_TEXT_LENGTH_FIELD, 4),
+            (ROOT_COUNT_FIELD, 4),
+        ];
+
+        let mut cursor = 0usize;
+        for (offset, size) in offsets {
+            assert_eq!(*offset, cursor, "field at expected position");
+            cursor += size;
+        }
+        assert_eq!(cursor, HEADER_SIZE, "fields fully cover the header");
+    }
+
+    #[test]
+    fn version_pack_unpack_roundtrip() {
+        for major in 0u8..=15 {
+            for minor in 0u8..=15 {
+                let byte = pack_version(major, minor);
+                assert_eq!(super::major(byte), major);
+                assert_eq!(super::minor(byte), minor);
+            }
+        }
+    }
+
+    #[test]
+    fn supported_version_byte_is_0x10() {
+        assert_eq!(SUPPORTED_VERSION_BYTE, 0x10);
+        assert_eq!(major(SUPPORTED_VERSION_BYTE), 1);
+        assert_eq!(minor(SUPPORTED_VERSION_BYTE), 0);
+    }
+
+    #[test]
+    fn compat_mode_flag_round_trips() {
+        let mut h = Header::default();
+        assert!(!h.compat_mode());
+        h.flags |= COMPAT_MODE_BIT;
+        assert!(h.compat_mode());
+        // Setting reserved bits must not affect the compat flag query.
+        h.flags |= 0b1010_1010 & FLAGS_RESERVED_MASK;
+        assert!(h.compat_mode());
+    }
+}

--- a/crates/ox_jsdoc_binary/src/format/kind.rs
+++ b/crates/ox_jsdoc_binary/src/format/kind.rs
@@ -1,0 +1,449 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Node kinds (62 in total) and category checks.
+//!
+//! See `design/007-binary-ast/ast-nodes.md#kind-number-space` for the full
+//! number-space layout. Quick summary:
+//!
+//! ```text
+//! 0x00         Sentinel               (1)
+//! 0x01 - 0x0F  Comment AST            (15 used + reserved)
+//! 0x10 - 0x3F  Comment AST headroom   (reserved)
+//! 0x40 - 0x7E  Globally reserved      (reserved)
+//! 0x7F         NodeList               (1)
+//! 0x80 - 0xAC  TypeNode               (45 used)
+//! 0xAD - 0xFF  TypeNode headroom      (reserved)
+//! ```
+//!
+//! Categories are designed so that hot-path checks compile to a single
+//! instruction:
+//!
+//! - [`is_type_node`]: `(kind & 0x80) != 0` (1 MSB test)
+//! - [`is_node_list`]: `kind == 0x7F` (1 compare)
+//! - [`is_sentinel`]:  `kind == 0x00` (1 compare)
+
+use core::fmt;
+
+/// All 62 node kinds defined by the Binary AST format.
+///
+/// Discriminants are stable across releases (per the protocol-compatibility
+/// rules in `ast-nodes.md`); deleted variants are kept as comments rather
+/// than reusing their slot.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Kind {
+    // -- Special ----------------------------------------------------------
+    /// `node[0]` sentinel; never written for any real node.
+    Sentinel = 0x00,
+
+    // -- Comment AST (15 kinds, 0x01 - 0x0F) ------------------------------
+    /// Root `JsdocBlock` for one `/** ... */` block.
+    JsdocBlock = 0x01,
+    /// `JsdocDescriptionLine`.
+    JsdocDescriptionLine = 0x02,
+    /// `JsdocTag` (block tag).
+    JsdocTag = 0x03,
+    /// `JsdocTagName` (the `@name` part of a tag).
+    JsdocTagName = 0x04,
+    /// `JsdocTagNameValue` (e.g. the `name` after the type in `@param`).
+    JsdocTagNameValue = 0x05,
+    /// `JsdocTypeSource` (raw `{...}` text inside a tag).
+    JsdocTypeSource = 0x06,
+    /// `JsdocTypeLine` (one source-preserving type-source line).
+    JsdocTypeLine = 0x07,
+    /// `JsdocInlineTag` (e.g. `{@link Foo}`).
+    JsdocInlineTag = 0x08,
+    /// `JsdocGenericTagBody` (`JsdocTagBody::Generic` variant).
+    JsdocGenericTagBody = 0x09,
+    /// `JsdocBorrowsTagBody` (`JsdocTagBody::Borrows` variant).
+    JsdocBorrowsTagBody = 0x0A,
+    /// `JsdocRawTagBody` (`JsdocTagBody::Raw` variant).
+    JsdocRawTagBody = 0x0B,
+    /// `JsdocParameterName` (`JsdocTagValue::Parameter` variant).
+    JsdocParameterName = 0x0C,
+    /// `JsdocNamepathSource` (`JsdocTagValue::Namepath` variant).
+    JsdocNamepathSource = 0x0D,
+    /// `JsdocIdentifier` (`JsdocTagValue::Identifier` variant).
+    JsdocIdentifier = 0x0E,
+    /// `JsdocText` (`JsdocTagValue::Raw` variant).
+    JsdocText = 0x0F,
+
+    // -- Special list wrapper ---------------------------------------------
+    /// Special wrapper for variable-length child arrays.
+    ///
+    /// **Deprecated** as of the NodeList-elimination format change. Lists
+    /// are now stored as direct children of the parent, with
+    /// `(head_index: u32, count: u16)` metadata embedded inline in the
+    /// parent's Extended Data block (see
+    /// [`crate::format::extended_data::LIST_METADATA_SIZE`]). The discriminant
+    /// `0x7F` remains reserved so legacy buffers still parse, but encoders
+    /// no longer emit nodes of this Kind.
+    NodeList = 0x7F,
+
+    // -- TypeNode (45 kinds, 0x80 - 0xAC) ---------------------------------
+    /// `TypeName` (basic identifier type).
+    TypeName = 0x80,
+    /// `TypeNumber` (numeric literal type).
+    TypeNumber = 0x81,
+    /// `TypeStringValue` (string literal type).
+    TypeStringValue = 0x82,
+    /// `TypeNull`.
+    TypeNull = 0x83,
+    /// `TypeUndefined`.
+    TypeUndefined = 0x84,
+    /// `TypeAny` (`*` or `any`).
+    TypeAny = 0x85,
+    /// `TypeUnknown`.
+    TypeUnknown = 0x86,
+    /// `TypeUnion`.
+    TypeUnion = 0x87,
+    /// `TypeIntersection`.
+    TypeIntersection = 0x88,
+    /// `TypeGeneric` (e.g. `Foo<T>` or `Foo[]`).
+    TypeGeneric = 0x89,
+    /// `TypeFunction`.
+    TypeFunction = 0x8A,
+    /// `TypeObject`.
+    TypeObject = 0x8B,
+    /// `TypeTuple`.
+    TypeTuple = 0x8C,
+    /// `TypeParenthesis`.
+    TypeParenthesis = 0x8D,
+    /// `TypeNamePath`.
+    TypeNamePath = 0x8E,
+    /// `TypeSpecialNamePath`.
+    TypeSpecialNamePath = 0x8F,
+    /// `TypeNullable` (`?T` / `T?`).
+    TypeNullable = 0x90,
+    /// `TypeNotNullable` (`!T` / `T!`).
+    TypeNotNullable = 0x91,
+    /// `TypeOptional` (`T=`).
+    TypeOptional = 0x92,
+    /// `TypeVariadic` (`...T`).
+    TypeVariadic = 0x93,
+    /// `TypeConditional`.
+    TypeConditional = 0x94,
+    /// `TypeInfer`.
+    TypeInfer = 0x95,
+    /// `TypeKeyOf`.
+    TypeKeyOf = 0x96,
+    /// `TypeTypeOf`.
+    TypeTypeOf = 0x97,
+    /// `TypeImport`.
+    TypeImport = 0x98,
+    /// `TypePredicate`.
+    TypePredicate = 0x99,
+    /// `TypeAsserts`.
+    TypeAsserts = 0x9A,
+    /// `TypeAssertsPlain`.
+    TypeAssertsPlain = 0x9B,
+    /// `TypeReadonlyArray`.
+    TypeReadonlyArray = 0x9C,
+    /// `TypeTemplateLiteral`.
+    TypeTemplateLiteral = 0x9D,
+    /// `TypeUniqueSymbol`.
+    TypeUniqueSymbol = 0x9E,
+    /// `TypeSymbol` (Closure-style `Symbol(...)` calls).
+    TypeSymbol = 0x9F,
+    /// `TypeObjectField`.
+    TypeObjectField = 0xA0,
+    /// `TypeJsdocObjectField`.
+    TypeJsdocObjectField = 0xA1,
+    /// `TypeKeyValue` (`a: T`).
+    TypeKeyValue = 0xA2,
+    /// `TypeProperty`.
+    TypeProperty = 0xA3,
+    /// `TypeIndexSignature` (`[K]: T`).
+    TypeIndexSignature = 0xA4,
+    /// `TypeMappedType` (`[K in U]: T`).
+    TypeMappedType = 0xA5,
+    /// `TypeTypeParameter`.
+    TypeTypeParameter = 0xA6,
+    /// `TypeCallSignature`.
+    TypeCallSignature = 0xA7,
+    /// `TypeConstructorSignature`.
+    TypeConstructorSignature = 0xA8,
+    /// `TypeMethodSignature`.
+    TypeMethodSignature = 0xA9,
+    /// `TypeIndexedAccessIndex`.
+    TypeIndexedAccessIndex = 0xAA,
+    /// `TypeParameterList`.
+    TypeParameterList = 0xAB,
+    /// `TypeReadonlyProperty`.
+    TypeReadonlyProperty = 0xAC,
+}
+
+/// First reserved Kind discriminant in the global-reserved range
+/// (`0x40 - 0x7E`); see `ast-nodes.md`.
+pub const FIRST_RESERVED_KIND: u8 = 0x40;
+/// Last reserved Kind discriminant in the global-reserved range.
+pub const LAST_RESERVED_KIND: u8 = 0x7E;
+/// First TypeNode Kind discriminant (`0x80`); the upper-bit cluster.
+pub const FIRST_TYPE_NODE_KIND: u8 = 0x80;
+/// Highest TypeNode Kind discriminant currently in use (`0xAC`).
+pub const LAST_TYPE_NODE_KIND_IN_USE: u8 = 0xAC;
+/// First Comment AST Kind discriminant (`0x01`).
+pub const FIRST_COMMENT_AST_KIND: u8 = 0x01;
+/// Last Comment AST Kind discriminant currently in use (`0x0F`).
+pub const LAST_COMMENT_AST_KIND_IN_USE: u8 = 0x0F;
+/// Sentinel discriminant (`0x00`).
+pub const SENTINEL_KIND: u8 = 0x00;
+/// `NodeList` discriminant (`0x7F`).
+pub const NODE_LIST_KIND: u8 = 0x7F;
+
+/// Error returned by [`Kind::from_u8`] for unknown discriminants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnknownKind(pub u8);
+
+impl fmt::Display for UnknownKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown Kind discriminant 0x{:02X}", self.0)
+    }
+}
+
+impl Kind {
+    /// Convert a raw byte to a [`Kind`]. Returns [`UnknownKind`] when the
+    /// byte falls in a reserved or undefined slot.
+    ///
+    /// This is the safe entry point used by decoders. Hot dispatch in the
+    /// lazy decoder may use unchecked transmutes after [`is_known`] returns
+    /// `true`.
+    #[inline]
+    pub const fn from_u8(value: u8) -> Result<Self, UnknownKind> {
+        match value {
+            0x00 => Ok(Kind::Sentinel),
+            0x01 => Ok(Kind::JsdocBlock),
+            0x02 => Ok(Kind::JsdocDescriptionLine),
+            0x03 => Ok(Kind::JsdocTag),
+            0x04 => Ok(Kind::JsdocTagName),
+            0x05 => Ok(Kind::JsdocTagNameValue),
+            0x06 => Ok(Kind::JsdocTypeSource),
+            0x07 => Ok(Kind::JsdocTypeLine),
+            0x08 => Ok(Kind::JsdocInlineTag),
+            0x09 => Ok(Kind::JsdocGenericTagBody),
+            0x0A => Ok(Kind::JsdocBorrowsTagBody),
+            0x0B => Ok(Kind::JsdocRawTagBody),
+            0x0C => Ok(Kind::JsdocParameterName),
+            0x0D => Ok(Kind::JsdocNamepathSource),
+            0x0E => Ok(Kind::JsdocIdentifier),
+            0x0F => Ok(Kind::JsdocText),
+            0x7F => Ok(Kind::NodeList),
+            0x80 => Ok(Kind::TypeName),
+            0x81 => Ok(Kind::TypeNumber),
+            0x82 => Ok(Kind::TypeStringValue),
+            0x83 => Ok(Kind::TypeNull),
+            0x84 => Ok(Kind::TypeUndefined),
+            0x85 => Ok(Kind::TypeAny),
+            0x86 => Ok(Kind::TypeUnknown),
+            0x87 => Ok(Kind::TypeUnion),
+            0x88 => Ok(Kind::TypeIntersection),
+            0x89 => Ok(Kind::TypeGeneric),
+            0x8A => Ok(Kind::TypeFunction),
+            0x8B => Ok(Kind::TypeObject),
+            0x8C => Ok(Kind::TypeTuple),
+            0x8D => Ok(Kind::TypeParenthesis),
+            0x8E => Ok(Kind::TypeNamePath),
+            0x8F => Ok(Kind::TypeSpecialNamePath),
+            0x90 => Ok(Kind::TypeNullable),
+            0x91 => Ok(Kind::TypeNotNullable),
+            0x92 => Ok(Kind::TypeOptional),
+            0x93 => Ok(Kind::TypeVariadic),
+            0x94 => Ok(Kind::TypeConditional),
+            0x95 => Ok(Kind::TypeInfer),
+            0x96 => Ok(Kind::TypeKeyOf),
+            0x97 => Ok(Kind::TypeTypeOf),
+            0x98 => Ok(Kind::TypeImport),
+            0x99 => Ok(Kind::TypePredicate),
+            0x9A => Ok(Kind::TypeAsserts),
+            0x9B => Ok(Kind::TypeAssertsPlain),
+            0x9C => Ok(Kind::TypeReadonlyArray),
+            0x9D => Ok(Kind::TypeTemplateLiteral),
+            0x9E => Ok(Kind::TypeUniqueSymbol),
+            0x9F => Ok(Kind::TypeSymbol),
+            0xA0 => Ok(Kind::TypeObjectField),
+            0xA1 => Ok(Kind::TypeJsdocObjectField),
+            0xA2 => Ok(Kind::TypeKeyValue),
+            0xA3 => Ok(Kind::TypeProperty),
+            0xA4 => Ok(Kind::TypeIndexSignature),
+            0xA5 => Ok(Kind::TypeMappedType),
+            0xA6 => Ok(Kind::TypeTypeParameter),
+            0xA7 => Ok(Kind::TypeCallSignature),
+            0xA8 => Ok(Kind::TypeConstructorSignature),
+            0xA9 => Ok(Kind::TypeMethodSignature),
+            0xAA => Ok(Kind::TypeIndexedAccessIndex),
+            0xAB => Ok(Kind::TypeParameterList),
+            0xAC => Ok(Kind::TypeReadonlyProperty),
+            other => Err(UnknownKind(other)),
+        }
+    }
+
+    /// Returns the raw u8 discriminant.
+    #[inline]
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Category checks (single-instruction hot paths).
+// ---------------------------------------------------------------------------
+
+/// Is `kind` in the TypeNode range (`0x80 - 0xFF`, MSB set)?
+///
+/// Compiles to a single MSB test such as `TEST AL, 0x80` (x86) or
+/// `TST W0, #0x80` (ARM).
+#[inline]
+#[must_use]
+pub const fn is_type_node(kind: u8) -> bool {
+    (kind & 0x80) != 0
+}
+
+/// Is `kind` exactly the `NodeList` discriminant (`0x7F`)?
+#[inline]
+#[must_use]
+pub const fn is_node_list(kind: u8) -> bool {
+    kind == NODE_LIST_KIND
+}
+
+/// Is `kind` the sentinel discriminant (`0x00`)?
+#[inline]
+#[must_use]
+pub const fn is_sentinel(kind: u8) -> bool {
+    kind == SENTINEL_KIND
+}
+
+/// Is `kind` in the comment-AST range (`0x01 - 0x3F`)?
+///
+/// Implementation: `(kind & 0xC0) == 0x00 && kind != 0x00`.
+#[inline]
+#[must_use]
+pub const fn is_comment_ast(kind: u8) -> bool {
+    (kind & 0xC0) == 0x00 && kind != SENTINEL_KIND
+}
+
+/// Is `kind` in the globally reserved range (`0x40 - 0x7E`, excluding NodeList)?
+///
+/// Implementation: `(kind & 0xC0) == 0x40 && kind != NodeList`.
+#[inline]
+#[must_use]
+pub const fn is_reserved(kind: u8) -> bool {
+    (kind & 0xC0) == 0x40 && kind != NODE_LIST_KIND
+}
+
+/// Is `kind` a defined node type (i.e. [`Kind::from_u8`] would return `Ok`)?
+#[inline]
+#[must_use]
+pub const fn is_known(kind: u8) -> bool {
+    Kind::from_u8(kind).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Total number of defined Kind values: 1 sentinel + 15 comment AST +
+    /// 1 NodeList + 45 TypeNode = 62.
+    const EXPECTED_KNOWN_KINDS: usize = 62;
+
+    #[test]
+    fn from_u8_recognizes_all_62_known_discriminants() {
+        let mut count = 0usize;
+        for byte in 0u8..=u8::MAX {
+            if Kind::from_u8(byte).is_ok() {
+                count += 1;
+            }
+        }
+        assert_eq!(count, EXPECTED_KNOWN_KINDS);
+    }
+
+    #[test]
+    fn from_u8_round_trips_for_all_known_kinds() {
+        for byte in 0u8..=u8::MAX {
+            if let Ok(kind) = Kind::from_u8(byte) {
+                assert_eq!(kind.as_u8(), byte);
+            }
+        }
+    }
+
+    #[test]
+    fn category_partition_covers_every_byte() {
+        // Every byte must fall into exactly one of: sentinel, comment AST,
+        // reserved, NodeList, TypeNode.
+        for byte in 0u8..=u8::MAX {
+            let mut hits = 0;
+            if is_sentinel(byte) {
+                hits += 1;
+            }
+            if is_comment_ast(byte) {
+                hits += 1;
+            }
+            if is_reserved(byte) {
+                hits += 1;
+            }
+            if is_node_list(byte) {
+                hits += 1;
+            }
+            if is_type_node(byte) {
+                hits += 1;
+            }
+            assert_eq!(hits, 1, "byte 0x{byte:02X} matched {hits} categories");
+        }
+    }
+
+    #[test]
+    fn type_node_range_count_matches_msb_bytes() {
+        let count = (0u8..=u8::MAX).filter(|&b| is_type_node(b)).count();
+        assert_eq!(count, 128);
+    }
+
+    #[test]
+    fn comment_ast_range_count_is_63() {
+        // 0x01 - 0x3F = 63 slots (15 currently used + 48 reserved for growth).
+        let count = (0u8..=u8::MAX).filter(|&b| is_comment_ast(b)).count();
+        assert_eq!(count, 63);
+    }
+
+    #[test]
+    fn reserved_range_count_is_63() {
+        // 0x40 - 0x7E = 63 slots (NodeList = 0x7F is excluded).
+        let count = (0u8..=u8::MAX).filter(|&b| is_reserved(b)).count();
+        assert_eq!(count, 63);
+    }
+
+    #[test]
+    fn known_kinds_are_a_subset_of_categorized_bytes() {
+        // Every defined Kind must be either Sentinel, NodeList,
+        // a comment-AST byte, or a TypeNode byte (never reserved).
+        for byte in 0u8..=u8::MAX {
+            if Kind::from_u8(byte).is_ok() {
+                assert!(
+                    is_sentinel(byte)
+                        || is_node_list(byte)
+                        || is_comment_ast(byte)
+                        || is_type_node(byte),
+                    "known Kind 0x{byte:02X} fell into reserved range"
+                );
+                assert!(!is_reserved(byte));
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_kind_error_carries_the_byte() {
+        let err = Kind::from_u8(0x40).unwrap_err();
+        assert_eq!(err.0, 0x40);
+    }
+
+    #[test]
+    fn first_and_last_constants_match_enum() {
+        assert_eq!(Kind::Sentinel.as_u8(), SENTINEL_KIND);
+        assert_eq!(Kind::JsdocBlock.as_u8(), FIRST_COMMENT_AST_KIND);
+        assert_eq!(Kind::JsdocText.as_u8(), LAST_COMMENT_AST_KIND_IN_USE);
+        assert_eq!(Kind::NodeList.as_u8(), NODE_LIST_KIND);
+        assert_eq!(Kind::TypeName.as_u8(), FIRST_TYPE_NODE_KIND);
+        assert_eq!(Kind::TypeReadonlyProperty.as_u8(), LAST_TYPE_NODE_KIND_IN_USE);
+    }
+}

--- a/crates/ox_jsdoc_binary/src/format/mod.rs
+++ b/crates/ox_jsdoc_binary/src/format/mod.rs
@@ -1,0 +1,28 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Binary AST format specification (constants, layouts, type definitions).
+//!
+//! The format is documented in detail in
+//! `design/007-binary-ast/format.md`; this module provides the canonical
+//! Rust constants and types corresponding to that spec.
+//!
+//! Layout overview:
+//!
+//! ```text
+//! [Header (40 bytes)] [Root Index Array (12N)] [String Offsets (8K)]
+//! [String Data] [Extended Data] [Diagnostics (4 + 8M)] [Nodes (24P)]
+//! ```
+//!
+//! Each section has its own submodule that exposes the constants required by
+//! both the writer (Phase 1.1a) and the lazy decoder (Phase 1.1b).
+
+pub mod diagnostics;
+pub mod extended_data;
+pub mod header;
+pub mod kind;
+pub mod node_record;
+pub mod root_index;
+pub mod string_field;
+pub mod string_table;

--- a/crates/ox_jsdoc_binary/src/format/node_record.rs
+++ b/crates/ox_jsdoc_binary/src/format/node_record.rs
@@ -1,0 +1,270 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Node record layout (24 bytes per node) and Node Data bit packing.
+//!
+//! See `design/007-binary-ast/format.md#nodes-section-24-bytesnode` and
+//! `format.md#node-data-bit-packing-32-bit` for the full specifications.
+//!
+//! ```text
+//! byte  0     : Kind            (u8)
+//! byte  1     : Common Data     (u8, lower 6 bit; upper 2 bit reserved)
+//! byte  2-3   : padding         (u16, zero-fill)
+//! byte  4-7   : Pos             (u32, UTF-16 offset relative to root sourceText)
+//! byte  8-11  : End             (u32, UTF-16 offset relative to root sourceText)
+//! byte 12-15  : Node Data       (u32, 2-bit type tag + 30-bit payload)
+//! byte 16-19  : parent_index    (u32, 0 = sentinel)
+//! byte 20-23  : next_sibling    (u32, 0 = no sibling)
+//! ```
+
+use core::fmt;
+
+/// Size of one node record in bytes (fixed for the entire format).
+pub const NODE_RECORD_SIZE: usize = 24;
+
+// ---------------------------------------------------------------------------
+// Field byte offsets within a node record.
+// ---------------------------------------------------------------------------
+
+/// Offset of the `Kind` byte.
+pub const KIND_OFFSET: usize = 0;
+/// Offset of the `Common Data` byte (lower 6 bit).
+pub const COMMON_DATA_OFFSET: usize = 1;
+/// Offset of the 2-byte alignment padding (zero-fill).
+pub const PADDING_OFFSET: usize = 2;
+/// Offset of the `Pos` field (u32, UTF-16 code units).
+pub const POS_OFFSET: usize = 4;
+/// Offset of the `End` field (u32, UTF-16 code units).
+pub const END_OFFSET: usize = 8;
+/// Offset of the `Node Data` field (u32, type tag + payload).
+pub const NODE_DATA_OFFSET: usize = 12;
+/// Offset of the `parent_index` field (u32, 0 = sentinel).
+pub const PARENT_INDEX_OFFSET: usize = 16;
+/// Offset of the `next_sibling` field (u32, 0 = no sibling).
+pub const NEXT_SIBLING_OFFSET: usize = 20;
+
+// ---------------------------------------------------------------------------
+// Common Data masks (byte 1).
+// ---------------------------------------------------------------------------
+
+/// Bit mask isolating the 6-bit Common Data payload (`bits[5:0]`).
+pub const COMMON_DATA_MASK: u8 = 0b0011_1111;
+/// Bit mask isolating the reserved upper bits of byte 1 (`bits[7:6]`).
+pub const COMMON_DATA_RESERVED_MASK: u8 = 0b1100_0000;
+/// Number of Common Data bits actually used (6 of 8).
+pub const COMMON_DATA_BITS: u8 = 6;
+
+// ---------------------------------------------------------------------------
+// Node Data bit packing (32-bit u32: 2-bit type tag + 30-bit payload).
+// ---------------------------------------------------------------------------
+
+/// Right shift amount for extracting the 2-bit type tag from Node Data.
+pub const TYPE_TAG_SHIFT: u32 = 30;
+/// Mask for the 2-bit type tag after shifting (`0b11`).
+pub const TYPE_TAG_MASK: u32 = 0b11;
+/// Mask for the 30-bit payload portion of Node Data.
+pub const PAYLOAD_MASK: u32 = 0x3FFF_FFFF;
+/// Maximum value the 30-bit payload can carry.
+pub const PAYLOAD_MAX: u32 = PAYLOAD_MASK;
+
+/// Type tag values stored in the upper 2 bits of Node Data.
+///
+/// Discriminants are stable per the format spec. String-leaf nodes use
+/// `TypeTag::String` (long strings, via String Offsets table) or
+/// `TypeTag::StringInline` (short strings ≤ 255 bytes, payload packed as
+/// `(offset: u22, length: u8)`); Extended-type records reach their string
+/// slots via inline [`crate::format::string_field::StringField`] entries
+/// (no offsets-table indirection).
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TypeTag {
+    /// `0b00` - payload is a 30-bit Children bitmask (visitor order).
+    Children = 0b00,
+    /// `0b01` - payload is a 30-bit String Offsets index. Used for
+    /// string-leaf nodes whose value is too long (≥ 256 bytes) or whose
+    /// String Data offset exceeds the inline 22-bit range; ED-internal
+    /// string slots embed StringField directly instead.
+    String = 0b01,
+    /// `0b10` - payload is a 30-bit byte offset into the Extended Data section.
+    Extended = 0b10,
+    /// `0b11` - payload is a packed `(offset: u22, length: u8)` directly
+    /// pointing into the String Data section. Skips the String Offsets table
+    /// indirection; preferred for short string-leaf values when the offset
+    /// fits the 22-bit range. See [`pack_string_inline`] / [`unpack_string_inline`].
+    StringInline = 0b11,
+}
+
+// ---------------------------------------------------------------------------
+// StringInline payload bit packing (within the 30-bit Node Data payload).
+// ---------------------------------------------------------------------------
+
+/// Number of bits the inline String payload reserves for the data-buffer
+/// offset (high portion of the 30-bit payload).
+pub const STRING_INLINE_OFFSET_BITS: u32 = 22;
+/// Number of bits the inline String payload reserves for the UTF-8 byte
+/// length (low portion of the 30-bit payload).
+pub const STRING_INLINE_LENGTH_BITS: u32 = 8;
+/// Maximum offset that fits in the inline-payload offset field (4 MB - 1).
+pub const STRING_INLINE_OFFSET_MAX: u32 = (1u32 << STRING_INLINE_OFFSET_BITS) - 1;
+/// Maximum UTF-8 byte length that fits in the inline-payload length field
+/// (255). Strings of length 256 or more must take the String Offsets path.
+pub const STRING_INLINE_LENGTH_MAX: u32 = (1u32 << STRING_INLINE_LENGTH_BITS) - 1;
+/// Bit mask isolating the length portion of an inline payload.
+pub const STRING_INLINE_LENGTH_MASK: u32 = STRING_INLINE_LENGTH_MAX;
+
+/// Pack `(offset, length)` into the 30-bit inline-payload layout.
+///
+/// `offset` MUST be ≤ [`STRING_INLINE_OFFSET_MAX`] (caller-checked).
+/// Length is stored in the low 8 bits, offset in the upper 22 bits.
+#[inline]
+#[must_use]
+pub const fn pack_string_inline(offset: u32, length: u8) -> u32 {
+    debug_assert!(offset <= STRING_INLINE_OFFSET_MAX);
+    (offset << STRING_INLINE_LENGTH_BITS) | (length as u32)
+}
+
+/// Unpack a 30-bit inline payload into `(offset, length)`.
+#[inline]
+#[must_use]
+pub const fn unpack_string_inline(payload: u32) -> (u32, u8) {
+    let offset = payload >> STRING_INLINE_LENGTH_BITS;
+    let length = (payload & STRING_INLINE_LENGTH_MASK) as u8;
+    (offset, length)
+}
+
+/// Error returned by [`TypeTag::from_u32`] when the value is outside `0b00 - 0b11`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidTypeTag(pub u32);
+
+impl fmt::Display for InvalidTypeTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid Node Data type tag 0b{:02b}", self.0)
+    }
+}
+
+impl TypeTag {
+    /// Convert the raw 2-bit tag value (`0..=3`) into a [`TypeTag`].
+    #[inline]
+    pub const fn from_u32(value: u32) -> Result<Self, InvalidTypeTag> {
+        match value {
+            0b00 => Ok(TypeTag::Children),
+            0b01 => Ok(TypeTag::String),
+            0b10 => Ok(TypeTag::Extended),
+            0b11 => Ok(TypeTag::StringInline),
+            other => Err(InvalidTypeTag(other)),
+        }
+    }
+}
+
+/// Sentinel for "absent" stored in a 30-bit String payload (`0x3FFF_FFFF`).
+///
+/// The encoder writes this when an `Option<&str>` is `None`. The same value
+/// happens to coincide with [`PAYLOAD_MAX`], so encoders **must** never assign
+/// a real string the index `2^30 - 1`; in practice this is enforced by the
+/// String Table being capped at the u16 limit (see `string_table.rs`).
+pub const STRING_PAYLOAD_NONE_SENTINEL: u32 = PAYLOAD_MAX;
+
+/// Pack a `(TypeTag, payload)` pair into a single Node Data u32.
+///
+/// The `payload` is masked to 30 bits; passing a larger value silently
+/// truncates the upper bits. Encoders should validate the range beforehand.
+#[inline]
+#[must_use]
+pub const fn pack_node_data(tag: TypeTag, payload: u32) -> u32 {
+    ((tag as u32) << TYPE_TAG_SHIFT) | (payload & PAYLOAD_MASK)
+}
+
+/// Extract the raw 2-bit type tag from a Node Data u32.
+#[inline]
+#[must_use]
+pub const fn type_tag_bits(node_data: u32) -> u32 {
+    (node_data >> TYPE_TAG_SHIFT) & TYPE_TAG_MASK
+}
+
+/// Extract the 30-bit payload from a Node Data u32.
+#[inline]
+#[must_use]
+pub const fn payload(node_data: u32) -> u32 {
+    node_data & PAYLOAD_MASK
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_record_size_is_24() {
+        assert_eq!(NODE_RECORD_SIZE, 24);
+    }
+
+    #[test]
+    fn field_offsets_partition_24_bytes() {
+        let layout: &[(usize, usize, &str)] = &[
+            (KIND_OFFSET, 1, "kind"),
+            (COMMON_DATA_OFFSET, 1, "common_data"),
+            (PADDING_OFFSET, 2, "padding"),
+            (POS_OFFSET, 4, "pos"),
+            (END_OFFSET, 4, "end"),
+            (NODE_DATA_OFFSET, 4, "node_data"),
+            (PARENT_INDEX_OFFSET, 4, "parent_index"),
+            (NEXT_SIBLING_OFFSET, 4, "next_sibling"),
+        ];
+        let mut cursor = 0usize;
+        for (offset, size, name) in layout {
+            assert_eq!(*offset, cursor, "{name} starts at expected offset");
+            cursor += size;
+        }
+        assert_eq!(cursor, NODE_RECORD_SIZE, "fields cover all 24 bytes");
+    }
+
+    #[test]
+    fn common_data_masks_are_complementary() {
+        assert_eq!(COMMON_DATA_MASK | COMMON_DATA_RESERVED_MASK, 0xFF);
+        assert_eq!(COMMON_DATA_MASK & COMMON_DATA_RESERVED_MASK, 0x00);
+        assert_eq!(COMMON_DATA_MASK.count_ones(), COMMON_DATA_BITS as u32);
+    }
+
+    #[test]
+    fn node_data_pack_unpack_round_trip() {
+        for tag in [TypeTag::Children, TypeTag::String, TypeTag::Extended, TypeTag::StringInline] {
+            for &payload_value in &[0u32, 1, 0xABCD, PAYLOAD_MAX, PAYLOAD_MAX - 1] {
+                let nd = pack_node_data(tag, payload_value);
+                let extracted_tag = TypeTag::from_u32(type_tag_bits(nd)).unwrap();
+                let extracted_payload = payload(nd);
+                assert_eq!(extracted_tag, tag, "tag round trip");
+                assert_eq!(
+                    extracted_payload, payload_value,
+                    "payload round trip for {tag:?} / 0x{payload_value:08X}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn payload_truncation_when_value_exceeds_30_bits() {
+        let nd = pack_node_data(TypeTag::String, 0xFFFF_FFFF);
+        assert_eq!(payload(nd), PAYLOAD_MAX);
+        assert_eq!(type_tag_bits(nd), TypeTag::String as u32);
+    }
+
+    #[test]
+    fn payload_max_is_2_pow_30_minus_1() {
+        assert_eq!(PAYLOAD_MAX, (1u32 << 30) - 1);
+        assert_eq!(STRING_PAYLOAD_NONE_SENTINEL, PAYLOAD_MAX);
+    }
+
+    #[test]
+    fn type_tag_from_u32_rejects_out_of_range() {
+        assert!(TypeTag::from_u32(4).is_err());
+        assert_eq!(TypeTag::from_u32(99).unwrap_err().0, 99);
+    }
+
+    #[test]
+    fn pack_keeps_payload_within_30_bits_when_in_range() {
+        // Top bits of payload must not bleed into the tag field.
+        let nd = pack_node_data(TypeTag::Children, PAYLOAD_MAX);
+        assert_eq!(type_tag_bits(nd), TypeTag::Children as u32);
+        assert_eq!(payload(nd), PAYLOAD_MAX);
+    }
+}

--- a/crates/ox_jsdoc_binary/src/format/root_index.rs
+++ b/crates/ox_jsdoc_binary/src/format/root_index.rs
@@ -1,0 +1,77 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Root index array constants (12 bytes per root).
+//!
+//! See `design/007-binary-ast/format.md#root-index-array-12n-bytes` for the
+//! full layout.
+//!
+//! ```text
+//! byte 0-3   : node_index             (u32, 0 = parse failure sentinel)
+//! byte 4-7   : source_offset_in_data  (u32, byte offset into String Data)
+//! byte 8-11  : base_offset            (u32, original-file absolute offset)
+//! ```
+
+/// Size of one root index entry in bytes.
+pub const ROOT_INDEX_ENTRY_SIZE: usize = 12;
+
+/// Byte offset of `node_index` within a root index entry.
+pub const NODE_INDEX_OFFSET: usize = 0;
+/// Byte offset of `source_offset_in_data` within a root index entry.
+pub const SOURCE_OFFSET_FIELD: usize = 4;
+/// Byte offset of `base_offset` within a root index entry.
+pub const BASE_OFFSET_FIELD: usize = 8;
+
+/// Sentinel value for `node_index` indicating that the corresponding comment
+/// failed to parse. The `Diagnostics` section is required to contain at least
+/// one entry with the matching `root_index` (see
+/// `design/007-binary-ast/format.md#root-index-array-12n-bytes` "Required on
+/// failure").
+pub const PARSE_FAILURE_SENTINEL: u32 = 0;
+
+/// Compute the total root-index-array size for `n` roots.
+#[inline]
+#[must_use]
+pub const fn section_size(n: usize) -> usize {
+    ROOT_INDEX_ENTRY_SIZE * n
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entry_size_is_12() {
+        assert_eq!(ROOT_INDEX_ENTRY_SIZE, 12);
+    }
+
+    #[test]
+    fn entry_field_offsets_partition_12_bytes() {
+        let layout: &[(usize, usize)] =
+            &[(NODE_INDEX_OFFSET, 4), (SOURCE_OFFSET_FIELD, 4), (BASE_OFFSET_FIELD, 4)];
+        let mut cursor = 0usize;
+        for (offset, size) in layout {
+            assert_eq!(*offset, cursor);
+            cursor += size;
+        }
+        assert_eq!(cursor, ROOT_INDEX_ENTRY_SIZE);
+    }
+
+    #[test]
+    fn parse_failure_sentinel_is_zero() {
+        // node[0] is also the all-zero sentinel; reusing `0` for failure is
+        // explicitly part of the spec.
+        assert_eq!(PARSE_FAILURE_SENTINEL, 0);
+    }
+
+    #[test]
+    fn section_size_examples() {
+        // Spec example: N=2 -> 24 bytes
+        assert_eq!(section_size(2), 24);
+        // N=1 (single comment): 12 bytes
+        assert_eq!(section_size(1), 12);
+        // N=0 (degenerate): 0 bytes
+        assert_eq!(section_size(0), 0);
+    }
+}

--- a/crates/ox_jsdoc_binary/src/format/string_field.rs
+++ b/crates/ox_jsdoc_binary/src/format/string_field.rs
@@ -1,0 +1,146 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! String field encoding (6 bytes per slot).
+//!
+//! Replaces the indirect "String Offsets" table by materializing every
+//! string reference inline as a [`StringField`] holding `(offset: u32,
+//! length: u16)` — readers slice the String Data section directly without
+//! the extra hop.
+//!
+//! Wire layout (little-endian, **not** naturally aligned):
+//!
+//! ```text
+//! byte 0-3 : offset (u32)
+//! byte 4-5 : length (u16)
+//! ```
+//!
+//! Each slot is 6 bytes. Records in Extended Data may pack consecutive
+//! StringField slots back-to-back; the surrounding Extended Data record's
+//! 8-byte alignment guarantees that the first slot's u32 sits on at least a
+//! 2-byte boundary, but later slots may straddle 4/8-byte boundaries.
+//! Decoders therefore must use byte-level reads (`from_le_bytes` on a
+//! `[u8; 4]` / `[u8; 2]` slice) rather than relying on natural alignment.
+
+/// Size of a single [`StringField`] in the on-wire encoding (6 bytes).
+pub const STRING_FIELD_SIZE: usize = 6;
+
+/// Offset value used by [`StringField::NONE`].
+///
+/// `u32::MAX` is reserved as the "absent string" sentinel; since the String
+/// Data section is bounded by [`crate::format::node_record::PAYLOAD_MAX`]
+/// (~1 GiB) in practice, no real string ever has this offset.
+pub const STRING_FIELD_NONE_OFFSET: u32 = u32::MAX;
+
+/// Length value used by [`StringField::NONE`]. Always zero so that the None
+/// sentinel is distinguishable from any valid empty-string field, which uses
+/// some valid `(offset, 0)` pair pointing into the data buffer (typically
+/// the COMMON_STRINGS prelude entry for `""`).
+pub const STRING_FIELD_NONE_LENGTH: u16 = 0;
+
+/// On-wire string reference: a `(offset, length)` pair into the String Data
+/// section.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StringField {
+    /// Byte offset within the String Data section where this string starts.
+    pub offset: u32,
+    /// UTF-8 byte length of the referenced string.
+    pub length: u16,
+}
+
+impl StringField {
+    /// Sentinel meaning "no string" (`Option<&str> = None`). Encoded as
+    /// `(offset = u32::MAX, length = 0)` so it never collides with a valid
+    /// reference.
+    pub const NONE: Self =
+        Self { offset: STRING_FIELD_NONE_OFFSET, length: STRING_FIELD_NONE_LENGTH };
+
+    /// Construct a `StringField` from raw `(offset, length)` parts.
+    #[inline]
+    #[must_use]
+    pub const fn new(offset: u32, length: u16) -> Self {
+        Self { offset, length }
+    }
+
+    /// Whether this `StringField` is the [`Self::NONE`] sentinel.
+    #[inline]
+    #[must_use]
+    pub const fn is_none(self) -> bool {
+        self.offset == STRING_FIELD_NONE_OFFSET && self.length == STRING_FIELD_NONE_LENGTH
+    }
+
+    /// Write the 6-byte little-endian encoding into `dst`.
+    ///
+    /// `dst` must be at least [`STRING_FIELD_SIZE`] bytes long; the write
+    /// debug-asserts on a too-short slice.
+    #[inline]
+    pub fn write_le(self, dst: &mut [u8]) {
+        debug_assert!(
+            dst.len() >= STRING_FIELD_SIZE,
+            "StringField::write_le slice too short ({} bytes)",
+            dst.len()
+        );
+        dst[0..4].copy_from_slice(&self.offset.to_le_bytes());
+        dst[4..6].copy_from_slice(&self.length.to_le_bytes());
+    }
+
+    /// Read a 6-byte little-endian encoded `StringField` from `src`.
+    #[inline]
+    #[must_use]
+    pub fn read_le(src: &[u8]) -> Self {
+        debug_assert!(
+            src.len() >= STRING_FIELD_SIZE,
+            "StringField::read_le slice too short ({} bytes)",
+            src.len()
+        );
+        let offset = u32::from_le_bytes([src[0], src[1], src[2], src[3]]);
+        let length = u16::from_le_bytes([src[4], src[5]]);
+        Self { offset, length }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn size_is_6_bytes() {
+        assert_eq!(STRING_FIELD_SIZE, 6);
+    }
+
+    #[test]
+    fn round_trip_through_write_read() {
+        let cases = [
+            StringField::new(0, 0),
+            StringField::new(1, 5),
+            StringField::new(0x1234_5678, 0xABCD),
+            StringField::new(u32::MAX - 1, u16::MAX),
+            StringField::NONE,
+        ];
+        let mut buf = [0u8; STRING_FIELD_SIZE];
+        for field in cases {
+            buf.fill(0);
+            field.write_le(&mut buf);
+            let decoded = StringField::read_le(&buf);
+            assert_eq!(decoded, field, "round trip {field:?}");
+        }
+    }
+
+    #[test]
+    fn none_sentinel_distinct_from_empty_string() {
+        let none = StringField::NONE;
+        assert!(none.is_none());
+        let empty = StringField::new(0, 0);
+        assert!(!empty.is_none(), "empty (offset=0, length=0) is a valid string, not NONE");
+    }
+
+    #[test]
+    fn write_le_lays_out_little_endian() {
+        let field = StringField::new(0x0403_0201, 0x0605);
+        let mut buf = [0u8; STRING_FIELD_SIZE];
+        field.write_le(&mut buf);
+        assert_eq!(buf, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+    }
+}

--- a/crates/ox_jsdoc_binary/src/format/string_table.rs
+++ b/crates/ox_jsdoc_binary/src/format/string_table.rs
@@ -1,0 +1,30 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! String table (String Offsets + String Data) constants.
+//!
+//! See `design/007-binary-ast/format.md#string-table` for the full layout.
+//!
+//! - **String Offsets**: 8 bytes per string (`u32 start, u32 end`).
+//!   Used by string-leaf nodes (TypeTag::String) and the diagnostics section.
+//! - **String Data**: contiguous UTF-8 bytes; strings are referenced either
+//!   by an index into the String Offsets table (string-leaf path, capped at
+//!   2³⁰−2 by the 30-bit Node Data payload + the
+//!   [`crate::format::node_record::STRING_PAYLOAD_NONE_SENTINEL`] sentinel)
+//!   or by an inline [`crate::format::string_field::StringField`] slot
+//!   (Extended Data path) which embeds `(offset, length)` directly without
+//!   the indirection.
+
+/// Size of one String Offsets entry in bytes (`u32 start` + `u32 end`).
+pub const STRING_OFFSET_ENTRY_SIZE: usize = 8;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entry_size_is_8() {
+        assert_eq!(STRING_OFFSET_ENTRY_SIZE, 8);
+    }
+}

--- a/crates/ox_jsdoc_binary/src/lib.rs
+++ b/crates/ox_jsdoc_binary/src/lib.rs
@@ -1,0 +1,24 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+#![allow(clippy::all, clippy::cargo, clippy::nursery, clippy::pedantic)]
+
+//! Binary AST for ox_jsdoc.
+//!
+//! This crate hosts the Binary AST format specification ([`format`]), the
+//! parser-integrated binary writer ([`writer`]), the parser entry point
+//! ([`parser`]), the Rust-side lazy decoder ([`decoder`]), and the
+//! UTF-8 → UTF-16 position converter ([`utf16`]) used at emit time to
+//! satisfy the wire-format requirement that Pos/End are UTF-16 code units.
+//!
+//! The Binary AST replaces the previous JSON serialization path between the
+//! Rust parser and JS bindings. The full design lives under
+//! `design/007-binary-ast/`. The format specification itself is in
+//! `design/007-binary-ast/format.md`; this crate is the Rust reference
+//! implementation for that spec.
+
+pub mod decoder;
+pub mod format;
+pub mod parser;
+pub mod writer;

--- a/crates/ox_jsdoc_binary/src/parser/checkpoint.rs
+++ b/crates/ox_jsdoc_binary/src/parser/checkpoint.rs
@@ -1,0 +1,47 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Parser state snapshots.
+//!
+//! Verbatim port of `crates/ox_jsdoc/src/parser/checkpoint.rs`. Checkpoints
+//! allow speculative parsing without cloning the arena. Rewind restores
+//! scalar parser state and truncates diagnostics emitted after the
+//! checkpoint.
+
+/// Quote mode used while scanning nested constructs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuoteKind {
+    /// `'...'` single-quoted string.
+    Single,
+    /// `"..."` double-quoted string.
+    Double,
+    /// `` `...` `` template literal.
+    Backtick,
+}
+
+/// Active fenced code block state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FenceState {
+    /// Number of backticks that opened the current fence.
+    pub tick_count: u8,
+}
+
+/// Rewindable parser state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Checkpoint {
+    /// Parser byte offset relative to the parsed comment slice.
+    pub offset: u32,
+    /// Current nested `{...}` depth.
+    pub brace_depth: u16,
+    /// Current nested `[...]` depth.
+    pub bracket_depth: u16,
+    /// Current nested `(...)` depth.
+    pub paren_depth: u16,
+    /// Active quote context, if scanning inside a quoted region.
+    pub quote: Option<QuoteKind>,
+    /// Active fenced code block context, if any.
+    pub fence: Option<FenceState>,
+    /// Diagnostic list length at the time the checkpoint was captured.
+    pub diagnostics_len: usize,
+}

--- a/crates/ox_jsdoc_binary/src/parser/context.rs
+++ b/crates/ox_jsdoc_binary/src/parser/context.rs
@@ -1,0 +1,1853 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Structural parser for one JSDoc block, emitting Binary AST directly.
+//!
+//! Mirrors the typed-AST `crates/ox_jsdoc/src/parser/context.rs` but
+//! replaces every `ArenaBox::new_in(JsdocXxx { ... })` with a `write_*`
+//! call against a [`BinaryWriter`].
+//!
+//! Two phases:
+//!
+//! 1. **Parse** — `parse_block_into_data` walks the source text and
+//!    collects intermediate plain-data structs (no allocation in the
+//!    arena-tracked binary buffer). All slices borrow from the original
+//!    source text.
+//! 2. **Emit** — `emit_block` walks those structs in DFS pre-order and
+//!    invokes the matching `write_*` helper. Each emission knows its
+//!    parent's `NodeIndex` because we strictly write top-down.
+//!
+//! The split keeps the `children_bitmask` upfront (which the writer needs)
+//! while still allowing the parser to make local decisions (e.g. drop
+//! empty lists).
+//!
+//! `parsed_type` emission is already integrated through the side-table path
+//! used by `TagData`; ongoing work here is about keeping the structural parse
+//! and emit layers aligned with the format and typed-AST behavior.
+
+use oxc_allocator::{Allocator, StringBuilder, Vec as ArenaVec};
+use oxc_span::Span;
+
+/// Path C-2: arena-allocated inline-tag list. Was `SmallVec<[_; 2]>` but
+/// SmallVec implements `Drop` (for the spilled-heap case), which prevents
+/// the surrounding `TagData` from itself being placed in `ArenaVec`. The
+/// `InlineTagData` payload is `Copy`, so `ArenaVec` is the cleanest fit.
+type InlineTagsVec<'arena, 'a> = ArenaVec<'arena, InlineTagData<'a>>;
+use crate::writer::nodes::comment_ast::{
+    write_jsdoc_block, write_jsdoc_block_compat_tail, write_jsdoc_description_line,
+    write_jsdoc_description_line_compat, write_jsdoc_generic_tag_body, write_jsdoc_identifier,
+    write_jsdoc_inline_tag, write_jsdoc_namepath_source, write_jsdoc_parameter_name,
+    write_jsdoc_tag, write_jsdoc_tag_compat_tail, write_jsdoc_tag_name, write_jsdoc_tag_name_value,
+    write_jsdoc_text, write_jsdoc_type_line, write_jsdoc_type_line_compat, write_jsdoc_type_source,
+};
+use crate::writer::{BinaryWriter, StringField};
+
+use super::ParseOptions;
+use super::checkpoint::{Checkpoint, FenceState, QuoteKind};
+use super::diagnostics::{DiagnosticKind, ParserDiagnosticKind, TypeDiagnosticKind};
+use super::scanner;
+use super::type_data::TypeNodeData;
+
+// ---------------------------------------------------------------------------
+// Diagnostic + parsed-data types
+// ---------------------------------------------------------------------------
+
+/// One diagnostic emitted while parsing a comment.
+///
+/// The parser stores the diagnostic kind + an optional source span so the
+/// caller can decide how to format the human-readable message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParsedDiagnostic {
+    /// Either a structural-parser or a type-parser diagnostic kind.
+    pub kind: DiagnosticKind,
+    /// Source span the diagnostic refers to, when known.
+    pub span: Option<Span>,
+}
+
+impl ParsedDiagnostic {
+    /// Convenience: get the static message string for this diagnostic.
+    #[inline]
+    #[must_use]
+    pub const fn message(&self) -> &'static str {
+        self.kind.message()
+    }
+}
+
+/// Inline tag body format mirroring `ox_jsdoc::ast::JsdocInlineTagFormat`.
+///
+/// Stored as a `u8` in the binary record's Common Data slot (3 bits used).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum InlineTagFormatData {
+    /// `{@link target}` — no separator, no display text.
+    Plain = 0,
+    /// `{@link target|text}` — pipe separator.
+    Pipe = 1,
+    /// `{@link target text}` — whitespace separator.
+    Space = 2,
+    /// `{@link prefix:body}` — prefix-style.
+    Prefix = 3,
+    /// Could not classify.
+    Unknown = 4,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TypeSourceData<'a> {
+    span: Span,
+    raw: &'a str,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TypeLineData<'a> {
+    span: Span,
+    raw_type: &'a str,
+    delimiter: &'a str,
+    post_delimiter: &'a str,
+    initial: &'a str,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DescriptionLineData<'a> {
+    span: Span,
+    description: &'a str,
+    delimiter: &'a str,
+    post_delimiter: &'a str,
+    initial: &'a str,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct InlineTagData<'a> {
+    span: Span,
+    tag_name_span: Span,
+    tag_name: &'a str,
+    namepath_or_url: Option<&'a str>,
+    text: Option<&'a str>,
+    format: InlineTagFormatData,
+    raw_body: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TagNameValueData<'a> {
+    span: Span,
+    raw: &'a str,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TagValueData<'a> {
+    Parameter { span: Span, path: &'a str, optional: bool, default_value: Option<&'a str> },
+    Namepath { span: Span, raw: &'a str },
+    Identifier { span: Span, name: &'a str },
+    Raw { span: Span, value: &'a str },
+}
+
+#[derive(Debug)]
+struct GenericTagBodyData<'a> {
+    span: Span,
+    has_dash_separator: bool,
+    type_source: Option<TypeSourceData<'a>>,
+    value: Option<TagValueData<'a>>,
+    description: Option<&'a str>,
+}
+
+#[derive(Debug)]
+enum TagBodyData<'a> {
+    Generic(GenericTagBodyData<'a>),
+}
+
+#[derive(Debug)]
+struct TagData<'arena, 'a> {
+    span: Span,
+    tag_name_span: Span,
+    tag_name: &'a str,
+    optional: bool,
+    default_value: Option<&'a str>,
+    description: Option<&'a str>,
+    /// Source-text-relative `(start, end)` byte offsets covering the raw
+    /// description region (with `*` prefix and blank lines intact).
+    /// `None` when the tag has no description. Emitted in compat-mode wire
+    /// format per `design/008-oxlint-oxfmt-support/README.md` §4.2.
+    description_raw_span: Option<(u32, u32)>,
+    raw_body: Option<&'a str>,
+    raw_type: Option<TypeSourceData<'a>>,
+    name: Option<TagNameValueData<'a>>,
+    /// Path C-2: `true` when this tag has a parsed type expression.
+    /// The actual `TypeNodeData` lives in [`BlockData::tags_parsed_types`]
+    /// (a side table) so `TagData` can stay non-Drop and live in `ArenaVec`.
+    has_parsed_type: bool,
+    body: Option<TagBodyData<'a>>,
+    /// Path C: arena-allocated. Walked once during emit, no need for std heap.
+    description_lines: ArenaVec<'arena, DescriptionLineData<'a>>,
+    type_lines: ArenaVec<'arena, TypeLineData<'a>>,
+    inline_tags: InlineTagsVec<'arena, 'a>,
+    header_initial: &'a str,
+    header_delimiter: &'a str,
+    header_post_delimiter: &'a str,
+    header_line_end: &'a str,
+    /// `post_tag` source-preserving slot (compat mode).
+    post_tag: &'a str,
+    /// `post_type` source-preserving slot (compat mode).
+    post_type: &'a str,
+    /// `post_name` source-preserving slot (compat mode).
+    post_name: &'a str,
+}
+
+#[derive(Debug)]
+struct BlockData<'arena, 'a> {
+    span: Span,
+    description: Option<&'a str>,
+    /// Source-text-relative `(start, end)` byte offsets covering the raw
+    /// block description region (with `*` prefix and blank lines intact).
+    /// Same shape as [`TagData::description_raw_span`].
+    description_raw_span: Option<(u32, u32)>,
+    description_lines: ArenaVec<'arena, DescriptionLineData<'a>>,
+    inline_tags: InlineTagsVec<'arena, 'a>,
+    /// Path C-2: arena-allocated. `TagData` is now non-Drop (parsed_type
+    /// moved to side table below) so `ArenaVec` accepts it.
+    tags: ArenaVec<'arena, TagData<'arena, 'a>>,
+    /// Side table: `(tag_index, parsed_type)` pairs for tags with
+    /// `has_parsed_type = true`. Sorted by `tag_index` ascending. Empty
+    /// when `parse_types: false` (the default), which keeps the emit
+    /// loop's lookup branch fully predictable.
+    tags_parsed_types: Vec<(u32, Box<TypeNodeData<'a>>)>,
+    line_end: &'a str,
+    delimiter_line_break: &'a str,
+    preterminal_line_break: &'a str,
+    /// 0-based line index of the closing `*/` line (compat mode).
+    end_line: u32,
+    description_start_line: Option<u32>,
+    description_end_line: Option<u32>,
+    last_description_line: Option<u32>,
+    has_preterminal_description: u8,
+    has_preterminal_tag_description: Option<u8>,
+}
+
+// ---------------------------------------------------------------------------
+// ParserContext
+// ---------------------------------------------------------------------------
+
+/// Stateful parser for one JSDoc block, producing intermediate data that
+/// the [`emit_block`] free function later flushes to a [`BinaryWriter`].
+///
+/// Mirrors `ParserContext` in the typed-AST parser (same offset/depth/
+/// quote/fence state) but stores diagnostics as plain
+/// [`ParsedDiagnostic`] so the binary parser does not depend on
+/// `oxc_diagnostics`.
+pub struct ParserContext<'arena, 'a> {
+    /// Path C: arena reference for allocating intermediate parse data
+    /// (description_lines, tags, etc.) into the bump allocator instead of
+    /// the std heap. The arena is the same one the writer uses; allocations
+    /// here live until the writer drops it.
+    pub(crate) arena: &'arena Allocator,
+    /// Complete source slice for one JSDoc block.
+    pub(crate) source_text: &'a str,
+    /// Absolute byte offset of `source_text` in the original file.
+    pub(crate) base_offset: u32,
+    /// Current parser offset relative to `source_text`.
+    pub(crate) offset: u32,
+    /// Feature switches for this parse.
+    pub(crate) options: ParseOptions,
+    /// Diagnostics emitted while parsing this comment.
+    pub(crate) diagnostics: Vec<ParsedDiagnostic>,
+    /// Current nested `{...}` depth for speculative scanners.
+    pub(crate) brace_depth: u16,
+    /// Current nested `[...]` depth for speculative scanners.
+    pub(crate) bracket_depth: u16,
+    /// Current nested `(...)` depth for speculative scanners.
+    pub(crate) paren_depth: u16,
+    /// Active quote context for speculative scanners.
+    pub(crate) quote: Option<QuoteKind>,
+    /// Active fenced code context for speculative scanners.
+    pub(crate) fence: Option<FenceState>,
+}
+
+impl<'arena, 'a> ParserContext<'arena, 'a> {
+    /// Create a parser context for one complete comment block.
+    #[must_use]
+    pub fn new(
+        arena: &'arena Allocator,
+        source_text: &'a str,
+        base_offset: u32,
+        options: ParseOptions,
+    ) -> Self {
+        Self {
+            arena,
+            source_text,
+            base_offset,
+            offset: 0,
+            options,
+            diagnostics: Vec::new(),
+            brace_depth: 0,
+            bracket_depth: 0,
+            paren_depth: 0,
+            quote: None,
+            fence: None,
+        }
+    }
+
+    /// Capture rewindable parser state.
+    #[must_use]
+    pub fn checkpoint(&self) -> Checkpoint {
+        Checkpoint {
+            offset: self.offset,
+            brace_depth: self.brace_depth,
+            bracket_depth: self.bracket_depth,
+            paren_depth: self.paren_depth,
+            quote: self.quote,
+            fence: self.fence,
+            diagnostics_len: self.diagnostics.len(),
+        }
+    }
+
+    /// Restore a previous checkpoint and discard diagnostics emitted after it.
+    pub fn rewind(&mut self, checkpoint: Checkpoint) {
+        self.offset = checkpoint.offset;
+        self.brace_depth = checkpoint.brace_depth;
+        self.bracket_depth = checkpoint.bracket_depth;
+        self.paren_depth = checkpoint.paren_depth;
+        self.quote = checkpoint.quote;
+        self.fence = checkpoint.fence;
+        self.diagnostics.truncate(checkpoint.diagnostics_len);
+    }
+
+    fn diag(&mut self, kind: ParserDiagnosticKind) {
+        self.diagnostics.push(ParsedDiagnostic { kind: DiagnosticKind::Parser(kind), span: None });
+    }
+
+    /// Push a type-parser diagnostic.
+    pub(crate) fn type_diag(&mut self, kind: TypeDiagnosticKind) {
+        self.diagnostics.push(ParsedDiagnostic { kind: DiagnosticKind::Type(kind), span: None });
+    }
+
+    fn absolute_end(&self) -> Option<u32> {
+        let len = u32::try_from(self.source_text.len()).ok()?;
+        self.base_offset.checked_add(len)
+    }
+}
+
+/// Outcome of [`parse_block_into_data`]: either a parsed block + diagnostics,
+/// or just diagnostics when the input could not be parsed at all (not a
+/// JSDoc block, unclosed, span overflow).
+#[derive(Debug)]
+pub struct ParsedBlock<'arena, 'a> {
+    block: Option<BlockData<'arena, 'a>>,
+    diagnostics: Vec<ParsedDiagnostic>,
+}
+
+impl<'arena, 'a> ParsedBlock<'arena, 'a> {
+    /// Diagnostics produced during parsing.
+    #[must_use]
+    pub fn diagnostics(&self) -> &[ParsedDiagnostic] {
+        &self.diagnostics
+    }
+
+    /// `true` when at least one parse-failure diagnostic was emitted.
+    #[must_use]
+    pub fn is_failure(&self) -> bool {
+        self.block.is_none()
+    }
+}
+
+/// Parse one JSDoc block into intermediate data. Use [`emit_block`] to
+/// flush the result into a [`BinaryWriter`].
+///
+/// Path C: takes the writer's arena so intermediate data structures
+/// (`description_lines`, `tags`, etc.) bump-allocate from the same arena
+/// instead of the std heap. The result `ParsedBlock<'arena, 'a>` borrows
+/// from both the source text (`'a`) and the arena (`'arena`); typical
+/// callers pass `&parse_to_bytes`'s arena or `&parse`'s caller-supplied
+/// arena.
+pub fn parse_block_into_data<'arena, 'a>(
+    arena: &'arena Allocator,
+    source_text: &'a str,
+    base_offset: u32,
+    options: ParseOptions,
+) -> ParsedBlock<'arena, 'a> {
+    let mut ctx = ParserContext::new(arena, source_text, base_offset, options);
+    if ctx.absolute_end().is_none() {
+        ctx.diag(ParserDiagnosticKind::SpanOverflow);
+        return ParsedBlock { block: None, diagnostics: ctx.diagnostics };
+    }
+    if !scanner::is_jsdoc_block(source_text) {
+        ctx.diag(ParserDiagnosticKind::NotAJSDocBlock);
+        return ParsedBlock { block: None, diagnostics: ctx.diagnostics };
+    }
+    if !scanner::has_closing_block(source_text) {
+        ctx.diag(ParserDiagnosticKind::UnclosedBlockComment);
+        return ParsedBlock { block: None, diagnostics: ctx.diagnostics };
+    }
+
+    let end = ctx.absolute_end().expect("checked above");
+    let span = Span::new(ctx.base_offset, end);
+
+    let scan = scanner::logical_lines(source_text, base_offset);
+    let (desc_range, tag_sections) = ctx.partition_sections(&scan);
+
+    let desc_lines_slice = &scan.lines[desc_range.start..desc_range.end];
+    let desc_margins_slice = &scan.margins[desc_range.start..desc_range.end];
+    let parsed_desc = ctx.parse_description_lines(desc_lines_slice, desc_margins_slice);
+    let (tags, tags_parsed_types) = ctx.parse_tag_sections(&tag_sections);
+
+    let line_count = scan.lines.len() as u32;
+    let end_line = if line_count > 0 { line_count - 1 } else { 0 };
+
+    let delimiter_line_break = if scan.lines.len() <= 1 { "" } else { "\n" };
+    let preterminal_line_break = if scan.lines.len() <= 1 {
+        ""
+    } else if scan.margins[scan.lines.len() - 1].is_content_empty {
+        "\n"
+    } else {
+        ""
+    };
+    let block_line_end = if scan.margins.is_empty() { "" } else { scan.margins[0].line_end };
+
+    let mut description_start_line: Option<u32> = None;
+    let mut description_end_line: Option<u32> = None;
+    let mut last_description_line: Option<u32> = None;
+    let mut has_preterminal_description: u8 = 0;
+    let mut has_preterminal_tag_description: Option<u8> = None;
+
+    let has_tags = !tag_sections.is_empty();
+    for (i, m) in desc_margins_slice.iter().enumerate() {
+        if !m.is_content_empty {
+            let idx = i as u32;
+            if description_start_line.is_none() {
+                description_start_line = Some(idx);
+            }
+            description_end_line = Some(idx);
+        }
+    }
+    if has_tags {
+        last_description_line = Some((desc_range.end - desc_range.start) as u32);
+    } else if !scan.lines.is_empty() {
+        last_description_line = Some(end_line);
+    }
+    if !scan.lines.is_empty() && !scan.margins[scan.lines.len() - 1].is_content_empty {
+        if has_tags {
+            has_preterminal_tag_description = Some(1);
+        } else {
+            has_preterminal_description = 1;
+        }
+    }
+
+    let description_raw_span =
+        description_raw_span_from_block_lines(&parsed_desc.lines, base_offset);
+
+    let block = BlockData {
+        span,
+        description: parsed_desc.text,
+        description_raw_span,
+        description_lines: parsed_desc.lines,
+        inline_tags: parsed_desc.inline_tags,
+        tags,
+        tags_parsed_types,
+        line_end: block_line_end,
+        delimiter_line_break,
+        preterminal_line_break,
+        end_line,
+        description_start_line,
+        description_end_line,
+        last_description_line,
+        has_preterminal_description,
+        has_preterminal_tag_description,
+    };
+
+    ParsedBlock { block: Some(block), diagnostics: ctx.diagnostics }
+}
+
+// ---------------------------------------------------------------------------
+// Section partitioning + parsing helpers (live on ParserContext)
+// ---------------------------------------------------------------------------
+
+/// Index range into the parallel lines/margins arrays for description lines.
+#[derive(Debug, Clone, Copy)]
+struct DescLineRange {
+    start: usize,
+    end: usize,
+}
+
+#[derive(Debug, Clone)]
+struct TagSection<'a> {
+    tag_name: &'a str,
+    tag_name_start: u32,
+    tag_name_end: u32,
+    body_lines: Vec<scanner::LogicalLine<'a>>,
+    end: u32,
+    header_initial: &'a str,
+    header_delimiter: &'a str,
+    header_post_delimiter: &'a str,
+    header_line_end: &'a str,
+}
+
+#[derive(Debug)]
+struct ParsedDescription<'arena, 'a> {
+    text: Option<&'a str>,
+    lines: ArenaVec<'arena, DescriptionLineData<'a>>,
+    inline_tags: InlineTagsVec<'arena, 'a>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NormalizedText<'a> {
+    text: &'a str,
+    span: Span,
+}
+
+#[inline]
+fn is_indented_code_block(
+    content_leading_whitespace: usize,
+    margin: &scanner::MarginInfo<'_>,
+) -> bool {
+    if margin.delimiter.is_empty() {
+        return false;
+    }
+
+    // Same threshold as `oxc_jsdoc`: one conventional space after `*`
+    // plus four Markdown indented-code spaces.
+    let spaces_after_star = margin.post_delimiter.len() + content_leading_whitespace;
+    spaces_after_star >= 5
+}
+
+#[derive(Debug)]
+struct ParsedTagBody<'arena, 'a> {
+    raw_body: &'a str,
+    raw_type: Option<TypeSourceData<'a>>,
+    name: Option<TagNameValueData<'a>>,
+    optional: bool,
+    default_value: Option<&'a str>,
+    description: Option<&'a str>,
+    type_lines: ArenaVec<'arena, TypeLineData<'a>>,
+    description_lines: ArenaVec<'arena, DescriptionLineData<'a>>,
+    inline_tags: InlineTagsVec<'arena, 'a>,
+    body: GenericTagBodyData<'a>,
+}
+
+impl<'arena, 'a> ParserContext<'arena, 'a> {
+    fn partition_sections(
+        &self,
+        scan: &scanner::ScanResult<'a>,
+    ) -> (DescLineRange, Vec<TagSection<'a>>) {
+        let lines = &scan.lines;
+        let margins = &scan.margins;
+        let mut desc_end = 0usize;
+        let mut tag_sections = Vec::new();
+        let mut current_tag: Option<TagSection<'a>> = None;
+        let mut in_fence = false;
+
+        for (idx, line) in lines.iter().enumerate() {
+            let trimmed = trim_start_fast(line.content);
+            let trimmed_delta = line.content.len() - trimmed.len();
+            // `trimmed_delta <= line.content.len()` and source offsets fit
+            // in u32 by encoder precondition; the panic check on
+            // `try_from(...).unwrap()` is dead weight on this hot loop
+            // (`partition_sections` runs once per logical line). Pattern #9.
+            let trimmed_start = line.content_start + trimmed_delta as u32;
+            let m = &margins[idx];
+            let tag_header = if !in_fence
+                && trimmed.starts_with('@')
+                && !is_indented_code_block(trimmed_delta, m)
+            {
+                parse_tag_header(trimmed, trimmed_start)
+            } else {
+                None
+            };
+
+            if let Some((tag_name, tag_name_start, body_start)) = tag_header {
+                if let Some(section) = current_tag.take() {
+                    tag_sections.push(section);
+                }
+                let mut body_lines = Vec::new();
+                if let Some((body, body_abs_start)) = body_start {
+                    // `body` is `trim_start`ed by `parse_tag_header`, so it
+                    // begins with a non-whitespace byte and is therefore
+                    // never whitespace-only.
+                    body_lines.push(scanner::LogicalLine {
+                        content: body,
+                        content_start: body_abs_start,
+                        is_content_empty: false,
+                    });
+                }
+                current_tag = Some(TagSection {
+                    tag_name,
+                    tag_name_start,
+                    // `tag_name` is a sub-slice of the source text; its
+                    // length fits in u32 by the same precondition that
+                    // bounds source offsets. Pattern #9.
+                    tag_name_end: tag_name_start + tag_name.len() as u32,
+                    body_lines,
+                    end: line.content_end(),
+                    header_initial: m.initial,
+                    header_delimiter: m.delimiter,
+                    header_post_delimiter: m.post_delimiter,
+                    header_line_end: m.line_end,
+                });
+            } else if !in_fence {
+                if let Some(section) = current_tag.as_mut() {
+                    section.body_lines.push(*line);
+                    section.end = line.content_end();
+                } else {
+                    desc_end = idx + 1;
+                }
+            } else if let Some(section) = current_tag.as_mut() {
+                section.body_lines.push(*line);
+                section.end = line.content_end();
+            } else {
+                desc_end = idx + 1;
+            }
+
+            if self.options.fence_aware && trimmed.starts_with("```") {
+                in_fence = !in_fence;
+            }
+        }
+
+        if let Some(section) = current_tag {
+            tag_sections.push(section);
+        }
+        (DescLineRange { start: 0, end: desc_end }, tag_sections)
+    }
+
+    fn parse_tag_sections(
+        &mut self,
+        sections: &[TagSection<'a>],
+    ) -> (ArenaVec<'arena, TagData<'arena, 'a>>, Vec<(u32, Box<TypeNodeData<'a>>)>) {
+        let mut tags = ArenaVec::with_capacity_in(sections.len(), self.arena);
+        // Side table: stays empty when parse_types is off (the default), so
+        // emit-loop's lookup branch is a single `peek().is_none()` predict.
+        let mut parsed_types: Vec<(u32, Box<TypeNodeData<'a>>)> = Vec::new();
+        for (i, section) in sections.iter().enumerate() {
+            let (tag, opt_pt) = self.parse_jsdoc_tag(section);
+            if let Some(pt) = opt_pt {
+                parsed_types.push((i as u32, pt));
+            }
+            tags.push(tag);
+        }
+        (tags, parsed_types)
+    }
+
+    fn parse_jsdoc_tag(
+        &mut self,
+        section: &TagSection<'a>,
+    ) -> (TagData<'arena, 'a>, Option<Box<TypeNodeData<'a>>>) {
+        let normalized = self.normalize_lines(&section.body_lines);
+        // Note 4 (compat-mode only): jsdoccomment customizes per-tag tokenization
+        // — `defaultNoTypes` skips the `{type}` step and `defaultNoNames` skips
+        // the name token. Mirror those rules so compat-mode AST shape matches
+        // `commentParserToESTree()`. Outside compat mode keep the uniform
+        // behavior (parser shape contract for non-jsdoccomment users).
+        let (skip_types, skip_names) = if self.options.compat_mode {
+            (jsdoccomment_no_type(section.tag_name), jsdoccomment_no_name(section.tag_name))
+        } else {
+            (false, false)
+        };
+        let parsed_body =
+            normalized.map(|n| self.parse_generic_tag_body(n, skip_types, skip_names));
+
+        let (
+            raw_type,
+            name,
+            optional,
+            default_value,
+            description,
+            type_lines,
+            description_lines,
+            inline_tags,
+            body,
+            raw_body,
+        ) = if let Some(p) = parsed_body {
+            (
+                p.raw_type,
+                p.name,
+                p.optional,
+                p.default_value,
+                p.description,
+                p.type_lines,
+                p.description_lines,
+                p.inline_tags,
+                Some(TagBodyData::Generic(p.body)),
+                Some(p.raw_body),
+            )
+        } else {
+            (
+                None,
+                None,
+                false,
+                None,
+                None,
+                ArenaVec::new_in(self.arena),
+                ArenaVec::new_in(self.arena),
+                InlineTagsVec::new_in(self.arena),
+                None,
+                None,
+            )
+        };
+
+        // parsedType: parse the {...} type expression when enabled.
+        let parsed_type = if self.options.parse_types {
+            raw_type.and_then(|ts| {
+                let mode = self.options.type_parse_mode;
+                self.parse_type_expression(ts.raw, ts.span.start + 1, mode)
+            })
+        } else {
+            None
+        };
+
+        let has_parsed_type = parsed_type.is_some();
+        let description_raw_span = description_raw_span_from_tag(
+            &description_lines,
+            &section.body_lines,
+            self.base_offset,
+        );
+        let tag = TagData {
+            span: Span::new(section.tag_name_start, section.end),
+            tag_name_span: Span::new(section.tag_name_start, section.tag_name_end),
+            tag_name: section.tag_name,
+            optional,
+            default_value,
+            description,
+            description_raw_span,
+            raw_body,
+            raw_type,
+            name,
+            has_parsed_type,
+            body,
+            description_lines,
+            type_lines,
+            inline_tags,
+            header_initial: section.header_initial,
+            header_delimiter: section.header_delimiter,
+            header_post_delimiter: section.header_post_delimiter,
+            header_line_end: section.header_line_end,
+            post_tag: " ",
+            post_type: " ",
+            post_name: " ",
+        };
+        (tag, parsed_type)
+    }
+
+    fn parse_generic_tag_body(
+        &mut self,
+        normalized: NormalizedText<'a>,
+        skip_types: bool,
+        skip_names: bool,
+    ) -> ParsedTagBody<'arena, 'a> {
+        let mut cursor = 0usize;
+        let bytes = normalized.text.as_bytes();
+        while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+
+        let type_source = if !skip_types && bytes.get(cursor) == Some(&b'{') {
+            match find_matching_type_end(normalized.text, cursor) {
+                Some(end) => {
+                    let raw = &normalized.text[cursor + 1..end];
+                    let span = relative_span(normalized.span, cursor as u32, (end + 1) as u32);
+                    cursor = end + 1;
+                    Some(TypeSourceData { span, raw })
+                }
+                None => {
+                    self.diag(ParserDiagnosticKind::UnclosedTypeExpression);
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        let mut type_lines: ArenaVec<'arena, TypeLineData<'a>> = ArenaVec::new_in(self.arena);
+        if let Some(ts) = type_source {
+            type_lines.push(TypeLineData {
+                span: ts.span,
+                raw_type: ts.raw,
+                delimiter: "",
+                post_delimiter: "",
+                initial: "",
+            });
+        }
+
+        while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+
+        // jsdoccomment's `@see {@link ...}` rule: when the body after `{type}`
+        // starts with an inline `{@link ...}`, skip name extraction so the
+        // link expression stays in the description.
+        let see_with_link = skip_names || see_starts_with_link(&normalized.text[cursor..]);
+
+        let value = if see_with_link {
+            None
+        } else {
+            let token_end = find_value_end(normalized.text, cursor);
+            if token_end > cursor {
+                let token = &normalized.text[cursor..token_end];
+                let span = relative_span(normalized.span, cursor as u32, token_end as u32);
+                cursor = token_end;
+                Some(parse_tag_value_token(token, span))
+            } else {
+                None
+            }
+        };
+        let (name, optional, default_value) = tag_value_name(value.as_ref());
+
+        let mut separator = false;
+        let mut remainder_start = cursor + leading_whitespace_len(&normalized.text[cursor..]);
+        let mut remainder = &normalized.text[remainder_start..];
+        if let Some(rest) = remainder.strip_prefix("- ") {
+            separator = true;
+            remainder_start += 2;
+            remainder = rest;
+        } else if remainder == "-" {
+            separator = true;
+            remainder_start = normalized.text.len();
+            remainder = "";
+        }
+
+        let description_span =
+            relative_span(normalized.span, remainder_start as u32, normalized.text.len() as u32);
+        let parsed_desc = self.parse_description_text(remainder, description_span);
+
+        ParsedTagBody {
+            raw_body: normalized.text,
+            raw_type: type_source,
+            name,
+            optional,
+            default_value,
+            description: parsed_desc.text,
+            type_lines,
+            description_lines: parsed_desc.lines,
+            inline_tags: parsed_desc.inline_tags,
+            body: GenericTagBodyData {
+                span: normalized.span,
+                has_dash_separator: separator,
+                type_source,
+                value,
+                description: parsed_desc.text,
+            },
+        }
+    }
+
+    fn parse_description_lines(
+        &mut self,
+        lines: &[scanner::LogicalLine<'a>],
+        margins: &[scanner::MarginInfo<'a>],
+    ) -> ParsedDescription<'arena, 'a> {
+        let mut description_lines: ArenaVec<'arena, DescriptionLineData<'a>> =
+            ArenaVec::new_in(self.arena);
+        for (line, margin) in lines.iter().zip(margins.iter()) {
+            if margin.is_content_empty {
+                continue;
+            }
+            description_lines.push(DescriptionLineData {
+                span: Span::new(line.content_start, line.content_end()),
+                description: trim_end_fast(line.content),
+                delimiter: margin.delimiter,
+                post_delimiter: margin.post_delimiter,
+                initial: margin.initial,
+            });
+        }
+
+        let Some(normalized) = self.normalize_lines(lines) else {
+            return ParsedDescription {
+                text: None,
+                lines: description_lines,
+                inline_tags: InlineTagsVec::new_in(self.arena),
+            };
+        };
+        let mut description = self.parse_description_text(normalized.text, normalized.span);
+        description.lines = description_lines;
+        description
+    }
+
+    fn parse_description_text(
+        &mut self,
+        text: &'a str,
+        span: Span,
+    ) -> ParsedDescription<'arena, 'a> {
+        let mut lines: ArenaVec<'arena, DescriptionLineData<'a>> = ArenaVec::new_in(self.arena);
+        let mut inline_tags = InlineTagsVec::new_in(self.arena);
+
+        if text.bytes().all(|b| b == b' ' || b == b'\t' || b == b'\n' || b == b'\r') {
+            return ParsedDescription { text: None, lines, inline_tags };
+        }
+
+        lines.push(DescriptionLineData {
+            span,
+            description: text,
+            delimiter: "",
+            post_delimiter: "",
+            initial: "",
+        });
+
+        // Fast path: most descriptions contain no `{@…}` inline tag at
+        // all, but the original `find("{@")` loop still pays a Boyer-Moore
+        // scan over the entire text. A single byte search for `@` is
+        // SIMD-accelerated via `memchr::memchr` and lets us skip the scan
+        // loop entirely when the description has no `@` to anchor on.
+        // (`[u8]::contains` doesn't currently lower to memchr; using it
+        // explicitly here matches `scanner::logical_lines`.)
+        if memchr::memchr(b'@', text.as_bytes()).is_none() {
+            return ParsedDescription { text: Some(text), lines, inline_tags };
+        }
+
+        let mut cursor = 0usize;
+        while let Some(rel_start) = text[cursor..].find("{@") {
+            let inline_start = cursor + rel_start;
+            let Some(rel_end) = text[inline_start + 2..].find('}') else {
+                self.diag(ParserDiagnosticKind::UnclosedInlineTag);
+                break;
+            };
+            let inline_end = inline_start + 2 + rel_end;
+            let inside = &text[inline_start + 2..inline_end];
+            let Some((tag_name, body)) = parse_inline_tag_header(inside) else {
+                self.diag(ParserDiagnosticKind::InvalidInlineTagStart);
+                cursor = inline_start + 2;
+                continue;
+            };
+
+            let inline_span = relative_span(span, inline_start as u32, (inline_end + 1) as u32);
+            let tag_name_start = inline_start + 2;
+            let tag_name_end = tag_name_start + tag_name.len();
+            let (np_or_url, link_text, format) = parse_inline_tag_body(body);
+            inline_tags.push(InlineTagData {
+                span: inline_span,
+                tag_name_span: relative_span(span, tag_name_start as u32, tag_name_end as u32),
+                tag_name,
+                namepath_or_url: np_or_url,
+                text: link_text,
+                format,
+                raw_body: if body.is_empty() { None } else { Some(body) },
+            });
+            cursor = inline_end + 1;
+        }
+
+        ParsedDescription { text: Some(text), lines, inline_tags }
+    }
+
+    fn normalize_lines(
+        &mut self,
+        lines: &[scanner::LogicalLine<'a>],
+    ) -> Option<NormalizedText<'a>> {
+        let first_index = lines.iter().position(|line| !line.is_content_empty)?;
+        let last_index = lines.iter().rposition(|line| !line.is_content_empty)?;
+        let lines = &lines[first_index..=last_index];
+        let first = &lines[0];
+        let last = &lines[lines.len() - 1];
+        let span = Span::new(first.content_start, last.content_end());
+
+        if lines.len() == 1 {
+            return Some(NormalizedText { text: trim_end_fast(lines[0].content), span });
+        }
+
+        // Build the joined text directly in the arena via `StringBuilder`
+        // — single copy of each line's bytes, no heap-side staging buffer.
+        // Pre-compute the exact capacity so the builder never resizes
+        // (resize on bumpalo means re-alloc + copy, defeating the purpose).
+        //
+        // `+ 1` per line covers the inter-line `\n` separator; the count
+        // overshoots by 1 (no separator after the last line) but
+        // pre-allocating one extra byte is cheaper than a branch in the
+        // hot loop.
+        let capacity: usize = lines.iter().map(|l| l.content.len() + 1).sum();
+        let mut builder = StringBuilder::with_capacity_in(capacity, self.arena);
+        for (index, line) in lines.iter().enumerate() {
+            if index > 0 {
+                builder.push_str("\n");
+            }
+            builder.push_str(trim_end_fast(line.content));
+        }
+        // `into_str()` finalizes the builder and yields a `&'arena str`
+        // that lives as long as the allocator. This replaces the prior
+        // `scratch: String` + `arena.alloc_str(&scratch)` two-step
+        // (which itself replaced an unsound `unsafe transmute` of a
+        // reused heap String — the original UAF).
+        let arena_str: &str = builder.into_str();
+        // SAFETY: widening `&'arena str` to `&'a str` is sound because the
+        // arena is the lifetime upper bound on every borrow in
+        // `BlockData<'arena, 'a>` — anything that consumes the returned
+        // text is itself bounded by the arena, so the bytes remain valid
+        // for the duration of every read. Mirrors how source slices
+        // (`&'a str` from `source_text`) flow through the same fields.
+        let widened: &'a str = unsafe { std::mem::transmute::<&str, &'a str>(arena_str) };
+        Some(NormalizedText { text: widened, span })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Local parsing helpers (no Self)
+// ---------------------------------------------------------------------------
+
+fn parse_tag_header(line: &str, line_start: u32) -> Option<(&str, u32, Option<(&str, u32)>)> {
+    let stripped = line.strip_prefix('@')?;
+    // Tag-name characters are ASCII-only by spec, so byte position search
+    // beats `chars().take_while().sum::<len_utf8>()` (no UTF-8 decoding,
+    // single-byte is_ascii_alphanumeric LUT).
+    let name_len = stripped
+        .as_bytes()
+        .iter()
+        .position(|&b| !(b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'!')))
+        .unwrap_or(stripped.len());
+    if name_len == 0 {
+        return None;
+    }
+    let tag_name = &stripped[..name_len];
+    let body = trim_start_fast(&stripped[name_len..]);
+    let body_start = if body.is_empty() {
+        None
+    } else {
+        // `body_delta <= line.len()` and source offsets fit in u32 by
+        // encoder precondition. Pattern #9.
+        let body_delta = line.len() - body.len();
+        Some((body, line_start + body_delta as u32))
+    };
+    Some((tag_name, line_start + 1, body_start))
+}
+
+fn parse_inline_tag_header(inside: &str) -> Option<(&str, &str)> {
+    let trimmed = trim_fast(inside);
+    let name_len = trimmed
+        .as_bytes()
+        .iter()
+        .position(|&b| !(b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'!')))
+        .unwrap_or(trimmed.len());
+    if name_len == 0 {
+        return None;
+    }
+    let tag_name = &trimmed[..name_len];
+    let body = trim_fast(&trimmed[name_len..]);
+    Some((tag_name, body))
+}
+
+fn parse_inline_tag_body(body: &str) -> (Option<&str>, Option<&str>, InlineTagFormatData) {
+    if body.is_empty() {
+        return (None, None, InlineTagFormatData::Plain);
+    }
+    if let Some((target, text)) = body.split_once('|') {
+        return (non_empty_trimmed(target), non_empty_trimmed(text), InlineTagFormatData::Pipe);
+    }
+    if let Some((target, text)) = body.split_once(char::is_whitespace) {
+        return (non_empty_trimmed(target), non_empty_trimmed(text), InlineTagFormatData::Space);
+    }
+    (Some(body), None, InlineTagFormatData::Plain)
+}
+
+fn non_empty_trimmed(value: &str) -> Option<&str> {
+    let trimmed = trim_fast(value);
+    if trimmed.is_empty() { None } else { Some(trimmed) }
+}
+
+fn leading_whitespace_len(value: &str) -> usize {
+    value.len() - trim_start_fast(value).len()
+}
+
+fn find_matching_type_end(text: &str, start: usize) -> Option<usize> {
+    // `{` and `}` are single-byte ASCII chars and unambiguous within UTF-8
+    // (continuation bytes never collide with ASCII), so byte iteration is
+    // both correct and avoids per-step UTF-8 decoding.
+    //
+    // Use `memchr2` to skip directly to the next brace; on
+    // typescript-checker.ts most `{Type}` bodies are 5-30 bytes, which is
+    // around memchr's SIMD break-even, but the per-comment frequency
+    // (tens of `{...}` per file) makes the cumulative win worthwhile.
+    let bytes = text.as_bytes();
+    let mut depth = 0usize;
+    let mut i = start;
+    while let Some(off) = memchr::memchr2(b'{', b'}', &bytes[i..]) {
+        i += off;
+        if bytes[i] == b'{' {
+            depth += 1;
+        } else {
+            depth -= 1;
+            if depth == 0 {
+                return Some(i);
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+fn find_value_end(text: &str, start: usize) -> usize {
+    let bytes = text.as_bytes();
+    if start >= bytes.len() {
+        return start;
+    }
+    if bytes[start] == b'[' {
+        // Bracket-depth scan: `[` and `]` are single-byte ASCII so byte loop
+        // suffices.
+        let mut depth = 0usize;
+        let mut i = start;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'[' => depth += 1,
+                b']' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return i + 1;
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        return text.len();
+    }
+    // Tag value tokens terminate at any whitespace. ASCII bytes are checked
+    // inline (LUT, no UTF-8 decode); the moment a non-ASCII byte appears we
+    // fall back to char_indices to preserve the original Unicode-whitespace
+    // semantics.
+    let mut i = start;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b < 0x80 {
+            if (b as char).is_whitespace() {
+                return i;
+            }
+            i += 1;
+        } else {
+            for (idx, ch) in text[i..].char_indices() {
+                if ch.is_whitespace() {
+                    return i + idx;
+                }
+            }
+            return text.len();
+        }
+    }
+    text.len()
+}
+
+fn parse_tag_value_token(token: &str, span: Span) -> TagValueData<'_> {
+    if token.starts_with('[') && token.ends_with(']') {
+        let inner = &token[1..token.len() - 1];
+        let (path, default_value) =
+            inner.split_once('=').map_or((inner, None), |(p, v)| (p, Some(v)));
+        return TagValueData::Parameter { span, path, optional: true, default_value };
+    }
+    if token
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '$' | '.' | '[' | ']'))
+    {
+        return TagValueData::Parameter { span, path: token, optional: false, default_value: None };
+    }
+    if token.contains(['.', '#', '~', '/', ':', '"', '\'', '(']) {
+        return TagValueData::Namepath { span, raw: token };
+    }
+    if token.chars().all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '$')) {
+        return TagValueData::Identifier { span, name: token };
+    }
+    TagValueData::Raw { span, value: token }
+}
+
+fn tag_value_name<'a>(
+    value: Option<&TagValueData<'a>>,
+) -> (Option<TagNameValueData<'a>>, bool, Option<&'a str>) {
+    match value {
+        Some(TagValueData::Parameter { span, path, optional, default_value }) => {
+            (Some(TagNameValueData { span: *span, raw: path }), *optional, *default_value)
+        }
+        Some(TagValueData::Namepath { span, raw }) => {
+            (Some(TagNameValueData { span: *span, raw }), false, None)
+        }
+        Some(TagValueData::Identifier { span, name }) => {
+            (Some(TagNameValueData { span: *span, raw: name }), false, None)
+        }
+        Some(TagValueData::Raw { span, value }) => {
+            (Some(TagNameValueData { span: *span, raw: value }), false, None)
+        }
+        None => (None, false, None),
+    }
+}
+
+fn relative_span(base: Span, relative_start: u32, relative_end: u32) -> Span {
+    let start = base.start.saturating_add(relative_start);
+    let end = base.start.saturating_add(relative_end);
+    Span::new(start.min(base.end), end.min(base.end).max(start.min(base.end)))
+}
+
+// ---------------------------------------------------------------------------
+// jsdoccomment compatibility: per-tag tokenization rules (Note 4)
+// ---------------------------------------------------------------------------
+//
+// Mirrors `defaultNoTypes` / `defaultNoNames` / `hasSeeWithLink` from
+// `@es-joy/jsdoccomment/src/parseComment.js`. Only consulted when
+// `ParseOptions::compat_mode` is enabled — basic-mode parses keep the
+// uniform `{type} name description` extraction that downstream typed
+// consumers rely on.
+
+/// Tags whose body has no `{type}` segment in jsdoccomment. Sorted for
+/// `binary_search` (the lookup runs once per block tag in compat mode).
+const NO_TYPE_TAGS: &[&str] = &[
+    "default",
+    "defaultvalue",
+    "description",
+    "example",
+    "file",
+    "fileoverview",
+    "license",
+    "overview",
+    "see",
+    "summary",
+];
+
+/// Tags whose body has no `name` segment in jsdoccomment. Sorted.
+const NO_NAME_TAGS: &[&str] = &[
+    "access",
+    "author",
+    "default",
+    "defaultvalue",
+    "description",
+    "example",
+    "exception",
+    "file",
+    "fileoverview",
+    "kind",
+    "license",
+    "overview",
+    "return",
+    "returns",
+    "since",
+    "summary",
+    "throws",
+    "variation",
+    "version",
+];
+
+/// `defaultNoTypes` lookup.
+fn jsdoccomment_no_type(tag: &str) -> bool {
+    NO_TYPE_TAGS.binary_search(&tag).is_ok()
+}
+
+/// `defaultNoNames` lookup.
+fn jsdoccomment_no_name(tag: &str) -> bool {
+    NO_NAME_TAGS.binary_search(&tag).is_ok()
+}
+
+/// jsdoccomment's `hasSeeWithLink` rule: when a body starts with
+/// `{@link <name>}`, skip name extraction so the inline-tag stays in the
+/// description. The match is intentionally conservative — only fires on
+/// the literal `{@link …}` prefix, leaving `@see {Foo}` / `@see Foo`
+/// alone (parsed normally).
+fn see_starts_with_link(after_type: &str) -> bool {
+    let trimmed = after_type.trim_start();
+    let Some(rest) = trimmed.strip_prefix("{@link") else {
+        return false;
+    };
+    let Some(closing_offset) = rest.find('}') else {
+        return false;
+    };
+    closing_offset > 0
+}
+
+// ---------------------------------------------------------------------------
+// Whitespace trim helpers (ASCII fast path + Unicode fallback)
+//
+// JSDoc source is overwhelmingly ASCII, so the byte-based `trim_ascii_*`
+// path covers the common case. We only fall back to the Unicode-aware
+// `trim_*` when the post-trim boundary still touches a non-ASCII byte
+// (i.e. a UTF-8 multi-byte character that might encode Unicode whitespace
+// such as U+00A0 NBSP or U+3000 IDEOGRAPHIC SPACE). UTF-8 invariant
+// guarantees ASCII trimming never bisects a multi-byte character (ASCII
+// whitespace bytes are all < 0x80; multi-byte lead/continuation bytes are
+// all ≥ 0x80).
+// ---------------------------------------------------------------------------
+
+#[inline(always)]
+fn trim_start_fast(s: &str) -> &str {
+    let t = s.trim_ascii_start();
+    if !t.is_empty() && t.as_bytes()[0] >= 0x80 { t.trim_start() } else { t }
+}
+
+#[inline(always)]
+fn trim_end_fast(s: &str) -> &str {
+    let t = s.trim_ascii_end();
+    if !t.is_empty() && t.as_bytes()[t.len() - 1] >= 0x80 { t.trim_end() } else { t }
+}
+
+#[inline(always)]
+fn trim_fast(s: &str) -> &str {
+    let t = s.trim_ascii();
+    let bytes = t.as_bytes();
+    if bytes.is_empty() {
+        return t;
+    }
+    let needs_unicode = bytes[0] >= 0x80 || bytes[bytes.len() - 1] >= 0x80;
+    if needs_unicode { t.trim() } else { t }
+}
+
+// ---------------------------------------------------------------------------
+// Emit phase — walk parsed data and write to BinaryWriter
+// ---------------------------------------------------------------------------
+
+/// Write a parsed JSDoc block into `writer` and return the assigned root
+/// node index. The caller is responsible for adding a corresponding entry
+/// to the Root index array via [`BinaryWriter::push_root`].
+pub fn emit_block<'arena>(
+    writer: &mut BinaryWriter<'arena>,
+    parsed: &ParsedBlock<'_, '_>,
+) -> Option<u32> {
+    let block = parsed.block.as_ref()?;
+    let compat = writer.compat_mode();
+    let preserve_ws = writer.preserve_whitespace_span();
+    Some(emit_block_inner(writer, block, compat, preserve_ws))
+}
+
+fn opt_string(writer: &mut BinaryWriter<'_>, value: Option<&str>) -> Option<StringField> {
+    value.map(|s| writer.intern_string(s))
+}
+
+/// `Option<&str>` variant of [`BinaryWriter::intern_source_slice_or_string`]
+/// for fields the parser surfaces as borrowed slices (description text,
+/// raw body, default value, inline-tag content). Pointer-arithmetic
+/// identification picks the zero-copy path automatically; multi-line
+/// `normalize_lines` joins (separate allocation) fall through to the
+/// unique-string path with no per-call branching at the call site.
+fn opt_source_string(writer: &mut BinaryWriter<'_>, value: Option<&str>) -> Option<StringField> {
+    value.map(|s| writer.intern_source_slice_or_string(s))
+}
+
+/// Compute the `description_raw_span` for a `JsdocBlock` from its
+/// description-line list. Returns source-text-relative `(start, end)`
+/// UTF-8 byte offsets, or `None` when the list is empty.
+///
+/// The boundary is `description_lines.first().span.start ..
+/// description_lines.last().span.end` per
+/// `design/008-oxlint-oxfmt-support/README.md` §4.1. For `JsdocBlock` each
+/// description line carries an accurate per-`LogicalLine` span, so this
+/// straight reduction is correct (no multi-line span correction needed).
+fn description_raw_span_from_block_lines(
+    description_lines: &[DescriptionLineData<'_>],
+    base_offset: u32,
+) -> Option<(u32, u32)> {
+    let first = description_lines.first()?;
+    let last = description_lines.last()?;
+    let start = first.span.start.checked_sub(base_offset)?;
+    let end = last.span.end.checked_sub(base_offset)?;
+    if start > end {
+        return None;
+    }
+    Some((start, end))
+}
+
+/// Compute the `description_raw_span` for a `JsdocTag` from the synthetic
+/// description line (built by `parse_description_text`) plus the tag's
+/// `body_lines`. The synthetic line's `span.start` points at the
+/// description's first byte in the original source, but its `span.end` is
+/// short by `(line_breaks * margin_chars_lost)` bytes for multi-line
+/// bodies because `normalize_lines` joins lines with a single `\n`. We
+/// take END from the last non-blank `body_line.content_end` to recover the
+/// correct original-source range.
+fn description_raw_span_from_tag(
+    description_lines: &[DescriptionLineData<'_>],
+    body_lines: &[scanner::LogicalLine<'_>],
+    base_offset: u32,
+) -> Option<(u32, u32)> {
+    let first = description_lines.first()?;
+    let last_body = body_lines
+        .iter()
+        .rev()
+        .find(|line| !line.content.bytes().all(|b| b == b' ' || b == b'\t'))?;
+    let start = first.span.start.checked_sub(base_offset)?;
+    let end = last_body.content_end().checked_sub(base_offset)?;
+    if start > end {
+        return None;
+    }
+    Some((start, end))
+}
+
+fn intern(writer: &mut BinaryWriter<'_>, value: &str) -> StringField {
+    writer.intern_string(value)
+}
+
+/// Hot-path resolver for the source-preserving line-end strings
+/// (`""`, `"\n"`, `"\r\n"`) used throughout `emit_block_inner` and
+/// `emit_tag`. Skips the length-bucketed `lookup_common` + 1-slot cache
+/// dance by mapping the three known cases to their pre-computed
+/// `StringField` directly; falls back to the interner for any other value
+/// (e.g. the rare `\r`-only or trimmed line ending).
+#[inline]
+fn intern_line_end(writer: &mut BinaryWriter<'_>, value: &str) -> StringField {
+    use crate::writer::{COMMON_CRLF, COMMON_EMPTY, COMMON_LF, common_string_field};
+    match value {
+        "" => common_string_field(COMMON_EMPTY),
+        "\n" => common_string_field(COMMON_LF),
+        "\r\n" => common_string_field(COMMON_CRLF),
+        other => writer.intern_string(other),
+    }
+}
+
+fn emit_block_inner<'arena>(
+    writer: &mut BinaryWriter<'arena>,
+    block: &BlockData<'_, '_>,
+    compat: bool,
+    preserve_whitespace_span: bool,
+) -> u32 {
+    let description_idx = opt_source_string(writer, block.description);
+
+    use crate::writer::{
+        COMMON_EMPTY, COMMON_SLASH_STAR, COMMON_SPACE, COMMON_STAR, common_string_field,
+    };
+
+    // Branchless bitmask: each `is_empty()` returns bool, cast to u8 (0 or 1).
+    // Compute first so `bitmask == 0` doubles as `is_empty_block(block)`,
+    // saving 3 redundant `is_empty()` calls vs the previous post_delim check
+    // calling `is_empty_block` separately.
+    let bitmask: u8 = ((!block.description_lines.is_empty()) as u8)
+        | (((!block.tags.is_empty()) as u8) << 1)
+        | (((!block.inline_tags.is_empty()) as u8) << 2);
+
+    // Pre-intern all source-preserving strings.
+    let post_delim_str =
+        if block.delimiter_line_break.is_empty() && bitmask != 0 { " " } else { "" };
+    let star = common_string_field(COMMON_STAR);
+    let close = common_string_field(COMMON_SLASH_STAR);
+    let empty_field = common_string_field(COMMON_EMPTY);
+    let post_delim =
+        if post_delim_str.is_empty() { empty_field } else { common_string_field(COMMON_SPACE) };
+    let line_end = intern_line_end(writer, block.line_end);
+    // `initial` reuses the same prelude-cached `""` slot as `post_delim`'s
+    // empty branch; one prelude lookup instead of two.
+    let initial = empty_field;
+    let dlb = intern_line_end(writer, block.delimiter_line_break);
+    let plb = intern_line_end(writer, block.preterminal_line_break);
+
+    // Phase 5: pass description_raw_span only when the writer-level opt-in
+    // is on; otherwise the per-node `has_description_raw_span` Common Data
+    // bit stays clear and the 8-byte slot is omitted.
+    let block_description_raw_span =
+        if preserve_whitespace_span { block.description_raw_span } else { None };
+
+    let (block_idx, block_ext) = write_jsdoc_block(
+        writer,
+        block.span,
+        0,
+        description_idx,
+        star,
+        post_delim,
+        close,
+        line_end,
+        initial,
+        dlb,
+        plb,
+        bitmask,
+        block_description_raw_span,
+    );
+
+    if compat {
+        write_jsdoc_block_compat_tail(
+            writer,
+            block_ext,
+            block.end_line,
+            block.description_start_line,
+            block.description_end_line,
+            block.last_description_line,
+            block.has_preterminal_description,
+            block.has_preterminal_tag_description,
+        );
+    }
+
+    let block_parent = block_idx.as_u32();
+
+    // description_lines list — children are emitted directly under the
+    // block (no NodeList wrapper); the writer patches (head, count) into
+    // the parent ED slot when the list closes.
+    let mut desc_list = writer.begin_node_list_at(
+        block_ext,
+        crate::writer::nodes::comment_ast::JSDOC_BLOCK_DESC_LINES_SLOT,
+    );
+    for line in &block.description_lines {
+        let child_idx = emit_description_line(writer, line, block_parent, compat);
+        writer.record_list_child(&mut desc_list, child_idx);
+    }
+    writer.finalize_node_list(desc_list);
+
+    let mut tag_list = writer
+        .begin_node_list_at(block_ext, crate::writer::nodes::comment_ast::JSDOC_BLOCK_TAGS_SLOT);
+    // Path C-2: side-table walk for parsed_type. Both `tags` and
+    // `tags_parsed_types` are emitted in tag-index order, so a single
+    // peekable iterator avoids the per-tag linear search.
+    let mut pt_iter = block.tags_parsed_types.iter().peekable();
+    for (i, tag) in block.tags.iter().enumerate() {
+        let parsed_type: Option<&TypeNodeData<'_>> = match pt_iter.peek() {
+            Some((idx, _)) if (*idx as usize) == i => {
+                let (_, pt) = pt_iter.next().unwrap();
+                Some(pt.as_ref())
+            }
+            _ => None,
+        };
+        let child_idx =
+            emit_tag(writer, tag, block_parent, compat, preserve_whitespace_span, parsed_type);
+        writer.record_list_child(&mut tag_list, child_idx);
+    }
+    writer.finalize_node_list(tag_list);
+
+    let mut inline_list = writer.begin_node_list_at(
+        block_ext,
+        crate::writer::nodes::comment_ast::JSDOC_BLOCK_INLINE_TAGS_SLOT,
+    );
+    for inline in &block.inline_tags {
+        let child_idx = emit_inline_tag(writer, inline, block_parent);
+        writer.record_list_child(&mut inline_list, child_idx);
+    }
+    writer.finalize_node_list(inline_list);
+
+    block_parent
+}
+
+fn emit_description_line(
+    writer: &mut BinaryWriter<'_>,
+    line: &DescriptionLineData<'_>,
+    parent_index: u32,
+    compat: bool,
+) -> u32 {
+    // Path A: `line.description` is `line.content.trim_ascii_end()`, i.e. a
+    // sub-slice of the source text that was just appended to `data_buffer`
+    // via `append_source_text`. Use the zero-copy intern paths so we
+    // register the offsets-only entry without re-copying the bytes — the
+    // dominant emit-phase cost we identified in
+    // `.notes/binary-ast-emit-phase-format-analysis.md`.
+    //
+    // The byte range is `[span.start, span.start + description.len())`;
+    // `span.end` would over-shoot because it includes the trailing
+    // whitespace that `trim_end()` removed.
+    let desc_byte_end = line.span.start + line.description.len() as u32;
+    if compat {
+        let desc_field = writer.intern_source_slice(line.span.start, desc_byte_end);
+        let delim = opt_string(writer, non_empty_str(line.delimiter));
+        let pdelim = opt_string(writer, non_empty_str(line.post_delimiter));
+        let init = opt_string(writer, non_empty_str(line.initial));
+        write_jsdoc_description_line_compat(
+            writer,
+            line.span,
+            parent_index,
+            desc_field,
+            delim,
+            pdelim,
+            init,
+        )
+        .as_u32()
+    } else {
+        let desc_idx = writer.intern_source_slice_for_leaf_payload(line.span.start, desc_byte_end);
+        write_jsdoc_description_line(writer, line.span, parent_index, desc_idx).as_u32()
+    }
+}
+
+fn non_empty_str(s: &str) -> Option<&str> {
+    if s.is_empty() { None } else { Some(s) }
+}
+
+fn emit_tag(
+    writer: &mut BinaryWriter<'_>,
+    tag: &TagData<'_, '_>,
+    parent_index: u32,
+    compat: bool,
+    preserve_whitespace_span: bool,
+    parsed_type: Option<&TypeNodeData<'_>>,
+) -> u32 {
+    let default_idx = opt_source_string(writer, tag.default_value);
+    let desc_idx = opt_source_string(writer, tag.description);
+    let raw_body_idx = opt_source_string(writer, tag.raw_body);
+
+    // bit0 = tag (mandatory, always 1). Remaining bits via branchless OR.
+    let bitmask: u8 = 0b0000_0001
+        | ((tag.raw_type.is_some() as u8) << 1)
+        | ((tag.name.is_some() as u8) << 2)
+        | ((tag.has_parsed_type as u8) << 3)
+        | ((tag.body.is_some() as u8) << 4)
+        | (((!tag.type_lines.is_empty()) as u8) << 5)
+        | (((!tag.description_lines.is_empty()) as u8) << 6)
+        | (((!tag.inline_tags.is_empty()) as u8) << 7);
+
+    // Phase 5: pass description_raw_span only when the writer-level opt-in
+    // is on (mirrors the JsdocBlock path).
+    let tag_description_raw_span =
+        if preserve_whitespace_span { tag.description_raw_span } else { None };
+
+    let (tag_idx, tag_ext) = write_jsdoc_tag(
+        writer,
+        tag.span,
+        parent_index,
+        tag.optional,
+        default_idx,
+        desc_idx,
+        raw_body_idx,
+        bitmask,
+        tag_description_raw_span,
+    );
+
+    if compat {
+        // Per-tag compat tail (delimiter strings). Defaults match
+        // ox_jsdoc's typed parser convention.
+        let post_tag_str = intern(writer, tag.post_tag);
+        let post_type_str = intern(writer, tag.post_type);
+        let post_name_str = intern(writer, tag.post_name);
+        let initial = intern(writer, tag.header_initial);
+        let line_end = intern(writer, tag.header_line_end);
+        let delim = intern(writer, tag.header_delimiter);
+        let pdelim = intern(writer, tag.header_post_delimiter);
+        write_jsdoc_tag_compat_tail(
+            writer,
+            tag_ext,
+            delim,
+            pdelim,
+            post_tag_str,
+            post_type_str,
+            post_name_str,
+            initial,
+            line_end,
+        );
+    }
+
+    let tag_parent = tag_idx.as_u32();
+
+    // Mandatory tag-name child (visitor index 0). Common tag names hit
+    // COMMON_STRINGS via the helper; uncommon ones zero-copy off the source.
+    let tn_idx = writer.intern_source_or_string_for_leaf_payload(tag.tag_name, tag.tag_name_span);
+    let _ = write_jsdoc_tag_name(writer, tag.tag_name_span, tag_parent, tn_idx);
+
+    if let Some(rt) = tag.raw_type.as_ref() {
+        let raw_idx = writer.intern_source_or_string_for_leaf_payload(rt.raw, rt.span);
+        let _ = write_jsdoc_type_source(writer, rt.span, tag_parent, raw_idx);
+    }
+    if let Some(name) = tag.name.as_ref() {
+        let raw_idx = writer.intern_source_or_string_for_leaf_payload(name.raw, name.span);
+        let _ = write_jsdoc_tag_name_value(writer, name.span, tag_parent, raw_idx);
+    }
+    if let Some(pt) = parsed_type {
+        super::type_emit::emit_type_node(writer, pt, tag_parent);
+    }
+
+    if let Some(body) = tag.body.as_ref() {
+        emit_tag_body(writer, body, tag_parent);
+    }
+
+    let mut type_list = writer
+        .begin_node_list_at(tag_ext, crate::writer::nodes::comment_ast::JSDOC_TAG_TYPE_LINES_SLOT);
+    for tl in &tag.type_lines {
+        let child_idx = if compat {
+            let raw_field = writer.intern_source_or_string(tl.raw_type, tl.span);
+            let delim = opt_string(writer, non_empty_str(tl.delimiter));
+            let pdelim = opt_string(writer, non_empty_str(tl.post_delimiter));
+            let init = opt_string(writer, non_empty_str(tl.initial));
+            write_jsdoc_type_line_compat(
+                writer, tl.span, tag_parent, raw_field, delim, pdelim, init,
+            )
+            .as_u32()
+        } else {
+            let raw_idx = writer.intern_source_or_string_for_leaf_payload(tl.raw_type, tl.span);
+            write_jsdoc_type_line(writer, tl.span, tag_parent, raw_idx).as_u32()
+        };
+        writer.record_list_child(&mut type_list, child_idx);
+    }
+    writer.finalize_node_list(type_list);
+
+    let mut desc_list = writer
+        .begin_node_list_at(tag_ext, crate::writer::nodes::comment_ast::JSDOC_TAG_DESC_LINES_SLOT);
+    for line in &tag.description_lines {
+        let child_idx = emit_description_line(writer, line, tag_parent, compat);
+        writer.record_list_child(&mut desc_list, child_idx);
+    }
+    writer.finalize_node_list(desc_list);
+
+    let mut inline_list = writer
+        .begin_node_list_at(tag_ext, crate::writer::nodes::comment_ast::JSDOC_TAG_INLINE_TAGS_SLOT);
+    for inline in &tag.inline_tags {
+        let child_idx = emit_inline_tag(writer, inline, tag_parent);
+        writer.record_list_child(&mut inline_list, child_idx);
+    }
+    writer.finalize_node_list(inline_list);
+
+    tag_idx.as_u32()
+}
+
+fn emit_tag_body(writer: &mut BinaryWriter<'_>, body: &TagBodyData<'_>, parent_index: u32) {
+    match body {
+        TagBodyData::Generic(g) => {
+            let desc_idx = opt_source_string(writer, g.description);
+            // Children bitmask: bit0 = type_source, bit1 = value (branchless).
+            let bm: u8 = (g.type_source.is_some() as u8) | ((g.value.is_some() as u8) << 1);
+            let body_idx = write_jsdoc_generic_tag_body(
+                writer,
+                g.span,
+                parent_index,
+                g.has_dash_separator,
+                desc_idx,
+                bm,
+            );
+            let body_parent = body_idx.as_u32();
+
+            if let Some(ts) = g.type_source.as_ref() {
+                let raw_idx = writer.intern_source_or_string_for_leaf_payload(ts.raw, ts.span);
+                let _ = write_jsdoc_type_source(writer, ts.span, body_parent, raw_idx);
+            }
+            if let Some(v) = g.value.as_ref() {
+                emit_tag_value(writer, v, body_parent);
+            }
+        }
+    }
+}
+
+fn emit_tag_value(writer: &mut BinaryWriter<'_>, value: &TagValueData<'_>, parent_index: u32) {
+    match value {
+        TagValueData::Parameter { span, path, optional, default_value } => {
+            let path_idx = writer.intern_source_or_string(path, *span);
+            let dv_idx = opt_source_string(writer, *default_value);
+            let _ = write_jsdoc_parameter_name(
+                writer,
+                *span,
+                parent_index,
+                *optional,
+                path_idx,
+                dv_idx,
+            );
+        }
+        TagValueData::Namepath { span, raw } => {
+            let raw_idx = writer.intern_source_or_string_for_leaf_payload(raw, *span);
+            let _ = write_jsdoc_namepath_source(writer, *span, parent_index, raw_idx);
+        }
+        TagValueData::Identifier { span, name } => {
+            let name_idx = writer.intern_source_or_string_for_leaf_payload(name, *span);
+            let _ = write_jsdoc_identifier(writer, *span, parent_index, name_idx);
+        }
+        TagValueData::Raw { span, value } => {
+            let val_idx = writer.intern_source_or_string_for_leaf_payload(value, *span);
+            let _ = write_jsdoc_text(writer, *span, parent_index, val_idx);
+        }
+    }
+}
+
+fn emit_inline_tag(
+    writer: &mut BinaryWriter<'_>,
+    inline: &InlineTagData<'_>,
+    parent_index: u32,
+) -> u32 {
+    let np_idx = opt_source_string(writer, inline.namepath_or_url);
+    let text_idx = opt_source_string(writer, inline.text);
+    let raw_idx = opt_source_string(writer, inline.raw_body);
+    let format = inline.format as u8;
+    let idx = write_jsdoc_inline_tag(
+        writer,
+        inline.span,
+        parent_index,
+        format,
+        np_idx,
+        text_idx,
+        raw_idx,
+    );
+    // Note: the inline tag's `tag` child (JsdocTagName) is referenced by the
+    // jsdoccomment AST shape but the binary writer's JsdocInlineTag does not
+    // currently include a child slot for it. This matches the Rust lazy
+    // decoder's surface.
+    let _ = inline.tag_name_span;
+    let _ = inline.tag_name;
+    idx.as_u32()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts() -> ParseOptions {
+        ParseOptions::default()
+    }
+
+    #[test]
+    fn parse_block_returns_none_for_non_jsdoc() {
+        let arena = oxc_allocator::Allocator::default();
+        let parsed = parse_block_into_data(&arena, "/* plain */", 0, opts());
+        assert!(parsed.is_failure());
+        assert!(matches!(
+            parsed.diagnostics()[0].kind,
+            DiagnosticKind::Parser(ParserDiagnosticKind::NotAJSDocBlock)
+        ));
+    }
+
+    #[test]
+    fn parse_block_returns_none_for_unclosed() {
+        let arena = oxc_allocator::Allocator::default();
+        let parsed = parse_block_into_data(&arena, "/** unclosed", 0, opts());
+        assert!(parsed.is_failure());
+        assert!(matches!(
+            parsed.diagnostics()[0].kind,
+            DiagnosticKind::Parser(ParserDiagnosticKind::UnclosedBlockComment)
+        ));
+    }
+
+    #[test]
+    fn parses_top_level_description() {
+        let arena = oxc_allocator::Allocator::default();
+        let parsed = parse_block_into_data(&arena, "/** ok */", 10, opts());
+        assert!(!parsed.is_failure());
+        let block = parsed.block.as_ref().unwrap();
+        assert_eq!(block.description, Some("ok"));
+        assert_eq!(block.description_lines.len(), 1);
+    }
+
+    #[test]
+    fn parses_param_tag_with_type_value_and_description() {
+        let arena = oxc_allocator::Allocator::default();
+        let parsed = parse_block_into_data(
+            &arena,
+            "/**\n * @param {string} id - The user ID\n */",
+            0,
+            opts(),
+        );
+        assert!(!parsed.is_failure());
+        let block = parsed.block.as_ref().unwrap();
+        assert_eq!(block.tags.len(), 1);
+        let tag = &block.tags[0];
+        assert_eq!(tag.tag_name, "param");
+        assert_eq!(tag.description, Some("The user ID"));
+        assert!(tag.raw_type.is_some());
+        assert_eq!(tag.raw_type.as_ref().unwrap().raw, "string");
+        assert!(tag.name.is_some());
+        assert_eq!(tag.name.as_ref().unwrap().raw, "id");
+    }
+
+    #[test]
+    fn parses_tags_like_oxc_jsdoc_tag_splitter() {
+        let cases = [
+            (
+                "backtick_inside_quotes",
+                "/**\n * @param {\"'\" | '\"' | '`'} string_start_char desc\n * @returns {number} The index\n */",
+                vec!["param", "returns"],
+            ),
+            (
+                "extra_closing_brace",
+                "/**\n * @param {AST.SvelteElement | AST.RegularElement} node}\n * @param {{ stop: () => void }} context\n */",
+                vec!["param", "param"],
+            ),
+            (
+                "inline_link",
+                "/**\n * @param {string} name See {@link Foo} for details\n * @returns {void}\n */",
+                vec!["param", "returns"],
+            ),
+            (
+                "at_sign_mid_line",
+                "/**\n * @param {string} email user@example.com address\n * @returns {void}\n */",
+                vec!["param", "returns"],
+            ),
+            (
+                "braces_inside_quotes",
+                "/**\n * \"props\" of the form \"{ [key: string]: { type?: \"String\" | \"Object\" }\"\n * @param {null} node\n * @returns {never}\n */",
+                vec!["param", "returns"],
+            ),
+            (
+                "indented_code_block_at_sign",
+                "/**\n * @deprecated\n *     @myDecorator\n *     class Foo {}\n * @type {string}\n */",
+                vec!["deprecated", "type"],
+            ),
+            (
+                "normal_indent_at_sign",
+                "/**\n * @deprecated\n *    @type {string}\n */",
+                vec!["deprecated", "type"],
+            ),
+        ];
+
+        for (name, source, expected) in cases {
+            let arena = oxc_allocator::Allocator::default();
+            let parsed = parse_block_into_data(&arena, source, 0, opts());
+            assert!(!parsed.is_failure(), "{name}");
+            let block = parsed.block.as_ref().unwrap();
+            let actual = block.tags.iter().map(|section| section.tag_name).collect::<Vec<_>>();
+
+            assert_eq!(actual, expected, "{name}");
+        }
+    }
+}

--- a/crates/ox_jsdoc_binary/src/parser/diagnostics.rs
+++ b/crates/ox_jsdoc_binary/src/parser/diagnostics.rs
@@ -1,0 +1,110 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Parser-level recovery and structural diagnostics.
+//!
+//! Verbatim port of `crates/ox_jsdoc/src/parser/diagnostics.rs`. Tag-policy
+//! validation lives in `validator` (Phase 1.3+).
+//!
+//! In the typed-AST parser these diagnostics are wrapped in
+//! `oxc_diagnostics::OxcDiagnostic`. The binary parser keeps a leaner
+//! representation that points at an interned message string + the
+//! offending span; consumers can convert into `OxcDiagnostic` at the API
+//! boundary if richer formatting is needed.
+
+/// Parser-level recovery and structural errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParserDiagnosticKind {
+    /// Input text does not start with `/**`.
+    NotAJSDocBlock,
+    /// Input text does not end with `*/`.
+    UnclosedBlockComment,
+    /// Source span exceeds the u32 byte offset range.
+    SpanOverflow,
+    /// `{@...}` inline tag is missing its closing `}`.
+    UnclosedInlineTag,
+    /// `{...}` type expression is missing its closing `}`.
+    UnclosedTypeExpression,
+    /// Triple-backtick fenced code block is missing its closing fence.
+    UnclosedFence,
+    /// Tag header could not be tokenised (e.g. `@` followed by non-identifier).
+    InvalidTagStart,
+    /// Inline tag body could not be tokenised.
+    InvalidInlineTagStart,
+}
+
+/// Human-readable message text for a parser diagnostic.
+#[must_use]
+pub const fn parser_diagnostic_message(kind: ParserDiagnosticKind) -> &'static str {
+    match kind {
+        ParserDiagnosticKind::NotAJSDocBlock => "input is not a JSDoc block comment",
+        ParserDiagnosticKind::UnclosedBlockComment => "JSDoc block comment is not closed",
+        ParserDiagnosticKind::SpanOverflow => "JSDoc comment span exceeds u32 byte offset range",
+        ParserDiagnosticKind::UnclosedInlineTag => "inline tag is not closed",
+        ParserDiagnosticKind::UnclosedTypeExpression => "type expression is not closed",
+        ParserDiagnosticKind::UnclosedFence => "fenced code block is not closed",
+        ParserDiagnosticKind::InvalidTagStart => "invalid block tag start",
+        ParserDiagnosticKind::InvalidInlineTagStart => "invalid inline tag start",
+    }
+}
+
+/// Type parser diagnostics for malformed `{...}` expressions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeDiagnosticKind {
+    /// No prefix parslet matched the current token.
+    NoParsletFound,
+    /// Expected a specific token but found something else.
+    ExpectedToken,
+    /// Generic type parameter list `<...>` is not closed.
+    UnclosedGeneric,
+    /// Parenthesized type `(...)` is not closed.
+    UnclosedParenthesis,
+    /// Tuple type `[...]` is not closed.
+    UnclosedTuple,
+    /// Object type `{...}` is not closed.
+    UnclosedObject,
+    /// Template literal type is not closed.
+    UnclosedTemplateLiteral,
+    /// General invalid type expression.
+    InvalidTypeExpression,
+    /// Unexpected token after a complete type expression.
+    EarlyEndOfParse,
+}
+
+/// Human-readable message text for a type-parser diagnostic.
+#[must_use]
+pub const fn type_diagnostic_message(kind: TypeDiagnosticKind) -> &'static str {
+    match kind {
+        TypeDiagnosticKind::NoParsletFound => "unexpected token in type expression",
+        TypeDiagnosticKind::ExpectedToken => "expected token in type expression",
+        TypeDiagnosticKind::UnclosedGeneric => "generic type parameter list is not closed",
+        TypeDiagnosticKind::UnclosedParenthesis => "parenthesized type is not closed",
+        TypeDiagnosticKind::UnclosedTuple => "tuple type is not closed",
+        TypeDiagnosticKind::UnclosedObject => "object type is not closed",
+        TypeDiagnosticKind::UnclosedTemplateLiteral => "template literal type is not closed",
+        TypeDiagnosticKind::InvalidTypeExpression => "invalid type expression",
+        TypeDiagnosticKind::EarlyEndOfParse => "unexpected token after type expression",
+    }
+}
+
+/// Either a parser-level or a type-parser-level diagnostic kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticKind {
+    /// Structural parser diagnostic.
+    Parser(ParserDiagnosticKind),
+    /// Type expression parser diagnostic.
+    Type(TypeDiagnosticKind),
+}
+
+impl DiagnosticKind {
+    /// Resolve into a static message string.
+    #[inline]
+    #[must_use]
+    pub const fn message(self) -> &'static str {
+        match self {
+            Self::Parser(k) => parser_diagnostic_message(k),
+            Self::Type(k) => type_diagnostic_message(k),
+        }
+    }
+}

--- a/crates/ox_jsdoc_binary/src/parser/lexer.rs
+++ b/crates/ox_jsdoc_binary/src/parser/lexer.rs
@@ -1,0 +1,335 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Zero-copy lexer for JSDoc type expressions.
+//!
+//! Verbatim port of `crates/ox_jsdoc/src/type_parser/lexer.rs`.
+//! Maintains a 1-token lookahead (`current` + `next`); all token text is
+//! borrowed from the source via `start..end` offsets.
+
+use super::token::{Token, TokenKind};
+
+/// Lexer state snapshot for speculative parsing (32 bytes, `Copy`).
+#[derive(Debug, Clone, Copy)]
+pub struct LexerState {
+    /// Byte offset into the type text (relative to type text start).
+    pub offset: usize,
+    /// Current token.
+    pub current: Token,
+    /// Lookahead token.
+    pub next: Token,
+}
+
+/// Two-token lookahead lexer.
+pub struct Lexer<'a> {
+    source: &'a str,
+    offset: usize,
+    base_offset: u32,
+    loose: bool,
+    /// Current token.
+    pub current: Token,
+    /// Lookahead token.
+    pub next: Token,
+}
+
+impl<'a> Lexer<'a> {
+    /// Create a fresh lexer over `source`. `base_offset` is added to every
+    /// emitted token's start/end so spans become absolute.
+    #[must_use]
+    pub fn new(source: &'a str, base_offset: u32, loose: bool) -> Self {
+        let mut lexer = Self {
+            source,
+            offset: 0,
+            base_offset,
+            loose,
+            current: Token::eof(base_offset),
+            next: Token::eof(base_offset),
+        };
+        lexer.current = lexer.read_token();
+        lexer.next = lexer.read_token();
+        lexer
+    }
+
+    /// Save the current state for speculative parsing.
+    #[inline]
+    #[must_use]
+    pub fn save(&self) -> LexerState {
+        LexerState { offset: self.offset, current: self.current, next: self.next }
+    }
+
+    /// Restore a previously saved state.
+    #[inline]
+    pub fn restore(&mut self, state: LexerState) {
+        self.offset = state.offset;
+        self.current = state.current;
+        self.next = state.next;
+    }
+
+    /// Advance the lexer: `current = next`, `next = read_token()`.
+    #[inline]
+    pub fn bump(&mut self) {
+        self.current = self.next;
+        self.next = self.read_token();
+    }
+
+    /// Borrow the source text slice covered by `token`.
+    #[inline]
+    #[must_use]
+    pub fn token_text(&self, token: Token) -> &'a str {
+        let start = (token.start - self.base_offset) as usize;
+        let end = (token.end - self.base_offset) as usize;
+        &self.source[start..end]
+    }
+
+    /// Remaining unparsed source text.
+    #[inline]
+    #[must_use]
+    pub fn remaining(&self) -> &'a str {
+        &self.source[self.offset..]
+    }
+
+    fn read_token(&mut self) -> Token {
+        self.skip_whitespace();
+        if self.offset >= self.source.len() {
+            return Token::eof(self.base_offset + self.offset as u32);
+        }
+        let bytes = self.source.as_bytes();
+        let start = self.offset;
+        let abs_start = self.base_offset + start as u32;
+        let b = bytes[start];
+
+        match b {
+            b'=' if self.peek_at(1) == Some(b'>') => {
+                self.offset += 2;
+                return Token::new(TokenKind::Arrow, abs_start, abs_start + 2);
+            }
+            b'.' if self.peek_at(1) == Some(b'.') && self.peek_at(2) == Some(b'.') => {
+                self.offset += 3;
+                return Token::new(TokenKind::Ellipsis, abs_start, abs_start + 3);
+            }
+            _ => {}
+        }
+
+        let single = match b {
+            b'(' => Some(TokenKind::LParen),
+            b')' => Some(TokenKind::RParen),
+            b'[' => Some(TokenKind::LBracket),
+            b']' => Some(TokenKind::RBracket),
+            b'{' => Some(TokenKind::LBrace),
+            b'}' => Some(TokenKind::RBrace),
+            b'|' => Some(TokenKind::Pipe),
+            b'&' => Some(TokenKind::Amp),
+            b'<' => Some(TokenKind::Lt),
+            b'>' => Some(TokenKind::Gt),
+            b';' => Some(TokenKind::Semicolon),
+            b',' => Some(TokenKind::Comma),
+            b'*' => Some(TokenKind::Star),
+            b'?' => Some(TokenKind::Question),
+            b'!' => Some(TokenKind::Bang),
+            b'=' => Some(TokenKind::Eq),
+            b':' => Some(TokenKind::Colon),
+            b'.' => Some(TokenKind::Dot),
+            b'@' => Some(TokenKind::At),
+            b'#' => Some(TokenKind::Hash),
+            b'~' => Some(TokenKind::Tilde),
+            b'/' => Some(TokenKind::Slash),
+            _ => None,
+        };
+        if let Some(kind) = single {
+            self.offset += 1;
+            return Token::new(kind, abs_start, abs_start + 1);
+        }
+
+        if b == b'"' || b == b'\'' {
+            return self.read_string(b, abs_start);
+        }
+        if b == b'`' {
+            return self.read_template_literal(abs_start);
+        }
+        if b == b'-' || b.is_ascii_digit() {
+            if let Some(token) = self.try_read_number(abs_start) {
+                return token;
+            }
+        }
+        if is_ident_start(b) || (self.loose && b == b'-') {
+            return self.read_identifier(abs_start);
+        }
+
+        self.offset += 1;
+        Token::new(TokenKind::EOF, abs_start, abs_start + 1)
+    }
+
+    #[inline]
+    fn skip_whitespace(&mut self) {
+        let bytes = self.source.as_bytes();
+        while self.offset < bytes.len() && bytes[self.offset].is_ascii_whitespace() {
+            self.offset += 1;
+        }
+    }
+
+    #[inline]
+    fn peek_at(&self, delta: usize) -> Option<u8> {
+        self.source.as_bytes().get(self.offset + delta).copied()
+    }
+
+    fn read_string(&mut self, quote: u8, abs_start: u32) -> Token {
+        self.offset += 1;
+        let bytes = self.source.as_bytes();
+        while self.offset < bytes.len() {
+            let b = bytes[self.offset];
+            if b == b'\\' && self.offset + 1 < bytes.len() {
+                self.offset += 2;
+            } else if b == quote {
+                self.offset += 1;
+                return Token::new(
+                    TokenKind::StringValue,
+                    abs_start,
+                    self.base_offset + self.offset as u32,
+                );
+            } else {
+                self.offset += 1;
+            }
+        }
+        Token::new(TokenKind::StringValue, abs_start, self.base_offset + self.offset as u32)
+    }
+
+    fn read_template_literal(&mut self, abs_start: u32) -> Token {
+        self.offset += 1;
+        let bytes = self.source.as_bytes();
+        while self.offset < bytes.len() {
+            let b = bytes[self.offset];
+            if b == b'\\' && self.offset + 1 < bytes.len() {
+                self.offset += 2;
+            } else if b == b'`' {
+                self.offset += 1;
+                return Token::new(
+                    TokenKind::TemplateLiteral,
+                    abs_start,
+                    self.base_offset + self.offset as u32,
+                );
+            } else {
+                self.offset += 1;
+            }
+        }
+        Token::new(TokenKind::TemplateLiteral, abs_start, self.base_offset + self.offset as u32)
+    }
+
+    fn try_read_number(&mut self, abs_start: u32) -> Option<Token> {
+        let bytes = self.source.as_bytes();
+        let mut pos = self.offset;
+        if pos < bytes.len() && bytes[pos] == b'-' {
+            pos += 1;
+        }
+        if self.loose && pos < bytes.len() {
+            if bytes[pos..].starts_with(b"NaN")
+                && !bytes.get(pos + 3).is_some_and(|&b| is_ident_continue(b))
+            {
+                self.offset = pos + 3;
+                return Some(Token::new(
+                    TokenKind::Number,
+                    abs_start,
+                    self.base_offset + self.offset as u32,
+                ));
+            }
+            if bytes[pos..].starts_with(b"Infinity")
+                && !bytes.get(pos + 8).is_some_and(|&b| is_ident_continue(b))
+            {
+                self.offset = pos + 8;
+                return Some(Token::new(
+                    TokenKind::Number,
+                    abs_start,
+                    self.base_offset + self.offset as u32,
+                ));
+            }
+        }
+        let has_integer = pos < bytes.len() && bytes[pos].is_ascii_digit();
+        if has_integer {
+            while pos < bytes.len() && bytes[pos].is_ascii_digit() {
+                pos += 1;
+            }
+        }
+        if pos < bytes.len() && bytes[pos] == b'.' {
+            let next_pos = pos + 1;
+            if next_pos < bytes.len() && bytes[next_pos].is_ascii_digit() {
+                pos = next_pos + 1;
+                while pos < bytes.len() && bytes[pos].is_ascii_digit() {
+                    pos += 1;
+                }
+            } else if !has_integer {
+                return None;
+            }
+        } else if !has_integer {
+            return None;
+        }
+        if pos < bytes.len() && (bytes[pos] == b'e' || bytes[pos] == b'E') {
+            let mut exp_pos = pos + 1;
+            if exp_pos < bytes.len() && (bytes[exp_pos] == b'+' || bytes[exp_pos] == b'-') {
+                exp_pos += 1;
+            }
+            if exp_pos < bytes.len() && bytes[exp_pos].is_ascii_digit() {
+                pos = exp_pos + 1;
+                while pos < bytes.len() && bytes[pos].is_ascii_digit() {
+                    pos += 1;
+                }
+            }
+        }
+        if pos == self.offset || (pos == self.offset + 1 && bytes[self.offset] == b'-') {
+            return None;
+        }
+        self.offset = pos;
+        Some(Token::new(TokenKind::Number, abs_start, self.base_offset + pos as u32))
+    }
+
+    fn read_identifier(&mut self, abs_start: u32) -> Token {
+        let bytes = self.source.as_bytes();
+        let start = self.offset;
+        if self.loose {
+            while self.offset < bytes.len()
+                && (is_ident_continue(bytes[self.offset]) || bytes[self.offset] == b'-')
+            {
+                self.offset += 1;
+            }
+        } else {
+            while self.offset < bytes.len() && is_ident_continue(bytes[self.offset]) {
+                self.offset += 1;
+            }
+        }
+        let text = &self.source[start..self.offset];
+        let abs_end = self.base_offset + self.offset as u32;
+        let kind = match text {
+            "null" => TokenKind::Null,
+            "undefined" => TokenKind::Undefined,
+            "function" => TokenKind::Function,
+            "this" => TokenKind::This,
+            "new" => TokenKind::New,
+            "module" => TokenKind::Module,
+            "event" => TokenKind::Event,
+            "extends" => TokenKind::Extends,
+            "external" => TokenKind::External,
+            "typeof" => TokenKind::Typeof,
+            "keyof" => TokenKind::Keyof,
+            "readonly" => TokenKind::Readonly,
+            "import" => TokenKind::Import,
+            "infer" => TokenKind::Infer,
+            "is" => TokenKind::Is,
+            "in" => TokenKind::In,
+            "asserts" => TokenKind::Asserts,
+            "unique" => TokenKind::Unique,
+            "symbol" => TokenKind::Symbol,
+            "NaN" | "Infinity" if self.loose => TokenKind::Number,
+            _ => TokenKind::Identifier,
+        };
+        Token::new(kind, abs_start, abs_end)
+    }
+}
+
+#[inline]
+fn is_ident_start(b: u8) -> bool {
+    b.is_ascii_alphabetic() || b == b'_' || b == b'$'
+}
+
+#[inline]
+fn is_ident_continue(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
+}

--- a/crates/ox_jsdoc_binary/src/parser/mod.rs
+++ b/crates/ox_jsdoc_binary/src/parser/mod.rs
@@ -1,0 +1,1020 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Public parser entry points.
+//!
+//! See `design/007-binary-ast/rust-impl.md#parser-integrated-binary-writer`
+//! and `design/007-binary-ast/batch-processing.md` for the design.
+//!
+//! The parser implements **approach c-1**: it walks the JSDoc source text
+//! once, and for every recognised node it invokes a `write_*` helper from
+//! [`super::writer`] that appends bytes directly into the arena-backed
+//! Binary AST buffer. There is no intermediate typed AST.
+//!
+//! Phase 1.2 parser path.
+//!
+//! `scanner` / `checkpoint` / `diagnostics` are ports from the typed-AST
+//! parser with no AST dependency. The structural parser (`context`) and the
+//! type expression parser (`type_parse`) are wired into this Binary AST path;
+//! ongoing Phase 1.2 work is focused on parity, cleanup, and binding/benchmark
+//! follow-through rather than on landing the basic parser skeleton itself.
+
+pub mod checkpoint;
+pub mod context;
+pub mod diagnostics;
+pub mod lexer;
+pub mod precedence;
+pub mod scanner;
+pub mod token;
+pub mod type_data;
+pub mod type_emit;
+pub mod type_parse;
+
+pub use checkpoint::{Checkpoint, FenceState, QuoteKind};
+pub use context::{
+    InlineTagFormatData, ParsedBlock, ParsedDiagnostic, ParserContext, emit_block,
+    parse_block_into_data,
+};
+pub use diagnostics::{
+    ParserDiagnosticKind, TypeDiagnosticKind, parser_diagnostic_message, type_diagnostic_message,
+};
+
+use oxc_allocator::{Allocator, Vec as ArenaVec};
+use oxc_span::Span;
+
+use crate::decoder::nodes::comment_ast::LazyJsdocBlock;
+use crate::decoder::source_file::LazySourceFile;
+use crate::writer::BinaryWriter;
+
+/// Options controlling parser behaviour.
+///
+/// Most ox-jsdoc users will leave every field at its [`Default`] value; the
+/// fields exist so binding code can flip `compat_mode` for jsdoccomment
+/// compatibility (see `design/007-binary-ast/encoding.md`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseOptions {
+    /// When `true`, the writer also emits the jsdoccomment-compat extension
+    /// region on `JsdocBlock` / `JsdocTag` / `JsdocDescriptionLine` /
+    /// `JsdocTypeLine`. Sets `Header.flags` bit 0.
+    pub compat_mode: bool,
+    /// Original-file absolute byte offset of `source`. Stored on the root
+    /// index entry so JS-side decoders can rebuild absolute ranges
+    /// (`base_offset + pos`).
+    ///
+    /// Default `0` is correct when the comment is parsed in isolation.
+    pub base_offset: u32,
+    /// Treat fenced code blocks as literal text so `@tags` inside examples
+    /// do not start new block tag sections.
+    pub fence_aware: bool,
+    /// Enable type expression parsing for `{...}` in tags. When `false`,
+    /// the `parsedType` slot is always omitted (zero cost).
+    pub parse_types: bool,
+    /// Parse mode for the type expression sub-parser. Only used when
+    /// `parse_types` is `true`. Defaults to [`type_data::ParseMode::Jsdoc`].
+    pub type_parse_mode: type_data::ParseMode,
+    /// When `true`, the writer emits an 8-byte `description_raw_span`
+    /// (UTF-8 byte offsets) at the **end** of every `JsdocBlock` /
+    /// `JsdocTag` Extended Data record that has a description. Presence
+    /// is signalled by the `has_description_raw_span` Common Data bit
+    /// (bit 0 for `JsdocBlock`, bit 1 for `JsdocTag`).
+    ///
+    /// Required for the JS decoder's `descriptionRaw` getter and
+    /// `descriptionText(true)` method to work — without it both return
+    /// `null`. Fully orthogonal to [`Self::compat_mode`].
+    ///
+    /// See `design/008-oxlint-oxfmt-support/README.md` §4.2 for the
+    /// gating matrix and §5.2 for the wire-size impact.
+    pub preserve_whitespace: bool,
+}
+
+impl Default for ParseOptions {
+    fn default() -> Self {
+        Self {
+            compat_mode: false,
+            base_offset: 0,
+            fence_aware: true,
+            parse_types: false,
+            type_parse_mode: type_data::ParseMode::Jsdoc,
+            preserve_whitespace: false,
+        }
+    }
+}
+
+/// One parser-emitted diagnostic.
+///
+/// `message` borrows from the parser's `&'static` diagnostic message table
+/// (see [`parser_diagnostic_message`] / [`type_diagnostic_message`]) so the
+/// struct itself owns no heap or arena data; it is `Copy` and outlives any
+/// arena. The on-wire representation lives in the `Diagnostics` section of
+/// the Binary AST, not in this struct directly.
+#[derive(Debug, Clone, Copy)]
+pub struct Diagnostic {
+    /// Human-readable description of the issue.
+    pub message: &'static str,
+    /// Source span the diagnostic refers to, when known.
+    pub span: Option<Span>,
+}
+
+/// Result of [`parse`].
+///
+/// `binary_bytes` is the canonical Binary AST byte stream (suitable for
+/// zero-copy sharing with NAPI/WASM bindings) and `lazy_root` is the
+/// matching Rust-side lazy view. Both borrow from the same arena, so they
+/// share a lifetime.
+#[derive(Debug)]
+pub struct ParseResult<'arena> {
+    /// Binary AST bytes laid out in the arena. Sized so the whole buffer is
+    /// 8-byte aligned for cross-target safety.
+    pub binary_bytes: &'arena [u8],
+    /// Lazy decoder root for Rust-side walkers. `None` when parsing failed
+    /// (the matching `Diagnostics` entry will explain why).
+    pub lazy_root: Option<LazyJsdocBlock<'arena>>,
+    /// Decoder handle that wraps `binary_bytes` and exposes the cached
+    /// Header offsets. Constructed once and shared with every lazy node.
+    pub source_file: LazySourceFile<'arena>,
+    /// Diagnostics produced while parsing.
+    pub diagnostics: ArenaVec<'arena, Diagnostic>,
+}
+
+/// Heap-owned counterpart of [`Diagnostic`] returned by [`parse_to_bytes`].
+///
+/// `message` is borrowed from the `&'static` table inside
+/// [`crate::parser::diagnostics`], so this struct itself owns no heap data.
+#[derive(Debug, Clone, Copy)]
+pub struct OwnedDiagnostic {
+    /// Human-readable description of the issue.
+    pub message: &'static str,
+    /// Source span the diagnostic refers to, when known.
+    pub span: Option<Span>,
+}
+
+/// Result of [`parse_to_bytes`] — the bytes-only path used by binding code.
+///
+/// Unlike [`ParseResult`], `binary_bytes` is a heap-owned `Vec<u8>` so it
+/// can move directly into a NAPI `Uint8Array` or a `Box<[u8]>` for WASM
+/// without going through an arena copy. Use this when you do not need the
+/// Rust-side `LazySourceFile` / `LazyJsdocBlock` handles.
+#[derive(Debug)]
+pub struct ParseBytesResult {
+    /// Binary AST bytes — owned, 8-byte aligned by the writer.
+    pub binary_bytes: Vec<u8>,
+    /// Diagnostics produced while parsing.
+    pub diagnostics: Vec<OwnedDiagnostic>,
+}
+
+/// Parse a single JSDoc block comment into Binary AST.
+///
+/// `source` is the raw `/** ... */` text exactly as it appears in the
+/// surrounding file. `arena` owns every allocation produced by the parser
+/// (the byte buffer, intern table, diagnostics) so the caller does not need
+/// to free anything explicitly.
+///
+/// Phase 1.2 parser path: emits the full comment AST plus optional
+/// `parsedType` children when [`ParseOptions::parse_types`] is enabled.
+/// The resulting bytes are the canonical binding-facing output for the
+/// Binary AST flavor.
+pub fn parse<'arena>(
+    arena: &'arena Allocator,
+    source: &'arena str,
+    options: ParseOptions,
+) -> ParseResult<'arena> {
+    // Use a freshly constructed writer. The shared body skips `reset()` —
+    // the writer is already in its post-`new()` state, and calling
+    // `reset()` here would re-pay the [`COMMON_STRINGS`] prelude memcpy
+    // for no reason.
+    let mut writer = BinaryWriter::new(arena);
+    parse_with_writer(arena, source, options, &mut writer)
+}
+
+/// Like [`parse`] but reuses a caller-supplied [`BinaryWriter`] across
+/// invocations.
+///
+/// The writer is reset back to its post-[`BinaryWriter::new`] state at the
+/// start of every call (preserving its arena-backed buffer capacity), so
+/// hot-loop callers can amortize the per-comment writer construction cost
+/// — most notably the [`crate::writer::string_table::COMMON_STRINGS`]
+/// prelude memcpy that dominates [`parse`]'s per-call self time on small
+/// comments.
+///
+/// The writer must be bound to the same arena that backs `source` and the
+/// returned [`ParseResult`].
+///
+/// Typical usage:
+///
+/// ```ignore
+/// let arena = Allocator::default();
+/// let mut writer = BinaryWriter::new(&arena);
+/// for src in comments {
+///     let result = parse_into(&arena, src, ParseOptions::default(), &mut writer);
+///     // …consume result before the next iteration; the lazy roots / bytes
+///     // borrow from `arena`, not from `writer`, so subsequent `reset()`
+///     // calls inside `parse_into` are safe.
+/// }
+/// ```
+pub fn parse_into<'arena>(
+    arena: &'arena Allocator,
+    source: &'arena str,
+    options: ParseOptions,
+    writer: &mut BinaryWriter<'arena>,
+) -> ParseResult<'arena> {
+    writer.reset();
+    parse_with_writer(arena, source, options, writer)
+}
+
+/// Inner shared body of [`parse`] and [`parse_into`]. Assumes the writer is
+/// in its post-[`BinaryWriter::new`] / post-[`BinaryWriter::reset`] state.
+fn parse_with_writer<'arena>(
+    arena: &'arena Allocator,
+    source: &'arena str,
+    options: ParseOptions,
+    writer: &mut BinaryWriter<'arena>,
+) -> ParseResult<'arena> {
+    if options.compat_mode {
+        writer.set_compat_mode(true);
+    }
+    if options.preserve_whitespace {
+        writer.set_preserve_whitespace_span(true);
+    }
+
+    // Parse with relative spans (base_offset = 0). The root index entry's
+    // base_offset captures the absolute position, and the lazy decoder's
+    // `range` getter combines them. This avoids double-counting when the
+    // caller passes a non-zero base_offset.
+    let parser_options = ParseOptions { base_offset: 0, ..options };
+    let parsed = context::parse_block_into_data(arena, source, 0, parser_options);
+
+    // Source text is appended after the writer's pre-interned common
+    // strings (`StringTableBuilder::new`); the returned offset is what
+    // `push_root` needs to record so the decoder can locate the source
+    // span via `root[i].source_offset_in_data`.
+    let source_offset = writer.append_source_text(source);
+
+    let root_node_index =
+        if parsed.is_failure() { 0 } else { context::emit_block(writer, &parsed).unwrap_or(0) };
+    writer.push_root(root_node_index, source_offset, options.base_offset);
+
+    // Single pass over diagnostics: push to writer (interned, on-wire) and
+    // mirror into the Rust-side `arena_diagnostics` vec. `diag.message()`
+    // is a `&'static str` from the parser's static message table, so it
+    // borrows directly into the Diagnostic struct without an `alloc_str`.
+    let mut arena_diagnostics: ArenaVec<'arena, Diagnostic> = ArenaVec::new_in(arena);
+    for diag in parsed.diagnostics() {
+        let message = diag.message();
+        writer.push_diagnostic(0, message);
+        arena_diagnostics.push(Diagnostic { message, span: diag.span });
+    }
+
+    // Build the bytes directly into the arena — saves the heap `Vec<u8>`
+    // allocation + the `arena.alloc_slice_copy` that the previous path
+    // paid to satisfy the `&'arena [u8]` lifetime needed by `LazySourceFile`.
+    let binary_bytes: &'arena [u8] = writer.finish_into_arena_reusing();
+    let source_file_owned = LazySourceFile::new(binary_bytes)
+        .expect("BinaryWriter::finish_into_arena_reusing() always produces a header-valid buffer");
+    let source_file_ref: &'arena LazySourceFile<'arena> = arena.alloc(source_file_owned);
+
+    let lazy_root =
+        if root_node_index == 0 { None } else { source_file_ref.asts().next().flatten() };
+
+    ParseResult {
+        binary_bytes,
+        lazy_root,
+        source_file: *source_file_ref,
+        diagnostics: arena_diagnostics,
+    }
+}
+
+/// Parse a single JSDoc block comment and return only the Binary AST bytes.
+///
+/// This is the bytes-only sibling of [`parse`]. Binding code that hands the
+/// buffer straight to JS (NAPI `Uint8Array`, WASM `Box<[u8]>`) should call
+/// this entry point: it skips the arena copy that [`parse`] performs to
+/// satisfy the `&'arena [u8]` lifetime needed by [`LazySourceFile`].
+///
+/// Output bytes are byte-for-byte identical to
+/// [`ParseResult::binary_bytes`] for the same input.
+#[must_use]
+pub fn parse_to_bytes(source: &str, options: ParseOptions) -> ParseBytesResult {
+    use crate::writer::BinaryWriter;
+
+    let arena = Allocator::default();
+
+    let parser_options = ParseOptions { base_offset: 0, ..options };
+    let parsed = context::parse_block_into_data(&arena, source, 0, parser_options);
+
+    let mut writer = BinaryWriter::new(&arena);
+    if options.compat_mode {
+        writer.set_compat_mode(true);
+    }
+    if options.preserve_whitespace {
+        writer.set_preserve_whitespace_span(true);
+    }
+    let source_offset = writer.append_source_text(source);
+
+    let root_node_index = if parsed.is_failure() {
+        0
+    } else {
+        context::emit_block(&mut writer, &parsed).unwrap_or(0)
+    };
+    writer.push_root(root_node_index, source_offset, options.base_offset);
+
+    for diag in parsed.diagnostics() {
+        writer.push_diagnostic(0, diag.message());
+    }
+
+    let diagnostics: Vec<OwnedDiagnostic> = parsed
+        .diagnostics()
+        .iter()
+        .map(|d| OwnedDiagnostic { message: d.message(), span: d.span })
+        .collect();
+
+    let binary_bytes = writer.finish();
+
+    ParseBytesResult { binary_bytes, diagnostics }
+}
+
+/// One input item for [`parse_batch`].
+///
+/// Mirrors the public `BatchItem` interface in `js-decoder.md` (the JS-side
+/// API takes the same shape so the NAPI binding can pass values through
+/// with no transformation).
+#[derive(Debug, Clone, Copy)]
+pub struct BatchItem<'a> {
+    /// `/** ... */` source text for this comment.
+    pub source_text: &'a str,
+    /// Original-file absolute byte offset.
+    pub base_offset: u32,
+}
+
+/// Diagnostic emitted by [`parse_batch`].
+///
+/// Carries the `root_index` so callers can correlate each diagnostic with
+/// the matching `lazy_roots[root_index]` entry without re-decoding the
+/// `Diagnostics` section of the Binary AST. `message` borrows from the
+/// parser's `&'static` message table, so this struct owns no arena data
+/// and is `Copy`.
+#[derive(Debug, Clone, Copy)]
+pub struct BatchDiagnostic {
+    /// Human-readable description of the issue.
+    pub message: &'static str,
+    /// Source span the diagnostic refers to, when known.
+    pub span: Option<Span>,
+    /// Index of the input item this diagnostic belongs to (`0..items.len()`).
+    pub root_index: u32,
+}
+
+/// Heap-owned counterpart of [`BatchDiagnostic`] returned by
+/// [`parse_batch_to_bytes`].
+#[derive(Debug, Clone, Copy)]
+pub struct OwnedBatchDiagnostic {
+    /// Human-readable description of the issue.
+    pub message: &'static str,
+    /// Source span the diagnostic refers to, when known.
+    pub span: Option<Span>,
+    /// Index of the input item this diagnostic belongs to.
+    pub root_index: u32,
+}
+
+/// Result of [`parse_batch`]; carries N roots in a single shared buffer.
+///
+/// The shape intentionally matches [`ParseResult`] but with a multi-root
+/// array — `lazy_roots[i]` is `None` when `items[i]` failed to parse. The
+/// matching `Diagnostics` entries (sorted by `root_index` ascending in the
+/// Binary AST) explain each failure.
+#[derive(Debug)]
+pub struct BatchResult<'arena> {
+    /// Binary AST bytes shared by all roots.
+    pub binary_bytes: &'arena [u8],
+    /// One entry per input `BatchItem`; `None` indicates a parse failure.
+    pub lazy_roots: ArenaVec<'arena, Option<LazyJsdocBlock<'arena>>>,
+    /// Decoder handle that wraps `binary_bytes`.
+    pub source_file: LazySourceFile<'arena>,
+    /// All diagnostics produced during the batch, in input order.
+    pub diagnostics: ArenaVec<'arena, BatchDiagnostic>,
+}
+
+/// Result of [`parse_batch_to_bytes`] — heap-owned bytes + diagnostics.
+///
+/// Bytes-only sibling of [`BatchResult`]; suitable for handing straight to
+/// NAPI/WASM bindings.
+#[derive(Debug)]
+pub struct ParseBatchBytesResult {
+    /// Binary AST bytes — owned, 8-byte aligned by the writer.
+    pub binary_bytes: Vec<u8>,
+    /// All diagnostics produced during the batch, in input order.
+    pub diagnostics: Vec<OwnedBatchDiagnostic>,
+}
+
+/// Parse N JSDoc block comments into a single shared Binary AST buffer.
+///
+/// All N roots share the same `String Data` (so common tag names like
+/// `param`, `returns` are interned once), the same Extended Data buffer,
+/// and the same Nodes section laid out side-by-side. See
+/// `design/007-binary-ast/batch-processing.md` for the format details.
+///
+/// On parse failure for `items[i]`, `lazy_roots[i]` is `None` and at least
+/// one matching diagnostic is recorded with `root_index == i`.
+pub fn parse_batch<'arena>(
+    arena: &'arena Allocator,
+    items: &[BatchItem<'_>],
+    options: ParseOptions,
+) -> BatchResult<'arena> {
+    let mut writer = BinaryWriter::new(arena);
+    parse_batch_with_writer(arena, items, options, &mut writer)
+}
+
+/// Like [`parse_batch`] but reuses a caller-supplied [`BinaryWriter`].
+///
+/// The writer is reset back to its post-[`BinaryWriter::new`] state at the
+/// start of every call so the same writer can drive many batches in a row
+/// without paying the per-call construction cost. See [`parse_into`] for
+/// the per-comment counterpart.
+pub fn parse_batch_into<'arena>(
+    arena: &'arena Allocator,
+    items: &[BatchItem<'_>],
+    options: ParseOptions,
+    writer: &mut BinaryWriter<'arena>,
+) -> BatchResult<'arena> {
+    writer.reset();
+    parse_batch_with_writer(arena, items, options, writer)
+}
+
+/// Inner shared body of [`parse_batch`] and [`parse_batch_into`]. Assumes
+/// the writer is already in its post-[`BinaryWriter::new`] /
+/// post-[`BinaryWriter::reset`] state.
+fn parse_batch_with_writer<'arena>(
+    arena: &'arena Allocator,
+    items: &[BatchItem<'_>],
+    options: ParseOptions,
+    writer: &mut BinaryWriter<'arena>,
+) -> BatchResult<'arena> {
+    if options.compat_mode {
+        writer.set_compat_mode(true);
+    }
+    if options.preserve_whitespace {
+        writer.set_preserve_whitespace_span(true);
+    }
+
+    // Parse with relative spans (base_offset = 0); each root index entry
+    // carries the absolute offset so the lazy decoder can rebuild ranges.
+    let parser_options = ParseOptions { base_offset: 0, ..options };
+
+    let mut arena_diagnostics: ArenaVec<'arena, BatchDiagnostic> = ArenaVec::new_in(arena);
+
+    for (index, item) in items.iter().enumerate() {
+        let root_index = index as u32;
+        let source_offset_in_data = writer.append_source_text(item.source_text);
+
+        let parsed = context::parse_block_into_data(arena, item.source_text, 0, parser_options);
+
+        let root_node_index =
+            if parsed.is_failure() { 0 } else { context::emit_block(writer, &parsed).unwrap_or(0) };
+        writer.push_root(root_node_index, source_offset_in_data, item.base_offset);
+
+        for diag in parsed.diagnostics() {
+            let message = diag.message();
+            writer.push_diagnostic(root_index, message);
+            arena_diagnostics.push(BatchDiagnostic { message, span: diag.span, root_index });
+        }
+    }
+
+    // Build the bytes directly into the arena — see [`parse`] for the
+    // rationale behind preferring `finish_into_arena` over `finish` +
+    // `alloc_slice_copy`.
+    let binary_bytes: &'arena [u8] = writer.finish_into_arena_reusing();
+    let source_file_owned = LazySourceFile::new(binary_bytes)
+        .expect("BinaryWriter::finish_into_arena_reusing() always produces a header-valid buffer");
+    let source_file_ref: &'arena LazySourceFile<'arena> = arena.alloc(source_file_owned);
+
+    let mut lazy_roots: ArenaVec<'arena, Option<LazyJsdocBlock<'arena>>> = ArenaVec::new_in(arena);
+    for root in source_file_ref.asts() {
+        lazy_roots.push(root);
+    }
+
+    BatchResult {
+        binary_bytes,
+        lazy_roots,
+        source_file: *source_file_ref,
+        diagnostics: arena_diagnostics,
+    }
+}
+
+/// Bytes-only sibling of [`parse_batch`].
+///
+/// Skips the arena copy used by [`parse_batch`] for `binary_bytes`; binding
+/// code that hands the buffer straight to JS should call this instead.
+///
+/// Output bytes are byte-for-byte identical to [`BatchResult::binary_bytes`]
+/// for the same input.
+#[must_use]
+pub fn parse_batch_to_bytes(
+    items: &[BatchItem<'_>],
+    options: ParseOptions,
+) -> ParseBatchBytesResult {
+    use crate::writer::BinaryWriter;
+
+    let arena = Allocator::default();
+    let mut writer = BinaryWriter::new(&arena);
+    if options.compat_mode {
+        writer.set_compat_mode(true);
+    }
+    if options.preserve_whitespace {
+        writer.set_preserve_whitespace_span(true);
+    }
+
+    let parser_options = ParseOptions { base_offset: 0, ..options };
+
+    let mut diagnostics: Vec<OwnedBatchDiagnostic> = Vec::new();
+
+    for (index, item) in items.iter().enumerate() {
+        let root_index = index as u32;
+        let source_offset_in_data = writer.append_source_text(item.source_text);
+
+        let parsed = context::parse_block_into_data(&arena, item.source_text, 0, parser_options);
+
+        let root_node_index = if parsed.is_failure() {
+            0
+        } else {
+            context::emit_block(&mut writer, &parsed).unwrap_or(0)
+        };
+        writer.push_root(root_node_index, source_offset_in_data, item.base_offset);
+
+        for diag in parsed.diagnostics() {
+            writer.push_diagnostic(root_index, diag.message());
+            diagnostics.push(OwnedBatchDiagnostic {
+                message: diag.message(),
+                span: diag.span,
+                root_index,
+            });
+        }
+    }
+
+    let binary_bytes = writer.finish();
+
+    ParseBatchBytesResult { binary_bytes, diagnostics }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_options_default_is_non_compat_zero_offset() {
+        let opts = ParseOptions::default();
+        assert!(!opts.compat_mode);
+        assert_eq!(opts.base_offset, 0);
+    }
+
+    #[test]
+    fn parse_options_is_copy() {
+        // Compile-time check: ParseOptions must be Copy so the parser can
+        // pass it by value into hot loops without lifetime gymnastics.
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<ParseOptions>();
+    }
+
+    #[test]
+    fn diagnostic_is_copy() {
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<Diagnostic>();
+        assert_copy::<BatchDiagnostic>();
+    }
+
+    #[test]
+    fn batch_item_is_copy() {
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<BatchItem<'static>>();
+    }
+
+    #[test]
+    fn parse_simple_block_emits_lazy_root() {
+        let arena = Allocator::default();
+        let result = parse(&arena, "/** ok */", ParseOptions::default());
+        assert!(result.diagnostics.is_empty());
+        let root = result.lazy_root.expect("root present");
+        assert_eq!(root.description(), Some("ok"));
+    }
+
+    #[test]
+    fn parse_param_tag_round_trips_through_lazy_decoder() {
+        let arena = Allocator::default();
+        let result =
+            parse(&arena, "/**\n * @param {string} id - The user ID\n */", ParseOptions::default());
+        assert!(result.diagnostics.is_empty());
+        let root = result.lazy_root.expect("root present");
+        let tags: Vec<_> = root.tags().collect();
+        assert_eq!(tags.len(), 1);
+        let tag = tags[0];
+        assert_eq!(tag.tag().value(), "param");
+        assert_eq!(tag.description(), Some("The user ID"));
+    }
+
+    #[test]
+    fn parse_failure_yields_diagnostic_and_no_root() {
+        let arena = Allocator::default();
+        let result = parse(&arena, "/* plain */", ParseOptions::default());
+        assert!(result.lazy_root.is_none());
+        assert_eq!(result.diagnostics.len(), 1);
+        assert!(result.diagnostics[0].message.contains("not a JSDoc block"));
+    }
+
+    #[test]
+    fn parse_with_parsed_type_emits_type_name() {
+        use crate::decoder::nodes::type_node::LazyTypeNode;
+        let arena = Allocator::default();
+        let mut opts = ParseOptions::default();
+        opts.parse_types = true;
+        let result = parse(&arena, "/**\n * @param {string} id\n */", opts);
+        assert!(result.diagnostics.is_empty());
+        let root = result.lazy_root.unwrap();
+        let tag = root.tags().next().expect("tag present");
+        let parsed = tag.parsed_type().expect("parsedType emitted");
+        match parsed {
+            LazyTypeNode::Name(n) => assert_eq!(n.value(), "string"),
+            other => panic!("expected TypeName, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_with_parsed_type_emits_union() {
+        use crate::decoder::nodes::type_node::LazyTypeNode;
+        let arena = Allocator::default();
+        let mut opts = ParseOptions::default();
+        opts.parse_types = true;
+        opts.type_parse_mode = crate::parser::type_data::ParseMode::Typescript;
+        let result = parse(&arena, "/**\n * @param {string | number} id\n */", opts);
+        assert!(result.diagnostics.is_empty());
+        let root = result.lazy_root.unwrap();
+        let tag = root.tags().next().expect("tag present");
+        let parsed = tag.parsed_type().expect("parsedType emitted");
+        match parsed {
+            LazyTypeNode::Union(u) => assert_eq!(u.elements().count(), 2),
+            other => panic!("expected TypeUnion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_with_parsed_type_emits_function_type() {
+        use crate::decoder::nodes::type_node::LazyTypeNode;
+        let arena = Allocator::default();
+        let mut opts = ParseOptions::default();
+        opts.parse_types = true;
+        opts.type_parse_mode = crate::parser::type_data::ParseMode::Jsdoc;
+        let result = parse(&arena, "/**\n * @returns {function(string): number} ok\n */", opts);
+        assert!(result.diagnostics.is_empty());
+        let root = result.lazy_root.unwrap();
+        let tag = root.tags().next().expect("tag present");
+        let parsed = tag.parsed_type().expect("parsedType emitted");
+        assert!(matches!(parsed, LazyTypeNode::Function(_)));
+    }
+
+    #[test]
+    fn parse_handles_generic_dot_notation() {
+        use crate::decoder::nodes::type_node::LazyTypeNode;
+        let arena = Allocator::default();
+        let mut opts = ParseOptions::default();
+        opts.parse_types = true;
+        let result = parse(&arena, "/**\n * @param {Array.<string>} ids\n */", opts);
+        assert!(result.diagnostics.is_empty());
+        let root = result.lazy_root.unwrap();
+        let tag = root.tags().next().expect("tag present");
+        match tag.parsed_type().expect("parsedType emitted") {
+            LazyTypeNode::Generic(g) => {
+                assert!(g.dot());
+                assert_eq!(g.elements().count(), 1);
+            }
+            other => panic!("expected TypeGeneric, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_handles_template_literal_type() {
+        use crate::decoder::nodes::type_node::LazyTypeNode;
+        let arena = Allocator::default();
+        let mut opts = ParseOptions::default();
+        opts.parse_types = true;
+        opts.type_parse_mode = crate::parser::type_data::ParseMode::Typescript;
+        let result = parse(&arena, "/**\n * @param {`hello-${T}`} value\n */", opts);
+        assert!(result.diagnostics.is_empty());
+        let root = result.lazy_root.unwrap();
+        let tag = root.tags().next().expect("tag present");
+        assert!(matches!(
+            tag.parsed_type().expect("parsedType emitted"),
+            LazyTypeNode::TemplateLiteral(_)
+        ));
+    }
+
+    #[test]
+    fn parse_to_bytes_matches_parse_for_simple_block() {
+        let arena = Allocator::default();
+        let opts = ParseOptions::default();
+        let typed = parse(&arena, "/** ok */", opts);
+        let bytes_only = parse_to_bytes("/** ok */", opts);
+        assert_eq!(typed.binary_bytes, bytes_only.binary_bytes.as_slice());
+        assert_eq!(typed.diagnostics.len(), bytes_only.diagnostics.len());
+    }
+
+    #[test]
+    fn parse_to_bytes_matches_parse_for_param_tag() {
+        let arena = Allocator::default();
+        let mut opts = ParseOptions::default();
+        opts.parse_types = true;
+        let src = "/**\n * @param {string | number} id - The user ID\n */";
+        let typed = parse(&arena, src, opts);
+        let bytes_only = parse_to_bytes(src, opts);
+        assert_eq!(typed.binary_bytes, bytes_only.binary_bytes.as_slice());
+    }
+
+    #[test]
+    fn parse_to_bytes_matches_parse_with_compat_mode() {
+        let arena = Allocator::default();
+        let mut opts = ParseOptions::default();
+        opts.compat_mode = true;
+        let src = "/**\n * Description.\n * @param x The value\n */";
+        let typed = parse(&arena, src, opts);
+        let bytes_only = parse_to_bytes(src, opts);
+        assert_eq!(typed.binary_bytes, bytes_only.binary_bytes.as_slice());
+    }
+
+    #[test]
+    fn parse_to_bytes_matches_parse_for_failure() {
+        let arena = Allocator::default();
+        let opts = ParseOptions::default();
+        let typed = parse(&arena, "/* plain */", opts);
+        let bytes_only = parse_to_bytes("/* plain */", opts);
+        assert_eq!(typed.binary_bytes, bytes_only.binary_bytes.as_slice());
+        assert_eq!(typed.diagnostics.len(), bytes_only.diagnostics.len());
+        assert_eq!(typed.diagnostics[0].message, bytes_only.diagnostics[0].message);
+    }
+
+    #[test]
+    fn parse_to_bytes_preserves_base_offset() {
+        let opts = ParseOptions { base_offset: 12345, ..ParseOptions::default() };
+        let arena = Allocator::default();
+        let typed = parse(&arena, "/** ok */", opts);
+        let bytes_only = parse_to_bytes("/** ok */", opts);
+        assert_eq!(typed.binary_bytes, bytes_only.binary_bytes.as_slice());
+    }
+
+    #[test]
+    fn parse_batch_empty_items_returns_empty_result() {
+        let arena = Allocator::default();
+        let result = parse_batch(&arena, &[], ParseOptions::default());
+        assert_eq!(result.lazy_roots.len(), 0);
+        assert_eq!(result.diagnostics.len(), 0);
+        assert_eq!(result.source_file.root_count, 0);
+    }
+
+    #[test]
+    fn parse_batch_single_item_emits_root() {
+        let arena = Allocator::default();
+        let items = [BatchItem { source_text: "/** ok */", base_offset: 0 }];
+        let result = parse_batch(&arena, &items, ParseOptions::default());
+        assert_eq!(result.lazy_roots.len(), 1);
+        let root = result.lazy_roots[0].expect("root present");
+        assert_eq!(root.description(), Some("ok"));
+        assert_eq!(result.diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn parse_batch_multiple_items_each_produces_root() {
+        let arena = Allocator::default();
+        let items = [
+            BatchItem { source_text: "/** first */", base_offset: 0 },
+            BatchItem { source_text: "/**\n * @param {string} id - second\n */", base_offset: 100 },
+            BatchItem { source_text: "/** third */", base_offset: 200 },
+        ];
+        let result = parse_batch(&arena, &items, ParseOptions::default());
+        assert_eq!(result.lazy_roots.len(), 3);
+        assert_eq!(result.lazy_roots[0].unwrap().description(), Some("first"));
+        let second_tag = result.lazy_roots[1].unwrap().tags().next().expect("tag");
+        assert_eq!(second_tag.tag().value(), "param");
+        assert_eq!(result.lazy_roots[2].unwrap().description(), Some("third"));
+    }
+
+    #[test]
+    fn parse_batch_failure_yields_none_root_and_diagnostic() {
+        let arena = Allocator::default();
+        let items = [
+            BatchItem { source_text: "/** good */", base_offset: 0 },
+            BatchItem { source_text: "/* not jsdoc */", base_offset: 50 },
+            BatchItem { source_text: "/** also good */", base_offset: 100 },
+        ];
+        let result = parse_batch(&arena, &items, ParseOptions::default());
+        assert_eq!(result.lazy_roots.len(), 3);
+        assert!(result.lazy_roots[0].is_some());
+        assert!(result.lazy_roots[1].is_none(), "failed parse → None");
+        assert!(result.lazy_roots[2].is_some());
+        assert!(result.diagnostics.iter().any(|d| d.root_index == 1));
+    }
+
+    #[test]
+    fn parse_batch_diagnostics_carry_root_index() {
+        let arena = Allocator::default();
+        let items = [
+            BatchItem { source_text: "/* first not jsdoc */", base_offset: 0 },
+            BatchItem { source_text: "/** ok */", base_offset: 100 },
+            BatchItem { source_text: "/* third not jsdoc */", base_offset: 200 },
+        ];
+        let result = parse_batch(&arena, &items, ParseOptions::default());
+        let indices: Vec<u32> = result.diagnostics.iter().map(|d| d.root_index).collect();
+        assert!(indices.contains(&0));
+        assert!(indices.contains(&2));
+        assert!(!indices.contains(&1));
+    }
+
+    #[test]
+    fn parse_batch_preserves_base_offset_per_item() {
+        let arena = Allocator::default();
+        let items = [
+            BatchItem { source_text: "/** a */", base_offset: 1000 },
+            BatchItem { source_text: "/** b */", base_offset: 2000 },
+        ];
+        let result = parse_batch(&arena, &items, ParseOptions::default());
+        assert_eq!(result.source_file.get_root_base_offset(0), 1000);
+        assert_eq!(result.source_file.get_root_base_offset(1), 2000);
+    }
+
+    #[test]
+    fn parse_batch_to_bytes_matches_parse_batch() {
+        let arena = Allocator::default();
+        let items = [
+            BatchItem { source_text: "/** alpha */", base_offset: 10 },
+            BatchItem {
+                source_text: "/**\n * @param {string} x - one\n * @returns {number} two\n */",
+                base_offset: 200,
+            },
+            BatchItem { source_text: "/* parse failure */", base_offset: 500 },
+        ];
+        let opts = ParseOptions::default();
+        let typed = parse_batch(&arena, &items, opts);
+        let bytes_only = parse_batch_to_bytes(&items, opts);
+        assert_eq!(typed.binary_bytes, bytes_only.binary_bytes.as_slice());
+        assert_eq!(typed.diagnostics.len(), bytes_only.diagnostics.len());
+        for (t, b) in typed.diagnostics.iter().zip(bytes_only.diagnostics.iter()) {
+            assert_eq!(t.message, b.message);
+            assert_eq!(t.root_index, b.root_index);
+        }
+    }
+
+    #[test]
+    fn parse_batch_dedups_strings_across_roots() {
+        // Same comment N times — String Data should not grow linearly with N
+        // because the dedup table stores common strings (`*`, `*/`, ` `, the
+        // tag name, etc.) once for the whole batch.
+        let single_src = "/**\n * @param {string} id\n */";
+        let single = parse_to_bytes(single_src, ParseOptions::default());
+        let single_size = single.binary_bytes.len();
+
+        let mut items: Vec<BatchItem<'_>> = Vec::with_capacity(50);
+        for _ in 0..50 {
+            items.push(BatchItem { source_text: single_src, base_offset: 0 });
+        }
+        let batch = parse_batch_to_bytes(&items, ParseOptions::default());
+        // Sanity: 50 roots emitted
+        let lazy = LazySourceFile::new(&batch.binary_bytes).unwrap();
+        assert_eq!(lazy.root_count, 50);
+        // Per-comment cost is much less than a standalone parse (header,
+        // string table dedup amortise away).
+        let per_comment = batch.binary_bytes.len() / 50;
+        assert!(
+            per_comment < single_size,
+            "per-comment size {per_comment} should be < standalone size {single_size}"
+        );
+    }
+
+    #[test]
+    fn parse_handles_conditional_type() {
+        use crate::decoder::nodes::type_node::LazyTypeNode;
+        let arena = Allocator::default();
+        let mut opts = ParseOptions::default();
+        opts.parse_types = true;
+        opts.type_parse_mode = crate::parser::type_data::ParseMode::Typescript;
+        let result = parse(&arena, "/**\n * @param {T extends U ? X : Y} v\n */", opts);
+        assert!(result.diagnostics.is_empty());
+        let root = result.lazy_root.unwrap();
+        let tag = root.tags().next().expect("tag present");
+        assert!(matches!(
+            tag.parsed_type().expect("parsedType emitted"),
+            LazyTypeNode::Conditional(_)
+        ));
+    }
+
+    /// `parse_into` with a freshly-constructed writer must produce the same
+    /// bytes (and the same lazy view) as the consuming `parse` API.
+    #[test]
+    fn parse_into_matches_parse_for_simple_block() {
+        let arena1 = Allocator::default();
+        let arena2 = Allocator::default();
+        let opts = ParseOptions::default();
+        let baseline = parse(&arena1, "/** ok */", opts);
+
+        let mut writer = BinaryWriter::new(&arena2);
+        let recycled = parse_into(&arena2, "/** ok */", opts, &mut writer);
+
+        assert_eq!(baseline.binary_bytes, recycled.binary_bytes);
+        assert_eq!(
+            baseline.lazy_root.unwrap().description(),
+            recycled.lazy_root.unwrap().description()
+        );
+    }
+
+    /// Reusing the writer across multiple `parse_into` calls must produce the
+    /// same bytes as the standalone `parse` path on every iteration. This
+    /// proves `BinaryWriter::reset` correctly truncates per-section buffers
+    /// without leaking previous-call state.
+    #[test]
+    fn parse_into_recycles_writer_without_state_leak() {
+        let inputs: &[&str] = &[
+            "/** first */",
+            "/**\n * @param {string} id - The user ID\n */",
+            "/** third with lots of text describing things */",
+            "/* parse failure (not jsdoc) */",
+            "/**\n * @returns {number} four\n */",
+            "/** fifth */",
+        ];
+
+        let arena_baseline = Allocator::default();
+        let baselines: Vec<Vec<u8>> = inputs
+            .iter()
+            .map(|src| {
+                let r = parse(&arena_baseline, src, ParseOptions::default());
+                r.binary_bytes.to_vec()
+            })
+            .collect();
+
+        let arena_recycle = Allocator::default();
+        let mut writer = BinaryWriter::new(&arena_recycle);
+        for (src, expected) in inputs.iter().zip(baselines.iter()) {
+            let r = parse_into(&arena_recycle, src, ParseOptions::default(), &mut writer);
+            assert_eq!(
+                r.binary_bytes, expected,
+                "recycled writer produced different bytes for `{src}`"
+            );
+        }
+    }
+
+    /// `parse_batch_into` with a fresh writer must match `parse_batch`.
+    #[test]
+    fn parse_batch_into_matches_parse_batch() {
+        let items = [
+            BatchItem { source_text: "/** alpha */", base_offset: 10 },
+            BatchItem { source_text: "/**\n * @param {string} x - one\n */", base_offset: 200 },
+            BatchItem { source_text: "/* parse failure */", base_offset: 500 },
+        ];
+
+        let arena1 = Allocator::default();
+        let baseline = parse_batch(&arena1, &items, ParseOptions::default());
+
+        let arena2 = Allocator::default();
+        let mut writer = BinaryWriter::new(&arena2);
+        let recycled = parse_batch_into(&arena2, &items, ParseOptions::default(), &mut writer);
+
+        assert_eq!(baseline.binary_bytes, recycled.binary_bytes);
+    }
+
+    /// Reusing one writer across several `parse_batch_into` calls — covers
+    /// the multi-batch case for [`BinaryWriter::reset`].
+    #[test]
+    fn parse_batch_into_recycles_writer_across_batches() {
+        let arena_baseline = Allocator::default();
+        let arena_recycle = Allocator::default();
+        let mut writer = BinaryWriter::new(&arena_recycle);
+
+        for round in 0..3 {
+            let items = [
+                BatchItem { source_text: "/** round */", base_offset: round * 100 },
+                BatchItem {
+                    source_text: "/** @param {number} n */",
+                    base_offset: round * 100 + 50,
+                },
+            ];
+
+            let baseline = parse_batch(&arena_baseline, &items, ParseOptions::default());
+            let recycled =
+                parse_batch_into(&arena_recycle, &items, ParseOptions::default(), &mut writer);
+
+            assert_eq!(
+                baseline.binary_bytes, recycled.binary_bytes,
+                "round {round}: bytes diverged"
+            );
+        }
+    }
+
+    /// A writer recycled after a compat-mode parse must clear the compat bit
+    /// when the subsequent caller doesn't ask for it. Regression guard for
+    /// `BinaryWriter::reset` clearing `header.flags`.
+    #[test]
+    fn parse_into_clears_compat_mode_between_calls() {
+        let arena = Allocator::default();
+        let mut writer = BinaryWriter::new(&arena);
+
+        let mut compat_opts = ParseOptions::default();
+        compat_opts.compat_mode = true;
+        let compat = parse_into(&arena, "/** ok */", compat_opts, &mut writer);
+        assert!(compat.source_file.compat_mode);
+
+        let plain = parse_into(&arena, "/** ok */", ParseOptions::default(), &mut writer);
+        assert!(!plain.source_file.compat_mode, "writer.reset() must clear the compat_mode flag");
+    }
+}

--- a/crates/ox_jsdoc_binary/src/parser/precedence.rs
+++ b/crates/ox_jsdoc_binary/src/parser/precedence.rs
@@ -1,0 +1,35 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Pratt parser precedence levels for JSDoc type expressions.
+//!
+//! Verbatim port of `crates/ox_jsdoc/src/type_parser/precedence.rs`.
+//! Higher numeric value = higher precedence = tighter binding.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+#[allow(missing_docs)]
+pub enum Precedence {
+    All = 0,
+    ParameterList = 1,
+    Object = 2,
+    KeyValue = 3,
+    IndexBrackets = 4,
+    Union = 5,
+    Intersection = 6,
+    Prefix = 7,
+    Infix = 8,
+    Tuple = 9,
+    Symbol = 10,
+    Optional = 11,
+    Nullable = 12,
+    KeyOfTypeOf = 13,
+    Function = 14,
+    Arrow = 15,
+    ArrayBrackets = 16,
+    Generic = 17,
+    NamePath = 18,
+    Parenthesis = 19,
+    SpecialTypes = 20,
+}

--- a/crates/ox_jsdoc_binary/src/parser/scanner.rs
+++ b/crates/ox_jsdoc_binary/src/parser/scanner.rs
@@ -1,0 +1,213 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Low-level scanner helpers for turning a raw block comment into logical
+//! content lines.
+//!
+//! Verbatim port of `crates/ox_jsdoc/src/parser/scanner.rs`. The scanner
+//! does not depend on the AST representation, so the binary parser shares
+//! identical logic with the typed-AST parser.
+
+/// One source line after stripping the comment prefix syntax.
+///
+/// Kept small (24 bytes) so that `Copy` in hot loops is cheap; doubling
+/// to 32 bytes regresses parse_batch by ~30 %, so any new field has to
+/// either replace an existing slot or live in the parallel `MarginInfo`
+/// array.
+///
+/// The `is_content_empty` flag is mirrored here (rather than only in
+/// `MarginInfo`) because it is read by callers that iterate only the
+/// lines array (`normalize_lines`, `partition_sections`); we save 4
+/// bytes by deriving the line-end offset from `content_start +
+/// content.len()` instead of storing it.
+#[derive(Debug, Clone, Copy)]
+pub struct LogicalLine<'a> {
+    /// Content after removing the visual JSDoc margin.
+    pub content: &'a str,
+    /// Absolute byte offset where `content` starts.
+    pub content_start: u32,
+    /// `true` when `content` contains only ASCII space/tab (or is empty).
+    /// Mirrored from [`MarginInfo::is_content_empty`] so consumers iterating
+    /// only the lines array can shortcut whitespace-only checks.
+    pub is_content_empty: bool,
+}
+
+impl<'a> LogicalLine<'a> {
+    /// Absolute byte offset where the original physical line ends. Equal to
+    /// `content_start + content.len()` because `content` is a sub-slice of
+    /// `raw_line` that runs to the line's end (the scanner does not trim
+    /// trailing whitespace from `content`).
+    #[inline]
+    #[must_use]
+    pub fn content_end(&self) -> u32 {
+        self.content_start + self.content.len() as u32
+    }
+}
+
+/// Source-preserving margin metadata for one logical line.
+#[derive(Debug, Clone, Copy)]
+pub struct MarginInfo<'a> {
+    /// Indentation before the `*` delimiter (spaces/tabs).
+    pub initial: &'a str,
+    /// The `*` delimiter itself, or `""` if absent.
+    pub delimiter: &'a str,
+    /// Whitespace after the `*` delimiter (at most one space/tab), or `""`.
+    pub post_delimiter: &'a str,
+    /// Line ending characters (`"\n"`, `"\r\n"`, or `""`).
+    pub line_end: &'a str,
+    /// Whether content (after margin stripping) is empty or whitespace-only.
+    pub is_content_empty: bool,
+}
+
+/// Result of `logical_lines()`: parallel arrays of content and margin info.
+pub struct ScanResult<'a> {
+    /// Content portion of each logical line.
+    pub lines: Vec<LogicalLine<'a>>,
+    /// Margin metadata for each logical line.
+    pub margins: Vec<MarginInfo<'a>>,
+}
+
+/// JSDoc blocks must start with `/**`; plain `/*` comments are rejected.
+#[must_use]
+pub fn is_jsdoc_block(source_text: &str) -> bool {
+    source_text.trim_start().starts_with("/**")
+}
+
+/// The parser currently accepts only complete block comments.
+#[must_use]
+pub fn has_closing_block(source_text: &str) -> bool {
+    source_text.trim_end().ends_with("*/")
+}
+
+/// Return the byte range between the opening `/**` and closing `*/`.
+#[must_use]
+pub fn body_range(source_text: &str) -> Option<(usize, usize)> {
+    if !is_jsdoc_block(source_text) || !has_closing_block(source_text) || source_text.len() < 5 {
+        return None;
+    }
+    let leading = source_text.len() - source_text.trim_start().len();
+    let trailing = source_text.len() - source_text.trim_end().len();
+    Some((leading + 3, source_text.len() - trailing - 2))
+}
+
+/// Split the comment body into content lines with parallel margin metadata.
+///
+/// Hot path on parse phase (~44% of `parse_block_into_data` on the
+/// typescript-checker.ts fixture per `examples/profile_parse_block.rs`).
+/// The implementation:
+///
+/// - uses `memchr` for both the line-count estimate and the per-iteration
+///   newline search (SIMD-accelerated on every target memchr supports),
+/// - converts `(raw_start + …) -> u32` via `as u32` instead of
+///   `u32::try_from(…).unwrap()` to drop the panic check (the encoder's
+///   precondition is that source offsets fit in u32 — see `format.md`).
+#[must_use]
+pub fn logical_lines(source_text: &str, base_offset: u32) -> ScanResult<'_> {
+    let Some((body_start, body_end)) = body_range(source_text) else {
+        return ScanResult { lines: Vec::new(), margins: Vec::new() };
+    };
+
+    let body = &source_text[body_start..body_end];
+    let body_bytes = body.as_bytes();
+    let body_len = body_bytes.len();
+
+    // Estimate line count from newline density. memchr's SIMD-accelerated
+    // iterator beats the generic `iter().filter().count()` lowering on the
+    // x86_64 / ARM64 targets we ship.
+    let estimated_lines = memchr::memchr_iter(b'\n', body_bytes).count() + 1;
+    let mut lines = Vec::with_capacity(estimated_lines);
+    let mut margins = Vec::with_capacity(estimated_lines);
+    let mut cursor = 0usize;
+
+    loop {
+        // memchr from `cursor` — single SIMD scan for the next '\n'.
+        let line_end = match memchr::memchr(b'\n', &body_bytes[cursor..]) {
+            Some(off) => cursor + off,
+            None => body_len,
+        };
+        let raw_line = &body[cursor..line_end];
+        let raw_start = body_start + cursor;
+
+        let mut pos = 0usize;
+        let bytes = raw_line.as_bytes();
+
+        let initial_start = pos;
+        while pos < bytes.len() && matches!(bytes[pos], b' ' | b'\t') {
+            pos += 1;
+        }
+        let initial = &raw_line[initial_start..pos];
+
+        let delimiter_start = pos;
+        if bytes.get(pos) == Some(&b'*') {
+            pos += 1;
+        }
+        let delimiter = &raw_line[delimiter_start..pos];
+
+        let post_delim_start = pos;
+        if !delimiter.is_empty() && matches!(bytes.get(pos), Some(b' ' | b'\t')) {
+            pos += 1;
+        }
+        let post_delimiter = &raw_line[post_delim_start..pos];
+
+        let content_start = pos;
+        let content = &raw_line[content_start..];
+
+        let is_content_empty = content.bytes().all(|b| b == b' ' || b == b'\t');
+
+        let line_end_str = if line_end < body_len {
+            if line_end > 0 && body_bytes[line_end - 1] == b'\r' { "\r\n" } else { "\n" }
+        } else {
+            ""
+        };
+
+        // Source offsets fit in u32 by encoder precondition; skip the
+        // `try_from(...).unwrap()` panic check.
+        let absolute_content_start = base_offset + (raw_start + content_start) as u32;
+
+        lines.push(LogicalLine {
+            content,
+            content_start: absolute_content_start,
+            is_content_empty,
+        });
+        margins.push(MarginInfo {
+            initial,
+            delimiter,
+            post_delimiter,
+            line_end: line_end_str,
+            is_content_empty,
+        });
+
+        if line_end == body_len {
+            break;
+        }
+        cursor = line_end + 1;
+    }
+
+    ScanResult { lines, margins }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{body_range, has_closing_block, is_jsdoc_block, logical_lines};
+
+    #[test]
+    fn recognizes_only_closed_jsdoc_blocks() {
+        assert!(is_jsdoc_block("/** ok */"));
+        assert!(!is_jsdoc_block("/* plain */"));
+        assert!(has_closing_block("/** ok */"));
+        assert!(!has_closing_block("/** unclosed"));
+        assert_eq!(body_range("/** ok */"), Some((3, 7)));
+        assert_eq!(body_range("/* plain */"), None);
+    }
+
+    #[test]
+    fn strips_jsdoc_margin_and_keeps_absolute_offsets() {
+        let source = "/**\n * Find a user.\n * @param {string} id\n */";
+        let result = logical_lines(source, 100);
+        assert_eq!(result.lines.len(), 4);
+        assert_eq!(result.lines[1].content, "Find a user.");
+        assert_eq!(result.lines[1].content_start, 107);
+        assert_eq!(result.margins[1].delimiter, "*");
+    }
+}

--- a/crates/ox_jsdoc_binary/src/parser/token.rs
+++ b/crates/ox_jsdoc_binary/src/parser/token.rs
@@ -1,0 +1,148 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Token definitions for the JSDoc type expression Pratt parser.
+//!
+//! Verbatim port of `crates/ox_jsdoc/src/type_parser/token.rs`.
+
+/// Token kind for JSDoc type expressions.
+///
+/// `#[repr(u8)]` keeps `Token` at 12 bytes (Copy-friendly).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+#[allow(missing_docs)]
+pub enum TokenKind {
+    LParen,
+    RParen,
+    LBracket,
+    RBracket,
+    LBrace,
+    RBrace,
+    Pipe,
+    Amp,
+    Lt,
+    Gt,
+    Semicolon,
+    Comma,
+    Star,
+    Question,
+    Bang,
+    Eq,
+    Colon,
+    Dot,
+    At,
+    Hash,
+    Tilde,
+    Slash,
+    Arrow,
+    Ellipsis,
+    Null,
+    Undefined,
+    Function,
+    This,
+    New,
+    Module,
+    Event,
+    Extends,
+    External,
+    Typeof,
+    Keyof,
+    Readonly,
+    Import,
+    Infer,
+    Is,
+    In,
+    Asserts,
+    Unique,
+    Symbol,
+    Identifier,
+    StringValue,
+    TemplateLiteral,
+    Number,
+    EOF,
+}
+
+impl TokenKind {
+    /// Whether this token kind is a keyword that can also serve as an
+    /// identifier in name contexts.
+    #[inline]
+    #[must_use]
+    pub fn is_keyword(self) -> bool {
+        matches!(
+            self,
+            Self::Null
+                | Self::Undefined
+                | Self::Function
+                | Self::This
+                | Self::New
+                | Self::Module
+                | Self::Event
+                | Self::Extends
+                | Self::External
+                | Self::Typeof
+                | Self::Keyof
+                | Self::Readonly
+                | Self::Import
+                | Self::Infer
+                | Self::Is
+                | Self::In
+                | Self::Asserts
+                | Self::Unique
+                | Self::Symbol
+        )
+    }
+
+    /// Whether this token can appear as a type name in prefix position.
+    #[inline]
+    #[must_use]
+    pub fn is_base_name_token(self) -> bool {
+        matches!(
+            self,
+            Self::Module
+                | Self::Keyof
+                | Self::Event
+                | Self::External
+                | Self::Readonly
+                | Self::Is
+                | Self::Typeof
+                | Self::In
+                | Self::Null
+                | Self::Undefined
+                | Self::Function
+                | Self::Asserts
+                | Self::Infer
+                | Self::Extends
+                | Self::Import
+                | Self::Unique
+                | Self::Symbol
+        )
+    }
+}
+
+/// A single token produced by the lexer (12 bytes, `Copy`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Token {
+    /// Absolute start byte offset in the source.
+    pub start: u32,
+    /// Absolute end byte offset in the source.
+    pub end: u32,
+    /// The kind of this token.
+    pub kind: TokenKind,
+}
+
+impl Token {
+    /// Construct a new token.
+    #[inline]
+    #[must_use]
+    pub fn new(kind: TokenKind, start: u32, end: u32) -> Self {
+        Self { start, end, kind }
+    }
+
+    /// Construct an EOF token at the given offset.
+    #[inline]
+    #[must_use]
+    pub fn eof(offset: u32) -> Self {
+        Self { start: offset, end: offset, kind: TokenKind::EOF }
+    }
+}

--- a/crates/ox_jsdoc_binary/src/parser/type_data.rs
+++ b/crates/ox_jsdoc_binary/src/parser/type_data.rs
@@ -1,0 +1,519 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Intermediate type-expression AST used by the binary parser.
+//!
+//! Mirrors `crates/ox_jsdoc/src/type_parser/ast.rs` (`TypeNode` and its 45
+//! variant structs) but uses the std heap rather than an arena so the
+//! binary parser does not need to thread an [`oxc_allocator::Allocator`]
+//! through its Pratt parser. The lifetime `'a` is the source-text borrow.
+//!
+//! After parsing, the [`crate::parser::type_emit`] module walks these
+//! values in DFS pre-order and writes them to a [`BinaryWriter`].
+//!
+//! [`BinaryWriter`]: crate::writer::BinaryWriter
+
+use oxc_span::Span;
+
+/// Position of a prefix/suffix modifier (`?T` vs `T?`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModifierPosition {
+    /// Modifier appears before the operand (`?T`).
+    Prefix,
+    /// Modifier appears after the operand (`T?`).
+    Suffix,
+}
+
+/// Brackets used for generic types (`Array<T>` vs `T[]`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GenericBrackets {
+    /// `<T>` angle brackets.
+    Angle,
+    /// `T[]` square brackets.
+    Square,
+}
+
+/// Quote style for string literals and property keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuoteStyle {
+    /// `'...'`
+    Single,
+    /// `"..."`
+    Double,
+}
+
+/// Separator used in object types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObjectSeparator {
+    /// `,`
+    Comma,
+    /// `;`
+    Semicolon,
+    /// `\n`
+    Linebreak,
+    /// `,\n`
+    CommaAndLinebreak,
+    /// `;\n`
+    SemicolonAndLinebreak,
+}
+
+/// Name path type for `A.B`, `A#B`, `A~B`, `A["key"]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NamePathType {
+    /// `.` property access.
+    Property,
+    /// `#` instance member.
+    Instance,
+    /// `~` inner member.
+    Inner,
+    /// `[...]` bracket access.
+    PropertyBrackets,
+}
+
+/// Special name path prefix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpecialPathType {
+    /// `module:x`
+    Module,
+    /// `event:x`
+    Event,
+    /// `external:x`
+    External,
+}
+
+/// Variadic position (`...T` vs `T...` vs bare `...`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VariadicPosition {
+    /// `...T`
+    Prefix,
+    /// `T...`
+    Suffix,
+}
+
+/// Parse mode for the type parser.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParseMode {
+    /// JSDoc mode: supports JSDoc-specific syntax with loose lexer.
+    Jsdoc,
+    /// Closure mode: supports Closure Compiler syntax with loose lexer.
+    Closure,
+    /// TypeScript mode: strict lexer.
+    Typescript,
+}
+
+impl ParseMode {
+    /// Whether the lexer should use loose rules (NaN, Infinity, hyphens).
+    #[inline]
+    #[must_use]
+    pub const fn is_loose(self) -> bool {
+        matches!(self, Self::Jsdoc | Self::Closure)
+    }
+
+    /// Whether this is jsdoc mode.
+    #[inline]
+    #[must_use]
+    pub const fn is_jsdoc(self) -> bool {
+        matches!(self, Self::Jsdoc)
+    }
+
+    /// Whether this is closure mode.
+    #[inline]
+    #[must_use]
+    pub const fn is_closure(self) -> bool {
+        matches!(self, Self::Closure)
+    }
+
+    /// Whether this is typescript mode.
+    #[inline]
+    #[must_use]
+    pub const fn is_typescript(self) -> bool {
+        matches!(self, Self::Typescript)
+    }
+}
+
+// ============================================================================
+// TypeNodeData enum + 45 variant structs (mirrors `TypeNode`).
+// ============================================================================
+
+/// Parsed type expression. Tree of variants matching the binary AST's 45
+/// TypeNode kinds.
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub enum TypeNodeData<'a> {
+    Name(TypeName<'a>),
+    Number(TypeNumber<'a>),
+    StringValue(TypeStringValue<'a>),
+    Null(TypeNull),
+    Undefined(TypeUndefined),
+    Any(TypeAny),
+    Unknown(TypeUnknown),
+    Union(TypeUnion<'a>),
+    Intersection(TypeIntersection<'a>),
+    Generic(TypeGeneric<'a>),
+    Function(TypeFunction<'a>),
+    Object(TypeObject<'a>),
+    Tuple(TypeTuple<'a>),
+    Parenthesis(TypeParenthesis<'a>),
+    NamePath(TypeNamePath<'a>),
+    SpecialNamePath(TypeSpecialNamePath<'a>),
+    Nullable(TypeNullable<'a>),
+    NotNullable(TypeNotNullable<'a>),
+    Optional(TypeOptional<'a>),
+    Variadic(TypeVariadic<'a>),
+    Conditional(TypeConditional<'a>),
+    Infer(TypeInfer<'a>),
+    KeyOf(TypeKeyOf<'a>),
+    TypeOf(TypeTypeOf<'a>),
+    Import(TypeImport<'a>),
+    Predicate(TypePredicate<'a>),
+    Asserts(TypeAsserts<'a>),
+    AssertsPlain(TypeAssertsPlain<'a>),
+    ReadonlyArray(TypeReadonlyArray<'a>),
+    TemplateLiteral(TypeTemplateLiteral<'a>),
+    UniqueSymbol(TypeUniqueSymbol),
+    Symbol(TypeSymbol<'a>),
+    ObjectField(TypeObjectField<'a>),
+    JsdocObjectField(TypeJsdocObjectField<'a>),
+    KeyValue(TypeKeyValue<'a>),
+    Property(TypeProperty<'a>),
+    IndexSignature(TypeIndexSignature<'a>),
+    MappedType(TypeMappedType<'a>),
+    TypeParameter(TypeTypeParameter<'a>),
+    CallSignature(TypeCallSignature<'a>),
+    ConstructorSignature(TypeConstructorSignature<'a>),
+    MethodSignature(TypeMethodSignature<'a>),
+    IndexedAccessIndex(TypeIndexedAccessIndex<'a>),
+    ParameterList(TypeParameterList<'a>),
+    ReadonlyProperty(TypeReadonlyProperty<'a>),
+}
+
+impl<'a> TypeNodeData<'a> {
+    /// Source span covered by this type expression.
+    #[inline]
+    #[must_use]
+    pub fn span(&self) -> Span {
+        match self {
+            Self::Name(n) => n.span,
+            Self::Number(n) => n.span,
+            Self::StringValue(n) => n.span,
+            Self::Null(n) => n.span,
+            Self::Undefined(n) => n.span,
+            Self::Any(n) => n.span,
+            Self::Unknown(n) => n.span,
+            Self::Union(n) => n.span,
+            Self::Intersection(n) => n.span,
+            Self::Generic(n) => n.span,
+            Self::Function(n) => n.span,
+            Self::Object(n) => n.span,
+            Self::Tuple(n) => n.span,
+            Self::Parenthesis(n) => n.span,
+            Self::NamePath(n) => n.span,
+            Self::SpecialNamePath(n) => n.span,
+            Self::Nullable(n) => n.span,
+            Self::NotNullable(n) => n.span,
+            Self::Optional(n) => n.span,
+            Self::Variadic(n) => n.span,
+            Self::Conditional(n) => n.span,
+            Self::Infer(n) => n.span,
+            Self::KeyOf(n) => n.span,
+            Self::TypeOf(n) => n.span,
+            Self::Import(n) => n.span,
+            Self::Predicate(n) => n.span,
+            Self::Asserts(n) => n.span,
+            Self::AssertsPlain(n) => n.span,
+            Self::ReadonlyArray(n) => n.span,
+            Self::TemplateLiteral(n) => n.span,
+            Self::UniqueSymbol(n) => n.span,
+            Self::Symbol(n) => n.span,
+            Self::ObjectField(n) => n.span,
+            Self::JsdocObjectField(n) => n.span,
+            Self::KeyValue(n) => n.span,
+            Self::Property(n) => n.span,
+            Self::IndexSignature(n) => n.span,
+            Self::MappedType(n) => n.span,
+            Self::TypeParameter(n) => n.span,
+            Self::CallSignature(n) => n.span,
+            Self::ConstructorSignature(n) => n.span,
+            Self::MethodSignature(n) => n.span,
+            Self::IndexedAccessIndex(n) => n.span,
+            Self::ParameterList(n) => n.span,
+            Self::ReadonlyProperty(n) => n.span,
+        }
+    }
+}
+
+#[allow(missing_docs)]
+mod structs {
+    use super::*;
+
+    #[derive(Debug)]
+    pub struct TypeName<'a> {
+        pub span: Span,
+        pub value: &'a str,
+    }
+    #[derive(Debug)]
+    pub struct TypeNumber<'a> {
+        pub span: Span,
+        pub value: &'a str,
+    }
+    #[derive(Debug)]
+    pub struct TypeStringValue<'a> {
+        pub span: Span,
+        pub value: &'a str,
+        pub quote: QuoteStyle,
+    }
+    #[derive(Debug)]
+    pub struct TypeNull {
+        pub span: Span,
+    }
+    #[derive(Debug)]
+    pub struct TypeUndefined {
+        pub span: Span,
+    }
+    #[derive(Debug)]
+    pub struct TypeAny {
+        pub span: Span,
+    }
+    #[derive(Debug)]
+    pub struct TypeUnknown {
+        pub span: Span,
+    }
+    #[derive(Debug)]
+    pub struct TypeUnion<'a> {
+        pub span: Span,
+        pub elements: Vec<Box<TypeNodeData<'a>>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeIntersection<'a> {
+        pub span: Span,
+        pub elements: Vec<Box<TypeNodeData<'a>>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeGeneric<'a> {
+        pub span: Span,
+        pub left: Box<TypeNodeData<'a>>,
+        pub elements: Vec<Box<TypeNodeData<'a>>>,
+        pub brackets: GenericBrackets,
+        pub dot: bool,
+    }
+    #[derive(Debug)]
+    pub struct TypeFunction<'a> {
+        pub span: Span,
+        pub parameters: Vec<Box<TypeNodeData<'a>>>,
+        pub return_type: Option<Box<TypeNodeData<'a>>>,
+        pub type_parameters: Vec<Box<TypeNodeData<'a>>>,
+        pub constructor: bool,
+        pub arrow: bool,
+        pub parenthesis: bool,
+    }
+    #[derive(Debug)]
+    pub struct TypeObject<'a> {
+        pub span: Span,
+        pub elements: Vec<Box<TypeNodeData<'a>>>,
+        pub separator: Option<ObjectSeparator>,
+    }
+    #[derive(Debug)]
+    pub struct TypeTuple<'a> {
+        pub span: Span,
+        pub elements: Vec<Box<TypeNodeData<'a>>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeParenthesis<'a> {
+        pub span: Span,
+        pub element: Box<TypeNodeData<'a>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeNamePath<'a> {
+        pub span: Span,
+        pub left: Box<TypeNodeData<'a>>,
+        pub right: Box<TypeNodeData<'a>>,
+        pub path_type: NamePathType,
+    }
+    #[derive(Debug)]
+    pub struct TypeSpecialNamePath<'a> {
+        pub span: Span,
+        pub value: &'a str,
+        pub special_type: SpecialPathType,
+        pub quote: Option<QuoteStyle>,
+    }
+    #[derive(Debug)]
+    pub struct TypeNullable<'a> {
+        pub span: Span,
+        pub element: Box<TypeNodeData<'a>>,
+        pub position: ModifierPosition,
+    }
+    #[derive(Debug)]
+    pub struct TypeNotNullable<'a> {
+        pub span: Span,
+        pub element: Box<TypeNodeData<'a>>,
+        pub position: ModifierPosition,
+    }
+    #[derive(Debug)]
+    pub struct TypeOptional<'a> {
+        pub span: Span,
+        pub element: Box<TypeNodeData<'a>>,
+        pub position: ModifierPosition,
+    }
+    #[derive(Debug)]
+    pub struct TypeVariadic<'a> {
+        pub span: Span,
+        pub element: Option<Box<TypeNodeData<'a>>>,
+        pub position: Option<VariadicPosition>,
+        pub square_brackets: bool,
+    }
+    #[derive(Debug)]
+    pub struct TypeConditional<'a> {
+        pub span: Span,
+        pub checks_type: Box<TypeNodeData<'a>>,
+        pub extends_type: Box<TypeNodeData<'a>>,
+        pub true_type: Box<TypeNodeData<'a>>,
+        pub false_type: Box<TypeNodeData<'a>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeInfer<'a> {
+        pub span: Span,
+        pub element: Box<TypeNodeData<'a>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeKeyOf<'a> {
+        pub span: Span,
+        pub element: Box<TypeNodeData<'a>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeTypeOf<'a> {
+        pub span: Span,
+        pub element: Box<TypeNodeData<'a>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeImport<'a> {
+        pub span: Span,
+        pub element: Box<TypeNodeData<'a>>,
+    }
+    #[derive(Debug)]
+    pub struct TypePredicate<'a> {
+        pub span: Span,
+        pub left: Box<TypeNodeData<'a>>,
+        pub right: Box<TypeNodeData<'a>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeAsserts<'a> {
+        pub span: Span,
+        pub left: Box<TypeNodeData<'a>>,
+        pub right: Box<TypeNodeData<'a>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeAssertsPlain<'a> {
+        pub span: Span,
+        pub element: Box<TypeNodeData<'a>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeReadonlyArray<'a> {
+        pub span: Span,
+        pub element: Box<TypeNodeData<'a>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeTemplateLiteral<'a> {
+        pub span: Span,
+        pub literals: Vec<&'a str>,
+        pub interpolations: Vec<Box<TypeNodeData<'a>>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeUniqueSymbol {
+        pub span: Span,
+    }
+    #[derive(Debug)]
+    pub struct TypeSymbol<'a> {
+        pub span: Span,
+        pub value: &'a str,
+        pub element: Option<Box<TypeNodeData<'a>>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeObjectField<'a> {
+        pub span: Span,
+        pub key: Box<TypeNodeData<'a>>,
+        pub right: Option<Box<TypeNodeData<'a>>>,
+        pub optional: bool,
+        pub readonly: bool,
+        pub quote: Option<QuoteStyle>,
+    }
+    #[derive(Debug)]
+    pub struct TypeJsdocObjectField<'a> {
+        pub span: Span,
+        pub left: Box<TypeNodeData<'a>>,
+        pub right: Box<TypeNodeData<'a>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeKeyValue<'a> {
+        pub span: Span,
+        pub key: &'a str,
+        pub right: Option<Box<TypeNodeData<'a>>>,
+        pub optional: bool,
+        pub variadic: bool,
+    }
+    #[derive(Debug)]
+    pub struct TypeProperty<'a> {
+        pub span: Span,
+        pub value: &'a str,
+        pub quote: Option<QuoteStyle>,
+    }
+    #[derive(Debug)]
+    pub struct TypeIndexSignature<'a> {
+        pub span: Span,
+        pub key: &'a str,
+        pub right: Box<TypeNodeData<'a>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeMappedType<'a> {
+        pub span: Span,
+        pub key: &'a str,
+        pub right: Box<TypeNodeData<'a>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeTypeParameter<'a> {
+        pub span: Span,
+        pub name: Box<TypeNodeData<'a>>,
+        pub constraint: Option<Box<TypeNodeData<'a>>>,
+        pub default_value: Option<Box<TypeNodeData<'a>>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeCallSignature<'a> {
+        pub span: Span,
+        pub parameters: Vec<Box<TypeNodeData<'a>>>,
+        pub return_type: Box<TypeNodeData<'a>>,
+        pub type_parameters: Vec<Box<TypeNodeData<'a>>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeConstructorSignature<'a> {
+        pub span: Span,
+        pub parameters: Vec<Box<TypeNodeData<'a>>>,
+        pub return_type: Box<TypeNodeData<'a>>,
+        pub type_parameters: Vec<Box<TypeNodeData<'a>>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeMethodSignature<'a> {
+        pub span: Span,
+        pub name: &'a str,
+        pub parameters: Vec<Box<TypeNodeData<'a>>>,
+        pub return_type: Box<TypeNodeData<'a>>,
+        pub type_parameters: Vec<Box<TypeNodeData<'a>>>,
+        pub quote: Option<QuoteStyle>,
+    }
+    #[derive(Debug)]
+    pub struct TypeIndexedAccessIndex<'a> {
+        pub span: Span,
+        pub right: Box<TypeNodeData<'a>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeParameterList<'a> {
+        pub span: Span,
+        pub elements: Vec<Box<TypeNodeData<'a>>>,
+    }
+    #[derive(Debug)]
+    pub struct TypeReadonlyProperty<'a> {
+        pub span: Span,
+        pub element: Box<TypeNodeData<'a>>,
+    }
+}
+
+pub use structs::*;

--- a/crates/ox_jsdoc_binary/src/parser/type_emit.rs
+++ b/crates/ox_jsdoc_binary/src/parser/type_emit.rs
@@ -1,0 +1,579 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Walk a [`TypeNodeData`] tree in DFS pre-order and emit it to a
+//! [`BinaryWriter`]. One `emit_type_node` per Kind; the helpers compute
+//! the Children bitmask up-front (the writer needs it before children are
+//! written), then recursively emit each present child with the parent's
+//! `NodeIndex`.
+//!
+//! Mirrors the layout assumed by `crates/ox_jsdoc_binary/src/decoder/nodes/type_node.rs`:
+//! - Single children (`element`, `left`, `right`, etc.) are direct children
+//!   of the parent at the matching visitor-bit slot.
+//! - Variable-length `elements` lists are emitted as direct children of the
+//!   parent with `(head_index, count)` patched into the parent's Extended
+//!   Data block at [`TYPE_LIST_PARENT_SLOT`]. The Kind 0x7F NodeList wrapper
+//!   that previously sat between parent and elements is no longer emitted.
+//! - Pattern 3 mixed nodes (`TypeKeyValue` etc.) place the optional child
+//!   directly after the parent without a Children bitmask.
+
+use crate::writer::nodes::type_node::*;
+use crate::writer::{BinaryWriter, ExtOffset, NodeIndex};
+
+use super::type_data::*;
+
+/// Emit a TypeNodeData node into `writer` and return the assigned NodeIndex.
+pub fn emit_type_node(
+    writer: &mut BinaryWriter<'_>,
+    node: &TypeNodeData<'_>,
+    parent_index: u32,
+) -> u32 {
+    match node {
+        TypeNodeData::Name(n) => {
+            let v = writer.intern_source_or_string_for_leaf_payload(n.value, n.span);
+            write_type_name(writer, n.span, parent_index, v).as_u32()
+        }
+        TypeNodeData::Number(n) => {
+            let v = writer.intern_source_or_string_for_leaf_payload(n.value, n.span);
+            write_type_number(writer, n.span, parent_index, v).as_u32()
+        }
+        TypeNodeData::StringValue(n) => {
+            let v = writer.intern_source_or_string_for_leaf_payload(n.value, n.span);
+            write_type_string_value(writer, n.span, parent_index, quote_to_u8(Some(n.quote)), v)
+                .as_u32()
+        }
+        TypeNodeData::Property(n) => {
+            // length-mismatch fallback handles the unquoted-property case
+            // (`"foo"` → value `foo`, span `"foo"`).
+            let v = writer.intern_source_or_string_for_leaf_payload(n.value, n.span);
+            write_type_property(writer, n.span, parent_index, quote_to_u8(n.quote), v).as_u32()
+        }
+        TypeNodeData::SpecialNamePath(n) => {
+            // Span here covers `module:foo` while value is just `foo` →
+            // length-mismatch fallback.
+            let v = writer.intern_source_or_string_for_leaf_payload(n.value, n.span);
+            let st = match n.special_type {
+                SpecialPathType::Module => 0,
+                SpecialPathType::Event => 1,
+                SpecialPathType::External => 2,
+            };
+            write_type_special_name_path(writer, n.span, parent_index, st, quote_to_u8(n.quote), v)
+                .as_u32()
+        }
+        TypeNodeData::Null(n) => write_type_null(writer, n.span, parent_index).as_u32(),
+        TypeNodeData::Undefined(n) => write_type_undefined(writer, n.span, parent_index).as_u32(),
+        TypeNodeData::Any(n) => write_type_any(writer, n.span, parent_index).as_u32(),
+        TypeNodeData::Unknown(n) => write_type_unknown(writer, n.span, parent_index).as_u32(),
+        TypeNodeData::UniqueSymbol(n) => {
+            write_type_unique_symbol(writer, n.span, parent_index).as_u32()
+        }
+
+        TypeNodeData::Union(n) => {
+            emit_elements_only(writer, parent_index, n.span, &n.elements, |w, s, p| {
+                write_type_union(w, s, p)
+            })
+        }
+        TypeNodeData::Intersection(n) => {
+            emit_elements_only(writer, parent_index, n.span, &n.elements, |w, s, p| {
+                write_type_intersection(w, s, p)
+            })
+        }
+        TypeNodeData::Tuple(n) => {
+            emit_elements_only(writer, parent_index, n.span, &n.elements, |w, s, p| {
+                write_type_tuple(w, s, p)
+            })
+        }
+        TypeNodeData::TypeParameter(n) => {
+            // TypeTypeParameter wraps name + optional constraint + optional default
+            // as a single elements list per the lazy decoder shape.
+            let mut wrapped: Vec<&TypeNodeData<'_>> = Vec::with_capacity(3);
+            wrapped.push(&n.name);
+            if let Some(c) = n.constraint.as_ref() {
+                wrapped.push(c);
+            }
+            if let Some(d) = n.default_value.as_ref() {
+                wrapped.push(d);
+            }
+            emit_borrowed_elements(writer, parent_index, n.span, &wrapped, |w, s, p| {
+                write_type_type_parameter(w, s, p)
+            })
+        }
+        TypeNodeData::ParameterList(n) => {
+            emit_elements_only(writer, parent_index, n.span, &n.elements, |w, s, p| {
+                write_type_parameter_list(w, s, p)
+            })
+        }
+
+        TypeNodeData::Object(n) => {
+            let sep = match n.separator {
+                Some(ObjectSeparator::Comma) => 1,
+                Some(ObjectSeparator::Semicolon) => 2,
+                Some(ObjectSeparator::Linebreak) => 3,
+                Some(ObjectSeparator::CommaAndLinebreak) => 4,
+                Some(ObjectSeparator::SemicolonAndLinebreak) => 5,
+                None => 0,
+            };
+            let (idx, ext) = write_type_object(writer, n.span, parent_index, sep);
+            let parent = idx.as_u32();
+            if !n.elements.is_empty() {
+                emit_node_list_into_parent(writer, ext, parent, &n.elements);
+            }
+            parent
+        }
+
+        TypeNodeData::Generic(n) => {
+            let (idx, ext) = write_type_generic(
+                writer,
+                n.span,
+                parent_index,
+                match n.brackets {
+                    GenericBrackets::Angle => 0,
+                    GenericBrackets::Square => 1,
+                },
+                n.dot,
+            );
+            let parent = idx.as_u32();
+            emit_type_node(writer, &n.left, parent);
+            if !n.elements.is_empty() {
+                emit_node_list_into_parent(writer, ext, parent, &n.elements);
+            }
+            parent
+        }
+
+        TypeNodeData::Function(n) => emit_function_like(
+            writer,
+            parent_index,
+            n.span,
+            &n.parameters,
+            n.return_type.as_deref(),
+            &n.type_parameters,
+            |w, s, p, b| {
+                write_type_function(w, s, p, n.constructor, n.arrow, n.parenthesis, b).as_u32()
+            },
+        ),
+
+        TypeNodeData::CallSignature(n) => emit_function_like(
+            writer,
+            parent_index,
+            n.span,
+            &n.parameters,
+            Some(&n.return_type),
+            &n.type_parameters,
+            |w, s, p, b| write_type_call_signature(w, s, p, b).as_u32(),
+        ),
+
+        TypeNodeData::ConstructorSignature(n) => emit_function_like(
+            writer,
+            parent_index,
+            n.span,
+            &n.parameters,
+            Some(&n.return_type),
+            &n.type_parameters,
+            |w, s, p, b| write_type_constructor_signature(w, s, p, b).as_u32(),
+        ),
+
+        TypeNodeData::Parenthesis(n) => {
+            emit_single_child(writer, parent_index, n.span, &n.element, |w, s, p, b| {
+                write_type_parenthesis(w, s, p, b).as_u32()
+            })
+        }
+        TypeNodeData::Infer(n) => {
+            emit_single_child(writer, parent_index, n.span, &n.element, |w, s, p, b| {
+                write_type_infer(w, s, p, b).as_u32()
+            })
+        }
+        TypeNodeData::KeyOf(n) => {
+            emit_single_child(writer, parent_index, n.span, &n.element, |w, s, p, b| {
+                write_type_key_of(w, s, p, b).as_u32()
+            })
+        }
+        TypeNodeData::TypeOf(n) => {
+            emit_single_child(writer, parent_index, n.span, &n.element, |w, s, p, b| {
+                write_type_type_of(w, s, p, b).as_u32()
+            })
+        }
+        TypeNodeData::Import(n) => {
+            emit_single_child(writer, parent_index, n.span, &n.element, |w, s, p, b| {
+                write_type_import(w, s, p, b).as_u32()
+            })
+        }
+        TypeNodeData::AssertsPlain(n) => {
+            emit_single_child(writer, parent_index, n.span, &n.element, |w, s, p, b| {
+                write_type_asserts_plain(w, s, p, b).as_u32()
+            })
+        }
+        TypeNodeData::ReadonlyArray(n) => {
+            emit_single_child(writer, parent_index, n.span, &n.element, |w, s, p, b| {
+                write_type_readonly_array(w, s, p, b).as_u32()
+            })
+        }
+        TypeNodeData::IndexedAccessIndex(n) => {
+            emit_single_child(writer, parent_index, n.span, &n.right, |w, s, p, b| {
+                write_type_indexed_access_index(w, s, p, b).as_u32()
+            })
+        }
+        TypeNodeData::ReadonlyProperty(n) => {
+            emit_single_child(writer, parent_index, n.span, &n.element, |w, s, p, b| {
+                write_type_readonly_property(w, s, p, b).as_u32()
+            })
+        }
+
+        TypeNodeData::Nullable(n) => emit_modifier_child(
+            writer,
+            parent_index,
+            n.span,
+            &n.element,
+            n.position,
+            |w, s, p, pos, b| write_type_nullable(w, s, p, pos, b).as_u32(),
+        ),
+        TypeNodeData::NotNullable(n) => emit_modifier_child(
+            writer,
+            parent_index,
+            n.span,
+            &n.element,
+            n.position,
+            |w, s, p, pos, b| write_type_not_nullable(w, s, p, pos, b).as_u32(),
+        ),
+        TypeNodeData::Optional(n) => emit_modifier_child(
+            writer,
+            parent_index,
+            n.span,
+            &n.element,
+            n.position,
+            |w, s, p, pos, b| write_type_optional(w, s, p, pos, b).as_u32(),
+        ),
+        TypeNodeData::Variadic(n) => {
+            let pos = n.position.map_or(0, |p| match p {
+                VariadicPosition::Prefix => 0,
+                VariadicPosition::Suffix => 1,
+            });
+            let bitmask = if n.element.is_some() { 0b1 } else { 0 };
+            let parent =
+                write_type_variadic(writer, n.span, parent_index, pos, n.square_brackets, bitmask)
+                    .as_u32();
+            if let Some(el) = n.element.as_ref() {
+                emit_type_node(writer, el, parent);
+            }
+            parent
+        }
+
+        TypeNodeData::Conditional(n) => {
+            let bitmask = 0b1111;
+            let parent = write_type_conditional(writer, n.span, parent_index, bitmask).as_u32();
+            emit_type_node(writer, &n.checks_type, parent);
+            emit_type_node(writer, &n.extends_type, parent);
+            emit_type_node(writer, &n.true_type, parent);
+            emit_type_node(writer, &n.false_type, parent);
+            parent
+        }
+
+        TypeNodeData::Predicate(n) => {
+            emit_left_right(writer, parent_index, n.span, &n.left, &n.right, |w, s, p, b| {
+                write_type_predicate(w, s, p, b).as_u32()
+            })
+        }
+        TypeNodeData::Asserts(n) => {
+            emit_left_right(writer, parent_index, n.span, &n.left, &n.right, |w, s, p, b| {
+                write_type_asserts(w, s, p, b).as_u32()
+            })
+        }
+
+        TypeNodeData::NamePath(n) => {
+            let pt = match n.path_type {
+                NamePathType::Property => 0,
+                NamePathType::Instance => 1,
+                NamePathType::Inner => 2,
+                NamePathType::PropertyBrackets => 3,
+            };
+            let bitmask = 0b11;
+            let parent = write_type_name_path(writer, n.span, parent_index, pt, bitmask).as_u32();
+            emit_type_node(writer, &n.left, parent);
+            emit_type_node(writer, &n.right, parent);
+            parent
+        }
+
+        TypeNodeData::ObjectField(n) => {
+            let mut bitmask = 0b1; // key
+            if n.right.is_some() {
+                bitmask |= 0b10;
+            }
+            let parent = write_type_object_field(
+                writer,
+                n.span,
+                parent_index,
+                n.optional,
+                n.readonly,
+                quote_to_u8(n.quote),
+                bitmask,
+            )
+            .as_u32();
+            emit_type_node(writer, &n.key, parent);
+            if let Some(r) = n.right.as_ref() {
+                emit_type_node(writer, r, parent);
+            }
+            parent
+        }
+        TypeNodeData::JsdocObjectField(n) => {
+            let bitmask = 0b11;
+            let parent =
+                write_type_jsdoc_object_field(writer, n.span, parent_index, bitmask).as_u32();
+            emit_type_node(writer, &n.left, parent);
+            emit_type_node(writer, &n.right, parent);
+            parent
+        }
+
+        // Pattern 3: Mixed (Extended Data + optional first child).
+        TypeNodeData::KeyValue(n) => {
+            // Span covers `key: value` (or `...key: value`); length-mismatch
+            // fallback when `key` is just the leading identifier.
+            let key = writer.intern_source_or_string(n.key, n.span);
+            let parent =
+                write_type_key_value(writer, n.span, parent_index, n.optional, n.variadic, key)
+                    .as_u32();
+            if let Some(r) = n.right.as_ref() {
+                emit_type_node(writer, r, parent);
+            }
+            parent
+        }
+        TypeNodeData::IndexSignature(n) => {
+            // Span covers `[key: K]: V`; key is just the leading identifier
+            // → length-mismatch fallback.
+            let key = writer.intern_source_or_string(n.key, n.span);
+            let parent = write_type_index_signature(writer, n.span, parent_index, key).as_u32();
+            emit_type_node(writer, &n.right, parent);
+            parent
+        }
+        TypeNodeData::MappedType(n) => {
+            // Same parent-spanning shape as IndexSignature.
+            let key = writer.intern_source_or_string(n.key, n.span);
+            let parent = write_type_mapped_type(writer, n.span, parent_index, key).as_u32();
+            emit_type_node(writer, &n.right, parent);
+            parent
+        }
+        TypeNodeData::MethodSignature(n) => {
+            // Span covers the entire method signature; name is just the
+            // leading identifier → length-mismatch fallback.
+            let name = writer.intern_source_or_string(n.name, n.span);
+            let has_params = !n.parameters.is_empty();
+            let has_tparams = !n.type_parameters.is_empty();
+            let parent = write_type_method_signature(
+                writer,
+                n.span,
+                parent_index,
+                quote_to_u8(n.quote),
+                has_params,
+                has_tparams,
+                name,
+            )
+            .as_u32();
+            // Currently the Rust lazy decoder treats MethodSignature as a leaf
+            // (no exposed children accessors). For round-trip parity with the
+            // typed parser we still emit the parameters/return/type-params
+            // sub-tree as siblings; this matches the design's "code generation
+            // will fill in the rest at Phase 4" note in
+            // `crates/ox_jsdoc_binary/src/decoder/visitor.rs`.
+            for p in &n.parameters {
+                emit_type_node(writer, p, parent);
+            }
+            emit_type_node(writer, &n.return_type, parent);
+            for tp in &n.type_parameters {
+                emit_type_node(writer, tp, parent);
+            }
+            parent
+        }
+        TypeNodeData::TemplateLiteral(n) => {
+            let interned: Vec<crate::writer::StringField> =
+                n.literals.iter().map(|s| writer.intern_string(s)).collect();
+            let parent =
+                write_type_template_literal(writer, n.span, parent_index, &interned).as_u32();
+            for interp in &n.interpolations {
+                emit_type_node(writer, interp, parent);
+            }
+            parent
+        }
+        TypeNodeData::Symbol(n) => {
+            // Span covers `Symbol(...)` while value is the leading name →
+            // length-mismatch fallback.
+            let value = writer.intern_source_or_string(n.value, n.span);
+            let parent =
+                write_type_symbol(writer, n.span, parent_index, n.element.is_some(), value)
+                    .as_u32();
+            if let Some(el) = n.element.as_ref() {
+                emit_type_node(writer, el, parent);
+            }
+            parent
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn quote_to_u8(quote: Option<QuoteStyle>) -> u8 {
+    match quote {
+        None => 0,
+        Some(QuoteStyle::Single) => 1,
+        Some(QuoteStyle::Double) => 2,
+    }
+}
+
+/// Emit `elements` as direct children of `parent_index` and patch the
+/// `(head, count)` metadata into the parent's Extended Data block at
+/// [`TYPE_LIST_PARENT_SLOT`].
+fn emit_node_list_into_parent(
+    writer: &mut BinaryWriter<'_>,
+    parent_ext: ExtOffset,
+    parent_index: u32,
+    elements: &[Box<TypeNodeData<'_>>],
+) {
+    let mut list = writer.begin_node_list_at(parent_ext, TYPE_LIST_PARENT_SLOT);
+    for el in elements {
+        let child_idx = emit_type_node(writer, el, parent_index);
+        writer.record_list_child(&mut list, child_idx);
+    }
+    writer.finalize_node_list(list);
+}
+
+fn emit_borrowed_node_list_into_parent(
+    writer: &mut BinaryWriter<'_>,
+    parent_ext: ExtOffset,
+    parent_index: u32,
+    elements: &[&TypeNodeData<'_>],
+) {
+    let mut list = writer.begin_node_list_at(parent_ext, TYPE_LIST_PARENT_SLOT);
+    for el in elements {
+        let child_idx = emit_type_node(writer, el, parent_index);
+        writer.record_list_child(&mut list, child_idx);
+    }
+    writer.finalize_node_list(list);
+}
+
+fn emit_elements_only<F>(
+    writer: &mut BinaryWriter<'_>,
+    parent_index: u32,
+    span: oxc_span::Span,
+    elements: &[Box<TypeNodeData<'_>>],
+    write_parent: F,
+) -> u32
+where
+    F: FnOnce(&mut BinaryWriter<'_>, oxc_span::Span, u32) -> (NodeIndex, ExtOffset),
+{
+    let (idx, ext) = write_parent(writer, span, parent_index);
+    let parent = idx.as_u32();
+    if !elements.is_empty() {
+        emit_node_list_into_parent(writer, ext, parent, elements);
+    }
+    parent
+}
+
+fn emit_borrowed_elements<F>(
+    writer: &mut BinaryWriter<'_>,
+    parent_index: u32,
+    span: oxc_span::Span,
+    elements: &[&TypeNodeData<'_>],
+    write_parent: F,
+) -> u32
+where
+    F: FnOnce(&mut BinaryWriter<'_>, oxc_span::Span, u32) -> (NodeIndex, ExtOffset),
+{
+    let (idx, ext) = write_parent(writer, span, parent_index);
+    let parent = idx.as_u32();
+    if !elements.is_empty() {
+        emit_borrowed_node_list_into_parent(writer, ext, parent, elements);
+    }
+    parent
+}
+
+fn emit_single_child<F>(
+    writer: &mut BinaryWriter<'_>,
+    parent_index: u32,
+    span: oxc_span::Span,
+    child: &TypeNodeData<'_>,
+    write_parent: F,
+) -> u32
+where
+    F: FnOnce(&mut BinaryWriter<'_>, oxc_span::Span, u32, u32) -> u32,
+{
+    let parent = write_parent(writer, span, parent_index, 0b1);
+    emit_type_node(writer, child, parent);
+    parent
+}
+
+fn emit_modifier_child<F>(
+    writer: &mut BinaryWriter<'_>,
+    parent_index: u32,
+    span: oxc_span::Span,
+    child: &TypeNodeData<'_>,
+    position: ModifierPosition,
+    write_parent: F,
+) -> u32
+where
+    F: FnOnce(&mut BinaryWriter<'_>, oxc_span::Span, u32, u8, u32) -> u32,
+{
+    let pos = match position {
+        ModifierPosition::Prefix => 0,
+        ModifierPosition::Suffix => 1,
+    };
+    let parent = write_parent(writer, span, parent_index, pos, 0b1);
+    emit_type_node(writer, child, parent);
+    parent
+}
+
+fn emit_left_right<F>(
+    writer: &mut BinaryWriter<'_>,
+    parent_index: u32,
+    span: oxc_span::Span,
+    left: &TypeNodeData<'_>,
+    right: &TypeNodeData<'_>,
+    write_parent: F,
+) -> u32
+where
+    F: FnOnce(&mut BinaryWriter<'_>, oxc_span::Span, u32, u32) -> u32,
+{
+    let parent = write_parent(writer, span, parent_index, 0b11);
+    emit_type_node(writer, left, parent);
+    emit_type_node(writer, right, parent);
+    parent
+}
+
+fn emit_function_like<F>(
+    writer: &mut BinaryWriter<'_>,
+    parent_index: u32,
+    span: oxc_span::Span,
+    parameters: &[Box<TypeNodeData<'_>>],
+    return_type: Option<&TypeNodeData<'_>>,
+    type_parameters: &[Box<TypeNodeData<'_>>],
+    write_parent: F,
+) -> u32
+where
+    F: FnOnce(&mut BinaryWriter<'_>, oxc_span::Span, u32, u32) -> u32,
+{
+    let mut bitmask = 0u32;
+    if !parameters.is_empty() {
+        bitmask |= 0b001;
+    }
+    if return_type.is_some() {
+        bitmask |= 0b010;
+    }
+    if !type_parameters.is_empty() {
+        bitmask |= 0b100;
+    }
+    let parent = write_parent(writer, span, parent_index, bitmask);
+
+    if !parameters.is_empty() {
+        // parameters child is itself a TypeParameterList that owns the
+        // elements list metadata in its own Extended Data block.
+        let (plist_idx, plist_ext) = write_type_parameter_list(writer, span, parent);
+        emit_node_list_into_parent(writer, plist_ext, plist_idx.as_u32(), parameters);
+    }
+    if let Some(rt) = return_type {
+        emit_type_node(writer, rt, parent);
+    }
+    if !type_parameters.is_empty() {
+        let (tplist_idx, tplist_ext) = write_type_parameter_list(writer, span, parent);
+        emit_node_list_into_parent(writer, tplist_ext, tplist_idx.as_u32(), type_parameters);
+    }
+    parent
+}

--- a/crates/ox_jsdoc_binary/src/parser/type_parse.rs
+++ b/crates/ox_jsdoc_binary/src/parser/type_parse.rs
@@ -1,0 +1,1783 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Type expression Pratt parser.
+//!
+//! Mirrors `crates/ox_jsdoc/src/parser/type_parse.rs` but builds
+//! [`TypeNodeData`] (heap `Box`) instead of arena-allocated `TypeNode`.
+//! The Pratt parser logic itself is identical.
+
+use oxc_span::Span;
+
+use super::context::ParserContext;
+use super::diagnostics::TypeDiagnosticKind;
+use super::lexer::Lexer;
+use super::precedence::Precedence;
+use super::token::TokenKind;
+use super::type_data::*;
+
+impl<'arena, 'a> ParserContext<'arena, 'a> {
+    /// Parse `{type}` text into a [`TypeNodeData`] expression.
+    pub(crate) fn parse_type_expression(
+        &mut self,
+        type_text: &'a str,
+        type_base_offset: u32,
+        mode: ParseMode,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let mut lexer = Lexer::new(type_text, type_base_offset, mode.is_loose());
+        let mut disallow_conditional = false;
+        let result =
+            self.parse_type_pratt(&mut lexer, mode, &mut disallow_conditional, Precedence::All)?;
+        if lexer.current.kind != TokenKind::EOF {
+            self.type_diag(TypeDiagnosticKind::EarlyEndOfParse);
+            return None;
+        }
+        Some(result)
+    }
+
+    fn parse_type_pratt(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+        min_precedence: Precedence,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let mut left = self.parse_prefix_type(lexer, mode, disallow_conditional)?;
+        loop {
+            if *disallow_conditional && lexer.current.kind == TokenKind::Question {
+                break;
+            }
+            let infix_prec = self.cur_infix_precedence(lexer, mode);
+            if infix_prec <= min_precedence {
+                break;
+            }
+            left = self.parse_infix_type(lexer, mode, disallow_conditional, left)?;
+        }
+        Some(left)
+    }
+
+    fn parse_prefix_type(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        match lexer.current.kind {
+            TokenKind::Identifier | TokenKind::This => self.parse_name(lexer, mode),
+            TokenKind::New if mode.is_typescript() && lexer.next.kind == TokenKind::LParen => {
+                self.parse_new_function(lexer, mode, disallow_conditional)
+            }
+            TokenKind::New => self.parse_name(lexer, mode),
+            TokenKind::Keyof if !mode.is_typescript() => self.parse_name(lexer, mode),
+            TokenKind::Event | TokenKind::External | TokenKind::In
+                if mode.is_typescript() || mode.is_closure() =>
+            {
+                self.parse_name(lexer, mode)
+            }
+            TokenKind::Null => {
+                let token = lexer.current;
+                lexer.bump();
+                Some(Box::new(TypeNodeData::Null(TypeNull {
+                    span: Span::new(token.start, token.end),
+                })))
+            }
+            TokenKind::Undefined => {
+                let token = lexer.current;
+                lexer.bump();
+                Some(Box::new(TypeNodeData::Undefined(TypeUndefined {
+                    span: Span::new(token.start, token.end),
+                })))
+            }
+            TokenKind::Star => {
+                let token = lexer.current;
+                lexer.bump();
+                Some(Box::new(TypeNodeData::Any(TypeAny {
+                    span: Span::new(token.start, token.end),
+                })))
+            }
+            TokenKind::Question => self.parse_nullable_prefix(lexer, mode, disallow_conditional),
+            TokenKind::Bang => self.parse_not_nullable_prefix(lexer, mode, disallow_conditional),
+            TokenKind::Eq if mode.is_jsdoc() || mode.is_closure() => {
+                self.parse_optional_prefix(lexer, mode, disallow_conditional)
+            }
+            TokenKind::Ellipsis => self.parse_variadic_prefix(lexer, mode, disallow_conditional),
+            TokenKind::LParen => {
+                self.parse_parenthesis_or_function(lexer, mode, disallow_conditional)
+            }
+            TokenKind::LBracket if mode.is_typescript() => {
+                self.parse_tuple(lexer, mode, disallow_conditional)
+            }
+            TokenKind::LBrace => self.parse_object_type(lexer, mode, disallow_conditional),
+            TokenKind::Function => self.parse_function_type(lexer, mode, disallow_conditional),
+            TokenKind::Typeof if mode.is_typescript() || mode.is_closure() => {
+                self.parse_typeof(lexer, mode, disallow_conditional)
+            }
+            TokenKind::Keyof if mode.is_typescript() => {
+                self.parse_keyof(lexer, mode, disallow_conditional)
+            }
+            TokenKind::Readonly if mode.is_typescript() => {
+                self.parse_readonly_array(lexer, mode, disallow_conditional)
+            }
+            TokenKind::Import if mode.is_typescript() => {
+                self.parse_import_type(lexer, mode, disallow_conditional)
+            }
+            TokenKind::Infer if mode.is_typescript() => self.parse_infer(lexer, mode),
+            TokenKind::Asserts if mode.is_typescript() => {
+                self.parse_asserts(lexer, mode, disallow_conditional)
+            }
+            TokenKind::Unique if mode.is_typescript() => self.parse_unique_symbol(lexer),
+            TokenKind::Number => self.parse_number_literal(lexer),
+            TokenKind::StringValue => self.parse_string_literal(lexer),
+            TokenKind::TemplateLiteral if mode.is_typescript() => {
+                self.parse_template_literal(lexer, mode, disallow_conditional)
+            }
+            TokenKind::Module => {
+                self.parse_special_name_path_or_name(lexer, mode, SpecialPathType::Module)
+            }
+            TokenKind::Event if mode.is_jsdoc() => {
+                self.parse_special_name_path_or_name(lexer, mode, SpecialPathType::Event)
+            }
+            TokenKind::External if mode.is_jsdoc() => {
+                self.parse_special_name_path_or_name(lexer, mode, SpecialPathType::External)
+            }
+            TokenKind::Symbol if mode.is_jsdoc() || mode.is_closure() => {
+                self.parse_name(lexer, mode)
+            }
+            TokenKind::Extends
+            | TokenKind::Is
+            | TokenKind::In
+            | TokenKind::Readonly
+            | TokenKind::Event
+            | TokenKind::External => self.parse_name(lexer, mode),
+            _ => {
+                self.type_diag(TypeDiagnosticKind::NoParsletFound);
+                None
+            }
+        }
+    }
+
+    #[inline]
+    fn cur_infix_precedence(&self, lexer: &Lexer<'a>, mode: ParseMode) -> Precedence {
+        match lexer.current.kind {
+            TokenKind::Pipe => Precedence::Union,
+            TokenKind::Amp if mode.is_typescript() => Precedence::Intersection,
+            TokenKind::Question => Precedence::Nullable,
+            TokenKind::Bang => Precedence::Nullable,
+            TokenKind::Eq => Precedence::Optional,
+            TokenKind::LBracket => Precedence::ArrayBrackets,
+            TokenKind::Lt => Precedence::Generic,
+            TokenKind::Dot if lexer.next.kind == TokenKind::Lt => Precedence::Generic,
+            TokenKind::Dot | TokenKind::Hash | TokenKind::Tilde => Precedence::NamePath,
+            TokenKind::Arrow => Precedence::Arrow,
+            TokenKind::Is if mode.is_typescript() => Precedence::Infix,
+            TokenKind::Extends if mode.is_typescript() => Precedence::Infix,
+            TokenKind::Ellipsis if mode.is_jsdoc() => Precedence::Infix,
+            TokenKind::LParen if mode.is_jsdoc() || mode.is_closure() => Precedence::Symbol,
+            _ => Precedence::All,
+        }
+    }
+
+    fn parse_infix_type(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+        left: Box<TypeNodeData<'a>>,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        match lexer.current.kind {
+            TokenKind::Pipe => self.parse_union(lexer, mode, disallow_conditional, left),
+            TokenKind::Amp if mode.is_typescript() => {
+                self.parse_intersection(lexer, mode, disallow_conditional, left)
+            }
+            TokenKind::Lt => self.parse_generic(lexer, mode, disallow_conditional, left),
+            TokenKind::Dot if lexer.next.kind == TokenKind::Lt => {
+                self.parse_generic(lexer, mode, disallow_conditional, left)
+            }
+            TokenKind::LBracket => {
+                self.parse_array_brackets_or_indexed(lexer, mode, disallow_conditional, left)
+            }
+            TokenKind::Dot | TokenKind::Hash | TokenKind::Tilde => {
+                self.parse_name_path(lexer, mode, left)
+            }
+            TokenKind::Question => self.parse_nullable_suffix(lexer, left),
+            TokenKind::Bang => self.parse_not_nullable_suffix(lexer, left),
+            TokenKind::Eq => self.parse_optional_suffix(lexer, left),
+            TokenKind::Arrow => self.parse_arrow_function(lexer, mode, disallow_conditional, left),
+            TokenKind::Is if mode.is_typescript() => {
+                self.parse_predicate(lexer, mode, disallow_conditional, left)
+            }
+            TokenKind::Extends if mode.is_typescript() => {
+                self.parse_conditional(lexer, mode, disallow_conditional, left)
+            }
+            TokenKind::Ellipsis if mode.is_jsdoc() => self.parse_variadic_suffix(lexer, left),
+            TokenKind::LParen if mode.is_jsdoc() || mode.is_closure() => {
+                self.parse_symbol(lexer, mode, disallow_conditional, left)
+            }
+            _ => Some(left),
+        }
+    }
+
+    fn try_parse_type<F, T>(&mut self, lexer: &mut Lexer<'a>, f: F) -> Option<T>
+    where
+        F: FnOnce(&mut Self, &mut Lexer<'a>) -> Option<T>,
+    {
+        let saved_lexer = lexer.save();
+        let saved_diag_len = self.diagnostics.len();
+        let result = f(self, lexer);
+        if result.is_none() {
+            lexer.restore(saved_lexer);
+            self.diagnostics.truncate(saved_diag_len);
+        }
+        result
+    }
+
+    #[inline]
+    fn eat(&self, lexer: &mut Lexer<'a>, kind: TokenKind) -> bool {
+        if lexer.current.kind == kind {
+            lexer.bump();
+            true
+        } else {
+            false
+        }
+    }
+
+    #[inline]
+    fn expect(&mut self, lexer: &mut Lexer<'a>, kind: TokenKind) -> bool {
+        if lexer.current.kind == kind {
+            lexer.bump();
+            true
+        } else {
+            self.type_diag(TypeDiagnosticKind::ExpectedToken);
+            false
+        }
+    }
+
+    #[inline]
+    fn parse_name(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        _mode: ParseMode,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let token = lexer.current;
+        let text = lexer.token_text(token);
+        lexer.bump();
+        Some(Box::new(TypeNodeData::Name(TypeName {
+            span: Span::new(token.start, token.end),
+            value: text,
+        })))
+    }
+
+    fn parse_nullable_prefix(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        lexer.bump();
+        match lexer.current.kind {
+            TokenKind::EOF
+            | TokenKind::Pipe
+            | TokenKind::Comma
+            | TokenKind::RParen
+            | TokenKind::RBracket
+            | TokenKind::RBrace
+            | TokenKind::Gt
+            | TokenKind::Eq => {
+                return Some(Box::new(TypeNodeData::Unknown(TypeUnknown {
+                    span: Span::new(start, start + 1),
+                })));
+            }
+            _ => {}
+        }
+        let element =
+            self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::Nullable)?;
+        let end = element.span().end;
+        Some(Box::new(TypeNodeData::Nullable(TypeNullable {
+            span: Span::new(start, end),
+            element,
+            position: ModifierPosition::Prefix,
+        })))
+    }
+
+    fn parse_not_nullable_prefix(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        lexer.bump();
+        let element =
+            self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::Prefix)?;
+        let end = element.span().end;
+        Some(Box::new(TypeNodeData::NotNullable(TypeNotNullable {
+            span: Span::new(start, end),
+            element,
+            position: ModifierPosition::Prefix,
+        })))
+    }
+
+    fn parse_optional_prefix(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        lexer.bump();
+        let element =
+            self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::Optional)?;
+        let end = element.span().end;
+        Some(Box::new(TypeNodeData::Optional(TypeOptional {
+            span: Span::new(start, end),
+            element,
+            position: ModifierPosition::Prefix,
+        })))
+    }
+
+    fn parse_variadic_prefix(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        lexer.bump();
+        if matches!(
+            lexer.current.kind,
+            TokenKind::EOF | TokenKind::Comma | TokenKind::RParen | TokenKind::RBracket
+        ) {
+            return Some(Box::new(TypeNodeData::Variadic(TypeVariadic {
+                span: Span::new(start, start + 3),
+                element: None,
+                position: None,
+                square_brackets: false,
+            })));
+        }
+        if mode.is_jsdoc() && lexer.current.kind == TokenKind::LBracket {
+            lexer.bump();
+            let element =
+                self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::All)?;
+            if !self.expect(lexer, TokenKind::RBracket) {
+                return None;
+            }
+            let end = lexer.current.start;
+            return Some(Box::new(TypeNodeData::Variadic(TypeVariadic {
+                span: Span::new(start, end),
+                element: Some(element),
+                position: Some(VariadicPosition::Prefix),
+                square_brackets: true,
+            })));
+        }
+        let element =
+            self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::Prefix)?;
+        let end = element.span().end;
+        Some(Box::new(TypeNodeData::Variadic(TypeVariadic {
+            span: Span::new(start, end),
+            element: Some(element),
+            position: Some(VariadicPosition::Prefix),
+            square_brackets: false,
+        })))
+    }
+
+    fn parse_parenthesis_or_function(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        if mode.is_typescript() {
+            if let Some(result) = self.try_parse_type(lexer, |this, lex| {
+                this.try_parse_arrow_function_prefix(lex, mode, disallow_conditional, start)
+            }) {
+                return Some(result);
+            }
+        }
+        lexer.bump();
+        let element = self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::All)?;
+        if !self.expect(lexer, TokenKind::RParen) {
+            return None;
+        }
+        let end = lexer.current.start;
+        Some(Box::new(TypeNodeData::Parenthesis(TypeParenthesis {
+            span: Span::new(start, end),
+            element,
+        })))
+    }
+
+    fn try_parse_arrow_function_prefix(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+        start: u32,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        lexer.bump();
+        let mut parameters = Vec::new();
+        if lexer.current.kind != TokenKind::RParen {
+            loop {
+                let param = self.parse_key_value_or_type(lexer, mode, disallow_conditional)?;
+                parameters.push(param);
+                if !self.eat(lexer, TokenKind::Comma) {
+                    break;
+                }
+                if lexer.current.kind == TokenKind::RParen {
+                    break;
+                }
+            }
+        }
+        if !self.eat(lexer, TokenKind::RParen) {
+            return None;
+        }
+        if lexer.current.kind != TokenKind::Arrow {
+            return None;
+        }
+        lexer.bump();
+        let return_type =
+            self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::All)?;
+        let end = return_type.span().end;
+        Some(Box::new(TypeNodeData::Function(TypeFunction {
+            span: Span::new(start, end),
+            parameters,
+            return_type: Some(return_type),
+            type_parameters: Vec::new(),
+            constructor: false,
+            arrow: true,
+            parenthesis: true,
+        })))
+    }
+
+    fn parse_key_value_or_type(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        if (lexer.current.kind == TokenKind::Identifier
+            || lexer.current.kind == TokenKind::This
+            || lexer.current.kind == TokenKind::New
+            || lexer.current.kind.is_keyword())
+            && (lexer.next.kind == TokenKind::Colon || lexer.next.kind == TokenKind::Question)
+        {
+            return self
+                .try_parse_type(lexer, |this, lex| {
+                    this.parse_key_value(lex, mode, disallow_conditional)
+                })
+                .or_else(|| {
+                    self.parse_type_pratt(
+                        lexer,
+                        mode,
+                        disallow_conditional,
+                        Precedence::ParameterList,
+                    )
+                });
+        }
+        if lexer.current.kind == TokenKind::Ellipsis {
+            let start = lexer.current.start;
+            lexer.bump();
+            if (lexer.current.kind == TokenKind::Identifier || lexer.current.kind.is_keyword())
+                && lexer.next.kind == TokenKind::Colon
+            {
+                let key_token = lexer.current;
+                let key = lexer.token_text(key_token);
+                lexer.bump();
+                lexer.bump();
+                let right = self.parse_type_pratt(
+                    lexer,
+                    mode,
+                    disallow_conditional,
+                    Precedence::ParameterList,
+                )?;
+                let end = right.span().end;
+                return Some(Box::new(TypeNodeData::KeyValue(TypeKeyValue {
+                    span: Span::new(start, end),
+                    key,
+                    right: Some(right),
+                    optional: false,
+                    variadic: true,
+                })));
+            }
+            let element =
+                self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::Prefix)?;
+            let end = element.span().end;
+            return Some(Box::new(TypeNodeData::Variadic(TypeVariadic {
+                span: Span::new(start, end),
+                element: Some(element),
+                position: Some(VariadicPosition::Prefix),
+                square_brackets: false,
+            })));
+        }
+        self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::ParameterList)
+    }
+
+    fn parse_key_value(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        let key_token = lexer.current;
+        let key = lexer.token_text(key_token);
+        lexer.bump();
+        let optional = self.eat(lexer, TokenKind::Question);
+        if !self.eat(lexer, TokenKind::Colon) {
+            return None;
+        }
+        let right =
+            self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::KeyValue)?;
+        let end = right.span().end;
+        Some(Box::new(TypeNodeData::KeyValue(TypeKeyValue {
+            span: Span::new(start, end),
+            key,
+            right: Some(right),
+            optional,
+            variadic: false,
+        })))
+    }
+
+    fn parse_tuple(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        lexer.bump();
+        let mut elements = Vec::new();
+        if lexer.current.kind != TokenKind::RBracket {
+            loop {
+                let element = self.parse_key_value_or_type(lexer, mode, disallow_conditional)?;
+                elements.push(element);
+                if !self.eat(lexer, TokenKind::Comma) {
+                    break;
+                }
+                if lexer.current.kind == TokenKind::RBracket {
+                    break;
+                }
+            }
+        }
+        if !self.expect(lexer, TokenKind::RBracket) {
+            self.type_diag(TypeDiagnosticKind::UnclosedTuple);
+            return None;
+        }
+        let end = lexer.current.start;
+        Some(Box::new(TypeNodeData::Tuple(TypeTuple { span: Span::new(start, end), elements })))
+    }
+
+    fn parse_object_type(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        lexer.bump();
+        let mut elements = Vec::new();
+        let mut separator = None;
+        if lexer.current.kind != TokenKind::RBrace {
+            loop {
+                let field = self.parse_object_field(lexer, mode, disallow_conditional)?;
+                elements.push(field);
+                if self.eat(lexer, TokenKind::Comma) {
+                    separator = Some(ObjectSeparator::Comma);
+                } else if self.eat(lexer, TokenKind::Semicolon) {
+                    separator = Some(ObjectSeparator::Semicolon);
+                } else {
+                    break;
+                }
+            }
+        }
+        if !self.expect(lexer, TokenKind::RBrace) {
+            self.type_diag(TypeDiagnosticKind::UnclosedObject);
+            return None;
+        }
+        let end = lexer.current.start;
+        Some(Box::new(TypeNodeData::Object(TypeObject {
+            span: Span::new(start, end),
+            elements,
+            separator,
+        })))
+    }
+
+    fn parse_object_field(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        let readonly = lexer.current.kind == TokenKind::Readonly
+            && lexer.next.kind != TokenKind::Colon
+            && lexer.next.kind != TokenKind::Comma
+            && lexer.next.kind != TokenKind::Semicolon
+            && lexer.next.kind != TokenKind::RBrace;
+        if readonly {
+            lexer.bump();
+        }
+        if lexer.current.kind == TokenKind::LBracket {
+            return self.parse_index_signature_or_mapped(
+                lexer,
+                mode,
+                disallow_conditional,
+                start,
+                readonly,
+            );
+        }
+        if lexer.current.kind == TokenKind::LParen && !readonly {
+            return self.parse_call_signature(lexer, mode, disallow_conditional, start);
+        }
+        if lexer.current.kind == TokenKind::New
+            && (lexer.next.kind == TokenKind::LParen || lexer.next.kind == TokenKind::Lt)
+            && mode.is_typescript()
+            && !readonly
+        {
+            return self.parse_constructor_signature(lexer, mode, disallow_conditional, start);
+        }
+        if lexer.current.kind == TokenKind::Lt && !readonly {
+            return self.parse_call_signature_with_type_params(
+                lexer,
+                mode,
+                disallow_conditional,
+                start,
+            );
+        }
+        let quote = match lexer.current.kind {
+            TokenKind::StringValue => {
+                if lexer.token_text(lexer.current).starts_with('"') {
+                    Some(QuoteStyle::Double)
+                } else {
+                    Some(QuoteStyle::Single)
+                }
+            }
+            _ => None,
+        };
+        if mode.is_jsdoc()
+            && !matches!(
+                lexer.next.kind,
+                TokenKind::Colon
+                    | TokenKind::Question
+                    | TokenKind::Comma
+                    | TokenKind::Semicolon
+                    | TokenKind::RBrace
+            )
+        {
+            let left =
+                self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::KeyValue)?;
+            if self.eat(lexer, TokenKind::Colon) {
+                let right =
+                    self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::KeyValue)?;
+                let end = right.span().end;
+                return Some(Box::new(TypeNodeData::JsdocObjectField(TypeJsdocObjectField {
+                    span: Span::new(start, end),
+                    left,
+                    right,
+                })));
+            }
+            let end = left.span().end;
+            return Some(Box::new(TypeNodeData::JsdocObjectField(TypeJsdocObjectField {
+                span: Span::new(start, end),
+                left: Box::new(TypeNodeData::Name(TypeName {
+                    span: Span::new(start, start),
+                    value: "",
+                })),
+                right: left,
+            })));
+        }
+        let key_token = lexer.current;
+        let key_text = lexer.token_text(key_token);
+        lexer.bump();
+        if (lexer.current.kind == TokenKind::LParen || lexer.current.kind == TokenKind::Lt)
+            && mode.is_typescript()
+            && !readonly
+        {
+            return self.parse_method_signature(
+                lexer,
+                mode,
+                disallow_conditional,
+                start,
+                key_text,
+                quote,
+            );
+        }
+        let key = Box::new(TypeNodeData::Name(TypeName {
+            span: Span::new(key_token.start, key_token.end),
+            value: key_text,
+        }));
+        let optional = self.eat(lexer, TokenKind::Question);
+        let right = if self.eat(lexer, TokenKind::Colon) {
+            Some(self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::KeyValue)?)
+        } else {
+            None
+        };
+        let end = right.as_ref().map_or(key_token.end, |r| r.span().end);
+        Some(Box::new(TypeNodeData::ObjectField(TypeObjectField {
+            span: Span::new(start, end),
+            key,
+            right,
+            optional,
+            readonly,
+            quote,
+        })))
+    }
+
+    fn parse_type_parameters(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Vec<Box<TypeNodeData<'a>>> {
+        let mut type_params = Vec::new();
+        if lexer.current.kind != TokenKind::Lt {
+            return type_params;
+        }
+        lexer.bump();
+        loop {
+            let tp_start = lexer.current.start;
+            let name_token = lexer.current;
+            let name_text = lexer.token_text(name_token);
+            lexer.bump();
+            let name = Box::new(TypeNodeData::Name(TypeName {
+                span: Span::new(name_token.start, name_token.end),
+                value: name_text,
+            }));
+            let constraint = if lexer.current.kind == TokenKind::Extends {
+                lexer.bump();
+                self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::Optional)
+            } else {
+                None
+            };
+            let default_value = if self.eat(lexer, TokenKind::Eq) {
+                self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::Optional)
+            } else {
+                None
+            };
+            let end = default_value
+                .as_ref()
+                .map_or(constraint.as_ref().map_or(name_token.end, |c| c.span().end), |d| {
+                    d.span().end
+                });
+            type_params.push(Box::new(TypeNodeData::TypeParameter(TypeTypeParameter {
+                span: Span::new(tp_start, end),
+                name,
+                constraint,
+                default_value,
+            })));
+            if !self.eat(lexer, TokenKind::Comma) {
+                break;
+            }
+        }
+        self.expect(lexer, TokenKind::Gt);
+        type_params
+    }
+
+    fn parse_call_signature(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+        start: u32,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        lexer.bump();
+        let mut parameters = Vec::new();
+        if lexer.current.kind != TokenKind::RParen {
+            loop {
+                let param = self.parse_key_value_or_type(lexer, mode, disallow_conditional)?;
+                parameters.push(param);
+                if !self.eat(lexer, TokenKind::Comma) {
+                    break;
+                }
+            }
+        }
+        self.expect(lexer, TokenKind::RParen);
+        self.expect(lexer, TokenKind::Colon);
+        let return_type =
+            self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::Prefix)?;
+        let end = return_type.span().end;
+        Some(Box::new(TypeNodeData::CallSignature(TypeCallSignature {
+            span: Span::new(start, end),
+            parameters,
+            return_type,
+            type_parameters: Vec::new(),
+        })))
+    }
+
+    fn parse_call_signature_with_type_params(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+        start: u32,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let type_parameters = self.parse_type_parameters(lexer, mode, disallow_conditional);
+        self.expect(lexer, TokenKind::LParen);
+        let mut parameters = Vec::new();
+        if lexer.current.kind != TokenKind::RParen {
+            loop {
+                let param = self.parse_key_value_or_type(lexer, mode, disallow_conditional)?;
+                parameters.push(param);
+                if !self.eat(lexer, TokenKind::Comma) {
+                    break;
+                }
+            }
+        }
+        self.expect(lexer, TokenKind::RParen);
+        self.expect(lexer, TokenKind::Colon);
+        let return_type =
+            self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::Prefix)?;
+        let end = return_type.span().end;
+        Some(Box::new(TypeNodeData::CallSignature(TypeCallSignature {
+            span: Span::new(start, end),
+            parameters,
+            return_type,
+            type_parameters,
+        })))
+    }
+
+    fn parse_constructor_signature(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+        start: u32,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        lexer.bump();
+        let type_parameters = self.parse_type_parameters(lexer, mode, disallow_conditional);
+        self.expect(lexer, TokenKind::LParen);
+        let mut parameters = Vec::new();
+        if lexer.current.kind != TokenKind::RParen {
+            loop {
+                let param = self.parse_key_value_or_type(lexer, mode, disallow_conditional)?;
+                parameters.push(param);
+                if !self.eat(lexer, TokenKind::Comma) {
+                    break;
+                }
+            }
+        }
+        self.expect(lexer, TokenKind::RParen);
+        self.expect(lexer, TokenKind::Colon);
+        let return_type =
+            self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::Prefix)?;
+        let end = return_type.span().end;
+        Some(Box::new(TypeNodeData::ConstructorSignature(TypeConstructorSignature {
+            span: Span::new(start, end),
+            parameters,
+            return_type,
+            type_parameters,
+        })))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn parse_method_signature(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+        start: u32,
+        name: &'a str,
+        quote: Option<QuoteStyle>,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let type_parameters = self.parse_type_parameters(lexer, mode, disallow_conditional);
+        self.expect(lexer, TokenKind::LParen);
+        let mut parameters = Vec::new();
+        if lexer.current.kind != TokenKind::RParen {
+            loop {
+                let param = self.parse_key_value_or_type(lexer, mode, disallow_conditional)?;
+                parameters.push(param);
+                if !self.eat(lexer, TokenKind::Comma) {
+                    break;
+                }
+            }
+        }
+        self.expect(lexer, TokenKind::RParen);
+        self.expect(lexer, TokenKind::Colon);
+        let return_type =
+            self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::Prefix)?;
+        let end = return_type.span().end;
+        Some(Box::new(TypeNodeData::MethodSignature(TypeMethodSignature {
+            span: Span::new(start, end),
+            name,
+            parameters,
+            return_type,
+            type_parameters,
+            quote,
+        })))
+    }
+
+    fn parse_index_signature_or_mapped(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+        start: u32,
+        readonly: bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        lexer.bump();
+        let key_token = lexer.current;
+        let key = lexer.token_text(key_token);
+        lexer.bump();
+        if lexer.current.kind == TokenKind::In {
+            lexer.bump();
+            let _right =
+                self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::All)?;
+            self.expect(lexer, TokenKind::RBracket);
+            self.eat(lexer, TokenKind::Question);
+            self.expect(lexer, TokenKind::Colon);
+            let value =
+                self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::KeyValue)?;
+            let end = value.span().end;
+            return Some(Box::new(TypeNodeData::MappedType(TypeMappedType {
+                span: Span::new(start, end),
+                key,
+                right: value,
+            })));
+        }
+        if lexer.current.kind == TokenKind::Colon {
+            lexer.bump();
+            let _index_type =
+                self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::All)?;
+            self.expect(lexer, TokenKind::RBracket);
+            self.expect(lexer, TokenKind::Colon);
+            let value =
+                self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::KeyValue)?;
+            let end = value.span().end;
+            return Some(Box::new(TypeNodeData::IndexSignature(TypeIndexSignature {
+                span: Span::new(start, end),
+                key,
+                right: value,
+            })));
+        }
+        self.expect(lexer, TokenKind::RBracket);
+        let optional = self.eat(lexer, TokenKind::Question);
+        if lexer.current.kind == TokenKind::LParen || lexer.current.kind == TokenKind::Lt {
+            let type_parameters = self.parse_type_parameters(lexer, mode, disallow_conditional);
+            self.expect(lexer, TokenKind::LParen);
+            let mut parameters = Vec::new();
+            if lexer.current.kind != TokenKind::RParen {
+                loop {
+                    let param = self.parse_key_value_or_type(lexer, mode, disallow_conditional)?;
+                    parameters.push(param);
+                    if !self.eat(lexer, TokenKind::Comma) {
+                        break;
+                    }
+                    if lexer.current.kind == TokenKind::RParen {
+                        break;
+                    }
+                }
+            }
+            self.expect(lexer, TokenKind::RParen);
+            self.expect(lexer, TokenKind::Colon);
+            let return_type =
+                self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::Prefix)?;
+            let end = return_type.span().end;
+            let key_node = Box::new(TypeNodeData::Name(TypeName {
+                span: Span::new(key_token.start, key_token.end),
+                value: key,
+            }));
+            return Some(Box::new(TypeNodeData::ObjectField(TypeObjectField {
+                span: Span::new(start, end),
+                key: key_node,
+                right: Some(Box::new(TypeNodeData::Function(TypeFunction {
+                    span: Span::new(key_token.start, end),
+                    parameters,
+                    return_type: Some(return_type),
+                    type_parameters,
+                    constructor: false,
+                    arrow: false,
+                    parenthesis: true,
+                }))),
+                optional,
+                readonly,
+                quote: None,
+            })));
+        }
+        self.expect(lexer, TokenKind::Colon);
+        let value =
+            self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::KeyValue)?;
+        let end = value.span().end;
+        let key_node = Box::new(TypeNodeData::Name(TypeName {
+            span: Span::new(key_token.start, key_token.end),
+            value: key,
+        }));
+        Some(Box::new(TypeNodeData::ObjectField(TypeObjectField {
+            span: Span::new(start, end),
+            key: key_node,
+            right: Some(value),
+            optional,
+            readonly,
+            quote: None,
+        })))
+    }
+
+    fn parse_function_type(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        lexer.bump();
+        if lexer.current.kind != TokenKind::LParen {
+            if mode.is_jsdoc() {
+                return Some(Box::new(TypeNodeData::Function(TypeFunction {
+                    span: Span::new(start, start + 8),
+                    parameters: Vec::new(),
+                    return_type: None,
+                    type_parameters: Vec::new(),
+                    constructor: false,
+                    arrow: false,
+                    parenthesis: false,
+                })));
+            }
+            return Some(Box::new(TypeNodeData::Name(TypeName {
+                span: Span::new(start, start + 8),
+                value: "function",
+            })));
+        }
+        lexer.bump();
+        let mut parameters = Vec::new();
+        let mut constructor = false;
+        if lexer.current.kind != TokenKind::RParen {
+            if lexer.current.kind == TokenKind::New && lexer.next.kind == TokenKind::Colon {
+                constructor = true;
+            }
+            loop {
+                let param = self.parse_key_value_or_type(lexer, mode, disallow_conditional)?;
+                parameters.push(param);
+                if !self.eat(lexer, TokenKind::Comma) {
+                    break;
+                }
+                if lexer.current.kind == TokenKind::RParen {
+                    break;
+                }
+            }
+        }
+        self.expect(lexer, TokenKind::RParen);
+        let return_type = if self.eat(lexer, TokenKind::Colon) {
+            Some(self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::Prefix)?)
+        } else {
+            None
+        };
+        let end = return_type.as_ref().map_or(lexer.current.start, |r| r.span().end);
+        Some(Box::new(TypeNodeData::Function(TypeFunction {
+            span: Span::new(start, end),
+            parameters,
+            return_type,
+            type_parameters: Vec::new(),
+            constructor,
+            arrow: false,
+            parenthesis: true,
+        })))
+    }
+
+    fn parse_new_function(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        lexer.bump();
+        lexer.bump();
+        let mut parameters = Vec::new();
+        if lexer.current.kind != TokenKind::RParen {
+            loop {
+                let param = self.parse_key_value_or_type(lexer, mode, disallow_conditional)?;
+                parameters.push(param);
+                if !self.eat(lexer, TokenKind::Comma) {
+                    break;
+                }
+            }
+        }
+        self.expect(lexer, TokenKind::RParen);
+        let (return_type, arrow) = if self.eat(lexer, TokenKind::Arrow) {
+            (
+                Some(self.parse_type_pratt(
+                    lexer,
+                    mode,
+                    disallow_conditional,
+                    Precedence::Prefix,
+                )?),
+                true,
+            )
+        } else if self.eat(lexer, TokenKind::Colon) {
+            (
+                Some(self.parse_type_pratt(
+                    lexer,
+                    mode,
+                    disallow_conditional,
+                    Precedence::Prefix,
+                )?),
+                false,
+            )
+        } else {
+            (None, false)
+        };
+        let end = return_type.as_ref().map_or(lexer.current.start, |r| r.span().end);
+        Some(Box::new(TypeNodeData::Function(TypeFunction {
+            span: Span::new(start, end),
+            parameters,
+            return_type,
+            type_parameters: Vec::new(),
+            constructor: true,
+            arrow,
+            parenthesis: true,
+        })))
+    }
+
+    fn parse_typeof(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        lexer.bump();
+        let element =
+            self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::KeyOfTypeOf)?;
+        let end = element.span().end;
+        Some(Box::new(TypeNodeData::TypeOf(TypeTypeOf { span: Span::new(start, end), element })))
+    }
+
+    fn parse_keyof(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        lexer.bump();
+        let element =
+            self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::KeyOfTypeOf)?;
+        let end = element.span().end;
+        Some(Box::new(TypeNodeData::KeyOf(TypeKeyOf { span: Span::new(start, end), element })))
+    }
+
+    fn parse_readonly_array(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        lexer.bump();
+        let element =
+            self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::Prefix)?;
+        let end = element.span().end;
+        Some(Box::new(TypeNodeData::ReadonlyArray(TypeReadonlyArray {
+            span: Span::new(start, end),
+            element,
+        })))
+    }
+
+    fn parse_import_type(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        _mode: ParseMode,
+        _disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        lexer.bump();
+        self.expect(lexer, TokenKind::LParen);
+        let element_token = lexer.current;
+        if element_token.kind != TokenKind::StringValue {
+            self.type_diag(TypeDiagnosticKind::ExpectedToken);
+            return None;
+        }
+        let text = lexer.token_text(element_token);
+        let element = Box::new(TypeNodeData::StringValue(TypeStringValue {
+            span: Span::new(element_token.start, element_token.end),
+            value: text,
+            quote: if text.starts_with('"') { QuoteStyle::Double } else { QuoteStyle::Single },
+        }));
+        lexer.bump();
+        if !self.expect(lexer, TokenKind::RParen) {
+            return None;
+        }
+        let end = lexer.current.start;
+        Some(Box::new(TypeNodeData::Import(TypeImport { span: Span::new(start, end), element })))
+    }
+
+    fn parse_infer(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        _mode: ParseMode,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        lexer.bump();
+        let name_token = lexer.current;
+        let name_text = lexer.token_text(name_token);
+        lexer.bump();
+        let element = Box::new(TypeNodeData::Name(TypeName {
+            span: Span::new(name_token.start, name_token.end),
+            value: name_text,
+        }));
+        let end = name_token.end;
+        Some(Box::new(TypeNodeData::Infer(TypeInfer { span: Span::new(start, end), element })))
+    }
+
+    fn parse_asserts(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        lexer.bump();
+        if !matches!(lexer.current.kind, TokenKind::Identifier | TokenKind::This | TokenKind::New)
+            && !lexer.current.kind.is_keyword()
+        {
+            self.type_diag(TypeDiagnosticKind::ExpectedToken);
+            return None;
+        }
+        let name_token = lexer.current;
+        let name_text = lexer.token_text(name_token);
+        lexer.bump();
+        let left = Box::new(TypeNodeData::Name(TypeName {
+            span: Span::new(name_token.start, name_token.end),
+            value: name_text,
+        }));
+        if lexer.current.kind == TokenKind::Is {
+            lexer.bump();
+            let right =
+                self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::All)?;
+            let end = right.span().end;
+            Some(Box::new(TypeNodeData::Asserts(TypeAsserts {
+                span: Span::new(start, end),
+                left,
+                right,
+            })))
+        } else {
+            let end = name_token.end;
+            Some(Box::new(TypeNodeData::AssertsPlain(TypeAssertsPlain {
+                span: Span::new(start, end),
+                element: left,
+            })))
+        }
+    }
+
+    fn parse_unique_symbol(&mut self, lexer: &mut Lexer<'a>) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        lexer.bump();
+        if lexer.current.kind == TokenKind::Symbol {
+            let end = lexer.current.end;
+            lexer.bump();
+            Some(Box::new(TypeNodeData::UniqueSymbol(TypeUniqueSymbol {
+                span: Span::new(start, end),
+            })))
+        } else {
+            Some(Box::new(TypeNodeData::Name(TypeName {
+                span: Span::new(start, start + 6),
+                value: "unique",
+            })))
+        }
+    }
+
+    fn parse_number_literal(&mut self, lexer: &mut Lexer<'a>) -> Option<Box<TypeNodeData<'a>>> {
+        let token = lexer.current;
+        let text = lexer.token_text(token);
+        lexer.bump();
+        Some(Box::new(TypeNodeData::Number(TypeNumber {
+            span: Span::new(token.start, token.end),
+            value: text,
+        })))
+    }
+
+    fn parse_string_literal(&mut self, lexer: &mut Lexer<'a>) -> Option<Box<TypeNodeData<'a>>> {
+        let token = lexer.current;
+        let text = lexer.token_text(token);
+        let quote = if text.starts_with('"') { QuoteStyle::Double } else { QuoteStyle::Single };
+        lexer.bump();
+        Some(Box::new(TypeNodeData::StringValue(TypeStringValue {
+            span: Span::new(token.start, token.end),
+            value: text,
+            quote,
+        })))
+    }
+
+    fn parse_template_literal(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let token = lexer.current;
+        let text = lexer.token_text(token);
+        lexer.bump();
+        let mut literals: Vec<&'a str> = Vec::new();
+        let mut interpolations: Vec<Box<TypeNodeData<'a>>> = Vec::new();
+        let inner = if text.len() >= 2 { &text[1..text.len() - 1] } else { text };
+        let bytes = inner.as_bytes();
+        let mut pos = 0;
+        let mut lit_start = 0;
+        while pos < bytes.len() {
+            if bytes[pos] == b'\\' && pos + 1 < bytes.len() {
+                pos += 2;
+            } else if bytes[pos] == b'$' && pos + 1 < bytes.len() && bytes[pos + 1] == b'{' {
+                literals.push(&inner[lit_start..pos]);
+                let interp_start = pos + 2;
+                let mut depth = 1u32;
+                let mut interp_end = interp_start;
+                while interp_end < bytes.len() && depth > 0 {
+                    if bytes[interp_end] == b'{' {
+                        depth += 1;
+                    } else if bytes[interp_end] == b'}' {
+                        depth -= 1;
+                    }
+                    if depth > 0 {
+                        interp_end += 1;
+                    }
+                }
+                let interp_text = &inner[interp_start..interp_end];
+                let interp_base = token.start + 1 + interp_start as u32;
+                let mut interp_lexer = Lexer::new(interp_text, interp_base, mode.is_loose());
+                if let Some(node) = self.parse_type_pratt(
+                    &mut interp_lexer,
+                    mode,
+                    disallow_conditional,
+                    Precedence::All,
+                ) {
+                    interpolations.push(node);
+                }
+                pos = if interp_end < bytes.len() { interp_end + 1 } else { interp_end };
+                lit_start = pos;
+            } else {
+                pos += 1;
+            }
+        }
+        literals.push(&inner[lit_start..]);
+        Some(Box::new(TypeNodeData::TemplateLiteral(TypeTemplateLiteral {
+            span: Span::new(token.start, token.end),
+            literals,
+            interpolations,
+        })))
+    }
+
+    fn parse_special_name_path_or_name(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        special_type: SpecialPathType,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = lexer.current.start;
+        if lexer.next.kind == TokenKind::Colon {
+            lexer.bump();
+            lexer.bump();
+            let quote = match lexer.current.kind {
+                TokenKind::StringValue => {
+                    let text = lexer.token_text(lexer.current);
+                    if text.starts_with('"') {
+                        Some(QuoteStyle::Double)
+                    } else {
+                        Some(QuoteStyle::Single)
+                    }
+                }
+                _ => None,
+            };
+            let value_start = lexer.current.start;
+            let mut value_end = lexer.current.end;
+            lexer.bump();
+            while matches!(
+                lexer.current.kind,
+                TokenKind::Dot | TokenKind::Slash | TokenKind::Identifier
+            ) || lexer.current.kind.is_keyword()
+            {
+                value_end = lexer.current.end;
+                lexer.bump();
+            }
+            let raw_value = self.get_type_source_text(lexer, value_start, value_end);
+            let value = if quote.is_some() && raw_value.len() >= 2 {
+                &raw_value[1..raw_value.len() - 1]
+            } else {
+                raw_value
+            };
+            return Some(Box::new(TypeNodeData::SpecialNamePath(TypeSpecialNamePath {
+                span: Span::new(start, value_end),
+                value,
+                special_type,
+                quote,
+            })));
+        }
+        self.parse_name(lexer, mode)
+    }
+
+    fn get_type_source_text(&self, lexer: &Lexer<'a>, abs_start: u32, abs_end: u32) -> &'a str {
+        let token =
+            super::token::Token::new(super::token::TokenKind::Identifier, abs_start, abs_end);
+        lexer.token_text(token)
+    }
+
+    // Infix implementations -------------------------------------------------
+
+    fn parse_union(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+        left: Box<TypeNodeData<'a>>,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = left.span().start;
+        lexer.bump();
+        let mut elements = Vec::with_capacity(4);
+        elements.push(left);
+        loop {
+            let element =
+                self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::Union)?;
+            elements.push(element);
+            if !self.eat(lexer, TokenKind::Pipe) {
+                break;
+            }
+        }
+        let end = elements.last().unwrap().span().end;
+        Some(Box::new(TypeNodeData::Union(TypeUnion { span: Span::new(start, end), elements })))
+    }
+
+    fn parse_intersection(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+        left: Box<TypeNodeData<'a>>,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = left.span().start;
+        lexer.bump();
+        let mut elements = Vec::with_capacity(4);
+        elements.push(left);
+        loop {
+            let element =
+                self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::Intersection)?;
+            elements.push(element);
+            if !self.eat(lexer, TokenKind::Amp) {
+                break;
+            }
+        }
+        let end = elements.last().unwrap().span().end;
+        Some(Box::new(TypeNodeData::Intersection(TypeIntersection {
+            span: Span::new(start, end),
+            elements,
+        })))
+    }
+
+    fn parse_generic(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+        left: Box<TypeNodeData<'a>>,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = left.span().start;
+        let dot = self.eat(lexer, TokenKind::Dot);
+        lexer.bump();
+        let mut elements = Vec::with_capacity(4);
+        loop {
+            let element = self.parse_type_pratt(
+                lexer,
+                mode,
+                disallow_conditional,
+                Precedence::ParameterList,
+            )?;
+            elements.push(element);
+            if !self.eat(lexer, TokenKind::Comma) {
+                break;
+            }
+        }
+        if !self.expect(lexer, TokenKind::Gt) {
+            self.type_diag(TypeDiagnosticKind::UnclosedGeneric);
+            return None;
+        }
+        let end = lexer.current.start;
+        Some(Box::new(TypeNodeData::Generic(TypeGeneric {
+            span: Span::new(start, end),
+            left,
+            elements,
+            brackets: GenericBrackets::Angle,
+            dot,
+        })))
+    }
+
+    fn parse_array_brackets_or_indexed(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+        left: Box<TypeNodeData<'a>>,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = left.span().start;
+        lexer.bump();
+        if lexer.current.kind == TokenKind::RBracket {
+            lexer.bump();
+            let end = lexer.current.start;
+            return Some(Box::new(TypeNodeData::Generic(TypeGeneric {
+                span: Span::new(start, end),
+                left,
+                elements: Vec::new(),
+                brackets: GenericBrackets::Square,
+                dot: false,
+            })));
+        }
+        if lexer.current.kind == TokenKind::StringValue {
+            let prop_token = lexer.current;
+            let prop_text = lexer.token_text(prop_token);
+            let quote = if prop_text.starts_with('"') {
+                Some(QuoteStyle::Double)
+            } else {
+                Some(QuoteStyle::Single)
+            };
+            let unquoted =
+                if prop_text.len() >= 2 { &prop_text[1..prop_text.len() - 1] } else { prop_text };
+            lexer.bump();
+            self.expect(lexer, TokenKind::RBracket);
+            let end = lexer.current.start;
+            let right = Box::new(TypeNodeData::Property(TypeProperty {
+                span: Span::new(prop_token.start, prop_token.end),
+                value: unquoted,
+                quote,
+            }));
+            return Some(Box::new(TypeNodeData::NamePath(TypeNamePath {
+                span: Span::new(start, end),
+                left,
+                right,
+                path_type: NamePathType::PropertyBrackets,
+            })));
+        }
+        if mode.is_typescript() {
+            let index =
+                self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::All)?;
+            if !self.expect(lexer, TokenKind::RBracket) {
+                return None;
+            }
+            let end = lexer.current.start;
+            let right = Box::new(TypeNodeData::IndexedAccessIndex(TypeIndexedAccessIndex {
+                span: Span::new(start, end),
+                right: index,
+            }));
+            return Some(Box::new(TypeNodeData::NamePath(TypeNamePath {
+                span: Span::new(start, end),
+                left,
+                right,
+                path_type: NamePathType::PropertyBrackets,
+            })));
+        }
+        if !self.expect(lexer, TokenKind::RBracket) {
+            return None;
+        }
+        let end = lexer.current.start;
+        Some(Box::new(TypeNodeData::Generic(TypeGeneric {
+            span: Span::new(start, end),
+            left,
+            elements: Vec::new(),
+            brackets: GenericBrackets::Square,
+            dot: false,
+        })))
+    }
+
+    fn parse_name_path(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        _mode: ParseMode,
+        left: Box<TypeNodeData<'a>>,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = left.span().start;
+        let path_type = match lexer.current.kind {
+            TokenKind::Dot => NamePathType::Property,
+            TokenKind::Hash => NamePathType::Instance,
+            TokenKind::Tilde => NamePathType::Inner,
+            _ => return Some(left),
+        };
+        lexer.bump();
+        let right_token = lexer.current;
+        let right_text = lexer.token_text(right_token);
+        let quote = match right_token.kind {
+            TokenKind::StringValue => {
+                if right_text.starts_with('"') {
+                    Some(QuoteStyle::Double)
+                } else {
+                    Some(QuoteStyle::Single)
+                }
+            }
+            _ => None,
+        };
+        lexer.bump();
+        let right = Box::new(TypeNodeData::Property(TypeProperty {
+            span: Span::new(right_token.start, right_token.end),
+            value: right_text,
+            quote,
+        }));
+        let end = right_token.end;
+        Some(Box::new(TypeNodeData::NamePath(TypeNamePath {
+            span: Span::new(start, end),
+            left,
+            right,
+            path_type,
+        })))
+    }
+
+    fn parse_nullable_suffix(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        left: Box<TypeNodeData<'a>>,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = left.span().start;
+        let end = lexer.current.end;
+        lexer.bump();
+        Some(Box::new(TypeNodeData::Nullable(TypeNullable {
+            span: Span::new(start, end),
+            element: left,
+            position: ModifierPosition::Suffix,
+        })))
+    }
+
+    fn parse_not_nullable_suffix(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        left: Box<TypeNodeData<'a>>,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = left.span().start;
+        let end = lexer.current.end;
+        lexer.bump();
+        Some(Box::new(TypeNodeData::NotNullable(TypeNotNullable {
+            span: Span::new(start, end),
+            element: left,
+            position: ModifierPosition::Suffix,
+        })))
+    }
+
+    fn parse_optional_suffix(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        left: Box<TypeNodeData<'a>>,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = left.span().start;
+        let end = lexer.current.end;
+        lexer.bump();
+        Some(Box::new(TypeNodeData::Optional(TypeOptional {
+            span: Span::new(start, end),
+            element: left,
+            position: ModifierPosition::Suffix,
+        })))
+    }
+
+    fn parse_arrow_function(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+        left: Box<TypeNodeData<'a>>,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = left.span().start;
+        lexer.bump();
+        let return_type =
+            self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::All)?;
+        let end = return_type.span().end;
+        let parameters = Vec::new();
+        Some(Box::new(TypeNodeData::Function(TypeFunction {
+            span: Span::new(start, end),
+            parameters,
+            return_type: Some(return_type),
+            type_parameters: Vec::new(),
+            constructor: false,
+            arrow: true,
+            parenthesis: true,
+        })))
+    }
+
+    fn parse_predicate(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+        left: Box<TypeNodeData<'a>>,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = left.span().start;
+        lexer.bump();
+        let right = self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::All)?;
+        let end = right.span().end;
+        Some(Box::new(TypeNodeData::Predicate(TypePredicate {
+            span: Span::new(start, end),
+            left,
+            right,
+        })))
+    }
+
+    fn parse_conditional(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+        left: Box<TypeNodeData<'a>>,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        if *disallow_conditional {
+            return Some(left);
+        }
+        let start = left.span().start;
+        lexer.bump();
+        let mut nested_disallow = true;
+        let extends_type =
+            self.parse_type_pratt(lexer, mode, &mut nested_disallow, Precedence::All)?;
+        self.expect(lexer, TokenKind::Question);
+        let true_type =
+            self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::All)?;
+        self.expect(lexer, TokenKind::Colon);
+        let false_type =
+            self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::All)?;
+        let end = false_type.span().end;
+        Some(Box::new(TypeNodeData::Conditional(TypeConditional {
+            span: Span::new(start, end),
+            checks_type: left,
+            extends_type,
+            true_type,
+            false_type,
+        })))
+    }
+
+    fn parse_variadic_suffix(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        left: Box<TypeNodeData<'a>>,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = left.span().start;
+        let end = lexer.current.end;
+        lexer.bump();
+        Some(Box::new(TypeNodeData::Variadic(TypeVariadic {
+            span: Span::new(start, end),
+            element: Some(left),
+            position: Some(VariadicPosition::Suffix),
+            square_brackets: false,
+        })))
+    }
+
+    fn parse_symbol(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        mode: ParseMode,
+        disallow_conditional: &mut bool,
+        left: Box<TypeNodeData<'a>>,
+    ) -> Option<Box<TypeNodeData<'a>>> {
+        let start = left.span().start;
+        let value = match left.as_ref() {
+            TypeNodeData::Name(name) => name.value,
+            _ => {
+                self.type_diag(TypeDiagnosticKind::InvalidTypeExpression);
+                return None;
+            }
+        };
+        lexer.bump();
+        let element = if lexer.current.kind != TokenKind::RParen {
+            Some(self.parse_type_pratt(lexer, mode, disallow_conditional, Precedence::All)?)
+        } else {
+            None
+        };
+        if !self.expect(lexer, TokenKind::RParen) {
+            return None;
+        }
+        let end = lexer.current.start;
+        Some(Box::new(TypeNodeData::Symbol(TypeSymbol {
+            span: Span::new(start, end),
+            value,
+            element,
+        })))
+    }
+}

--- a/crates/ox_jsdoc_binary/src/writer/binary_writer.rs
+++ b/crates/ox_jsdoc_binary/src/writer/binary_writer.rs
@@ -1,0 +1,1107 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! [`BinaryWriter`] — the top-level entry point for emitting Binary AST.
+
+use oxc_allocator::{Allocator, Vec as ArenaVec};
+use oxc_span::Span;
+
+use crate::format::diagnostics;
+use crate::format::header::{
+    COMPAT_MODE_BIT, DIAGNOSTICS_OFFSET_FIELD, EXTENDED_DATA_OFFSET_FIELD, FLAGS_OFFSET,
+    HEADER_SIZE, Header, NODE_COUNT_FIELD, NODES_OFFSET_FIELD, ROOT_ARRAY_OFFSET_FIELD,
+    ROOT_COUNT_FIELD, SOURCE_TEXT_LENGTH_FIELD, STRING_DATA_OFFSET_FIELD,
+    STRING_OFFSETS_OFFSET_FIELD, SUPPORTED_VERSION_BYTE, VERSION_OFFSET,
+};
+use crate::format::kind::Kind;
+use crate::format::node_record::{
+    COMMON_DATA_MASK, NEXT_SIBLING_OFFSET, NODE_RECORD_SIZE, STRING_INLINE_LENGTH_MAX,
+    STRING_INLINE_OFFSET_MAX, TypeTag, pack_node_data, pack_string_inline,
+};
+use crate::format::root_index::ROOT_INDEX_ENTRY_SIZE;
+use crate::format::string_field::StringField;
+
+use super::extended_data::{ExtOffset, ExtendedDataBuilder};
+use super::nodes::NodeIndex;
+use super::string_table::{
+    LeafStringPayload, StringIndex, StringTableBuilder, common_string_field, lookup_common,
+};
+
+/// Tracks one in-progress NodeList — the head index and element count that
+/// will be patched into the owning parent's Extended Data block when the
+/// list closes.
+///
+/// Constructed by [`BinaryWriter::begin_node_list_at`], updated by
+/// [`BinaryWriter::record_list_child`], and consumed by
+/// [`BinaryWriter::finalize_node_list`]. The struct intentionally has no
+/// `Default` impl: an unfinished list must be wired up to an Extended Data
+/// slot or it has no place to land.
+#[derive(Debug)]
+pub struct ListInProgress {
+    parent_ext: ExtOffset,
+    slot_offset: usize,
+    head_index: u32,
+    count: u16,
+}
+
+/// Top-level writer that owns one buffer per Binary AST section.
+///
+/// Construction: [`BinaryWriter::new`] pre-writes the 24-byte sentinel
+/// `node[0]` so that real nodes start at index 1.
+///
+/// Lifecycle: parser code drives [`BinaryWriter`] through the
+/// `write_*` helpers (see the [`super::nodes`] module). When all roots and
+/// diagnostics have been written, [`BinaryWriter::finish`] concatenates the
+/// per-section buffers and patches the [`Header`] with the resolved offsets,
+/// returning the final Binary AST byte stream.
+///
+/// All buffers are arena-allocated against the borrow-checker-tracked
+/// `'arena` lifetime, so the resulting bytes can be shared zero-copy with
+/// NAPI/WASM bindings as long as the arena outlives the consumer.
+pub struct BinaryWriter<'arena> {
+    /// In-memory header; field offsets are patched in at [`Self::finish`].
+    pub(crate) header: Header,
+    /// Root index array buffer (`12N` bytes, see `format::root_index`).
+    pub(crate) root_index_buffer: ArenaVec<'arena, u8>,
+    /// Diagnostics entries (`(root_index, message_index)`); sorted at
+    /// [`Self::finish`] before being serialized.
+    pub(crate) diagnostics: ArenaVec<'arena, (u32, u32)>,
+    /// Nodes section buffer (`24P` bytes), starting with the sentinel.
+    pub(crate) nodes_buffer: ArenaVec<'arena, u8>,
+    /// String table builder (handles dedup + offsets/data buffers).
+    pub(crate) strings: StringTableBuilder<'arena>,
+    /// Extended Data builder (handles 8-byte alignment).
+    pub(crate) extended: ExtendedDataBuilder<'arena>,
+    /// Total length of source-text bytes appended via
+    /// [`StringTableBuilder::append_source_text`]. Stored separately from
+    /// `strings.data_buffer.len()` because that buffer also contains
+    /// interned strings.
+    pub(crate) source_text_length: u32,
+    /// `data_buffer` byte offset where the **most recently appended**
+    /// source text region starts. Used by [`Self::intern_source_slice`] to
+    /// translate a source-relative byte range into the absolute offset
+    /// pair that lands in the `String Offsets` section.
+    ///
+    /// Updated on every [`Self::append_source_text`] call. The contract
+    /// for `intern_source_slice` callers is that they must intern source
+    /// slices belonging to the **latest** appended source text — which is
+    /// what every `emit_block` call does (parse-then-emit per item in
+    /// `parse_batch_to_bytes`).
+    pub(crate) current_source_data_offset: u32,
+    /// Byte length of the most recently appended source text. Together
+    /// with [`Self::current_source_data_offset`] this defines the valid
+    /// byte range that [`Self::intern_source_slice`] callers must keep
+    /// their span within.
+    pub(crate) current_source_length: u32,
+    /// Raw start pointer of the most recently appended source text, stored
+    /// as `usize` to avoid lifetime tracking on the writer.
+    ///
+    /// Used by [`Self::intern_source_slice_or_string`] to detect whether a
+    /// borrowed `&str` value is a sub-slice of the appended source via
+    /// pointer arithmetic. The pointer is only ever compared (never
+    /// dereferenced through this field), and its underlying allocation is
+    /// guaranteed to outlive every emit call within the same
+    /// `parse_*_to_bytes` iteration that registered the source via
+    /// [`Self::append_source_text`].
+    pub(crate) current_source_ptr: usize,
+    /// Per-parent backpatch table: `next_sibling_patch[parent_index]`
+    /// stores the byte offset of the most recent child of `parent_index`
+    /// (so the next call to [`Self::emit_node_record`] can patch its
+    /// `next_sibling` field). `0` means "no previous sibling".
+    pub(crate) next_sibling_patch: ArenaVec<'arena, u32>,
+    /// Per-writer opt-in for emitting the trailing `description_raw_span`
+    /// slot on `JsdocBlock` / `JsdocTag` ED records. Set via
+    /// [`Self::set_preserve_whitespace_span`]; consumed by the per-node
+    /// emit phase in `parser/context.rs`. Orthogonal to compat mode.
+    pub(crate) preserve_whitespace_span: bool,
+    /// Reference to the underlying arena, used by the per-node helpers when
+    /// they need to allocate scratch space.
+    pub(crate) arena: &'arena Allocator,
+}
+
+impl<'arena> BinaryWriter<'arena> {
+    /// Create a fresh writer bound to the supplied arena.
+    ///
+    /// Pre-allocates the per-section buffers and writes the all-zero
+    /// `node[0]` sentinel. After construction, calling [`Self::finish`]
+    /// without writing any roots yields a valid empty Binary AST buffer.
+    #[must_use]
+    pub fn new(arena: &'arena Allocator) -> Self {
+        let mut nodes_buffer = ArenaVec::new_in(arena);
+        // Pre-write the all-zero sentinel `node[0]` so real nodes start at
+        // index 1 and `parent_index = 0` / `next_sibling = 0` mean
+        // "no link" without a special case.
+        nodes_buffer.extend(core::iter::repeat_n(0u8, NODE_RECORD_SIZE));
+
+        let mut header = Header::default();
+        header.version = SUPPORTED_VERSION_BYTE;
+
+        BinaryWriter {
+            header,
+            root_index_buffer: ArenaVec::new_in(arena),
+            diagnostics: ArenaVec::new_in(arena),
+            nodes_buffer,
+            strings: StringTableBuilder::new(arena),
+            extended: ExtendedDataBuilder::new(arena),
+            source_text_length: 0,
+            current_source_data_offset: 0,
+            current_source_length: 0,
+            current_source_ptr: 0,
+            next_sibling_patch: ArenaVec::new_in(arena),
+            preserve_whitespace_span: false,
+            arena,
+        }
+    }
+
+    /// Truncate the writer back to its post-[`Self::new`] state without
+    /// freeing any arena memory. Per-section buffers retain their capacity
+    /// so subsequent emit calls reuse the existing allocations instead of
+    /// growing from zero on every per-comment writer construction.
+    ///
+    /// Pairs with [`crate::parser::parse_into`] /
+    /// [`crate::parser::parse_batch_into`] for hot-loop callers (lint
+    /// runners, doc generators) that want per-comment `parse()` semantics
+    /// without paying the per-call writer construction cost.
+    ///
+    /// Restores after `reset()`:
+    /// - the all-zero `node[0]` sentinel (preserved as the first 24 bytes
+    ///   of `nodes_buffer`),
+    /// - the [`super::string_table::COMMON_STRINGS`] prelude in the string
+    ///   table,
+    /// - `compat_mode` / `preserve_whitespace_span` cleared (callers must
+    ///   re-enable them on the recycled writer when needed).
+    pub fn reset(&mut self) {
+        // Header: keep version, clear flags (compat_mode / preserve_ws span
+        // bits are caller-controlled and must be re-set on the recycled writer).
+        self.header.flags = 0;
+
+        // Nodes buffer: keep the 24-byte sentinel, drop everything after it.
+        // truncate retains capacity.
+        self.nodes_buffer.truncate(NODE_RECORD_SIZE);
+
+        self.root_index_buffer.truncate(0);
+        self.diagnostics.truncate(0);
+        self.next_sibling_patch.truncate(0);
+
+        self.strings.reset();
+        self.extended.reset();
+
+        self.source_text_length = 0;
+        self.current_source_data_offset = 0;
+        self.current_source_length = 0;
+        self.current_source_ptr = 0;
+
+        self.preserve_whitespace_span = false;
+    }
+
+    /// Emit one 24-byte node record into the Nodes section and return its
+    /// new [`NodeIndex`].
+    ///
+    /// Side effect: updates `next_sibling_patch` so the next sibling of
+    /// `parent_index` will be backpatched to point at the freshly-emitted
+    /// node. `parent_index = 0` means "child of the sentinel" (i.e. a
+    /// root).
+    ///
+    /// `common_data` is masked to its lower 6 bits before being stored, so
+    /// callers can pass the raw bit field without worrying about the
+    /// reserved upper 2 bits.
+    pub(crate) fn emit_node_record(
+        &mut self,
+        parent_index: u32,
+        kind: Kind,
+        common_data: u8,
+        span: Span,
+        node_data: u32,
+    ) -> NodeIndex {
+        let new_index = self.node_count();
+        let new_byte_offset = self.nodes_buffer.len() as u32;
+
+        // Build the node record directly into the buffer's spare capacity
+        // via a single 24-byte aligned struct write — measurably faster than
+        // the previous "stack record + extend_from_slice memcpy" path on the
+        // typescript-checker.ts fixture (probe showed ~12% of parse_to_bytes
+        // is spent in this single emit, with stack-build vs memcpy split
+        // roughly even).
+        //
+        // SAFETY:
+        // - `reserve(NODE_RECORD_SIZE)` guarantees the spare capacity has
+        //   at least 24 bytes.
+        // - `NodeRecord` is `#[repr(C)]` with the exact byte layout the
+        //   format spec requires (verified by the assertion below).
+        // - `write_unaligned` is correct because the buffer pointer's
+        //   alignment is unknown; we don't rely on natural alignment.
+        // - `set_len` is sound because we just initialised those bytes.
+        #[repr(C)]
+        struct NodeRecord {
+            kind: u8,
+            common_data: u8,
+            padding: u16,
+            span_start: u32,
+            span_end: u32,
+            node_data: u32,
+            parent_index: u32,
+            next_sibling: u32,
+        }
+        const _: () = assert!(core::mem::size_of::<NodeRecord>() == NODE_RECORD_SIZE);
+
+        let cur_len = self.nodes_buffer.len();
+        self.nodes_buffer.reserve(NODE_RECORD_SIZE);
+        unsafe {
+            let dst = self.nodes_buffer.as_mut_ptr().add(cur_len) as *mut NodeRecord;
+            dst.write_unaligned(NodeRecord {
+                kind: kind.as_u8(),
+                common_data: common_data & COMMON_DATA_MASK,
+                padding: 0,
+                span_start: span.start.to_le(),
+                span_end: span.end.to_le(),
+                node_data: node_data.to_le(),
+                parent_index: parent_index.to_le(),
+                next_sibling: 0,
+            });
+            self.nodes_buffer.set_len(cur_len + NODE_RECORD_SIZE);
+        }
+
+        // Backpatch the previous sibling's `next_sibling` to this node, if
+        // any.
+        let parent_idx = parent_index as usize;
+        if parent_idx >= self.next_sibling_patch.len() {
+            self.next_sibling_patch.resize(parent_idx + 1, 0);
+        }
+        let prev_byte_offset = self.next_sibling_patch[parent_idx];
+        if prev_byte_offset != 0 {
+            let patch_at = prev_byte_offset as usize + NEXT_SIBLING_OFFSET;
+            let bytes = new_index.to_le_bytes();
+            self.nodes_buffer[patch_at..patch_at + 4].copy_from_slice(&bytes);
+        }
+        self.next_sibling_patch[parent_idx] = new_byte_offset;
+
+        NodeIndex::new(new_index).expect("node_index 0 is reserved for the sentinel")
+    }
+
+    /// Convenience for **String-type** leaves: emit a node whose Node Data
+    /// payload is a 30-bit String Offsets index. Used by string-leaf Kinds
+    /// where embedding the index in Node Data is cheaper than allocating a
+    /// 6-byte Extended Data record.
+    ///
+    /// Dispatches on the [`LeafStringPayload`] variant to pick the right
+    /// `TypeTag`: `Inline` short strings pack `(offset, length)` directly into
+    /// the 30-bit Node Data payload (`TypeTag::StringInline`), `Index`
+    /// fallback uses the legacy String Offsets table indirection
+    /// (`TypeTag::String`).
+    ///
+    /// `#[inline(always)]` because the only work this fn does on top of
+    /// `emit_node_record` is one `pack_node_data` call; `#[inline]` alone
+    /// is not enough to convince LLVM to inline through the per-Kind
+    /// `write_jsdoc_*` helpers in `writer/nodes/`.
+    #[inline(always)]
+    pub(crate) fn emit_string_node(
+        &mut self,
+        parent_index: u32,
+        kind: Kind,
+        common_data: u8,
+        span: Span,
+        payload: LeafStringPayload,
+    ) -> NodeIndex {
+        let node_data = match payload {
+            LeafStringPayload::Inline { offset, length } => {
+                pack_node_data(TypeTag::StringInline, pack_string_inline(offset, length))
+            }
+            LeafStringPayload::Index(idx) => pack_node_data(TypeTag::String, idx.as_u32()),
+        };
+        self.emit_node_record(parent_index, kind, common_data, span, node_data)
+    }
+
+    /// Convenience for **Children-type** nodes: emit a node whose Node Data
+    /// payload is a 30-bit visitor-order Children bitmask.
+    #[inline(always)]
+    pub(crate) fn emit_children_node(
+        &mut self,
+        parent_index: u32,
+        kind: Kind,
+        common_data: u8,
+        span: Span,
+        children_bitmask: u32,
+    ) -> NodeIndex {
+        let node_data = pack_node_data(TypeTag::Children, children_bitmask);
+        self.emit_node_record(parent_index, kind, common_data, span, node_data)
+    }
+
+    /// Convenience for **Extended-type** nodes: emit a node whose Node Data
+    /// payload is the supplied Extended Data byte offset.
+    #[inline(always)]
+    pub(crate) fn emit_extended_node(
+        &mut self,
+        parent_index: u32,
+        kind: Kind,
+        common_data: u8,
+        span: Span,
+        ext_offset: ExtOffset,
+    ) -> NodeIndex {
+        let node_data = pack_node_data(TypeTag::Extended, ext_offset.as_u32());
+        self.emit_node_record(parent_index, kind, common_data, span, node_data)
+    }
+
+    /// Set the `compat_mode` flag bit on the header.
+    ///
+    /// Must be called before any node is written, since the bit affects the
+    /// per-Kind Extended Data layouts emitted by `write_*` helpers.
+    pub fn set_compat_mode(&mut self, enabled: bool) {
+        if enabled {
+            self.header.flags |= COMPAT_MODE_BIT;
+        } else {
+            self.header.flags &= !COMPAT_MODE_BIT;
+        }
+    }
+
+    /// Whether `compat_mode` is currently enabled. `write_*` helpers consult
+    /// this to decide whether to emit the compat extension region.
+    #[inline]
+    #[must_use]
+    pub const fn compat_mode(&self) -> bool {
+        self.header.compat_mode()
+    }
+
+    /// Enable / disable per-node emission of the `description_raw_span` slot
+    /// on `JsdocBlock` / `JsdocTag`. When enabled, the parser-side emitter
+    /// passes the span to the writer and the per-node `has_description_raw_span`
+    /// Common Data bit is set. When disabled (default), the bit stays clear
+    /// and the 8-byte slot is omitted entirely.
+    ///
+    /// Must be called before any node is written, since the flag affects the
+    /// per-record ED size emitted by `write_jsdoc_block` / `write_jsdoc_tag`.
+    /// Fully orthogonal to [`Self::set_compat_mode`].
+    ///
+    /// See `design/008-oxlint-oxfmt-support/README.md` §4.2.
+    pub fn set_preserve_whitespace_span(&mut self, enabled: bool) {
+        self.preserve_whitespace_span = enabled;
+    }
+
+    /// Whether the per-node `description_raw_span` opt-in is currently
+    /// enabled. The parser's emit phase consults this to decide whether to
+    /// pass the span through to the per-node `write_*` helper.
+    #[inline]
+    #[must_use]
+    pub const fn preserve_whitespace_span(&self) -> bool {
+        self.preserve_whitespace_span
+    }
+
+    /// Append one root entry to the Root Index Array.
+    ///
+    /// `node_index = 0` indicates parse failure (per
+    /// [`crate::format::root_index::PARSE_FAILURE_SENTINEL`]); when used,
+    /// at least one matching diagnostic must subsequently be emitted via
+    /// [`Self::push_diagnostic`].
+    pub fn push_root(&mut self, node_index: u32, source_offset_in_data: u32, base_offset: u32) {
+        self.root_index_buffer.extend_from_slice(&node_index.to_le_bytes());
+        self.root_index_buffer.extend_from_slice(&source_offset_in_data.to_le_bytes());
+        self.root_index_buffer.extend_from_slice(&base_offset.to_le_bytes());
+    }
+
+    /// Append one diagnostic entry. The entries are sorted by `root_index`
+    /// ascending at [`Self::finish`] (so callers may insert them in any
+    /// order).
+    pub fn push_diagnostic(&mut self, root_index: u32, message: &str) {
+        let message_index = self.strings.intern_for_leaf(message);
+        self.diagnostics.push((root_index, message_index.as_u32()));
+    }
+
+    /// Borrow the underlying string table builder. Used by per-Kind
+    /// `write_*` helpers to intern delimiter / description strings.
+    pub fn strings(&mut self) -> &mut StringTableBuilder<'arena> {
+        &mut self.strings
+    }
+
+    /// Borrow the underlying Extended Data builder.
+    pub fn extended(&mut self) -> &mut ExtendedDataBuilder<'arena> {
+        &mut self.extended
+    }
+
+    /// Convenience: intern a string into the table. Returns the
+    /// [`StringField`] that can be embedded in an Extended Data record.
+    pub fn intern_string(&mut self, value: &str) -> StringField {
+        self.strings.intern(value)
+    }
+
+    /// Intern a string and return its [`StringIndex`] (String Offsets table
+    /// path). Used by string-leaf Kinds (`emit_string_node`) where the
+    /// 30-bit index packed into Node Data is cheaper than a 6-byte ED
+    /// record.
+    pub fn intern_string_index(&mut self, value: &str) -> StringIndex {
+        self.strings.intern_for_leaf(value)
+    }
+
+    /// Intern a string and return a [`LeafStringPayload`] suitable for
+    /// [`Self::emit_string_node`]. Picks the inline path when both
+    /// `value.len() <= 255` and the resulting String Data offset fits in
+    /// 22 bits; otherwise falls back to the legacy [`StringIndex`] path.
+    ///
+    /// This is the Path B-leaf entry point: it elides the 8-byte append to
+    /// `offsets_buffer` for short strings, replacing it with a pure
+    /// `(offset, length)` pack into Node Data. See
+    /// `tasks/benchmark/results/2026-04-23-…` for the design rationale.
+    pub fn intern_string_payload(&mut self, value: &str) -> LeafStringPayload {
+        let field = self.strings.intern(value);
+        if (value.len() as u32) <= STRING_INLINE_LENGTH_MAX
+            && field.offset <= STRING_INLINE_OFFSET_MAX
+        {
+            LeafStringPayload::Inline { offset: field.offset, length: value.len() as u8 }
+        } else {
+            LeafStringPayload::Index(self.strings.intern_for_leaf(value))
+        }
+    }
+
+    /// Skip-dedup variant of [`Self::intern_string`] for callers who know
+    /// their string is dominated by per-call unique content (description
+    /// text, raw type source). Trades a small amount of binary growth
+    /// (duplicate content stored twice) for the FxHash + lookup work the
+    /// dedup map would otherwise perform on every call.
+    pub fn intern_string_unique(&mut self, value: &str) -> StringField {
+        self.strings.intern_unique(value)
+    }
+
+    /// Convenience: append a sourceText prefix and remember its byte length
+    /// so [`Header.source_text_length`] is set correctly at [`Self::finish`].
+    ///
+    /// Also caches the appended region's data-buffer offset / length so
+    /// the next [`Self::emit_block`] cycle can use [`Self::intern_source_slice`]
+    /// to zero-copy intern source-derived strings (description text,
+    /// tag names, raw type sources) without re-copying their bytes into
+    /// the data buffer.
+    pub fn append_source_text(&mut self, value: &str) -> u32 {
+        let offset = self.strings.append_source_text(value);
+        self.source_text_length = self.source_text_length.saturating_add(value.len() as u32);
+        self.current_source_data_offset = offset;
+        self.current_source_length = value.len() as u32;
+        // Stash the source's start address as a usize so subsequent
+        // `intern_source_slice_or_string` calls can detect borrowed sub-slices
+        // via pointer arithmetic (no dereference). The pointer is valid for
+        // the remainder of the current `parse_*_to_bytes` iteration; we never
+        // store one across iterations.
+        self.current_source_ptr = value.as_ptr() as usize;
+        offset
+    }
+
+    /// Zero-copy intern: register a String Offsets entry that points into
+    /// the **most recently appended** source text (see
+    /// [`Self::append_source_text`]) without writing the bytes a second
+    /// time into the String Data section.
+    ///
+    /// `source_byte_start` and `source_byte_end` are byte offsets relative
+    /// to the start of the latest source text (i.e. matching the spans
+    /// produced by `parse_block_into_data` when called with
+    /// `base_offset = 0`). The caller must ensure the range falls within
+    /// `[0, current_source_length]`.
+    ///
+    /// This is the Path-A optimization: it eliminates the per-call
+    /// `data_buffer.extend_from_slice(value.as_bytes())` that
+    /// [`Self::intern_string_unique`] does for every source-slice field
+    /// (description, tag name, raw type, parameter name, …), trading the
+    /// duplicated bytes for an offsets-only registration. See
+    /// `.notes/binary-ast-emit-phase-format-analysis.md` for context.
+    #[inline]
+    pub fn intern_source_slice(
+        &mut self,
+        source_byte_start: u32,
+        source_byte_end: u32,
+    ) -> StringField {
+        debug_assert!(
+            source_byte_end <= self.current_source_length,
+            "intern_source_slice end {source_byte_end} > current source length {}",
+            self.current_source_length
+        );
+        let absolute_start = self.current_source_data_offset.saturating_add(source_byte_start);
+        let absolute_end = self.current_source_data_offset.saturating_add(source_byte_end);
+        self.strings.intern_at_offset(absolute_start, absolute_end)
+    }
+
+    /// String-leaf-targeted variant of [`Self::intern_source_slice`].
+    ///
+    /// Returns a [`StringIndex`] (allocates a String Offsets entry) so the
+    /// caller can pass it to [`Self::emit_string_node`]. Used by
+    /// description-line / type-line basic-mode emission where the source
+    /// slice becomes the String-payload of a leaf node.
+    ///
+    /// The bytes themselves are **not** copied; only the (start, end) pair
+    /// is appended to the offsets table.
+    #[inline]
+    pub fn intern_source_slice_for_leaf(
+        &mut self,
+        source_byte_start: u32,
+        source_byte_end: u32,
+    ) -> StringIndex {
+        debug_assert!(
+            source_byte_end <= self.current_source_length,
+            "intern_source_slice_for_leaf end {source_byte_end} > current source length {}",
+            self.current_source_length
+        );
+        let absolute_start = self.current_source_data_offset.saturating_add(source_byte_start);
+        let absolute_end = self.current_source_data_offset.saturating_add(source_byte_end);
+        self.strings.intern_at_offset_for_leaf(absolute_start, absolute_end)
+    }
+
+    /// Path B-leaf variant of [`Self::intern_source_slice_for_leaf`]: when
+    /// the source slice is short enough (length ≤ 255 and offset ≤ 4 MB),
+    /// returns a [`LeafStringPayload::Inline`] that packs `(offset, length)`
+    /// directly into Node Data — skipping the 8-byte append to
+    /// `offsets_buffer` and the [`StringIndex`] payload allocation entirely.
+    /// Long slices fall back to the legacy `intern_at_offset_for_leaf` path.
+    #[inline]
+    pub fn intern_source_slice_for_leaf_payload(
+        &mut self,
+        source_byte_start: u32,
+        source_byte_end: u32,
+    ) -> LeafStringPayload {
+        debug_assert!(
+            source_byte_end <= self.current_source_length,
+            "intern_source_slice_for_leaf_payload end {source_byte_end} > current source length {}",
+            self.current_source_length
+        );
+        let absolute_start = self.current_source_data_offset.saturating_add(source_byte_start);
+        let absolute_end = self.current_source_data_offset.saturating_add(source_byte_end);
+        let length = absolute_end - absolute_start;
+        if length <= STRING_INLINE_LENGTH_MAX && absolute_start <= STRING_INLINE_OFFSET_MAX {
+            LeafStringPayload::Inline { offset: absolute_start, length: length as u8 }
+        } else {
+            LeafStringPayload::Index(
+                self.strings.intern_at_offset_for_leaf(absolute_start, absolute_end),
+            )
+        }
+    }
+
+    /// Intern `value` choosing the cheapest of three paths automatically,
+    /// using the supplied `span` as a hint for the zero-copy case.
+    ///
+    /// 1. **Common-string fast path** — when `value` is a pre-seeded
+    ///    common string (`*`, `*/`, `param`, …), return its predetermined
+    ///    index with no state mutation. Same cost as
+    ///    [`Self::intern_string`] on a hit.
+    /// 2. **Zero-copy source slice** — when `value.len()` equals the span
+    ///    length and the span fits inside the most recently appended source
+    ///    text, register an offsets-only entry pointing at those source
+    ///    bytes (no `data_buffer` copy, no HashMap probe). Equivalent to
+    ///    [`Self::intern_source_slice`] but autoguarded.
+    /// 3. **Unique fresh entry** — otherwise (synthesized strings,
+    ///    quote-stripped variants whose lengths differ from the span,
+    ///    parent-spanning aggregates whose span covers more than just
+    ///    `value`), append `value` bytes via [`Self::intern_string_unique`].
+    ///
+    /// The length-equality check is what makes path 2 safe even when the
+    /// caller doesn't know up-front whether `value` is a true sub-slice of
+    /// the source (e.g. `TypeProperty.value` may have its outer quotes
+    /// stripped while its span still includes them). See
+    /// `.notes/binary-ast-emit-intern-audit.md` for the per-caller analysis.
+    ///
+    /// `#[inline]` because the per-Kind `parse_*` callers in
+    /// `parser/context.rs` invoke this once per emitted string field; cross-
+    /// crate inlining is not implicit for `pub fn` even at `-O3`.
+    #[inline]
+    pub fn intern_source_or_string(&mut self, value: &str, span: Span) -> StringField {
+        if let Some(idx) = lookup_common(value) {
+            return common_string_field(idx);
+        }
+        let span_len = span.end.saturating_sub(span.start);
+        if span_len as usize == value.len() && span.end <= self.current_source_length {
+            return self.intern_source_slice(span.start, span.end);
+        }
+        self.strings.intern_unique(value)
+    }
+
+    /// String-leaf-targeted variant of [`Self::intern_source_or_string`]
+    /// — returns a [`StringIndex`] suitable for [`Self::emit_string_node`].
+    ///
+    /// Mirrors the same three-path decision tree (common-string fast path,
+    /// zero-copy source slice, dedup'd unique entry) but allocates a
+    /// String Offsets index for the result.
+    #[inline]
+    pub fn intern_source_or_string_for_leaf(&mut self, value: &str, span: Span) -> StringIndex {
+        if let Some(idx) = lookup_common(value) {
+            return StringIndex::from_u32(idx).expect("common index in range");
+        }
+        let span_len = span.end.saturating_sub(span.start);
+        if span_len as usize == value.len() && span.end <= self.current_source_length {
+            return self.intern_source_slice_for_leaf(span.start, span.end);
+        }
+        self.strings.intern_for_leaf(value)
+    }
+
+    /// Path B-leaf variant of [`Self::intern_source_or_string_for_leaf`].
+    ///
+    /// Returns a [`LeafStringPayload`] that picks the inline path
+    /// (`TypeTag::StringInline`) when the resulting string fits the
+    /// `(offset ≤ 4 MB, length ≤ 255)` constraints, falling back to the
+    /// legacy `StringIndex` path (`TypeTag::String`) otherwise.
+    ///
+    /// Implements the same three-path decision tree as the non-payload
+    /// sibling: common-string fast path, zero-copy source slice, dedup'd
+    /// unique entry. Each path is short-circuited to inline when the slot
+    /// fits the inline encoding.
+    #[inline]
+    pub fn intern_source_or_string_for_leaf_payload(
+        &mut self,
+        value: &str,
+        span: Span,
+    ) -> LeafStringPayload {
+        if let Some(idx) = lookup_common(value) {
+            // COMMON_STRINGS live at the start of the data buffer (well
+            // within 4 MB) and are all <= 10 bytes, so they always inline.
+            let field = common_string_field(idx);
+            return LeafStringPayload::Inline { offset: field.offset, length: field.length as u8 };
+        }
+        let span_len = span.end.saturating_sub(span.start);
+        if span_len as usize == value.len() && span.end <= self.current_source_length {
+            return self.intern_source_slice_for_leaf_payload(span.start, span.end);
+        }
+        // Synthesized / quote-stripped value → dedup via HashMap. Inline
+        // when the dedup'd field fits the (offset ≤ 4 MB, length ≤ 255)
+        // window; otherwise fall back to the legacy leaf path.
+        let field = self.strings.intern(value);
+        if (value.len() as u32) <= STRING_INLINE_LENGTH_MAX
+            && field.offset <= STRING_INLINE_OFFSET_MAX
+        {
+            LeafStringPayload::Inline { offset: field.offset, length: value.len() as u8 }
+        } else {
+            LeafStringPayload::Index(self.strings.intern_for_leaf(value))
+        }
+    }
+
+    /// Span-less sibling of [`Self::intern_source_or_string`] for callers that
+    /// hold an `&str` without an explicit byte range (e.g. fields surfaced
+    /// by `Option<&str>` getters where the parser merged or normalized the
+    /// underlying source bytes).
+    ///
+    /// Detection is via pointer arithmetic against the most recently
+    /// appended source text — when `value` lies inside that buffer's
+    /// allocation, register an offsets-only entry pointing at it; otherwise
+    /// fall through to the common-string fast path or a unique fresh entry.
+    /// The pointer comparison never dereferences either pointer, so the
+    /// check is safe even when the source allocation has since been
+    /// mutated (it cannot have moved while we still hold the borrow).
+    ///
+    /// Pointer-arithmetic identification handles the synthesized vs
+    /// source-slice ambiguity in `normalize_lines` results: single-line
+    /// descriptions remain a sub-slice of the source and take path 2;
+    /// multi-line joins live in the parser's scratch String (separate
+    /// allocation) and fall through to path 3.
+    ///
+    /// `#[inline]` because this is the single hottest writer entry point
+    /// (per `examples/profile_parse_batch.rs` samply runs ≈ 14.8% self
+    /// time): cross-crate inlining with the per-Kind `parse_*` callers
+    /// in `parser/context.rs` lets LLVM fold the lookup_common hit and
+    /// the pointer-comparison branches into the surrounding emission.
+    #[inline]
+    pub fn intern_source_slice_or_string(&mut self, value: &str) -> StringField {
+        if let Some(idx) = lookup_common(value) {
+            return common_string_field(idx);
+        }
+        let value_ptr = value.as_ptr() as usize;
+        let source_start = self.current_source_ptr;
+        if source_start != 0 {
+            let source_end = source_start.saturating_add(self.current_source_length as usize);
+            let value_end = value_ptr.saturating_add(value.len());
+            if value_ptr >= source_start && value_end <= source_end {
+                let offset = (value_ptr - source_start) as u32;
+                return self.intern_source_slice(offset, offset + value.len() as u32);
+            }
+        }
+        self.strings.intern_unique(value)
+    }
+
+    /// String-leaf-targeted variant of [`Self::intern_source_slice_or_string`]
+    /// — returns a [`StringIndex`] suitable for [`Self::emit_string_node`].
+    #[inline]
+    pub fn intern_source_slice_or_string_for_leaf(&mut self, value: &str) -> StringIndex {
+        if let Some(idx) = lookup_common(value) {
+            return StringIndex::from_u32(idx).expect("common index in range");
+        }
+        let value_ptr = value.as_ptr() as usize;
+        let source_start = self.current_source_ptr;
+        if source_start != 0 {
+            let source_end = source_start.saturating_add(self.current_source_length as usize);
+            let value_end = value_ptr.saturating_add(value.len());
+            if value_ptr >= source_start && value_end <= source_end {
+                let offset = (value_ptr - source_start) as u32;
+                return self.intern_source_slice_for_leaf(offset, offset + value.len() as u32);
+            }
+        }
+        self.strings.intern_for_leaf(value)
+    }
+
+    /// Number of node records currently in the Nodes section (including the
+    /// `node[0]` sentinel).
+    #[inline]
+    #[must_use]
+    pub fn node_count(&self) -> u32 {
+        (self.nodes_buffer.len() / NODE_RECORD_SIZE) as u32
+    }
+
+    /// Open a NodeList cursor at `(parent_ext + slot_offset)`.
+    ///
+    /// Pattern (per parent that owns one or more lists):
+    /// 1. Emit the parent via `write_*` helper. The helper now returns
+    ///    `(NodeIndex, ExtOffset)` so the caller can address the ED block.
+    /// 2. `begin_node_list_at(ext, slot_offset)` opens a cursor for one list.
+    /// 3. After each child emit, [`Self::record_list_child`] updates the
+    ///    cursor's head/count.
+    /// 4. [`Self::finalize_node_list`] patches `(head: u32, count: u16)` into
+    ///    the parent's ED block at the recorded slot.
+    #[inline]
+    #[must_use]
+    pub fn begin_node_list_at(&self, parent_ext: ExtOffset, slot_offset: usize) -> ListInProgress {
+        ListInProgress { parent_ext, slot_offset, head_index: 0, count: 0 }
+    }
+
+    /// Record one child added to the in-progress list. `child_index` is the
+    /// `u32` returned by the per-child `write_*` helper (or `emit_type_node`).
+    #[inline]
+    pub fn record_list_child(&mut self, list: &mut ListInProgress, child_index: u32) {
+        if list.count == 0 {
+            list.head_index = child_index;
+        }
+        list.count = list.count.checked_add(1).expect("NodeList exceeds u16::MAX elements");
+    }
+
+    /// Patch `(head_index: u32, count: u16)` into the parent's Extended Data
+    /// block at `(parent_ext + slot_offset)`. Must be called exactly once per
+    /// list opened via [`Self::begin_node_list_at`].
+    pub fn finalize_node_list(&mut self, list: ListInProgress) {
+        let base = list.parent_ext.as_u32() as usize + list.slot_offset;
+        let buf = &mut self.extended.buffer[base..base + 6];
+        buf[0..4].copy_from_slice(&list.head_index.to_le_bytes());
+        buf[4..6].copy_from_slice(&list.count.to_le_bytes());
+    }
+
+    /// Number of roots currently in the Root Index Array.
+    #[inline]
+    #[must_use]
+    pub fn root_count(&self) -> u32 {
+        (self.root_index_buffer.len() / ROOT_INDEX_ENTRY_SIZE) as u32
+    }
+
+    /// Reference to the arena passed at [`Self::new`]. Useful when
+    /// per-Kind helpers need scratch allocations.
+    #[inline]
+    #[must_use]
+    pub fn arena(&self) -> &'arena Allocator {
+        self.arena
+    }
+
+    /// Finish writing and produce the concatenated Binary AST byte stream.
+    ///
+    /// At this point the writer:
+    /// - sorts the diagnostic entries by `root_index` ascending,
+    /// - resolves each section's start offset and patches the [`Header`],
+    /// - writes Header (40 bytes) + all section buffers in canonical order
+    ///   (Root index array → String Offsets → String Data → Extended Data
+    ///   → Diagnostics → Nodes).
+    ///
+    /// The returned `Vec<u8>` is owned (not arena-backed) so it can be sent
+    /// across NAPI/WASM boundaries without lifetime concerns.
+    #[must_use]
+    pub fn finish(mut self) -> Vec<u8> {
+        let layout = self.prepare_finish_layout();
+        let mut out: Vec<u8> = vec![0u8; layout.total_size];
+        write_finish_layout(&self, &layout, &mut out);
+        out
+    }
+
+    /// Finish writing into the writer's owning arena and return the bytes
+    /// as `&'arena [u8]`. Avoids the heap [`Vec<u8>`] allocation +
+    /// [`Allocator::alloc_slice_copy`] step that callers like [`crate::parser::parse`]
+    /// would otherwise pay to materialize a `&'arena [u8]` view of
+    /// [`Self::finish`]'s output.
+    ///
+    /// Output bytes are byte-for-byte identical to [`Self::finish`] for the
+    /// same writer state.
+    #[must_use]
+    pub fn finish_into_arena(self) -> &'arena [u8] {
+        // Delegate to the borrow-based variant. `self` is dropped at the
+        // end of this scope; its arena-backed buffers are kept alive by
+        // the arena, and the returned slice is valid for `'arena`.
+        let mut writer = self;
+        writer.finish_into_arena_reusing()
+    }
+
+    /// Like [`Self::finish_into_arena`] but takes `&mut self` instead of
+    /// consuming, so the writer can subsequently be [`Self::reset`]ed and
+    /// reused for the next per-comment parse.
+    ///
+    /// Used by [`crate::parser::parse_into`] /
+    /// [`crate::parser::parse_batch_into`] to amortize writer construction
+    /// across many parse calls.
+    ///
+    /// The returned slice borrows from the writer's arena (lifetime
+    /// `'arena`), independent of the writer itself, so [`Self::reset`] can
+    /// be called immediately afterwards without invalidating it.
+    ///
+    /// Output bytes are byte-for-byte identical to [`Self::finish`] for the
+    /// same writer state.
+    #[must_use]
+    pub fn finish_into_arena_reusing(&mut self) -> &'arena [u8] {
+        let layout = self.prepare_finish_layout();
+        let arena = self.arena;
+        let mut out: ArenaVec<'arena, u8> = ArenaVec::with_capacity_in(layout.total_size, arena);
+        out.resize(layout.total_size, 0);
+        write_finish_layout(self, &layout, &mut out);
+        out.into_bump_slice()
+    }
+
+    /// Sort diagnostics + compute layout. Mutating helper shared by
+    /// [`Self::finish`] and [`Self::finish_into_arena`] — the only
+    /// pre-write side effect either path needs.
+    fn prepare_finish_layout(&mut self) -> FinishLayout {
+        // -- 1. sort diagnostics by root_index ascending --------------------
+        // Empty skip: most batches finish without diagnostics (parse success
+        // path), so avoid the function-call overhead entirely. Unstable
+        // sort is sufficient because each push is unique enough; the order
+        // among entries with the same root_index is not load-bearing.
+        if !self.diagnostics.is_empty() {
+            self.diagnostics.sort_unstable_by_key(|(root_index, _)| *root_index);
+        }
+
+        // -- 2. compute counts and section sizes ----------------------------
+        let root_array_size = self.root_index_buffer.len();
+        let string_offsets_size = self.strings.offsets_buffer.len();
+        let string_data_size = self.strings.data_buffer.len();
+        let extended_data_size = self.extended.buffer.len();
+        let diagnostics_size = diagnostics::section_size(self.diagnostics.len());
+        let nodes_size = self.nodes_buffer.len();
+
+        // -- 3. compute absolute section offsets ----------------------------
+        //
+        // Padding requirement: every section that contains u32 reads must
+        // start at a 4-byte aligned offset so the JS-side decoder can use
+        // `Uint32Array[idx]` (5-10× faster than `DataView.getUint32`)
+        // instead of going through DataView. The `string_data` section
+        // contains arbitrary UTF-8 byte lengths, so the boundary right
+        // after it (Extended Data start) and every later boundary need
+        // to round up.
+        let root_array_offset = HEADER_SIZE as u32;
+        let string_offsets_offset = root_array_offset + root_array_size as u32;
+        let string_data_offset = string_offsets_offset + string_offsets_size as u32;
+        // Pad after String Data so Extended Data starts 4-byte aligned.
+        let extended_data_offset = align_up_4(string_data_offset + string_data_size as u32);
+        // Pad after Extended Data so Diagnostics starts 4-byte aligned.
+        let diagnostics_offset = align_up_4(extended_data_offset + extended_data_size as u32);
+        // diagnostics_size is `4 + 8M` (always 4-aligned), so the next
+        // boundary is automatically 4-aligned. Compute defensively anyway.
+        let nodes_offset = align_up_4(diagnostics_offset + diagnostics_size as u32);
+
+        let total_size = nodes_offset as usize + nodes_size;
+
+        FinishLayout {
+            root_array_offset,
+            string_offsets_offset,
+            string_data_offset,
+            extended_data_offset,
+            diagnostics_offset,
+            nodes_offset,
+            root_array_size,
+            string_offsets_size,
+            string_data_size,
+            extended_data_size,
+            nodes_size,
+            total_size,
+        }
+    }
+}
+
+/// Pre-computed section offsets + sizes for [`BinaryWriter::finish`] /
+/// [`BinaryWriter::finish_into_arena`]. Computed once from
+/// [`BinaryWriter::prepare_finish_layout`] and consumed by
+/// [`write_finish_layout`].
+struct FinishLayout {
+    root_array_offset: u32,
+    string_offsets_offset: u32,
+    string_data_offset: u32,
+    extended_data_offset: u32,
+    diagnostics_offset: u32,
+    nodes_offset: u32,
+    root_array_size: usize,
+    string_offsets_size: usize,
+    string_data_size: usize,
+    extended_data_size: usize,
+    nodes_size: usize,
+    total_size: usize,
+}
+
+/// Write the header + every section into a pre-allocated, zero-initialized
+/// buffer of exactly [`FinishLayout::total_size`] bytes. Padding regions are
+/// covered by the caller's zero-init.
+fn write_finish_layout(writer: &BinaryWriter<'_>, layout: &FinishLayout, out: &mut [u8]) {
+    debug_assert_eq!(out.len(), layout.total_size);
+
+    let node_count = writer.node_count();
+    let root_count = writer.root_count();
+    let diagnostic_count = writer.diagnostics.len() as u32;
+
+    // -- Header ---------------------------------------------------------
+    out[VERSION_OFFSET] = writer.header.version;
+    out[FLAGS_OFFSET] = writer.header.flags;
+    // bytes 2-3 already zero (reserved)
+    write_u32(out, ROOT_ARRAY_OFFSET_FIELD, layout.root_array_offset);
+    write_u32(out, STRING_OFFSETS_OFFSET_FIELD, layout.string_offsets_offset);
+    write_u32(out, STRING_DATA_OFFSET_FIELD, layout.string_data_offset);
+    write_u32(out, EXTENDED_DATA_OFFSET_FIELD, layout.extended_data_offset);
+    write_u32(out, DIAGNOSTICS_OFFSET_FIELD, layout.diagnostics_offset);
+    write_u32(out, NODES_OFFSET_FIELD, layout.nodes_offset);
+    write_u32(out, NODE_COUNT_FIELD, node_count);
+    write_u32(out, SOURCE_TEXT_LENGTH_FIELD, writer.source_text_length);
+    write_u32(out, ROOT_COUNT_FIELD, root_count);
+
+    // -- Root index array ----------------------------------------------
+    let root_start = layout.root_array_offset as usize;
+    out[root_start..root_start + layout.root_array_size].copy_from_slice(&writer.root_index_buffer);
+
+    // -- String Offsets / Data -----------------------------------------
+    let so_start = layout.string_offsets_offset as usize;
+    out[so_start..so_start + layout.string_offsets_size]
+        .copy_from_slice(&writer.strings.offsets_buffer);
+
+    let sd_start = layout.string_data_offset as usize;
+    out[sd_start..sd_start + layout.string_data_size].copy_from_slice(&writer.strings.data_buffer);
+    // String Data → Extended Data padding: already zero (out was zero-init).
+
+    // -- Extended Data --------------------------------------------------
+    let ed_start = layout.extended_data_offset as usize;
+    out[ed_start..ed_start + layout.extended_data_size].copy_from_slice(&writer.extended.buffer);
+    // Extended Data → Diagnostics padding: already zero.
+
+    // -- Diagnostics: count header + 8-byte entries --------------------
+    let diag_start = layout.diagnostics_offset as usize;
+    out[diag_start..diag_start + 4].copy_from_slice(&diagnostic_count.to_le_bytes());
+    let mut cursor = diag_start + 4;
+    for (root_index, message_index) in &writer.diagnostics {
+        out[cursor..cursor + 4].copy_from_slice(&root_index.to_le_bytes());
+        out[cursor + 4..cursor + 8].copy_from_slice(&message_index.to_le_bytes());
+        cursor += 8;
+    }
+    // Diagnostics → Nodes padding: already zero.
+
+    // -- Nodes ----------------------------------------------------------
+    let nodes_start = layout.nodes_offset as usize;
+    out[nodes_start..nodes_start + layout.nodes_size].copy_from_slice(&writer.nodes_buffer);
+
+    debug_assert_eq!(layout.extended_data_offset & 3, 0, "Extended Data must be 4-aligned");
+    debug_assert_eq!(layout.diagnostics_offset & 3, 0, "Diagnostics must be 4-aligned");
+    debug_assert_eq!(layout.nodes_offset & 3, 0, "Nodes must be 4-aligned");
+}
+
+/// Round `value` up to the next multiple of 4.
+#[inline]
+fn align_up_4(value: u32) -> u32 {
+    (value + 3) & !3
+}
+
+/// Write a little-endian u32 at the given byte offset.
+#[inline]
+fn write_u32(buf: &mut [u8], offset: usize, value: u32) {
+    buf[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decoder::source_file::LazySourceFile;
+
+    #[test]
+    fn empty_buffer_roundtrips_through_lazy_source_file() {
+        use crate::writer::string_table::COMMON_STRING_COUNT;
+
+        let arena = Allocator::default();
+        let writer = BinaryWriter::new(&arena);
+        assert_eq!(writer.node_count(), 1, "sentinel node[0] is pre-written");
+        assert_eq!(writer.root_count(), 0);
+        assert!(!writer.compat_mode());
+        // The string table is seeded with `COMMON_STRING_COUNT` entries
+        // (delimiters, whitespace, common tag names) so per-call
+        // `intern_for_leaf` can skip the HashMap.
+        assert_eq!(writer.strings.len(), COMMON_STRING_COUNT);
+
+        let bytes = writer.finish();
+
+        let sf = LazySourceFile::new(&bytes).expect("empty buffer must parse");
+        assert_eq!(sf.node_count, 1);
+        assert_eq!(sf.root_count, 0);
+        assert!(!sf.compat_mode);
+        // Sections sit in canonical order; offsets shift by the size of
+        // the common-string prelude.
+        assert_eq!(sf.root_array_offset, 40);
+        assert_eq!(sf.string_offsets_offset, 40);
+        // Each interned entry occupies 8 bytes in the offsets table.
+        let prelude_offsets_bytes = COMMON_STRING_COUNT * 8;
+        assert_eq!(sf.string_data_offset, 40 + prelude_offsets_bytes);
+    }
+
+    #[test]
+    fn set_compat_mode_round_trips() {
+        let arena = Allocator::default();
+        let mut writer = BinaryWriter::new(&arena);
+        writer.set_compat_mode(true);
+        let bytes = writer.finish();
+        assert_eq!(bytes[FLAGS_OFFSET] & COMPAT_MODE_BIT, COMPAT_MODE_BIT);
+
+        let sf = LazySourceFile::new(&bytes).unwrap();
+        assert!(sf.compat_mode);
+    }
+
+    #[test]
+    fn push_root_writes_12_byte_entry_in_canonical_order() {
+        let arena = Allocator::default();
+        let mut writer = BinaryWriter::new(&arena);
+        writer.push_root(1, 0, 100);
+        writer.push_root(0, 7, 200); // parse failure sentinel
+        assert_eq!(writer.root_count(), 2);
+
+        let bytes = writer.finish();
+        let sf = LazySourceFile::new(&bytes).unwrap();
+        assert_eq!(sf.root_count, 2);
+        // Each entry is 12 bytes; the first one starts at root_array_offset.
+        let root0 = sf.root_array_offset as usize;
+        assert_eq!(read_u32_at(&bytes, root0), 1, "node_index of root 0");
+        assert_eq!(read_u32_at(&bytes, root0 + 4), 0, "source_offset_in_data");
+        assert_eq!(read_u32_at(&bytes, root0 + 8), 100, "base_offset");
+        assert_eq!(read_u32_at(&bytes, root0 + 12), 0, "node_index of root 1 (failure)");
+        assert_eq!(read_u32_at(&bytes, root0 + 20), 200);
+    }
+
+    #[test]
+    fn push_diagnostic_sorts_by_root_index() {
+        let arena = Allocator::default();
+        let mut writer = BinaryWriter::new(&arena);
+        // Insert out of order; finish() must sort ascending by root_index.
+        writer.push_diagnostic(2, "second");
+        writer.push_diagnostic(0, "zero");
+        writer.push_diagnostic(1, "one");
+
+        let bytes = writer.finish();
+        let sf = LazySourceFile::new(&bytes).unwrap();
+        let diag_offset = sf.diagnostics_offset as usize;
+        assert_eq!(read_u32_at(&bytes, diag_offset), 3, "diagnostic count");
+
+        // First entry: root_index = 0
+        assert_eq!(read_u32_at(&bytes, diag_offset + 4), 0);
+        // Second entry: root_index = 1
+        assert_eq!(read_u32_at(&bytes, diag_offset + 4 + 8), 1);
+        // Third entry: root_index = 2
+        assert_eq!(read_u32_at(&bytes, diag_offset + 4 + 16), 2);
+    }
+
+    #[test]
+    fn finish_records_source_text_length() {
+        let arena = Allocator::default();
+        let mut writer = BinaryWriter::new(&arena);
+        let _ = writer.append_source_text("/** @param x */");
+        let bytes = writer.finish();
+        let sf = LazySourceFile::new(&bytes).unwrap();
+        // sourceText length is in bytes, not chars; ASCII-only here so they match.
+        let expected = "/** @param x */".len() as u32;
+        assert_eq!(read_u32_at(&bytes, SOURCE_TEXT_LENGTH_FIELD), expected);
+        // Spot-check the LazySourceFile path doesn't panic on the same buffer.
+        assert_eq!(sf.node_count, 1);
+    }
+
+    fn read_u32_at(buf: &[u8], offset: usize) -> u32 {
+        u32::from_le_bytes(buf[offset..offset + 4].try_into().unwrap())
+    }
+}

--- a/crates/ox_jsdoc_binary/src/writer/extended_data.rs
+++ b/crates/ox_jsdoc_binary/src/writer/extended_data.rs
@@ -1,0 +1,198 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Extended Data buffer builder used by [`super::BinaryWriter`].
+//!
+//! Manages a single byte buffer onto which per-Kind Extended Data records
+//! are appended. Each new record is prefixed with zero-fill padding so its
+//! starting byte offset is divisible by
+//! [`crate::format::extended_data::EXTENDED_DATA_ALIGNMENT`] (8 bytes).
+//!
+//! See `design/007-binary-ast/format.md#extended-data-section` for the
+//! per-Kind layouts.
+
+use core::num::NonZeroU32;
+
+use oxc_allocator::{Allocator, Vec as ArenaVec};
+
+use crate::format::extended_data::EXTENDED_DATA_ALIGNMENT;
+
+/// Byte offset into the Extended Data section.
+///
+/// Newtype wrapper to avoid mixing up Extended Data offsets with String
+/// Offsets indices or node indices. Stored as `offset + 1` internally so the
+/// type can use `NonZeroU32` for niche optimization (`Option<ExtOffset>` is
+/// 4 bytes).
+///
+/// The wire representation in Node Data uses the *raw* offset packed into
+/// 30 bits (see `format::node_record::PAYLOAD_MASK`); offset 0 is a valid
+/// position because the very first record sits at byte 0 of the section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ExtOffset(NonZeroU32);
+
+impl ExtOffset {
+    /// Construct an [`ExtOffset`] from the raw byte offset.
+    ///
+    /// Returns `None` only when `offset + 1` overflows `u32` (i.e. `offset`
+    /// is `u32::MAX`).
+    #[inline]
+    #[must_use]
+    pub const fn from_u32(offset: u32) -> Option<Self> {
+        match NonZeroU32::new(offset.wrapping_add(1)) {
+            Some(nz) => Some(ExtOffset(nz)),
+            None => None,
+        }
+    }
+
+    /// Get the raw byte offset.
+    #[inline]
+    #[must_use]
+    pub const fn as_u32(self) -> u32 {
+        self.0.get() - 1
+    }
+}
+
+/// Builder that appends Extended Data records with the required 8-byte
+/// alignment.
+pub struct ExtendedDataBuilder<'arena> {
+    /// Concatenated Extended Data records.
+    pub(crate) buffer: ArenaVec<'arena, u8>,
+}
+
+impl<'arena> ExtendedDataBuilder<'arena> {
+    /// Create an empty builder backed by the supplied arena.
+    #[must_use]
+    pub fn new(arena: &'arena Allocator) -> Self {
+        ExtendedDataBuilder { buffer: ArenaVec::new_in(arena) }
+    }
+
+    /// Truncate the builder back to its post-[`Self::new`] state, keeping the
+    /// arena-backed buffer capacity. Used by
+    /// [`crate::writer::BinaryWriter::reset`] to recycle a writer across
+    /// per-comment parse calls.
+    pub(crate) fn reset(&mut self) {
+        self.buffer.truncate(0);
+    }
+
+    /// Reserve `size` bytes for a new record, returning the resulting
+    /// [`ExtOffset`].
+    ///
+    /// Inserts zero-fill padding before the record so the offset is
+    /// 8-byte aligned. The returned offset points to the first reserved
+    /// byte; the reserved bytes themselves are zeroed and can be patched
+    /// in place by the caller using indexing.
+    pub fn reserve(&mut self, size: usize) -> ExtOffset {
+        let aligned_offset = self.next_aligned_offset();
+        let new_len = aligned_offset + size;
+        // `Vec::resize(len, 0)` lowers to `memset` for `Vec<u8>`, which is
+        // measurably tighter than `extend(repeat_n(...))` because the
+        // latter retains the iterator dispatch.
+        self.buffer.resize(new_len, 0);
+        ExtOffset::from_u32(aligned_offset as u32).expect("Extended Data offset overflow")
+    }
+
+    /// Mutable view of `len` bytes starting at `offset` in the underlying
+    /// buffer. Helper for callers that want to write multi-byte fields
+    /// after [`Self::reserve`].
+    #[inline]
+    pub fn slice_mut(&mut self, offset: ExtOffset, len: usize) -> &mut [u8] {
+        let start = offset.as_u32() as usize;
+        &mut self.buffer[start..start + len]
+    }
+
+    /// Combined [`Self::reserve`] + [`Self::slice_mut`]: reserve `size`
+    /// bytes and return both the resulting offset and a mutable slice
+    /// pointing at the just-allocated zone. Saves one bounds check + one
+    /// arithmetic round-trip on the per-Kind `write_*` hot path.
+    #[inline]
+    pub fn reserve_mut(&mut self, size: usize) -> (ExtOffset, &mut [u8]) {
+        let aligned_offset = self.next_aligned_offset();
+        let new_len = aligned_offset + size;
+        self.buffer.resize(new_len, 0);
+        let off =
+            ExtOffset::from_u32(aligned_offset as u32).expect("Extended Data offset overflow");
+        let slice = &mut self.buffer[aligned_offset..new_len];
+        (off, slice)
+    }
+
+    /// Total Extended Data section size in bytes (includes padding).
+    #[inline]
+    #[must_use]
+    pub fn size(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// Whether the buffer is empty.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    /// Round the current buffer length up to the next 8-byte boundary.
+    /// Equivalent to `unaligned.div_ceil(8) * 8`, but the bitwise form
+    /// compiles to two instructions vs the more involved div+mul lowering
+    /// the generic version produces (rustc 1.x doesn't reliably constant
+    /// fold the `align = 8` for the helper here even though it does at
+    /// the call site).
+    #[inline]
+    fn next_aligned_offset(&self) -> usize {
+        const _: () = assert!(EXTENDED_DATA_ALIGNMENT == 8);
+        (self.buffer.len() + 7) & !7
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ext_offset_round_trips() {
+        for raw in [0u32, 1, 7, 8, 0x3FFF_FFFE] {
+            let off = ExtOffset::from_u32(raw).unwrap();
+            assert_eq!(off.as_u32(), raw);
+        }
+    }
+
+    #[test]
+    fn ext_offset_zero_is_representable() {
+        let off = ExtOffset::from_u32(0).unwrap();
+        assert_eq!(off.as_u32(), 0);
+    }
+
+    #[test]
+    fn ext_offset_rejects_u32_max() {
+        assert!(ExtOffset::from_u32(u32::MAX).is_none());
+    }
+
+    #[test]
+    fn reserve_first_record_starts_at_zero() {
+        let arena = Allocator::default();
+        let mut b = ExtendedDataBuilder::new(&arena);
+        let off = b.reserve(2);
+        assert_eq!(off.as_u32(), 0);
+        assert_eq!(b.size(), 2);
+    }
+
+    #[test]
+    fn reserve_pads_to_8_byte_alignment() {
+        let arena = Allocator::default();
+        let mut b = ExtendedDataBuilder::new(&arena);
+        // First reserve 2 bytes (so the buffer ends at offset 2)
+        let _ = b.reserve(2);
+        // Second reserve must round up to offset 8 (6 bytes padding inserted)
+        let off = b.reserve(2);
+        assert_eq!(off.as_u32(), 8);
+        assert_eq!(b.size(), 10);
+    }
+
+    #[test]
+    fn slice_mut_round_trip() {
+        let arena = Allocator::default();
+        let mut b = ExtendedDataBuilder::new(&arena);
+        let off = b.reserve(4);
+        b.slice_mut(off, 4).copy_from_slice(&[1, 2, 3, 4]);
+        assert_eq!(&b.buffer[..], &[1, 2, 3, 4]);
+    }
+}

--- a/crates/ox_jsdoc_binary/src/writer/mod.rs
+++ b/crates/ox_jsdoc_binary/src/writer/mod.rs
@@ -1,0 +1,34 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Binary AST writer (parser-integrated, approach c-1).
+//!
+//! See `design/007-binary-ast/rust-impl.md#parser-integrated-binary-writer`
+//! for the design rationale.
+//!
+//! The writer is invoked from inside the parser as it produces nodes. It
+//! emits Binary AST bytes directly into an arena-backed buffer per section
+//! ([`BinaryWriter`]), then concatenates them into the final `Vec<u8>` at
+//! [`BinaryWriter::finish`]. There is no separate encoder pass; parsing
+//! and encoding happen in lockstep.
+//!
+//! Per-Kind emit helpers live in [`nodes`]; the top-level orchestration
+//! (section buffers, header patching, root array, diagnostics, UTF-16
+//! position conversion via [`crate::utf16::Utf16PositionMap`]) lives in
+//! [`BinaryWriter`].
+
+mod binary_writer;
+mod extended_data;
+pub mod nodes;
+mod string_table;
+
+pub use crate::format::string_field::StringField;
+pub use binary_writer::{BinaryWriter, ListInProgress};
+pub use extended_data::{ExtOffset, ExtendedDataBuilder};
+pub use nodes::NodeIndex;
+pub use string_table::{
+    COMMON_CRLF, COMMON_EMPTY, COMMON_LF, COMMON_SLASH_STAR, COMMON_SLASH_STAR_STAR, COMMON_SPACE,
+    COMMON_STAR, COMMON_TAB, LeafStringPayload, StringIndex, StringTableBuilder,
+    common_string_field,
+};

--- a/crates/ox_jsdoc_binary/src/writer/nodes/comment_ast.rs
+++ b/crates/ox_jsdoc_binary/src/writer/nodes/comment_ast.rs
@@ -1,0 +1,678 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! `write_*` helpers for the 15 comment AST kinds (`0x01 - 0x0F`).
+//!
+//! Convention: every helper takes the writer first, then the node's
+//! `Span`, then its `parent_index` (`0` = sentinel parent = root),
+//! followed by the per-Kind payload parameters. Each helper returns the
+//! [`NodeIndex`] of the freshly written node so that the parser can wire
+//! it as a child of its parent (via backpatched `next_sibling`).
+//!
+//! String reference encoding:
+//!
+//! - **String-leaf nodes** (`JsdocTagName`, `JsdocText`, `JsdocTypeSource`,
+//!   `JsdocRawTagBody`, `JsdocNamepathSource`, `JsdocIdentifier`,
+//!   `JsdocTagNameValue`, plus the basic-mode forms of
+//!   `JsdocDescriptionLine` and `JsdocTypeLine`) use `TypeTag::String`
+//!   with a 30-bit `StringIndex` packed into Node Data — no Extended Data
+//!   record allocated.
+//! - **Extended Data string slots** (e.g. `JsdocBlock.delimiter`,
+//!   `JsdocTag.description`, `JsdocInlineTag.text`) use inline 6-byte
+//!   `StringField` slots, bypassing the offsets-table indirection.
+
+use oxc_span::Span;
+
+use crate::format::extended_data::LIST_METADATA_SIZE;
+use crate::format::kind::Kind;
+use crate::format::string_field::{STRING_FIELD_SIZE, StringField};
+
+use super::super::{BinaryWriter, ExtOffset, LeafStringPayload};
+use super::NodeIndex;
+
+// ---------------------------------------------------------------------------
+// 0x01 JsdocBlock (Extended, root)
+// ---------------------------------------------------------------------------
+
+/// Number of NodeList slots embedded in a `JsdocBlock` Extended Data block:
+/// description_lines, tags, inline_tags.
+const JSDOC_BLOCK_LIST_COUNT: usize = 3;
+/// Byte offset where the per-list metadata region begins inside a
+/// `JsdocBlock` Extended Data block (right after the 8 inline StringFields).
+pub(crate) const JSDOC_BLOCK_LISTS_BASE: usize = 1 + 1 + 8 * STRING_FIELD_SIZE;
+/// `description_lines` list metadata slot offset (basic-mode ED).
+pub const JSDOC_BLOCK_DESC_LINES_SLOT: usize = JSDOC_BLOCK_LISTS_BASE;
+/// `tags` list metadata slot offset (basic-mode ED).
+pub const JSDOC_BLOCK_TAGS_SLOT: usize = JSDOC_BLOCK_LISTS_BASE + LIST_METADATA_SIZE;
+/// `inline_tags` list metadata slot offset (basic-mode ED).
+pub const JSDOC_BLOCK_INLINE_TAGS_SLOT: usize = JSDOC_BLOCK_LISTS_BASE + 2 * LIST_METADATA_SIZE;
+
+/// Basic-mode Extended Data size for [`JsdocBlock`]:
+/// `1 + 1 + 8 × StringField + 3 × ListMetadata = 68` bytes.
+pub(crate) const JSDOC_BLOCK_BASIC_SIZE: usize =
+    JSDOC_BLOCK_LISTS_BASE + JSDOC_BLOCK_LIST_COUNT * LIST_METADATA_SIZE;
+/// Compat-mode Extended Data size for [`JsdocBlock`]: basic + `22` bytes
+/// of compat tail (line indices + `has_preterminal_*_description` flags).
+/// `description_raw_span` is **not** part of the compat tail in Phase 5 —
+/// it is opt-in per the per-node Common Data bit (see [`Self::write_jsdoc_block`]).
+///
+/// Inter-record 8-byte alignment is handled by the writer
+/// (`crate::writer::extended_data::ExtendedDataWriter::reserve_mut` pads
+/// before each new record), so this constant does not include any extra
+/// trailing padding.
+pub(crate) const JSDOC_BLOCK_COMPAT_SIZE: usize = JSDOC_BLOCK_BASIC_SIZE + 22;
+/// Compat tail base offset (start of the compat-only region).
+const JSDOC_BLOCK_COMPAT_TAIL_BASE: usize = JSDOC_BLOCK_BASIC_SIZE;
+
+/// Size of the optional `description_raw_span` slot appended at the **end**
+/// of every `JsdocBlock` / `JsdocTag` Extended Data record when the
+/// `has_description_raw_span` Common Data bit is set. See
+/// `design/008-oxlint-oxfmt-support/README.md` §4.2 for the wire layout
+/// and §5.2 for the per-mode total ED sizes.
+pub(crate) const DESCRIPTION_RAW_SPAN_SIZE: usize = 8;
+
+/// Common Data bit signalling presence of `description_raw_span` on a
+/// `JsdocBlock` Extended Data record. Bit 0 of the 6-bit Common Data
+/// field. (bits 1–5 reserved.)
+pub(crate) const JSDOC_BLOCK_HAS_DESCRIPTION_RAW_SPAN_BIT: u8 = 1 << 0;
+
+/// Write a `JsdocBlock` (Kind `0x01`, Extended type).
+///
+/// Extended Data layout (basic 68 bytes; compat tail adds 22 bytes via
+/// [`write_jsdoc_block_compat_tail`]; an optional 8-byte
+/// `description_raw_span` is appended at the **very end** when
+/// `description_raw_span` is `Some`):
+///
+/// ```text
+/// byte 0      : Children bitmask (u8, retained for visitor framework)
+/// byte 1      : padding (u8)
+/// byte 2-7    : description     (StringField, NONE if absent)
+/// byte 8-13   : delimiter
+/// byte 14-19  : post_delimiter
+/// byte 20-25  : terminal
+/// byte 26-31  : line_end
+/// byte 32-37  : initial
+/// byte 38-43  : delimiter_line_break
+/// byte 44-49  : preterminal_line_break
+/// byte 50-55  : description_lines list metadata (head: u32, count: u16)
+/// byte 56-61  : tags list metadata
+/// byte 62-67  : inline_tags list metadata
+/// [compat tail (bytes 68-89) — only present in compat mode]
+/// [description_raw_span (last 8 bytes) — only when bit 0 of Common Data set]
+/// ```
+///
+/// Per-mode total sizes (matrix from
+/// `design/008-oxlint-oxfmt-support/README.md` §5.2):
+///
+/// | compat | preserve | total |
+/// |--------|----------|-------|
+/// | false  | false    | 68    |
+/// | false  | true     | 76    |
+/// | true   | false    | 90    |
+/// | true   | true     | 98    |
+///
+/// When `description_raw_span` is `Some`, the [`JSDOC_BLOCK_HAS_DESCRIPTION_RAW_SPAN_BIT`]
+/// is set in Common Data so the decoder knows to read the trailing 8 bytes.
+///
+/// Returns `(NodeIndex, ExtOffset)` so the caller can patch the per-list
+/// metadata via [`BinaryWriter::begin_node_list_at`] /
+/// [`BinaryWriter::finalize_node_list`] once all children of each list have
+/// been emitted.
+#[allow(clippy::too_many_arguments)]
+pub fn write_jsdoc_block(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    description: Option<StringField>,
+    delimiter: StringField,
+    post_delimiter: StringField,
+    terminal: StringField,
+    line_end: StringField,
+    initial: StringField,
+    delimiter_line_break: StringField,
+    preterminal_line_break: StringField,
+    children_bitmask: u8,
+    description_raw_span: Option<(u32, u32)>,
+) -> (NodeIndex, ExtOffset) {
+    let base_size =
+        if writer.compat_mode() { JSDOC_BLOCK_COMPAT_SIZE } else { JSDOC_BLOCK_BASIC_SIZE };
+    let total_size = if description_raw_span.is_some() {
+        base_size + DESCRIPTION_RAW_SPAN_SIZE
+    } else {
+        base_size
+    };
+    let (off, dst) = writer.extended.reserve_mut(total_size);
+    dst[0] = children_bitmask;
+    dst[1] = 0;
+    write_opt_string_field(dst, 2, description);
+    write_string_field(dst, 8, delimiter);
+    write_string_field(dst, 14, post_delimiter);
+    write_string_field(dst, 20, terminal);
+    write_string_field(dst, 26, line_end);
+    write_string_field(dst, 32, initial);
+    write_string_field(dst, 38, delimiter_line_break);
+    write_string_field(dst, 44, preterminal_line_break);
+    // List metadata bytes 50..68 are zeroed by reserve_mut and patched later
+    // via begin_node_list_at / finalize_node_list.
+
+    // Phase 5: optional description_raw_span at the very end of the ED.
+    let common_data = if let Some((raw_start, raw_end)) = description_raw_span {
+        let span_off = total_size - DESCRIPTION_RAW_SPAN_SIZE;
+        dst[span_off..span_off + 4].copy_from_slice(&raw_start.to_le_bytes());
+        dst[span_off + 4..span_off + 8].copy_from_slice(&raw_end.to_le_bytes());
+        JSDOC_BLOCK_HAS_DESCRIPTION_RAW_SPAN_BIT
+    } else {
+        0
+    };
+
+    let idx = writer.emit_extended_node(parent_index, Kind::JsdocBlock, common_data, span, off);
+    (idx, off)
+}
+
+/// Patch the compat-mode tail on a previously written `JsdocBlock` Extended
+/// Data record. Only call this when [`BinaryWriter::compat_mode`] is `true`
+/// (the basic write helper already reserved the extra bytes).
+///
+/// Tail layout (offsets relative to the parent's Extended Data start; the
+/// region begins at byte 68 = `JSDOC_BLOCK_COMPAT_TAIL_BASE`):
+/// ```text
+/// byte 68-69 : padding (u16, zero-fill)
+/// byte 70-73 : end_line (u32)
+/// byte 74-77 : description_start_line (u32, 0xFFFF_FFFF = None)
+/// byte 78-81 : description_end_line   (u32, 0xFFFF_FFFF = None)
+/// byte 82-85 : last_description_line  (u32, 0xFFFF_FFFF = None)
+/// byte 86    : has_preterminal_description (u8)
+/// byte 87    : has_preterminal_tag_description (u8, 0xFF = None)
+/// byte 88-89 : padding (u16, zero-fill)
+/// ```
+///
+/// `description_raw_span` is **not** part of the compat tail in Phase 5 —
+/// it is written by [`write_jsdoc_block`] at the very end of the ED record
+/// when opted in (see `design/008-oxlint-oxfmt-support/README.md` §4.2).
+#[allow(clippy::too_many_arguments)]
+pub fn write_jsdoc_block_compat_tail(
+    writer: &mut BinaryWriter<'_>,
+    ext_offset: ExtOffset,
+    end_line: u32,
+    description_start_line: Option<u32>,
+    description_end_line: Option<u32>,
+    last_description_line: Option<u32>,
+    has_preterminal_description: u8,
+    has_preterminal_tag_description: Option<u8>,
+) {
+    debug_assert!(
+        writer.compat_mode(),
+        "write_jsdoc_block_compat_tail called but compat_mode is off"
+    );
+    let dst = writer.extended.slice_mut(ext_offset, JSDOC_BLOCK_COMPAT_SIZE);
+    let base = JSDOC_BLOCK_COMPAT_TAIL_BASE;
+    // bytes [base..base+2] are u32 alignment padding (already zero)
+    dst[base + 2..base + 6].copy_from_slice(&end_line.to_le_bytes());
+    dst[base + 6..base + 10]
+        .copy_from_slice(&opt_u32_sentinel(description_start_line).to_le_bytes());
+    dst[base + 10..base + 14]
+        .copy_from_slice(&opt_u32_sentinel(description_end_line).to_le_bytes());
+    dst[base + 14..base + 18]
+        .copy_from_slice(&opt_u32_sentinel(last_description_line).to_le_bytes());
+    dst[base + 18] = has_preterminal_description;
+    dst[base + 19] = has_preterminal_tag_description.unwrap_or(0xFF);
+    // bytes [base+20..base+22] trailing alignment padding (already zero)
+}
+
+// ---------------------------------------------------------------------------
+// 0x02 JsdocDescriptionLine (String basic / Extended compat)
+// ---------------------------------------------------------------------------
+
+/// Compat-mode Extended Data size for [`JsdocDescriptionLine`]: 4 ×
+/// StringField (description + 3 optional delimiter strings).
+const JSDOC_DESCRIPTION_LINE_COMPAT_SIZE: usize = 4 * STRING_FIELD_SIZE;
+
+/// Write a `JsdocDescriptionLine` (Kind `0x02`, basic mode).
+///
+/// Node Data: `TypeTag::String` carrying the description's StringIndex.
+/// No Extended Data record is allocated.
+pub fn write_jsdoc_description_line(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    description: LeafStringPayload,
+) -> NodeIndex {
+    writer.emit_string_node(parent_index, Kind::JsdocDescriptionLine, 0, span, description)
+}
+
+/// Write a `JsdocDescriptionLine` (Kind `0x02`, compat mode).
+///
+/// Extended Data layout (24 bytes):
+/// - byte 0-5   : description    (StringField, required)
+/// - byte 6-11  : delimiter      (StringField, NONE if absent)
+/// - byte 12-17 : post_delimiter (StringField, NONE if absent)
+/// - byte 18-23 : initial        (StringField, NONE if absent)
+pub fn write_jsdoc_description_line_compat(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    description: StringField,
+    delimiter: Option<StringField>,
+    post_delimiter: Option<StringField>,
+    initial: Option<StringField>,
+) -> NodeIndex {
+    debug_assert!(writer.compat_mode());
+    let (off, dst) = writer.extended.reserve_mut(JSDOC_DESCRIPTION_LINE_COMPAT_SIZE);
+    write_string_field(dst, 0, description);
+    write_opt_string_field(dst, 6, delimiter);
+    write_opt_string_field(dst, 12, post_delimiter);
+    write_opt_string_field(dst, 18, initial);
+    writer.emit_extended_node(parent_index, Kind::JsdocDescriptionLine, 0, span, off)
+}
+
+// ---------------------------------------------------------------------------
+// 0x03 JsdocTag (Extended)
+// ---------------------------------------------------------------------------
+
+/// Number of NodeList slots embedded in a `JsdocTag` Extended Data block:
+/// type_lines, description_lines, inline_tags.
+const JSDOC_TAG_LIST_COUNT: usize = 3;
+/// Byte offset where the per-list metadata region begins inside a
+/// `JsdocTag` Extended Data block (right after the 3 inline StringFields).
+pub(crate) const JSDOC_TAG_LISTS_BASE: usize = 1 + 1 + 3 * STRING_FIELD_SIZE;
+/// `type_lines` list metadata slot offset.
+pub const JSDOC_TAG_TYPE_LINES_SLOT: usize = JSDOC_TAG_LISTS_BASE;
+/// `description_lines` list metadata slot offset.
+pub const JSDOC_TAG_DESC_LINES_SLOT: usize = JSDOC_TAG_LISTS_BASE + LIST_METADATA_SIZE;
+/// `inline_tags` list metadata slot offset.
+pub const JSDOC_TAG_INLINE_TAGS_SLOT: usize = JSDOC_TAG_LISTS_BASE + 2 * LIST_METADATA_SIZE;
+
+/// Basic-mode Extended Data size for [`JsdocTag`]:
+/// `1 + 1 + 3 × StringField + 3 × ListMetadata = 38` bytes.
+pub(crate) const JSDOC_TAG_BASIC_SIZE: usize =
+    JSDOC_TAG_LISTS_BASE + JSDOC_TAG_LIST_COUNT * LIST_METADATA_SIZE;
+/// Compat-mode Extended Data size for [`JsdocTag`]: basic + 42 bytes of
+/// compat tail (7 × `StringField` for the delimiter group).
+/// `description_raw_span` is **not** part of the compat tail in Phase 5 —
+/// it is opt-in per the per-node Common Data bit (see [`Self::write_jsdoc_tag`]).
+pub(crate) const JSDOC_TAG_COMPAT_SIZE: usize = JSDOC_TAG_BASIC_SIZE + 7 * STRING_FIELD_SIZE;
+/// Compat tail base offset (start of the compat-only region).
+const JSDOC_TAG_COMPAT_TAIL_BASE: usize = JSDOC_TAG_BASIC_SIZE;
+
+/// Common Data bit signalling presence of `description_raw_span` on a
+/// `JsdocTag` Extended Data record. Bit 1 of the 6-bit Common Data
+/// field (bit 0 is `optional`; bits 2–5 reserved).
+pub(crate) const JSDOC_TAG_HAS_DESCRIPTION_RAW_SPAN_BIT: u8 = 1 << 1;
+
+/// Write a `JsdocTag` (Kind `0x03`, Extended type).
+///
+/// Common Data layout: bit 0 = `optional`, bit 1 =
+/// `has_description_raw_span` (set when `description_raw_span` is `Some`).
+/// bits 2–5 reserved.
+///
+/// Extended Data layout (basic 38 bytes; compat tail adds 42 bytes via
+/// [`write_jsdoc_tag_compat_tail`]; an optional 8-byte
+/// `description_raw_span` is appended at the **very end** when
+/// `description_raw_span` is `Some`):
+///
+/// ```text
+/// byte 0      : Children bitmask (u8, retained for visitor framework)
+/// byte 1      : padding (u8)
+/// byte 2-7    : default_value (StringField, NONE if absent)
+/// byte 8-13   : description    (StringField, NONE if absent)
+/// byte 14-19  : raw_body       (StringField, NONE if absent)
+/// byte 20-25  : type_lines       list metadata (head: u32, count: u16)
+/// byte 26-31  : description_lines list metadata
+/// byte 32-37  : inline_tags      list metadata
+/// [compat tail: 7 × StringField at bytes 38..=79 — only in compat mode]
+/// [description_raw_span (last 8 bytes) — only when bit 1 of Common Data set]
+/// ```
+///
+/// Per-mode total sizes (matrix from
+/// `design/008-oxlint-oxfmt-support/README.md` §5.2):
+///
+/// | compat | preserve | total |
+/// |--------|----------|-------|
+/// | false  | false    | 38    |
+/// | false  | true     | 46    |
+/// | true   | false    | 80    |
+/// | true   | true     | 88    |
+///
+/// Returns `(NodeIndex, ExtOffset)` so the caller can patch the per-list
+/// metadata via [`BinaryWriter::begin_node_list_at`] /
+/// [`BinaryWriter::finalize_node_list`].
+#[allow(clippy::too_many_arguments)]
+pub fn write_jsdoc_tag(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    optional: bool,
+    default_value: Option<StringField>,
+    description: Option<StringField>,
+    raw_body: Option<StringField>,
+    children_bitmask: u8,
+    description_raw_span: Option<(u32, u32)>,
+) -> (NodeIndex, ExtOffset) {
+    let base_size = if writer.compat_mode() { JSDOC_TAG_COMPAT_SIZE } else { JSDOC_TAG_BASIC_SIZE };
+    let total_size = if description_raw_span.is_some() {
+        base_size + DESCRIPTION_RAW_SPAN_SIZE
+    } else {
+        base_size
+    };
+    let (off, dst) = writer.extended.reserve_mut(total_size);
+    dst[0] = children_bitmask;
+    dst[1] = 0;
+    write_opt_string_field(dst, 2, default_value);
+    write_opt_string_field(dst, 8, description);
+    write_opt_string_field(dst, 14, raw_body);
+    // List metadata bytes 20..38 are zeroed by reserve_mut and patched
+    // later via begin_node_list_at / finalize_node_list.
+
+    // Phase 5: optional description_raw_span at the very end of the ED.
+    let common_data = {
+        let mut cd = optional as u8;
+        if let Some((raw_start, raw_end)) = description_raw_span {
+            let span_off = total_size - DESCRIPTION_RAW_SPAN_SIZE;
+            dst[span_off..span_off + 4].copy_from_slice(&raw_start.to_le_bytes());
+            dst[span_off + 4..span_off + 8].copy_from_slice(&raw_end.to_le_bytes());
+            cd |= JSDOC_TAG_HAS_DESCRIPTION_RAW_SPAN_BIT;
+        }
+        cd
+    };
+
+    let idx = writer.emit_extended_node(parent_index, Kind::JsdocTag, common_data, span, off);
+    (idx, off)
+}
+
+/// Write the 7 delimiter [`StringField`]s (42 bytes total) at the compat
+/// tail of a previously written `JsdocTag` Extended Data record.
+///
+/// `description_raw_span` is **not** part of the compat tail in Phase 5 —
+/// it is written by [`write_jsdoc_tag`] at the very end of the ED record
+/// when opted in (see `design/008-oxlint-oxfmt-support/README.md` §4.2).
+#[allow(clippy::too_many_arguments)]
+pub fn write_jsdoc_tag_compat_tail(
+    writer: &mut BinaryWriter<'_>,
+    ext_offset: ExtOffset,
+    delimiter: StringField,
+    post_delimiter: StringField,
+    post_tag: StringField,
+    post_type: StringField,
+    post_name: StringField,
+    initial: StringField,
+    line_end: StringField,
+) {
+    debug_assert!(writer.compat_mode());
+    let dst = writer.extended.slice_mut(ext_offset, JSDOC_TAG_COMPAT_SIZE);
+    let base = JSDOC_TAG_COMPAT_TAIL_BASE;
+    write_string_field(dst, base, delimiter);
+    write_string_field(dst, base + STRING_FIELD_SIZE, post_delimiter);
+    write_string_field(dst, base + 2 * STRING_FIELD_SIZE, post_tag);
+    write_string_field(dst, base + 3 * STRING_FIELD_SIZE, post_type);
+    write_string_field(dst, base + 4 * STRING_FIELD_SIZE, post_name);
+    write_string_field(dst, base + 5 * STRING_FIELD_SIZE, initial);
+    write_string_field(dst, base + 6 * STRING_FIELD_SIZE, line_end);
+}
+
+// ---------------------------------------------------------------------------
+// 0x04 JsdocTagName (String leaf)
+// ---------------------------------------------------------------------------
+
+/// Write a `JsdocTagName` leaf (Kind `0x04`, String type).
+pub fn write_jsdoc_tag_name(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    value: LeafStringPayload,
+) -> NodeIndex {
+    writer.emit_string_node(parent_index, Kind::JsdocTagName, 0, span, value)
+}
+
+// ---------------------------------------------------------------------------
+// 0x05 JsdocTagNameValue (String leaf)
+// ---------------------------------------------------------------------------
+
+/// Write a `JsdocTagNameValue` leaf (Kind `0x05`, String type).
+pub fn write_jsdoc_tag_name_value(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    raw: LeafStringPayload,
+) -> NodeIndex {
+    writer.emit_string_node(parent_index, Kind::JsdocTagNameValue, 0, span, raw)
+}
+
+// ---------------------------------------------------------------------------
+// 0x06 JsdocTypeSource (String leaf)
+// ---------------------------------------------------------------------------
+
+/// Write a `JsdocTypeSource` leaf (Kind `0x06`, String type).
+pub fn write_jsdoc_type_source(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    raw: LeafStringPayload,
+) -> NodeIndex {
+    writer.emit_string_node(parent_index, Kind::JsdocTypeSource, 0, span, raw)
+}
+
+// ---------------------------------------------------------------------------
+// 0x07 JsdocTypeLine (String basic / Extended compat)
+// ---------------------------------------------------------------------------
+
+/// Compat-mode Extended Data size for [`JsdocTypeLine`]: 4 × StringField
+/// (raw_type + 3 optional delimiter strings).
+const JSDOC_TYPE_LINE_COMPAT_SIZE: usize = 4 * STRING_FIELD_SIZE;
+
+/// Write a `JsdocTypeLine` (Kind `0x07`, basic mode).
+///
+/// Node Data: `TypeTag::String` carrying the raw_type's StringIndex.
+pub fn write_jsdoc_type_line(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    raw_type: LeafStringPayload,
+) -> NodeIndex {
+    writer.emit_string_node(parent_index, Kind::JsdocTypeLine, 0, span, raw_type)
+}
+
+/// Write a `JsdocTypeLine` (Kind `0x07`, compat mode).
+///
+/// Extended Data layout (24 bytes):
+/// - byte 0-5   : raw_type       (StringField, required)
+/// - byte 6-11  : delimiter      (StringField, NONE if absent)
+/// - byte 12-17 : post_delimiter (StringField, NONE if absent)
+/// - byte 18-23 : initial        (StringField, NONE if absent)
+pub fn write_jsdoc_type_line_compat(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    raw_type: StringField,
+    delimiter: Option<StringField>,
+    post_delimiter: Option<StringField>,
+    initial: Option<StringField>,
+) -> NodeIndex {
+    debug_assert!(writer.compat_mode());
+    let (off, dst) = writer.extended.reserve_mut(JSDOC_TYPE_LINE_COMPAT_SIZE);
+    write_string_field(dst, 0, raw_type);
+    write_opt_string_field(dst, 6, delimiter);
+    write_opt_string_field(dst, 12, post_delimiter);
+    write_opt_string_field(dst, 18, initial);
+    writer.emit_extended_node(parent_index, Kind::JsdocTypeLine, 0, span, off)
+}
+
+// ---------------------------------------------------------------------------
+// 0x08 JsdocInlineTag (Extended)
+// ---------------------------------------------------------------------------
+
+/// Extended Data size for [`JsdocInlineTag`]: 3 × StringField = 18 bytes.
+const JSDOC_INLINE_TAG_SIZE: usize = 3 * STRING_FIELD_SIZE;
+
+/// Write a `JsdocInlineTag` (Kind `0x08`, Extended type).
+///
+/// Common Data: `bits[0:2] = format`. Extended Data: 18 bytes
+/// (3 × StringField for `namepath_or_url`, `text`, `raw_body`).
+pub fn write_jsdoc_inline_tag(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    format: u8,
+    namepath_or_url: Option<StringField>,
+    text: Option<StringField>,
+    raw_body: Option<StringField>,
+) -> NodeIndex {
+    let (off, dst) = writer.extended.reserve_mut(JSDOC_INLINE_TAG_SIZE);
+    write_opt_string_field(dst, 0, namepath_or_url);
+    write_opt_string_field(dst, 6, text);
+    write_opt_string_field(dst, 12, raw_body);
+    writer.emit_extended_node(parent_index, Kind::JsdocInlineTag, format & 0b111, span, off)
+}
+
+// ---------------------------------------------------------------------------
+// 0x09 JsdocGenericTagBody (Extended)
+// ---------------------------------------------------------------------------
+
+/// Extended Data size for [`JsdocGenericTagBody`]: bitmask + padding +
+/// StringField = 8 bytes.
+const JSDOC_GENERIC_TAG_BODY_SIZE: usize = 1 + 1 + STRING_FIELD_SIZE;
+
+/// Write a `JsdocGenericTagBody` (Kind `0x09`, Extended type).
+///
+/// Common Data: `bit0 = has_dash_separator`. Extended Data: 8 bytes
+/// (Children bitmask u8 + padding u8 + description StringField).
+pub fn write_jsdoc_generic_tag_body(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    has_dash_separator: bool,
+    description: Option<StringField>,
+    children_bitmask: u8,
+) -> NodeIndex {
+    let (off, dst) = writer.extended.reserve_mut(JSDOC_GENERIC_TAG_BODY_SIZE);
+    dst[0] = children_bitmask;
+    dst[1] = 0;
+    write_opt_string_field(dst, 2, description);
+    writer.emit_extended_node(
+        parent_index,
+        Kind::JsdocGenericTagBody,
+        has_dash_separator as u8,
+        span,
+        off,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// 0x0A JsdocBorrowsTagBody (Children)
+// ---------------------------------------------------------------------------
+
+/// Write a `JsdocBorrowsTagBody` (Kind `0x0A`, Children type; 2 children:
+/// `source` + `target`).
+pub fn write_jsdoc_borrows_tag_body(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(parent_index, Kind::JsdocBorrowsTagBody, 0, span, children_bitmask)
+}
+
+// ---------------------------------------------------------------------------
+// 0x0B JsdocRawTagBody (String leaf)
+// ---------------------------------------------------------------------------
+
+/// Write a `JsdocRawTagBody` leaf (Kind `0x0B`, String type).
+pub fn write_jsdoc_raw_tag_body(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    raw: LeafStringPayload,
+) -> NodeIndex {
+    writer.emit_string_node(parent_index, Kind::JsdocRawTagBody, 0, span, raw)
+}
+
+// ---------------------------------------------------------------------------
+// 0x0C JsdocParameterName (Extended)
+// ---------------------------------------------------------------------------
+
+/// Extended Data size for [`JsdocParameterName`]: 2 × StringField = 12 bytes.
+const JSDOC_PARAMETER_NAME_SIZE: usize = 2 * STRING_FIELD_SIZE;
+
+/// Write a `JsdocParameterName` (Kind `0x0C`, Extended type).
+///
+/// Common Data: `bit0 = optional`. Extended Data: 12 bytes (`path`
+/// StringField (required) + `default_value` StringField (Optional)).
+pub fn write_jsdoc_parameter_name(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    optional: bool,
+    path: StringField,
+    default_value: Option<StringField>,
+) -> NodeIndex {
+    let (off, dst) = writer.extended.reserve_mut(JSDOC_PARAMETER_NAME_SIZE);
+    write_string_field(dst, 0, path);
+    write_opt_string_field(dst, 6, default_value);
+    writer.emit_extended_node(parent_index, Kind::JsdocParameterName, optional as u8, span, off)
+}
+
+// ---------------------------------------------------------------------------
+// 0x0D JsdocNamepathSource (String leaf)
+// ---------------------------------------------------------------------------
+
+/// Write a `JsdocNamepathSource` leaf (Kind `0x0D`, String type).
+pub fn write_jsdoc_namepath_source(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    raw: LeafStringPayload,
+) -> NodeIndex {
+    writer.emit_string_node(parent_index, Kind::JsdocNamepathSource, 0, span, raw)
+}
+
+// ---------------------------------------------------------------------------
+// 0x0E JsdocIdentifier (String leaf)
+// ---------------------------------------------------------------------------
+
+/// Write a `JsdocIdentifier` leaf (Kind `0x0E`, String type).
+pub fn write_jsdoc_identifier(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    name: LeafStringPayload,
+) -> NodeIndex {
+    writer.emit_string_node(parent_index, Kind::JsdocIdentifier, 0, span, name)
+}
+
+// ---------------------------------------------------------------------------
+// 0x0F JsdocText (String leaf)
+// ---------------------------------------------------------------------------
+
+/// Write a `JsdocText` leaf (Kind `0x0F`, String type).
+pub fn write_jsdoc_text(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    value: LeafStringPayload,
+) -> NodeIndex {
+    writer.emit_string_node(parent_index, Kind::JsdocText, 0, span, value)
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+/// Write a [`StringField`] at `offset` inside `dst`. Caller guarantees that
+/// `dst[offset..offset+6]` is in range.
+#[inline]
+fn write_string_field(dst: &mut [u8], offset: usize, field: StringField) {
+    field.write_le(&mut dst[offset..offset + STRING_FIELD_SIZE]);
+}
+
+/// Write `opt.unwrap_or(StringField::NONE)` at `offset` inside `dst`.
+#[inline]
+fn write_opt_string_field(dst: &mut [u8], offset: usize, opt: Option<StringField>) {
+    let field = opt.unwrap_or(StringField::NONE);
+    field.write_le(&mut dst[offset..offset + STRING_FIELD_SIZE]);
+}
+
+/// Sentinel-conversion helper for compat-mode `Option<u32>` line indices.
+#[inline]
+fn opt_u32_sentinel(opt: Option<u32>) -> u32 {
+    opt.unwrap_or(0xFFFF_FFFF)
+}

--- a/crates/ox_jsdoc_binary/src/writer/nodes/mod.rs
+++ b/crates/ox_jsdoc_binary/src/writer/nodes/mod.rs
@@ -1,0 +1,76 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! Per-Kind `write_*` helpers (Phase 1.0b: signatures only).
+//!
+//! There is one `write_*` function per concrete node Kind (15 comment AST
+//! kinds + 45 TypeNode kinds = 60 helpers, organized in two submodules).
+//! `Sentinel` and `NodeList` are emitted internally by [`super::BinaryWriter`]
+//! and have no dedicated helper.
+//!
+//! Each helper:
+//! 1. Resolves a [`NodeIndex`] for the new node (= `nodes_buffer.len() / 24`),
+//! 2. Writes a 24-byte node record (`Kind` + Common Data + padding +
+//!    Pos/End + Node Data + parent_index + next_sibling),
+//! 3. For Extended-type Kinds, reserves Extended Data via
+//!    [`super::ExtendedDataBuilder::reserve`] and writes the per-Kind
+//!    payload,
+//! 4. Backpatches the previous sibling's `next_sibling` field if needed,
+//! 5. Returns the new [`NodeIndex`] so the caller can wire it as a child.
+//!
+//! Phase 1.0b only ships the function signatures with `unimplemented!()`
+//! bodies — Phase 1.1a will fill them in following the per-Kind layouts in
+//! `format::node_record` and the spec text in
+//! `design/007-binary-ast/format.md`.
+
+pub mod comment_ast;
+pub mod type_node;
+
+use core::num::NonZeroU32;
+
+/// Index into the **Nodes** section.
+///
+/// Newtype around `u32` (with `0` reserved for the `node[0]` sentinel; the
+/// wrapper itself uses `NonZeroU32` storage so `Option<NodeIndex>` is
+/// 4 bytes).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NodeIndex(NonZeroU32);
+
+impl NodeIndex {
+    /// Construct a [`NodeIndex`] from a raw `u32`. Returns `None` when
+    /// `value == 0` (the sentinel slot).
+    #[inline]
+    #[must_use]
+    pub const fn new(value: u32) -> Option<Self> {
+        match NonZeroU32::new(value) {
+            Some(nz) => Some(NodeIndex(nz)),
+            None => None,
+        }
+    }
+
+    /// Get the raw `u32` index.
+    #[inline]
+    #[must_use]
+    pub const fn as_u32(self) -> u32 {
+        self.0.get()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_index_round_trips() {
+        for raw in [1u32, 2, 100, u32::MAX] {
+            let idx = NodeIndex::new(raw).unwrap();
+            assert_eq!(idx.as_u32(), raw);
+        }
+    }
+
+    #[test]
+    fn node_index_zero_is_sentinel() {
+        assert!(NodeIndex::new(0).is_none());
+    }
+}

--- a/crates/ox_jsdoc_binary/src/writer/nodes/type_node.rs
+++ b/crates/ox_jsdoc_binary/src/writer/nodes/type_node.rs
@@ -1,0 +1,621 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! `write_*` helpers for the 45 TypeNode kinds (`0x80 - 0xAC`).
+//!
+//! TypeNodes split into 4 patterns (see `format.md` "Node catalog matrix"):
+//!
+//! - **Pattern 1 — String leaf** (5 kinds): Extended type with a 6-byte ED
+//!   record holding a single [`StringField`] (formerly the v1 String-tag
+//!   payload).
+//! - **Pattern 2 — Children only** (29 kinds): payload is a 30-bit Children
+//!   bitmask.
+//! - **Pattern 3 — Mixed string + children** (6 kinds): payload is a
+//!   30-bit Extended Data offset; Extended Data holds the per-Kind layout.
+//! - **Others** (5 kinds): pure leaves with no payload (`TypeNull` /
+//!   `TypeUndefined` / `TypeAny` / `TypeUnknown` / `TypeUniqueSymbol`).
+
+use oxc_span::Span;
+
+use crate::format::extended_data::LIST_METADATA_SIZE;
+use crate::format::kind::Kind;
+use crate::format::node_record::{TypeTag, pack_node_data};
+use crate::format::string_field::{STRING_FIELD_SIZE, StringField};
+
+use super::super::{BinaryWriter, ExtOffset, LeafStringPayload};
+use super::NodeIndex;
+
+/// Single per-list metadata slot offset for TypeNode parents that own
+/// exactly one variable-length child list (TypeUnion, TypeIntersection,
+/// TypeTuple, TypeObject, TypeGeneric, TypeTypeParameter, TypeParameterList).
+pub const TYPE_LIST_PARENT_SLOT: usize = 0;
+/// Extended Data size for TypeNode parents above: 6-byte list metadata
+/// padded to the 8-byte alignment boundary so the next ED record can sit at
+/// a 8-byte boundary without extra padding.
+const TYPE_LIST_PARENT_SIZE: usize = LIST_METADATA_SIZE + 2;
+
+// ===========================================================================
+// Pattern 1: String only (5 kinds, payload = StringIndex)
+// ===========================================================================
+
+/// `TypeName` (Kind `0x80`, Pattern 1).
+pub fn write_type_name(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    value: LeafStringPayload,
+) -> NodeIndex {
+    writer.emit_string_node(parent_index, Kind::TypeName, 0, span, value)
+}
+
+/// `TypeNumber` (Kind `0x81`, Pattern 1).
+pub fn write_type_number(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    value: LeafStringPayload,
+) -> NodeIndex {
+    writer.emit_string_node(parent_index, Kind::TypeNumber, 0, span, value)
+}
+
+/// `TypeStringValue` (Kind `0x82`, Pattern 1; Common Data: bits[0:1] = quote 3-state).
+pub fn write_type_string_value(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    quote: u8,
+    value: LeafStringPayload,
+) -> NodeIndex {
+    writer.emit_string_node(parent_index, Kind::TypeStringValue, quote & 0b11, span, value)
+}
+
+/// `TypeProperty` (Kind `0xA3`, Pattern 1; Common Data: bits[0:1] = quote 3-state).
+pub fn write_type_property(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    quote: u8,
+    value: LeafStringPayload,
+) -> NodeIndex {
+    writer.emit_string_node(parent_index, Kind::TypeProperty, quote & 0b11, span, value)
+}
+
+/// `TypeSpecialNamePath` (Kind `0x8F`, Pattern 1).
+///
+/// Common Data: `bits[0:1] = special_type` (3 variants) + `bits[2:3] = quote` (3-state).
+pub fn write_type_special_name_path(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    special_type: u8,
+    quote: u8,
+    value: LeafStringPayload,
+) -> NodeIndex {
+    let common = (special_type & 0b11) | ((quote & 0b11) << 2);
+    writer.emit_string_node(parent_index, Kind::TypeSpecialNamePath, common, span, value)
+}
+
+// ===========================================================================
+// Pattern 2: Children only (29 kinds, payload = Children bitmask)
+// ===========================================================================
+
+/// `TypeUnion` (Kind `0x87`, Pattern 3; ED holds list metadata).
+///
+/// Returns `(NodeIndex, ExtOffset)` so the caller can patch the elements
+/// list head/count via [`BinaryWriter::begin_node_list_at`] /
+/// [`BinaryWriter::finalize_node_list`] at byte
+/// [`TYPE_LIST_PARENT_SLOT`] of the returned ED block.
+pub fn write_type_union(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+) -> (NodeIndex, ExtOffset) {
+    let (off, _dst) = writer.extended.reserve_mut(TYPE_LIST_PARENT_SIZE);
+    let idx = writer.emit_extended_node(parent_index, Kind::TypeUnion, 0, span, off);
+    (idx, off)
+}
+
+/// `TypeIntersection` (Kind `0x88`, Pattern 3; ED holds list metadata).
+pub fn write_type_intersection(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+) -> (NodeIndex, ExtOffset) {
+    let (off, _dst) = writer.extended.reserve_mut(TYPE_LIST_PARENT_SIZE);
+    let idx = writer.emit_extended_node(parent_index, Kind::TypeIntersection, 0, span, off);
+    (idx, off)
+}
+
+/// `TypeGeneric` (Kind `0x89`, Pattern 3).
+///
+/// Common Data: `bit0 = brackets`, `bit1 = dot`. ED holds the elements list
+/// metadata; the `left` child is the parent's first direct child (no
+/// Children bitmask).
+pub fn write_type_generic(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    brackets: u8,
+    dot: bool,
+) -> (NodeIndex, ExtOffset) {
+    let common = (brackets & 1) | ((dot as u8) << 1);
+    let (off, _dst) = writer.extended.reserve_mut(TYPE_LIST_PARENT_SIZE);
+    let idx = writer.emit_extended_node(parent_index, Kind::TypeGeneric, common, span, off);
+    (idx, off)
+}
+
+/// `TypeFunction` (Kind `0x8A`, Pattern 2).
+///
+/// Common Data: `bit0=constructor`, `bit1=arrow`, `bit2=parenthesis`. The
+/// fixed children (parameters, return, type_parameters) remain a Children
+/// bitmask; only the inner `TypeParameterList` children moved their list
+/// metadata into Extended Data.
+pub fn write_type_function(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    constructor: bool,
+    arrow: bool,
+    parenthesis: bool,
+    children_bitmask: u32,
+) -> NodeIndex {
+    let common = (constructor as u8) | ((arrow as u8) << 1) | ((parenthesis as u8) << 2);
+    writer.emit_children_node(parent_index, Kind::TypeFunction, common, span, children_bitmask)
+}
+
+/// `TypeObject` (Kind `0x8B`, Pattern 3).
+///
+/// Common Data: `bits[0:2] = separator`. ED holds the elements list metadata.
+pub fn write_type_object(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    separator: u8,
+) -> (NodeIndex, ExtOffset) {
+    let (off, _dst) = writer.extended.reserve_mut(TYPE_LIST_PARENT_SIZE);
+    let idx =
+        writer.emit_extended_node(parent_index, Kind::TypeObject, separator & 0b111, span, off);
+    (idx, off)
+}
+
+/// `TypeTuple` (Kind `0x8C`, Pattern 3; ED holds list metadata).
+pub fn write_type_tuple(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+) -> (NodeIndex, ExtOffset) {
+    let (off, _dst) = writer.extended.reserve_mut(TYPE_LIST_PARENT_SIZE);
+    let idx = writer.emit_extended_node(parent_index, Kind::TypeTuple, 0, span, off);
+    (idx, off)
+}
+
+/// `TypeParenthesis` (Kind `0x8D`, Pattern 2; 1 child).
+pub fn write_type_parenthesis(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(parent_index, Kind::TypeParenthesis, 0, span, children_bitmask)
+}
+
+/// `TypeNamePath` (Kind `0x8E`, Pattern 2).
+///
+/// Common Data: `bits[0:1] = path_type` (4 variants). Children: 2 (left + right).
+pub fn write_type_name_path(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    path_type: u8,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(
+        parent_index,
+        Kind::TypeNamePath,
+        path_type & 0b11,
+        span,
+        children_bitmask,
+    )
+}
+
+/// `TypeNullable` (Kind `0x90`, Pattern 2; 1 child).
+pub fn write_type_nullable(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    position: u8,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(
+        parent_index,
+        Kind::TypeNullable,
+        position & 1,
+        span,
+        children_bitmask,
+    )
+}
+
+/// `TypeNotNullable` (Kind `0x91`, Pattern 2; 1 child).
+pub fn write_type_not_nullable(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    position: u8,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(
+        parent_index,
+        Kind::TypeNotNullable,
+        position & 1,
+        span,
+        children_bitmask,
+    )
+}
+
+/// `TypeOptional` (Kind `0x92`, Pattern 2; 1 child).
+pub fn write_type_optional(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    position: u8,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(
+        parent_index,
+        Kind::TypeOptional,
+        position & 1,
+        span,
+        children_bitmask,
+    )
+}
+
+/// `TypeVariadic` (Kind `0x93`, Pattern 2; 1 child).
+pub fn write_type_variadic(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    position: u8,
+    square_brackets: bool,
+    children_bitmask: u32,
+) -> NodeIndex {
+    let common = (position & 1) | ((square_brackets as u8) << 1);
+    writer.emit_children_node(parent_index, Kind::TypeVariadic, common, span, children_bitmask)
+}
+
+/// `TypeConditional` (Kind `0x94`, Pattern 2; 4 children).
+pub fn write_type_conditional(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(parent_index, Kind::TypeConditional, 0, span, children_bitmask)
+}
+
+/// `TypeInfer` (Kind `0x95`, Pattern 2; 1 child).
+pub fn write_type_infer(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(parent_index, Kind::TypeInfer, 0, span, children_bitmask)
+}
+
+/// `TypeKeyOf` (Kind `0x96`, Pattern 2; 1 child).
+pub fn write_type_key_of(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(parent_index, Kind::TypeKeyOf, 0, span, children_bitmask)
+}
+
+/// `TypeTypeOf` (Kind `0x97`, Pattern 2; 1 child).
+pub fn write_type_type_of(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(parent_index, Kind::TypeTypeOf, 0, span, children_bitmask)
+}
+
+/// `TypeImport` (Kind `0x98`, Pattern 2; 1 child = element).
+pub fn write_type_import(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(parent_index, Kind::TypeImport, 0, span, children_bitmask)
+}
+
+/// `TypePredicate` (Kind `0x99`, Pattern 2; 2 children).
+pub fn write_type_predicate(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(parent_index, Kind::TypePredicate, 0, span, children_bitmask)
+}
+
+/// `TypeAsserts` (Kind `0x9A`, Pattern 2; 2 children).
+pub fn write_type_asserts(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(parent_index, Kind::TypeAsserts, 0, span, children_bitmask)
+}
+
+/// `TypeAssertsPlain` (Kind `0x9B`, Pattern 2; 1 child).
+pub fn write_type_asserts_plain(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(parent_index, Kind::TypeAssertsPlain, 0, span, children_bitmask)
+}
+
+/// `TypeReadonlyArray` (Kind `0x9C`, Pattern 2; 1 child).
+pub fn write_type_readonly_array(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(parent_index, Kind::TypeReadonlyArray, 0, span, children_bitmask)
+}
+
+/// `TypeObjectField` (Kind `0xA0`, Pattern 2; 1-2 children).
+///
+/// Common Data: `bit0=optional`, `bit1=readonly`, `bits[2:3]=quote (3-state)`.
+pub fn write_type_object_field(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    optional: bool,
+    readonly: bool,
+    quote: u8,
+    children_bitmask: u32,
+) -> NodeIndex {
+    let common = (optional as u8) | ((readonly as u8) << 1) | ((quote & 0b11) << 2);
+    writer.emit_children_node(parent_index, Kind::TypeObjectField, common, span, children_bitmask)
+}
+
+/// `TypeJsdocObjectField` (Kind `0xA1`, Pattern 2; 2 children).
+pub fn write_type_jsdoc_object_field(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(parent_index, Kind::TypeJsdocObjectField, 0, span, children_bitmask)
+}
+
+/// `TypeIndexedAccessIndex` (Kind `0xAA`, Pattern 2; 1 child).
+pub fn write_type_indexed_access_index(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(parent_index, Kind::TypeIndexedAccessIndex, 0, span, children_bitmask)
+}
+
+/// `TypeCallSignature` (Kind `0xA7`, Pattern 2; 3 children).
+pub fn write_type_call_signature(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(parent_index, Kind::TypeCallSignature, 0, span, children_bitmask)
+}
+
+/// `TypeConstructorSignature` (Kind `0xA8`, Pattern 2; 3 children).
+pub fn write_type_constructor_signature(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(
+        parent_index,
+        Kind::TypeConstructorSignature,
+        0,
+        span,
+        children_bitmask,
+    )
+}
+
+/// `TypeTypeParameter` (Kind `0xA6`, Pattern 3; ED holds list metadata).
+pub fn write_type_type_parameter(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+) -> (NodeIndex, ExtOffset) {
+    let (off, _dst) = writer.extended.reserve_mut(TYPE_LIST_PARENT_SIZE);
+    let idx = writer.emit_extended_node(parent_index, Kind::TypeTypeParameter, 0, span, off);
+    (idx, off)
+}
+
+/// `TypeParameterList` (Kind `0xAB`, Pattern 3; ED holds list metadata).
+pub fn write_type_parameter_list(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+) -> (NodeIndex, ExtOffset) {
+    let (off, _dst) = writer.extended.reserve_mut(TYPE_LIST_PARENT_SIZE);
+    let idx = writer.emit_extended_node(parent_index, Kind::TypeParameterList, 0, span, off);
+    (idx, off)
+}
+
+/// `TypeReadonlyProperty` (Kind `0xAC`, Pattern 2; 1 child).
+pub fn write_type_readonly_property(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    children_bitmask: u32,
+) -> NodeIndex {
+    writer.emit_children_node(parent_index, Kind::TypeReadonlyProperty, 0, span, children_bitmask)
+}
+
+// ===========================================================================
+// Pattern 3: Mixed string + children (6 kinds, payload = Extended Data offset)
+//
+// Each helper:
+// 1. Reserves Extended Data of the per-Kind size.
+// 2. Writes the per-Kind layout (one or more StringField slots).
+// 3. Emits the node record with `TypeTag::Extended` payload pointing to the
+//    reserved offset.
+// ===========================================================================
+
+/// `TypeKeyValue` (Kind `0xA2`, Pattern 3; 6-byte ED = key StringField).
+///
+/// Common Data: `bit0 = optional`, `bit1 = variadic`.
+pub fn write_type_key_value(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    optional: bool,
+    variadic: bool,
+    key: StringField,
+) -> NodeIndex {
+    let common = (optional as u8) | ((variadic as u8) << 1);
+    let (off, dst) = writer.extended.reserve_mut(STRING_FIELD_SIZE);
+    key.write_le(dst);
+    writer.emit_extended_node(parent_index, Kind::TypeKeyValue, common, span, off)
+}
+
+/// `TypeIndexSignature` (Kind `0xA4`, Pattern 3; 1 child + 6-byte ED = key).
+pub fn write_type_index_signature(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    key: StringField,
+) -> NodeIndex {
+    let (off, dst) = writer.extended.reserve_mut(STRING_FIELD_SIZE);
+    key.write_le(dst);
+    writer.emit_extended_node(parent_index, Kind::TypeIndexSignature, 0, span, off)
+}
+
+/// `TypeMappedType` (Kind `0xA5`, Pattern 3; 1 child + 6-byte ED = key).
+pub fn write_type_mapped_type(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    key: StringField,
+) -> NodeIndex {
+    let (off, dst) = writer.extended.reserve_mut(STRING_FIELD_SIZE);
+    key.write_le(dst);
+    writer.emit_extended_node(parent_index, Kind::TypeMappedType, 0, span, off)
+}
+
+/// `TypeMethodSignature` (Kind `0xA9`, Pattern 3; 6-byte ED = name StringField).
+///
+/// Common Data: `bits[0:1]=quote`, `bit2=has_parameters`, `bit3=has_type_parameters`.
+pub fn write_type_method_signature(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    quote: u8,
+    has_parameters: bool,
+    has_type_parameters: bool,
+    name: StringField,
+) -> NodeIndex {
+    let common =
+        (quote & 0b11) | ((has_parameters as u8) << 2) | ((has_type_parameters as u8) << 3);
+    let (off, dst) = writer.extended.reserve_mut(STRING_FIELD_SIZE);
+    name.write_le(dst);
+    writer.emit_extended_node(parent_index, Kind::TypeMethodSignature, common, span, off)
+}
+
+/// `TypeTemplateLiteral` (Kind `0x9D`, Pattern 3; 1 NodeList child).
+///
+/// Extended Data: `2 + 6N` bytes (`u16 literal_count` + `N × StringField`).
+pub fn write_type_template_literal(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    literals: &[StringField],
+) -> NodeIndex {
+    let n = literals.len();
+    let size = 2 + STRING_FIELD_SIZE * n;
+    let (off, dst) = writer.extended.reserve_mut(size);
+    let len_u16 = u16::try_from(n).expect("literal count exceeds u16");
+    dst[0..2].copy_from_slice(&len_u16.to_le_bytes());
+    for (i, lit) in literals.iter().enumerate() {
+        let pos = 2 + i * STRING_FIELD_SIZE;
+        lit.write_le(&mut dst[pos..pos + STRING_FIELD_SIZE]);
+    }
+    writer.emit_extended_node(parent_index, Kind::TypeTemplateLiteral, 0, span, off)
+}
+
+/// `TypeSymbol` (Kind `0x9F`, Pattern 3; 0 or 1 child + 6-byte ED = value).
+///
+/// Common Data: `bit0 = has_element`.
+pub fn write_type_symbol(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+    has_element: bool,
+    value: StringField,
+) -> NodeIndex {
+    let common = has_element as u8;
+    let (off, dst) = writer.extended.reserve_mut(STRING_FIELD_SIZE);
+    value.write_le(dst);
+    writer.emit_extended_node(parent_index, Kind::TypeSymbol, common, span, off)
+}
+
+// ===========================================================================
+// Others: pure leaves (5 kinds, no payload)
+// ===========================================================================
+
+/// `TypeNull` (Kind `0x83`, leaf).
+pub fn write_type_null(writer: &mut BinaryWriter<'_>, span: Span, parent_index: u32) -> NodeIndex {
+    let node_data = pack_node_data(TypeTag::Children, 0);
+    writer.emit_node_record(parent_index, Kind::TypeNull, 0, span, node_data)
+}
+
+/// `TypeUndefined` (Kind `0x84`, leaf).
+pub fn write_type_undefined(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+) -> NodeIndex {
+    let node_data = pack_node_data(TypeTag::Children, 0);
+    writer.emit_node_record(parent_index, Kind::TypeUndefined, 0, span, node_data)
+}
+
+/// `TypeAny` (Kind `0x85`, leaf).
+pub fn write_type_any(writer: &mut BinaryWriter<'_>, span: Span, parent_index: u32) -> NodeIndex {
+    let node_data = pack_node_data(TypeTag::Children, 0);
+    writer.emit_node_record(parent_index, Kind::TypeAny, 0, span, node_data)
+}
+
+/// `TypeUnknown` (Kind `0x86`, leaf).
+pub fn write_type_unknown(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+) -> NodeIndex {
+    let node_data = pack_node_data(TypeTag::Children, 0);
+    writer.emit_node_record(parent_index, Kind::TypeUnknown, 0, span, node_data)
+}
+
+/// `TypeUniqueSymbol` (Kind `0x9E`, leaf).
+pub fn write_type_unique_symbol(
+    writer: &mut BinaryWriter<'_>,
+    span: Span,
+    parent_index: u32,
+) -> NodeIndex {
+    let node_data = pack_node_data(TypeTag::Children, 0);
+    writer.emit_node_record(parent_index, Kind::TypeUniqueSymbol, 0, span, node_data)
+}

--- a/crates/ox_jsdoc_binary/src/writer/string_table.rs
+++ b/crates/ox_jsdoc_binary/src/writer/string_table.rs
@@ -1,0 +1,681 @@
+// @author kazuya kawaguchi (a.k.a. kazupon)
+// @license MIT
+//
+
+//! String table builder used by [`super::BinaryWriter`].
+//!
+//! Owns the **String Offsets** + **String Data** buffers. Strings are
+//! deduplicated by content via a HashMap so that repeated values
+//! (`param`, `returns`, etc.) shared across a batch of comments are
+//! interned only once.
+//!
+//! Two intern result types coexist:
+//!
+//! - [`StringIndex`] — index into the String Offsets table; used for
+//!   string-leaf nodes (TypeTag::String) and the diagnostics section's
+//!   `message_index`. Embedded as a 30-bit payload in Node Data, so each
+//!   leaf node costs 0 extra bytes beyond its 24-byte record.
+//! - [`crate::format::string_field::StringField`] — inline `(offset,
+//!   length)` pair returned for Extended Data string slots; readers
+//!   bypass the offsets table entirely.
+//!
+//! Both forms share the same `data_buffer`; dedup hits return whichever
+//! representation the caller asked for, allocating the other lazily on
+//! first use. See `design/007-binary-ast/format.md#string-table`.
+
+use core::num::NonZeroU32;
+use std::sync::OnceLock;
+
+use oxc_allocator::{Allocator, Vec as ArenaVec};
+use rustc_hash::FxHashMap;
+
+use crate::format::string_field::StringField;
+
+/// Index into the **String Offsets** table.
+///
+/// Newtype wrapper so a string index cannot accidentally be confused with a
+/// node index, an extended-data offset, or a raw `u32`. String-type Node
+/// Data leaves can reference up to 30 bits (the
+/// [`crate::format::node_record::STRING_PAYLOAD_NONE_SENTINEL`] reserves
+/// the last value).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StringIndex(NonZeroU32);
+
+impl StringIndex {
+    /// Construct a [`StringIndex`] from a raw `u32`.
+    ///
+    /// Returns `None` only when `value == u32::MAX` (so `value + 1`
+    /// overflows the `NonZeroU32` storage). Index 0 itself is a valid
+    /// string index, so the wrapper internally stores `index + 1`.
+    #[inline]
+    #[must_use]
+    pub const fn from_u32(value: u32) -> Option<Self> {
+        match NonZeroU32::new(value.wrapping_add(1)) {
+            Some(nz) => Some(StringIndex(nz)),
+            None => None,
+        }
+    }
+
+    /// Get the raw `u32` index.
+    #[inline]
+    #[must_use]
+    pub const fn as_u32(self) -> u32 {
+        self.0.get() - 1
+    }
+}
+
+/// String-leaf payload — selects between the inline `(offset, length)` packing
+/// (fast path, `TypeTag::StringInline`) and the legacy `StringIndex` (fallback,
+/// `TypeTag::String`). Used by `emit_string_node` to pick the right Node Data
+/// tag at write time.
+///
+/// **Selection rule**: short strings (`length <= 255`) whose data-buffer
+/// offset fits in 22 bits use [`Self::Inline`]; everything else falls back to
+/// [`Self::Index`]. The decoder dispatches on the same boundary.
+#[derive(Debug, Clone, Copy)]
+pub enum LeafStringPayload {
+    /// Short string packed directly into Node Data (`TypeTag::StringInline`).
+    Inline {
+        /// Byte offset within the String Data section. Must fit in 22 bits.
+        offset: u32,
+        /// UTF-8 byte length (0..=255).
+        length: u8,
+    },
+    /// Long string or out-of-range offset; resolved through the String
+    /// Offsets table (`TypeTag::String`).
+    Index(StringIndex),
+}
+
+/// Number of common strings pre-interned by [`StringTableBuilder::new`].
+/// Useful for tests that assert against the post-construction state.
+pub const COMMON_STRING_COUNT: u32 = COMMON_STRINGS.len() as u32;
+
+// -- Per-entry [`COMMON_STRINGS`] indices ------------------------------------
+//
+// Hot-path callers (e.g. `parser/context.rs::emit_block_inner`) look up the
+// pre-computed StringField via [`common_string_field`]. Using the named
+// constants instead of the generic [`lookup_common`] / [`StringTableBuilder::intern`]
+// path skips the length-bucketed match + dedup probe entirely (~2% self time
+// in the parse_batch_to_bytes profile).
+
+/// Index of `""` inside [`COMMON_STRINGS`].
+pub const COMMON_EMPTY: u32 = 0;
+/// Index of `" "` (single space) inside [`COMMON_STRINGS`].
+pub const COMMON_SPACE: u32 = 1;
+/// Index of `"*"` (margin delimiter) inside [`COMMON_STRINGS`].
+pub const COMMON_STAR: u32 = 2;
+/// Index of `"*/"` (block terminal) inside [`COMMON_STRINGS`].
+pub const COMMON_SLASH_STAR: u32 = 3;
+/// Index of `"\n"` inside [`COMMON_STRINGS`].
+pub const COMMON_LF: u32 = 4;
+/// Index of `"\t"` inside [`COMMON_STRINGS`].
+pub const COMMON_TAB: u32 = 5;
+/// Index of `"\r\n"` inside [`COMMON_STRINGS`].
+pub const COMMON_CRLF: u32 = 6;
+/// Index of `"/**"` inside [`COMMON_STRINGS`].
+pub const COMMON_SLASH_STAR_STAR: u32 = 7;
+
+/// Strings that the writer pre-interns at construction so the common case
+/// (delimiters, whitespace, well-known tag names) skips the HashMap entirely.
+///
+/// Each entry's array index is its predetermined `StringIndex`. The
+/// length-bucketed `lookup_common` helper below MUST stay in sync — adding
+/// or reordering entries here without updating it will cause the fast path
+/// to return wrong indices.
+const COMMON_STRINGS: &[&str] = &[
+    // 0..=4: source-preserving leaves
+    "",
+    " ",
+    "*",
+    "*/",
+    "\n",
+    // 5..=7: less common whitespace
+    "\t",
+    "\r\n",
+    "/**",
+    // 8..=27: most common JSDoc tag names (eslint-plugin-jsdoc usage data)
+    "param",
+    "returns",
+    "return",
+    "throws",
+    "type",
+    "see",
+    "example",
+    "deprecated",
+    "since",
+    "default",
+    "author",
+    "internal",
+    "private",
+    "public",
+    "protected",
+    "static",
+    "this",
+    "override",
+    "readonly",
+    "yields",
+];
+
+/// Length-bucketed perfect-hash style match for [`COMMON_STRINGS`]. Returns
+/// the predetermined index when `value` is a common string, otherwise `None`.
+///
+/// The `match value.len()` arm lets the compiler skip whole comparison
+/// chains for non-matching lengths in one branch, which is what makes this
+/// path cheaper than the generic `HashMap::get`.
+#[inline]
+pub(crate) fn lookup_common(value: &str) -> Option<u32> {
+    match value.len() {
+        0 => Some(0), // ""
+        1 => match value.as_bytes()[0] {
+            b' ' => Some(1),
+            b'*' => Some(2),
+            b'\n' => Some(4),
+            b'\t' => Some(5),
+            _ => None,
+        },
+        2 => match value {
+            "*/" => Some(3),
+            "\r\n" => Some(6),
+            _ => None,
+        },
+        3 => match value {
+            "/**" => Some(7),
+            "see" => Some(13),
+            _ => None,
+        },
+        4 => match value {
+            "type" => Some(12),
+            "this" => Some(24),
+            _ => None,
+        },
+        5 => match value {
+            "param" => Some(8),
+            "since" => Some(16),
+            _ => None,
+        },
+        6 => match value {
+            "return" => Some(10),
+            "throws" => Some(11),
+            "author" => Some(18),
+            "public" => Some(21),
+            "static" => Some(23),
+            "yields" => Some(27),
+            _ => None,
+        },
+        7 => match value {
+            "returns" => Some(9),
+            "example" => Some(14),
+            "default" => Some(17),
+            "private" => Some(20),
+            _ => None,
+        },
+        8 => match value {
+            "internal" => Some(19),
+            "readonly" => Some(26),
+            "override" => Some(25),
+            _ => None,
+        },
+        9 => match value {
+            "protected" => Some(22),
+            _ => None,
+        },
+        10 => match value {
+            "deprecated" => Some(15),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Pre-computed `(start, end)` u32-LE pairs for [`COMMON_STRINGS`], cached
+/// on first use so every [`StringTableBuilder::new`] is just two memcpys
+/// rather than 28 individual HashMap inserts and arena `alloc_str` calls.
+fn prelude_offsets() -> &'static [u8] {
+    static CACHE: OnceLock<Vec<u8>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        let mut buf = Vec::with_capacity(COMMON_STRINGS.len() * 8);
+        let mut pos = 0u32;
+        for s in COMMON_STRINGS {
+            let start = pos;
+            pos += s.len() as u32;
+            let end = pos;
+            buf.extend_from_slice(&start.to_le_bytes());
+            buf.extend_from_slice(&end.to_le_bytes());
+        }
+        buf
+    })
+}
+
+/// Pre-computed concatenated bytes for [`COMMON_STRINGS`] — same caching
+/// rationale as [`prelude_offsets`].
+fn prelude_data() -> &'static [u8] {
+    static CACHE: OnceLock<Vec<u8>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        let mut buf = Vec::new();
+        for s in COMMON_STRINGS {
+            buf.extend_from_slice(s.as_bytes());
+        }
+        buf
+    })
+}
+
+/// Pre-computed [`StringField`] for each entry in [`COMMON_STRINGS`].
+///
+/// Built once at first use by walking `COMMON_STRINGS` and tracking the
+/// running data-buffer offset. Returned to callers by [`lookup_common`] hits
+/// without touching `data_buffer` or the dedup map.
+fn common_string_fields() -> &'static [StringField] {
+    static CACHE: OnceLock<Vec<StringField>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        let mut fields = Vec::with_capacity(COMMON_STRINGS.len());
+        let mut pos = 0u32;
+        for s in COMMON_STRINGS {
+            let length = u16::try_from(s.len()).expect("common string longer than u16");
+            fields.push(StringField { offset: pos, length });
+            pos += s.len() as u32;
+        }
+        fields
+    })
+}
+
+/// Resolve the pre-computed [`StringField`] for the [`lookup_common`]
+/// fast-path index `idx`. Used by writer combined-intern helpers to
+/// short-circuit the COMMON_STRINGS dedup without copying bytes.
+#[inline]
+pub fn common_string_field(idx: u32) -> StringField {
+    common_string_fields()[idx as usize]
+}
+
+/// One entry in the dedup table — tracks both representations a string
+/// might be requested as. The `index` is `None` until a string-leaf caller
+/// first asks for the [`StringIndex`] form (lazy offsets-table allocation).
+#[derive(Debug, Clone, Copy)]
+struct DedupEntry {
+    field: StringField,
+    index: Option<StringIndex>,
+}
+
+/// Builds the String Offsets + String Data buffers incrementally.
+///
+/// Internally:
+/// - `data_buffer` accumulates UTF-8 bytes (zero-copy slice from source
+///   text whenever possible),
+/// - `offsets_buffer` accumulates `(start, end)` u32 pairs (8 bytes each)
+///   only for strings actually requested as [`StringIndex`],
+/// - a hash map from `&'arena str` to a [`DedupEntry`] enables both forms
+///   of dedup without redundant byte writes.
+pub struct StringTableBuilder<'arena> {
+    /// `8K` bytes of `(start, end)` u32 pairs, one per StringIndex requested.
+    pub(crate) offsets_buffer: ArenaVec<'arena, u8>,
+    /// Raw concatenated UTF-8 bytes for every interned string and every
+    /// appended sourceText.
+    pub(crate) data_buffer: ArenaVec<'arena, u8>,
+    /// Number of [`StringIndex`] entries allocated so far. Equal to
+    /// `offsets_buffer.len() / 8`.
+    pub(crate) count: u32,
+    /// Reference to the underlying arena, used to allocate dedup keys with
+    /// `'arena` lifetime.
+    arena: &'arena Allocator,
+    /// Dedup map: arena-allocated string → its [`DedupEntry`]. Stored on
+    /// the `std` heap (not the arena) because `HashMap` cannot live inside
+    /// `oxc_allocator` without a custom allocator binding.
+    ///
+    /// Uses `FxHashMap` (rustc-hash) instead of the default `SipHash` for
+    /// ~2x faster hashing on the unique-string slow path.
+    dedup: FxHashMap<&'arena str, DedupEntry>,
+    /// 1-slot recent-call cache. Stores the most recently interned
+    /// `&str`'s pointer + length and the resulting `(StringField, Option<StringIndex>)`.
+    /// Hot when callers re-intern the same literal back-to-back
+    /// (e.g. `intern("")` for empty source slots, or `intern("param")` /
+    /// `intern("returns")` repeatedly across a batch).
+    ///
+    /// The pointer is only ever compared (never dereferenced) and its
+    /// underlying allocation outlives the builder by virtue of the arena.
+    last_key_ptr: *const u8,
+    last_key_len: usize,
+    last_entry: DedupEntry,
+}
+
+impl<'arena> StringTableBuilder<'arena> {
+    /// Create a builder seeded with [`COMMON_STRINGS`] at fixed indices.
+    ///
+    /// The seeding is two cheap memcpys (offsets + data); the dedup
+    /// HashMap stays empty so common strings never enter it — the fast
+    /// path in [`Self::intern`] returns early via [`lookup_common`]
+    /// before consulting the map.
+    #[must_use]
+    pub fn new(arena: &'arena Allocator) -> Self {
+        let mut offsets_buffer = ArenaVec::new_in(arena);
+        offsets_buffer.extend_from_slice(prelude_offsets());
+
+        let mut data_buffer = ArenaVec::new_in(arena);
+        data_buffer.extend_from_slice(prelude_data());
+
+        StringTableBuilder {
+            offsets_buffer,
+            data_buffer,
+            count: COMMON_STRING_COUNT,
+            arena,
+            dedup: FxHashMap::default(),
+            // Sentinel pointer never matches a real `&str` (length-0 reads
+            // are guarded by the `len` check too).
+            last_key_ptr: core::ptr::null(),
+            last_key_len: 0,
+            last_entry: DedupEntry { field: StringField::NONE, index: None },
+        }
+    }
+
+    /// Intern `value` as a [`StringField`] (Extended Data slot path).
+    ///
+    /// Fast path: [`lookup_common`] returns the pre-computed StringField
+    /// for the well-known strings without HashMap lookup.
+    ///
+    /// Slow path: regular HashMap dedup; on miss, append to `data_buffer`
+    /// only (no `offsets_buffer` write) and cache the resulting
+    /// StringField for future hits.
+    pub fn intern(&mut self, value: &str) -> StringField {
+        // 1-slot recent-call cache: skip lookup_common + HashMap probe
+        // when the caller passes the same `&str` (same backing allocation
+        // and length) twice in a row.
+        if value.as_ptr() == self.last_key_ptr && value.len() == self.last_key_len {
+            return self.last_entry.field;
+        }
+        if let Some(idx) = lookup_common(value) {
+            let field = common_string_field(idx);
+            self.update_recent_cache(value, DedupEntry { field, index: None });
+            return field;
+        }
+        if let Some(entry) = self.dedup.get(value) {
+            let snapshot = *entry;
+            self.update_recent_cache(value, snapshot);
+            return snapshot.field;
+        }
+        let field = self.append_no_dedup(value);
+        let key: &'arena str = self.arena.alloc_str(value);
+        let entry = DedupEntry { field, index: None };
+        self.dedup.insert(key, entry);
+        self.update_recent_cache(value, entry);
+        field
+    }
+
+    /// Intern `value` as a [`StringIndex`] — used by string-leaf nodes
+    /// (TypeTag::String) and the diagnostics section's `message_index`.
+    ///
+    /// Fast path: [`lookup_common`] returns the pre-seeded index.
+    ///
+    /// Slow path: HashMap dedup. On hit, allocates a StringIndex lazily
+    /// (so ED-only strings never pay the `offsets_buffer` write).
+    pub fn intern_for_leaf(&mut self, value: &str) -> StringIndex {
+        // 1-slot recent-call cache hit: only valid if the cached entry
+        // already has an `index` allocated (recent path may have stored
+        // a StringField-only entry).
+        if value.as_ptr() == self.last_key_ptr && value.len() == self.last_key_len {
+            if let Some(idx) = self.last_entry.index {
+                return idx;
+            }
+        }
+        if let Some(idx) = lookup_common(value) {
+            // SAFETY: idx < COMMON_STRINGS.len() < u32::MAX.
+            return StringIndex::from_u32(idx).expect("common index in range");
+        }
+        if let Some(entry) = self.dedup.get(value) {
+            if let Some(idx) = entry.index {
+                let snapshot = *entry;
+                self.update_recent_cache(value, snapshot);
+                return idx;
+            }
+            // Same string was previously interned as StringField only —
+            // promote it now by allocating an offsets-table entry.
+            let field = entry.field;
+            let idx = self.assign_index(field);
+            let entry = DedupEntry { field, index: Some(idx) };
+            // Re-fetch & write back. (`get_mut` was unavailable while we
+            // held the borrow on `assign_index` to mutate offsets_buffer.)
+            if let Some(entry_mut) = self.dedup.get_mut(value) {
+                *entry_mut = entry;
+            }
+            self.update_recent_cache(value, entry);
+            return idx;
+        }
+        // First-touch: append data_buffer + offsets_buffer together.
+        let field = self.append_no_dedup(value);
+        let idx = self.assign_index(field);
+        let key: &'arena str = self.arena.alloc_str(value);
+        let entry = DedupEntry { field, index: Some(idx) };
+        self.dedup.insert(key, entry);
+        self.update_recent_cache(value, entry);
+        idx
+    }
+
+    /// Append `value` as a fresh [`StringField`] without [`lookup_common`]
+    /// or dedup. Use this for strings dominated by per-call unique values
+    /// (description-line text, raw `{type}` source, etc.) where paying the
+    /// FxHash + lookup work for a key that will never be revisited is
+    /// pure overhead.
+    pub fn intern_unique(&mut self, value: &str) -> StringField {
+        self.append_no_dedup(value)
+    }
+
+    /// Materialize a [`StringField`] pointing at an existing range of
+    /// `data_buffer` — typically the source text region appended via
+    /// [`Self::append_source_text`] — **without copying any bytes**.
+    #[inline]
+    pub fn intern_at_offset(&mut self, start: u32, end: u32) -> StringField {
+        debug_assert!(
+            (end as usize) <= self.data_buffer.len(),
+            "intern_at_offset range [{start}, {end}) extends past data_buffer length {}",
+            self.data_buffer.len()
+        );
+        debug_assert!(start <= end, "intern_at_offset start > end");
+        debug_assert!(
+            (end - start) <= u16::MAX as u32,
+            "source slice length {} exceeds u16 (StringField max)",
+            end - start
+        );
+        StringField { offset: start, length: (end - start) as u16 }
+    }
+
+    /// Allocate a [`StringIndex`] pointing at an existing range of
+    /// `data_buffer` (typically a slice of the just-appended source
+    /// text). Writes a `(start, end)` pair into `offsets_buffer` so the
+    /// reader can resolve the index without scanning.
+    ///
+    /// Used by string-leaf emitters (description-line / type-line basic)
+    /// where the source slice becomes the String payload of a leaf node.
+    pub fn intern_at_offset_for_leaf(&mut self, start: u32, end: u32) -> StringIndex {
+        debug_assert!(
+            (end as usize) <= self.data_buffer.len(),
+            "intern_at_offset_for_leaf range [{start}, {end}) extends past data_buffer length {}",
+            self.data_buffer.len()
+        );
+        debug_assert!(start <= end, "intern_at_offset_for_leaf start > end");
+        push_offset_pair(&mut self.offsets_buffer, start, end);
+        let idx = StringIndex::from_u32(self.count).expect("string index overflow");
+        self.count = self.count.checked_add(1).expect("string table overflow");
+        idx
+    }
+
+    /// Append a sourceText prefix to `data_buffer` (no offsets-table entry).
+    pub fn append_source_text(&mut self, value: &str) -> u32 {
+        let offset = self.data_buffer.len() as u32;
+        self.data_buffer.extend_from_slice(value.as_bytes());
+        offset
+    }
+
+    /// Truncate the builder back to its post-[`Self::new`] state without
+    /// freeing arena memory. The arena-backed `offsets_buffer` /
+    /// `data_buffer` keep their capacity, so subsequent
+    /// [`Self::intern_for_leaf`] / [`Self::append_source_text`] calls reuse
+    /// the existing allocations instead of growing from zero on every
+    /// per-comment writer construction.
+    ///
+    /// Used by [`crate::writer::BinaryWriter::reset`] to recycle a single
+    /// writer across many parse calls (see
+    /// [`crate::parser::parse_into`] / [`crate::parser::parse_batch_into`]).
+    pub(crate) fn reset(&mut self) {
+        // Restore the prelude bytes. Truncate first so capacity is retained,
+        // then `extend_from_slice` reuses that capacity for the prelude.
+        let prelude_offsets_bytes = prelude_offsets();
+        let prelude_data_bytes = prelude_data();
+        self.offsets_buffer.truncate(0);
+        self.offsets_buffer.extend_from_slice(prelude_offsets_bytes);
+        self.data_buffer.truncate(0);
+        self.data_buffer.extend_from_slice(prelude_data_bytes);
+        self.count = COMMON_STRING_COUNT;
+        // Wipe dedup but keep the HashMap's bucket allocation (FxHashMap's
+        // `clear` retains capacity).
+        self.dedup.clear();
+        self.last_key_ptr = core::ptr::null();
+        self.last_key_len = 0;
+        self.last_entry = DedupEntry { field: StringField::NONE, index: None };
+    }
+
+    /// Number of strings registered in the offsets table so far.
+    #[inline]
+    #[must_use]
+    pub const fn len(&self) -> u32 {
+        self.count
+    }
+
+    /// Whether nothing has been registered in the offsets table yet.
+    #[inline]
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Internal: refresh the 1-slot recent-call cache so the next intern
+    /// of the same `&str` slice can short-circuit before HashMap probe.
+    #[inline]
+    fn update_recent_cache(&mut self, value: &str, entry: DedupEntry) {
+        self.last_key_ptr = value.as_ptr();
+        self.last_key_len = value.len();
+        self.last_entry = entry;
+    }
+
+    /// Internal: append `value` to `data_buffer` and return the resulting
+    /// [`StringField`]. Shared between [`Self::intern`] (after dedup miss)
+    /// and [`Self::intern_unique`].
+    ///
+    /// `value.len()` is cast directly to `u16`; the encoder's contract is
+    /// that no individual JSDoc field exceeds 65 KiB (description text is
+    /// the worst case in practice). A debug-assert catches the overflow in
+    /// development builds without paying the panic check on the release
+    /// hot path.
+    #[inline]
+    fn append_no_dedup(&mut self, value: &str) -> StringField {
+        debug_assert!(
+            value.len() <= u16::MAX as usize,
+            "string length {} exceeds u16 (StringField max)",
+            value.len()
+        );
+        let offset = self.data_buffer.len() as u32;
+        self.data_buffer.extend_from_slice(value.as_bytes());
+        let length = value.len() as u16;
+        StringField { offset, length }
+    }
+
+    /// Internal: allocate a fresh [`StringIndex`] for an existing
+    /// [`StringField`] by writing a (start, end) pair into `offsets_buffer`.
+    fn assign_index(&mut self, field: StringField) -> StringIndex {
+        let idx = StringIndex::from_u32(self.count).expect("string index overflow");
+        self.count = self.count.checked_add(1).expect("string table overflow");
+        let end = field.offset + field.length as u32;
+        push_offset_pair(&mut self.offsets_buffer, field.offset, end);
+        idx
+    }
+}
+
+/// Append an `(start, end)` u32-LE pair to the offsets buffer as a single
+/// 8-byte write. Combines the two `extend_from_slice(&[u8; 4])` calls into
+/// one realloc-check + one 8-byte memcpy — cuts `intern_at_offset_for_leaf`
+/// self time roughly in half on `parse_batch_to_bytes`.
+#[inline]
+fn push_offset_pair(buf: &mut ArenaVec<'_, u8>, start: u32, end: u32) {
+    let mut bytes = [0u8; 8];
+    bytes[..4].copy_from_slice(&start.to_le_bytes());
+    bytes[4..].copy_from_slice(&end.to_le_bytes());
+    buf.extend_from_slice(&bytes);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn string_index_round_trips() {
+        for raw in [0u32, 1, 100, 0xFFFE, 0x3FFF_FFFE] {
+            let idx = StringIndex::from_u32(raw).unwrap();
+            assert_eq!(idx.as_u32(), raw);
+        }
+    }
+
+    #[test]
+    fn string_index_rejects_overflow() {
+        assert!(StringIndex::from_u32(u32::MAX).is_none());
+    }
+
+    #[test]
+    fn intern_dedups_repeated_values_as_string_field() {
+        let arena = Allocator::default();
+        let mut builder = StringTableBuilder::new(&arena);
+        let a = builder.intern("custom_alpha");
+        let b = builder.intern("custom_beta");
+        let a_again = builder.intern("custom_alpha");
+        assert_eq!(a, a_again);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn intern_for_leaf_is_lazy_about_offsets_entry() {
+        let arena = Allocator::default();
+        let mut builder = StringTableBuilder::new(&arena);
+        let prelude_count = COMMON_STRING_COUNT;
+        // Intern as field only — must not allocate an offsets entry.
+        let _f = builder.intern("custom_xyz");
+        assert_eq!(builder.len(), prelude_count, "no offsets entry for ED-only intern");
+        // Now ask for the leaf form — that allocates one entry.
+        let _idx = builder.intern_for_leaf("custom_xyz");
+        assert_eq!(builder.len(), prelude_count + 1, "leaf intern allocates offsets entry");
+        // Calling intern_for_leaf again must dedup, no extra allocation.
+        let _idx2 = builder.intern_for_leaf("custom_xyz");
+        assert_eq!(builder.len(), prelude_count + 1, "dedup on second leaf intern");
+    }
+
+    #[test]
+    fn append_source_text_does_not_register_an_index() {
+        let arena = Allocator::default();
+        let mut builder = StringTableBuilder::new(&arena);
+        let common_data_bytes = builder.data_buffer.len() as u32;
+        let off = builder.append_source_text("/** @x */");
+        assert_eq!(
+            off, common_data_bytes,
+            "source text starts immediately after the common-string prelude"
+        );
+        assert_eq!(
+            builder.len(),
+            COMMON_STRING_COUNT,
+            "source text does not count as an offsets entry"
+        );
+    }
+
+    #[test]
+    fn intern_common_string_returns_predetermined_field() {
+        let arena = Allocator::default();
+        let mut builder = StringTableBuilder::new(&arena);
+        let field = builder.intern("param");
+        let expected = common_string_fields()[8];
+        assert_eq!(field, expected);
+    }
+
+    #[test]
+    fn intern_for_leaf_common_string_returns_predetermined_index() {
+        let arena = Allocator::default();
+        let mut builder = StringTableBuilder::new(&arena);
+        // "param" is COMMON_STRINGS[8].
+        assert_eq!(builder.intern_for_leaf("param").as_u32(), 8);
+        let pre_count = builder.len();
+        assert_eq!(builder.intern_for_leaf("param").as_u32(), 8);
+        assert_eq!(builder.len(), pre_count, "fast path must not append");
+    }
+}

--- a/npm/vite-plugin-ox-content/src/docs.test.ts
+++ b/npm/vite-plugin-ox-content/src/docs.test.ts
@@ -187,4 +187,57 @@ export interface RenderContext<TValue extends Record<string, unknown> = Record<s
     expect(markdown["interface.md"]).toContain("ox-api-entry__signature--highlighted");
     expect(markdown["index.md"]).toContain("ox-api-module__signature--highlighted");
   });
+
+  it("uses Rust-side JSDoc metadata for optional params and fenced examples", async () => {
+    const srcDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-docs-src-"));
+    tempDirs.push(srcDir);
+
+    const filePath = path.join(srcDir, "format.ts");
+    await fs.writeFile(
+      filePath,
+      `/**
+ * Formats a value.
+ *
+ * @param {number} value - Input value.
+ * @param {"short" | "long"} [mode="short"] - Format mode.
+ * @returns {string} Rendered label.
+ * @example
+ * \`\`\`ts
+ * const snippet = "@param not-a-real-tag";
+ * formatValue(1, "short");
+ * \`\`\`
+ * @since 2.4.0
+ */
+export function formatValue(value: number, mode: "short" | "long" = "short"): string {
+  return mode === "short" ? String(value) : \`value: \${value}\`;
+}
+`,
+      "utf-8",
+    );
+
+    const docs = await extractDocs([srcDir], resolveDocsOptions({ include: ["**/*.ts"] })!);
+    const entry = docs[0]?.entries[0];
+
+    expect(entry?.description).toBe("Formats a value.");
+    expect(entry?.params).toEqual([
+      {
+        name: "value",
+        type: "number",
+        description: "Input value.",
+      },
+      {
+        name: "mode",
+        type: '"short" | "long"',
+        description: "Format mode.",
+        optional: true,
+        default: '"short"',
+      },
+    ]);
+    expect(entry?.returns).toEqual({
+      type: "string",
+      description: "Rendered label.",
+    });
+    expect(entry?.examples?.[0]).toContain("@param not-a-real-tag");
+    expect(entry?.tags).toEqual({ since: "2.4.0" });
+  });
 });

--- a/npm/vite-plugin-ox-content/src/docs.ts
+++ b/npm/vite-plugin-ox-content/src/docs.ts
@@ -7,7 +7,7 @@
  *
  * ## Features
  *
- * - **Automatic Extraction**: Parses JSDoc comments from functions, classes, interfaces, and types
+ * - **Automatic Extraction**: Parses declarations and structured JSDoc metadata in Rust
  * - **Flexible Filtering**: Include/exclude patterns for selective documentation
  * - **Markdown Generation**: Converts extracted docs to organized Markdown files
  * - **Navigation Generation**: Auto-generates sidebar navigation metadata
@@ -349,6 +349,8 @@ interface NapiDocItem {
   signature?: string;
   params: NapiDocParam[];
   returnType?: string;
+  returnDescription?: string;
+  examples: string[];
   tags: NapiDocTag[];
 }
 
@@ -363,7 +365,7 @@ interface NapiDocItem {
  *
  * 1. **File Discovery**: Recursively walks directories, applying filters
  * 2. **File Reading**: Loads each matching file's content
- * 3. **JSDoc Extraction**: Parses JSDoc comments using regex patterns
+ * 3. **JSDoc Extraction**: Uses Rust-side JSDoc metadata from @ox-content/napi
  * 4. **Declaration Matching**: Pairs JSDoc comments with source declarations
  * 5. **Result Collection**: Aggregates extracted documentation by file
  *
@@ -512,128 +514,21 @@ function parseNapiDocItem(item: NapiDocItem): DocEntry | null {
     return null;
   }
 
-  const params: ParamDoc[] = [];
-  const examples: string[] = [];
+  const params = item.params.map((param) => ({
+    name: param.name,
+    type: param.typeAnnotation ?? "unknown",
+    description: param.description ?? "",
+    optional: param.optional || undefined,
+    default: param.defaultValue,
+  }));
+  const returns = item.returnType
+    ? {
+        type: item.returnType,
+        description: item.returnDescription ?? "",
+      }
+    : undefined;
   const tags: Record<string, string> = {};
-  let description = "";
-  let returns: { type: string; description: string } | undefined;
   let isPrivate = false;
-
-  const rawLines = (item.jsdoc ?? "").split("\n").map((line) => {
-    const trimmedStart = line.trimStart();
-    const withoutStar = trimmedStart.startsWith("*") ? trimmedStart.slice(1) : trimmedStart;
-    return withoutStar.startsWith(" ") ? withoutStar.slice(1) : withoutStar;
-  });
-  const cleanedLines = rawLines.map((line) => line.trim()).filter(Boolean);
-
-  let currentExample = "";
-  let inExample = false;
-  let rawLineIndex = 0;
-
-  for (const lineText of cleanedLines) {
-    // Find the corresponding raw line to get original indentation for examples
-    while (rawLineIndex < rawLines.length && rawLines[rawLineIndex].trim() !== lineText) {
-      rawLineIndex++;
-    }
-    const rawLine = rawLineIndex < rawLines.length ? rawLines[rawLineIndex] : lineText;
-    rawLineIndex++;
-
-    if (lineText.startsWith("@")) {
-      if (inExample) {
-        examples.push(currentExample.trim());
-        currentExample = "";
-        inExample = false;
-      }
-
-      const tagMatch = /@(\w+)\s*(?:\{([^}]*)\})?(.*)/.exec(lineText);
-      if (tagMatch) {
-        const [, tagName, tagType, tagRest] = tagMatch;
-
-        switch (tagName) {
-          case "param":
-            const paramMatch = /(\w+)\s*-?\s*(.*)/.exec(tagRest.trim());
-            if (paramMatch) {
-              params.push({
-                name: paramMatch[1],
-                type: tagType || "unknown",
-                description: paramMatch[2],
-              });
-            }
-            break;
-          case "returns":
-          case "return":
-            returns = {
-              type: tagType || "unknown",
-              description: tagRest.trim(),
-            };
-            break;
-          case "example":
-            inExample = true;
-            break;
-          case "private":
-            isPrivate = true;
-            break;
-          default:
-            tags[tagName] = tagRest.trim();
-        }
-      }
-    } else if (inExample) {
-      currentExample += rawLine + "\n";
-    } else if (!description) {
-      description = lineText;
-    } else {
-      description += "\n" + lineText;
-    }
-  }
-
-  if (inExample && currentExample) {
-    examples.push(currentExample.trim());
-  }
-
-  if (params.length === 0 && item.params.length > 0) {
-    params.push(
-      ...item.params.map((param) => ({
-        name: param.name,
-        type: param.typeAnnotation ?? "unknown",
-        description: param.description ?? "",
-        optional: param.optional || undefined,
-        default: param.defaultValue,
-      })),
-    );
-  } else if (item.params.length > 0) {
-    const paramMap = new Map(item.params.map((param) => [param.name, param]));
-    for (const param of params) {
-      const rustParam = paramMap.get(param.name);
-      if (!rustParam) {
-        continue;
-      }
-      if (param.type === "unknown" && rustParam.typeAnnotation) {
-        param.type = rustParam.typeAnnotation;
-      }
-      if (!param.description && rustParam.description) {
-        param.description = rustParam.description;
-      }
-      if (param.optional === undefined && rustParam.optional) {
-        param.optional = true;
-      }
-      if (!param.default && rustParam.defaultValue) {
-        param.default = rustParam.defaultValue;
-      }
-    }
-  }
-
-  if (!returns && item.returnType) {
-    returns = {
-      type: item.returnType,
-      description: "",
-    };
-  } else if (returns && returns.type === "unknown" && item.returnType) {
-    returns.type = item.returnType;
-  }
-
-  if (!description) {
-    description = item.doc ?? "";
-  }
 
   for (const tag of item.tags) {
     if (
@@ -656,10 +551,10 @@ function parseNapiDocItem(item: NapiDocItem): DocEntry | null {
   return {
     name: item.name,
     kind,
-    description,
+    description: item.doc ?? "",
     params: params.length > 0 ? params : undefined,
     returns,
-    examples: examples.length > 0 ? examples : undefined,
+    examples: item.examples.length > 0 ? item.examples : undefined,
     tags: Object.keys(tags).length > 0 ? tags : undefined,
     private: isPrivate,
     file: item.sourcePath,
@@ -1235,6 +1130,11 @@ function generateSourceLink(
   return `**[Source](${generateSourceHref(filePath, githubUrl, lineNumber, endLineNumber)})**`;
 }
 
+export function resolveDocsOptions(options: false): false;
+export function resolveDocsOptions(options?: import("./types").DocsOptions): ResolvedDocsOptions;
+export function resolveDocsOptions(
+  options: import("./types").DocsOptions | false | undefined,
+): ResolvedDocsOptions | false;
 export function resolveDocsOptions(
   options: import("./types").DocsOptions | false | undefined,
 ): ResolvedDocsOptions | false {


### PR DESCRIPTION
## Summary
- parse structured JSDoc metadata through ox_jsdoc_binary in the Rust docs extractor
- vendor ox_jsdoc_binary as a workspace crate so Cargo/CI can resolve it without upstream submodules
- expose return descriptions and examples through the N-API docs item
- simplify the Vite plugin docs mapper so it consumes Rust-side metadata directly
- cover optional/default params, return descriptions, fenced examples, and pass-through tags

## Validation
- pnpm exec vp check
- cargo test -p ox_jsdoc_binary
- cargo test -p ox_content_docs
- pnpm --filter @ox-content/vite-plugin exec vp test run src/docs.test.ts src/docs.snapshot.test.ts