### PR TITLE
fix: harden renderer urls and workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,8 +6,10 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -20,6 +22,8 @@ jobs:
       CARGO_TARGET_DIR: /tmp/ox-content-cargo-target
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Checkout base
         uses: actions/checkout@v4
@@ -27,6 +31,7 @@ jobs:
           repository: ${{ github.repository }}
           ref: ${{ github.event.pull_request.base.sha }}
           path: .benchmark/base
+          persist-credentials: false
 
       - name: Checkout head
         uses: actions/checkout@v4
@@ -34,6 +39,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
           path: .benchmark/head
+          persist-credentials: false
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1
@@ -63,8 +69,36 @@ jobs:
         working-directory: .benchmark/head
         run: node "$GITHUB_WORKSPACE/.github/scripts/compare-pr-benchmark.mjs"
 
+      - name: Upload benchmark comment
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-comment
+          path: ${{ runner.temp }}/benchmark-comment.md
+          if-no-files-found: error
+          retention-days: 1
+
+  comment:
+    name: Comment
+    runs-on: ubuntu-latest
+    needs: benchmark
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Download benchmark comment
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-comment
+          path: ${{ runner.temp }}
+
       - name: Comment on pull request
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_PATH: ${{ runner.temp }}/benchmark-comment.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -15,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1
@@ -39,6 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1
@@ -64,6 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -19,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -73,6 +73,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -29,6 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1
@@ -76,6 +81,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1
@@ -183,6 +190,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1
@@ -321,6 +330,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -365,6 +376,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/crates/ox_content_renderer/src/html.rs
+++ b/crates/ox_content_renderer/src/html.rs
@@ -798,6 +798,44 @@ impl HtmlRenderer {
         }
     }
 
+    fn sanitized_url<'a>(&self, url: &'a str, fallback: &'static str) -> &'a str {
+        if !self.options.sanitize {
+            return url;
+        }
+
+        let trimmed =
+            url.trim_matches(|ch: char| ch.is_ascii_control() || ch.is_ascii_whitespace());
+
+        if Self::is_safe_url(trimmed) {
+            trimmed
+        } else {
+            fallback
+        }
+    }
+
+    fn is_safe_url(url: &str) -> bool {
+        if url.bytes().any(|byte| byte.is_ascii_control()) {
+            return false;
+        }
+
+        let Some(colon_index) = url.find(':') else {
+            return true;
+        };
+
+        let first_path_marker = url.find(&['/', '?', '#'][..]).unwrap_or(usize::MAX);
+        if first_path_marker < colon_index {
+            return true;
+        }
+
+        let scheme = url[..colon_index]
+            .chars()
+            .filter(|ch| !ch.is_ascii_whitespace())
+            .map(|ch| ch.to_ascii_lowercase())
+            .collect::<String>();
+
+        matches!(scheme.as_str(), "http" | "https" | "mailto" | "tel")
+    }
+
     fn render_paragraph_with_skipped_text_prefix<'a>(
         &self,
         paragraph: &Paragraph<'a>,
@@ -1327,15 +1365,17 @@ impl<'a> Visit<'a> for HtmlRenderer {
 
     fn visit_link(&mut self, link: &Link<'a>) {
         self.write("<a href=\"");
-        if self.options.convert_md_links {
-            let url = self.convert_md_url(link.url);
-            self.write_url_escaped(&url);
+        let converted_url;
+        let href = if self.options.convert_md_links {
+            converted_url = self.convert_md_url(link.url);
+            self.sanitized_url(&converted_url, "#")
         } else {
-            self.write_url_escaped(link.url);
-        }
+            self.sanitized_url(link.url, "#")
+        };
+        self.write_url_escaped(href);
         self.write("\"");
         // Add target="_blank" for external links (http:// or https://)
-        if link.url.starts_with("http://") || link.url.starts_with("https://") {
+        if href.starts_with("http://") || href.starts_with("https://") {
             self.write(" target=\"_blank\" rel=\"noopener noreferrer\"");
         }
         if let Some(title) = link.title {
@@ -1352,7 +1392,7 @@ impl<'a> Visit<'a> for HtmlRenderer {
 
     fn visit_image(&mut self, image: &Image<'a>) {
         self.write("<img src=\"");
-        self.write_url_escaped(image.url);
+        self.write_url_escaped(self.sanitized_url(image.url, ""));
         self.write("\" alt=\"");
         self.write_escaped(image.alt);
         self.write("\"");

--- a/crates/ox_content_renderer/tests/edge_cases.rs
+++ b/crates/ox_content_renderer/tests/edge_cases.rs
@@ -52,6 +52,52 @@ fn html_blocks_are_escaped_when_sanitize_is_enabled() {
 }
 
 #[test]
+fn unsafe_link_urls_are_neutralized_when_sanitize_is_enabled() {
+    let html = render(
+        "[run](javascript:alert(1))",
+        ParserOptions::default(),
+        HtmlRendererOptions { sanitize: true, ..Default::default() },
+    );
+
+    assert_eq!(html, "<p><a href=\"#\">run</a></p>\n");
+}
+
+#[test]
+fn obfuscated_unsafe_link_schemes_are_neutralized() {
+    let html = render(
+        "[run](  JaVa ScRiPt:alert(1))",
+        ParserOptions::default(),
+        HtmlRendererOptions { sanitize: true, ..Default::default() },
+    );
+
+    assert_eq!(html, "<p><a href=\"#\">run</a></p>\n");
+}
+
+#[test]
+fn unsafe_image_urls_are_cleared_when_sanitize_is_enabled() {
+    let html = render(
+        "![x](data:text/html,<script>alert(1)</script>)",
+        ParserOptions::default(),
+        HtmlRendererOptions { sanitize: true, ..Default::default() },
+    );
+
+    assert_eq!(html, "<p><img src=\"\" alt=\"x\"></p>\n");
+}
+
+#[test]
+fn sanitize_keeps_relative_and_allowed_url_schemes() {
+    let html = render(
+        "[guide](./guide.md) [mail](mailto:hi@example.com) [phone](tel:+123)",
+        ParserOptions::default(),
+        HtmlRendererOptions { sanitize: true, ..Default::default() },
+    );
+
+    assert!(html.contains("href=\"./guide.md\""));
+    assert!(html.contains("href=\"mailto:hi@example.com\""));
+    assert!(html.contains("href=\"tel:+123\""));
+}
+
+#[test]
 fn ordered_lists_preserve_start_attribute() {
     let html =
         render("3. third\n4. fourth", ParserOptions::default(), HtmlRendererOptions::default());


### PR DESCRIPTION
## Summary

- Extend sanitized HTML rendering so Markdown link and image URLs reject unsafe schemes.
- Add renderer edge-case tests for unsafe, obfuscated, relative, and allowed URL schemes.
- Harden workflows with read-only defaults, disabled checkout credential persistence, stale PR run cancellation, and separated benchmark commenting permissions.
- Update the benchmark report to show runtime in milliseconds to microsecond precision and head speed normalized to base = 1.00 (100%).

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ox_content_renderer --test edge_cases`
- `cargo clippy -p ox_content_renderer --all-targets -- -D warnings`
- `uvx --from actionlint-py actionlint .github/workflows/ci.yml .github/workflows/benchmark.yml .github/workflows/deploy.yml .github/workflows/publish.yml`
- `node --check benchmarks/bundle-size/compare-pr-benchmark.mjs`
- `vp fmt --check benchmarks/bundle-size/compare-pr-benchmark.mjs`
- Sample benchmark report generation with temporary base/head JSON
- `uvx zizmor .github/workflows` reports remaining pre-existing findings around unpinned action references and release cache/template risks, with credential persistence and deploy workflow-level write permissions addressed here.