### PR TITLE
fix: parse napi frontmatter with yaml

### DIFF
--- a/crates/ox_content_napi/Cargo.toml
+++ b/crates/ox_content_napi/Cargo.toml
@@ -34,6 +34,7 @@ napi = { workspace = true }
 napi-derive = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 regex = { workspace = true }
 unicode-normalization = { workspace = true }
 

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -359,55 +359,62 @@ pub fn transform(source: String, options: Option<JsTransformOptions>) -> Transfo
 
 /// Parses YAML frontmatter from Markdown content.
 fn parse_frontmatter(source: &str) -> (String, HashMap<String, serde_json::Value>) {
-    let mut frontmatter = HashMap::new();
-
     // Check for frontmatter delimiter
     if !source.starts_with("---") {
-        return (source.to_string(), frontmatter);
+        return (source.to_string(), HashMap::new());
     }
 
     // Find the closing delimiter
     let rest = &source[3..];
     let Some(end_pos) = rest.find("\n---") else {
-        return (source.to_string(), frontmatter);
+        return (source.to_string(), HashMap::new());
     };
 
-    let frontmatter_str = &rest[..end_pos].trim_start_matches('\n');
-    let content = &rest[end_pos + 4..].trim_start_matches('\n');
-
-    // Parse simple YAML key-value pairs
-    for line in frontmatter_str.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-
-        if let Some(colon_pos) = line.find(':') {
-            let key = line[..colon_pos].trim().to_string();
-            let value_str = line[colon_pos + 1..].trim();
-
-            let value = if value_str == "true" {
-                serde_json::Value::Bool(true)
-            } else if value_str == "false" {
-                serde_json::Value::Bool(false)
-            } else if let Ok(n) = value_str.parse::<i64>() {
-                serde_json::Value::Number(n.into())
-            } else if let Ok(n) = value_str.parse::<f64>() {
-                serde_json::Number::from_f64(n).map_or_else(
-                    || serde_json::Value::String(value_str.to_string()),
-                    serde_json::Value::Number,
-                )
-            } else {
-                // Remove surrounding quotes if present
-                let s = value_str.trim_matches('"').trim_matches('\'');
-                serde_json::Value::String(s.to_string())
-            };
-
-            frontmatter.insert(key, value);
-        }
-    }
+    let frontmatter_str = rest[..end_pos].trim_start_matches('\n');
+    let content = rest[end_pos + 4..].trim_start_matches('\n');
+    let frontmatter = serde_yaml::from_str(frontmatter_str).unwrap_or_default();
 
     (content.to_string(), frontmatter)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::parse_frontmatter;
+
+    #[test]
+    fn parses_nested_yaml_frontmatter() {
+        let (content, frontmatter) = parse_frontmatter(
+            "---\ntitle: Guide\nmeta:\n  tags:\n    - rust\n    - napi\n  draft: false\n---\n# Body",
+        );
+
+        assert_eq!(content, "# Body");
+        assert_eq!(frontmatter.get("title"), Some(&json!("Guide")));
+        assert_eq!(
+            frontmatter.get("meta"),
+            Some(&json!({"tags": ["rust", "napi"], "draft": false}))
+        );
+    }
+
+    #[test]
+    fn frontmatter_preserves_yaml_scalars_and_quoted_colons() {
+        let (_, frontmatter) = parse_frontmatter(
+            "---\ncount: 3\nratio: 1.5\ncanonical: \"https://example.com/a:b\"\n---\n",
+        );
+
+        assert_eq!(frontmatter.get("count"), Some(&json!(3)));
+        assert_eq!(frontmatter.get("ratio"), Some(&json!(1.5)));
+        assert_eq!(frontmatter.get("canonical"), Some(&json!("https://example.com/a:b")));
+    }
+
+    #[test]
+    fn malformed_yaml_strips_block_and_returns_empty_frontmatter() {
+        let (content, frontmatter) = parse_frontmatter("---\ntitle: [broken\n---\nBody");
+
+        assert_eq!(content, "Body");
+        assert!(frontmatter.is_empty());
+    }
 }
 
 /// Extracts table of contents from document headings.


### PR DESCRIPTION
## Summary

- Replace the NAPI transform frontmatter parser with `serde_yaml` so nested objects, arrays, and quoted scalar values survive native parsing.
- Keep malformed frontmatter behavior conservative by stripping the block and returning an empty object.
- Add Rust unit coverage for nested YAML, scalar values, quoted colons, and malformed YAML fallback.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ox_content_napi frontmatter`
- `cargo clippy -p ox_content_napi --all-targets -- -D warnings`