### PR TITLE
fix: terminate html blocks on blank lines

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -237,12 +237,22 @@ impl<'a> Parser<'a> {
             return Ok(None);
         };
 
-        let closing_tag = format!("</{tag_name}");
-
-        loop {
-            let consumed = self.consume_line();
-            if consumed.to_ascii_lowercase().contains(&closing_tag) || self.is_at_end() {
-                break;
+        if Self::is_type1_html_block_tag(&tag_name) {
+            let closing_tag = format!("</{tag_name}");
+            loop {
+                let consumed = self.consume_line();
+                if consumed.to_ascii_lowercase().contains(&closing_tag) || self.is_at_end() {
+                    break;
+                }
+            }
+        } else {
+            self.consume_line();
+            while !self.is_at_end() {
+                let next = self.remaining().lines().next().unwrap_or("");
+                if next.trim().is_empty() {
+                    break;
+                }
+                self.consume_line();
             }
         }
 
@@ -302,7 +312,9 @@ impl<'a> Parser<'a> {
             "ol",
             "p",
             "pre",
+            "script",
             "section",
+            "style",
             "summary",
             "table",
             "tbody",
@@ -310,11 +322,18 @@ impl<'a> Parser<'a> {
             "tfoot",
             "th",
             "thead",
+            "textarea",
             "tr",
             "ul",
         ]
         .iter()
         .any(|candidate| tag_name.eq_ignore_ascii_case(candidate))
+    }
+
+    fn is_type1_html_block_tag(tag_name: &str) -> bool {
+        ["pre", "script", "style", "textarea"]
+            .iter()
+            .any(|candidate| tag_name.eq_ignore_ascii_case(candidate))
     }
 
     /// Checks if the current position starts a block quote.

--- a/crates/ox_content_parser/tests/edge_cases.rs
+++ b/crates/ox_content_parser/tests/edge_cases.rs
@@ -225,6 +225,60 @@ fn html_details_block_is_preserved_as_raw_html() {
 }
 
 #[test]
+fn html_type6_details_terminates_at_first_blank_line() {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(
+        &allocator,
+        "<details>\n\n<summary>Click to expand</summary>\n\n**bold should be markdown**\n\n- list\n\n```js\nconsole.log(\"code\");\n```\n\n</details>",
+        ParserOptions::default(),
+    );
+
+    assert!(matches!(&doc.children[0], Node::Html(html) if html.value.trim() == "<details>"));
+    assert!(matches!(&doc.children[1], Node::Html(html) if html.value.contains("<summary>")));
+    assert!(
+        matches!(&doc.children[2], Node::Paragraph(paragraph) if matches!(&paragraph.children[0], Node::Strong(_)))
+    );
+    assert!(matches!(&doc.children[3], Node::List(_)));
+    assert!(matches!(&doc.children[4], Node::CodeBlock(block) if block.lang == Some("js")));
+    assert!(matches!(&doc.children[5], Node::Html(html) if html.value.contains("</details>")));
+}
+
+#[test]
+fn html_type6_div_stops_before_markdown_after_blank_line() {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(
+        &allocator,
+        "<div>\nraw html line\n\n**markdown**\n\n</div>",
+        ParserOptions::default(),
+    );
+
+    assert!(matches!(&doc.children[0], Node::Html(html) if !html.value.contains("**markdown**")));
+    assert!(
+        matches!(&doc.children[1], Node::Paragraph(paragraph) if matches!(&paragraph.children[0], Node::Strong(_)))
+    );
+    assert!(matches!(&doc.children[2], Node::Html(html) if html.value.contains("</div>")));
+}
+
+#[test]
+fn html_type1_pre_ignores_blank_lines_until_closing_tag() {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(
+        &allocator,
+        "<pre>\n\n**not markdown**\n</pre>\n\nAfter",
+        ParserOptions::default(),
+    );
+
+    match &doc.children[0] {
+        Node::Html(html) => {
+            assert!(html.value.contains("**not markdown**"));
+            assert!(html.value.contains("</pre>"));
+        }
+        other => panic!("expected html block, got {other:?}"),
+    }
+    assert!(matches!(&doc.children[1], Node::Paragraph(_)));
+}
+
+#[test]
 fn table_alignment_variants_are_parsed() {
     let allocator = Allocator::new();
     let doc = parse_with_options(

--- a/crates/ox_content_renderer/tests/edge_cases.rs
+++ b/crates/ox_content_renderer/tests/edge_cases.rs
@@ -214,3 +214,18 @@ fn hard_breaks_render_inside_paragraphs() {
     let html = render("line 1\\\nline 2", ParserOptions::default(), HtmlRendererOptions::default());
     assert_eq!(html, "<p>line 1<br>\nline 2</p>\n");
 }
+
+#[test]
+fn html_type6_details_allows_markdown_after_blank_line() {
+    let html = render(
+        "<details>\n\n<summary>Click to expand</summary>\n\n**bold should be markdown**\n\n- list\n\n```js\nconsole.log(\"code\");\n```\n\n</details>",
+        ParserOptions::default(),
+        HtmlRendererOptions::default(),
+    );
+
+    assert!(html.contains("<details>"));
+    assert!(html.contains("<summary>Click to expand</summary>"));
+    assert!(html.contains("<strong>bold should be markdown</strong>"));
+    assert!(html.contains("<ul>"));
+    assert!(html.contains("<pre><code class=\"language-js\">"));
+}


### PR DESCRIPTION
## Summary

- Terminate CommonMark Type 6 HTML blocks at the first blank line.
- Keep Type 1 raw HTML blocks (`pre`, `script`, `style`, `textarea`) consuming through their closing tags.
- Add parser and renderer regression coverage for Markdown inside `details`.

Closes #56

## Validation

- `cargo test -p ox_content_parser html_type --test edge_cases`
- `cargo test -p ox_content_renderer html_type6_details_allows_markdown_after_blank_line --test edge_cases`
- `cargo fmt --check -p ox_content_parser -p ox_content_renderer`
- `git diff --check`