### PR TITLE
fix: render inline raw html

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -993,7 +993,7 @@ impl<'a> Parser<'a> {
             // Look for special characters
             while pos < content.len() {
                 let ch = bytes[pos];
-                if matches!(ch, b'*' | b'_' | b'`' | b'[' | b'!' | b'~' | b'\\') {
+                if matches!(ch, b'*' | b'_' | b'`' | b'[' | b'!' | b'~' | b'\\' | b'<') {
                     break;
                 }
                 pos += 1;
@@ -1022,6 +1022,19 @@ impl<'a> Parser<'a> {
                     };
                     children.push(Node::Break(break_node));
                     pos += 2;
+                }
+                b'<' => {
+                    if let Some((html, end)) = Self::parse_inline_html(content, pos, offset) {
+                        children.push(Node::Html(html));
+                        pos = end;
+                    } else {
+                        let text = Text {
+                            value: "<",
+                            span: Span::new((offset + pos) as u32, (offset + pos + 1) as u32),
+                        };
+                        children.push(Node::Text(text));
+                        pos += 1;
+                    }
                 }
                 b'\\' if pos + 1 < content.len() => {
                     // Escape sequence
@@ -1346,6 +1359,82 @@ impl<'a> Parser<'a> {
         }
 
         Ok(children)
+    }
+
+    fn parse_inline_html(content: &'a str, pos: usize, offset: usize) -> Option<(Html<'a>, usize)> {
+        let bytes = content.as_bytes();
+
+        if content[pos..].starts_with("<!--") {
+            let end = content[pos + 4..].find("-->").map(|found| pos + 4 + found + 3)?;
+            return Some((
+                Html {
+                    value: &content[pos..end],
+                    span: Span::new((offset + pos) as u32, (offset + end) as u32),
+                },
+                end,
+            ));
+        }
+
+        let closing = bytes.get(pos + 1) == Some(&b'/');
+        let tag_start = if closing { pos + 2 } else { pos + 1 };
+        if !bytes.get(tag_start).is_some_and(u8::is_ascii_alphabetic) {
+            return None;
+        }
+
+        let mut tag_end = tag_start + 1;
+        while tag_end < bytes.len()
+            && (bytes[tag_end].is_ascii_alphanumeric() || bytes[tag_end] == b'-')
+        {
+            tag_end += 1;
+        }
+
+        let mut cursor = tag_end;
+        if closing {
+            while cursor < bytes.len() && matches!(bytes[cursor], b' ' | b'\t') {
+                cursor += 1;
+            }
+            if bytes.get(cursor) != Some(&b'>') {
+                return None;
+            }
+            let end = cursor + 1;
+            return Some((
+                Html {
+                    value: &content[pos..end],
+                    span: Span::new((offset + pos) as u32, (offset + end) as u32),
+                },
+                end,
+            ));
+        }
+
+        if !matches!(bytes.get(cursor), Some(b' ' | b'\t' | b'/' | b'>')) {
+            return None;
+        }
+
+        let mut quote = None;
+        while cursor < bytes.len() {
+            let byte = bytes[cursor];
+            if let Some(quote_byte) = quote {
+                if byte == quote_byte {
+                    quote = None;
+                }
+            } else if matches!(byte, b'"' | b'\'') {
+                quote = Some(byte);
+            } else if byte == b'>' {
+                let end = cursor + 1;
+                return Some((
+                    Html {
+                        value: &content[pos..end],
+                        span: Span::new((offset + pos) as u32, (offset + end) as u32),
+                    },
+                    end,
+                ));
+            } else if byte == b'\n' {
+                return None;
+            }
+            cursor += 1;
+        }
+
+        None
     }
 }
 

--- a/crates/ox_content_parser/tests/edge_cases.rs
+++ b/crates/ox_content_parser/tests/edge_cases.rs
@@ -317,6 +317,62 @@ fn inline_link_handles_nested_parentheses() {
 }
 
 #[test]
+fn inline_raw_html_is_preserved_as_html_node() {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(
+        &allocator,
+        "before <input type=\"checkbox\"> after",
+        ParserOptions::default(),
+    );
+
+    match &doc.children[0] {
+        Node::Paragraph(paragraph) => {
+            assert!(
+                matches!(&paragraph.children[1], Node::Html(html) if html.value == "<input type=\"checkbox\">")
+            );
+        }
+        other => panic!("expected paragraph, got {other:?}"),
+    }
+}
+
+#[test]
+fn list_item_allows_inline_raw_html() {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(
+        &allocator,
+        "- <input type=\"checkbox\"> task",
+        ParserOptions::default(),
+    );
+
+    match &doc.children[0] {
+        Node::List(list) => match &list.children[0].children[0] {
+            Node::Paragraph(paragraph) => {
+                assert!(
+                    matches!(&paragraph.children[0], Node::Html(html) if html.value == "<input type=\"checkbox\">")
+                );
+            }
+            other => panic!("expected paragraph, got {other:?}"),
+        },
+        other => panic!("expected list, got {other:?}"),
+    }
+}
+
+#[test]
+fn inline_code_keeps_raw_html_literal() {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(&allocator, "`<input>`", ParserOptions::default());
+
+    match &doc.children[0] {
+        Node::Paragraph(paragraph) => {
+            assert!(
+                matches!(&paragraph.children[0], Node::InlineCode(code) if code.value == "<input>")
+            );
+        }
+        other => panic!("expected paragraph, got {other:?}"),
+    }
+}
+
+#[test]
 fn image_url_handles_nested_parentheses() {
     let allocator = Allocator::new();
     let doc =

--- a/crates/ox_content_renderer/src/html.rs
+++ b/crates/ox_content_renderer/src/html.rs
@@ -1071,6 +1071,24 @@ impl HtmlRenderer {
         }
     }
 
+    fn write_html_value(&mut self, value: &str) {
+        if self.options.sanitize {
+            self.write_escaped(value);
+        } else if self.options.convert_md_links {
+            let rewritten = self.rewrite_html_root_urls(value);
+            self.write(&rewritten);
+        } else {
+            self.write(value);
+        }
+    }
+
+    fn visit_inline_node(&mut self, node: &Node<'_>) {
+        match node {
+            Node::Html(html) => self.write_html_value(html.value),
+            _ => self.visit_node(node),
+        }
+    }
+
     fn convert_markdown_url(&self, url: &str) -> String {
         let converted = self.convert_md_url(url);
         if converted != url {
@@ -1291,7 +1309,7 @@ impl<'a> Visit<'a> for HtmlRenderer {
     fn visit_paragraph(&mut self, paragraph: &Paragraph<'a>) {
         self.write("<p>");
         for child in &paragraph.children {
-            self.visit_node(child);
+            self.visit_inline_node(child);
         }
         self.write("</p>\n");
     }
@@ -1309,7 +1327,7 @@ impl<'a> Visit<'a> for HtmlRenderer {
         self.write(tag);
         self.write(">");
         for child in &heading.children {
-            self.visit_node(child);
+            self.visit_inline_node(child);
         }
         self.write("</");
         self.write(tag);
@@ -1431,14 +1449,7 @@ impl<'a> Visit<'a> for HtmlRenderer {
     }
 
     fn visit_html(&mut self, html: &Html<'a>) {
-        if self.options.sanitize {
-            self.write_escaped(html.value);
-        } else if self.options.convert_md_links {
-            let rewritten = self.rewrite_html_root_urls(html.value);
-            self.write(&rewritten);
-        } else {
-            self.write(html.value);
-        }
+        self.write_html_value(html.value);
         self.write("\n");
     }
 
@@ -1468,7 +1479,7 @@ impl<'a> Visit<'a> for HtmlRenderer {
     fn visit_emphasis(&mut self, emphasis: &Emphasis<'a>) {
         self.write("<em>");
         for child in &emphasis.children {
-            self.visit_node(child);
+            self.visit_inline_node(child);
         }
         self.write("</em>");
     }
@@ -1476,7 +1487,7 @@ impl<'a> Visit<'a> for HtmlRenderer {
     fn visit_strong(&mut self, strong: &Strong<'a>) {
         self.write("<strong>");
         for child in &strong.children {
-            self.visit_node(child);
+            self.visit_inline_node(child);
         }
         self.write("</strong>");
     }
@@ -1513,7 +1524,7 @@ impl<'a> Visit<'a> for HtmlRenderer {
         }
         self.write(">");
         for child in &link.children {
-            self.visit_node(child);
+            self.visit_inline_node(child);
         }
         self.write("</a>");
     }
@@ -1546,7 +1557,7 @@ impl<'a> Visit<'a> for HtmlRenderer {
     fn visit_delete(&mut self, delete: &Delete<'a>) {
         self.write("<del>");
         for child in &delete.children {
-            self.visit_node(child);
+            self.visit_inline_node(child);
         }
         self.write("</del>");
     }
@@ -1607,7 +1618,7 @@ impl HtmlRenderer {
 
     fn visit_table_cell(&mut self, cell: &TableCell<'_>) {
         for child in &cell.children {
-            self.visit_node(child);
+            self.visit_inline_node(child);
         }
     }
 }

--- a/crates/ox_content_renderer/tests/edge_cases.rs
+++ b/crates/ox_content_renderer/tests/edge_cases.rs
@@ -216,6 +216,28 @@ fn hard_breaks_render_inside_paragraphs() {
 }
 
 #[test]
+fn inline_raw_html_renders_without_extra_newline() {
+    let html = render(
+        "- <input type=\"checkbox\"> task",
+        ParserOptions::default(),
+        HtmlRendererOptions::default(),
+    );
+
+    assert_eq!(html, "<ul>\n<li><p><input type=\"checkbox\"> task</p>\n</li>\n</ul>\n");
+}
+
+#[test]
+fn inline_raw_html_is_escaped_when_sanitize_is_enabled() {
+    let html = render(
+        "<span>ok</span>",
+        ParserOptions::default(),
+        HtmlRendererOptions { sanitize: true, ..Default::default() },
+    );
+
+    assert_eq!(html, "<p>&lt;span&gt;ok&lt;/span&gt;</p>\n");
+}
+
+#[test]
 fn html_type6_details_allows_markdown_after_blank_line() {
     let html = render(
         "<details>\n\n<summary>Click to expand</summary>\n\n**bold should be markdown**\n\n- list\n\n```js\nconsole.log(\"code\");\n```\n\n</details>",


### PR DESCRIPTION
## Summary

- Parse CommonMark inline raw HTML tags and comments as HTML nodes instead of text.
- Render inline HTML inside paragraphs, headings, links, emphasis, and table cells without inserting block newlines.
- Preserve sanitize behavior by escaping inline HTML when sanitization is enabled.

Closes #57

## Validation

- `cargo test -p ox_content_parser inline --test edge_cases`
- `cargo test -p ox_content_renderer inline_raw_html --test edge_cases`
- `cargo clippy -p ox_content_parser -p ox_content_renderer --all-targets -- -D warnings`
- `cargo fmt --check -p ox_content_parser -p ox_content_renderer`
- `git diff --check`