### PR TITLE
test: expect heading anchor id in vite transform

### DIFF
--- a/crates/ox_content_vite/src/transform.rs
+++ b/crates/ox_content_vite/src/transform.rs
@@ -62,6 +62,6 @@ mod tests {
     fn test_transform() {
         let ctx = TransformContext::new();
         let html = ctx.transform("# Hello World").unwrap();
-        assert!(html.contains("<h1>"));
+        assert!(html.contains("<h1 id=\"hello-world\">"));
     }
 }


### PR DESCRIPTION
## Summary
- update the Vite transform test for heading anchor ids generated by #80

## Checks
- cargo test -p ox_content_vite --lib
- cargo fmt --check -p ox_content_vite
- git diff --check

Follow-up to #80