### PR TITLE
feat: render toc outline in ssg theme

### DIFF
--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -414,6 +414,8 @@ struct PageTemplate<'a> {
     embed_sidebar_after: &'a str,
     embed_content_before: &'a str,
     main_content: &'a str,
+    has_toc: bool,
+    toc_html: &'a str,
     embed_content_after: &'a str,
     embed_footer_before: &'a str,
     footer_html: &'a str,
@@ -744,6 +746,38 @@ fn page_content_contains_any(content: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| content.contains(needle))
 }
 
+fn escape_html(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '&' => output.push_str("&amp;"),
+            '<' => output.push_str("&lt;"),
+            '>' => output.push_str("&gt;"),
+            '"' => output.push_str("&quot;"),
+            '\'' => output.push_str("&#39;"),
+            _ => output.push(ch),
+        }
+    }
+    output
+}
+
+fn generate_toc_html(toc: &[TocEntry]) -> String {
+    let mut html = String::new();
+
+    for entry in toc {
+        let depth = entry.depth.clamp(1, 6);
+        html.push_str("        <li class=\"toc-item\"><a href=\"#");
+        html.push_str(&escape_html(&entry.slug));
+        html.push_str("\" class=\"toc-link toc-link--depth-");
+        html.push_str(&depth.to_string());
+        html.push_str("\">");
+        html.push_str(&escape_html(&entry.text));
+        html.push_str("</a></li>\n");
+    }
+
+    html
+}
+
 /// Generates a complete HTML page for SSG.
 ///
 /// This function creates a full HTML document with navigation sidebar,
@@ -797,6 +831,8 @@ pub fn generate_html(page_data: &PageData, nav_groups: &[NavGroup], config: &Ssg
     }
 
     let all_css = css_sections.join("");
+    let toc_html = generate_toc_html(&page_data.toc);
+    let has_toc = !toc_html.is_empty();
 
     // Embedded HTML for specific positions
     let embed_head = embed.and_then(|e| e.head.as_deref()).unwrap_or("");
@@ -913,6 +949,8 @@ pub fn generate_html(page_data: &PageData, nav_groups: &[NavGroup], config: &Ssg
         embed_sidebar_after,
         embed_content_before,
         main_content: &main_content,
+        has_toc,
+        toc_html: &toc_html,
         embed_content_after,
         embed_footer_before,
         footer_html: &footer_html,
@@ -1023,6 +1061,8 @@ mod tests {
         assert!(html.contains("Test Page - Test Site"));
         assert!(html.contains("<h1>Hello</h1>"));
         assert!(html.contains("Guide"));
+        assert!(html.contains("class=\"toc\""));
+        assert!(html.contains("href=\"#hello\""));
     }
 
     #[test]
@@ -1064,6 +1104,44 @@ mod tests {
         // Check footer is present
         assert!(html.contains("Built with ox-content"));
         assert!(html.contains("2025 Test"));
+    }
+
+    #[test]
+    fn test_generate_html_without_toc_omits_outline() {
+        let page_data = PageData {
+            title: "No TOC".to_string(),
+            description: None,
+            content: "<p>Content</p>".to_string(),
+            toc: vec![],
+            path: "no-toc".to_string(),
+            entry_page: None,
+        };
+        let config = SsgConfig {
+            site_name: "Test Site".to_string(),
+            base: "/".to_string(),
+            og_image: None,
+            theme: None,
+            locale: None,
+            available_locales: None,
+        };
+
+        let html = generate_html(&page_data, &[], &config);
+
+        assert!(!html.contains("class=\"toc\""));
+        assert!(!html.contains("<main class=\"main main--with-toc\">"));
+    }
+
+    #[test]
+    fn test_generate_toc_html_escapes_entries() {
+        let html = generate_toc_html(&[TocEntry {
+            depth: 2,
+            text: "A <script>".to_string(),
+            slug: "a\" onclick=\"alert(1)".to_string(),
+        }]);
+
+        assert!(html.contains("A &lt;script&gt;"));
+        assert!(html.contains("href=\"#a&quot; onclick=&quot;alert(1)\""));
+        assert!(!html.contains("A <script>"));
     }
 
     #[test]

--- a/crates/ox_content_ssg/src/ssg.css
+++ b/crates/ox_content_ssg/src/ssg.css
@@ -572,6 +572,9 @@ a:hover {
   min-width: 0;
   overflow-x: hidden;
 }
+.main--with-toc {
+  padding-right: 2rem;
+}
 .content {
   max-width: var(--octc-max-content-width);
   margin: 0 auto;
@@ -1157,6 +1160,60 @@ a:hover {
 .content .ox-api-entry__return {
   margin: 0;
 }
+.toc {
+  display: none;
+  position: fixed;
+  top: var(--octc-header-height);
+  right: 0;
+  bottom: 0;
+  width: 15rem;
+  padding: 2rem 1rem;
+  border-left: 1px solid color-mix(in srgb, var(--octc-color-border) 58%, transparent);
+  overflow-y: auto;
+}
+.toc-title {
+  margin-bottom: 0.75rem;
+  color: var(--octc-color-text-muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.toc-list {
+  list-style: none;
+}
+.toc-item {
+  margin: 0;
+}
+.toc-link {
+  display: block;
+  padding: 0.25rem 0.5rem;
+  color: var(--octc-color-text-muted);
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  border-left: 1px solid transparent;
+}
+.toc-link:hover {
+  color: var(--octc-color-primary);
+  text-decoration: none;
+  border-left-color: var(--octc-color-primary);
+}
+.toc-link--depth-3 {
+  padding-left: 1rem;
+}
+.toc-link--depth-4,
+.toc-link--depth-5,
+.toc-link--depth-6 {
+  padding-left: 1.5rem;
+}
+@media (min-width: 1440px) {
+  .toc {
+    display: block;
+  }
+  .main--with-toc {
+    padding-right: 17rem;
+  }
+}
 /* Mobile Footer Bar */
 .mobile-footer {
   display: none;
@@ -1255,6 +1312,9 @@ a:hover {
     margin-left: 0;
     padding: 0.9rem 0.5rem;
     padding-bottom: calc(56px + 0.9rem);
+  }
+  .main--with-toc {
+    padding-right: 0.5rem;
   }
   .content {
     padding: 0;

--- a/crates/ox_content_ssg/templates/page.html
+++ b/crates/ox_content_ssg/templates/page.html
@@ -93,13 +93,21 @@
 {{ embed_sidebar_after|safe }}
     </aside>
 {% endif %}
-    <main class="main">
+    <main class="main{% if has_toc %} main--with-toc{% endif %}">
 {{ embed_content_before|safe }}
 {{ main_content|safe }}
 {{ embed_content_after|safe }}
 {{ embed_footer_before|safe }}
 {{ footer_html|safe }}
     </main>
+{% if has_toc %}
+    <aside class="toc" aria-label="On this page">
+      <div class="toc-title">On this page</div>
+      <ul class="toc-list">
+{{ toc_html|safe }}
+      </ul>
+    </aside>
+{% endif %}
   </div>
   <footer class="mobile-footer">
     <button class="mobile-footer-btn" aria-label="Menu" data-mobile-menu>


### PR DESCRIPTION
## Summary
- render PageData.toc as an On this page outline in the Rust SSG theme
- hide the outline when a page has no TOC entries
- escape TOC labels and fragments before writing HTML

## Checks
- cargo test -p ox_content_ssg --lib
- cargo clippy -p ox_content_ssg --all-targets -- -D warnings
- cargo fmt --check -p ox_content_ssg
- git diff origin/main --check

Closes #59