### PR TITLE
feat: support git last updated

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -43,6 +43,9 @@ export declare function generateOgImageSvg(data: JsOgImageData, config?: JsOgIma
 /** Generates SSG HTML page with navigation and search. */
 export declare function generateSsgHtml(pageData: JsSsgPageData, navGroups: Array<JsSsgNavGroup>, config: JsSsgConfig): string
 
+/** Returns the last git commit timestamp for a file in milliseconds. */
+export declare function getGitLastUpdated(filePath: string, root?: string | undefined | null): number | null
+
 /** Result of i18n checking. */
 export interface I18NCheckResult {
   /** All diagnostics. */
@@ -391,6 +394,8 @@ export interface JsSsgPageData {
   content: string
   /** Table of contents entries. */
   toc: Array<TocEntry>
+  /** Last updated timestamp in milliseconds since the Unix epoch. */
+  lastUpdated?: number
   /** URL path. */
   path: string
   /** Entry page configuration (if layout: entry). */

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -11,7 +11,8 @@ use napi::bindgen_prelude::*;
 use napi::Task;
 use napi_derive::napi;
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use ox_content_allocator::Allocator;
 use ox_content_ast::{Document, Heading, Node};
@@ -931,10 +932,34 @@ pub struct JsSsgPageData {
     pub content: String,
     /// Table of contents entries.
     pub toc: Vec<TocEntry>,
+    /// Last updated timestamp in milliseconds since the Unix epoch.
+    pub last_updated: Option<f64>,
     /// URL path.
     pub path: String,
     /// Entry page configuration (if layout: entry).
     pub entry_page: Option<JsEntryPageConfig>,
+}
+
+/// Returns the last git commit timestamp for a file in milliseconds.
+#[napi]
+pub fn get_git_last_updated(file_path: String, root: Option<String>) -> Option<f64> {
+    let root = root.map(PathBuf::from)?;
+    let file = PathBuf::from(&file_path);
+    let pathspec = file.strip_prefix(&root).ok().and_then(|p| p.to_str()).unwrap_or(&file_path);
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["log", "-1", "--format=%ct", "--"])
+        .arg(pathspec)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let seconds = String::from_utf8(output.stdout).ok()?.trim().parse::<f64>().ok()?;
+    Some(seconds * 1_000.0)
 }
 
 // =============================================================================
@@ -1239,6 +1264,10 @@ pub fn generate_ssg_html(
             .into_iter()
             .map(|t| ox_content_ssg::TocEntry { depth: t.depth, text: t.text, slug: t.slug })
             .collect(),
+        last_updated: page_data
+            .last_updated
+            .filter(|timestamp| timestamp.is_finite() && *timestamp >= 0.0)
+            .map(|timestamp| timestamp as i64),
         path: page_data.path,
         entry_page: convert_entry_page_config(page_data.entry_page),
     };
@@ -1706,11 +1735,13 @@ pub fn extract_translation_keys(
 #[cfg(test)]
 mod tests {
     use serde_json::json;
+    use std::fs;
+    use std::process::Command;
 
     use ox_content_allocator::Allocator;
     use ox_content_parser::Parser;
 
-    use super::{extract_toc, parse_frontmatter};
+    use super::{extract_toc, get_git_last_updated, parse_frontmatter};
 
     #[test]
     fn parses_nested_yaml_frontmatter() {
@@ -1766,5 +1797,40 @@ mod tests {
 
         assert!(result.html.contains("href=\"#intro\""));
         assert!(!result.html.contains("href=\"#api\""));
+    }
+
+    #[test]
+    fn git_last_updated_uses_root_relative_path() {
+        let root = std::env::temp_dir().join(format!("ox-content-git-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(root.join("docs")).unwrap();
+        fs::write(root.join("docs/page.md"), "# Page").unwrap();
+
+        for args in [
+            vec!["init"],
+            vec!["add", "docs/page.md"],
+            vec![
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "-m",
+                "init",
+            ],
+        ] {
+            let mut cmd = Command::new("git");
+            cmd.arg("-C").arg(&root).args(args);
+            cmd.env("GIT_AUTHOR_DATE", "@1234567890");
+            cmd.env("GIT_COMMITTER_DATE", "@1234567890");
+            assert!(cmd.status().unwrap().success());
+        }
+
+        let updated = get_git_last_updated(
+            root.join("docs/page.md").to_string_lossy().into_owned(),
+            Some(root.to_string_lossy().into_owned()),
+        );
+        assert_eq!(updated, Some(1_234_567_890_000.0));
+        let _ = fs::remove_dir_all(root);
     }
 }

--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -278,6 +278,8 @@ pub struct PageData {
     pub content: String,
     /// Table of contents entries.
     pub toc: Vec<TocEntry>,
+    /// Last updated timestamp in milliseconds since the Unix epoch.
+    pub last_updated: Option<i64>,
     /// URL path.
     pub path: String,
     /// Entry page configuration (if layout: entry).
@@ -387,6 +389,11 @@ struct EntryTemplate<'a> {
     features: Option<&'a [FeatureView]>,
 }
 
+struct LastUpdatedView {
+    text: String,
+    datetime: String,
+}
+
 /// Main page template.
 #[derive(Template)]
 #[template(path = "page.html")]
@@ -416,6 +423,7 @@ struct PageTemplate<'a> {
     main_content: &'a str,
     has_toc: bool,
     toc_html: &'a str,
+    last_updated: Option<&'a LastUpdatedView>,
     embed_content_after: &'a str,
     embed_footer_before: &'a str,
     footer_html: &'a str,
@@ -778,6 +786,31 @@ fn generate_toc_html(toc: &[TocEntry]) -> String {
     html
 }
 
+fn civil_from_days(days: i64) -> (i64, i64, i64) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let year = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = mp + if mp < 10 { 3 } else { -9 };
+    let year = year + i64::from(month <= 2);
+    (year, month, day)
+}
+
+fn format_last_updated(timestamp_ms: i64) -> Option<LastUpdatedView> {
+    if timestamp_ms < 0 {
+        return None;
+    }
+
+    let days = (timestamp_ms / 1_000).div_euclid(86_400);
+    let (year, month, day) = civil_from_days(days);
+    let date = format!("{year:04}-{month:02}-{day:02}");
+    Some(LastUpdatedView { text: date.clone(), datetime: date })
+}
+
 /// Generates a complete HTML page for SSG.
 ///
 /// This function creates a full HTML document with navigation sidebar,
@@ -833,6 +866,7 @@ pub fn generate_html(page_data: &PageData, nav_groups: &[NavGroup], config: &Ssg
     let all_css = css_sections.join("");
     let toc_html = generate_toc_html(&page_data.toc);
     let has_toc = !toc_html.is_empty();
+    let last_updated = page_data.last_updated.and_then(format_last_updated);
 
     // Embedded HTML for specific positions
     let embed_head = embed.and_then(|e| e.head.as_deref()).unwrap_or("");
@@ -951,6 +985,7 @@ pub fn generate_html(page_data: &PageData, nav_groups: &[NavGroup], config: &Ssg
         main_content: &main_content,
         has_toc,
         toc_html: &toc_html,
+        last_updated: last_updated.as_ref(),
         embed_content_after,
         embed_footer_before,
         footer_html: &footer_html,
@@ -1034,6 +1069,7 @@ mod tests {
             description: Some("Test description".to_string()),
             content: "<h1>Hello</h1>".to_string(),
             toc: vec![TocEntry { depth: 1, text: "Hello".to_string(), slug: "hello".to_string() }],
+            last_updated: Some(0),
             path: "test".to_string(),
             entry_page: None,
         };
@@ -1063,6 +1099,8 @@ mod tests {
         assert!(html.contains("Guide"));
         assert!(html.contains("class=\"toc\""));
         assert!(html.contains("href=\"#hello\""));
+        assert!(html.contains("Last updated:"));
+        assert!(html.contains("<time datetime=\"1970-01-01\">1970-01-01</time>"));
     }
 
     #[test]
@@ -1072,6 +1110,7 @@ mod tests {
             description: None,
             content: "<p>Content</p>".to_string(),
             toc: vec![],
+            last_updated: None,
             path: "themed".to_string(),
             entry_page: None,
         };
@@ -1113,6 +1152,7 @@ mod tests {
             description: None,
             content: "<p>Content</p>".to_string(),
             toc: vec![],
+            last_updated: None,
             path: "no-toc".to_string(),
             entry_page: None,
         };
@@ -1129,6 +1169,12 @@ mod tests {
 
         assert!(!html.contains("class=\"toc\""));
         assert!(!html.contains("<main class=\"main main--with-toc\">"));
+        assert!(!html.contains("Last updated:"));
+    }
+
+    #[test]
+    fn test_format_last_updated_rejects_invalid_timestamps() {
+        assert!(format_last_updated(-1).is_none());
     }
 
     #[test]

--- a/crates/ox_content_ssg/src/lib.rs
+++ b/crates/ox_content_ssg/src/lib.rs
@@ -24,6 +24,7 @@
 //!     description: Some("Learn how to use ox-content".to_string()),
 //!     content: "<h1>Getting Started</h1><p>Welcome!</p>".to_string(),
 //!     toc: vec![TocEntry { depth: 1, text: "Getting Started".to_string(), slug: "getting-started".to_string() }],
+//!     last_updated: None,
 //!     path: "getting-started".to_string(),
 //!     entry_page: None,
 //! };

--- a/crates/ox_content_ssg/src/ssg.css
+++ b/crates/ox_content_ssg/src/ssg.css
@@ -582,6 +582,14 @@ a:hover {
   word-wrap: break-word;
   word-break: break-word;
 }
+.last-updated {
+  max-width: var(--octc-max-content-width);
+  margin: 2rem auto 0;
+  padding-top: 1rem;
+  border-top: 1px solid color-mix(in srgb, var(--octc-color-border) 78%, transparent);
+  color: var(--octc-color-text-muted);
+  font-size: 0.875rem;
+}
 .content h1 {
   font-size: clamp(2.4rem, 5vw, 3.1rem);
   margin-bottom: 1rem;

--- a/crates/ox_content_ssg/templates/page.html
+++ b/crates/ox_content_ssg/templates/page.html
@@ -96,6 +96,9 @@
     <main class="main{% if has_toc %} main--with-toc{% endif %}">
 {{ embed_content_before|safe }}
 {{ main_content|safe }}
+{% if let Some(updated) = last_updated %}
+      <p class="last-updated">Last updated: <time datetime="{{ updated.datetime }}">{{ updated.text }}</time></p>
+{% endif %}
 {{ embed_content_after|safe }}
 {{ embed_footer_before|safe }}
 {{ footer_html|safe }}

--- a/npm/vite-plugin-ox-content-react/src/transform.ts
+++ b/npm/vite-plugin-ox-content-react/src/transform.ts
@@ -81,6 +81,7 @@ export async function transformMarkdownWithReact(
       clean: false,
       bare: false,
       generateOgImage: false,
+      lastUpdated: false,
     },
     gfm: options.gfm,
     frontmatter: false,

--- a/npm/vite-plugin-ox-content-svelte/src/transform.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/transform.ts
@@ -82,6 +82,7 @@ export async function transformMarkdownWithSvelte(
       clean: false,
       bare: false,
       generateOgImage: false,
+      lastUpdated: false,
     },
     gfm: options.gfm,
     frontmatter: false,

--- a/npm/vite-plugin-ox-content-vue/src/transform.ts
+++ b/npm/vite-plugin-ox-content-vue/src/transform.ts
@@ -100,6 +100,7 @@ export async function transformMarkdownWithVue(
       clean: false,
       bare: false,
       generateOgImage: false,
+      lastUpdated: false,
     },
     gfm: options.gfm,
     frontmatter: false, // Already extracted

--- a/npm/vite-plugin-ox-content/src/code-annotations.test.ts
+++ b/npm/vite-plugin-ox-content/src/code-annotations.test.ts
@@ -121,6 +121,7 @@ function createResolvedOptions(overrides: Partial<ResolvedOptions> = {}): Resolv
       clean: false,
       bare: false,
       generateOgImage: false,
+      lastUpdated: false,
     },
     gfm: true,
     footnotes: true,

--- a/npm/vite-plugin-ox-content/src/page-context.ts
+++ b/npm/vite-plugin-ox-content/src/page-context.ts
@@ -40,6 +40,8 @@ export interface BasePageProps {
   html: string;
   /** Table of contents entries */
   toc: TocEntry[];
+  /** Last git commit timestamp in milliseconds */
+  lastUpdated?: number;
   /** Source file path (relative to docs root) */
   path: string;
   /** Output URL path */

--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vite-plus/test";
+import { resolveSsgOptions } from "./ssg";
+
+describe("resolveSsgOptions", () => {
+  it("disables git timestamps by default", () => {
+    expect(resolveSsgOptions(undefined).lastUpdated).toBe(false);
+  });
+
+  it("enables git timestamps when requested", () => {
+    expect(resolveSsgOptions({ lastUpdated: true }).lastUpdated).toBe(true);
+  });
+});

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -51,6 +51,7 @@ export interface SsgPageData {
   description?: string;
   content: string;
   toc: TocEntry[];
+  lastUpdated?: number;
   frontmatter: Record<string, unknown>;
   path: string;
   href: string;
@@ -1412,6 +1413,7 @@ export function resolveSsgOptions(ssg: SsgOptions | boolean | undefined): Resolv
       clean: false,
       bare: false,
       generateOgImage: false,
+      lastUpdated: false,
     };
   }
 
@@ -1422,6 +1424,7 @@ export function resolveSsgOptions(ssg: SsgOptions | boolean | undefined): Resolv
       clean: false,
       bare: false,
       generateOgImage: false,
+      lastUpdated: false,
       theme: resolveTheme(undefined),
     };
   }
@@ -1434,6 +1437,7 @@ export function resolveSsgOptions(ssg: SsgOptions | boolean | undefined): Resolv
     siteName: ssg.siteName,
     ogImage: ssg.ogImage,
     generateOgImage: ssg.generateOgImage ?? false,
+    lastUpdated: ssg.lastUpdated ?? false,
     siteUrl: ssg.siteUrl,
     theme: resolveTheme(ssg.theme),
   };
@@ -1619,6 +1623,7 @@ export async function generateHtmlPage(
       description: pageData.description,
       content: pageData.content,
       toc: tocForRust,
+      lastUpdated: pageData.lastUpdated,
       path: pageData.path,
       entryPage: entryPageForRust,
     },
@@ -2216,10 +2221,12 @@ export async function buildSsg(
     transformedHtml: string;
     title: string;
     description?: string;
+    lastUpdated?: number;
     frontmatter: Record<string, unknown>;
     toc: TocEntry[];
   }
   const pageResults: PageProcessResult[] = [];
+  const napi = ssgOptions.lastUpdated ? await importNapiModule() : undefined;
 
   // Process each file: transform markdown and collect metadata
   for (const inputPath of markdownFiles) {
@@ -2268,6 +2275,7 @@ export async function buildSsg(
         transformedHtml,
         title,
         description,
+        lastUpdated: napi?.getGitLastUpdated(inputPath, root) ?? undefined,
         frontmatter: result.frontmatter,
         toc: result.toc,
       });
@@ -2330,7 +2338,8 @@ export async function buildSsg(
   // Generate HTML pages
   for (const pageResult of pageResults) {
     try {
-      const { inputPath, transformedHtml, title, description, frontmatter, toc } = pageResult;
+      const { inputPath, transformedHtml, title, description, lastUpdated, frontmatter, toc } =
+        pageResult;
 
       // Determine OG image URL for this page
       let pageOgImage = ssgOptions.ogImage; // fallback to static URL
@@ -2357,6 +2366,7 @@ export async function buildSsg(
           description,
           content: transformedHtml,
           toc,
+          lastUpdated,
           frontmatter,
           path: getUrlPath(inputPath, srcDir),
           href: getHref(inputPath, srcDir, base, ssgOptions.extension),

--- a/npm/vite-plugin-ox-content/src/theme-renderer.ts
+++ b/npm/vite-plugin-ox-content/src/theme-renderer.ts
@@ -44,6 +44,8 @@ export interface PageData {
   html: string;
   /** Table of contents */
   toc: TocEntry[];
+  /** Last git commit timestamp in milliseconds */
+  lastUpdated?: number;
   /** Source file path */
   path: string;
   /** Output URL path */
@@ -88,6 +90,7 @@ export function renderPage(page: PageData, options: ThemeRenderOptions): string 
     description: page.description,
     html: page.html,
     toc: page.toc,
+    lastUpdated: page.lastUpdated,
     path: page.path,
     url: page.url,
     frontmatter: page.frontmatter,
@@ -104,6 +107,7 @@ export function renderPage(page: PageData, options: ThemeRenderOptions): string 
       description: p.description,
       html: p.html,
       toc: p.toc,
+      lastUpdated: p.lastUpdated,
       path: p.path,
       url: p.url,
       frontmatter: p.frontmatter,

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -143,6 +143,12 @@ export interface SsgOptions {
   generateOgImage?: boolean;
 
   /**
+   * Add each page's last git commit timestamp to the default theme.
+   * @default false
+   */
+  lastUpdated?: boolean;
+
+  /**
    * Site URL for generating absolute OG image URLs.
    * Required for proper SNS sharing.
    * Example: 'https://example.com'
@@ -167,6 +173,7 @@ export interface ResolvedSsgOptions {
   siteName?: string;
   ogImage?: string;
   generateOgImage: boolean;
+  lastUpdated: boolean;
   siteUrl?: string;
   theme?: ResolvedThemeConfig;
 }

--- a/npm/vite-plugin-ox-content/test/fixtures/docs-fixture.ts
+++ b/npm/vite-plugin-ox-content/test/fixtures/docs-fixture.ts
@@ -103,6 +103,7 @@ export function createDocsResolvedOptions(
       bare: false,
       siteName: "Ox Content",
       generateOgImage: false,
+      lastUpdated: false,
     },
     gfm: true,
     footnotes: true,

--- a/npm/vite-plugin-ox-content/test/vrt/code-highlighting.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/code-highlighting.spec.ts
@@ -16,6 +16,7 @@ function createResolvedOptions(): ResolvedOptions {
       bare: false,
       siteName: "Ox Content",
       generateOgImage: false,
+      lastUpdated: false,
     },
     gfm: true,
     footnotes: true,


### PR DESCRIPTION
## Summary
- add an opt-in SSG lastUpdated flag
- resolve each page's last git commit timestamp through the native binding
- render the date in the default SSG theme when available

Closes #61

## Validation
- cargo test -p ox_content_ssg --lib
- cargo test -p ox_content_napi git_last_updated_uses_root_relative_path --lib
- vp test run npm/vite-plugin-ox-content/src/ssg.test.ts
- vp check --no-lint npm/vite-plugin-ox-content/src/ssg.ts npm/vite-plugin-ox-content/src/types.ts npm/vite-plugin-ox-content/src/ssg.test.ts npm/vite-plugin-ox-content/src/page-context.ts npm/vite-plugin-ox-content/src/theme-renderer.ts npm/vite-plugin-ox-content/src/code-annotations.test.ts npm/vite-plugin-ox-content/test/fixtures/docs-fixture.ts npm/vite-plugin-ox-content/test/vrt/code-highlighting.spec.ts npm/vite-plugin-ox-content-react/src/transform.ts npm/vite-plugin-ox-content-svelte/src/transform.ts npm/vite-plugin-ox-content-vue/src/transform.ts