### PR TITLE
feat: support custom social links

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -314,6 +314,20 @@ export interface JsSocialLinks {
   twitter?: string
   /** Discord URL. */
   discord?: string
+  /** Custom social links. */
+  links?: Array<JsSocialLink>
+}
+
+/** Custom social link for JavaScript. */
+export interface JsSocialLink {
+  /** Icon label. */
+  icon?: string
+  /** Inline SVG icon. */
+  iconSvg?: string
+  /** Link URL. */
+  link: string
+  /** Accessible label. */
+  ariaLabel?: string
 }
 
 /** Source documentation item extracted from a JS/TS file. */

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -1033,6 +1033,22 @@ pub struct JsSocialLinks {
     pub twitter: Option<String>,
     /// Discord URL.
     pub discord: Option<String>,
+    /// Custom social links.
+    pub links: Option<Vec<JsSocialLink>>,
+}
+
+/// Custom social link for JavaScript.
+#[napi(object)]
+#[derive(Clone)]
+pub struct JsSocialLink {
+    /// Icon label.
+    pub icon: Option<String>,
+    /// Inline SVG icon.
+    pub icon_svg: Option<String>,
+    /// Link URL.
+    pub link: String,
+    /// Accessible label.
+    pub aria_label: Option<String>,
 }
 
 /// Embedded HTML content for specific positions.
@@ -1159,6 +1175,17 @@ fn convert_theme_config(theme: Option<JsThemeConfig>) -> Option<ox_content_ssg::
             github: s.github,
             twitter: s.twitter,
             discord: s.discord,
+            links: s.links.map(|links| {
+                links
+                    .into_iter()
+                    .map(|l| ox_content_ssg::SocialLink {
+                        icon: l.icon,
+                        icon_svg: l.icon_svg,
+                        link: l.link,
+                        aria_label: l.aria_label,
+                    })
+                    .collect()
+            }),
         }),
         embed: t.embed.map(|e| ox_content_ssg::ThemeEmbed {
             head: e.head,

--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -95,6 +95,21 @@ pub struct SocialLinks {
     pub twitter: Option<String>,
     /// Discord URL.
     pub discord: Option<String>,
+    /// Custom social links.
+    pub links: Option<Vec<SocialLink>>,
+}
+
+/// Custom social link.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SocialLink {
+    /// Icon label or built HTML icon source.
+    pub icon: Option<String>,
+    /// Trusted inline SVG icon.
+    pub icon_svg: Option<String>,
+    /// Link URL.
+    pub link: String,
+    /// Accessible label.
+    pub aria_label: Option<String>,
 }
 
 /// Embedded HTML content for specific positions in the page layout.
@@ -1006,7 +1021,13 @@ fn generate_social_links_html(links: &SocialLinks) -> String {
         twitter: links.twitter.as_deref(),
         discord: links.discord.as_deref(),
     };
-    template.render().unwrap_or_default()
+    let mut html = template.render().unwrap_or_default();
+    if let Some(custom_links) = &links.links {
+        for link in custom_links {
+            html.push_str(&render_custom_social_link(link, false));
+        }
+    }
+    html
 }
 
 fn generate_mobile_social_links_html(links: &SocialLinks) -> String {
@@ -1015,7 +1036,51 @@ fn generate_mobile_social_links_html(links: &SocialLinks) -> String {
         twitter: links.twitter.as_deref(),
         discord: links.discord.as_deref(),
     };
-    template.render().unwrap_or_default()
+    let mut html = template.render().unwrap_or_default();
+    if let Some(custom_links) = &links.links {
+        for link in custom_links {
+            html.push_str(&render_custom_social_link(link, true));
+        }
+    }
+    html
+}
+
+fn render_custom_social_link(link: &SocialLink, mobile: bool) -> String {
+    let label = link.aria_label.as_deref().or(link.icon.as_deref()).unwrap_or("Social link");
+    let href = escape_html(&link.link);
+    let label = escape_html(label);
+    let icon_html = render_social_icon(link);
+
+    if mobile {
+        format!(
+            "<a href=\"{href}\" class=\"mobile-footer-btn\" aria-label=\"{label}\" target=\"_blank\" rel=\"noopener\">{icon_html}<span class=\"mobile-footer-label\">{label}</span></a>\n"
+        )
+    } else {
+        format!(
+            "<a href=\"{href}\" class=\"social-link\" aria-label=\"{label}\" target=\"_blank\" rel=\"noopener\">{icon_html}</a>\n"
+        )
+    }
+}
+
+fn render_social_icon(link: &SocialLink) -> String {
+    if let Some(svg) = link.icon_svg.as_deref().and_then(validate_social_svg) {
+        return svg.to_string();
+    }
+
+    link.icon
+        .as_deref()
+        .map(|icon| format!("<span class=\"social-link-icon\">{}</span>", escape_html(icon)))
+        .unwrap_or_default()
+}
+
+fn validate_social_svg(svg: &str) -> Option<&str> {
+    let trimmed = svg.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    if trimmed.starts_with("<svg") && !lower.contains("<script") {
+        Some(trimmed)
+    } else {
+        None
+    }
 }
 
 fn generate_nav_html(nav_groups: &[NavGroup], current_path: &str) -> String {
@@ -1104,6 +1169,44 @@ mod tests {
         // Check footer is present
         assert!(html.contains("Built with ox-content"));
         assert!(html.contains("2025 Test"));
+    }
+
+    #[test]
+    fn test_generate_html_with_custom_social_link() {
+        let page_data = PageData {
+            title: "Social Page".to_string(),
+            description: None,
+            content: "<p>Content</p>".to_string(),
+            toc: vec![],
+            path: "social".to_string(),
+            entry_page: None,
+        };
+        let config = SsgConfig {
+            site_name: "Social Site".to_string(),
+            base: "/".to_string(),
+            og_image: None,
+            locale: None,
+            available_locales: None,
+            theme: Some(ThemeConfig {
+                social_links: Some(SocialLinks {
+                    links: Some(vec![SocialLink {
+                        icon: None,
+                        icon_svg: Some("<svg viewBox=\"0 0 24 24\"></svg>".to_string()),
+                        link: "https://example.com".to_string(),
+                        aria_label: Some("Example".to_string()),
+                    }]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        };
+
+        let html = generate_html(&page_data, &[], &config);
+
+        assert!(html.contains("aria-label=\"Example\""));
+        assert!(html.contains("href=\"https://example.com\""));
+        assert!(html.contains("<svg viewBox=\"0 0 24 24\"></svg>"));
+        assert!(html.contains("<span class=\"mobile-footer-label\">Example</span>"));
     }
 
     #[test]

--- a/crates/ox_content_ssg/src/lib.rs
+++ b/crates/ox_content_ssg/src/lib.rs
@@ -51,7 +51,7 @@ mod html;
 
 pub use html::{
     generate_html, EntryPageConfig, FeatureConfig, HeroAction, HeroConfig, HeroImage,
-    HeroNoticeConfig, LocaleInfo, NavGroup, NavItem, PageData, SocialLinks, SsgConfig, ThemeColors,
-    ThemeConfig, ThemeEmbed, ThemeEntryPage, ThemeFonts, ThemeFooter, ThemeHeader, ThemeLayout,
-    TocEntry,
+    HeroNoticeConfig, LocaleInfo, NavGroup, NavItem, PageData, SocialLink, SocialLinks, SsgConfig,
+    ThemeColors, ThemeConfig, ThemeEmbed, ThemeEntryPage, ThemeFonts, ThemeFooter, ThemeHeader,
+    ThemeLayout, TocEntry,
 };

--- a/npm/vite-plugin-ox-content/src/theme.test.ts
+++ b/npm/vite-plugin-ox-content/src/theme.test.ts
@@ -116,6 +116,7 @@ describe("theme", () => {
         footer: { message: "Test", copyright: "2025" },
         entryPage: { mode: "subtle" },
         header: { logoLight: "wordmark.svg", showSiteNameText: false },
+        socialLinks: { github: "https://github.com/example" },
       });
 
       const napi = themeToNapi(resolved);
@@ -124,6 +125,23 @@ describe("theme", () => {
       expect(napi.header?.showSiteNameText).toBe(false);
       expect(napi.footer?.message).toBe("Test");
       expect(napi.footer?.copyright).toBe("2025");
+      expect(napi.socialLinks?.github).toBe("https://github.com/example");
+    });
+
+    it("should convert custom social links to NAPI format", () => {
+      const svg = '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>';
+      const resolved = resolveTheme({
+        socialLinks: [{ icon: { svg }, link: "https://example.com", ariaLabel: "Example" }],
+      });
+
+      const napi = themeToNapi(resolved);
+
+      expect(napi.socialLinks?.links?.[0]).toEqual({
+        icon: undefined,
+        iconSvg: svg,
+        link: "https://example.com",
+        ariaLabel: "Example",
+      });
     });
 
     it("should omit empty sections", () => {

--- a/npm/vite-plugin-ox-content/src/theme.ts
+++ b/npm/vite-plugin-ox-content/src/theme.ts
@@ -86,10 +86,18 @@ export interface ThemeFooter {
   copyright?: string;
 }
 
-/**
- * Social links configuration.
- */
-export interface SocialLinks {
+/** Custom social link icon. */
+export type SocialLinkIcon = string | { svg: string };
+
+/** Custom social link. */
+export interface SocialLink {
+  icon: SocialLinkIcon;
+  link: string;
+  ariaLabel?: string;
+}
+
+/** Legacy social links configuration. */
+export interface LegacySocialLinks {
   /** GitHub URL */
   github?: string;
   /** Twitter/X URL */
@@ -97,6 +105,9 @@ export interface SocialLinks {
   /** Discord URL */
   discord?: string;
 }
+
+/** Social links configuration. */
+export type SocialLinks = LegacySocialLinks | SocialLink[];
 
 /**
  * Embedded HTML content for specific positions in the page layout.
@@ -353,6 +364,8 @@ export function resolveTheme(config?: ThemeConfig): ResolvedThemeConfig {
  * Converts resolved theme to the format expected by Rust NAPI.
  */
 export function themeToNapi(theme: ResolvedThemeConfig): NapiThemeConfig {
+  const socialLinks = socialLinksToNapi(theme.socialLinks);
+
   return {
     colors: theme.colors.primary
       ? {
@@ -416,18 +429,26 @@ export function themeToNapi(theme: ResolvedThemeConfig): NapiThemeConfig {
             copyright: theme.footer.copyright,
           }
         : undefined,
-    socialLinks:
-      theme.socialLinks.github || theme.socialLinks.twitter || theme.socialLinks.discord
-        ? {
-            github: theme.socialLinks.github,
-            twitter: theme.socialLinks.twitter,
-            discord: theme.socialLinks.discord,
-          }
-        : undefined,
+    socialLinks,
     embed: Object.keys(theme.embed).length > 0 ? theme.embed : undefined,
     css: theme.css || undefined,
     js: theme.js || undefined,
   };
+}
+
+function socialLinksToNapi(links: SocialLinks): NapiSocialLinks | undefined {
+  if (Array.isArray(links)) {
+    const items = links.map((item) => {
+      const icon = typeof item.icon === "string" ? item.icon : undefined;
+      const iconSvg = typeof item.icon === "object" ? item.icon.svg : undefined;
+      return { icon, iconSvg, link: item.link, ariaLabel: item.ariaLabel };
+    });
+    return items.length > 0 ? { links: items } : undefined;
+  }
+
+  return links.github || links.twitter || links.discord
+    ? { github: links.github, twitter: links.twitter, discord: links.discord }
+    : undefined;
 }
 
 /**
@@ -496,6 +517,14 @@ export interface NapiSocialLinks {
   github?: string;
   twitter?: string;
   discord?: string;
+  links?: NapiSocialLink[];
+}
+
+export interface NapiSocialLink {
+  icon?: string;
+  iconSvg?: string;
+  link: string;
+  ariaLabel?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add array-form socialLinks with custom SVG icons
- keep legacy github/twitter/discord social links working
- render custom links in desktop header and mobile footer

Closes #62

## Validation
- cargo test -p ox_content_ssg custom_social --lib
- cargo clippy -p ox_content_ssg -p ox_content_napi --all-targets -- -D warnings
- vp test run npm/vite-plugin-ox-content/src/theme.test.ts
- vp check --no-lint npm/vite-plugin-ox-content/src/theme.ts npm/vite-plugin-ox-content/src/theme.test.ts