### PR TITLE
feat: add Intl localization helpers

### DIFF
--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -411,6 +411,8 @@ struct LastUpdatedView {
 #[derive(Template)]
 #[template(path = "page.html")]
 struct PageTemplate<'a> {
+    html_lang: &'a str,
+    html_dir: &'a str,
     site_name: &'a str,
     document_title: &'a str,
     description: Option<&'a str>,
@@ -824,6 +826,33 @@ fn format_last_updated(timestamp_ms: i64) -> Option<LastUpdatedView> {
     Some(LastUpdatedView { text: date.clone(), datetime: date })
 }
 
+fn infer_locale_dir(locale: &str) -> &'static str {
+    match locale.split('-').next().unwrap_or_default().to_ascii_lowercase().as_str() {
+        "ar" | "fa" | "he" | "iw" | "ps" | "sd" | "ug" | "ur" | "yi" => "rtl",
+        _ => "ltr",
+    }
+}
+
+fn html_locale_attrs(config: &SsgConfig) -> (&str, &str) {
+    let lang = config
+        .locale
+        .as_deref()
+        .filter(|locale| !locale.trim().is_empty())
+        .or_else(|| config.available_locales.as_ref()?.first().map(|locale| locale.code.as_str()))
+        .unwrap_or("en");
+    let configured_dir = config.available_locales.as_ref().and_then(|locales| {
+        locales.iter().find(|locale| locale.code == lang).and_then(|locale| {
+            match locale.dir.as_str() {
+                "ltr" => Some("ltr"),
+                "rtl" => Some("rtl"),
+                _ => None,
+            }
+        })
+    });
+
+    (lang, configured_dir.unwrap_or_else(|| infer_locale_dir(lang)))
+}
+
 /// Generates a complete HTML page for SSG.
 ///
 /// This function creates a full HTML document with navigation sidebar,
@@ -971,8 +1000,11 @@ pub fn generate_html(page_data: &PageData, nav_groups: &[NavGroup], config: &Ssg
     } else {
         format!("{} - {}", page_data.title, config.site_name)
     };
+    let (html_lang, html_dir) = html_locale_attrs(config);
 
     let template = PageTemplate {
+        html_lang,
+        html_dir,
         site_name: &config.site_name,
         document_title: &document_title,
         description: page_data.description.as_deref(),
@@ -1368,6 +1400,32 @@ mod tests {
     #[test]
     fn test_format_last_updated_rejects_invalid_timestamps() {
         assert!(format_last_updated(-1).is_none());
+    }
+
+    #[test]
+    fn test_html_locale_attrs_use_current_locale_and_direction() {
+        let config = SsgConfig {
+            site_name: "Localized".to_string(),
+            base: "/".to_string(),
+            og_image: None,
+            theme: None,
+            locale: Some("ar".to_string()),
+            available_locales: None,
+        };
+
+        assert_eq!(html_locale_attrs(&config), ("ar", "rtl"));
+
+        let page_data = PageData {
+            title: "مرحبا".to_string(),
+            description: None,
+            content: "<p>Content</p>".to_string(),
+            toc: vec![],
+            last_updated: None,
+            path: "ar".to_string(),
+            entry_page: None,
+        };
+        let html = generate_html(&page_data, &[], &config);
+        assert!(html.contains("<html lang=\"ar\" dir=\"rtl\">"));
     }
 
     #[test]

--- a/crates/ox_content_ssg/templates/page.html
+++ b/crates/ox_content_ssg/templates/page.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ html_lang }}" dir="{{ html_dir }}">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/content/packages/i18n.md
+++ b/docs/content/packages/i18n.md
@@ -151,6 +151,7 @@ The plugin provides a `virtual:ox-content/i18n` module with translation utilitie
 ```ts
 import {
   t,
+  createIntl,
   getLocaleFromPath,
   localePath,
   i18nConfig,
@@ -183,6 +184,19 @@ Constructs a localized path for a given locale. Respects `hideDefaultLocale`.
 ```ts
 localePath("/about", "ja"); // '/ja/about'
 localePath("/about", "en"); // '/about' (when hideDefaultLocale is true)
+```
+
+### Intl helpers
+
+The virtual module includes Intl-backed formatting helpers for rich localized UI.
+
+```ts
+const ja = createIntl("ja-JP", { date: { timeZone: "Asia/Tokyo" } });
+ja.date(new Date(), { dateStyle: "long" });
+ja.number(1234.5, { style: "currency", currency: "JPY" });
+ja.relativeTime(-1, "day", { numeric: "auto" });
+ja.list(["docs", "api", "cli"]);
+ja.displayName("en-US", "language");
 ```
 
 ### i18nConfig

--- a/npm/vite-plugin-ox-content/src/i18n.test.ts
+++ b/npm/vite-plugin-ox-content/src/i18n.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vite-plus/test";
+import { generateI18nModule, resolveI18nOptions } from "./i18n";
+
+function importVirtualI18n() {
+  const options = resolveI18nOptions({
+    enabled: true,
+    defaultLocale: "en-US",
+    locales: [
+      { code: "en-US", name: "English" },
+      { code: "ja-JP", name: "日本語" },
+      { code: "ar", name: "العربية", dir: "rtl" },
+    ],
+    check: false,
+  });
+  if (!options) throw new Error("expected resolved i18n options");
+  const code = generateI18nModule(options, "/__missing__");
+  return import(`data:text/javascript;charset=utf-8,${encodeURIComponent(code)}`);
+}
+
+describe("virtual i18n Intl helpers", () => {
+  it("formats values and exposes locale-scoped helpers", async () => {
+    const mod = await importVirtualI18n();
+    const intl = mod.createIntl("en-US", { number: { useGrouping: false } });
+
+    expect(mod.formatDate(Date.UTC(2025, 0, 2), { dateStyle: "medium", timeZone: "UTC" })).toBe(
+      "Jan 2, 2025",
+    );
+    expect(mod.formatNumber(1234.5, undefined, "ja-JP")).toBe("1,234.5");
+    expect(mod.formatRelativeTime(-1, "day", { numeric: "auto" })).toBe("yesterday");
+    expect(mod.formatList(["docs", "api", "cli"], undefined, "en-US")).toBe("docs, api, and cli");
+    expect(mod.formatDisplayName("ja", "language", undefined, "en-US")).toBe("Japanese");
+    expect(mod.getLocaleMeta("ar")).toMatchObject({ code: "ar", dir: "rtl" });
+    expect(mod.createIntl("ar").dir).toBe("rtl");
+    expect(intl.number(1234)).toBe("1234");
+    expect(intl.number(1234, { useGrouping: true })).toBe("1,234");
+    expect(mod.getLocaleFromPath("/ja-JP/guide")).toBe("ja-JP");
+    expect(mod.localePath("/ja-JP/guide", "en-US")).toBe("/guide");
+  });
+});

--- a/npm/vite-plugin-ox-content/src/i18n.ts
+++ b/npm/vite-plugin-ox-content/src/i18n.ts
@@ -148,7 +148,7 @@ export function createI18nPlugin(resolvedOptions: ResolvedOptions): Plugin {
 
         // Parse locale from URL
         const url = req.url;
-        const localeMatch = url.match(/^\/([a-z]{2}(?:-[a-zA-Z]+)?)(\/|$)/);
+        const localeMatch = url.match(/^\/([A-Za-z]{2,3}(?:-[A-Za-z0-9]+)*)(\/|$)/);
 
         if (localeMatch) {
           const localeCode = localeMatch[1];
@@ -171,7 +171,7 @@ export function createI18nPlugin(resolvedOptions: ResolvedOptions): Plugin {
 /**
  * Generates the virtual module for i18n configuration.
  */
-function generateI18nModule(options: ResolvedI18nOptions, root: string): string {
+export function generateI18nModule(options: ResolvedI18nOptions, root: string): string {
   const dictDir = path.resolve(root, options.dir);
   const localesJson = JSON.stringify(options.locales);
   const defaultLocale = JSON.stringify(options.defaultLocale);
@@ -217,14 +217,14 @@ export function t(key, params, locale) {
   }
   if (params) {
     for (const [k, v] of Object.entries(params)) {
-      message = message.replace(new RegExp('\\\\{\\\\$' + k + '\\\\}', 'g'), String(v));
+      message = message.split('{$' + k + '}').join(String(v));
     }
   }
   return message;
 }
 
 export function getLocaleFromPath(pathname) {
-  const match = pathname.match(/^\\/([a-z]{2}(?:-[a-zA-Z]+)?)(\\//|$)/);
+  const match = pathname.match(new RegExp('^/([A-Za-z]{2,3}(?:-[A-Za-z0-9]+)*)(/|$)'));
   if (match) {
     const code = match[1];
     if (i18nConfig.locales.some(l => l.code === code)) {
@@ -238,7 +238,9 @@ export function localePath(pathname, locale) {
   const current = getLocaleFromPath(pathname);
   let clean = pathname;
   if (current !== i18nConfig.defaultLocale || !i18nConfig.hideDefaultLocale) {
-    clean = pathname.replace(new RegExp('^/' + current + '(/|$)'), '/');
+    const prefix = '/' + current;
+    if (clean === prefix) clean = '/';
+    else if (clean.startsWith(prefix + '/')) clean = clean.slice(prefix.length);
   }
   if (locale === i18nConfig.defaultLocale && i18nConfig.hideDefaultLocale) {
     return clean || '/';
@@ -246,8 +248,95 @@ export function localePath(pathname, locale) {
   return '/' + locale + (clean.startsWith('/') ? clean : '/' + clean);
 }
 
-export default { i18nConfig, dictionaries, t, getLocaleFromPath, localePath };
-`;
+const formatterCache = new Map();
+
+function getFormatter(kind, locale, options) {
+  const key = kind + ':' + locale + ':' + JSON.stringify(options || {});
+  if (!formatterCache.has(key)) {
+    formatterCache.set(key, new Intl[kind](locale, options));
+  }
+  return formatterCache.get(key);
+}
+
+export function getLocaleMeta(locale) {
+  const code = locale || i18nConfig.defaultLocale;
+  return i18nConfig.locales.find(l => l.code === code) || { code, name: code, dir: 'ltr' };
+}
+
+export function formatDate(value, options, locale) {
+  return getFormatter('DateTimeFormat', locale || i18nConfig.defaultLocale, options).format(
+    value instanceof Date ? value : new Date(value),
+  );
+}
+
+export function formatDateParts(value, options, locale) {
+  return getFormatter('DateTimeFormat', locale || i18nConfig.defaultLocale, options).formatToParts(
+    value instanceof Date ? value : new Date(value),
+  );
+}
+
+export function formatNumber(value, options, locale) {
+  return getFormatter('NumberFormat', locale || i18nConfig.defaultLocale, options).format(value);
+}
+
+export function formatNumberParts(value, options, locale) {
+  return getFormatter('NumberFormat', locale || i18nConfig.defaultLocale, options).formatToParts(value);
+}
+
+export function formatRelativeTime(value, unit, options, locale) {
+  return getFormatter('RelativeTimeFormat', locale || i18nConfig.defaultLocale, options).format(value, unit);
+}
+
+export function formatList(values, options, locale) {
+  return getFormatter('ListFormat', locale || i18nConfig.defaultLocale, options).format(values);
+}
+
+export function formatListParts(values, options, locale) {
+  return getFormatter('ListFormat', locale || i18nConfig.defaultLocale, options).formatToParts(values);
+}
+
+export function formatDisplayName(value, type, options, locale) {
+  if (!Intl.DisplayNames) return String(value);
+  const displayType = type || 'language';
+  return getFormatter('DisplayNames', locale || i18nConfig.defaultLocale, { type: displayType, ...options }).of(value) || String(value);
+}
+
+export function createIntl(locale, defaults = {}) {
+  const meta = getLocaleMeta(locale);
+  const code = meta.code;
+  return {
+    locale: code,
+    meta,
+    dir: meta.dir || 'ltr',
+    date: (value, options) => formatDate(value, { ...defaults.date, ...options }, code),
+    dateParts: (value, options) => formatDateParts(value, { ...defaults.date, ...options }, code),
+    number: (value, options) => formatNumber(value, { ...defaults.number, ...options }, code),
+    numberParts: (value, options) => formatNumberParts(value, { ...defaults.number, ...options }, code),
+    relativeTime: (value, unit, options) => formatRelativeTime(value, unit, { ...defaults.relativeTime, ...options }, code),
+    list: (values, options) => formatList(values, { ...defaults.list, ...options }, code),
+    listParts: (values, options) => formatListParts(values, { ...defaults.list, ...options }, code),
+    displayName: (value, type, options) => formatDisplayName(value, type, { ...defaults.displayName, ...options }, code),
+  };
+}
+
+export default {
+  i18nConfig,
+  dictionaries,
+  t,
+  getLocaleFromPath,
+  localePath,
+  getLocaleMeta,
+  createIntl,
+  formatDate,
+  formatDateParts,
+  formatNumber,
+  formatNumberParts,
+  formatRelativeTime,
+  formatList,
+  formatListParts,
+  formatDisplayName,
+};
+  `;
 }
 
 /**

--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { resolveSsgOptions } from "./ssg";
+import { getPageLocale, resolveSsgOptions } from "./ssg";
 
 describe("resolveSsgOptions", () => {
   it("disables git timestamps by default", () => {
@@ -8,5 +8,26 @@ describe("resolveSsgOptions", () => {
 
   it("enables git timestamps when requested", () => {
     expect(resolveSsgOptions({ lastUpdated: true }).lastUpdated).toBe(true);
+  });
+});
+
+describe("getPageLocale", () => {
+  it("derives BCP 47 locales from localized paths", () => {
+    const i18n = {
+      enabled: true,
+      dir: "content/i18n",
+      defaultLocale: "en-US",
+      locales: [
+        { code: "en-US", name: "English" },
+        { code: "zh-Hans-CN", name: "简体中文" },
+      ],
+      hideDefaultLocale: true,
+      check: false,
+      functionNames: ["t"],
+    };
+
+    expect(getPageLocale("zh-Hans-CN/guide", i18n)).toBe("zh-Hans-CN");
+    expect(getPageLocale("guide", i18n)).toBe("en-US");
+    expect(getPageLocale("guide", false)).toBeUndefined();
   });
 });

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -21,6 +21,7 @@ import type {
   TocEntry,
   HeroConfig,
   FeatureConfig,
+  LocaleConfig,
 } from "./types";
 import { resolveTheme, themeToNapi } from "./theme";
 import type { ResolvedThemeConfig, SidebarItem } from "./theme";
@@ -1554,6 +1555,8 @@ export async function generateHtmlPage(
   base: string,
   ogImage?: string,
   theme?: ResolvedThemeConfig,
+  locale?: string,
+  availableLocales?: LocaleConfig[],
 ): Promise<string> {
   const mod = await importNapiModule();
 
@@ -1639,6 +1642,12 @@ export async function generateHtmlPage(
       base,
       ogImage,
       theme: themeForRust,
+      locale,
+      availableLocales: availableLocales?.map((l) => ({
+        code: l.code,
+        name: l.name,
+        dir: l.dir ?? "ltr",
+      })),
     },
   );
 }
@@ -1992,6 +2001,12 @@ export function getHref(
     return `${base}index${extension}`;
   }
   return `${base}${urlPath}/index${extension}`;
+}
+
+export function getPageLocale(urlPath: string, i18n: ResolvedOptions["i18n"]): string | undefined {
+  if (!i18n) return undefined;
+  const firstSegment = urlPath.split("/").filter(Boolean)[0];
+  return i18n.locales.some((l) => l.code === firstSegment) ? firstSegment : i18n.defaultLocale;
 }
 
 /**
@@ -2480,6 +2495,8 @@ export async function buildSsg(
           base,
           pageOgImage,
           ssgOptions.theme,
+          getPageLocale(pageData.path, options.i18n),
+          options.i18n ? options.i18n.locales : undefined,
         );
       }
 


### PR DESCRIPTION
## Summary
- add Intl-backed helpers to `virtual:ox-content/i18n` for date, number, relative time, list, display name, and locale-scoped formatting
- pass resolved i18n locale metadata into native SSG rendering and emit localized `<html lang dir>` attributes
- cover BCP 47 path locale detection, Intl helper behavior, and native RTL HTML output

## Scope
- 249 insertions, 9 deletions
- TypeScript remains a thin Intl facade; HTML locale metadata is rendered in Rust

## Checks
- `vp test run npm/vite-plugin-ox-content/src/i18n.test.ts npm/vite-plugin-ox-content/src/ssg.test.ts`
- `cargo test -p ox_content_ssg test_html_locale_attrs_use_current_locale_and_direction --lib`
- `cargo fmt --check && git diff --check`
