### PR TITLE
feat: add runtime path helpers

### DIFF
--- a/docs/content/packages/vite-plugin-ox-content.md
+++ b/docs/content/packages/vite-plugin-ox-content.md
@@ -312,8 +312,11 @@ The plugin provides virtual modules:
 
 ```ts
 import config from "virtual:ox-content/config";
-import { useMarkdown } from "virtual:ox-content/runtime";
+import { useMarkdown, withBase, withoutBase } from "virtual:ox-content/runtime";
 import { search, searchOptions } from "virtual:ox-content/search";
+
+const assetUrl = withBase("/og.png");
+const routePath = withoutBase("/docs/guide");
 
 // Use the search function
 const results = await search("query", { limit: 10 });

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -453,17 +453,43 @@ function resolveCodeAnnotationsOptions(
 /**
  * Generates virtual module content.
  */
-function generateVirtualModule(path: string, options: ResolvedOptions): string {
+export function generateVirtualModule(path: string, options: ResolvedOptions): string {
   if (path === "config") {
     return `export default ${JSON.stringify(options)};`;
   }
 
   if (path === "runtime") {
+    const base = normalizeRuntimeBase(options.base);
     return `
+      export const base = ${JSON.stringify(base)};
+      export const runtimeConfig = { base };
+
+      export function isExternalUrl(value) {
+        return /^(?:https?:)?\\/\\//i.test(value) || /^(?:mailto|tel):/i.test(value);
+      }
+
+      export function withBase(pathname = "") {
+        const value = String(pathname);
+        if (!value || value === "/") return base;
+        if (value.startsWith("#") || isExternalUrl(value)) return value;
+        return base + (value.startsWith("/") ? value.slice(1) : value);
+      }
+
+      export function withoutBase(pathname = "") {
+        const value = String(pathname);
+        if (base === "/" || value.startsWith("#") || isExternalUrl(value)) return value;
+        const bareBase = base.slice(0, -1);
+        if (value === bareBase) return "/";
+        if (value.startsWith(base)) return "/" + value.slice(base.length);
+        return value;
+      }
+
       export function useMarkdown() {
         return {
+          base,
+          withBase,
+          withoutBase,
           render: (content) => {
-            // Client-side rendering if needed
             return content;
           },
         };
@@ -472,6 +498,13 @@ function generateVirtualModule(path: string, options: ResolvedOptions): string {
   }
 
   return "export default {};";
+}
+
+function normalizeRuntimeBase(base: string): string {
+  const trimmed = base.trim();
+  if (!trimmed || trimmed === "/") return "/";
+  const withLeading = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return withLeading.endsWith("/") ? withLeading : `${withLeading}/`;
 }
 
 // Re-export types and utilities

--- a/npm/vite-plugin-ox-content/src/runtime.test.ts
+++ b/npm/vite-plugin-ox-content/src/runtime.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vite-plus/test";
+import { generateVirtualModule } from "./index";
+import type { ResolvedOptions } from "./types";
+
+function importRuntime(base: string) {
+  const options = {
+    base,
+    ssg: { enabled: false },
+    docs: false,
+    search: { enabled: false },
+    i18n: false,
+  } as ResolvedOptions;
+  const code = generateVirtualModule("runtime", options);
+  return import(`data:text/javascript;charset=utf-8,${encodeURIComponent(code)}`);
+}
+
+describe("runtime helpers", () => {
+  it("adds and removes the configured base for local paths", async () => {
+    const runtime = await importRuntime("docs");
+
+    expect(runtime.base).toBe("/docs/");
+    expect(runtime.withBase("/guide")).toBe("/docs/guide");
+    expect(runtime.withBase("guide")).toBe("/docs/guide");
+    expect(runtime.withoutBase("/docs/guide")).toBe("/guide");
+    expect(runtime.withoutBase("/docs")).toBe("/");
+  });
+
+  it("leaves external and hash-only links untouched", async () => {
+    const runtime = await importRuntime("/docs/");
+
+    expect(runtime.withBase("https://example.com/a")).toBe("https://example.com/a");
+    expect(runtime.withBase("mailto:team@example.com")).toBe("mailto:team@example.com");
+    expect(runtime.withBase("#section")).toBe("#section");
+    expect(runtime.withBase("javascript:alert(1)")).toBe("/docs/javascript:alert(1)");
+    expect(runtime.withoutBase("//cdn.example.com/app.js")).toBe("//cdn.example.com/app.js");
+  });
+});


### PR DESCRIPTION
## Summary
- add `withBase`, `withoutBase`, `base`, and `runtimeConfig` to `virtual:ox-content/runtime`
- keep external/hash-only links unchanged and treat unsafe schemes as local path text when applying `withBase`
- document the runtime path helpers

Closes #15.

## Scope
- 76 insertions, 3 deletions

## Checks
- `vp test run npm/vite-plugin-ox-content/src/runtime.test.ts`
- `vp check`
