### PR TITLE
fix: harden embed inputs

### DIFF
--- a/npm/vite-plugin-ox-content/src/embed.test.ts
+++ b/npm/vite-plugin-ox-content/src/embed.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vite-plus/test";
+import { collectGitHubRepos, isSafeGitHubRepo, transformGitHub } from "./plugins/github";
+import { collectOgpUrls, isSafeOgpUrl, transformOgp } from "./plugins/ogp";
+
+describe("builtin embed input hardening", () => {
+  it("accepts only safe GitHub repo references", async () => {
+    expect(isSafeGitHubRepo("ubugeeei/ox-content")).toBe(true);
+    expect(isSafeGitHubRepo("../secret")).toBe(false);
+    expect(isSafeGitHubRepo("owner/repo?tab=readme")).toBe(false);
+
+    await expect(
+      collectGitHubRepos(
+        '<GitHub repo="ubugeeei/ox-content"></GitHub><GitHub repo="../secret"></GitHub>',
+      ),
+    ).resolves.toEqual(["ubugeeei/ox-content"]);
+
+    const html = await transformGitHub(
+      '<GitHub repo="../secret"></GitHub>',
+      new Map([["../secret", null]]),
+    );
+    expect(html).toContain('href="#"');
+  });
+
+  it("accepts only public http OGP URLs", async () => {
+    expect(isSafeOgpUrl("https://example.com/post")).toBe(true);
+    expect(isSafeOgpUrl("http://127.0.0.1/admin")).toBe(false);
+    expect(isSafeOgpUrl("http://[::1]/admin")).toBe(false);
+    expect(isSafeOgpUrl("https://fcdomain.example/post")).toBe(true);
+    expect(isSafeOgpUrl("javascript:alert(1)")).toBe(false);
+
+    await expect(
+      collectOgpUrls(
+        '<OgCard url="https://example.com/post"></OgCard><OgCard url="http://127.0.0.1/admin"></OgCard>',
+      ),
+    ).resolves.toEqual(["https://example.com/post"]);
+
+    const html = await transformOgp(
+      '<OgCard url="javascript:alert(1)"></OgCard>',
+      new Map([["javascript:alert(1)", null]]),
+    );
+    expect(html).toContain('href="#"');
+  });
+});

--- a/npm/vite-plugin-ox-content/src/plugins/github.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/github.ts
@@ -41,6 +41,13 @@ const defaultOptions: Required<GitHubOptions> = {
 
 // Simple in-memory cache
 const repoCache = new Map<string, { data: GitHubRepoData; timestamp: number }>();
+const GITHUB_REPO_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+export function isSafeGitHubRepo(repo: string): boolean {
+  return (
+    GITHUB_REPO_RE.test(repo) && !repo.split("/").some((part) => part === "." || part === "..")
+  );
+}
 
 /**
  * Get element attribute value.
@@ -72,6 +79,10 @@ export async function fetchRepoData(
   repo: string,
   options: Required<GitHubOptions>,
 ): Promise<GitHubRepoData | null> {
+  if (!isSafeGitHubRepo(repo)) {
+    return null;
+  }
+
   // Check cache
   if (options.cache) {
     const cached = repoCache.get(repo);
@@ -263,12 +274,13 @@ function createGitHubCard(repoData: GitHubRepoData): Element {
  * Create fallback element when repo data is unavailable.
  */
 function createFallbackCard(repo: string): Element {
+  const href = isSafeGitHubRepo(repo) ? `https://github.com/${repo}` : "#";
   return {
     type: "element",
     tagName: "a",
     properties: {
       className: ["ox-github-card", "error"],
-      href: `https://github.com/${repo}`,
+      href,
       target: "_blank",
       rel: "noopener noreferrer",
     },
@@ -318,7 +330,9 @@ export async function collectGitHubRepos(html: string): Promise<string[]> {
 
   let match;
   while ((match = repoPattern.exec(html)) !== null) {
-    repos.push(match[1]);
+    if (isSafeGitHubRepo(match[1])) {
+      repos.push(match[1]);
+    }
   }
 
   return repos;

--- a/npm/vite-plugin-ox-content/src/plugins/ogp.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/ogp.ts
@@ -40,6 +40,43 @@ const defaultOptions: Required<OgpOptions> = {
 // Simple in-memory cache
 const ogpCache = new Map<string, { data: OgpData; timestamp: number }>();
 
+function isPrivateIPv4(hostname: string): boolean {
+  const parts = hostname.split(".").map(Number);
+  if (
+    parts.length !== 4 ||
+    parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)
+  ) {
+    return false;
+  }
+  const [a, b] = parts;
+  return (
+    a === 10 ||
+    a === 127 ||
+    a === 0 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 169 && b === 254)
+  );
+}
+
+export function isSafeOgpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    const host = url.hostname.toLowerCase();
+    const ipv6 = host.replace(/^\[|\]$/g, "");
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+    if (host === "localhost" || host.endsWith(".localhost")) return false;
+    if (
+      ipv6.includes(":") &&
+      (ipv6 === "::1" || ipv6.startsWith("fc") || ipv6.startsWith("fd") || ipv6.startsWith("fe80"))
+    )
+      return false;
+    return !isPrivateIPv4(host);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Get element attribute value.
  */
@@ -144,6 +181,10 @@ export async function fetchOgpData(
   url: string,
   options: Required<OgpOptions>,
 ): Promise<OgpData | null> {
+  if (!isSafeOgpUrl(url)) {
+    return null;
+  }
+
   // Check cache
   if (options.cache) {
     const cached = ogpCache.get(url);
@@ -275,7 +316,7 @@ function createOgpCard(data: OgpData): Element {
     tagName: "a",
     properties: {
       className: ["ox-ogp-card"],
-      href: data.url,
+      href: isSafeOgpUrl(data.url) ? data.url : "#",
       target: "_blank",
       rel: "noopener noreferrer",
     },
@@ -292,7 +333,7 @@ function createFallbackCard(url: string): Element {
     tagName: "a",
     properties: {
       className: ["ox-ogp-simple"],
-      href: url,
+      href: isSafeOgpUrl(url) ? url : "#",
       target: "_blank",
       rel: "noopener noreferrer",
     },
@@ -331,7 +372,9 @@ export async function collectOgpUrls(html: string): Promise<string[]> {
 
   let match;
   while ((match = urlPattern.exec(html)) !== null) {
-    urls.push(match[1]);
+    if (isSafeOgpUrl(match[1])) {
+      urls.push(match[1]);
+    }
   }
 
   return urls;


### PR DESCRIPTION
## Summary
- validate GitHub embed repo references before fetch/prefetch and fallback link rendering
- restrict OGP embed fetches to public HTTP(S) URLs and block localhost/private address targets
- add focused transform/collector tests for unsafe embed inputs

Refs #20, #21.

## Scope
- 105 insertions, 5 deletions

## Checks
- `vp test run npm/vite-plugin-ox-content/src/embed.test.ts`
- `vp check`
