### PR TITLE
refactor: move i18n runtime generation to Rust

### DIFF
--- a/crates/ox_content_i18n/src/lib.rs
+++ b/crates/ox_content_i18n/src/lib.rs
@@ -18,6 +18,7 @@ pub mod error;
 pub mod key;
 pub mod locale;
 pub mod mf2;
+pub mod runtime;
 
 pub use dictionary::{Dictionary, DictionarySet};
 pub use error::{I18nError, I18nResult};

--- a/crates/ox_content_i18n/src/runtime.rs
+++ b/crates/ox_content_i18n/src/runtime.rs
@@ -1,0 +1,125 @@
+//! JavaScript runtime module generation for Ox Content i18n.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::dictionary::DictionarySet;
+use crate::I18nResult;
+
+const RUNTIME_TEMPLATE: &str = include_str!("../templates/i18n-runtime.js");
+const DEFAULT_LOCALE_TOKEN: &str = "__OX_I18N_DEFAULT_LOCALE__";
+const LOCALES_TOKEN: &str = "__OX_I18N_LOCALES__";
+const HIDE_DEFAULT_LOCALE_TOKEN: &str = "__OX_I18N_HIDE_DEFAULT_LOCALE__";
+const DICTIONARIES_TOKEN: &str = "__OX_I18N_DICTIONARIES__";
+
+/// Locale metadata embedded in the generated runtime module.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct I18nRuntimeLocale {
+    /// BCP 47 locale tag.
+    pub code: String,
+    /// Display name for the locale.
+    pub name: String,
+    /// Text direction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dir: Option<String>,
+}
+
+/// Configuration embedded in the generated runtime module.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct I18nRuntimeConfig {
+    /// Default locale tag.
+    pub default_locale: String,
+    /// Available locales.
+    pub locales: Vec<I18nRuntimeLocale>,
+    /// Whether URLs should omit the default locale prefix.
+    pub hide_default_locale: bool,
+}
+
+/// Flat dictionaries keyed by locale, then translation key.
+pub type FlatDictionaries = HashMap<String, HashMap<String, String>>;
+
+/// Converts a dictionary set into the flat shape consumed by the JS runtime.
+#[must_use]
+pub fn flatten_dictionary_set(set: &DictionarySet) -> FlatDictionaries {
+    let mut result = HashMap::new();
+
+    for locale in set.locales() {
+        if let Some(dict) = set.get(locale) {
+            let flat =
+                dict.iter().map(|(key, value)| (key.to_string(), value.to_string())).collect();
+            result.insert(locale.to_string(), flat);
+        }
+    }
+
+    result
+}
+
+/// Loads dictionaries from disk and converts them into the runtime shape.
+pub fn load_flat_dictionaries(dir: &Path) -> I18nResult<FlatDictionaries> {
+    let set = crate::dictionary::load_from_dir(dir)?;
+    Ok(flatten_dictionary_set(&set))
+}
+
+/// Generates the virtual JavaScript module used by `virtual:ox-content/i18n`.
+#[must_use]
+pub fn generate_runtime_module(
+    config: &I18nRuntimeConfig,
+    dictionaries: &FlatDictionaries,
+) -> String {
+    let default_locale =
+        serde_json::to_string(&config.default_locale).unwrap_or_else(|_| "\"en\"".to_string());
+    let locales = serde_json::to_string(&config.locales).unwrap_or_else(|_| "[]".to_string());
+    let hide_default_locale =
+        serde_json::to_string(&config.hide_default_locale).unwrap_or_else(|_| "true".to_string());
+    let dictionaries = serde_json::to_string(dictionaries).unwrap_or_else(|_| "{}".to_string());
+
+    RUNTIME_TEMPLATE
+        .replace(DEFAULT_LOCALE_TOKEN, &default_locale)
+        .replace(LOCALES_TOKEN, &locales)
+        .replace(HIDE_DEFAULT_LOCALE_TOKEN, &hide_default_locale)
+        .replace(DICTIONARIES_TOKEN, &dictionaries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> I18nRuntimeConfig {
+        I18nRuntimeConfig {
+            default_locale: "en-US".to_string(),
+            locales: vec![
+                I18nRuntimeLocale {
+                    code: "en-US".to_string(),
+                    name: "English".to_string(),
+                    dir: None,
+                },
+                I18nRuntimeLocale {
+                    code: "ar".to_string(),
+                    name: "Arabic".to_string(),
+                    dir: Some("rtl".to_string()),
+                },
+            ],
+            hide_default_locale: true,
+        }
+    }
+
+    #[test]
+    fn runtime_module_embeds_config_and_dictionaries() {
+        let mut dictionaries = FlatDictionaries::new();
+        dictionaries.insert(
+            "en-US".to_string(),
+            HashMap::from([("common.greeting".to_string(), "Hello".to_string())]),
+        );
+
+        let module = generate_runtime_module(&test_config(), &dictionaries);
+
+        assert!(module.contains("defaultLocale: \"en-US\""));
+        assert!(module.contains("\"common.greeting\":\"Hello\""));
+        assert!(module.contains("export function createIntl"));
+        assert!(module.contains("formatDisplayName"));
+        assert!(module.contains("\"dir\":\"rtl\""));
+    }
+}

--- a/crates/ox_content_i18n/templates/i18n-runtime.js
+++ b/crates/ox_content_i18n/templates/i18n-runtime.js
@@ -1,0 +1,152 @@
+export const i18nConfig = {
+  enabled: true,
+  defaultLocale: __OX_I18N_DEFAULT_LOCALE__,
+  locales: __OX_I18N_LOCALES__,
+  hideDefaultLocale: __OX_I18N_HIDE_DEFAULT_LOCALE__,
+};
+
+export const dictionaries = __OX_I18N_DICTIONARIES__;
+
+export function t(key, params, locale) {
+  const dict = dictionaries[locale || i18nConfig.defaultLocale] || {};
+  let message = dict[key];
+  if (!message) {
+    const fallback = dictionaries[i18nConfig.defaultLocale] || {};
+    message = fallback[key] || key;
+  }
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      message = message.split("{$" + k + "}").join(String(v));
+    }
+  }
+  return message;
+}
+
+export function getLocaleFromPath(pathname) {
+  const match = pathname.match(new RegExp("^/([A-Za-z]{2,3}(?:-[A-Za-z0-9]+)*)(/|$)"));
+  if (match) {
+    const code = match[1];
+    if (i18nConfig.locales.some((l) => l.code === code)) {
+      return code;
+    }
+  }
+  return i18nConfig.defaultLocale;
+}
+
+export function localePath(pathname, locale) {
+  const current = getLocaleFromPath(pathname);
+  let clean = pathname;
+  if (current !== i18nConfig.defaultLocale || !i18nConfig.hideDefaultLocale) {
+    const prefix = "/" + current;
+    if (clean === prefix) clean = "/";
+    else if (clean.startsWith(prefix + "/")) clean = clean.slice(prefix.length);
+  }
+  if (locale === i18nConfig.defaultLocale && i18nConfig.hideDefaultLocale) {
+    return clean || "/";
+  }
+  return "/" + locale + (clean.startsWith("/") ? clean : "/" + clean);
+}
+
+const formatterCache = new Map();
+
+function getFormatter(kind, locale, options) {
+  const key = kind + ":" + locale + ":" + JSON.stringify(options || {});
+  if (!formatterCache.has(key)) {
+    formatterCache.set(key, new Intl[kind](locale, options));
+  }
+  return formatterCache.get(key);
+}
+
+export function getLocaleMeta(locale) {
+  const code = locale || i18nConfig.defaultLocale;
+  return i18nConfig.locales.find((l) => l.code === code) || { code, name: code, dir: "ltr" };
+}
+
+export function formatDate(value, options, locale) {
+  return getFormatter("DateTimeFormat", locale || i18nConfig.defaultLocale, options).format(
+    value instanceof Date ? value : new Date(value),
+  );
+}
+
+export function formatDateParts(value, options, locale) {
+  return getFormatter("DateTimeFormat", locale || i18nConfig.defaultLocale, options).formatToParts(
+    value instanceof Date ? value : new Date(value),
+  );
+}
+
+export function formatNumber(value, options, locale) {
+  return getFormatter("NumberFormat", locale || i18nConfig.defaultLocale, options).format(value);
+}
+
+export function formatNumberParts(value, options, locale) {
+  return getFormatter("NumberFormat", locale || i18nConfig.defaultLocale, options).formatToParts(
+    value,
+  );
+}
+
+export function formatRelativeTime(value, unit, options, locale) {
+  return getFormatter("RelativeTimeFormat", locale || i18nConfig.defaultLocale, options).format(
+    value,
+    unit,
+  );
+}
+
+export function formatList(values, options, locale) {
+  return getFormatter("ListFormat", locale || i18nConfig.defaultLocale, options).format(values);
+}
+
+export function formatListParts(values, options, locale) {
+  return getFormatter("ListFormat", locale || i18nConfig.defaultLocale, options).formatToParts(
+    values,
+  );
+}
+
+export function formatDisplayName(value, type, options, locale) {
+  if (!Intl.DisplayNames) return String(value);
+  const displayType = type || "language";
+  return (
+    getFormatter("DisplayNames", locale || i18nConfig.defaultLocale, {
+      type: displayType,
+      ...options,
+    }).of(value) || String(value)
+  );
+}
+
+export function createIntl(locale, defaults = {}) {
+  const meta = getLocaleMeta(locale);
+  const code = meta.code;
+  return {
+    locale: code,
+    meta,
+    dir: meta.dir || "ltr",
+    date: (value, options) => formatDate(value, { ...defaults.date, ...options }, code),
+    dateParts: (value, options) => formatDateParts(value, { ...defaults.date, ...options }, code),
+    number: (value, options) => formatNumber(value, { ...defaults.number, ...options }, code),
+    numberParts: (value, options) =>
+      formatNumberParts(value, { ...defaults.number, ...options }, code),
+    relativeTime: (value, unit, options) =>
+      formatRelativeTime(value, unit, { ...defaults.relativeTime, ...options }, code),
+    list: (values, options) => formatList(values, { ...defaults.list, ...options }, code),
+    listParts: (values, options) => formatListParts(values, { ...defaults.list, ...options }, code),
+    displayName: (value, type, options) =>
+      formatDisplayName(value, type, { ...defaults.displayName, ...options }, code),
+  };
+}
+
+export default {
+  i18nConfig,
+  dictionaries,
+  t,
+  getLocaleFromPath,
+  localePath,
+  getLocaleMeta,
+  createIntl,
+  formatDate,
+  formatDateParts,
+  formatNumber,
+  formatNumberParts,
+  formatRelativeTime,
+  formatList,
+  formatListParts,
+  formatDisplayName,
+};

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -32,6 +32,9 @@ export declare function extractSearchContent(source: string, id: string, url: st
  */
 export declare function extractTranslationKeys(source: string, filePath: string, functionNames?: Array<string> | undefined | null): Array<I18NKeyUsage>
 
+/** Generates the `virtual:ox-content/i18n` runtime module. */
+export declare function generateI18nModule(dictDir: string, config: JsI18NRuntimeConfig): string
+
 /**
  * Generates an OG image as SVG.
  *
@@ -162,6 +165,26 @@ export interface JsHeroNotice {
   title?: string
   /** Notice paragraphs. */
   body?: Array<string>
+}
+
+/** Configuration for generated i18n runtime modules. */
+export interface JsI18NRuntimeConfig {
+  /** Default locale tag. */
+  defaultLocale: string
+  /** Available locales. */
+  locales: Array<JsI18NRuntimeLocale>
+  /** Whether URLs should omit the default locale prefix. */
+  hideDefaultLocale: boolean
+}
+
+/** Locale metadata for generated i18n runtime modules. */
+export interface JsI18NRuntimeLocale {
+  /** BCP 47 locale tag. */
+  code: string
+  /** Display name for this locale. */
+  name: string
+  /** Text direction. */
+  dir?: string
 }
 
 /** Locale information for the locale switcher. */
@@ -309,18 +332,6 @@ export interface JsSearchResult {
   snippet: string
 }
 
-/** Social links for JavaScript. */
-export interface JsSocialLinks {
-  /** GitHub URL. */
-  github?: string
-  /** Twitter/X URL. */
-  twitter?: string
-  /** Discord URL. */
-  discord?: string
-  /** Custom social links. */
-  links?: Array<JsSocialLink>
-}
-
 /** Custom social link for JavaScript. */
 export interface JsSocialLink {
   /** Icon label. */
@@ -331,6 +342,18 @@ export interface JsSocialLink {
   link: string
   /** Accessible label. */
   ariaLabel?: string
+}
+
+/** Social links for JavaScript. */
+export interface JsSocialLinks {
+  /** GitHub URL. */
+  github?: string
+  /** Twitter/X URL. */
+  twitter?: string
+  /** Discord URL. */
+  discord?: string
+  /** Custom social links. */
+  links?: Array<JsSocialLink>
 }
 
 /** Source documentation item extracted from a JS/TS file. */

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -87,6 +87,7 @@ module.exports.generateSsgHtml = binding.generateSsgHtml;
 module.exports.transformMermaid = binding.transformMermaid;
 module.exports.loadDictionaries = binding.loadDictionaries;
 module.exports.loadDictionariesFlat = binding.loadDictionariesFlat;
+module.exports.generateI18nModule = binding.generateI18nModule;
 module.exports.validateMf2 = binding.validateMf2;
 module.exports.checkI18n = binding.checkI18n;
 module.exports.extractTranslationKeys = binding.extractTranslationKeys;

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -1579,6 +1579,29 @@ pub struct I18nLoadResult {
     pub errors: Vec<String>,
 }
 
+/// Locale metadata for generated i18n runtime modules.
+#[napi(object)]
+#[derive(Clone)]
+pub struct JsI18nRuntimeLocale {
+    /// BCP 47 locale tag.
+    pub code: String,
+    /// Display name for this locale.
+    pub name: String,
+    /// Text direction.
+    pub dir: Option<String>,
+}
+
+/// Configuration for generated i18n runtime modules.
+#[napi(object)]
+pub struct JsI18nRuntimeConfig {
+    /// Default locale tag.
+    pub default_locale: String,
+    /// Available locales.
+    pub locales: Vec<JsI18nRuntimeLocale>,
+    /// Whether URLs should omit the default locale prefix.
+    pub hide_default_locale: bool,
+}
+
 /// Result of MF2 validation.
 #[napi(object)]
 pub struct Mf2ValidateResult {
@@ -1637,19 +1660,30 @@ pub fn load_dictionaries(dir: String) -> I18nLoadResult {
 #[napi]
 pub fn load_dictionaries_flat(dir: String) -> HashMap<String, HashMap<String, String>> {
     let path = std::path::Path::new(&dir);
-    let Ok(set) = ox_content_i18n::dictionary::load_from_dir(path) else {
-        return HashMap::new();
-    };
+    ox_content_i18n::runtime::load_flat_dictionaries(path).unwrap_or_default()
+}
 
-    let mut result = HashMap::new();
-    for locale in set.locales() {
-        if let Some(dict) = set.get(locale) {
-            let flat: HashMap<String, String> =
-                dict.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect();
-            result.insert(locale.to_string(), flat);
-        }
-    }
-    result
+/// Generates the `virtual:ox-content/i18n` runtime module.
+#[napi(js_name = "generateI18nModule")]
+pub fn generate_i18n_module(dict_dir: String, config: JsI18nRuntimeConfig) -> String {
+    let config = ox_content_i18n::runtime::I18nRuntimeConfig {
+        default_locale: config.default_locale,
+        locales: config
+            .locales
+            .into_iter()
+            .map(|locale| ox_content_i18n::runtime::I18nRuntimeLocale {
+                code: locale.code,
+                name: locale.name,
+                dir: locale.dir,
+            })
+            .collect(),
+        hide_default_locale: config.hide_default_locale,
+    };
+    let dictionaries =
+        ox_content_i18n::runtime::load_flat_dictionaries(std::path::Path::new(&dict_dir))
+            .unwrap_or_default();
+
+    ox_content_i18n::runtime::generate_runtime_module(&config, &dictionaries)
 }
 
 /// Validates an MF2 message string.

--- a/npm/vite-plugin-ox-content/src/i18n.ts
+++ b/npm/vite-plugin-ox-content/src/i18n.ts
@@ -173,226 +173,30 @@ export function createI18nPlugin(resolvedOptions: ResolvedOptions): Plugin {
  */
 export function generateI18nModule(options: ResolvedI18nOptions, root: string): string {
   const dictDir = path.resolve(root, options.dir);
-  const localesJson = JSON.stringify(options.locales);
-  const defaultLocale = JSON.stringify(options.defaultLocale);
+  const config = {
+    defaultLocale: options.defaultLocale,
+    locales: options.locales,
+    hideDefaultLocale: options.hideDefaultLocale,
+  };
 
-  // Load dictionaries synchronously for the virtual module
-  let dictionariesCode = "{}";
-
-  // Try NAPI-based loading first (supports JSON + YAML)
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const napi = require("@ox-content/napi");
-    if (napi.loadDictionariesFlat) {
-      const dictData = napi.loadDictionariesFlat(dictDir);
-      dictionariesCode = JSON.stringify(dictData);
-    } else {
-      dictionariesCode = JSON.stringify(loadDictionariesFallback(options, dictDir));
+    const napi = require("@ox-content/napi") as {
+      generateI18nModule?: (dictDir: string, runtimeConfig: typeof config) => string;
+    };
+
+    if (typeof napi.generateI18nModule === "function") {
+      return napi.generateI18nModule(dictDir, config);
     }
-  } catch {
-    // NAPI not available — fallback to TS-based JSON loading
-    try {
-      dictionariesCode = JSON.stringify(loadDictionariesFallback(options, dictDir));
-    } catch {
-      // Fallback to empty dictionaries
-    }
+  } catch (error) {
+    throw new Error(
+      `[ox-content:i18n] Failed to load @ox-content/napi for i18n module generation: ${String(error)}`,
+    );
   }
 
-  return `
-export const i18nConfig = {
-  enabled: true,
-  defaultLocale: ${defaultLocale},
-  locales: ${localesJson},
-  hideDefaultLocale: ${JSON.stringify(options.hideDefaultLocale)},
-};
-
-export const dictionaries = ${dictionariesCode};
-
-export function t(key, params, locale) {
-  const dict = dictionaries[locale || i18nConfig.defaultLocale] || {};
-  let message = dict[key];
-  if (!message) {
-    const fallback = dictionaries[i18nConfig.defaultLocale] || {};
-    message = fallback[key] || key;
-  }
-  if (params) {
-    for (const [k, v] of Object.entries(params)) {
-      message = message.split('{$' + k + '}').join(String(v));
-    }
-  }
-  return message;
-}
-
-export function getLocaleFromPath(pathname) {
-  const match = pathname.match(new RegExp('^/([A-Za-z]{2,3}(?:-[A-Za-z0-9]+)*)(/|$)'));
-  if (match) {
-    const code = match[1];
-    if (i18nConfig.locales.some(l => l.code === code)) {
-      return code;
-    }
-  }
-  return i18nConfig.defaultLocale;
-}
-
-export function localePath(pathname, locale) {
-  const current = getLocaleFromPath(pathname);
-  let clean = pathname;
-  if (current !== i18nConfig.defaultLocale || !i18nConfig.hideDefaultLocale) {
-    const prefix = '/' + current;
-    if (clean === prefix) clean = '/';
-    else if (clean.startsWith(prefix + '/')) clean = clean.slice(prefix.length);
-  }
-  if (locale === i18nConfig.defaultLocale && i18nConfig.hideDefaultLocale) {
-    return clean || '/';
-  }
-  return '/' + locale + (clean.startsWith('/') ? clean : '/' + clean);
-}
-
-const formatterCache = new Map();
-
-function getFormatter(kind, locale, options) {
-  const key = kind + ':' + locale + ':' + JSON.stringify(options || {});
-  if (!formatterCache.has(key)) {
-    formatterCache.set(key, new Intl[kind](locale, options));
-  }
-  return formatterCache.get(key);
-}
-
-export function getLocaleMeta(locale) {
-  const code = locale || i18nConfig.defaultLocale;
-  return i18nConfig.locales.find(l => l.code === code) || { code, name: code, dir: 'ltr' };
-}
-
-export function formatDate(value, options, locale) {
-  return getFormatter('DateTimeFormat', locale || i18nConfig.defaultLocale, options).format(
-    value instanceof Date ? value : new Date(value),
+  throw new Error(
+    "[ox-content:i18n] @ox-content/napi does not expose generateI18nModule. Please rebuild the NAPI package.",
   );
-}
-
-export function formatDateParts(value, options, locale) {
-  return getFormatter('DateTimeFormat', locale || i18nConfig.defaultLocale, options).formatToParts(
-    value instanceof Date ? value : new Date(value),
-  );
-}
-
-export function formatNumber(value, options, locale) {
-  return getFormatter('NumberFormat', locale || i18nConfig.defaultLocale, options).format(value);
-}
-
-export function formatNumberParts(value, options, locale) {
-  return getFormatter('NumberFormat', locale || i18nConfig.defaultLocale, options).formatToParts(value);
-}
-
-export function formatRelativeTime(value, unit, options, locale) {
-  return getFormatter('RelativeTimeFormat', locale || i18nConfig.defaultLocale, options).format(value, unit);
-}
-
-export function formatList(values, options, locale) {
-  return getFormatter('ListFormat', locale || i18nConfig.defaultLocale, options).format(values);
-}
-
-export function formatListParts(values, options, locale) {
-  return getFormatter('ListFormat', locale || i18nConfig.defaultLocale, options).formatToParts(values);
-}
-
-export function formatDisplayName(value, type, options, locale) {
-  if (!Intl.DisplayNames) return String(value);
-  const displayType = type || 'language';
-  return getFormatter('DisplayNames', locale || i18nConfig.defaultLocale, { type: displayType, ...options }).of(value) || String(value);
-}
-
-export function createIntl(locale, defaults = {}) {
-  const meta = getLocaleMeta(locale);
-  const code = meta.code;
-  return {
-    locale: code,
-    meta,
-    dir: meta.dir || 'ltr',
-    date: (value, options) => formatDate(value, { ...defaults.date, ...options }, code),
-    dateParts: (value, options) => formatDateParts(value, { ...defaults.date, ...options }, code),
-    number: (value, options) => formatNumber(value, { ...defaults.number, ...options }, code),
-    numberParts: (value, options) => formatNumberParts(value, { ...defaults.number, ...options }, code),
-    relativeTime: (value, unit, options) => formatRelativeTime(value, unit, { ...defaults.relativeTime, ...options }, code),
-    list: (values, options) => formatList(values, { ...defaults.list, ...options }, code),
-    listParts: (values, options) => formatListParts(values, { ...defaults.list, ...options }, code),
-    displayName: (value, type, options) => formatDisplayName(value, type, { ...defaults.displayName, ...options }, code),
-  };
-}
-
-export default {
-  i18nConfig,
-  dictionaries,
-  t,
-  getLocaleFromPath,
-  localePath,
-  getLocaleMeta,
-  createIntl,
-  formatDate,
-  formatDateParts,
-  formatNumber,
-  formatNumberParts,
-  formatRelativeTime,
-  formatList,
-  formatListParts,
-  formatDisplayName,
-};
-  `;
-}
-
-/**
- * Flattens a nested object into dot-separated keys.
- */
-function flattenObject(
-  obj: Record<string, unknown>,
-  prefix: string,
-  result: Record<string, string>,
-): void {
-  for (const [key, value] of Object.entries(obj)) {
-    const fullKey = `${prefix}.${key}`;
-    if (typeof value === "string") {
-      result[fullKey] = value;
-    } else if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-      flattenObject(value as Record<string, unknown>, fullKey, result);
-    } else {
-      result[fullKey] = String(value);
-    }
-  }
-}
-
-/**
- * Fallback dictionary loading using TS-based JSON file reading.
- */
-function loadDictionariesFallback(
-  options: ResolvedI18nOptions,
-  dictDir: string,
-): Record<string, Record<string, string>> {
-  const dictData: Record<string, Record<string, string>> = {};
-
-  for (const locale of options.locales) {
-    const localeDir = path.join(dictDir, locale.code);
-    if (!fs.existsSync(localeDir)) continue;
-
-    const files = fs.readdirSync(localeDir);
-    const localeDict: Record<string, string> = {};
-
-    for (const file of files) {
-      if (!file.endsWith(".json")) continue;
-      const filePath = path.join(localeDir, file);
-      const content = fs.readFileSync(filePath, "utf-8");
-      const namespace = path.basename(file, ".json");
-
-      try {
-        const data = JSON.parse(content);
-        flattenObject(data, namespace, localeDict);
-      } catch {
-        // Skip invalid JSON files
-      }
-    }
-
-    dictData[locale.code] = localeDict;
-  }
-
-  return dictData;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Move virtual i18n module generation into the Rust i18n crate.
- Keep the runtime JavaScript in a template file and inject serialized config/dictionaries from Rust.
- Expose `generateI18nModule` through the NAPI package and generated typings.
- Keep the Vite plugin TypeScript side as a thin NAPI call.

## Validation

- `vp check`
- `cargo test -p ox_content_i18n -p ox_content_napi`
- `pnpm --filter @ox-content/napi build:debug`
- `pnpm exec vp test npm/vite-plugin-ox-content/src/i18n.test.ts`
- Node smoke check for `generateI18nModule` export

## Notes

- `vp check` reports two existing lint warnings outside this change, but exits successfully.
