### PR TITLE
chore: tune language statistics attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,13 @@
-# Exclude runnable examples from GitHub language statistics.
-/examples/** linguist-generated=true
+# Keep GitHub language statistics focused on maintained source code.
+/docs/** linguist-documentation=true
+/examples/** linguist-documentation=true
+/benchmarks/** linguist-documentation=true
+
+# Generated API/reference artifacts.
+/docs/content/api/** linguist-generated=true
+/**/docs/api/** linguist-generated=true
+/crates/ox_content_napi/index.d.ts linguist-generated=true
+
+# Test snapshots and rendered VRT baselines.
+/npm/vite-plugin-ox-content/src/__snapshots__/** linguist-generated=true
+/npm/vite-plugin-ox-content/test/vrt/**/*-snapshots/** linguist-generated=true


### PR DESCRIPTION
## Summary

- Mark docs, examples, and benchmark fixtures as documentation for GitHub Linguist.
- Mark generated API docs, the generated NAPI declaration file, and snapshots as generated.
- Leave maintained package implementation under `npm/**` counted as source.

## Validation

- `git check-attr linguist-documentation linguist-generated -- docs/vite.config.ts docs/content/api/nav.ts examples/integ-react/src/main.tsx benchmarks/bundle-size/apps/ox-content/src/main.ts crates/ox_content_napi/index.d.ts npm/vite-plugin-ox-content/src/__snapshots__/docs.snapshot.test.ts.snap npm/vite-plugin-ox-content/src/docs.ts`
- No runtime code changed.
