### PR TITLE
refactor: move docs normalization to Rust

### DIFF
--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -89,6 +89,35 @@ pub struct DocTag {
     pub tag: String,
     /// Tag value.
     pub value: String,
+    /// JSDoc type annotation, when the tag has a `{type}` part.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_annotation: Option<String>,
+    /// JSDoc name, when the tag has a name part.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Whether the named part was marked optional.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub optional: Option<bool>,
+    /// Default value from `[name=value]` syntax.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_value: Option<String>,
+    /// Structured tag description parsed by `ox_jsdoc`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl DocTag {
+    fn new(tag: String, value: String) -> Self {
+        Self {
+            tag,
+            value,
+            type_annotation: None,
+            name: None,
+            optional: None,
+            default_value: None,
+            description: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -307,10 +336,56 @@ impl<'a> DocVisitor<'a> {
     }
 
     fn convert_jsdoc_tag(tag: LazyJsdocTag<'_>) -> DocTag {
-        DocTag { tag: tag.tag().value().to_string(), value: Self::format_jsdoc_tag_value(tag) }
+        let tag_name = tag.tag().value().to_string();
+        let value = Self::format_jsdoc_tag_value(&tag_name, &tag);
+        let type_annotation = tag
+            .raw_type()
+            .map(|raw_type| raw_type.raw().trim().to_string())
+            .filter(|value| !value.is_empty());
+        let name =
+            tag.name().map(|name| name.raw().trim().to_string()).filter(|value| !value.is_empty());
+        let optional = name.as_ref().map(|_| tag.optional());
+        let default_value = tag.default_value().map(str::trim).filter(|value| !value.is_empty());
+        let description =
+            Self::format_structured_tag_description(&tag_name, &tag, type_annotation.as_deref());
+
+        DocTag {
+            tag: tag_name,
+            value,
+            type_annotation,
+            name,
+            optional,
+            default_value: default_value.map(str::to_string),
+            description,
+        }
     }
 
-    fn format_jsdoc_tag_value(tag: LazyJsdocTag<'_>) -> String {
+    fn format_structured_tag_description(
+        tag_name: &str,
+        tag: &LazyJsdocTag<'_>,
+        type_annotation: Option<&str>,
+    ) -> Option<String> {
+        if matches!(tag_name, "returns" | "return") {
+            let raw_body = tag.raw_body().map(str::trim).filter(|value| !value.is_empty())?;
+            let without_type = type_annotation
+                .and_then(|type_annotation| {
+                    raw_body.strip_prefix(&format!("{{{type_annotation}}}")).map(str::trim_start)
+                })
+                .unwrap_or(raw_body);
+            return Self::clean_tag_description(without_type);
+        }
+
+        tag.description().and_then(Self::clean_tag_description)
+    }
+
+    fn format_jsdoc_tag_value(tag_name: &str, tag: &LazyJsdocTag<'_>) -> String {
+        if !matches!(tag_name, "param" | "arg" | "argument") {
+            if let Some(raw_body) = tag.raw_body().map(str::trim).filter(|value| !value.is_empty())
+            {
+                return raw_body.to_string();
+            }
+        }
+
         let mut parts = Vec::new();
 
         if let Some(raw_type) = tag.raw_type() {
@@ -380,7 +455,7 @@ impl<'a> DocVisitor<'a> {
             if let Some(without_at) = trimmed.strip_prefix('@') {
                 // Save previous tag if any
                 if let Some((tag, value_lines)) = current_tag.take() {
-                    tags.push(DocTag { tag, value: value_lines.join("\n").trim().to_string() });
+                    tags.push(DocTag::new(tag, value_lines.join("\n").trim().to_string()));
                 }
 
                 let split_at = without_at
@@ -399,7 +474,7 @@ impl<'a> DocVisitor<'a> {
 
         // Save last tag if any
         if let Some((tag, value_lines)) = current_tag {
-            tags.push(DocTag { tag, value: value_lines.join("\n").trim().to_string() });
+            tags.push(DocTag::new(tag, value_lines.join("\n").trim().to_string()));
         }
 
         (description_lines.join("\n").trim().to_string(), tags)
@@ -697,18 +772,41 @@ impl<'a> DocVisitor<'a> {
         })
     }
 
+    fn parse_param_tag(tag: &DocTag) -> Option<ParsedParamTag> {
+        if tag.name.is_none()
+            && tag.type_annotation.is_none()
+            && tag.default_value.is_none()
+            && tag.description.is_none()
+        {
+            return Self::parse_param_tag_value(&tag.value);
+        }
+
+        let name = tag.name.as_ref()?.trim().to_string();
+        (!name.is_empty()).then(|| ParsedParamTag {
+            name,
+            type_annotation: tag.type_annotation.clone(),
+            optional: tag.optional.unwrap_or(false),
+            default_value: tag.default_value.clone(),
+            description: tag.description.clone(),
+        })
+    }
+
     fn find_param_tag(tags: &[DocTag], name: &str) -> Option<ParsedParamTag> {
         tags.iter()
             .filter(|tag| matches!(tag.tag.as_str(), "param" | "arg" | "argument"))
-            .filter_map(|tag| Self::parse_param_tag_value(&tag.value))
+            .filter_map(Self::parse_param_tag)
             .find(|tag| {
                 let tag_name = tag.name.trim_start_matches("...");
                 tag_name == name || tag_name.split('.').next() == Some(name)
             })
     }
 
-    fn parse_return_tag_value(value: &str) -> (Option<String>, Option<String>) {
-        let (type_annotation, rest) = Self::split_leading_jsdoc_type(value);
+    fn parse_return_tag(tag: &DocTag) -> (Option<String>, Option<String>) {
+        if tag.type_annotation.is_some() || tag.description.is_some() {
+            return (tag.type_annotation.clone(), tag.description.clone());
+        }
+
+        let (type_annotation, rest) = Self::split_leading_jsdoc_type(&tag.value);
         (type_annotation, Self::clean_tag_description(rest))
     }
 
@@ -890,7 +988,7 @@ impl<'a> DocVisitor<'a> {
     ) -> Option<String> {
         return_type.map(|r| self.format_ts_type(&r.type_annotation)).or_else(|| {
             tags.iter().find(|tag| tag.tag == "returns" || tag.tag == "return").and_then(|tag| {
-                let (type_annotation, description) = Self::parse_return_tag_value(&tag.value);
+                let (type_annotation, description) = Self::parse_return_tag(tag);
                 type_annotation.or(description)
             })
         })
@@ -1500,5 +1598,26 @@ export function label(value, maxLength = 20) {
             items[0].params[1].description.as_deref(),
             Some("Maximum length before truncation")
         );
+
+        let value_tag = items[0]
+            .tags
+            .iter()
+            .find(|tag| tag.tag == "param" && tag.name.as_deref() == Some("value"))
+            .unwrap();
+        assert_eq!(value_tag.type_annotation.as_deref(), Some("string"));
+        assert_eq!(value_tag.description.as_deref(), Some("The label source"));
+
+        let max_length_tag = items[0]
+            .tags
+            .iter()
+            .find(|tag| tag.tag == "param" && tag.name.as_deref() == Some("maxLength"))
+            .unwrap();
+        assert_eq!(max_length_tag.type_annotation.as_deref(), Some("number"));
+        assert_eq!(max_length_tag.optional, Some(true));
+        assert_eq!(max_length_tag.default_value.as_deref(), Some("20"));
+
+        let returns_tag = items[0].tags.iter().find(|tag| tag.tag == "returns").unwrap();
+        assert_eq!(returns_tag.type_annotation.as_deref(), Some("string"));
+        assert_eq!(returns_tag.description.as_deref(), Some("Formatted label"));
     }
 }

--- a/crates/ox_content_docs/src/lib.rs
+++ b/crates/ox_content_docs/src/lib.rs
@@ -7,9 +7,14 @@
 mod config;
 mod extractor;
 mod generator;
+mod normalize;
 
 pub use config::DocsConfig;
 pub use extractor::{
     DocExtractor, DocItem, DocItemKind, DocTag, ExtractError, ExtractResult, ParamDoc,
 };
 pub use generator::{DocsGenerator, GenerateError, GenerateResult};
+pub use normalize::{
+    normalize_doc_item, normalize_doc_items, NormalizedDocEntry, NormalizedDocKind,
+    NormalizedParamDoc, NormalizedReturnDoc,
+};

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -1,0 +1,357 @@
+//! Normalized documentation entries for JavaScript-facing generators.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::extractor::{DocItem, DocItemKind, DocTag, ParamDoc};
+
+const UNKNOWN_TYPE: &str = "unknown";
+const PARAM_TAG_NAMES: [&str; 3] = ["param", "arg", "argument"];
+const RETURN_TAG_NAMES: [&str; 2] = ["returns", "return"];
+const EXAMPLE_TAG_NAME: &str = "example";
+const PRIVATE_TAG_NAME: &str = "private";
+
+/// Documentation item kind supported by the generated API reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NormalizedDocKind {
+    /// Function declaration or function-valued variable.
+    Function,
+    /// Class declaration.
+    Class,
+    /// TypeScript interface declaration.
+    Interface,
+    /// Type alias or enum.
+    Type,
+    /// Variable declaration.
+    Variable,
+    /// Module or namespace.
+    Module,
+}
+
+impl NormalizedDocKind {
+    /// Converts extractor-level kinds into public documentation kinds.
+    #[must_use]
+    pub fn from_doc_item_kind(kind: DocItemKind) -> Option<Self> {
+        match kind {
+            DocItemKind::Function => Some(Self::Function),
+            DocItemKind::Class => Some(Self::Class),
+            DocItemKind::Interface => Some(Self::Interface),
+            DocItemKind::Type | DocItemKind::Enum => Some(Self::Type),
+            DocItemKind::Variable => Some(Self::Variable),
+            DocItemKind::Module => Some(Self::Module),
+            DocItemKind::Method
+            | DocItemKind::Property
+            | DocItemKind::Constructor
+            | DocItemKind::Getter
+            | DocItemKind::Setter => None,
+        }
+    }
+
+    /// Returns the JavaScript-facing string for this kind.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Function => "function",
+            Self::Class => "class",
+            Self::Interface => "interface",
+            Self::Type => "type",
+            Self::Variable => "variable",
+            Self::Module => "module",
+        }
+    }
+}
+
+/// Normalized parameter documentation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NormalizedParamDoc {
+    /// Parameter name.
+    pub name: String,
+    /// Parameter type, or `unknown` if it cannot be inferred.
+    pub type_annotation: String,
+    /// Parameter description.
+    pub description: String,
+    /// Whether the parameter is optional.
+    pub optional: bool,
+    /// Default value if specified.
+    pub default_value: Option<String>,
+}
+
+/// Normalized return documentation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NormalizedReturnDoc {
+    /// Return type, or `unknown` if it cannot be inferred.
+    pub type_annotation: String,
+    /// Return value description.
+    pub description: String,
+}
+
+/// Normalized documentation entry consumed by generated API docs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NormalizedDocEntry {
+    /// Entry name.
+    pub name: String,
+    /// Entry kind.
+    pub kind: NormalizedDocKind,
+    /// Human-readable description.
+    pub description: String,
+    /// Parameters, if any.
+    pub params: Vec<NormalizedParamDoc>,
+    /// Return documentation, if any.
+    pub returns: Option<NormalizedReturnDoc>,
+    /// Example blocks.
+    pub examples: Vec<String>,
+    /// Custom JSDoc tags.
+    pub tags: BTreeMap<String, String>,
+    /// Whether the entry is marked private.
+    pub private: bool,
+    /// Source file path.
+    pub file: String,
+    /// Declaration start line.
+    pub line: u32,
+    /// Declaration end line.
+    pub end_line: u32,
+    /// Signature text.
+    pub signature: Option<String>,
+}
+
+/// Normalizes extracted documentation items into API reference entries.
+#[must_use]
+pub fn normalize_doc_items(items: Vec<DocItem>) -> Vec<NormalizedDocEntry> {
+    items.into_iter().filter_map(normalize_doc_item).collect()
+}
+
+/// Normalizes a single extracted documentation item into an API reference entry.
+#[must_use]
+pub fn normalize_doc_item(item: DocItem) -> Option<NormalizedDocEntry> {
+    let kind = NormalizedDocKind::from_doc_item_kind(item.kind)?;
+
+    let mut params = Vec::new();
+    let mut returns = None;
+    let mut examples = Vec::new();
+    let mut tags = BTreeMap::new();
+    let mut is_private = false;
+
+    for tag in &item.tags {
+        match tag.tag.as_str() {
+            tag_name if PARAM_TAG_NAMES.contains(&tag_name) => {
+                if let Some(param) = normalized_param_from_tag(tag) {
+                    merge_param(&mut params, param);
+                }
+            }
+            tag_name if RETURN_TAG_NAMES.contains(&tag_name) => {
+                let parsed_returns = normalized_return_from_tag(tag);
+                merge_returns(&mut returns, parsed_returns);
+            }
+            EXAMPLE_TAG_NAME => {
+                let example = tag.value.trim();
+                if !example.is_empty() && !examples.iter().any(|existing| existing == example) {
+                    examples.push(example.to_string());
+                }
+            }
+            PRIVATE_TAG_NAME => {
+                is_private = true;
+            }
+            tag_name => {
+                tags.entry(tag_name.to_string()).or_insert_with(|| tag.value.clone());
+            }
+        }
+    }
+
+    for param in item.params {
+        if is_placeholder_param(&params, &param) {
+            continue;
+        }
+
+        merge_param(
+            &mut params,
+            NormalizedParamDoc {
+                name: param.name,
+                type_annotation: param.type_annotation.unwrap_or_else(|| UNKNOWN_TYPE.to_string()),
+                description: param.description.unwrap_or_default(),
+                optional: param.optional,
+                default_value: param.default_value,
+            },
+        );
+    }
+
+    if let Some(return_type) = item.return_type {
+        match &mut returns {
+            Some(current) => current.type_annotation = return_type,
+            None => {
+                returns = Some(NormalizedReturnDoc {
+                    type_annotation: return_type,
+                    description: String::new(),
+                });
+            }
+        }
+    }
+
+    Some(NormalizedDocEntry {
+        name: item.name,
+        kind,
+        description: item.doc.unwrap_or_default(),
+        params,
+        returns,
+        examples,
+        tags,
+        private: is_private,
+        file: item.source_path,
+        line: item.line,
+        end_line: item.end_line,
+        signature: item.signature,
+    })
+}
+
+fn is_placeholder_param(existing_params: &[NormalizedParamDoc], param: &ParamDoc) -> bool {
+    !existing_params.is_empty()
+        && param.name == PARAM_TAG_NAMES[0]
+        && param.type_annotation.is_none()
+        && param.description.is_none()
+        && param.default_value.is_none()
+}
+
+fn merge_param(params: &mut Vec<NormalizedParamDoc>, next: NormalizedParamDoc) {
+    let Some(existing) = params.iter_mut().find(|param| param.name == next.name) else {
+        params.push(next);
+        return;
+    };
+
+    if existing.type_annotation == UNKNOWN_TYPE || next.type_annotation != UNKNOWN_TYPE {
+        existing.type_annotation = next.type_annotation;
+    }
+    if !next.description.is_empty() {
+        existing.description = next.description;
+    }
+    if next.optional {
+        existing.optional = true;
+    }
+    if next.default_value.is_some() {
+        existing.default_value = next.default_value;
+    }
+}
+
+fn merge_returns(returns: &mut Option<NormalizedReturnDoc>, next: NormalizedReturnDoc) {
+    let Some(existing) = returns else {
+        *returns = Some(next);
+        return;
+    };
+
+    if existing.type_annotation == UNKNOWN_TYPE {
+        existing.type_annotation = next.type_annotation;
+    }
+    if existing.description.is_empty() {
+        existing.description = next.description;
+    }
+}
+
+fn normalized_param_from_tag(tag: &DocTag) -> Option<NormalizedParamDoc> {
+    let name = tag.name.as_ref()?.trim().to_string();
+    (!name.is_empty()).then(|| NormalizedParamDoc {
+        name,
+        type_annotation: tag.type_annotation.clone().unwrap_or_else(|| UNKNOWN_TYPE.to_string()),
+        description: tag.description.clone().unwrap_or_default(),
+        optional: tag.optional.unwrap_or(false),
+        default_value: tag.default_value.clone(),
+    })
+}
+
+fn normalized_return_from_tag(tag: &DocTag) -> NormalizedReturnDoc {
+    NormalizedReturnDoc {
+        type_annotation: tag.type_annotation.clone().unwrap_or_else(|| UNKNOWN_TYPE.to_string()),
+        description: tag.description.clone().unwrap_or_default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use oxc_span::SourceType;
+
+    use super::*;
+    use crate::extractor::DocExtractor;
+
+    #[test]
+    fn normalizes_jsdoc_types_and_custom_tags() {
+        let source = r#"
+/**
+ * Creates a user-facing label.
+ *
+ * @param {string} value - The label source
+ * @param {number} [maxLength=20] - Maximum length before truncation
+ * @returns {string} Formatted label
+ * @example
+ * label("hello", 3)
+ * @since 1.2.3
+ */
+export function label(value, maxLength = 20) {
+    return value.slice(0, maxLength);
+}
+"#;
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "labels.js", SourceType::mjs()).unwrap();
+        let entries = normalize_doc_items(items);
+
+        assert_eq!(entries.len(), 1);
+        let entry = &entries[0];
+        assert_eq!(entry.name, "label");
+        assert_eq!(entry.kind, NormalizedDocKind::Function);
+        assert_eq!(entry.description, "Creates a user-facing label.");
+        assert!(!entry.private);
+        assert_eq!(entry.params.len(), 2);
+        assert_eq!(entry.params[0].type_annotation, "string");
+        assert_eq!(entry.params[0].description, "The label source");
+        assert_eq!(entry.params[1].type_annotation, "number");
+        assert!(entry.params[1].optional);
+        assert_eq!(entry.params[1].default_value.as_deref(), Some("20"));
+        assert_eq!(entry.params[1].description, "Maximum length before truncation");
+        assert_eq!(
+            entry.returns,
+            Some(NormalizedReturnDoc {
+                type_annotation: "string".to_string(),
+                description: "Formatted label".to_string()
+            })
+        );
+        assert_eq!(entry.examples, vec!["label(\"hello\", 3)"]);
+        assert_eq!(entry.tags.get("since").map(String::as_str), Some("1.2.3"));
+    }
+
+    #[test]
+    fn preserves_private_flag_when_private_items_are_included() {
+        let source = r"
+/**
+ * Internal helper.
+ * @private
+ */
+export function internalHelper(): void {}
+";
+
+        let extractor = DocExtractor::with_private(true);
+        let items = extractor.extract_source(source, "internal.ts", SourceType::ts()).unwrap();
+        let entries = normalize_doc_items(items);
+
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].private);
+    }
+
+    #[test]
+    fn maps_enums_to_type_entries() {
+        let source = r"
+/**
+ * Available modes.
+ */
+export enum Mode {
+    Fast,
+    Slow,
+}
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "mode.ts", SourceType::ts()).unwrap();
+        let entries = normalize_doc_items(items);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].kind, NormalizedDocKind::Type);
+    }
+}

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -15,6 +15,9 @@ export declare function buildSearchIndex(documents: Array<JsSearchDocument>): st
  */
 export declare function checkI18n(dictDir: string, usedKeys: Array<string>): I18NCheckResult
 
+/** Extracts normalized documentation entries from a JavaScript/TypeScript file using Oxc. */
+export declare function extractFileDocEntries(filePath: string, includePrivate?: boolean | undefined | null): Array<JsDocEntry>
+
 /** Extracts documented declarations from a JavaScript/TypeScript file using Oxc. */
 export declare function extractFileDocs(filePath: string, includePrivate?: boolean | undefined | null): Array<JsSourceDocItem>
 
@@ -93,6 +96,37 @@ export interface I18NLoadResult {
   locales: Array<string>
   /** Errors encountered during loading. */
   errors: Array<string>
+}
+
+/** Normalized documentation entry used by generated API docs. */
+export interface JsDocEntry {
+  name: string
+  kind: string
+  description: string
+  params?: Array<JsDocParam>
+  returns?: JsDocReturn
+  examples?: Array<string>
+  tags?: Record<string, string>
+  private: boolean
+  file: string
+  line: number
+  endLine: number
+  signature?: string
+}
+
+/** Normalized parameter documentation used by generated API docs. */
+export interface JsDocParam {
+  name: string
+  type: string
+  description: string
+  optional?: boolean
+  default?: string
+}
+
+/** Normalized return documentation used by generated API docs. */
+export interface JsDocReturn {
+  type: string
+  description: string
 }
 
 /** Entry page configuration. */

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -79,6 +79,7 @@ module.exports.transform = binding.transform;
 module.exports.transformAsync = binding.transformAsync;
 module.exports.version = binding.version;
 module.exports.extractFileDocs = binding.extractFileDocs;
+module.exports.extractFileDocEntries = binding.extractFileDocEntries;
 module.exports.generateOgImageSvg = binding.generateOgImageSvg;
 module.exports.buildSearchIndex = binding.buildSearchIndex;
 module.exports.searchIndex = binding.searchIndex;

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -16,7 +16,10 @@ use std::process::Command;
 
 use ox_content_allocator::Allocator;
 use ox_content_ast::{Document, Heading, Node};
-use ox_content_docs::{DocExtractor, DocItem, DocItemKind, DocTag, ParamDoc};
+use ox_content_docs::{
+    normalize_doc_items, DocExtractor, DocItem, DocItemKind, DocTag, NormalizedDocEntry,
+    NormalizedParamDoc, NormalizedReturnDoc, ParamDoc,
+};
 use ox_content_parser::{Parser, ParserOptions};
 use ox_content_renderer::{HtmlRenderer, HtmlRendererOptions};
 use ox_content_search::{DocumentIndexer, SearchIndex, SearchIndexBuilder, SearchOptions};
@@ -108,6 +111,43 @@ pub struct JsSourceDocItem {
     pub params: Vec<JsSourceDocParam>,
     pub return_type: Option<String>,
     pub tags: Vec<JsSourceDocTag>,
+}
+
+/// Normalized parameter documentation used by generated API docs.
+#[napi(object)]
+#[derive(Clone)]
+pub struct JsDocParam {
+    pub name: String,
+    pub r#type: String,
+    pub description: String,
+    pub optional: Option<bool>,
+    pub r#default: Option<String>,
+}
+
+/// Normalized return documentation used by generated API docs.
+#[napi(object)]
+#[derive(Clone)]
+pub struct JsDocReturn {
+    pub r#type: String,
+    pub description: String,
+}
+
+/// Normalized documentation entry used by generated API docs.
+#[napi(object)]
+#[derive(Clone)]
+pub struct JsDocEntry {
+    pub name: String,
+    pub kind: String,
+    pub description: String,
+    pub params: Option<Vec<JsDocParam>>,
+    pub returns: Option<JsDocReturn>,
+    pub examples: Option<Vec<String>>,
+    pub tags: Option<HashMap<String, String>>,
+    pub private: bool,
+    pub file: String,
+    pub line: u32,
+    pub end_line: u32,
+    pub signature: Option<String>,
 }
 
 /// Transform options for JavaScript.
@@ -294,6 +334,38 @@ fn map_doc_item(item: DocItem) -> JsSourceDocItem {
     }
 }
 
+fn map_normalized_param_doc(param: NormalizedParamDoc) -> JsDocParam {
+    JsDocParam {
+        name: param.name,
+        r#type: param.type_annotation,
+        description: param.description,
+        optional: param.optional.then_some(true),
+        r#default: param.default_value,
+    }
+}
+
+fn map_normalized_return_doc(return_doc: NormalizedReturnDoc) -> JsDocReturn {
+    JsDocReturn { r#type: return_doc.type_annotation, description: return_doc.description }
+}
+
+fn map_normalized_doc_entry(entry: NormalizedDocEntry) -> JsDocEntry {
+    JsDocEntry {
+        name: entry.name,
+        kind: entry.kind.as_str().to_string(),
+        description: entry.description,
+        params: (!entry.params.is_empty())
+            .then(|| entry.params.into_iter().map(map_normalized_param_doc).collect()),
+        returns: entry.returns.map(map_normalized_return_doc),
+        examples: (!entry.examples.is_empty()).then_some(entry.examples),
+        tags: (!entry.tags.is_empty()).then(|| entry.tags.into_iter().collect()),
+        private: entry.private,
+        file: entry.file,
+        line: entry.line,
+        end_line: entry.end_line,
+        signature: entry.signature,
+    }
+}
+
 /// Extracts documented declarations from a JavaScript/TypeScript file using Oxc.
 #[napi]
 pub fn extract_file_docs(
@@ -306,6 +378,20 @@ pub fn extract_file_docs(
         .map_err(|err| Error::from_reason(err.to_string()))?;
 
     Ok(items.into_iter().map(map_doc_item).collect())
+}
+
+/// Extracts normalized documentation entries from a JavaScript/TypeScript file using Oxc.
+#[napi(js_name = "extractFileDocEntries")]
+pub fn extract_file_doc_entries(
+    file_path: String,
+    include_private: Option<bool>,
+) -> Result<Vec<JsDocEntry>> {
+    let extractor = DocExtractor::with_private(include_private.unwrap_or(false));
+    let items = extractor
+        .extract_file(Path::new(&file_path))
+        .map_err(|err| Error::from_reason(err.to_string()))?;
+
+    Ok(normalize_doc_items(items).into_iter().map(map_normalized_doc_entry).collect())
 }
 
 /// Restores code block metadata after JavaScript-side syntax highlighting.

--- a/npm/vite-plugin-ox-content/src/docs.ts
+++ b/npm/vite-plugin-ox-content/src/docs.ts
@@ -56,7 +56,6 @@ import type {
   ExtractedDocs,
   DocEntry,
   ParamDoc,
-  ReturnDoc,
   GeneratedDocsData,
   DocsSummary,
 } from "./types";
@@ -457,148 +456,6 @@ function buildDocsData(docs: ExtractedDocs[]): GeneratedDocsData {
     })),
   };
 }
-interface NapiDocTag {
-  tag: string;
-  value: string;
-}
-
-interface NapiDocParam {
-  name: string;
-  typeAnnotation?: string;
-  optional: boolean;
-  defaultValue?: string;
-  description?: string;
-}
-
-interface NapiDocItem {
-  name: string;
-  kind: string;
-  doc?: string;
-  jsdoc?: string;
-  sourcePath: string;
-  line: number;
-  endLine: number;
-  exported: boolean;
-  signature?: string;
-  params: NapiDocParam[];
-  returnType?: string;
-  tags: NapiDocTag[];
-}
-
-function consumeJSDocType(value: string): { type?: string; rest: string } {
-  const trimmed = value.trimStart();
-  if (!trimmed.startsWith("{")) {
-    return { rest: trimmed };
-  }
-
-  let depth = 0;
-  for (let index = 0; index < trimmed.length; index++) {
-    const char = trimmed[index];
-    if (char === "{") {
-      depth++;
-    } else if (char === "}") {
-      depth--;
-      if (depth === 0) {
-        const type = trimmed.slice(1, index).trim();
-        return {
-          type: type || undefined,
-          rest: trimmed.slice(index + 1).trimStart(),
-        };
-      }
-    }
-  }
-
-  return { rest: trimmed };
-}
-
-function cleanTagDescription(value: string): string {
-  return value.trim().replace(/^-\s*/, "").trim();
-}
-
-function splitTagNameAndDescription(value: string): { name: string; description: string } {
-  const trimmed = value.trimStart();
-  if (trimmed.startsWith("[")) {
-    const closeIndex = trimmed.indexOf("]");
-    if (closeIndex >= 0) {
-      return {
-        name: trimmed.slice(0, closeIndex + 1),
-        description: trimmed.slice(closeIndex + 1).trimStart(),
-      };
-    }
-  }
-
-  const match = /^(\S+)(?:\s+([\s\S]*))?$/u.exec(trimmed);
-  return {
-    name: match?.[1] ?? "",
-    description: match?.[2] ?? "",
-  };
-}
-
-function parseParamTagValue(value: string): ParamDoc | null {
-  const { type, rest } = consumeJSDocType(value);
-  const { name: rawName, description } = splitTagNameAndDescription(rest);
-  let name = rawName.trim();
-  if (!name) {
-    return null;
-  }
-
-  let optional = false;
-  let defaultValue: string | undefined;
-  const optionalMatch = /^\[(.*)\]$/u.exec(name);
-  if (optionalMatch) {
-    optional = true;
-    const [innerName, innerDefault] = optionalMatch[1].split(/=(.*)/su);
-    name = innerName.trim();
-    defaultValue = innerDefault?.trim() || undefined;
-  }
-
-  if (!name) {
-    return null;
-  }
-
-  return {
-    name,
-    type: type || "unknown",
-    description: cleanTagDescription(description),
-    optional: optional || undefined,
-    default: defaultValue,
-  };
-}
-
-function parseReturnsTagValue(value: string): ReturnDoc {
-  const { type, rest } = consumeJSDocType(value);
-  return {
-    type: type || "unknown",
-    description: cleanTagDescription(rest),
-  };
-}
-
-function normalizeReturnType(value: string): string {
-  const parsed = parseReturnsTagValue(value);
-  return parsed.type === "unknown" ? value : parsed.type;
-}
-
-function mergeParam(params: ParamDoc[], next: ParamDoc): void {
-  const existing = params.find((param) => param.name === next.name);
-  if (!existing) {
-    params.push(next);
-    return;
-  }
-
-  if (next.type && (existing.type === "unknown" || next.type !== "unknown")) {
-    existing.type = next.type;
-  }
-  if (next.description) {
-    existing.description = next.description;
-  }
-  if (next.optional) {
-    existing.optional = true;
-  }
-  if (next.default) {
-    existing.default = next.default;
-  }
-}
-
 /**
  * Extracts JSDoc documentation from source files in specified directories.
  *
@@ -669,12 +526,12 @@ export async function extractDocs(
   options: ResolvedDocsOptions,
 ): Promise<ExtractedDocs[]> {
   const napi = await importNapiModule();
-  const extractFileDocs = (
-    napi as { extractFileDocs?: (filePath: string, includePrivate?: boolean) => NapiDocItem[] }
-  ).extractFileDocs;
+  const extractFileDocEntries = (
+    napi as { extractFileDocEntries?: (filePath: string, includePrivate?: boolean) => DocEntry[] }
+  ).extractFileDocEntries;
 
-  if (!extractFileDocs) {
-    throw new Error("[ox-content] extractFileDocs is not available from @ox-content/napi.");
+  if (!extractFileDocEntries) {
+    throw new Error("[ox-content] extractFileDocEntries is not available from @ox-content/napi.");
   }
 
   const results: ExtractedDocs[] = [];
@@ -683,9 +540,7 @@ export async function extractDocs(
     const files = await findFiles(srcDir, options);
 
     for (const file of files) {
-      const entries = extractFileDocs(file, options.private)
-        .map(parseNapiDocItem)
-        .filter((entry): entry is DocEntry => Boolean(entry));
+      const entries = extractFileDocEntries(file, options.private);
 
       if (entries.length > 0) {
         results.push({ file, entries });
@@ -751,191 +606,6 @@ function isExcluded(file: string, patterns: string[]): boolean {
     }
     return false;
   });
-}
-
-function parseNapiDocItem(item: NapiDocItem): DocEntry | null {
-  const kind = normalizeNapiKind(item.kind);
-  if (!kind) {
-    return null;
-  }
-
-  const params: ParamDoc[] = [];
-  const examples: string[] = [];
-  const tags: Record<string, string> = {};
-  let description = "";
-  let returns: { type: string; description: string } | undefined;
-  let isPrivate = false;
-
-  const rawLines = (item.jsdoc ?? "").split("\n").map((line) => {
-    const trimmedStart = line.trimStart();
-    const withoutStar = trimmedStart.startsWith("*") ? trimmedStart.slice(1) : trimmedStart;
-    return withoutStar.startsWith(" ") ? withoutStar.slice(1) : withoutStar;
-  });
-  const cleanedLines = rawLines.map((line) => line.trim()).filter(Boolean);
-
-  let currentExample = "";
-  let inExample = false;
-  let rawLineIndex = 0;
-
-  for (const lineText of cleanedLines) {
-    // Find the corresponding raw line to get original indentation for examples
-    while (rawLineIndex < rawLines.length && rawLines[rawLineIndex].trim() !== lineText) {
-      rawLineIndex++;
-    }
-    const rawLine = rawLineIndex < rawLines.length ? rawLines[rawLineIndex] : lineText;
-    rawLineIndex++;
-
-    if (lineText.startsWith("@")) {
-      if (inExample) {
-        examples.push(currentExample.trim());
-        currentExample = "";
-        inExample = false;
-      }
-
-      const tagMatch = /^@(\S+)\s*([\s\S]*)$/u.exec(lineText);
-      if (tagMatch) {
-        const [, tagName, tagValue = ""] = tagMatch;
-
-        switch (tagName) {
-          case "param":
-          case "arg":
-          case "argument": {
-            const param = parseParamTagValue(tagValue);
-            if (param) {
-              mergeParam(params, param);
-            }
-            break;
-          }
-          case "returns":
-          case "return":
-            returns = parseReturnsTagValue(tagValue);
-            break;
-          case "example":
-            inExample = true;
-            currentExample = tagValue.trim() ? `${tagValue.trim()}\n` : "";
-            break;
-          case "private":
-            isPrivate = true;
-            break;
-          default:
-            tags[tagName] = tagValue.trim();
-        }
-      }
-    } else if (inExample) {
-      currentExample += rawLine + "\n";
-    } else if (!description) {
-      description = lineText;
-    } else {
-      description += "\n" + lineText;
-    }
-  }
-
-  if (inExample && currentExample) {
-    examples.push(currentExample.trim());
-  }
-
-  for (const param of item.params) {
-    if (
-      params.length > 0 &&
-      param.name === "param" &&
-      !param.typeAnnotation &&
-      !param.description &&
-      !param.defaultValue
-    ) {
-      continue;
-    }
-
-    mergeParam(params, {
-      name: param.name,
-      type: param.typeAnnotation ?? "unknown",
-      description: param.description ?? "",
-      optional: param.optional || undefined,
-      default: param.defaultValue,
-    });
-  }
-
-  if (!returns && item.returnType) {
-    returns = {
-      type: normalizeReturnType(item.returnType),
-      description: "",
-    };
-  } else if (returns && item.returnType) {
-    returns.type = normalizeReturnType(item.returnType);
-  }
-
-  if (!description) {
-    description = item.doc ?? "";
-  }
-
-  for (const tag of item.tags) {
-    if (
-      tag.tag === "param" ||
-      tag.tag === "arg" ||
-      tag.tag === "argument" ||
-      tag.tag === "returns" ||
-      tag.tag === "return"
-    ) {
-      if (tag.tag === "param" || tag.tag === "arg" || tag.tag === "argument") {
-        const param = parseParamTagValue(tag.value);
-        if (param) {
-          mergeParam(params, param);
-        }
-      } else {
-        const parsedReturns = parseReturnsTagValue(tag.value);
-        if (!returns) {
-          returns = parsedReturns;
-        } else {
-          returns.type = returns.type === "unknown" ? parsedReturns.type : returns.type;
-          returns.description ||= parsedReturns.description;
-        }
-      }
-      continue;
-    }
-    if (tag.tag === "example") {
-      if (tag.value && !examples.includes(tag.value)) {
-        examples.push(tag.value);
-      }
-      continue;
-    }
-    if (tag.tag === "private") {
-      isPrivate = true;
-      continue;
-    }
-    if (!tags[tag.tag]) {
-      tags[tag.tag] = tag.value;
-    }
-  }
-
-  return {
-    name: item.name,
-    kind,
-    description,
-    params: params.length > 0 ? params : undefined,
-    returns,
-    examples: examples.length > 0 ? examples : undefined,
-    tags: Object.keys(tags).length > 0 ? tags : undefined,
-    private: isPrivate,
-    file: item.sourcePath,
-    line: item.line,
-    endLine: item.endLine,
-    signature: item.signature,
-  };
-}
-
-function normalizeNapiKind(kind: string): DocEntry["kind"] | null {
-  switch (kind) {
-    case "function":
-    case "class":
-    case "interface":
-    case "type":
-    case "variable":
-    case "module":
-      return kind;
-    case "enum":
-      return "type";
-    default:
-      return null;
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- move DocEntry normalization from the Vite plugin TypeScript into ox_content_docs
- keep JSDoc tag parsing on ox_jsdoc structured fields instead of re-parsing flattened strings in TypeScript or normalization
- expose normalized docs through a new extractFileDocEntries NAPI API while keeping extractFileDocs for lower-level consumers

## Validation
- cargo test -p ox_content_docs -p ox_content_napi
- pnpm --filter @ox-content/napi build:debug
- pnpm exec vp test npm/vite-plugin-ox-content/src/docs.test.ts
- pnpm exec vp check