### PR TITLE
refactor: move SSG asset externalization to Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ unicode-normalization = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
+sha2 = "0.10"
 
 # LSP
 tower-lsp = "0.20"

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -15,6 +15,9 @@ export declare function buildSearchIndex(documents: Array<JsSearchDocument>): st
  */
 export declare function checkI18n(dictDir: string, usedKeys: Array<string>): I18NCheckResult
 
+/** Extracts shared CSS and JavaScript assets from generated SSG pages. */
+export declare function externalizeSsgAssets(pages: Array<JsSsgGeneratedHtmlPage>, outDir: string, base: string): JsSsgExternalizedAssets
+
 /** Extracts normalized documentation entries from a JavaScript/TypeScript file using Oxc. */
 export declare function extractFileDocEntries(filePath: string, includePrivate?: boolean | undefined | null): Array<JsDocEntry>
 
@@ -437,6 +440,24 @@ export interface JsSsgConfig {
   availableLocales?: Array<JsLocaleInfo>
 }
 
+/** Result of SSG shared asset extraction. */
+export interface JsSsgExternalizedAssets {
+  /** HTML pages with inline assets replaced. */
+  pages: Array<JsSsgGeneratedHtmlPage>
+  /** Extracted shared assets. */
+  assets: Array<JsSsgSharedAsset>
+}
+
+/** Generated SSG HTML page for shared asset extraction. */
+export interface JsSsgGeneratedHtmlPage {
+  /** Source Markdown path. */
+  inputPath: string
+  /** Output HTML path. */
+  outputPath: string
+  /** HTML content. */
+  html: string
+}
+
 /** Navigation group for SSG. */
 export interface JsSsgNavGroup {
   /** Group title. */
@@ -474,6 +495,16 @@ export interface JsSsgPageData {
   path: string
   /** Entry page configuration (if layout: entry). */
   entryPage?: JsEntryPageConfig
+}
+
+/** Shared SSG asset extracted from generated pages. */
+export interface JsSsgSharedAsset {
+  /** Output file path. */
+  outputPath: string
+  /** Public URL path used from HTML. */
+  publicPath: string
+  /** Asset content. */
+  content: string
 }
 
 /** Theme colors for JavaScript. */

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -85,6 +85,7 @@ module.exports.buildSearchIndex = binding.buildSearchIndex;
 module.exports.searchIndex = binding.searchIndex;
 module.exports.extractSearchContent = binding.extractSearchContent;
 module.exports.generateSsgHtml = binding.generateSsgHtml;
+module.exports.externalizeSsgAssets = binding.externalizeSsgAssets;
 module.exports.transformMermaid = binding.transformMermaid;
 module.exports.loadDictionaries = binding.loadDictionaries;
 module.exports.loadDictionariesFlat = binding.loadDictionariesFlat;

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -926,6 +926,39 @@ pub struct JsSsgNavGroup {
     pub collapsed: Option<bool>,
 }
 
+/// Generated SSG HTML page for shared asset extraction.
+#[napi(object)]
+#[derive(Clone)]
+pub struct JsSsgGeneratedHtmlPage {
+    /// Source Markdown path.
+    pub input_path: String,
+    /// Output HTML path.
+    pub output_path: String,
+    /// HTML content.
+    pub html: String,
+}
+
+/// Shared SSG asset extracted from generated pages.
+#[napi(object)]
+#[derive(Clone)]
+pub struct JsSsgSharedAsset {
+    /// Output file path.
+    pub output_path: String,
+    /// Public URL path used from HTML.
+    pub public_path: String,
+    /// Asset content.
+    pub content: String,
+}
+
+/// Result of SSG shared asset extraction.
+#[napi(object)]
+pub struct JsSsgExternalizedAssets {
+    /// HTML pages with inline assets replaced.
+    pub pages: Vec<JsSsgGeneratedHtmlPage>,
+    /// Extracted shared assets.
+    pub assets: Vec<JsSsgSharedAsset>,
+}
+
 /// Hero action for entry page.
 #[napi(object)]
 #[derive(Clone, Default)]
@@ -1373,6 +1406,30 @@ fn convert_nav_item(item: JsSsgNavItem) -> ox_content_ssg::NavItem {
     }
 }
 
+fn convert_generated_html_page(page: JsSsgGeneratedHtmlPage) -> ox_content_ssg::GeneratedHtmlPage {
+    ox_content_ssg::GeneratedHtmlPage {
+        input_path: page.input_path,
+        output_path: page.output_path,
+        html: page.html,
+    }
+}
+
+fn map_generated_html_page(page: ox_content_ssg::GeneratedHtmlPage) -> JsSsgGeneratedHtmlPage {
+    JsSsgGeneratedHtmlPage {
+        input_path: page.input_path,
+        output_path: page.output_path,
+        html: page.html,
+    }
+}
+
+fn map_shared_asset(asset: ox_content_ssg::SharedAsset) -> JsSsgSharedAsset {
+    JsSsgSharedAsset {
+        output_path: asset.output_path,
+        public_path: asset.public_path,
+        content: asset.content,
+    }
+}
+
 /// Generates SSG HTML page with navigation and search.
 #[napi]
 pub fn generate_ssg_html(
@@ -1422,6 +1479,25 @@ pub fn generate_ssg_html(
     };
 
     ox_content_ssg::generate_html(&ssg_page_data, &ssg_nav_groups, &ssg_config)
+}
+
+/// Extracts shared CSS and JavaScript assets from generated SSG pages.
+#[napi(js_name = "externalizeSsgAssets")]
+pub fn externalize_ssg_assets(
+    pages: Vec<JsSsgGeneratedHtmlPage>,
+    out_dir: String,
+    base: String,
+) -> JsSsgExternalizedAssets {
+    let result = ox_content_ssg::externalize_shared_page_assets(
+        pages.into_iter().map(convert_generated_html_page).collect(),
+        &out_dir,
+        &base,
+    );
+
+    JsSsgExternalizedAssets {
+        pages: result.pages.into_iter().map(map_generated_html_page).collect(),
+        assets: result.assets.into_iter().map(map_shared_asset).collect(),
+    }
 }
 
 /// Extracts searchable content from Markdown source.

--- a/crates/ox_content_ssg/Cargo.toml
+++ b/crates/ox_content_ssg/Cargo.toml
@@ -18,3 +18,4 @@ workspace = true
 askama = "0.12"
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }

--- a/crates/ox_content_ssg/src/assets.rs
+++ b/crates/ox_content_ssg/src/assets.rs
@@ -1,0 +1,567 @@
+//! Shared asset extraction for generated SSG pages.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const STYLE_BLOCK_START: &str = "<!-- ox-content:styles:start -->";
+const STYLE_BLOCK_END: &str = "<!-- ox-content:styles:end -->";
+const SCRIPT_BLOCK_START: &str = "<!-- ox-content:scripts:start -->";
+const SCRIPT_BLOCK_END: &str = "<!-- ox-content:scripts:end -->";
+const STYLE_OPEN: &str = "<style>";
+const STYLE_CLOSE: &str = "</style>";
+const SCRIPT_OPEN: &str = "<script>";
+const SCRIPT_CLOSE: &str = "</script>";
+const BODY_CLOSE: &str = "</body>";
+const CSS_SECTION_PREFIX: &str = "/* ox-content:css:";
+const CSS_SECTION_START_SUFFIX: &str = ":start */";
+const CSS_SECTION_END_SUFFIX: &str = ":end */";
+const SEARCH_CHUNK_START: &str = "// ox-content:search:start";
+const SEARCH_CHUNK_END: &str = "// ox-content:search:end";
+const SEARCH_CHUNK_PLACEHOLDER: &str = "__OX_CONTENT_SEARCH_CHUNK__";
+const CORE_CSS_SECTION_NAMES: [&str; 2] = ["base", "footer"];
+const THEME_INLINE_CSS_MAX_BYTES: usize = 2048;
+
+/// Generated HTML page before or after asset extraction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GeneratedHtmlPage {
+    /// Source Markdown path.
+    pub input_path: String,
+    /// Output HTML path.
+    pub output_path: String,
+    /// HTML content.
+    pub html: String,
+}
+
+/// Shared CSS or JavaScript asset extracted from generated pages.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SharedAsset {
+    /// Output file path.
+    pub output_path: String,
+    /// Public URL path used from HTML.
+    pub public_path: String,
+    /// Asset content.
+    pub content: String,
+}
+
+/// Result of shared asset extraction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalizedAssets {
+    /// HTML pages with inline assets replaced.
+    pub pages: Vec<GeneratedHtmlPage>,
+    /// Extracted shared assets.
+    pub assets: Vec<SharedAsset>,
+}
+
+#[derive(Debug, Clone)]
+struct CssSection {
+    name: String,
+    content: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum AssetKind {
+    Css,
+    Js,
+}
+
+impl AssetKind {
+    const fn extension(self) -> &'static str {
+        match self {
+            Self::Css => "css",
+            Self::Js => "js",
+        }
+    }
+}
+
+struct BlockMatch {
+    start: usize,
+    end: usize,
+    content: String,
+}
+
+#[derive(Default)]
+struct AssetCache {
+    indexes_by_content: HashMap<String, usize>,
+    chunks: Vec<SharedAsset>,
+}
+
+impl AssetCache {
+    fn get_or_create(
+        &mut self,
+        kind: AssetKind,
+        label: &str,
+        content: &str,
+        out_dir: &str,
+        base: &str,
+    ) -> &SharedAsset {
+        if let Some(index) = self.indexes_by_content.get(content).copied() {
+            return &self.chunks[index];
+        }
+
+        let index = self.chunks.len();
+        self.chunks.push(create_shared_asset_chunk(kind, label, content, out_dir, base));
+        self.indexes_by_content.insert(content.to_string(), index);
+        &self.chunks[index]
+    }
+
+    fn into_chunks(self) -> Vec<SharedAsset> {
+        self.chunks
+    }
+}
+
+/// Extracts shared CSS/JS chunks from generated HTML pages.
+#[must_use]
+pub fn externalize_shared_page_assets(
+    pages: Vec<GeneratedHtmlPage>,
+    out_dir: &str,
+    base: &str,
+) -> ExternalizedAssets {
+    let mut css_chunks = AssetCache::default();
+    let mut js_chunks = AssetCache::default();
+
+    let optimized_pages = pages
+        .into_iter()
+        .map(|page| {
+            let mut html = page.html;
+
+            if let Some(block) = find_marked_block(
+                &html,
+                STYLE_BLOCK_START,
+                STYLE_BLOCK_END,
+                STYLE_OPEN,
+                STYLE_CLOSE,
+            ) {
+                let replacement =
+                    build_style_replacement(&block.content, &mut css_chunks, out_dir, base);
+                html.replace_range(block.start..block.end, &replacement);
+            } else if let Some(block) = find_first_tag_block(&html, STYLE_OPEN, STYLE_CLOSE) {
+                let replacement =
+                    build_style_replacement(&block.content, &mut css_chunks, out_dir, base);
+                html.replace_range(block.start..block.end, &replacement);
+            }
+
+            if let Some(block) = find_marked_block(
+                &html,
+                SCRIPT_BLOCK_START,
+                SCRIPT_BLOCK_END,
+                SCRIPT_OPEN,
+                SCRIPT_CLOSE,
+            ) {
+                let replacement =
+                    build_script_replacement(&block.content, &mut js_chunks, out_dir, base);
+                html.replace_range(block.start..block.end, &replacement);
+            } else if let Some(block) = find_last_body_script_block(&html) {
+                let replacement =
+                    build_script_replacement(&block.content, &mut js_chunks, out_dir, base);
+                let replacement = if replacement.is_empty() {
+                    BODY_CLOSE.to_string()
+                } else {
+                    format!("{replacement}\n{BODY_CLOSE}")
+                };
+                html.replace_range(block.start..block.end, &replacement);
+            }
+
+            GeneratedHtmlPage { html, ..page }
+        })
+        .collect();
+
+    let assets = css_chunks.into_chunks().into_iter().chain(js_chunks.into_chunks()).collect();
+
+    ExternalizedAssets { pages: optimized_pages, assets }
+}
+
+fn build_style_replacement(
+    css_content: &str,
+    css_chunks: &mut AssetCache,
+    out_dir: &str,
+    base: &str,
+) -> String {
+    let sections = extract_css_sections(css_content);
+    let effective_sections = if sections.is_empty() {
+        vec![CssSection { name: "css".to_string(), content: css_content.trim().to_string() }]
+    } else {
+        sections
+    };
+
+    let core_content = effective_sections
+        .iter()
+        .filter(|section| CORE_CSS_SECTION_NAMES.contains(&section.name.as_str()))
+        .map(|section| section.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string();
+
+    let mut fragments = Vec::new();
+    if !core_content.is_empty() {
+        let core_chunk =
+            css_chunks.get_or_create(AssetKind::Css, "core", &core_content, out_dir, base);
+        fragments.push(format!("  <link rel=\"stylesheet\" href=\"{}\">", core_chunk.public_path));
+    }
+
+    for section in effective_sections {
+        if CORE_CSS_SECTION_NAMES.contains(&section.name.as_str()) {
+            continue;
+        }
+
+        let has_relative_urls = has_relative_css_urls(&section.content);
+        let should_inline_theme = section.name == "theme"
+            && (has_relative_urls || section.content.len() <= THEME_INLINE_CSS_MAX_BYTES);
+        if should_inline_theme || has_relative_urls {
+            fragments.push(format!("  <style>{}</style>", section.content));
+            continue;
+        }
+
+        let chunk = css_chunks.get_or_create(
+            AssetKind::Css,
+            &section.name,
+            &section.content,
+            out_dir,
+            base,
+        );
+        fragments.push(format!("  <link rel=\"stylesheet\" href=\"{}\">", chunk.public_path));
+    }
+
+    fragments.join("\n")
+}
+
+fn build_script_replacement(
+    js_content: &str,
+    js_chunks: &mut AssetCache,
+    out_dir: &str,
+    base: &str,
+) -> String {
+    if let Some(search_chunk) = find_search_chunk(js_content) {
+        if js_content.contains(SEARCH_CHUNK_PLACEHOLDER) {
+            let search_content = search_chunk.content.trim();
+            if !search_content.is_empty() {
+                let search_public_path = js_chunks
+                    .get_or_create(AssetKind::Js, "search", search_content, out_dir, base)
+                    .public_path
+                    .clone();
+                let mut core_content = String::new();
+                core_content.push_str(&js_content[..search_chunk.start]);
+                core_content.push_str(&js_content[search_chunk.end..]);
+                let core_content = core_content
+                    .replace(SEARCH_CHUNK_PLACEHOLDER, &search_public_path)
+                    .trim()
+                    .to_string();
+
+                if !core_content.is_empty() {
+                    let core_chunk = js_chunks.get_or_create(
+                        AssetKind::Js,
+                        "core",
+                        &core_content,
+                        out_dir,
+                        base,
+                    );
+                    return format!("  <script defer src=\"{}\"></script>", core_chunk.public_path);
+                }
+            }
+        }
+    }
+
+    let fallback_content = js_content.trim();
+    if fallback_content.is_empty() {
+        return String::new();
+    }
+
+    let chunk = js_chunks.get_or_create(AssetKind::Js, "js", fallback_content, out_dir, base);
+    format!("  <script defer src=\"{}\"></script>", chunk.public_path)
+}
+
+fn create_shared_asset_chunk(
+    kind: AssetKind,
+    label: &str,
+    content: &str,
+    out_dir: &str,
+    base: &str,
+) -> SharedAsset {
+    let hash = create_content_hash(content);
+    let file_name =
+        format!("ox-content-{}-{hash}.{}", sanitize_chunk_label(label), kind.extension());
+    let output_path =
+        Path::new(out_dir).join("assets").join(&file_name).to_string_lossy().to_string();
+
+    SharedAsset {
+        output_path,
+        public_path: to_public_asset_path(base, &file_name),
+        content: content.to_string(),
+    }
+}
+
+fn create_content_hash(content: &str) -> String {
+    let hash = Sha256::digest(content.as_bytes());
+    format!("{hash:x}").chars().take(10).collect()
+}
+
+fn sanitize_chunk_label(label: &str) -> String {
+    let mut output = String::new();
+    let mut pending_dash = false;
+
+    for ch in label.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            if pending_dash && !output.is_empty() {
+                output.push('-');
+            }
+            output.push(ch);
+            pending_dash = false;
+        } else {
+            pending_dash = true;
+        }
+    }
+
+    if output.is_empty() {
+        "asset".to_string()
+    } else {
+        output
+    }
+}
+
+fn to_public_asset_path(base: &str, file_name: &str) -> String {
+    let normalized_base = if base.ends_with('/') { base.to_string() } else { format!("{base}/") };
+    format!("{normalized_base}assets/{file_name}")
+}
+
+fn extract_css_sections(css_content: &str) -> Vec<CssSection> {
+    let mut sections = Vec::new();
+    let mut cursor = 0;
+
+    while let Some(start_rel) = css_content[cursor..].find(CSS_SECTION_PREFIX) {
+        let marker_start = cursor + start_rel;
+        let name_start = marker_start + CSS_SECTION_PREFIX.len();
+        let Some(name_end_rel) = css_content[name_start..].find(CSS_SECTION_START_SUFFIX) else {
+            break;
+        };
+        let name_end = name_start + name_end_rel;
+        let name = &css_content[name_start..name_end];
+        if !name.chars().all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-') {
+            cursor = name_end;
+            continue;
+        }
+
+        let content_start = name_end + CSS_SECTION_START_SUFFIX.len();
+        let end_marker = format!("{CSS_SECTION_PREFIX}{name}{CSS_SECTION_END_SUFFIX}");
+        let Some(end_rel) = css_content[content_start..].find(&end_marker) else {
+            break;
+        };
+        let content_end = content_start + end_rel;
+        let content = css_content[content_start..content_end].trim();
+        if !content.is_empty() {
+            sections.push(CssSection { name: name.to_string(), content: content.to_string() });
+        }
+        cursor = content_end + end_marker.len();
+    }
+
+    sections
+}
+
+fn has_relative_css_urls(css: &str) -> bool {
+    let mut cursor = 0;
+    let bytes = css.as_bytes();
+
+    while let Some(url_rel) = css[cursor..].find("url(") {
+        let url_index = cursor + url_rel;
+        let mut value_start = url_index + 4;
+        while value_start < bytes.len() && bytes[value_start].is_ascii_whitespace() {
+            value_start += 1;
+        }
+
+        let quote = match bytes.get(value_start).copied() {
+            Some(b'"' | b'\'') => {
+                let quote = bytes[value_start];
+                value_start += 1;
+                Some(quote)
+            }
+            _ => None,
+        };
+
+        let mut value_end = value_start;
+        while value_end < bytes.len() {
+            let byte = bytes[value_end];
+            if let Some(quote) = quote {
+                if byte == b'\\' {
+                    value_end = value_end.saturating_add(2);
+                    continue;
+                }
+                if byte == quote {
+                    break;
+                }
+            } else if byte == b')' {
+                break;
+            }
+            value_end += 1;
+        }
+
+        let value = css[value_start..value_end].trim();
+        if !value.is_empty()
+            && !value.starts_with("data:")
+            && !value.starts_with("http:")
+            && !value.starts_with("https:")
+            && !value.starts_with("//")
+            && !value.starts_with('/')
+            && !value.starts_with('#')
+            && !value.starts_with("blob:")
+            && !value.starts_with("var(")
+        {
+            return true;
+        }
+
+        cursor = value_end.saturating_add(1);
+    }
+
+    false
+}
+
+fn find_marked_block(
+    html: &str,
+    block_start_marker: &str,
+    block_end_marker: &str,
+    inner_open: &str,
+    inner_close: &str,
+) -> Option<BlockMatch> {
+    let marker_start = html.find(block_start_marker)?;
+    let start = include_leading_horizontal_ws(html, marker_start);
+    let open_start = marker_start + html[marker_start..].find(inner_open)?;
+    let content_start = open_start + inner_open.len();
+    let content_end = content_start + html[content_start..].find(inner_close)?;
+    let close_end = content_end + inner_close.len();
+    let block_end = close_end + html[close_end..].find(block_end_marker)? + block_end_marker.len();
+
+    Some(BlockMatch {
+        start,
+        end: block_end,
+        content: html[content_start..content_end].to_string(),
+    })
+}
+
+fn find_first_tag_block(html: &str, open: &str, close: &str) -> Option<BlockMatch> {
+    let open_start = html.find(open)?;
+    let start = include_leading_horizontal_ws(html, open_start);
+    let content_start = open_start + open.len();
+    let content_end = content_start + html[content_start..].find(close)?;
+    Some(BlockMatch {
+        start,
+        end: content_end + close.len(),
+        content: html[content_start..content_end].to_string(),
+    })
+}
+
+fn find_last_body_script_block(html: &str) -> Option<BlockMatch> {
+    let body_start = html.rfind(BODY_CLOSE)?;
+    let before_body = &html[..body_start];
+    let script_start = before_body.rfind(SCRIPT_OPEN)?;
+    let content_start = script_start + SCRIPT_OPEN.len();
+    let content_end = content_start + html[content_start..body_start].find(SCRIPT_CLOSE)?;
+    let script_end = content_end + SCRIPT_CLOSE.len();
+    if !html[script_end..body_start].trim().is_empty() {
+        return None;
+    }
+
+    Some(BlockMatch {
+        start: include_leading_horizontal_ws(html, script_start),
+        end: body_start + BODY_CLOSE.len(),
+        content: html[content_start..content_end].to_string(),
+    })
+}
+
+fn find_search_chunk(js_content: &str) -> Option<BlockMatch> {
+    let start = js_content.find(SEARCH_CHUNK_START)?;
+    let content_start = start + SEARCH_CHUNK_START.len();
+    let end_start = content_start + js_content[content_start..].find(SEARCH_CHUNK_END)?;
+    Some(BlockMatch {
+        start,
+        end: end_start + SEARCH_CHUNK_END.len(),
+        content: js_content[content_start..end_start].trim().to_string(),
+    })
+}
+
+fn include_leading_horizontal_ws(value: &str, start: usize) -> usize {
+    let bytes = value.as_bytes();
+    let mut cursor = start;
+    while cursor > 0 && matches!(bytes[cursor - 1], b' ' | b'\t') {
+        cursor -= 1;
+    }
+    cursor
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_shared_style_and_script_assets() {
+        let pages = vec![
+            GeneratedHtmlPage {
+                input_path: "a.md".to_string(),
+                output_path: "/tmp/site/a/index.html".to_string(),
+                html: format_page("A"),
+            },
+            GeneratedHtmlPage {
+                input_path: "b.md".to_string(),
+                output_path: "/tmp/site/b/index.html".to_string(),
+                html: format_page("B"),
+            },
+        ];
+
+        let result = externalize_shared_page_assets(pages, "/tmp/site", "/docs/");
+
+        assert_eq!(result.pages.len(), 2);
+        assert_eq!(result.assets.len(), 3);
+        assert!(result.pages[0]
+            .html
+            .contains("<link rel=\"stylesheet\" href=\"/docs/assets/ox-content-core-"));
+        assert!(result.pages[0].html.contains("<script defer src=\"/docs/assets/ox-content-core-"));
+        assert!(!result.pages[0].html.contains("ox-content:styles:start"));
+        assert!(!result.pages[0].html.contains("const searchData = true;"));
+        assert!(result.assets.iter().any(|asset| asset.output_path.ends_with(".css")));
+        assert!(result.assets.iter().any(|asset| asset.output_path.ends_with(".js")));
+    }
+
+    #[test]
+    fn keeps_relative_url_css_inline() {
+        let pages = vec![GeneratedHtmlPage {
+            input_path: "a.md".to_string(),
+            output_path: "/tmp/site/a/index.html".to_string(),
+            html: "<html><head><style>.hero{background:url('./hero.png')}</style></head><body></body></html>"
+                .to_string(),
+        }];
+
+        let result = externalize_shared_page_assets(pages, "/tmp/site", "/docs/");
+
+        assert!(result.assets.is_empty());
+        assert!(result.pages[0]
+            .html
+            .contains("<style>.hero{background:url('./hero.png')}</style>"));
+    }
+
+    fn format_page(title: &str) -> String {
+        format!(
+            r#"<!doctype html>
+<html>
+<head>
+  <!-- ox-content:styles:start -->
+  <style>/* ox-content:css:base:start */
+body {{ color: red; }}
+/* ox-content:css:base:end */
+/* ox-content:css:theme:start */
+:root {{ --title: "{title}"; }}
+/* ox-content:css:theme:end */</style>
+  <!-- ox-content:styles:end -->
+</head>
+<body>
+  <h1>{title}</h1>
+  <!-- ox-content:scripts:start -->
+  <script>const boot = "__OX_CONTENT_SEARCH_CHUNK__";
+// ox-content:search:start
+const searchData = true;
+// ox-content:search:end</script>
+  <!-- ox-content:scripts:end -->
+</body>
+</html>"#
+        )
+    }
+}

--- a/crates/ox_content_ssg/src/lib.rs
+++ b/crates/ox_content_ssg/src/lib.rs
@@ -51,8 +51,12 @@
 //! let html = generate_html(&page_data, &nav_groups, &config);
 //! ```
 
+mod assets;
 mod html;
 
+pub use assets::{
+    externalize_shared_page_assets, ExternalizedAssets, GeneratedHtmlPage, SharedAsset,
+};
 pub use html::{
     generate_html, EntryPageConfig, FeatureConfig, HeroAction, HeroConfig, HeroImage,
     HeroNoticeConfig, LocaleInfo, NavGroup, NavItem, PageData, SocialLink, SocialLinks, SsgConfig,

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -2,7 +2,6 @@
  * SSG (Static Site Generation) module for ox-content
  */
 
-import { createHash } from "node:crypto";
 import * as fs from "fs/promises";
 import * as path from "path";
 import { glob } from "glob";
@@ -1658,241 +1657,9 @@ interface GeneratedHtmlPage {
   html: string;
 }
 
-interface SharedAssetChunk {
+interface ExternalizedSharedAsset {
   outputPath: string;
-  publicPath: string;
   content: string;
-}
-
-interface CssSection {
-  name: string;
-  content: string;
-}
-
-const SSG_STYLE_BLOCK_RE =
-  /[ \t]*<!-- ox-content:styles:start -->\s*<style>([\s\S]*?)<\/style>\s*<!-- ox-content:styles:end -->/;
-const SSG_SCRIPT_BLOCK_RE =
-  /[ \t]*<!-- ox-content:scripts:start -->\s*<script>([\s\S]*?)<\/script>\s*<!-- ox-content:scripts:end -->/;
-const FIRST_INLINE_STYLE_RE = /[ \t]*<style>([\s\S]*?)<\/style>/;
-const LAST_INLINE_BODY_SCRIPT_RE = /[ \t]*<script>([\s\S]*?)<\/script>\s*<\/body>/;
-const CSS_SECTION_RE =
-  /\/\* ox-content:css:([a-z0-9-]+):start \*\/\s*([\s\S]*?)\s*\/\* ox-content:css:\1:end \*\//g;
-const SEARCH_CHUNK_RE = /\/\/ ox-content:search:start\s*([\s\S]*?)\s*\/\/ ox-content:search:end/;
-const SEARCH_CHUNK_PLACEHOLDER = "__OX_CONTENT_SEARCH_CHUNK__";
-const CORE_CSS_SECTION_NAMES = new Set(["base", "footer"]);
-const THEME_INLINE_CSS_MAX_BYTES = 2048;
-
-function createContentHash(content: string): string {
-  return createHash("sha256").update(content).digest("hex").slice(0, 10);
-}
-
-function sanitizeChunkLabel(label: string): string {
-  return (
-    label
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "") || "asset"
-  );
-}
-
-function toPublicAssetPath(base: string, fileName: string): string {
-  const normalizedBase = base.endsWith("/") ? base : `${base}/`;
-  return `${normalizedBase}assets/${fileName}`;
-}
-
-function hasRelativeCssUrls(css: string): boolean {
-  let cursor = 0;
-
-  while (cursor < css.length) {
-    const urlIndex = css.indexOf("url(", cursor);
-    if (urlIndex === -1) {
-      return false;
-    }
-
-    let valueStart = urlIndex + 4;
-    while (valueStart < css.length && /\s/.test(css[valueStart])) {
-      valueStart++;
-    }
-
-    const quote = css[valueStart] === '"' || css[valueStart] === "'" ? css[valueStart] : "";
-    if (quote) {
-      valueStart++;
-    }
-
-    let valueEnd = valueStart;
-    while (valueEnd < css.length) {
-      const char = css[valueEnd];
-      if (quote) {
-        if (char === "\\") {
-          valueEnd += 2;
-          continue;
-        }
-        if (char === quote) {
-          break;
-        }
-      } else if (char === ")") {
-        break;
-      }
-      valueEnd++;
-    }
-
-    const value = css.slice(valueStart, valueEnd).trim();
-    if (
-      value &&
-      !value.startsWith("data:") &&
-      !value.startsWith("http:") &&
-      !value.startsWith("https:") &&
-      !value.startsWith("//") &&
-      !value.startsWith("/") &&
-      !value.startsWith("#") &&
-      !value.startsWith("blob:") &&
-      !value.startsWith("var(")
-    ) {
-      return true;
-    }
-
-    cursor = valueEnd + 1;
-  }
-
-  return false;
-}
-
-function createSharedAssetChunk(
-  type: "css" | "js",
-  label: string,
-  content: string,
-  outDir: string,
-  base: string,
-): SharedAssetChunk {
-  const hash = createContentHash(content);
-  const fileName = `ox-content-${sanitizeChunkLabel(label)}-${hash}.${type}`;
-
-  return {
-    outputPath: path.join(outDir, "assets", fileName),
-    publicPath: toPublicAssetPath(base, fileName),
-    content,
-  };
-}
-
-function extractCssSections(cssContent: string): CssSection[] {
-  return Array.from(cssContent.matchAll(CSS_SECTION_RE))
-    .map(([, name, content]) => ({
-      name,
-      content: content.trim(),
-    }))
-    .filter((section) => section.content.length > 0);
-}
-
-function getOrCreateSharedChunk(
-  chunks: Map<string, SharedAssetChunk>,
-  type: "css" | "js",
-  label: string,
-  content: string,
-  outDir: string,
-  base: string,
-): SharedAssetChunk {
-  let chunk = chunks.get(content);
-  if (!chunk) {
-    chunk = createSharedAssetChunk(type, label, content, outDir, base);
-    chunks.set(content, chunk);
-  }
-  return chunk;
-}
-
-function buildStyleReplacement(
-  cssContent: string,
-  cssChunks: Map<string, SharedAssetChunk>,
-  outDir: string,
-  base: string,
-): string {
-  const sections = extractCssSections(cssContent);
-  const effectiveSections =
-    sections.length > 0
-      ? sections
-      : [
-          {
-            name: "css",
-            content: cssContent.trim(),
-          },
-        ];
-
-  const coreContent = effectiveSections
-    .filter((section) => CORE_CSS_SECTION_NAMES.has(section.name))
-    .map((section) => section.content)
-    .join("\n")
-    .trim();
-  const fragments: string[] = [];
-
-  if (coreContent) {
-    const coreChunk = getOrCreateSharedChunk(cssChunks, "css", "core", coreContent, outDir, base);
-    fragments.push(`  <link rel="stylesheet" href="${coreChunk.publicPath}">`);
-  }
-
-  for (const section of effectiveSections) {
-    if (CORE_CSS_SECTION_NAMES.has(section.name)) {
-      continue;
-    }
-
-    const shouldInlineTheme =
-      section.name === "theme" &&
-      (hasRelativeCssUrls(section.content) || section.content.length <= THEME_INLINE_CSS_MAX_BYTES);
-    if (shouldInlineTheme || hasRelativeCssUrls(section.content)) {
-      fragments.push(`  <style>${section.content}</style>`);
-      continue;
-    }
-
-    const chunk = getOrCreateSharedChunk(
-      cssChunks,
-      "css",
-      section.name,
-      section.content,
-      outDir,
-      base,
-    );
-    fragments.push(`  <link rel="stylesheet" href="${chunk.publicPath}">`);
-  }
-
-  return fragments.join("\n");
-}
-
-function buildScriptReplacement(
-  jsContent: string,
-  jsChunks: Map<string, SharedAssetChunk>,
-  outDir: string,
-  base: string,
-): string {
-  const searchMatch = jsContent.match(SEARCH_CHUNK_RE);
-
-  if (searchMatch && jsContent.includes(SEARCH_CHUNK_PLACEHOLDER)) {
-    const searchContent = searchMatch[1].trim();
-    if (searchContent) {
-      const searchChunk = getOrCreateSharedChunk(
-        jsChunks,
-        "js",
-        "search",
-        searchContent,
-        outDir,
-        base,
-      );
-      const coreContent = jsContent
-        .replace(SEARCH_CHUNK_RE, "")
-        .replaceAll(SEARCH_CHUNK_PLACEHOLDER, searchChunk.publicPath)
-        .trim();
-
-      if (coreContent) {
-        const coreChunk = getOrCreateSharedChunk(jsChunks, "js", "core", coreContent, outDir, base);
-        return `  <script defer src="${coreChunk.publicPath}"></script>`;
-      }
-    }
-  }
-
-  const fallbackContent = jsContent.trim();
-  if (!fallbackContent) {
-    return "";
-  }
-
-  const chunk = getOrCreateSharedChunk(jsChunks, "js", "js", fallbackContent, outDir, base);
-  return `  <script defer src="${chunk.publicPath}"></script>`;
 }
 
 async function externalizeSharedPageAssets(
@@ -1900,56 +1667,22 @@ async function externalizeSharedPageAssets(
   outDir: string,
   base: string,
 ): Promise<{ pages: GeneratedHtmlPage[]; assets: string[] }> {
-  const cssChunks = new Map<string, SharedAssetChunk>();
-  const jsChunks = new Map<string, SharedAssetChunk>();
+  const mod = await importNapiModule();
+  const optimized = mod.externalizeSsgAssets(pages, outDir, base) as {
+    pages: GeneratedHtmlPage[];
+    assets: ExternalizedSharedAsset[];
+  };
 
-  const optimizedPages = pages.map((page) => {
-    let html = page.html;
-
-    const styleMatch = html.match(SSG_STYLE_BLOCK_RE);
-    if (styleMatch) {
-      const replacement = buildStyleReplacement(styleMatch[1], cssChunks, outDir, base);
-      html = html.replace(SSG_STYLE_BLOCK_RE, replacement);
-    } else {
-      const inlineStyleMatch = html.match(FIRST_INLINE_STYLE_RE);
-      if (inlineStyleMatch) {
-        const replacement = buildStyleReplacement(inlineStyleMatch[1], cssChunks, outDir, base);
-        html = html.replace(FIRST_INLINE_STYLE_RE, replacement);
-      }
-    }
-
-    const scriptMatch = html.match(SSG_SCRIPT_BLOCK_RE);
-    if (scriptMatch) {
-      const replacement = buildScriptReplacement(scriptMatch[1], jsChunks, outDir, base);
-      html = html.replace(SSG_SCRIPT_BLOCK_RE, replacement);
-    } else {
-      const inlineScriptMatch = html.match(LAST_INLINE_BODY_SCRIPT_RE);
-      if (inlineScriptMatch) {
-        const replacement = buildScriptReplacement(inlineScriptMatch[1], jsChunks, outDir, base);
-        html = html.replace(
-          LAST_INLINE_BODY_SCRIPT_RE,
-          replacement ? `${replacement}\n</body>` : "</body>",
-        );
-      }
-    }
-
-    return {
-      ...page,
-      html,
-    };
-  });
-
-  const chunks = [...cssChunks.values(), ...jsChunks.values()];
   await Promise.all(
-    chunks.map(async (chunk) => {
-      await fs.mkdir(path.dirname(chunk.outputPath), { recursive: true });
-      await fs.writeFile(chunk.outputPath, chunk.content, "utf-8");
+    optimized.assets.map(async (asset) => {
+      await fs.mkdir(path.dirname(asset.outputPath), { recursive: true });
+      await fs.writeFile(asset.outputPath, asset.content, "utf-8");
     }),
   );
 
   return {
-    pages: optimizedPages,
-    assets: chunks.map((chunk) => chunk.outputPath),
+    pages: optimized.pages,
+    assets: optimized.assets.map((asset) => asset.outputPath),
   };
 }
 


### PR DESCRIPTION
## Summary
- move SSG shared CSS/JS asset extraction and hashing into `ox_content_ssg`
- expose `externalizeSsgAssets` through the NAPI package
- keep TypeScript focused on calling NAPI and writing generated assets

## Validation
- `cargo fmt --all`
- `cargo test -p ox_content_ssg -p ox_content_napi`
- `pnpm --filter @ox-content/napi build:debug`
- `pnpm exec vp test npm/vite-plugin-ox-content/src/ssg.test.ts`
- `pnpm exec vp check`
- `git diff --check`