### PR TITLE
feat(vite-plugin): support mdx content files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 
 - **Blazing Fast** - Arena-allocated parser with zero-copy parsing
 - **mdast Compatible** - Run custom mdast plugins and existing remark/unified transforms
+- **MDX-ready Files** - Process `.mdx` alongside Markdown in Vite, SSG, and framework integrations
 - **GFM Support** - Tables, task lists, strikethrough, autolinks, footnotes
 - **Multi-Runtime** - Node.js (NAPI), WebAssembly, Native Rust
 - **Framework Agnostic** - Works with Vue, React, Svelte, and more

--- a/crates/ox_content_renderer/src/html.rs
+++ b/crates/ox_content_renderer/src/html.rs
@@ -1344,7 +1344,7 @@ impl HtmlRenderer {
         output
     }
 
-    /// Converts a `.md` URL to `.html` URL for SSG output.
+    /// Converts a Markdown URL to an `.html` URL for SSG output.
     fn convert_md_url(&self, url: &str) -> String {
         // Split URL into path and fragment
         let (path, fragment) = match url.split_once('#') {
@@ -1352,16 +1352,23 @@ impl HtmlRenderer {
             None => (url, None),
         };
 
-        let is_md = std::path::Path::new(path)
-            .extension()
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("md"));
+        let markdown_extension =
+            std::path::Path::new(path).extension().and_then(|ext| ext.to_str()).filter(|ext| {
+                ext.eq_ignore_ascii_case("md")
+                    || ext.eq_ignore_ascii_case("mdx")
+                    || ext.eq_ignore_ascii_case("markdown")
+            });
 
-        if !self.options.convert_md_links || !is_md {
+        let Some(markdown_extension) = markdown_extension else {
+            return url.to_string();
+        };
+
+        if !self.options.convert_md_links {
             return url.to_string();
         }
 
-        // Remove the .md extension
-        let path_without_ext = &path[..path.len() - 3];
+        // Remove the Markdown extension, including the leading dot.
+        let path_without_ext = &path[..path.len() - markdown_extension.len() - 1];
 
         // Check if the source file is an index file
         // index.md stays at the directory level, so relative paths work differently
@@ -2246,6 +2253,23 @@ mod tests {
             html.contains("href=\"./types/index.html\""),
             "Expected ./types/index.html but got: {html}"
         );
+    }
+
+    #[test]
+    fn test_convert_mdx_and_markdown_links() {
+        let allocator = Allocator::new();
+        let doc = Parser::new(&allocator, "[Component](./component.mdx) [Guide](guide.markdown)")
+            .parse()
+            .unwrap();
+        let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
+            convert_md_links: true,
+            base_url: "/".to_string(),
+            source_path: "api/index.mdx".to_string(),
+            ..Default::default()
+        });
+        let html = renderer.render(&doc);
+        assert!(html.contains("href=\"./component/index.html\""), "Got: {html}");
+        assert!(html.contains("href=\"./guide/index.html\""), "Got: {html}");
     }
 
     #[test]

--- a/crates/ox_content_ssg/src/routes.rs
+++ b/crates/ox_content_ssg/src/routes.rs
@@ -325,6 +325,9 @@ fn strip_markdown_extension(path: &str) -> String {
     if path.len() >= 3 && path[path.len() - 3..].eq_ignore_ascii_case(".md") {
         return path[..path.len() - 3].to_string();
     }
+    if path.len() >= 4 && path[path.len() - 4..].eq_ignore_ascii_case(".mdx") {
+        return path[..path.len() - 4].to_string();
+    }
     if path.len() >= 9 && path[path.len() - 9..].eq_ignore_ascii_case(".markdown") {
         return path[..path.len() - 9].to_string();
     }
@@ -489,6 +492,7 @@ mod tests {
             get_output_path("/repo/docs/guide/intro.md", root, "/repo/dist", ".html"),
             join_path("/repo/dist", "guide/intro/index.html")
         );
+        assert_eq!(get_url_path("/repo/docs/reference.mdx", root), "reference");
         assert_eq!(
             get_og_image_url(
                 "/repo/docs/guide/index.markdown",

--- a/docs/content/packages/vite-plugin-ox-content.md
+++ b/docs/content/packages/vite-plugin-ox-content.md
@@ -71,6 +71,13 @@ ox-content's `layout: entry`.
 
 Source directory for Markdown files.
 
+### extensions
+
+- Type: `string[]`
+- Default: `['.md', '.markdown', '.mdx']`
+
+Markdown-like file extensions processed by the Vite plugin, SSG, dev server, search index, and OG viewer.
+
 ### outDir
 
 - Type: `string`

--- a/npm/unplugin-ox-content/src/index.ts
+++ b/npm/unplugin-ox-content/src/index.ts
@@ -87,7 +87,7 @@ function resolveDocsConfig(docs: boolean | DocsConfig | undefined): ResolvedDocs
  * Resolves plugin options with defaults.
  */
 function resolveOptions(options: OxContentOptions): ResolvedOptions {
-  const extensions = options.extensions ?? [".md", ".markdown"];
+  const extensions = options.extensions ?? [".md", ".markdown", ".mdx"];
   return {
     srcDir: options.srcDir ?? "docs",
     gfm: options.gfm ?? true,

--- a/npm/unplugin-ox-content/src/transform.test.ts
+++ b/npm/unplugin-ox-content/src/transform.test.ts
@@ -335,7 +335,7 @@ function createResolvedOptions(overrides?: Partial<ResolvedOptions>): ResolvedOp
     frontmatter: true,
     toc: true,
     tocMaxDepth: 3,
-    extensions: [".md"],
+    extensions: [".md", ".markdown", ".mdx"],
     include: [],
     exclude: [],
     plugin: {

--- a/npm/unplugin-ox-content/src/types.ts
+++ b/npm/unplugin-ox-content/src/types.ts
@@ -353,7 +353,7 @@ export interface OxContentOptions {
 
   /**
    * File extensions to process.
-   * @default ['.md', '.markdown']
+   * @default ['.md', '.markdown', '.mdx']
    */
   extensions?: string[];
 

--- a/npm/vite-plugin-ox-content-react/src/index.ts
+++ b/npm/vite-plugin-ox-content-react/src/index.ts
@@ -17,6 +17,25 @@ import type {
   ComponentsOption,
 } from "./types";
 
+const DEFAULT_MARKDOWN_EXTENSIONS = [".md", ".markdown", ".mdx"] as const;
+
+function normalizeMarkdownExtensions(extensions?: readonly string[]): string[] {
+  const values = extensions?.length ? extensions : DEFAULT_MARKDOWN_EXTENSIONS;
+  return Array.from(
+    new Map(
+      values.map((extension) => {
+        const value = extension.startsWith(".") ? extension : `.${extension}`;
+        return [value.toLowerCase(), value] as const;
+      }),
+    ).values(),
+  );
+}
+
+function isMarkdownFilePath(filePath: string, extensions: readonly string[]): boolean {
+  const pathname = filePath.split("?")[0].split("#")[0].toLowerCase();
+  return extensions.some((extension) => pathname.endsWith(extension.toLowerCase()));
+}
+
 export type {
   ReactIntegrationOptions,
   ResolvedReactOptions,
@@ -73,7 +92,7 @@ export function oxContentReact(options: ReactIntegrationOptions = {}): PluginOpt
     },
 
     async transform(code, id) {
-      if (!id.endsWith(".md")) {
+      if (!isMarkdownFilePath(id, resolved.extensions)) {
         return null;
       }
 
@@ -141,8 +160,8 @@ export function oxContentReact(options: ReactIntegrationOptions = {}): PluginOpt
       );
 
       if (isComponent) {
-        const mdModules = Array.from(server.moduleGraph.idToModuleMap.values()).filter((mod) =>
-          mod.file?.endsWith(".md"),
+        const mdModules = Array.from(server.moduleGraph.idToModuleMap.values()).filter(
+          (mod) => mod.file && isMarkdownFilePath(mod.file, resolved.extensions),
         );
 
         if (mdModules.length > 0) {
@@ -179,6 +198,7 @@ function resolveReactOptions(
     srcDir: options.srcDir ?? "docs",
     outDir: options.outDir ?? "dist",
     base: options.base ?? "/",
+    extensions: normalizeMarkdownExtensions(options.extensions),
     gfm: options.gfm ?? true,
     frontmatter: options.frontmatter ?? true,
     toc: options.toc ?? true,

--- a/npm/vite-plugin-ox-content-react/src/transform.ts
+++ b/npm/vite-plugin-ox-content-react/src/transform.ts
@@ -75,6 +75,7 @@ export async function transformMarkdownWithReact(
     srcDir: options.srcDir,
     outDir: options.outDir,
     base: options.base,
+    extensions: options.extensions,
     ssg: {
       enabled: false,
       extension: ".html",

--- a/npm/vite-plugin-ox-content-react/src/types.ts
+++ b/npm/vite-plugin-ox-content-react/src/types.ts
@@ -19,6 +19,12 @@ export type ComponentsOption = ComponentsMap | string | string[];
 
 export interface ReactIntegrationOptions extends OxContentOptions {
   /**
+   * Markdown-like file extensions to process.
+   * @default ['.md', '.markdown', '.mdx']
+   */
+  extensions?: string[];
+
+  /**
    * Components to register for use in Markdown.
    * Can be a map of names to paths, a glob pattern, or an array of globs.
    * When using glob patterns, component names are derived from file names.
@@ -41,6 +47,7 @@ export interface ResolvedReactOptions {
   srcDir: string;
   outDir: string;
   base: string;
+  extensions: string[];
   gfm: boolean;
   frontmatter: boolean;
   toc: boolean;

--- a/npm/vite-plugin-ox-content-svelte/src/index.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/index.ts
@@ -17,6 +17,25 @@ import type {
   ComponentsOption,
 } from "./types";
 
+const DEFAULT_MARKDOWN_EXTENSIONS = [".md", ".markdown", ".mdx"] as const;
+
+function normalizeMarkdownExtensions(extensions?: readonly string[]): string[] {
+  const values = extensions?.length ? extensions : DEFAULT_MARKDOWN_EXTENSIONS;
+  return Array.from(
+    new Map(
+      values.map((extension) => {
+        const value = extension.startsWith(".") ? extension : `.${extension}`;
+        return [value.toLowerCase(), value] as const;
+      }),
+    ).values(),
+  );
+}
+
+function isMarkdownFilePath(filePath: string, extensions: readonly string[]): boolean {
+  const pathname = filePath.split("?")[0].split("#")[0].toLowerCase();
+  return extensions.some((extension) => pathname.endsWith(extension.toLowerCase()));
+}
+
 export type {
   SvelteIntegrationOptions,
   ResolvedSvelteOptions,
@@ -73,7 +92,7 @@ export function oxContentSvelte(options: SvelteIntegrationOptions = {}): PluginO
     },
 
     async transform(code, id) {
-      if (!id.endsWith(".md")) {
+      if (!isMarkdownFilePath(id, resolved.extensions)) {
         return null;
       }
 
@@ -137,8 +156,8 @@ export function oxContentSvelte(options: SvelteIntegrationOptions = {}): PluginO
       );
 
       if (isComponent) {
-        const mdModules = Array.from(server.moduleGraph.idToModuleMap.values()).filter((mod) =>
-          mod.file?.endsWith(".md"),
+        const mdModules = Array.from(server.moduleGraph.idToModuleMap.values()).filter(
+          (mod) => mod.file && isMarkdownFilePath(mod.file, resolved.extensions),
         );
 
         if (mdModules.length > 0) {
@@ -175,6 +194,7 @@ function resolveSvelteOptions(
     srcDir: options.srcDir ?? "docs",
     outDir: options.outDir ?? "dist",
     base: options.base ?? "/",
+    extensions: normalizeMarkdownExtensions(options.extensions),
     gfm: options.gfm ?? true,
     frontmatter: options.frontmatter ?? true,
     toc: options.toc ?? true,

--- a/npm/vite-plugin-ox-content-svelte/src/transform.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/transform.ts
@@ -76,6 +76,7 @@ export async function transformMarkdownWithSvelte(
     srcDir: options.srcDir,
     outDir: options.outDir,
     base: options.base,
+    extensions: options.extensions,
     ssg: {
       enabled: false,
       extension: ".html",

--- a/npm/vite-plugin-ox-content-svelte/src/types.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/types.ts
@@ -19,6 +19,12 @@ export type ComponentsOption = ComponentsMap | string | string[];
 
 export interface SvelteIntegrationOptions extends OxContentOptions {
   /**
+   * Markdown-like file extensions to process.
+   * @default ['.md', '.markdown', '.mdx']
+   */
+  extensions?: string[];
+
+  /**
    * Components to register for use in Markdown.
    * Can be a map of names to paths, a glob pattern, or an array of globs.
    * When using glob patterns, component names are derived from file names.
@@ -41,6 +47,7 @@ export interface ResolvedSvelteOptions {
   srcDir: string;
   outDir: string;
   base: string;
+  extensions: string[];
   gfm: boolean;
   frontmatter: boolean;
   toc: boolean;

--- a/npm/vite-plugin-ox-content-vue/src/environment.ts
+++ b/npm/vite-plugin-ox-content-vue/src/environment.ts
@@ -54,7 +54,7 @@ export function createVueMarkdownEnvironment(
     // Development server options (client only)
     ...(!isSSR && {
       dev: {
-        warmup: ["./src/**/*.vue", "./docs/**/*.md"],
+        warmup: ["./src/**/*.vue", "./docs/**/*.{md,markdown,mdx}"],
       },
     }),
   };

--- a/npm/vite-plugin-ox-content-vue/src/index.ts
+++ b/npm/vite-plugin-ox-content-vue/src/index.ts
@@ -18,6 +18,25 @@ import type {
   ComponentsOption,
 } from "./types";
 
+const DEFAULT_MARKDOWN_EXTENSIONS = [".md", ".markdown", ".mdx"] as const;
+
+function normalizeMarkdownExtensions(extensions?: readonly string[]): string[] {
+  const values = extensions?.length ? extensions : DEFAULT_MARKDOWN_EXTENSIONS;
+  return Array.from(
+    new Map(
+      values.map((extension) => {
+        const value = extension.startsWith(".") ? extension : `.${extension}`;
+        return [value.toLowerCase(), value] as const;
+      }),
+    ).values(),
+  );
+}
+
+function isMarkdownFilePath(filePath: string, extensions: readonly string[]): boolean {
+  const pathname = filePath.split("?")[0].split("#")[0].toLowerCase();
+  return extensions.some((extension) => pathname.endsWith(extension.toLowerCase()));
+}
+
 export type {
   VueIntegrationOptions,
   ResolvedVueOptions,
@@ -79,7 +98,7 @@ export function oxContentVue(options: VueIntegrationOptions = {}): PluginOption[
     },
 
     async transform(code, id) {
-      if (!id.endsWith(".md")) {
+      if (!isMarkdownFilePath(id, resolved.extensions)) {
         return null;
       }
 
@@ -167,8 +186,8 @@ export function oxContentVue(options: VueIntegrationOptions = {}): PluginOption[
 
       if (isComponent) {
         // Invalidate all Markdown modules that might use this component
-        const mdModules = Array.from(server.moduleGraph.idToModuleMap.values()).filter((mod) =>
-          mod.file?.endsWith(".md"),
+        const mdModules = Array.from(server.moduleGraph.idToModuleMap.values()).filter(
+          (mod) => mod.file && isMarkdownFilePath(mod.file, resolved.extensions),
         );
 
         if (mdModules.length > 0) {
@@ -207,6 +226,7 @@ function resolveVueOptions(options: VueIntegrationOptions): ResolvedVueOptions {
     srcDir: options.srcDir ?? "docs",
     outDir: options.outDir ?? "dist",
     base: options.base ?? "/",
+    extensions: normalizeMarkdownExtensions(options.extensions),
     gfm: options.gfm ?? true,
     frontmatter: options.frontmatter ?? true,
     toc: options.toc ?? true,

--- a/npm/vite-plugin-ox-content-vue/src/transform.ts
+++ b/npm/vite-plugin-ox-content-vue/src/transform.ts
@@ -94,6 +94,7 @@ export async function transformMarkdownWithVue(
     srcDir: options.srcDir,
     outDir: options.outDir,
     base: options.base,
+    extensions: options.extensions,
     ssg: {
       enabled: false,
       extension: ".html",
@@ -134,7 +135,7 @@ export async function transformMarkdownWithVue(
       hotkey: "k",
     },
     i18n: false,
-  } as Parameters<typeof baseTransformMarkdown>[2] & {
+  } as unknown as Parameters<typeof baseTransformMarkdown>[2] & {
     codeAnnotations?: TransformOptions["codeAnnotations"];
   };
 

--- a/npm/vite-plugin-ox-content-vue/src/types.ts
+++ b/npm/vite-plugin-ox-content-vue/src/types.ts
@@ -44,6 +44,12 @@ export type ComponentsOption = ComponentsMap | string | string[];
  */
 export interface VueIntegrationOptions extends OxContentOptions {
   /**
+   * Markdown-like file extensions to process.
+   * @default ['.md', '.markdown', '.mdx']
+   */
+  extensions?: string[];
+
+  /**
    * Components to register for use in Markdown.
    * Can be a map of names to paths, a glob pattern, or an array of globs.
    * When using glob patterns, component names are derived from file names.
@@ -82,6 +88,7 @@ export interface ResolvedVueOptions {
   srcDir: string;
   outDir: string;
   base: string;
+  extensions: string[];
   gfm: boolean;
   frontmatter: boolean;
   toc: boolean;

--- a/npm/vite-plugin-ox-content/src/code-annotations.test.ts
+++ b/npm/vite-plugin-ox-content/src/code-annotations.test.ts
@@ -115,6 +115,7 @@ function createResolvedOptions(overrides: Partial<ResolvedOptions> = {}): Resolv
     srcDir: "content",
     outDir: "dist",
     base: "/",
+    extensions: [".md", ".markdown", ".mdx"],
     ssg: {
       enabled: true,
       extension: ".html",

--- a/npm/vite-plugin-ox-content/src/dev-server.ts
+++ b/npm/vite-plugin-ox-content/src/dev-server.ts
@@ -27,6 +27,7 @@ import type { NavGroup, SsgPageData, SsgEntryPageConfig } from "./ssg";
 import type { ResolvedOptions } from "./types";
 import type { HeroConfig, FeatureConfig } from "./types";
 import { normalizeVitePressFrontmatter } from "./vitepress";
+import { isMarkdownFilePath } from "./markdown";
 
 /** File extensions to skip in the middleware. */
 const SKIP_EXTENSIONS = new Set([
@@ -83,7 +84,11 @@ function shouldSkip(url: string): boolean {
  * Resolve a request URL to a markdown file path.
  * Returns null if no matching file exists.
  */
-async function resolveMarkdownFile(url: string, srcDir: string): Promise<string | null> {
+async function resolveMarkdownFile(
+  url: string,
+  srcDir: string,
+  extensions: readonly string[],
+): Promise<string | null> {
   // Remove query string and hash
   let pathname = url.split("?")[0].split("#")[0];
 
@@ -97,30 +102,35 @@ async function resolveMarkdownFile(url: string, srcDir: string): Promise<string 
     pathname = pathname.slice(0, -1);
   }
 
-  // Map URL to potential markdown file path
-  let relativePath: string;
-  if (pathname === "/") {
-    relativePath = "index.md";
-  } else {
-    // Remove leading slash
-    relativePath = pathname.slice(1) + ".md";
+  const routePath = pathname === "/" ? "" : pathname.slice(1);
+  const directCandidates =
+    pathname === "/"
+      ? extensions.map((extension) => `index${extension}`)
+      : isMarkdownFilePath(routePath, extensions)
+        ? [routePath]
+        : extensions.map((extension) => `${routePath}${extension}`);
+
+  for (const relativePath of directCandidates) {
+    const filePath = path.join(srcDir, relativePath);
+    try {
+      await fs.access(filePath);
+      return filePath;
+    } catch {
+      // Try the next extension.
+    }
   }
 
-  const filePath = path.join(srcDir, relativePath);
-
-  try {
-    await fs.access(filePath);
-    return filePath;
-  } catch {
-    // Try as directory index
-    const indexPath = path.join(srcDir, pathname === "/" ? "" : pathname.slice(1), "index.md");
+  for (const extension of extensions) {
+    const indexPath = path.join(srcDir, routePath, `index${extension}`);
     try {
       await fs.access(indexPath);
       return indexPath;
     } catch {
-      return null;
+      // Try the next extension.
     }
   }
+
+  return null;
 }
 
 /**
@@ -374,7 +384,7 @@ export function createDevServerMiddleware(
     if (shouldSkip(routeUrl)) return next();
 
     // Resolve markdown file
-    const filePath = await resolveMarkdownFile(routeUrl, srcDir);
+    const filePath = await resolveMarkdownFile(routeUrl, srcDir, options.extensions);
     if (!filePath) return next();
 
     try {
@@ -394,7 +404,7 @@ export function createDevServerMiddleware(
 
       // Build navigation if not cached
       if (!cache.navGroups) {
-        const markdownFiles = await collectMarkdownFiles(srcDir);
+        const markdownFiles = await collectMarkdownFiles(srcDir, options.extensions);
         cache.navGroups =
           resolveNavigationGroups(options.ssg.navigation, base, options.ssg.extension) ??
           (options.ssg.theme?.sidebar.length

--- a/npm/vite-plugin-ox-content/src/environment.ts
+++ b/npm/vite-plugin-ox-content/src/environment.ts
@@ -7,6 +7,7 @@
 
 import type { EnvironmentOptions } from "vite";
 import type { ResolvedOptions } from "./types";
+import { isMarkdownFilePath } from "./markdown";
 
 /**
  * Creates the Markdown processing environment configuration.
@@ -58,8 +59,8 @@ export function createMarkdownEnvironment(options: ResolvedOptions): Environment
 
     // Resolve configuration
     resolve: {
-      // Handle .md files
-      extensions: [".md", ".markdown"],
+      // Handle Markdown-like files
+      extensions: options.extensions,
 
       // Conditions for module resolution
       conditions: ["markdown", "node", "import"],
@@ -146,7 +147,7 @@ export async function prerender(
  *
  * Creates plugins specific to the Markdown environment.
  */
-export function createEnvironmentPlugins(_options: ResolvedOptions) {
+export function createEnvironmentPlugins(options: ResolvedOptions) {
   return [
     {
       name: "ox-content:markdown-env",
@@ -158,7 +159,7 @@ export function createEnvironmentPlugins(_options: ResolvedOptions) {
 
       // Transform within the environment
       transform(code: string, id: string) {
-        if (!id.endsWith(".md")) {
+        if (!isMarkdownFilePath(id, options.extensions)) {
           return null;
         }
 

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -26,6 +26,7 @@ import {
 } from "./dev-server";
 import { createOgViewerPlugin } from "./og-viewer";
 import { resolveI18nOptions, createI18nPlugin } from "./i18n";
+import { isMarkdownFilePath, normalizeMarkdownExtensions } from "./markdown";
 import type { OxContentOptions, ResolvedOptions } from "./types";
 
 export type { OxContentOptions } from "./types";
@@ -113,7 +114,7 @@ export function oxContent(options: OxContentOptions = {}): Plugin[] {
       // Add middleware for serving Markdown files
       devServer.middlewares.use(async (req, res, next) => {
         const url = req.url;
-        if (!url || !url.endsWith(".md")) {
+        if (!url || !isMarkdownFilePath(url, resolvedOptions.extensions)) {
           return next();
         }
 
@@ -128,8 +129,8 @@ export function oxContent(options: OxContentOptions = {}): Plugin[] {
         return "\0" + id;
       }
 
-      // Resolve .md files
-      if (id.endsWith(".md")) {
+      // Resolve Markdown files
+      if (isMarkdownFilePath(id, resolvedOptions.extensions)) {
         return id;
       }
 
@@ -147,7 +148,7 @@ export function oxContent(options: OxContentOptions = {}): Plugin[] {
     },
 
     async transform(code, id) {
-      if (!id.endsWith(".md")) {
+      if (!isMarkdownFilePath(id, resolvedOptions.extensions)) {
         return null;
       }
 
@@ -162,7 +163,7 @@ export function oxContent(options: OxContentOptions = {}): Plugin[] {
 
     // Hot Module Replacement support
     async handleHotUpdate({ file, server }) {
-      if (file.endsWith(".md")) {
+      if (isMarkdownFilePath(file, resolvedOptions.extensions)) {
         // Notify client about the update
         server.ws.send({
           type: "custom",
@@ -264,7 +265,7 @@ export function oxContent(options: OxContentOptions = {}): Plugin[] {
 
       // Watch for .md file add/unlink to invalidate nav cache
       devServer.watcher.on("add", (file: string) => {
-        if (file.startsWith(srcDir) && file.endsWith(".md")) {
+        if (file.startsWith(srcDir) && isMarkdownFilePath(file, resolvedOptions.extensions)) {
           invalidateNavCache(ssgDevCache);
           devServer.ws.send({
             type: "custom",
@@ -274,7 +275,7 @@ export function oxContent(options: OxContentOptions = {}): Plugin[] {
         }
       });
       devServer.watcher.on("unlink", (file: string) => {
-        if (file.startsWith(srcDir) && file.endsWith(".md")) {
+        if (file.startsWith(srcDir) && isMarkdownFilePath(file, resolvedOptions.extensions)) {
           invalidateNavCache(ssgDevCache);
           devServer.ws.send({
             type: "custom",
@@ -286,7 +287,7 @@ export function oxContent(options: OxContentOptions = {}): Plugin[] {
 
       // Watch for .md file changes to invalidate page cache
       devServer.watcher.on("change", (file: string) => {
-        if (file.startsWith(srcDir) && file.endsWith(".md")) {
+        if (file.startsWith(srcDir) && isMarkdownFilePath(file, resolvedOptions.extensions)) {
           invalidatePageCache(ssgDevCache, file);
         }
       });
@@ -353,7 +354,11 @@ export function oxContent(options: OxContentOptions = {}): Plugin[] {
       const srcDir = path.resolve(root, resolvedOptions.srcDir);
 
       try {
-        searchIndexJson = await buildSearchIndex(srcDir, resolvedOptions.base);
+        searchIndexJson = await buildSearchIndex(
+          srcDir,
+          resolvedOptions.base,
+          resolvedOptions.extensions,
+        );
         console.log("[ox-content] Search index built");
       } catch (err) {
         console.warn("[ox-content] Failed to build search index:", err);
@@ -399,6 +404,7 @@ function resolveOptions(options: OxContentOptions): ResolvedOptions {
     srcDir: options.srcDir ?? "content",
     outDir: options.outDir ?? "dist",
     base: options.base ?? "/",
+    extensions: normalizeMarkdownExtensions(options.extensions),
     ssg: resolveSsgOptions(options.ssg),
     gfm: options.gfm ?? true,
     footnotes: options.footnotes ?? true,
@@ -535,6 +541,12 @@ export type {
 } from "./lint-files";
 export { buildSsg, resolveSsgOptions, DEFAULT_HTML_TEMPLATE } from "./ssg";
 export { resolveSearchOptions, buildSearchIndex, writeSearchIndex } from "./search";
+export {
+  DEFAULT_MARKDOWN_EXTENSIONS,
+  normalizeMarkdownExtensions,
+  isMarkdownFilePath,
+  stripMarkdownExtension,
+} from "./markdown";
 export { defineTheme, defaultTheme, mergeThemes, resolveTheme } from "./theme";
 export {
   fromVitePressConfig,

--- a/npm/vite-plugin-ox-content/src/lint-files.ts
+++ b/npm/vite-plugin-ox-content/src/lint-files.ts
@@ -9,7 +9,7 @@ import {
   type MarkdownLintResult,
 } from "./lint";
 
-const DEFAULT_LINT_FILE_INCLUDE = ["**/*.md", "**/*.markdown"] as const;
+const DEFAULT_LINT_FILE_INCLUDE = ["**/*.md", "**/*.markdown", "**/*.mdx"] as const;
 const DEFAULT_LINT_FILE_EXCLUDE = ["**/node_modules/**", "**/.git/**", "**/dist/**"] as const;
 
 /**
@@ -28,7 +28,7 @@ export interface MarkdownLintFileOptions extends MarkdownLintOptions {
 
   /**
    * Glob patterns for files to lint.
-   * @default ['**\/*.md', '**\/*.markdown']
+   * @default ['**\/*.md', '**\/*.markdown', '**\/*.mdx']
    */
   include?: string[];
 

--- a/npm/vite-plugin-ox-content/src/markdown.test.ts
+++ b/npm/vite-plugin-ox-content/src/markdown.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  isMarkdownFilePath,
+  markdownGlobPattern,
+  normalizeMarkdownExtensions,
+  stripMarkdownExtension,
+} from "./markdown";
+
+describe("markdown extension helpers", () => {
+  it("treats mdx as a first-class markdown extension", () => {
+    const extensions = normalizeMarkdownExtensions(["md", ".markdown", ".mdx", ".MD"]);
+
+    expect(extensions).toEqual([".md", ".markdown", ".mdx"]);
+    expect(isMarkdownFilePath("/docs/page.mdx?raw", extensions)).toBe(true);
+    expect(stripMarkdownExtension("guide/component.mdx", extensions)).toBe("guide/component");
+    expect(stripMarkdownExtension("guide/intro.markdown", extensions)).toBe("guide/intro");
+  });
+
+  it("builds glob patterns for configured markdown extensions", () => {
+    expect(markdownGlobPattern("/repo/docs", [".mdx"])).toBe("/repo/docs/**/*.mdx");
+    expect(markdownGlobPattern("/repo/docs", [".md", ".mdx"])).toBe("/repo/docs/**/*.{md,mdx}");
+  });
+});

--- a/npm/vite-plugin-ox-content/src/markdown.ts
+++ b/npm/vite-plugin-ox-content/src/markdown.ts
@@ -1,0 +1,47 @@
+import * as path from "path";
+
+export const DEFAULT_MARKDOWN_EXTENSIONS = [".md", ".markdown", ".mdx"] as const;
+
+export function normalizeMarkdownExtensions(extensions?: readonly string[]): string[] {
+  const values = extensions?.length ? extensions : DEFAULT_MARKDOWN_EXTENSIONS;
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const extension of values) {
+    const value = extension.startsWith(".") ? extension : `.${extension}`;
+    const key = value.toLowerCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      normalized.push(value);
+    }
+  }
+
+  return normalized;
+}
+
+export function isMarkdownFilePath(
+  filePath: string,
+  extensions: readonly string[] = DEFAULT_MARKDOWN_EXTENSIONS,
+): boolean {
+  const pathname = filePath.split("?")[0].split("#")[0].toLowerCase();
+  return extensions.some((extension) => pathname.endsWith(extension.toLowerCase()));
+}
+
+export function stripMarkdownExtension(
+  filePath: string,
+  extensions: readonly string[] = DEFAULT_MARKDOWN_EXTENSIONS,
+): string {
+  const match = [...extensions]
+    .sort((left, right) => right.length - left.length)
+    .find((extension) => filePath.toLowerCase().endsWith(extension.toLowerCase()));
+
+  return match ? filePath.slice(0, -match.length) : filePath;
+}
+
+export function markdownGlobPattern(srcDir: string, extensions: readonly string[]): string {
+  const suffixes = extensions.map((extension) => extension.replace(/^\./, ""));
+  if (suffixes.length === 1) {
+    return path.join(srcDir, `**/*.${suffixes[0]}`);
+  }
+  return path.join(srcDir, `**/*.{${suffixes.join(",")}}`);
+}

--- a/npm/vite-plugin-ox-content/src/og-viewer.ts
+++ b/npm/vite-plugin-ox-content/src/og-viewer.ts
@@ -12,6 +12,7 @@ import { glob } from "glob";
 import type { Plugin } from "vite";
 import type { ResolvedOptions } from "./types";
 import { normalizeVitePressFrontmatter } from "./vitepress";
+import { markdownGlobPattern, stripMarkdownExtension } from "./markdown";
 
 // =============================================================================
 // Types
@@ -76,9 +77,9 @@ function extractTitle(content: string, frontmatter: Record<string, unknown>): st
   return match ? match[1].trim() : "";
 }
 
-function getUrlPath(filePath: string, srcDir: string): string {
+function getUrlPath(filePath: string, srcDir: string, extensions: readonly string[]): string {
   let rel = path.relative(srcDir, filePath).replace(/\\/g, "/");
-  rel = rel.replace(/\.md$/, "");
+  rel = stripMarkdownExtension(rel, extensions);
   if (rel === "index") return "/";
   if (rel.endsWith("/index")) rel = rel.slice(0, -"/index".length);
   return "/" + rel;
@@ -139,7 +140,7 @@ function validatePage(
 
 async function collectPages(options: ResolvedOptions, root: string): Promise<PageOgData[]> {
   const srcDir = path.resolve(root, options.srcDir);
-  const files = await glob("**/*.md", { cwd: srcDir, absolute: true });
+  const files = await glob(markdownGlobPattern(srcDir, options.extensions), { absolute: true });
 
   const pages: PageOgData[] = [];
   const generateOgImage = options.ogImage || options.ssg.generateOgImage;
@@ -160,7 +161,7 @@ async function collectPages(options: ResolvedOptions, root: string): Promise<Pag
         ? [frontmatter.tags]
         : [];
 
-    const urlPath = getUrlPath(file, srcDir);
+    const urlPath = getUrlPath(file, srcDir, options.extensions);
     const ogImageUrl = computeOgImageUrl(
       urlPath,
       options.base,

--- a/npm/vite-plugin-ox-content/src/search.ts
+++ b/npm/vite-plugin-ox-content/src/search.ts
@@ -7,6 +7,11 @@
 import * as fs from "fs/promises";
 import * as path from "path";
 import { importNapiModule, importNapiModuleSync } from "./napi";
+import {
+  DEFAULT_MARKDOWN_EXTENSIONS,
+  isMarkdownFilePath,
+  stripMarkdownExtension,
+} from "./markdown";
 import type {
   SearchOptions,
   ResolvedSearchOptions,
@@ -85,7 +90,10 @@ export function resolveSearchOptions(
 /**
  * Collects all Markdown files from a directory.
  */
-async function collectMarkdownFiles(dir: string): Promise<string[]> {
+async function collectMarkdownFiles(
+  dir: string,
+  extensions: readonly string[] = DEFAULT_MARKDOWN_EXTENSIONS,
+): Promise<string[]> {
   const files: string[] = [];
 
   async function walk(currentDir: string) {
@@ -97,7 +105,7 @@ async function collectMarkdownFiles(dir: string): Promise<string[]> {
 
         if (entry.isDirectory() && !entry.name.startsWith(".") && entry.name !== "node_modules") {
           await walk(fullPath);
-        } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        } else if (entry.isFile() && isMarkdownFilePath(entry.name, extensions)) {
           files.push(fullPath);
         }
       }
@@ -113,7 +121,11 @@ async function collectMarkdownFiles(dir: string): Promise<string[]> {
 /**
  * Builds the search index from Markdown files.
  */
-export async function buildSearchIndex(srcDir: string, base: string): Promise<string> {
+export async function buildSearchIndex(
+  srcDir: string,
+  base: string,
+  extensions: readonly string[] = DEFAULT_MARKDOWN_EXTENSIONS,
+): Promise<string> {
   const napi = await getOxContent();
 
   if (!napi) {
@@ -126,15 +138,15 @@ export async function buildSearchIndex(srcDir: string, base: string): Promise<st
     });
   }
 
-  const files = await collectMarkdownFiles(srcDir);
+  const files = await collectMarkdownFiles(srcDir, extensions);
   const documents: SearchDocument[] = [];
 
   for (const file of files) {
     try {
       const content = await fs.readFile(file, "utf-8");
       const relativePath = path.relative(srcDir, file);
-      const url = base + relativePath.replace(/\.md$/, "").replace(/\\/g, "/");
-      const id = relativePath.replace(/\.md$/, "").replace(/\\/g, "/");
+      const id = stripMarkdownExtension(relativePath, extensions).replace(/\\/g, "/");
+      const url = base + id;
 
       // Use Rust bindings to extract search content (if available)
       const extractSearchContent = (napi as any).extractSearchContent;

--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -53,6 +53,12 @@ describe("SSG route helpers", () => {
     );
     expect(getUrlPath(inputPath, srcDir)).toBe("guide/intro");
     expect(getHref(inputPath, srcDir, "/docs/", ".html")).toBe("/docs/guide/intro/index.html");
+
+    const mdxPath = path.join(srcDir, "components", "button.mdx");
+    expect(getOutputPath(mdxPath, srcDir, outDir, ".html")).toBe(
+      path.join(outDir, "components", "button", "index.html"),
+    );
+    expect(getUrlPath(mdxPath, srcDir)).toBe("components/button");
   });
 
   it("builds nav groups in the default SSG order", () => {

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -13,6 +13,7 @@ import type { TransformAllOptions } from "./plugins";
 import { protectMermaidSvgs, restoreMermaidSvgs } from "./plugins/mermaid-protect";
 import { transformIslands, hasIslands } from "./island";
 import { importNapiModule, importNapiModuleSync } from "./napi";
+import { DEFAULT_MARKDOWN_EXTENSIONS, markdownGlobPattern } from "./markdown";
 import type {
   ResolvedOptions,
   ResolvedSsgOptions,
@@ -1810,8 +1811,11 @@ export function formatTitle(name: string): string {
 /**
  * Collects all markdown files from the source directory.
  */
-export async function collectMarkdownFiles(srcDir: string): Promise<string[]> {
-  const pattern = path.join(srcDir, "**/*.{md,markdown}");
+export async function collectMarkdownFiles(
+  srcDir: string,
+  extensions: readonly string[] = DEFAULT_MARKDOWN_EXTENSIONS,
+): Promise<string[]> {
+  const pattern = markdownGlobPattern(srcDir, extensions);
   const files = await glob(pattern, {
     nodir: true,
     ignore: ["**/node_modules/**", "**/dist/**", "**/.git/**"],
@@ -1880,7 +1884,7 @@ export async function buildSsg(
   }
 
   // Collect markdown files
-  const markdownFiles = await collectMarkdownFiles(srcDir);
+  const markdownFiles = await collectMarkdownFiles(srcDir, options.extensions);
 
   // Build navigation
   const navItems =

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -236,6 +236,12 @@ export interface OxContentOptions {
   base?: string;
 
   /**
+   * Markdown-like file extensions to process.
+   * @default ['.md', '.markdown', '.mdx']
+   */
+  extensions?: string[];
+
+  /**
    * SSG (Static Site Generation) options.
    * Set to false to disable SSG completely.
    * @default { enabled: true }
@@ -380,6 +386,7 @@ export interface ResolvedOptions {
   srcDir: string;
   outDir: string;
   base: string;
+  extensions: string[];
   ssg: ResolvedSsgOptions;
   gfm: boolean;
   footnotes: boolean;

--- a/npm/vite-plugin-ox-content/test/fixtures/docs-fixture.ts
+++ b/npm/vite-plugin-ox-content/test/fixtures/docs-fixture.ts
@@ -96,6 +96,7 @@ export function createDocsResolvedOptions(
     srcDir: "content",
     outDir: "dist",
     base: "/",
+    extensions: [".md", ".markdown", ".mdx"],
     ssg: {
       enabled: true,
       extension: ".html",


### PR DESCRIPTION
## Summary
- Add `.mdx` to the default content extensions across the vite plugin and framework integrations.
- Preserve MDX file handling in routes, links, docs tooling, search, linting, and OG viewer paths.
- Add focused markdown/route tests and document the MDX default.

## Checks
- `pnpm --filter @ox-content/vite-plugin exec -- vp test src/markdown.test.ts src/ssg.test.ts`
- `cargo test -p ox_content_ssg routes::tests::resolves_index_and_nested_routes`
- `cargo test -p ox_content_renderer html::tests::test_convert_mdx_and_markdown_links`
- `pnpm --filter @ox-content/vite-plugin-react typecheck`
- `pnpm --filter @ox-content/vite-plugin-vue typecheck`
- `pnpm --filter @ox-content/vite-plugin-svelte typecheck`

Closes #18.
