### PR TITLE
feat(vite-plugin): add builtin open graph embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 - **Multi-Runtime** - Node.js (NAPI), WebAssembly, Native Rust
 - **Framework Agnostic** - Works with Vue, React, Svelte, and more
 - **Built-in SSG** - Static site generation with theming, search, and OG images
-- **Built-in Embeds** - Static GitHub repository and source code cards
+- **Built-in Embeds** - Static GitHub repository, source code, and Open Graph link cards
 - **API Docs Generation** - Generate docs from JSDoc/TypeScript (like `cargo doc`)
 - **i18n** - ICU MessageFormat 2 parser, dictionary management, static checker, and LSP
 - **Editor Tooling** - Markdown/MDC LSP plus VS Code, Zed, and Neovim integrations

--- a/docs/content/packages/vite-plugin-ox-content.md
+++ b/docs/content/packages/vite-plugin-ox-content.md
@@ -277,13 +277,27 @@ Source code card classes:
 - `.ox-github-code-line-number`
 - `.ox-github-code-line-content`
 
+Open Graph card classes:
+
+- `.ox-ogp-card`
+- `.ox-ogp-simple`
+- `.ox-ogp-content`
+- `.ox-ogp-title`
+- `.ox-ogp-description`
+- `.ox-ogp-image`
+- `.ox-ogp-meta`
+- `.ox-ogp-domain`
+- `.ox-ogp-favicon`
+
 ```css
 .ox-github-card,
-.ox-github-code {
+.ox-github-code,
+.ox-ogp-card {
   border-color: var(--my-border-color);
 }
 
-.ox-github-code-line-number {
+.ox-github-code-line-number,
+.ox-ogp-domain {
   color: var(--my-muted-color);
 }
 ```

--- a/docs/content/packages/vite-plugin-ox-content.md
+++ b/docs/content/packages/vite-plugin-ox-content.md
@@ -212,7 +212,7 @@ Generate table of contents.
 ### embeds
 
 - Type: `BuiltinEmbedOptions | false`
-- Default: `{ github: true }`
+- Default: `{ github: true, openGraph: true }`
 
 Built-in static embeds are rendered at transform time, with no client-side JavaScript.
 
@@ -222,6 +222,8 @@ Built-in static embeds are rendered at transform time, with no client-side JavaS
 <GitHub permalink="https://github.com/ubugeeei/ox-content/blob/278098b/README.md#L1-L12" />
 
 <GitHub repo="ubugeeei/ox-content" path="README.md" ref="main" loc="1-12" />
+
+<OgCard url="https://github.com/ubugeeei/ox-content" />
 ```
 
 `permalink`, `url`, and `href` accept GitHub `blob` URLs. The `#L1-L12` fragment is used as the source line range. You can also use `repo`, `path`, `ref`, and `loc` when you do not want to paste the full permalink. Source embeds fetch the GitHub contents API and render code directly instead of using an Open Graph preview.
@@ -235,6 +237,9 @@ oxContent({
       token: process.env.GITHUB_TOKEN,
       maxSourceBytes: 200000,
       maxSourceLines: 120,
+    },
+    openGraph: {
+      timeout: 5000,
     },
   },
 });

--- a/npm/vite-plugin-ox-content-react/src/index.ts
+++ b/npm/vite-plugin-ox-content-react/src/index.ts
@@ -40,9 +40,10 @@ function isMarkdownFilePath(filePath: string, extensions: readonly string[]): bo
 function resolveBuiltinEmbedOptions(
   options: BuiltinEmbedOptions | false | undefined,
 ): ResolvedReactOptions["embeds"] {
-  if (options === false) return { github: false };
+  if (options === false) return { github: false, openGraph: false };
   return {
     github: resolveSingleEmbedOptions(options?.github),
+    openGraph: resolveSingleEmbedOptions(options?.openGraph),
   };
 }
 
@@ -59,6 +60,7 @@ export type {
   ComponentsMap,
   BuiltinEmbedOptions,
   GitHubEmbedOptions,
+  OpenGraphEmbedOptions,
   ResolvedBuiltinEmbedOptions,
   ReactTransformResult,
   ComponentIsland,

--- a/npm/vite-plugin-ox-content-react/src/types.ts
+++ b/npm/vite-plugin-ox-content-react/src/types.ts
@@ -52,12 +52,21 @@ export interface GitHubEmbedOptions {
   maxSourceLines?: number;
 }
 
+export interface OpenGraphEmbedOptions {
+  timeout?: number;
+  cache?: boolean;
+  cacheTTL?: number;
+  userAgent?: string;
+}
+
 export interface BuiltinEmbedOptions {
   github?: boolean | GitHubEmbedOptions;
+  openGraph?: boolean | OpenGraphEmbedOptions;
 }
 
 export interface ResolvedBuiltinEmbedOptions {
   github: GitHubEmbedOptions | false;
+  openGraph: OpenGraphEmbedOptions | false;
 }
 
 export interface ResolvedReactOptions {

--- a/npm/vite-plugin-ox-content-svelte/src/index.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/index.ts
@@ -40,9 +40,10 @@ function isMarkdownFilePath(filePath: string, extensions: readonly string[]): bo
 function resolveBuiltinEmbedOptions(
   options: BuiltinEmbedOptions | false | undefined,
 ): ResolvedSvelteOptions["embeds"] {
-  if (options === false) return { github: false };
+  if (options === false) return { github: false, openGraph: false };
   return {
     github: resolveSingleEmbedOptions(options?.github),
+    openGraph: resolveSingleEmbedOptions(options?.openGraph),
   };
 }
 
@@ -59,6 +60,7 @@ export type {
   ComponentsMap,
   BuiltinEmbedOptions,
   GitHubEmbedOptions,
+  OpenGraphEmbedOptions,
   ResolvedBuiltinEmbedOptions,
   SvelteTransformResult,
   ComponentIsland,

--- a/npm/vite-plugin-ox-content-svelte/src/types.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/types.ts
@@ -52,12 +52,21 @@ export interface GitHubEmbedOptions {
   maxSourceLines?: number;
 }
 
+export interface OpenGraphEmbedOptions {
+  timeout?: number;
+  cache?: boolean;
+  cacheTTL?: number;
+  userAgent?: string;
+}
+
 export interface BuiltinEmbedOptions {
   github?: boolean | GitHubEmbedOptions;
+  openGraph?: boolean | OpenGraphEmbedOptions;
 }
 
 export interface ResolvedBuiltinEmbedOptions {
   github: GitHubEmbedOptions | false;
+  openGraph: OpenGraphEmbedOptions | false;
 }
 
 export interface ResolvedSvelteOptions {

--- a/npm/vite-plugin-ox-content-vue/src/index.ts
+++ b/npm/vite-plugin-ox-content-vue/src/index.ts
@@ -41,9 +41,10 @@ function isMarkdownFilePath(filePath: string, extensions: readonly string[]): bo
 function resolveBuiltinEmbedOptions(
   options: BuiltinEmbedOptions | false | undefined,
 ): ResolvedVueOptions["embeds"] {
-  if (options === false) return { github: false };
+  if (options === false) return { github: false, openGraph: false };
   return {
     github: resolveSingleEmbedOptions(options?.github),
+    openGraph: resolveSingleEmbedOptions(options?.openGraph),
   };
 }
 
@@ -60,6 +61,7 @@ export type {
   ComponentsMap,
   BuiltinEmbedOptions,
   GitHubEmbedOptions,
+  OpenGraphEmbedOptions,
   ResolvedBuiltinEmbedOptions,
   VueTransformResult,
   ComponentIsland,

--- a/npm/vite-plugin-ox-content-vue/src/types.ts
+++ b/npm/vite-plugin-ox-content-vue/src/types.ts
@@ -90,12 +90,21 @@ export interface GitHubEmbedOptions {
   maxSourceLines?: number;
 }
 
+export interface OpenGraphEmbedOptions {
+  timeout?: number;
+  cache?: boolean;
+  cacheTTL?: number;
+  userAgent?: string;
+}
+
 export interface BuiltinEmbedOptions {
   github?: boolean | GitHubEmbedOptions;
+  openGraph?: boolean | OpenGraphEmbedOptions;
 }
 
 export interface ResolvedBuiltinEmbedOptions {
   github: GitHubEmbedOptions | false;
+  openGraph: OpenGraphEmbedOptions | false;
 }
 
 /**

--- a/npm/vite-plugin-ox-content/src/code-annotations.test.ts
+++ b/npm/vite-plugin-ox-content/src/code-annotations.test.ts
@@ -162,6 +162,7 @@ function createResolvedOptions(overrides: Partial<ResolvedOptions> = {}): Resolv
     ogViewer: false,
     embeds: {
       github: {},
+      openGraph: {},
     },
     i18n: false,
     ...overrides,

--- a/npm/vite-plugin-ox-content/src/dev-server.ts
+++ b/npm/vite-plugin-ox-content/src/dev-server.ts
@@ -304,7 +304,7 @@ async function renderPage(
     tabs: true,
     youtube: true,
     github: options.embeds.github,
-    ogp: true,
+    openGraph: options.embeds.openGraph,
     mermaid: true,
     githubToken: process.env.GITHUB_TOKEN,
   });

--- a/npm/vite-plugin-ox-content/src/embed.test.ts
+++ b/npm/vite-plugin-ox-content/src/embed.test.ts
@@ -107,20 +107,26 @@ describe("builtin embed input hardening", () => {
     expect(html).toContain('href="#"');
   });
 
-  it("runs GitHub embeds through the shared builtin transform", async () => {
-    const html = await transformBuiltinEmbeds('<GitHub repo="../secret"></GitHub>', {
-      github: {},
-    });
+  it("runs GitHub and Open Graph embeds through the shared builtin transform", async () => {
+    const html = await transformBuiltinEmbeds(
+      '<GitHub repo="../secret"></GitHub><OgCard url="javascript:alert(1)"></OgCard>',
+      {
+        github: {},
+        openGraph: {},
+      },
+    );
 
     expect(html).toContain("ox-github-card");
+    expect(html).toContain("ox-ogp-simple");
     expect(html).toContain('href="#"');
   });
 
   it("can disable builtin embeds", async () => {
-    const input = '<GitHub repo="../secret"></GitHub>';
+    const input = '<GitHub repo="../secret"></GitHub><OgCard url="javascript:alert(1)"></OgCard>';
     await expect(
       transformBuiltinEmbeds(input, {
         github: false,
+        openGraph: false,
       }),
     ).resolves.toBe(input);
   });

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -438,11 +438,13 @@ export function resolveBuiltinEmbedOptions(
   if (options === false) {
     return {
       github: false,
+      openGraph: false,
     };
   }
 
   return {
     github: resolveSingleEmbedOptions(options?.github),
+    openGraph: resolveSingleEmbedOptions(options?.openGraph),
   };
 }
 

--- a/npm/vite-plugin-ox-content/src/plugins/index.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/index.ts
@@ -6,6 +6,7 @@
  */
 
 import type { GitHubOptions } from "./github";
+import type { OgpOptions } from "./ogp";
 
 export { transformTabs, generateTabsCSS, resetTabGroupCounter } from "./tabs";
 
@@ -47,7 +48,8 @@ export interface TransformAllOptions {
   tabs?: boolean;
   youtube?: boolean;
   github?: boolean | GitHubOptions;
-  ogp?: boolean;
+  ogp?: boolean | OgpOptions;
+  openGraph?: boolean | OgpOptions;
   mermaid?: boolean;
   githubToken?: string;
 }
@@ -63,12 +65,14 @@ export async function transformAllPlugins(
     tabs = true,
     youtube = true,
     github = true,
-    ogp = true,
+    ogp,
+    openGraph,
     mermaid = true,
     githubToken,
   } = options;
 
   let result = html;
+  const ogpOptions = openGraph ?? ogp ?? true;
 
   // Order matters: process in dependency order
 
@@ -92,9 +96,13 @@ export async function transformAllPlugins(
   }
 
   // 4. OGP (requires fetch calls)
-  if (ogp) {
+  if (ogpOptions !== false) {
     const { transformOgp } = await import("./ogp");
-    result = await transformOgp(result);
+    result = await transformOgp(
+      result,
+      undefined,
+      typeof ogpOptions === "object" ? ogpOptions : {},
+    );
   }
 
   // 5. Mermaid (requires mermaid library)
@@ -113,6 +121,7 @@ export async function transformBuiltinEmbeds(
   html: string,
   options: {
     github: GitHubOptions | false;
+    openGraph: OgpOptions | false;
   },
 ): Promise<string> {
   let result = html;
@@ -123,6 +132,11 @@ export async function transformBuiltinEmbeds(
       token: process.env.GITHUB_TOKEN,
       ...options.github,
     });
+  }
+
+  if (options.openGraph) {
+    const { transformOgp } = await import("./ogp");
+    result = await transformOgp(result, undefined, options.openGraph);
   }
 
   return result;

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -1957,7 +1957,7 @@ export async function buildSsg(
         tabs: true,
         youtube: true,
         github: options.embeds.github,
-        ogp: true,
+        openGraph: options.embeds.openGraph,
         mermaid: true,
         githubToken: process.env.GITHUB_TOKEN,
       };

--- a/npm/vite-plugin-ox-content/src/transform.ts
+++ b/npm/vite-plugin-ox-content/src/transform.ts
@@ -467,6 +467,7 @@ export async function transformMarkdown(
     html,
     options.embeds ?? {
       github: {},
+      openGraph: {},
     },
   );
 

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -4,7 +4,7 @@
 
 import type { LanguageRegistration, ThemeRegistration } from "shiki";
 import type { ThemeConfig, ResolvedThemeConfig } from "./theme";
-import type { GitHubOptions } from "./plugins";
+import type { GitHubOptions, OgpOptions } from "./plugins";
 
 // =============================================================================
 // Entry Page Types (VitePress-like)
@@ -375,7 +375,7 @@ export interface OxContentOptions {
   /**
    * Built-in static embeds rendered during Markdown transformation.
    * Set to `false` to disable all built-in embeds.
-   * @default { github: true }
+   * @default { github: true, openGraph: true }
    */
   embeds?: BuiltinEmbedOptions | false;
 
@@ -429,6 +429,13 @@ export interface BuiltinEmbedOptions {
    * @default true
    */
   github?: boolean | GitHubOptions;
+
+  /**
+   * Render `<OgCard url="https://example.com" />` Open Graph link cards.
+   * Pass an options object to configure fetching.
+   * @default true
+   */
+  openGraph?: boolean | OgpOptions;
 }
 
 /**
@@ -436,6 +443,7 @@ export interface BuiltinEmbedOptions {
  */
 export interface ResolvedBuiltinEmbedOptions {
   github: GitHubOptions | false;
+  openGraph: OgpOptions | false;
 }
 
 /**

--- a/npm/vite-plugin-ox-content/test/fixtures/docs-fixture.ts
+++ b/npm/vite-plugin-ox-content/test/fixtures/docs-fixture.ts
@@ -144,6 +144,7 @@ export function createDocsResolvedOptions(
     ogViewer: false,
     embeds: {
       github: {},
+      openGraph: {},
     },
     i18n: false,
     ...overrides,


### PR DESCRIPTION
## Summary
- Add `embeds.openGraph` options for static `<OgCard />` link cards.
- Wire Open Graph embed configuration through core, SSG/dev rendering, and React/Vue/Svelte integrations.
- Extend docs and embed tests to cover the combined GitHub/Open Graph built-in transform, including CSS classes for style customization.

## Stack
- Base: `codex/issue-20-github-embed` (#20)
- Replacement for #100 after the #20 branch was restored to GitHub-only changes.

## Checks
- `pnpm --filter @ox-content/vite-plugin exec -- vp test src/embed.test.ts`
- `pnpm --filter @ox-content/vite-plugin-react typecheck`
- `pnpm --filter @ox-content/vite-plugin-vue typecheck`
- `pnpm --filter @ox-content/vite-plugin-svelte typecheck`

Note: Rust-side verification is left to GitHub Actions.

Closes #21.
