### PR TITLE
refactor: build search index in rust

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -7,6 +7,14 @@
  */
 export declare function buildSearchIndex(documents: Array<JsSearchDocument>): string
 
+/**
+ * Builds a search index directly from Markdown files under a source directory.
+ *
+ * File discovery, Markdown parsing, search document extraction, and index
+ * construction all run on the Rust side.
+ */
+export declare function buildSearchIndexFromDirectory(srcDir: string, base: string, extensions: Array<string>): string
+
 /** Builds SSG navigation groups from markdown files. */
 export declare function buildSsgNavItems(markdownFiles: Array<string>, srcDir: string, base: string, extension: string): Array<JsSsgNavGroup>
 

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -88,6 +88,7 @@ module.exports.collectDocsSourceFiles = binding.collectDocsSourceFiles;
 module.exports.generateDocsMarkdown = binding.generateDocsMarkdown;
 module.exports.generateOgImageSvg = binding.generateOgImageSvg;
 module.exports.buildSearchIndex = binding.buildSearchIndex;
+module.exports.buildSearchIndexFromDirectory = binding.buildSearchIndexFromDirectory;
 module.exports.searchIndex = binding.searchIndex;
 module.exports.extractSearchContent = binding.extractSearchContent;
 module.exports.parseScopedSearchQuery = binding.parseScopedSearchQuery;

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -14,6 +14,7 @@ use napi::bindgen_prelude::*;
 use napi::Task;
 use napi_derive::napi;
 use std::collections::HashMap;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -26,7 +27,9 @@ use ox_content_docs::{
 };
 use ox_content_parser::{Parser, ParserOptions};
 use ox_content_renderer::HtmlRenderer;
-use ox_content_search::{DocumentIndexer, SearchIndex, SearchIndexBuilder, SearchOptions};
+use ox_content_search::{
+    DocumentIndexer, SearchDocument, SearchIndex, SearchIndexBuilder, SearchOptions,
+};
 use transfer::TransferPayloadKind;
 use transformer::{parse_frontmatter, MarkdownTransformer};
 
@@ -817,6 +820,76 @@ pub struct JsSearchDocument {
     pub code: Vec<String>,
 }
 
+fn map_search_document(doc: SearchDocument) -> JsSearchDocument {
+    JsSearchDocument {
+        id: doc.id,
+        title: doc.title,
+        url: doc.url,
+        body: doc.body,
+        headings: doc.headings,
+        code: doc.code,
+    }
+}
+
+fn extract_search_document_from_source(
+    source: &str,
+    id: String,
+    url: String,
+    parser_options: ParserOptions,
+) -> SearchDocument {
+    let (content, frontmatter) = parse_frontmatter(source);
+    let frontmatter_title = frontmatter.get("title").and_then(|v| v.as_str()).map(String::from);
+    let allocator = create_allocator_for_source(&content);
+    let parser = Parser::with_options(&allocator, &content, parser_options);
+
+    let result = parser.parse();
+    let document = match &result {
+        Ok(doc) => {
+            let mut indexer = DocumentIndexer::new();
+            indexer.extract(doc);
+
+            SearchDocument {
+                id,
+                title: frontmatter_title
+                    .unwrap_or_else(|| indexer.title().map(String::from).unwrap_or_default()),
+                url,
+                body: indexer.body().to_string(),
+                headings: indexer.headings().to_vec(),
+                code: indexer.code().to_vec(),
+            }
+        }
+        Err(_) => SearchDocument {
+            id,
+            title: frontmatter_title.unwrap_or_default(),
+            url,
+            body: String::new(),
+            headings: Vec::new(),
+            code: Vec::new(),
+        },
+    };
+    drop(result);
+
+    document
+}
+
+fn build_search_index_json(documents: impl IntoIterator<Item = SearchDocument>) -> String {
+    let mut builder = SearchIndexBuilder::new();
+
+    for doc in documents {
+        builder.add_document(doc);
+    }
+
+    builder.build().to_json()
+}
+
+fn search_document_id(src_dir: &Path, file: &str, extensions: &[String]) -> String {
+    let file_path = Path::new(file);
+    let relative_path = file_path.strip_prefix(src_dir).unwrap_or(file_path);
+    let relative_path = relative_path.to_string_lossy().replace('\\', "/");
+
+    ox_content_search::strip_markdown_extension(&relative_path, extensions)
+}
+
 /// Search result for JavaScript.
 #[napi(object)]
 pub struct JsSearchResult {
@@ -873,21 +946,39 @@ impl From<JsSearchOptions> for SearchOptions {
 /// Takes an array of documents and returns a serialized search index as JSON.
 #[napi]
 pub fn build_search_index(documents: Vec<JsSearchDocument>) -> String {
-    let mut builder = SearchIndexBuilder::new();
+    build_search_index_json(documents.into_iter().map(|doc| SearchDocument {
+        id: doc.id,
+        title: doc.title,
+        url: doc.url,
+        body: doc.body,
+        headings: doc.headings,
+        code: doc.code,
+    }))
+}
 
-    for doc in documents {
-        builder.add_document(ox_content_search::SearchDocument {
-            id: doc.id,
-            title: doc.title,
-            url: doc.url,
-            body: doc.body,
-            headings: doc.headings,
-            code: doc.code,
+/// Builds a search index directly from Markdown files under a source directory.
+///
+/// File discovery, Markdown parsing, search document extraction, and index
+/// construction all run on the Rust side.
+#[napi(js_name = "buildSearchIndexFromDirectory")]
+pub fn build_search_index_from_directory(
+    src_dir: String,
+    base: String,
+    extensions: Vec<String>,
+) -> String {
+    let src_path = Path::new(&src_dir);
+    let parser_options = ParserOptions::gfm();
+    let documents = ox_content_search::collect_markdown_files(&src_dir, &extensions)
+        .into_iter()
+        .filter_map(|file| {
+            let source = fs::read_to_string(&file).ok()?;
+            let id = search_document_id(src_path, &file, &extensions);
+            let url = format!("{base}{id}");
+
+            Some(extract_search_document_from_source(&source, id, url, parser_options.clone()))
         });
-    }
 
-    let index = builder.build();
-    index.to_json()
+    build_search_index_json(documents)
 }
 
 /// Searches a serialized index.
@@ -1782,32 +1873,8 @@ pub fn extract_search_content(
     url: String,
     options: Option<JsParserOptions>,
 ) -> JsSearchDocument {
-    // Parse frontmatter first
-    let (content, frontmatter) = parse_frontmatter(&source);
-    let allocator = create_allocator_for_source(&content);
     let parser_options = options.map(ParserOptions::from).unwrap_or_default();
-
-    // Try to get title from frontmatter
-    let frontmatter_title = frontmatter.get("title").and_then(|v| v.as_str()).map(String::from);
-
-    let parser = Parser::with_options(&allocator, &content, parser_options);
-
-    let result = parser.parse();
-    let (title, body, headings, code) = if let Ok(ref doc) = result {
-        let mut indexer = DocumentIndexer::new();
-        indexer.extract(doc);
-
-        let title = frontmatter_title
-            .unwrap_or_else(|| indexer.title().map(String::from).unwrap_or_default());
-
-        (title, indexer.body().to_string(), indexer.headings().to_vec(), indexer.code().to_vec())
-    } else {
-        (frontmatter_title.unwrap_or_default(), String::new(), Vec::new(), Vec::new())
-    };
-    // Explicitly drop the result to release the borrow
-    drop(result);
-
-    JsSearchDocument { id, title, url, body, headings, code }
+    map_search_document(extract_search_document_from_source(&source, id, url, parser_options))
 }
 
 // =============================================================================
@@ -2288,6 +2355,35 @@ mod tests {
 
         assert!(result.html.contains("href=\"#intro\""));
         assert!(!result.html.contains("href=\"#api\""));
+    }
+
+    #[test]
+    fn builds_search_index_from_directory() {
+        let root =
+            std::env::temp_dir().join(format!("ox-content-napi-search-{}", std::process::id()));
+        let docs_dir = root.join("docs");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(docs_dir.join("guide")).unwrap();
+        fs::write(
+            docs_dir.join("guide/intro.markdown"),
+            "---\ntitle: Native Search\n---\n# Intro\n\nSearch body text.",
+        )
+        .unwrap();
+
+        let index_json = super::build_search_index_from_directory(
+            docs_dir.to_string_lossy().into_owned(),
+            "/docs/".to_string(),
+            vec![".md".to_string(), ".markdown".to_string()],
+        );
+        let index = ox_content_search::SearchIndex::from_json(&index_json).unwrap();
+
+        assert_eq!(index.doc_count, 1);
+        assert_eq!(index.documents[0].id, "guide/intro");
+        assert_eq!(index.documents[0].title, "Native Search");
+        assert_eq!(index.documents[0].url, "/docs/guide/intro");
+        assert!(index.documents[0].body.contains("Search body text"));
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/ox_content_search/src/files.rs
+++ b/crates/ox_content_search/src/files.rs
@@ -13,6 +13,19 @@ pub fn collect_markdown_files(src_dir: &str, extensions: &[String]) -> Vec<Strin
     files
 }
 
+/// Removes the matching Markdown extension from a file path.
+#[must_use]
+pub fn strip_markdown_extension(file_path: &str, extensions: &[String]) -> String {
+    let mut extensions = normalize_markdown_extensions(extensions);
+    extensions.sort_by_key(|extension| std::cmp::Reverse(extension.len()));
+
+    let lower_path = file_path.to_ascii_lowercase();
+    extensions.iter().find(|extension| lower_path.ends_with(extension.as_str())).map_or_else(
+        || file_path.to_string(),
+        |extension| file_path[..file_path.len() - extension.len()].to_string(),
+    )
+}
+
 fn collect_markdown_files_inner(dir: &Path, extensions: &[String], files: &mut Vec<String>) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;
@@ -86,5 +99,24 @@ mod tests {
         assert!(files.iter().any(|file| file.ends_with("docs/guide/intro.mdx")));
 
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn strips_longest_matching_markdown_extension() {
+        assert_eq!(
+            strip_markdown_extension(
+                "guide/reference.markdown",
+                &[".md".to_string(), ".markdown".to_string()]
+            ),
+            "guide/reference"
+        );
+        assert_eq!(
+            strip_markdown_extension("guide/reference.MDX", &["mdx".to_string()]),
+            "guide/reference"
+        );
+        assert_eq!(
+            strip_markdown_extension("guide/reference.txt", &["md".to_string()]),
+            "guide/reference.txt"
+        );
     }
 }

--- a/crates/ox_content_search/src/lib.rs
+++ b/crates/ox_content_search/src/lib.rs
@@ -35,7 +35,7 @@ mod runtime;
 mod scope;
 mod tokenizer;
 
-pub use files::collect_markdown_files;
+pub use files::{collect_markdown_files, strip_markdown_extension};
 pub use index::{Field, Posting, SearchDocument, SearchIndex, SearchIndexBuilder};
 pub use indexer::DocumentIndexer;
 pub use query::{SearchOptions, SearchResult};

--- a/npm/vite-plugin-ox-content/src/search.test.ts
+++ b/npm/vite-plugin-ox-content/src/search.test.ts
@@ -1,11 +1,21 @@
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
+  buildSearchIndex,
   generateSearchModule,
   getSearchDocumentScopes,
   matchesSearchScopes,
   parseScopedSearchQuery,
   resolveSearchOptions,
 } from "./search";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
 
 describe("parseScopedSearchQuery", () => {
   it("separates scope prefixes from free-text terms", () => {
@@ -47,5 +57,37 @@ describe("generateSearchModule", () => {
     expect(mod).toContain("const searchOptions =");
     expect(mod).toContain('fetch("/docs/search-index.json")');
     expect(mod).toContain("export async function search");
+  });
+});
+
+describe("buildSearchIndex", () => {
+  it("builds the index from Markdown files through the native binding", async () => {
+    const srcDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-search-"));
+    tempDirs.push(srcDir);
+    await fs.mkdir(path.join(srcDir, "guide"), { recursive: true });
+    await fs.writeFile(
+      path.join(srcDir, "guide", "intro.markdown"),
+      `---
+title: Native Search
+---
+# Ignored heading
+
+Body text with a searchable phrase.
+`,
+      "utf-8",
+    );
+
+    const index = JSON.parse(await buildSearchIndex(srcDir, "/docs/")) as {
+      doc_count: number;
+      documents: Array<{ id: string; title: string; url: string; body: string }>;
+    };
+
+    expect(index.doc_count).toBe(1);
+    expect(index.documents[0]).toMatchObject({
+      id: "guide/intro",
+      title: "Native Search",
+      url: "/docs/guide/intro",
+    });
+    expect(index.documents[0]?.body).toContain("searchable phrase");
   });
 });

--- a/npm/vite-plugin-ox-content/src/search.ts
+++ b/npm/vite-plugin-ox-content/src/search.ts
@@ -7,7 +7,7 @@
 import * as fs from "fs/promises";
 import * as path from "path";
 import { importNapiModule, importNapiModuleSync } from "./napi";
-import { DEFAULT_MARKDOWN_EXTENSIONS, stripMarkdownExtension } from "./markdown";
+import { DEFAULT_MARKDOWN_EXTENSIONS } from "./markdown";
 import type {
   SearchOptions,
   ResolvedSearchOptions,
@@ -103,44 +103,7 @@ export async function buildSearchIndex(
     });
   }
 
-  const files = napi.collectSearchMarkdownFiles(srcDir, [...extensions]);
-  const documents: SearchDocument[] = [];
-
-  for (const file of files) {
-    try {
-      const content = await fs.readFile(file, "utf-8");
-      const relativePath = path.relative(srcDir, file);
-      const id = stripMarkdownExtension(relativePath, extensions).replace(/\\/g, "/");
-      const url = base + id;
-
-      // Use Rust bindings to extract search content (if available)
-      const extractSearchContent = (napi as any).extractSearchContent;
-      if (!extractSearchContent) {
-        console.warn("[ox-content] Search not available: extractSearchContent not implemented");
-        return "[]";
-      }
-      const doc = extractSearchContent(content, id, url, { gfm: true });
-
-      documents.push({
-        id: doc.id,
-        title: doc.title,
-        url: doc.url,
-        body: doc.body,
-        headings: doc.headings,
-        code: doc.code,
-      });
-    } catch {
-      // Skip files that can't be processed
-    }
-  }
-
-  // Build the index using Rust bindings (if available)
-  const buildSearchIndex = (napi as any).buildSearchIndex;
-  if (!buildSearchIndex) {
-    console.warn("[ox-content] Search not available: buildSearchIndex not implemented");
-    return JSON.stringify(documents);
-  }
-  return buildSearchIndex(documents);
+  return napi.buildSearchIndexFromDirectory(srcDir, base, [...extensions]);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Move Markdown search index generation into Rust/NAPI, including file reads, document id generation, parsing, extraction, and index construction
- Share the Rust search extraction path with extractSearchContent and add Rust-side markdown extension stripping
- Reduce TS buildSearchIndex to a native binding call with targeted coverage

## Tests
- cargo test -p ox_content_search -p ox_content_napi
- cargo clippy -p ox_content_search -p ox_content_napi --all-targets -- -D warnings
- pnpm exec vp exec --filter @ox-content/vite-plugin -- vp test src/search.test.ts
- pnpm exec vp run check:ts
- pnpm exec vp run @ox-content/vite-plugin#build
- pnpm exec vp run test