### PR TITLE
refactor: write search index in rust

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -15,6 +15,9 @@ export declare function buildSearchIndex(documents: Array<JsSearchDocument>): st
  */
 export declare function buildSearchIndexFromDirectory(srcDir: string, base: string, extensions: Array<string>): string
 
+/** Writes a serialized search index to `search-index.json` under an output directory. */
+export declare function writeSearchIndex(indexJson: string, outDir: string): void
+
 /** Builds SSG navigation groups from markdown files. */
 export declare function buildSsgNavItems(markdownFiles: Array<string>, srcDir: string, base: string, extension: string): Array<JsSsgNavGroup>
 

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -89,6 +89,7 @@ module.exports.generateDocsMarkdown = binding.generateDocsMarkdown;
 module.exports.generateOgImageSvg = binding.generateOgImageSvg;
 module.exports.buildSearchIndex = binding.buildSearchIndex;
 module.exports.buildSearchIndexFromDirectory = binding.buildSearchIndexFromDirectory;
+module.exports.writeSearchIndex = binding.writeSearchIndex;
 module.exports.searchIndex = binding.searchIndex;
 module.exports.extractSearchContent = binding.extractSearchContent;
 module.exports.parseScopedSearchQuery = binding.parseScopedSearchQuery;

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -1042,6 +1042,14 @@ pub fn collect_search_markdown_files(src_dir: String, extensions: Vec<String>) -
     ox_content_search::collect_markdown_files(&src_dir, &extensions)
 }
 
+/// Writes a serialized search index to `search-index.json` under an output directory.
+#[napi(js_name = "writeSearchIndex")]
+pub fn write_search_index(index_json: String, out_dir: String) -> Result<()> {
+    ox_content_search::write_search_index(&index_json, &out_dir)
+        .map_err(|err| Error::from_reason(format!("failed to write search index: {err}")))?;
+    Ok(())
+}
+
 // =============================================================================
 // SSG HTML Generation API
 // =============================================================================
@@ -2382,6 +2390,23 @@ mod tests {
         assert_eq!(index.documents[0].title, "Native Search");
         assert_eq!(index.documents[0].url, "/docs/guide/intro");
         assert!(index.documents[0].body.contains("Search body text"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn writes_search_index_through_napi() {
+        let root =
+            std::env::temp_dir().join(format!("ox-content-napi-search-out-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+
+        super::write_search_index(r#"{"doc_count":0}"#.to_string(), root.to_string_lossy().into())
+            .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(root.join("search-index.json")).unwrap(),
+            r#"{"doc_count":0}"#
+        );
 
         let _ = fs::remove_dir_all(root);
     }

--- a/crates/ox_content_search/src/files.rs
+++ b/crates/ox_content_search/src/files.rs
@@ -1,7 +1,7 @@
 //! File discovery helpers for search indexing.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Collects Markdown files under `src_dir` for search indexing.
 #[must_use]
@@ -24,6 +24,17 @@ pub fn strip_markdown_extension(file_path: &str, extensions: &[String]) -> Strin
         || file_path.to_string(),
         |extension| file_path[..file_path.len() - extension.len()].to_string(),
     )
+}
+
+/// Writes a serialized search index to `search-index.json` under `out_dir`.
+pub fn write_search_index(index_json: &str, out_dir: &str) -> std::io::Result<PathBuf> {
+    let out_dir = Path::new(out_dir);
+    fs::create_dir_all(out_dir)?;
+
+    let index_path = out_dir.join("search-index.json");
+    fs::write(&index_path, index_json)?;
+
+    Ok(index_path)
 }
 
 fn collect_markdown_files_inner(dir: &Path, extensions: &[String], files: &mut Vec<String>) {
@@ -118,5 +129,20 @@ mod tests {
             strip_markdown_extension("guide/reference.txt", &["md".to_string()]),
             "guide/reference.txt"
         );
+    }
+
+    #[test]
+    fn writes_search_index_file() {
+        let root =
+            std::env::temp_dir().join(format!("ox-content-search-index-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+
+        let index_path =
+            write_search_index(r#"{"doc_count":0}"#, root.to_string_lossy().as_ref()).unwrap();
+
+        assert_eq!(index_path.file_name().unwrap(), "search-index.json");
+        assert_eq!(std::fs::read_to_string(&index_path).unwrap(), r#"{"doc_count":0}"#);
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/ox_content_search/src/lib.rs
+++ b/crates/ox_content_search/src/lib.rs
@@ -35,7 +35,7 @@ mod runtime;
 mod scope;
 mod tokenizer;
 
-pub use files::{collect_markdown_files, strip_markdown_extension};
+pub use files::{collect_markdown_files, strip_markdown_extension, write_search_index};
 pub use index::{Field, Posting, SearchDocument, SearchIndex, SearchIndexBuilder};
 pub use indexer::DocumentIndexer;
 pub use query::{SearchOptions, SearchResult};

--- a/npm/vite-plugin-ox-content/src/search.test.ts
+++ b/npm/vite-plugin-ox-content/src/search.test.ts
@@ -9,6 +9,7 @@ import {
   matchesSearchScopes,
   parseScopedSearchQuery,
   resolveSearchOptions,
+  writeSearchIndex,
 } from "./search";
 
 const tempDirs: string[] = [];
@@ -89,5 +90,18 @@ Body text with a searchable phrase.
       url: "/docs/guide/intro",
     });
     expect(index.documents[0]?.body).toContain("searchable phrase");
+  });
+});
+
+describe("writeSearchIndex", () => {
+  it("writes the index through the native binding", async () => {
+    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-search-out-"));
+    tempDirs.push(outDir);
+
+    await writeSearchIndex('{"doc_count":0}', outDir);
+
+    expect(await fs.readFile(path.join(outDir, "search-index.json"), "utf-8")).toBe(
+      '{"doc_count":0}',
+    );
   });
 });

--- a/npm/vite-plugin-ox-content/src/search.ts
+++ b/npm/vite-plugin-ox-content/src/search.ts
@@ -4,8 +4,6 @@
  * Generates search index at build time and provides client-side search.
  */
 
-import * as fs from "fs/promises";
-import * as path from "path";
 import { importNapiModule, importNapiModuleSync } from "./napi";
 import { DEFAULT_MARKDOWN_EXTENSIONS } from "./markdown";
 import type {
@@ -110,13 +108,13 @@ export async function buildSearchIndex(
  * Writes the search index to a file.
  */
 export async function writeSearchIndex(indexJson: string, outDir: string): Promise<void> {
-  const indexPath = path.join(outDir, "search-index.json");
+  const napi = await getOxContent();
 
-  // Ensure output directory exists
-  await fs.mkdir(outDir, { recursive: true });
+  if (!napi) {
+    return;
+  }
 
-  // Write the index
-  await fs.writeFile(indexPath, indexJson, "utf-8");
+  napi.writeSearchIndex(indexJson, outDir);
 }
 
 /**


### PR DESCRIPTION
## Summary
- move `search-index.json` writing into `ox_content_search`
- expose `writeSearchIndex` through `@ox-content/napi`
- keep the TypeScript search helper as a thin native binding wrapper

## Validation
- `cargo test -p ox_content_search writes_search_index_file`
- `cargo test -p ox_content_napi writes_search_index_through_napi`
- `cargo fmt --all -- --check`
- `vp run check:ts`

Actions should be the source of truth before merging.
