### PR TITLE
refactor: type search module options

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -93,6 +93,9 @@ export declare function generateOgImageSvg(data: JsOgImageData, config?: JsOgIma
 /** Generates the client-side search runtime module. */
 export declare function generateSearchModule(optionsJson: string, indexPath: string): string
 
+/** Generates the client-side search runtime module from typed options. */
+export declare function generateSearchModuleFromOptions(options: JsSearchRuntimeOptions, indexPath: string): string
+
 /** Generates SSG HTML page with navigation and search. */
 export declare function generateSsgHtml(pageData: JsSsgPageData, navGroups: Array<JsSsgNavGroup>, config: JsSsgConfig): string
 
@@ -459,6 +462,20 @@ export interface JsSearchOptions {
   fuzzy?: boolean
   /** Minimum score threshold. */
   threshold?: number
+}
+
+/** Resolved search runtime options for JavaScript. */
+export interface JsSearchRuntimeOptions {
+  /** Whether search is enabled. */
+  enabled: boolean
+  /** Maximum number of results. */
+  limit: number
+  /** Enable prefix matching. */
+  prefix: boolean
+  /** Search input placeholder. */
+  placeholder: string
+  /** Keyboard shortcut to focus search. */
+  hotkey: string
 }
 
 /** Search result for JavaScript. */

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -96,6 +96,7 @@ module.exports.parseScopedSearchQuery = binding.parseScopedSearchQuery;
 module.exports.getSearchDocumentScopes = binding.getSearchDocumentScopes;
 module.exports.matchesSearchScopes = binding.matchesSearchScopes;
 module.exports.generateSearchModule = binding.generateSearchModule;
+module.exports.generateSearchModuleFromOptions = binding.generateSearchModuleFromOptions;
 module.exports.collectSearchMarkdownFiles = binding.collectSearchMarkdownFiles;
 module.exports.generateSsgHtml = binding.generateSsgHtml;
 module.exports.resolveSsgRoutePaths = binding.resolveSsgRoutePaths;

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -29,6 +29,7 @@ use ox_content_parser::{Parser, ParserOptions};
 use ox_content_renderer::HtmlRenderer;
 use ox_content_search::{
     DocumentIndexer, SearchDocument, SearchIndex, SearchIndexBuilder, SearchOptions,
+    SearchRuntimeOptions,
 };
 use transfer::TransferPayloadKind;
 use transformer::{parse_frontmatter, MarkdownTransformer};
@@ -941,6 +942,33 @@ impl From<JsSearchOptions> for SearchOptions {
     }
 }
 
+/// Resolved search runtime options for JavaScript.
+#[napi(object)]
+pub struct JsSearchRuntimeOptions {
+    /// Whether search is enabled.
+    pub enabled: bool,
+    /// Maximum number of results.
+    pub limit: u32,
+    /// Enable prefix matching.
+    pub prefix: bool,
+    /// Search input placeholder.
+    pub placeholder: String,
+    /// Keyboard shortcut to focus search.
+    pub hotkey: String,
+}
+
+impl From<JsSearchRuntimeOptions> for SearchRuntimeOptions {
+    fn from(options: JsSearchRuntimeOptions) -> Self {
+        Self {
+            enabled: options.enabled,
+            limit: options.limit,
+            prefix: options.prefix,
+            placeholder: options.placeholder,
+            hotkey: options.hotkey,
+        }
+    }
+}
+
 /// Builds a search index from documents.
 ///
 /// Takes an array of documents and returns a serialized search index as JSON.
@@ -1034,6 +1062,15 @@ pub fn matches_search_scopes(id: String, url: String, scopes: Vec<String>) -> bo
 #[napi(js_name = "generateSearchModule")]
 pub fn generate_search_module(options_json: String, index_path: String) -> String {
     ox_content_search::generate_search_module(&options_json, &index_path)
+}
+
+/// Generates the client-side search runtime module from typed options.
+#[napi(js_name = "generateSearchModuleFromOptions")]
+pub fn generate_search_module_from_options(
+    options: JsSearchRuntimeOptions,
+    index_path: String,
+) -> String {
+    ox_content_search::generate_search_module_with_options(&options.into(), &index_path)
 }
 
 /// Collects Markdown files for search indexing from a source directory.
@@ -2409,6 +2446,24 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn generates_search_module_from_typed_options() {
+        let module = super::generate_search_module_from_options(
+            super::JsSearchRuntimeOptions {
+                enabled: true,
+                limit: 7,
+                prefix: false,
+                placeholder: "Find".to_string(),
+                hotkey: "k".to_string(),
+            },
+            "/docs/search-index.json".to_string(),
+        );
+
+        assert!(module.contains(
+            r#"const searchOptions = {"enabled":true,"limit":7,"prefix":false,"placeholder":"Find","hotkey":"k"};"#
+        ));
     }
 
     #[test]

--- a/crates/ox_content_search/src/lib.rs
+++ b/crates/ox_content_search/src/lib.rs
@@ -39,7 +39,9 @@ pub use files::{collect_markdown_files, strip_markdown_extension, write_search_i
 pub use index::{Field, Posting, SearchDocument, SearchIndex, SearchIndexBuilder};
 pub use indexer::DocumentIndexer;
 pub use query::{SearchOptions, SearchResult};
-pub use runtime::generate_search_module;
+pub use runtime::{
+    generate_search_module, generate_search_module_with_options, SearchRuntimeOptions,
+};
 pub use scope::{
     get_search_document_scopes, matches_search_scopes, parse_scoped_search_query, ScopedSearchQuery,
 };

--- a/crates/ox_content_search/src/runtime.rs
+++ b/crates/ox_content_search/src/runtime.rs
@@ -1,6 +1,23 @@
 //! Client-side search runtime module generation.
 
+use serde::Serialize;
+
 const SEARCH_RUNTIME_MODULE: &str = include_str!("search-runtime.js");
+
+/// Resolved options embedded in the client-side search runtime.
+#[derive(Clone, Debug, Serialize)]
+pub struct SearchRuntimeOptions {
+    /// Whether search is enabled.
+    pub enabled: bool,
+    /// Maximum number of results.
+    pub limit: u32,
+    /// Enable prefix matching.
+    pub prefix: bool,
+    /// Search input placeholder.
+    pub placeholder: String,
+    /// Keyboard shortcut to focus search.
+    pub hotkey: String,
+}
 
 /// Generates the client-side search runtime module.
 pub fn generate_search_module(options_json: &str, index_path: &str) -> String {
@@ -10,6 +27,15 @@ pub fn generate_search_module(options_json: &str, index_path: &str) -> String {
     SEARCH_RUNTIME_MODULE
         .replace("__OX_CONTENT_SEARCH_OPTIONS__", options_json)
         .replace("__OX_CONTENT_SEARCH_INDEX_PATH__", &index_path_json)
+}
+
+/// Generates the client-side search runtime module from typed options.
+pub fn generate_search_module_with_options(
+    options: &SearchRuntimeOptions,
+    index_path: &str,
+) -> String {
+    let options_json = serde_json::to_string(options).unwrap_or_else(|_| "{}".to_string());
+    generate_search_module(&options_json, index_path)
 }
 
 #[cfg(test)]
@@ -23,5 +49,24 @@ mod tests {
         assert!(module.contains("const searchOptions = {\"limit\":5,\"prefix\":true};"));
         assert!(module.contains("fetch(\"/docs/search's.json\")"));
         assert!(module.contains("export async function search"));
+    }
+
+    #[test]
+    fn serializes_typed_options() {
+        let module = generate_search_module_with_options(
+            &SearchRuntimeOptions {
+                enabled: true,
+                limit: 12,
+                prefix: false,
+                placeholder: "Find docs".to_string(),
+                hotkey: "k".to_string(),
+            },
+            "/docs/search-index.json",
+        );
+
+        assert!(module.contains(
+            r#"const searchOptions = {"enabled":true,"limit":12,"prefix":false,"placeholder":"Find docs","hotkey":"k"};"#
+        ));
+        assert!(module.contains(r#"fetch("/docs/search-index.json")"#));
     }
 }

--- a/npm/vite-plugin-ox-content/src/search.ts
+++ b/npm/vite-plugin-ox-content/src/search.ts
@@ -122,5 +122,5 @@ export async function writeSearchIndex(indexJson: string, outDir: string): Promi
  * This is injected into the bundle as a virtual module.
  */
 export function generateSearchModule(options: ResolvedSearchOptions, indexPath: string): string {
-  return importNapiModuleSync().generateSearchModule(JSON.stringify(options), indexPath);
+  return importNapiModuleSync().generateSearchModuleFromOptions(options, indexPath);
 }


### PR DESCRIPTION
## Summary
- add typed search runtime options in `ox_content_search`
- expose `generateSearchModuleFromOptions` through `@ox-content/napi` while keeping the existing JSON-string API
- make the Vite plugin call the typed native API instead of `JSON.stringify` in TypeScript

## Validation
- `cargo test -p ox_content_search serializes_typed_options`
- `cargo test -p ox_content_napi generates_search_module_from_typed_options`
- `cargo fmt --all -- --check`
- `vp run check:ts`
- `cargo clippy -p ox_content_search -p ox_content_napi --all-targets -- -D warnings`

Actions should be the source of truth before merging.
