### PR TITLE
refactor: move i18n project checks into napi

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -32,6 +32,16 @@ export declare function buildSsgThemeNavItems(sidebar: Array<JsSsgSidebarItem>, 
  */
 export declare function checkI18n(dictDir: string, usedKeys: Array<string>): I18NCheckResult
 
+/**
+ * Runs project-level i18n checks by collecting source keys and validating dictionaries.
+ *
+ * `dict_dir` is the path to the i18n directory with locale subdirectories.
+ * `src_dirs` are source/content directories to scan recursively.
+ * `function_names` are translation call names to collect from JS/TS source.
+ * `default_locale` is used for dictionary fallback rules.
+ */
+export declare function checkI18nProject(dictDir: string, srcDirs: Array<string>, functionNames: Array<string>, defaultLocale: string): I18NCheckResult
+
 /** Collects source files for generated API documentation. */
 export declare function collectDocsSourceFiles(srcDir: string, include: Array<string>, exclude: Array<string>): Array<string>
 

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -117,4 +117,5 @@ module.exports.loadDictionariesFlat = binding.loadDictionariesFlat;
 module.exports.generateI18nModule = binding.generateI18nModule;
 module.exports.validateMf2 = binding.validateMf2;
 module.exports.checkI18n = binding.checkI18n;
+module.exports.checkI18nProject = binding.checkI18nProject;
 module.exports.extractTranslationKeys = binding.extractTranslationKeys;

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -2183,6 +2183,50 @@ pub struct I18nCheckResult {
     pub warning_count: u32,
 }
 
+fn i18n_check_result_from_diagnostics(
+    diagnostics: Vec<ox_content_i18n::checker::Diagnostic>,
+) -> I18nCheckResult {
+    let mut error_count = 0u32;
+    let mut warning_count = 0u32;
+    let js_diagnostics: Vec<I18nDiagnostic> = diagnostics
+        .into_iter()
+        .map(|d| {
+            let severity = match d.severity {
+                ox_content_i18n::checker::Severity::Error => {
+                    error_count += 1;
+                    "error"
+                }
+                ox_content_i18n::checker::Severity::Warning => {
+                    warning_count += 1;
+                    "warning"
+                }
+                ox_content_i18n::checker::Severity::Info => "info",
+            };
+            I18nDiagnostic {
+                severity: severity.to_string(),
+                message: d.message,
+                key: d.key,
+                locale: d.locale,
+            }
+        })
+        .collect();
+
+    I18nCheckResult { diagnostics: js_diagnostics, error_count, warning_count }
+}
+
+fn i18n_check_error(message: String) -> I18nCheckResult {
+    I18nCheckResult {
+        diagnostics: vec![I18nDiagnostic {
+            severity: "error".to_string(),
+            message,
+            key: None,
+            locale: None,
+        }],
+        error_count: 1,
+        warning_count: 0,
+    }
+}
+
 /// Loads dictionaries from the given directory.
 ///
 /// The directory should contain locale subdirectories (e.g., `en/`, `ja/`)
@@ -2256,49 +2300,40 @@ pub fn check_i18n(dict_dir: String, used_keys: Vec<String>) -> I18nCheckResult {
     let path = std::path::Path::new(&dict_dir);
     let dict_set = match ox_content_i18n::dictionary::load_from_dir(path) {
         Ok(set) => set,
-        Err(e) => {
-            return I18nCheckResult {
-                diagnostics: vec![I18nDiagnostic {
-                    severity: "error".to_string(),
-                    message: e.to_string(),
-                    key: None,
-                    locale: None,
-                }],
-                error_count: 1,
-                warning_count: 0,
-            };
-        }
+        Err(e) => return i18n_check_error(e.to_string()),
     };
 
     let keys_set: std::collections::HashSet<String> = used_keys.into_iter().collect();
     let diagnostics = ox_content_i18n::checker::check_all(&keys_set, &dict_set);
 
-    let mut error_count = 0u32;
-    let mut warning_count = 0u32;
-    let js_diagnostics: Vec<I18nDiagnostic> = diagnostics
-        .into_iter()
-        .map(|d| {
-            let severity = match d.severity {
-                ox_content_i18n::checker::Severity::Error => {
-                    error_count += 1;
-                    "error"
-                }
-                ox_content_i18n::checker::Severity::Warning => {
-                    warning_count += 1;
-                    "warning"
-                }
-                ox_content_i18n::checker::Severity::Info => "info",
-            };
-            I18nDiagnostic {
-                severity: severity.to_string(),
-                message: d.message,
-                key: d.key,
-                locale: d.locale,
-            }
-        })
-        .collect();
+    i18n_check_result_from_diagnostics(diagnostics)
+}
 
-    I18nCheckResult { diagnostics: js_diagnostics, error_count, warning_count }
+/// Runs project-level i18n checks by collecting source keys and validating dictionaries.
+///
+/// `dict_dir` is the path to the i18n directory with locale subdirectories.
+/// `src_dirs` are source/content directories to scan recursively.
+/// `function_names` are translation call names to collect from JS/TS source.
+/// `default_locale` is used for dictionary fallback rules.
+#[napi(js_name = "checkI18nProject")]
+pub fn check_i18n_project(
+    dict_dir: String,
+    src_dirs: Vec<String>,
+    function_names: Vec<String>,
+    default_locale: String,
+) -> I18nCheckResult {
+    let config = ox_content_i18n_checker::CheckConfig {
+        dict_dir,
+        src_dirs,
+        function_names,
+        default_locale: Some(default_locale),
+        ..Default::default()
+    };
+
+    match ox_content_i18n_checker::check(&config) {
+        Ok(result) => i18n_check_result_from_diagnostics(result.diagnostics),
+        Err(error) => i18n_check_error(error),
+    }
 }
 
 /// A translation key usage found in source code.
@@ -2444,6 +2479,45 @@ mod tests {
             fs::read_to_string(root.join("search-index.json")).unwrap(),
             r#"{"doc_count":0}"#
         );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn check_i18n_project_collects_source_and_markdown_keys() {
+        let unique =
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos();
+        let root = std::env::temp_dir()
+            .join(format!("ox-content-napi-i18n-{}-{unique}", std::process::id()));
+        let dict_root = root.join("content/i18n");
+        let src_dir = root.join("src");
+        let content_dir = root.join("content");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(dict_root.join("en")).unwrap();
+        fs::create_dir_all(&src_dir).unwrap();
+
+        fs::write(
+            dict_root.join("en/common.json"),
+            r#"{"fromSrc":"From source","fromMd":"From markdown"}"#,
+        )
+        .unwrap();
+        fs::write(src_dir.join("app.ts"), "const label = t('common.fromSrc');").unwrap();
+        fs::write(content_dir.join("guide.md"), "{{t('common.fromMd')}}").unwrap();
+
+        let result = super::check_i18n_project(
+            dict_root.to_string_lossy().into_owned(),
+            vec![
+                src_dir.to_string_lossy().into_owned(),
+                content_dir.to_string_lossy().into_owned(),
+            ],
+            vec!["t".to_string(), "$t".to_string()],
+            "en".to_string(),
+        );
+        let messages: Vec<&str> = result.diagnostics.iter().map(|d| d.message.as_str()).collect();
+
+        assert_eq!(result.error_count, 0, "diagnostics: {messages:?}");
+        assert_eq!(result.warning_count, 0, "diagnostics: {messages:?}");
+        assert!(result.diagnostics.is_empty());
 
         let _ = fs::remove_dir_all(root);
     }

--- a/npm/vite-plugin-ox-content/src/i18n.ts
+++ b/npm/vite-plugin-ox-content/src/i18n.ts
@@ -86,25 +86,13 @@ export function createI18nPlugin(resolvedOptions: ResolvedOptions): Plugin {
       }
 
       try {
-        const { loadDictionaries, checkI18n, extractTranslationKeys } = await importNapiModule();
-
-        // Load and validate dictionaries
-        const loadResult = loadDictionaries(dictDir);
-        if (loadResult.errors.length > 0) {
-          for (const error of loadResult.errors) {
-            console.warn(`[ox-content:i18n] ${error}`);
-          }
-          return;
-        }
-
-        console.log(
-          `[ox-content:i18n] Loaded ${loadResult.localeCount} locales: ${loadResult.locales.join(", ")}`,
+        const { checkI18nProject } = await importNapiModule();
+        const checkResult = checkI18nProject(
+          dictDir,
+          [path.resolve(root, "src"), path.resolve(root, "content")],
+          i18nOptions.functionNames,
+          i18nOptions.defaultLocale,
         );
-
-        // Collect translation keys from source files
-        const collectedKeys = collectKeysFromSource(root, extractTranslationKeys, i18nOptions);
-
-        const checkResult = checkI18n(dictDir, collectedKeys);
         if (checkResult.errorCount > 0 || checkResult.warningCount > 0) {
           for (const diag of checkResult.diagnostics) {
             if (diag.severity === "error") {
@@ -197,63 +185,4 @@ export function generateI18nModule(options: ResolvedI18nOptions, root: string): 
   throw new Error(
     "[ox-content:i18n] @ox-content/napi does not expose generateI18nModule. Please rebuild the NAPI package.",
   );
-}
-
-/**
- * Collects translation keys from source files using NAPI extractTranslationKeys.
- */
-function collectKeysFromSource(
-  root: string,
-  extractTranslationKeys: (
-    source: string,
-    filePath: string,
-    functionNames?: string[],
-  ) => Array<{ key: string }>,
-  options: ResolvedI18nOptions,
-): string[] {
-  const srcDir = path.resolve(root, "src");
-  const keys = new Set<string>();
-
-  // Scan TS/JS/TSX/JSX files in src/
-  if (fs.existsSync(srcDir)) {
-    walkDir(srcDir, /\.(ts|tsx|js|jsx)$/, (filePath) => {
-      const source = fs.readFileSync(filePath, "utf-8");
-      const usages = extractTranslationKeys(source, filePath, options.functionNames);
-      for (const usage of usages) {
-        keys.add(usage.key);
-      }
-    });
-  }
-
-  // Scan Markdown files for {{t('key')}} patterns
-  const contentDir = path.resolve(root, "content");
-  if (fs.existsSync(contentDir)) {
-    const tPattern = /\{\{t\(['"]([^'"]+)['"]\)\}\}/g;
-    walkDir(contentDir, /\.(md|mdx)$/, (filePath) => {
-      const content = fs.readFileSync(filePath, "utf-8");
-      let match;
-      while ((match = tPattern.exec(content)) !== null) {
-        keys.add(match[1]);
-      }
-      tPattern.lastIndex = 0;
-    });
-  }
-
-  return Array.from(keys);
-}
-
-/**
- * Recursively walks a directory, calling the callback for files matching the pattern.
- */
-function walkDir(dir: string, pattern: RegExp, callback: (filePath: string) => void): void {
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      if (entry.name === "node_modules" || entry.name === ".git") continue;
-      walkDir(fullPath, pattern, callback);
-    } else if (pattern.test(entry.name)) {
-      callback(fullPath);
-    }
-  }
 }


### PR DESCRIPTION
## Summary
- add a Rust-backed `checkI18nProject` NAPI entrypoint that collects source keys and validates dictionaries
- replace the TypeScript recursive source walker and Markdown regex scan in the Vite i18n plugin
- keep module generation and dev-server locale routing in TypeScript

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p ox_content_napi check_i18n_project_collects_source_and_markdown_keys`
- `cargo test -p ox_content_i18n_checker`

TypeScript validation is left to CI because this local worktree does not have `node_modules`/`tsgo` installed.