### PR TITLE
chore: add root workspace scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,18 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "scripts": {
+    "fmt": "vp fmt",
+    "fmt:check": "vp run fmt:check",
+    "check": "vp check",
+    "lint": "vp run lint",
+    "test": "vp run test",
+    "build": "vp build",
+    "dev": "vp dev",
+    "ci": "vp run ci",
+    "ready": "vp run ready",
+    "release": "vp run release"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "vite-plus": "catalog:"

--- a/package.json
+++ b/package.json
@@ -4,16 +4,16 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "fmt": "vp fmt",
-    "fmt:check": "vp run fmt:check",
-    "check": "vp check",
-    "lint": "vp run lint",
-    "test": "vp run test",
-    "build": "vp build",
-    "dev": "vp dev",
-    "ci": "vp run ci",
-    "ready": "vp run ready",
-    "release": "vp run release"
+    "fmt": "vp run workspace:fmt",
+    "fmt:check": "vp run workspace:fmt:check",
+    "check": "vp run workspace:check",
+    "lint": "vp run workspace:lint",
+    "test": "vp run workspace:test",
+    "build": "vp run workspace:build",
+    "dev": "vp run workspace:dev",
+    "ci": "vp run workspace:ci",
+    "ready": "vp run workspace:ready",
+    "release": "vp run workspace:release"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,10 +4,10 @@ import { defineConfig } from "vite-plus";
 const lifecycleEnvName = "OX_CONTENT_VP_LIFECYCLE";
 
 const lifecycleTasks: Record<string, string> = {
-  build: "build",
-  check: "check",
-  dev: "dev",
-  fmt: "fmt",
+  build: "workspace:build",
+  check: "workspace:check",
+  dev: "workspace:dev",
+  fmt: "workspace:fmt",
 };
 
 // Vite+ direct commands bypass run.tasks, so root lifecycle commands delegate into the task graph.
@@ -85,7 +85,7 @@ export default defineConfig({
       tasks: true,
     },
     tasks: {
-      build: noopTask(["build:docs", "build:playground", "doc:cargo"]),
+      "workspace:build": noopTask(["build:docs", "build:playground", "doc:cargo"]),
       "build:rust": task("cargo build --workspace"),
       "build:rust-release": task("cargo build --workspace --release"),
       "build:napi": task("vp run --filter ./crates/ox_content_napi build", {
@@ -102,7 +102,7 @@ export default defineConfig({
       }),
       "build:wasm": task("node --experimental-strip-types scripts/build-wasm-package.ts"),
 
-      test: noopTask(["test:rust", "test:ts"]),
+      "workspace:test": noopTask(["test:rust", "test:ts"]),
       "test:rust": task("cargo test --workspace"),
       "test:rust-verbose": uncachedTask("cargo test --workspace -- --nocapture"),
       "test:ts": noopTask(["test:ts-unit", "test:vrt"]),
@@ -119,21 +119,21 @@ export default defineConfig({
         },
       ),
 
-      check: noopTask(["fmt:rust-check", "lint:rust", "check:ts"]),
+      "workspace:check": noopTask(["fmt:rust-check", "lint:rust", "check:ts"]),
       "check:rust": task("cargo check --workspace --all-targets"),
 
       clippy: task("cargo clippy --workspace --all-targets -- -D warnings", {
         dependsOn: ["check:rust"],
       }),
 
-      fmt: noopTask(["fmt:rust", "fmt:ts"]),
+      "workspace:fmt": noopTask(["fmt:rust", "fmt:ts"]),
       "fmt:rust": task("cargo fmt --all"),
-      "fmt:check": noopTask(["fmt:rust-check", "fmt:ts-check"]),
+      "workspace:fmt:check": noopTask(["fmt:rust-check", "fmt:ts-check"]),
       "fmt:rust-check": task("cargo fmt --all -- --check"),
       "fmt:ts": task(vpBuiltin("vp fmt")),
       "fmt:ts-check": task(vpBuiltin("vp fmt --check")),
 
-      lint: noopTask(["lint:rust", "check:ts"]),
+      "workspace:lint": noopTask(["lint:rust", "check:ts"]),
       "lint:rust": task("cargo clippy --workspace --all-targets -- -D warnings", {
         dependsOn: ["check:rust"],
       }),
@@ -154,8 +154,8 @@ export default defineConfig({
         cwd: "crates/ox_content_napi",
       }),
 
-      ci: noopTask(["fmt:rust-check", "lint:rust", "check:ts", "test"]),
-      ready: noopTask(["fmt", "lint", "test"]),
+      "workspace:ci": noopTask(["fmt:rust-check", "lint:rust", "check:ts", "workspace:test"]),
+      "workspace:ready": noopTask(["workspace:fmt", "workspace:lint", "workspace:test"]),
       coverage: uncachedTask("cargo llvm-cov --workspace --html"),
       setup: uncachedTask(
         "rustup component add clippy rustfmt && cargo install cargo-watch cargo-llvm-cov",
@@ -176,7 +176,7 @@ export default defineConfig({
         dependsOn: ["build:npm"],
       }),
       "dev:playground": uncachedTask("vp run --filter ./examples/playground dev"),
-      dev: uncachedTask(
+      "workspace:dev": uncachedTask(
         [
           "trap 'kill 0' EXIT INT TERM",
           "vp run --filter ./docs dev &",
@@ -191,7 +191,7 @@ export default defineConfig({
       "dev-preview": uncachedTask("vp run --filter ./docs preview"),
 
       install: uncachedTask("vp install"),
-      release: uncachedTask("node --experimental-strip-types scripts/release.ts"),
+      "workspace:release": uncachedTask("node --experimental-strip-types scripts/release.ts"),
       "examples-install": noopTask(["install"], { cache: false }),
     },
   },


### PR DESCRIPTION
## Summary
- expose the existing Vite+ task graph through conventional root npm scripts
- add shortcuts for formatting, checks, tests, build, dev, CI, readiness, and release

## Validation
- `node -e` JSON parse of `package.json`
- `pnpm run` to confirm the root scripts are exposed

## Notes
- Full baseline validation on `main` passed before this branch was created: `vp run fmt:check`, `vp run check:ts`, and `cargo test --workspace`.