### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    labels:
+      - "enhancement"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    labels:
+      - "enhancement"
+    open-pull-requests-limit: 5
+    groups:
+      npm-production:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      npm-development:
+        dependency-type: "development"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    labels:
+      - "enhancement"
+    open-pull-requests-limit: 5
+    groups:
+      cargo:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- add weekly Dependabot updates for GitHub Actions, npm/pnpm, and Cargo
- group update PRs to keep production-readiness maintenance reviewable
- use the existing `enhancement` label

## Validation
- parsed YAML with `yq e '.' .github/dependabot.yml`
- confirmed supported ecosystems: `github-actions`, `npm`, `cargo`
- confirmed existing label `enhancement` via `gh label list`

## Notes
- Full baseline validation on `main` passed before this branch was created: `vp run fmt:check`, `vp run check:ts`, and `cargo test --workspace`.