### PR TITLE
chore: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: Report a reproducible defect or regression.
+title: "bug: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for reproducible defects. Include enough detail for someone else to verify the issue.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken, and what impact does it have?
+      placeholder: The content build fails when...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest reliable sequence of steps.
+      placeholder: |
+        1. Run ...
+        2. Open ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should happen instead?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened, including errors or logs if available?
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Blocker - production or release is stopped
+        - High - core workflow is broken
+        - Medium - workaround exists
+        - Low - minor defect
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, browser, Node/package manager versions, branch, or deployment target.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security issue
+    url: https://github.com/ubugeeei/ox-content/security/advisories/new
+    about: Please report suspected vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/documentation_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_improvement.yml
@@ -1,0 +1,36 @@
+name: Documentation improvement
+description: Request a correction, clarification, or missing documentation.
+title: "docs: "
+labels: ["documentation", "needs-triage"]
+body:
+  - type: textarea
+    id: location
+    attributes:
+      label: Location
+      description: Link or path to the affected documentation, if known.
+      placeholder: docs/... or README section...
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is inaccurate, missing, confusing, or stale?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed improvement
+      description: What should the documentation say or explain?
+    validations:
+      required: true
+  - type: checkboxes
+    id: readiness
+    attributes:
+      label: Readiness checks
+      options:
+        - label: I checked for an existing issue or pull request.
+          required: true
+        - label: I included enough context for a reviewer to validate the change.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+name: Feature request
+description: Propose a production-ready enhancement.
+title: "feat: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or opportunity
+      description: What user or maintainer need does this address?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the expected behavior and scope.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Note simpler options, prior art, or why this belongs here.
+    validations:
+      required: true
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Production impact
+      options:
+        - User-facing behavior change
+        - Maintainer or workflow change
+        - Internal implementation only
+        - Unsure
+    validations:
+      required: true
+  - type: checkboxes
+    id: readiness
+    attributes:
+      label: Readiness checks
+      options:
+        - label: I checked for an existing issue or pull request.
+          required: true
+        - label: I described validation or rollout considerations.
+          required: true

--- a/.github/ISSUE_TEMPLATE/production_readiness.yml
+++ b/.github/ISSUE_TEMPLATE/production_readiness.yml
@@ -1,0 +1,52 @@
+name: Production-readiness task
+description: Track reliability, release, observability, security, or operational hardening work.
+title: "chore: "
+labels: ["production-readiness", "needs-triage"]
+body:
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What production risk or operational gap does this reduce?
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - Reliability
+        - Security
+        - Observability
+        - Release or rollback
+        - Performance
+        - Compliance or dependency hygiene
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List concrete conditions that must be true before this is complete.
+      placeholder: |
+        - ...
+        - ...
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation plan
+      description: Commands, checks, dashboards, or manual steps that prove readiness.
+    validations:
+      required: true
+  - type: checkboxes
+    id: release
+    attributes:
+      label: Release considerations
+      options:
+        - label: Rollback or recovery path is known.
+          required: true
+        - label: Documentation or runbook impact has been considered.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+- 
+
+## Risk
+
+- Risk level: low / medium / high
+- User or production impact:
+- Rollback plan:
+
+## Validation
+
+- [ ] Automated tests or checks run:
+- [ ] Manual verification completed:
+- [ ] Edge cases or failure modes considered:
+
+## Release and docs checklist
+
+- [ ] Documentation, comments, or runbooks updated, or not needed.
+- [ ] Configuration, migration, or environment changes documented, or not needed.
+- [ ] Observability, logging, and alerting impact considered, or not needed.
+- [ ] Security, privacy, and dependency impact considered, or not needed.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Summary
 
-- 
+-
 
 ## Risk
 


### PR DESCRIPTION
## Summary
- add structured issue forms for bugs, features, documentation improvements, and production-readiness work
- disable blank issues and route security reports to private advisories
- add a PR template covering summary, risk, validation, release/docs, and security impact

## Validation
- confirmed expected template files exist
- parsed all YAML issue templates successfully
- verified required issue template names and PR sections are present
- created the `needs-triage` and `production-readiness` repository labels used by the templates

## Notes
- Full baseline validation on `main` passed before this branch was created: `vp run fmt:check`, `vp run check:ts`, and `cargo test --workspace`.