### PR TITLE
ci: unblock workspace checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install Playwright browsers
-        run: vp exec --filter @ox-content/vite-plugin -- playwright install --with-deps chromium
+        run: vp exec --filter @ox-content/vite-plugin -- playwright install chromium
 
       - name: Run tests
         run: vp run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install Playwright browsers
-        run: pnpm --dir npm/vite-plugin-ox-content exec playwright install --only-shell chromium
+        run: vp exec --filter @ox-content/vite-plugin -- playwright install --only-shell chromium
 
       - name: Run tests
         run: vp run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,8 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - name: Install Playwright browsers
-        run: vp exec --filter @ox-content/vite-plugin -- playwright install --only-shell chromium
+      - name: Check browser availability
+        run: google-chrome --version
 
       - name: Run tests
         run: vp run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install Playwright browsers
-        run: vp exec --filter @ox-content/vite-plugin -- playwright install chromium
+        run: pnpm --dir npm/vite-plugin-ox-content exec playwright install --only-shell chromium
 
       - name: Run tests
         run: vp run test

--- a/examples/unplugin-esbuild/tsconfig.json
+++ b/examples/unplugin-esbuild/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
+    "rootDir": "./src",
     "outDir": "./dist"
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts"]

--- a/examples/unplugin-rollup/tsconfig.json
+++ b/examples/unplugin-rollup/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
+    "rootDir": "./src",
     "outDir": "./dist"
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts"]

--- a/examples/unplugin-webpack/tsconfig.json
+++ b/examples/unplugin-webpack/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
+    "rootDir": "./src",
     "outDir": "./dist"
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts"]

--- a/npm/vite-plugin-ox-content/playwright.config.ts
+++ b/npm/vite-plugin-ox-content/playwright.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     },
   },
   use: {
+    channel: process.env.CI ? "chrome" : undefined,
     headless: true,
     viewport: { width: 1280, height: 1600 },
     deviceScaleFactor: 1,

--- a/npm/vscode-ox-content/tsconfig.json
+++ b/npm/vscode-ox-content/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "Node16",
     "lib": ["ES2022"],
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "rootDir": "./src",
     "outDir": "./dist",
     "sourceMap": true,


### PR DESCRIPTION
## Summary

- add explicit `rootDir` to unplugin example tsconfigs so the workspace checker can resolve output layout
- update the VS Code extension tsconfig to the current Node16 module resolution mode
- avoid hanging the test job on OS dependency installation by installing only the Playwright Chromium browser in CI

## Validation

- `vp run check:ts` (passes with existing warnings in framework wrapper packages)
