### PR TITLE
fix(ssg): escape bare page titles

### DIFF
--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -1288,6 +1288,15 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_bare_html_escapes_title_but_keeps_content_raw() {
+        let html = generate_bare_html("<h1>Raw & ready</h1>", "<script>alert(1)</script>");
+
+        assert!(html.contains("<title>&lt;script&gt;alert(1)&lt;/script&gt;</title>"));
+        assert!(html.contains("<h1>Raw & ready</h1>"));
+        assert!(!html.contains("<title><script>"));
+    }
+
+    #[test]
     fn test_generate_nav_html_with_nested_collapsed_items() {
         let nav_groups = vec![NavGroup {
             title: "Guide & API".to_string(),

--- a/crates/ox_content_ssg/templates/bare_page.html
+++ b/crates/ox_content_ssg/templates/bare_page.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{{ title|safe }}</title>
+  <title>{{ title }}</title>
 </head>
 <body>
 {{ content|safe }}

--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -4,6 +4,7 @@ import {
   buildNavItems,
   buildThemeNavItems,
   formatTitle,
+  generateBareHtmlPage,
   getHref,
   getOutputPath,
   getPageLocale,
@@ -44,6 +45,13 @@ describe("getPageLocale", () => {
 });
 
 describe("SSG route helpers", () => {
+  it("generates bare HTML through the NAPI-backed wrapper", () => {
+    const html = generateBareHtmlPage("<main>Body</main>", "Bare <Page>");
+
+    expect(html).toContain("<title>Bare &lt;Page&gt;</title>");
+    expect(html).toContain("<main>Body</main>");
+  });
+
   it("resolves output paths, URL paths, and hrefs through NAPI", () => {
     const srcDir = path.join(process.cwd(), "docs");
     const outDir = path.join(process.cwd(), "dist");


### PR DESCRIPTION
## Summary

- escape bare SSG page titles instead of rendering them as safe HTML
- add Rust coverage that keeps page content raw while escaping `<title>`
- cover the NAPI-backed Vite wrapper for bare HTML generation

Closes #115.
Closes #112.

## Validation

- `cargo test -p ox_content_ssg test_generate_bare_html`
- `vp run build:napi`
- `vp exec --filter @ox-content/vite-plugin -- vp test src/ssg.test.ts`
