### PR TITLE
fix(vite): protect public export surface

### DIFF
--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -564,7 +564,7 @@ export type {
   MarkdownLintFilesResult,
   MarkdownLintFileOptions as MarkdownLintProjectOptions,
 } from "./lint-files";
-export { buildSsg, resolveSsgOptions } from "./ssg";
+export { buildSsg, resolveSsgOptions, DEFAULT_HTML_TEMPLATE } from "./ssg";
 export { resolveSearchOptions, buildSearchIndex, writeSearchIndex } from "./search";
 export {
   DEFAULT_MARKDOWN_EXTENSIONS,

--- a/npm/vite-plugin-ox-content/src/public-exports.test.ts
+++ b/npm/vite-plugin-ox-content/src/public-exports.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test";
+import * as publicApi from "./index";
+
+describe("public export surface", () => {
+  it("keeps compatibility exports available from the package entrypoint", () => {
+    const guardedExports = [
+      "DEFAULT_HTML_TEMPLATE",
+      "DEFAULT_MARKDOWN_EXTENSIONS",
+      "buildSearchIndex",
+      "buildSsg",
+      "extractDocs",
+      "generateMarkdown",
+      "isMarkdownFilePath",
+      "oxContent",
+      "resolveDocsOptions",
+      "resolveI18nOptions",
+      "resolveOgImageOptions",
+      "resolveSearchOptions",
+      "resolveSsgOptions",
+      "transformMarkdown",
+      "writeDocs",
+      "writeSearchIndex",
+    ].sort();
+
+    const actual = Object.keys(publicApi)
+      .filter((key) => guardedExports.includes(key))
+      .sort();
+
+    expect(actual).toEqual(guardedExports);
+  });
+});

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -71,6 +71,14 @@ interface SsgRoutePaths {
 }
 
 /**
+ * Deprecated compatibility export for consumers that imported the former
+ * TypeScript SSG template. HTML generation is Rust-backed now.
+ *
+ * @deprecated Use `generateHtmlPage`/`buildSsg` instead.
+ */
+export const DEFAULT_HTML_TEMPLATE = "<!-- ox-content default HTML template is Rust-backed -->";
+
+/**
  * Resolves SSG options with defaults.
  */
 export function resolveSsgOptions(ssg: SsgOptions | boolean | undefined): ResolvedSsgOptions {


### PR DESCRIPTION
## Summary

- restore a deprecated `DEFAULT_HTML_TEMPLATE` compatibility export from the Vite plugin entrypoint
- add a public export surface test so accidental removals are caught

Closes #117.

## Validation

- `vp exec --filter @ox-content/vite-plugin -- vp test src/public-exports.test.ts`
- `vp run check:ts`
