### PR TITLE
feat(mdc): add component checker diagnostics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ ox_content_search = { version = "2.11.0", path = "crates/ox_content_search" }
 ox_content_ssg = { version = "2.11.0", path = "crates/ox_content_ssg" }
 ox_content_i18n = { version = "2.11.0", path = "crates/ox_content_i18n" }
 ox_content_i18n_checker = { version = "2.11.0", path = "crates/ox_content_i18n_checker" }
+ox_content_mdc_checker = { version = "2.11.0", path = "crates/ox_content_mdc_checker" }
 ox_jsdoc = "0.0.15"
 
 # Memory allocation

--- a/README.md
+++ b/README.md
@@ -171,7 +171,13 @@ Supported features include:
 - i18n key completion, hover, go-to-definition, diagnostics, and inlay hints for JS/TS
 - table / code fence / callout insertion commands
 - preview HTML generation for editor UIs
-- `.mdc` authoring support
+- `.mdc` authoring support with component tag diagnostics
+
+For CI or editor-independent checks, run:
+
+```bash
+cargo run -p ox_content_mdc_checker --bin ox-content-mdc-check -- docs/page.mdc
+```
 
 **[Read the full documentation →](https://ubugeeei.github.io/ox-content/)**
 

--- a/crates/ox_content_lsp/Cargo.toml
+++ b/crates/ox_content_lsp/Cargo.toml
@@ -23,6 +23,7 @@ ox_content_allocator = { workspace = true }
 ox_content_ast = { workspace = true }
 ox_content_i18n = { workspace = true }
 ox_content_i18n_checker = { workspace = true }
+ox_content_mdc_checker = { workspace = true }
 ox_content_parser = { workspace = true }
 ox_content_renderer = { workspace = true }
 oxc_span = { workspace = true }

--- a/crates/ox_content_lsp/src/backend.rs
+++ b/crates/ox_content_lsp/src/backend.rs
@@ -70,11 +70,16 @@ impl Backend {
             return;
         };
 
-        let diagnostics = self.diagnostics(&document).await;
+        let is_mdc = uri
+            .to_file_path()
+            .ok()
+            .and_then(|path| path.extension().and_then(|ext| ext.to_str()).map(str::to_string))
+            .is_some_and(|ext| ext == "mdc");
+        let diagnostics = self.diagnostics(&document, is_mdc).await;
         self.client.publish_diagnostics(uri.clone(), diagnostics, None).await;
     }
 
-    async fn diagnostics(&self, document: &TextDocumentState) -> Vec<Diagnostic> {
+    async fn diagnostics(&self, document: &TextDocumentState, is_mdc: bool) -> Vec<Diagnostic> {
         let config = self.resolved_config().await;
         let frontmatter = frontmatter::parse_frontmatter(document);
         let mut diagnostics = frontmatter
@@ -83,6 +88,9 @@ impl Backend {
             .map_or_else(Vec::new, |block| Self::frontmatter_diagnostics(block, &config));
         diagnostics
             .extend(diagnostics::markdown_parse_diagnostics(document, frontmatter.block.as_ref()));
+        if is_mdc {
+            diagnostics.extend(diagnostics::mdc_diagnostics(document, frontmatter.block.as_ref()));
+        }
         diagnostics
     }
 

--- a/crates/ox_content_lsp/src/backend/diagnostics.rs
+++ b/crates/ox_content_lsp/src/backend/diagnostics.rs
@@ -29,6 +29,46 @@ pub(super) fn markdown_parse_diagnostics(
     diagnostics
 }
 
+pub(super) fn mdc_diagnostics(
+    document: &TextDocumentState,
+    block: Option<&FrontmatterBlock>,
+) -> Vec<Diagnostic> {
+    let (source, line_offset) = block.map_or_else(
+        || (document.text(), 0),
+        |block| {
+            let before = &document.text()[..block.content_start_offset];
+            (
+                &document.text()[block.content_start_offset..block.content_end_offset],
+                before.chars().filter(|ch| *ch == '\n').count() as u32,
+            )
+        },
+    );
+
+    ox_content_mdc_checker::check(source)
+        .into_iter()
+        .map(|diagnostic| {
+            let start_line = diagnostic.line.saturating_sub(1) + line_offset;
+            let end_line = diagnostic.end_line.saturating_sub(1) + line_offset;
+            Diagnostic {
+                range: tower_lsp::lsp_types::Range {
+                    start: tower_lsp::lsp_types::Position {
+                        line: start_line,
+                        character: diagnostic.column.saturating_sub(1),
+                    },
+                    end: tower_lsp::lsp_types::Position {
+                        line: end_line,
+                        character: diagnostic.end_column.saturating_sub(1),
+                    },
+                },
+                severity: Some(DiagnosticSeverity::ERROR),
+                source: Some("ox-content-mdc".to_string()),
+                message: diagnostic.message,
+                ..Default::default()
+            }
+        })
+        .collect()
+}
+
 fn parse_error_to_diagnostic(
     document: &TextDocumentState,
     base_offset: usize,

--- a/crates/ox_content_mdc_checker/Cargo.toml
+++ b/crates/ox_content_mdc_checker/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ox_content_mdc_checker"
+version.workspace = true
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Static checker for Ox Content MDC component syntax"
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "ox-content-mdc-check"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/ox_content_mdc_checker/src/lib.rs
+++ b/crates/ox_content_mdc_checker/src/lib.rs
@@ -1,0 +1,359 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub message: String,
+    pub line: u32,
+    pub column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct OpenTag {
+    name: String,
+    name_start: usize,
+    name_end: usize,
+}
+
+#[must_use]
+pub fn check(source: &str) -> Vec<Diagnostic> {
+    let line_index = LineIndex::new(source);
+    let masked = masked_fence_ranges(source);
+    let mut diagnostics = Vec::new();
+    let mut stack: Vec<OpenTag> = Vec::new();
+    let bytes = source.as_bytes();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] != b'<' || is_masked(index, &masked) {
+            index += 1;
+            continue;
+        }
+
+        let Some(tag) = parse_tag(source, index) else {
+            index += 1;
+            continue;
+        };
+
+        if tag.name.starts_with(|ch: char| ch.is_ascii_lowercase()) {
+            index = tag.end;
+            continue;
+        }
+
+        diagnostics.extend(check_attributes(source, &line_index, &tag));
+
+        if tag.closing {
+            match stack.pop() {
+                Some(open) if open.name == tag.name => {}
+                Some(open) => {
+                    diagnostics.push(diagnostic(
+                        &line_index,
+                        tag.name_start,
+                        tag.name_end,
+                        format!("MDC closing tag </{}> does not match <{}>.", tag.name, open.name),
+                        Some(tag.name),
+                    ));
+                    stack.push(open);
+                }
+                None => diagnostics.push(diagnostic(
+                    &line_index,
+                    tag.name_start,
+                    tag.name_end,
+                    format!("MDC closing tag </{}> has no matching opening tag.", tag.name),
+                    Some(tag.name),
+                )),
+            }
+        } else if !tag.self_closing {
+            stack.push(OpenTag {
+                name: tag.name,
+                name_start: tag.name_start,
+                name_end: tag.name_end,
+            });
+        }
+
+        index = tag.end;
+    }
+
+    for open in stack.into_iter().rev() {
+        diagnostics.push(diagnostic(
+            &line_index,
+            open.name_start,
+            open.name_end,
+            format!("MDC component <{}> is missing a closing tag.", open.name),
+            Some(open.name),
+        ));
+    }
+
+    diagnostics
+}
+
+#[derive(Debug)]
+struct ParsedTag {
+    name: String,
+    end: usize,
+    name_start: usize,
+    name_end: usize,
+    attributes_start: usize,
+    attributes_end: usize,
+    closing: bool,
+    self_closing: bool,
+}
+
+fn parse_tag(source: &str, start: usize) -> Option<ParsedTag> {
+    let bytes = source.as_bytes();
+    let mut cursor = start + 1;
+    let closing = bytes.get(cursor) == Some(&b'/');
+    if closing {
+        cursor += 1;
+    }
+
+    let name_start = cursor;
+    while let Some(byte) = bytes.get(cursor) {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-') {
+            cursor += 1;
+        } else {
+            break;
+        }
+    }
+
+    if cursor == name_start {
+        return None;
+    }
+
+    let name_end = cursor;
+    let name = source[name_start..name_end].to_string();
+    let attributes_start = cursor;
+    let mut quote: Option<u8> = None;
+    let mut brace_depth = 0u32;
+
+    while cursor < bytes.len() {
+        let byte = bytes[cursor];
+        if let Some(quote_byte) = quote {
+            if byte == quote_byte {
+                quote = None;
+            }
+            cursor += 1;
+            continue;
+        }
+
+        match byte {
+            b'"' | b'\'' => quote = Some(byte),
+            b'{' => brace_depth += 1,
+            b'}' => brace_depth = brace_depth.saturating_sub(1),
+            b'>' if brace_depth == 0 => {
+                let attributes_end = cursor;
+                let self_closing = source[start..cursor].trim_end().ends_with('/');
+                return Some(ParsedTag {
+                    name,
+                    end: cursor + 1,
+                    name_start,
+                    name_end,
+                    attributes_start,
+                    attributes_end,
+                    closing,
+                    self_closing,
+                });
+            }
+            b'\n' if quote.is_none() && brace_depth == 0 => return None,
+            _ => {}
+        }
+        cursor += 1;
+    }
+
+    None
+}
+
+fn check_attributes(source: &str, line_index: &LineIndex, tag: &ParsedTag) -> Vec<Diagnostic> {
+    if tag.closing {
+        return Vec::new();
+    }
+
+    let mut diagnostics = Vec::new();
+    let mut cursor = tag.attributes_start;
+    let end = tag.attributes_end;
+    let bytes = source.as_bytes();
+
+    while cursor < end {
+        while cursor < end && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        if cursor >= end || bytes[cursor] == b'/' {
+            break;
+        }
+
+        let attr_start = cursor;
+        while cursor < end
+            && (bytes[cursor].is_ascii_alphanumeric()
+                || matches!(bytes[cursor], b':' | b'_' | b'-'))
+        {
+            cursor += 1;
+        }
+        if cursor == attr_start {
+            cursor += 1;
+            continue;
+        }
+
+        while cursor < end && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        if cursor >= end || bytes[cursor] != b'=' {
+            continue;
+        }
+
+        cursor += 1;
+        while cursor < end && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        if cursor >= end || !matches!(bytes[cursor], b'"' | b'\'' | b'{') {
+            diagnostics.push(diagnostic(
+                line_index,
+                attr_start,
+                cursor.max(attr_start + 1),
+                "MDC prop values must be quoted strings or brace expressions.".to_string(),
+                Some(tag.name.clone()),
+            ));
+            continue;
+        }
+
+        cursor = skip_attribute_value(bytes, cursor, end);
+    }
+
+    diagnostics
+}
+
+fn skip_attribute_value(bytes: &[u8], start: usize, end: usize) -> usize {
+    let first = bytes[start];
+    if first == b'"' || first == b'\'' {
+        let mut cursor = start + 1;
+        while cursor < end {
+            if bytes[cursor] == first {
+                return cursor + 1;
+            }
+            cursor += 1;
+        }
+        return cursor;
+    }
+
+    let mut cursor = start + 1;
+    let mut depth = 1u32;
+    while cursor < end {
+        match bytes[cursor] {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return cursor + 1;
+                }
+            }
+            _ => {}
+        }
+        cursor += 1;
+    }
+    cursor
+}
+
+fn masked_fence_ranges(source: &str) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    let mut cursor = 0;
+    let mut fence: Option<(u8, usize)> = None;
+
+    for line in source.split_inclusive('\n') {
+        let line_start = cursor;
+        let trimmed = line.trim_start();
+        let indent = line.len() - trimmed.len();
+        if indent <= 3 && (trimmed.starts_with("```") || trimmed.starts_with("~~~")) {
+            let marker = trimmed.as_bytes()[0];
+            if let Some((open_marker, start)) = fence {
+                if marker == open_marker {
+                    ranges.push((start, line_start + line.len()));
+                    fence = None;
+                }
+            } else {
+                fence = Some((marker, line_start));
+            }
+        }
+        cursor += line.len();
+    }
+
+    if let Some((_, start)) = fence {
+        ranges.push((start, source.len()));
+    }
+
+    ranges
+}
+
+fn is_masked(offset: usize, ranges: &[(usize, usize)]) -> bool {
+    ranges.iter().any(|(start, end)| offset >= *start && offset < *end)
+}
+
+fn diagnostic(
+    line_index: &LineIndex,
+    start: usize,
+    end: usize,
+    message: String,
+    component: Option<String>,
+) -> Diagnostic {
+    let (line, column) = line_index.position(start);
+    let (end_line, end_column) = line_index.position(end);
+    Diagnostic { severity: Severity::Error, message, line, column, end_line, end_column, component }
+}
+
+struct LineIndex {
+    starts: Vec<usize>,
+}
+
+impl LineIndex {
+    fn new(source: &str) -> Self {
+        let mut starts = vec![0];
+        for (index, ch) in source.char_indices() {
+            if ch == '\n' {
+                starts.push(index + 1);
+            }
+        }
+        Self { starts }
+    }
+
+    fn position(&self, offset: usize) -> (u32, u32) {
+        let line = self.starts.partition_point(|start| *start <= offset).saturating_sub(1);
+        let column = offset.saturating_sub(self.starts[line]);
+        (line as u32 + 1, column as u32 + 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check;
+
+    #[test]
+    fn accepts_balanced_components_and_quoted_props() {
+        let diagnostics = check("<Alert tone=\"info\" :count={count}>Hello</Alert>\n<Card />");
+        assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_mismatched_and_unquoted_component_props() {
+        let diagnostics = check("<Alert tone=info><Panel></Alert>");
+        let messages: Vec<&str> =
+            diagnostics.iter().map(|diagnostic| diagnostic.message.as_str()).collect();
+
+        assert!(messages.iter().any(|message| message.contains("quoted strings")));
+        assert!(messages.iter().any(|message| message.contains("does not match")));
+        assert!(messages.iter().any(|message| message.contains("missing a closing tag")));
+    }
+
+    #[test]
+    fn ignores_component_like_text_inside_fences() {
+        let diagnostics = check("```mdc\n<Alert tone=bad>\n```\n<Alert />");
+        assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    }
+}

--- a/crates/ox_content_mdc_checker/src/main.rs
+++ b/crates/ox_content_mdc_checker/src/main.rs
@@ -1,0 +1,90 @@
+use std::fs;
+use std::path::PathBuf;
+
+use clap::{Parser, ValueEnum};
+
+#[derive(Parser)]
+#[command(name = "ox-content-mdc-check", about = "Check MDC component syntax")]
+struct Cli {
+    /// Files to check.
+    #[arg(required = true)]
+    files: Vec<PathBuf>,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = Format::Text)]
+    format: Format,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum Format {
+    Text,
+    Json,
+}
+
+#[derive(serde::Serialize)]
+struct FileDiagnostics {
+    file: String,
+    diagnostics: Vec<ox_content_mdc_checker::Diagnostic>,
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let mut results = Vec::new();
+    let mut error_count = 0usize;
+
+    for file in &cli.files {
+        match fs::read_to_string(file) {
+            Ok(source) => {
+                let diagnostics = ox_content_mdc_checker::check(&source);
+                error_count += diagnostics.len();
+                results.push(FileDiagnostics {
+                    file: file.to_string_lossy().into_owned(),
+                    diagnostics,
+                });
+            }
+            Err(error) => {
+                error_count += 1;
+                results.push(FileDiagnostics {
+                    file: file.to_string_lossy().into_owned(),
+                    diagnostics: vec![ox_content_mdc_checker::Diagnostic {
+                        severity: ox_content_mdc_checker::Severity::Error,
+                        message: error.to_string(),
+                        line: 1,
+                        column: 1,
+                        end_line: 1,
+                        end_column: 1,
+                        component: None,
+                    }],
+                });
+            }
+        }
+    }
+
+    match cli.format {
+        Format::Json => {
+            #[allow(clippy::print_stdout)]
+            {
+                println!("{}", serde_json::to_string_pretty(&results).unwrap_or_default());
+            }
+        }
+        Format::Text => print_text(&results),
+    }
+
+    if error_count > 0 {
+        std::process::exit(1);
+    }
+}
+
+fn print_text(results: &[FileDiagnostics]) {
+    for result in results {
+        for diagnostic in &result.diagnostics {
+            #[allow(clippy::print_stdout)]
+            {
+                println!(
+                    "{}:{}:{}: {}",
+                    result.file, diagnostic.line, diagnostic.column, diagnostic.message
+                );
+            }
+        }
+    }
+}

--- a/npm/vscode-ox-content/README.md
+++ b/npm/vscode-ox-content/README.md
@@ -9,4 +9,4 @@ Features:
 - i18n key completion, hover, definition, diagnostics, and inlay hints for JS/TS
 - command palette actions for table/code fence/callout insertion
 - Ox Content HTML preview
-- `.mdc` files associated with Markdown
+- `.mdc` files associated with Markdown and component tag diagnostics


### PR DESCRIPTION
## Summary

- add `ox_content_mdc_checker` with an `ox-content-mdc-check` CLI for component tag diagnostics
- surface MDC component diagnostics through the Markdown LSP for `.mdc` files
- document editor-independent checker usage and VS Code MDC diagnostics

Closes #8.

## Validation

- `cargo test -p ox_content_mdc_checker`
- `cargo test -p ox_content_lsp`
- `cargo clippy -p ox_content_mdc_checker -p ox_content_lsp --all-targets -- -D warnings`
