### PR TITLE
ci: add dependency policy gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,42 @@ jobs:
       - name: Run tests
         run: vp run test
 
+  dependency-policy:
+    name: Dependency policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: true
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Install Cargo audit tools
+        run: cargo install cargo-audit cargo-deny --locked
+
+      - name: Check Cargo advisories
+        run: cargo audit --deny warnings
+
+      - name: Check Cargo licenses
+        run: cargo deny check licenses
+
+      - name: Check npm advisories
+        run: node scripts/check-npm-advisories.mjs
+
+      - name: Check npm licenses
+        run: node scripts/check-npm-licenses.mjs
+
   package-dry-run:
     name: Package dry-run
     runs-on: ubuntu-latest

--- a/config/dependency-policy.json
+++ b/config/dependency-policy.json
@@ -1,0 +1,192 @@
+{
+  "npmAudit": {
+    "minimumSeverity": "high",
+    "advisoryAllowlist": [
+      {
+        "id": "GHSA-g2pg-6438-jwpf",
+        "reason": "Current benchmark/example dependency; revisit during scheduled dependency refresh.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-vw5p-8cq8-m7mv",
+        "reason": "Current benchmark/example dependency; revisit during scheduled dependency refresh.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-7h2j-956f-4vf2",
+        "reason": "Transitive glob dependency in tooling path; revisit during scheduled dependency refresh.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-3ppc-4f35-3m26",
+        "reason": "Transitive glob dependency in tooling path; revisit during scheduled dependency refresh.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-mw96-cpmx-2vgc",
+        "reason": "Build tooling dependency; no runtime file-write surface exposed by packages.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-5rq4-664w-9x2c",
+        "reason": "Puppeteer browser downloader dependency, not application FTP usage.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-7r86-cg39-jmmj",
+        "reason": "Transitive glob dependency in tooling path; revisit during scheduled dependency refresh.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-23c5-xmqv-rm74",
+        "reason": "Transitive glob dependency in tooling path; revisit during scheduled dependency refresh.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-5c6j-r48x-rmvq",
+        "reason": "Build/test serialization dependency; revisit during scheduled dependency refresh.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-xpqw-6gx7-v673",
+        "reason": "Mermaid CLI/SVG optimization tooling path; untrusted SVG input is not accepted.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-22cc-p3c6-wpvm",
+        "reason": "Benchmark/example Astro dependency; not shipped in published packages.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-c2c7-rcm5-vvqj",
+        "reason": "Build/example glob matching dependency; revisit during scheduled dependency refresh.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-r5fr-rjxr-66jc",
+        "reason": "Mermaid transitive dependency; no user-controlled template execution surface.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-737v-mqg7-c878",
+        "reason": "Benchmark/example Astro dependency; not shipped in published packages.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-v2wj-q39q-566r",
+        "reason": "Vite dev/build tooling dependency; revisit during scheduled dependency refresh.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-p9ff-h696-f583",
+        "reason": "Vite dev/build tooling dependency; revisit during scheduled dependency refresh.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-6v7q-wjvx-w8wg",
+        "reason": "Puppeteer browser downloader dependency, not application FTP usage.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-mp2g-9vg9-f4cg",
+        "reason": "Benchmark/example Astro dependency; not shipped in published packages.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-rp42-5vxx-qpwr",
+        "reason": "Puppeteer browser downloader dependency, not application FTP usage.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-33r3-4whc-44c2",
+        "reason": "Repository-local toolchain dependency; upgrade tracked separately from package runtime.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-q3j6-qgpj-74h6",
+        "reason": "Webpack example dependency; not shipped in published packages.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-v39h-62p7-jpjc",
+        "reason": "Webpack example dependency; not shipped in published packages.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-rpmf-866q-6p89",
+        "reason": "Puppeteer browser downloader dependency, not application FTP usage.",
+        "expires": "2026-08-31"
+      },
+      {
+        "id": "GHSA-77vg-94rm-hx3p",
+        "reason": "Svelte integration example dependency; not shipped in published packages.",
+        "expires": "2026-08-31"
+      }
+    ]
+  },
+  "licenses": {
+    "allowed": [
+      "(MIT AND Zlib)",
+      "(MIT OR CC0-1.0)",
+      "(MPL-2.0 OR Apache-2.0)",
+      "0BSD",
+      "Apache-2.0",
+      "BSD",
+      "BSD-2-Clause",
+      "BSD-3-Clause",
+      "BlueOak-1.0.0",
+      "CC0-1.0",
+      "ISC",
+      "MIT",
+      "MPL-2.0",
+      "Unlicense"
+    ],
+    "exceptions": [
+      {
+        "name": "@cspell/dict-de-de",
+        "license": "LGPL-3.0",
+        "reason": "Development-only spellcheck dictionary data."
+      },
+      {
+        "name": "@cspell/dict-pl_pl",
+        "license": "LGPL-3.0+",
+        "reason": "Development-only spellcheck dictionary data."
+      },
+      {
+        "name": "@img/sharp-libvips-darwin-arm64",
+        "license": "LGPL-3.0-or-later",
+        "reason": "Optional native image processing binary used by tooling."
+      },
+      {
+        "name": "@img/sharp-libvips-linux-x64",
+        "license": "LGPL-3.0-or-later",
+        "reason": "Optional native image processing binary used by tooling."
+      },
+      {
+        "name": "@img/sharp-libvips-linuxmusl-x64",
+        "license": "LGPL-3.0-or-later",
+        "reason": "Optional native image processing binary used by tooling."
+      },
+      {
+        "name": "@cspell/dict-en-common-misspellings",
+        "license": "CC BY-SA 4.0",
+        "reason": "Development-only spellcheck dictionary data."
+      },
+      {
+        "name": "caniuse-lite",
+        "license": "CC-BY-4.0",
+        "reason": "Browser compatibility dataset used by build tooling."
+      },
+      {
+        "name": "argparse",
+        "license": "Python-2.0",
+        "reason": "Transitive CLI parsing utility used by tooling."
+      },
+      {
+        "name": "khroma",
+        "license": "Unknown",
+        "reason": "Transitive color utility; review upstream metadata during dependency refresh."
+      }
+    ]
+  }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,17 @@
+[licenses]
+version = 2
+confidence-threshold = 0.8
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Unicode-3.0",
+  "0BSD",
+  "BSD-2-Clause",
+  "ISC",
+  "BSL-1.0",
+  "Zlib",
+  "Unlicense",
+]
+
+[licenses.private]
+ignore = true

--- a/docs/dependency-policy.md
+++ b/docs/dependency-policy.md
@@ -1,0 +1,18 @@
+# Dependency Policy
+
+CI gates dependency advisories and licenses for both Rust and npm surfaces.
+
+## Advisories
+
+- Cargo advisories run through `cargo audit`.
+- npm advisories run through `scripts/check-npm-advisories.mjs`.
+- The npm gate fails on new `high` or `critical` advisories unless an item is explicitly listed in `config/dependency-policy.json`.
+
+Allowed advisories must include a reason and an expiry date. Remove the entry when the dependency is upgraded or the advisory no longer applies.
+
+## Licenses
+
+- Cargo license policy lives in `deny.toml` and is checked by `cargo deny check licenses`.
+- npm license policy lives in `config/dependency-policy.json` and is checked by `scripts/check-npm-licenses.mjs`.
+
+Prefer permissive licenses such as MIT, Apache-2.0, BSD, ISC, Unicode-3.0, Zlib, CC0, MPL-2.0, and Unlicense. Exceptions must name the package, license, and reason so maintainers can audit them during dependency refreshes.

--- a/scripts/check-npm-advisories.mjs
+++ b/scripts/check-npm-advisories.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const policy = readPolicy();
+const minimumSeverity = policy.npmAudit?.minimumSeverity ?? "high";
+const allowlist = new Map(
+  (policy.npmAudit?.advisoryAllowlist ?? []).map((item) => [item.id, item]),
+);
+const audit = runAudit();
+const advisories = Object.values(audit.advisories ?? {});
+const failures = [];
+const allowed = [];
+
+for (const advisory of advisories) {
+  const severity = String(advisory.severity ?? "unknown");
+  if (severityRank(severity) < severityRank(minimumSeverity)) {
+    continue;
+  }
+
+  const id = advisory.github_advisory_id ?? String(advisory.id);
+  const allowedAdvisory = allowlist.get(id);
+  if (allowedAdvisory) {
+    if (isExpired(allowedAdvisory.expires)) {
+      failures.push(
+        `${id} ${severity} ${advisory.module_name} allowlist expired on ${allowedAdvisory.expires}`,
+      );
+      continue;
+    }
+    allowed.push(`${id} ${severity} ${advisory.module_name}`);
+    continue;
+  }
+
+  failures.push(`${id} ${severity} ${advisory.module_name} ${advisory.vulnerable_versions}`);
+}
+
+if (allowed.length > 0) {
+  console.log(`Allowed ${allowed.length} npm advisories from policy:`);
+  for (const line of allowed.sort()) {
+    console.log(`  - ${line}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`Blocked ${failures.length} npm advisories at ${minimumSeverity}+ severity:`);
+  for (const line of failures.sort()) {
+    console.error(`  - ${line}`);
+  }
+  process.exit(1);
+}
+
+console.log(`No unapproved npm advisories at ${minimumSeverity}+ severity.`);
+
+function runAudit() {
+  const result = runPnpm(["audit", "--json"]);
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  const output = result.stdout.trim();
+  if (!output) {
+    if (result.status === 0) {
+      return { advisories: {} };
+    }
+    throw new Error(result.stderr || "pnpm audit produced no JSON output.");
+  }
+
+  return parseJsonOutput(output);
+}
+
+function runPnpm(args) {
+  const result = spawnSync("corepack", ["pnpm", ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error?.code !== "ENOENT") {
+    return result;
+  }
+
+  return spawnSync("pnpm", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function readPolicy() {
+  return JSON.parse(readFileSync(resolve("config/dependency-policy.json"), "utf8"));
+}
+
+function isExpired(expires) {
+  if (!expires) {
+    return false;
+  }
+  return Date.parse(`${expires}T23:59:59.999Z`) < Date.now();
+}
+
+function severityRank(severity) {
+  return (
+    {
+      info: 0,
+      low: 1,
+      moderate: 2,
+      high: 3,
+      critical: 4,
+    }[severity] ?? 0
+  );
+}
+
+function parseJsonOutput(output) {
+  const jsonStart = output.indexOf("{");
+  if (jsonStart === -1) {
+    throw new Error(`pnpm audit did not emit JSON output:\n${output}`);
+  }
+
+  return JSON.parse(output.slice(jsonStart));
+}

--- a/scripts/check-npm-licenses.mjs
+++ b/scripts/check-npm-licenses.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const policy = JSON.parse(readFileSync(resolve("config/dependency-policy.json"), "utf8"));
+const allowedLicenses = new Set(policy.licenses?.allowed ?? []);
+const exceptions = new Set(
+  (policy.licenses?.exceptions ?? []).map((item) => `${item.name}\0${item.license}`),
+);
+const report = runLicenseList();
+const violations = [];
+const licenseGroups = collectLicenseGroups(report);
+
+for (const { license, packages } of licenseGroups) {
+  for (const pkg of packages) {
+    const key = `${pkg.name}\0${license}`;
+    if (allowedLicenses.has(license) || exceptions.has(key)) {
+      continue;
+    }
+
+    violations.push(`${pkg.name}@${(pkg.versions ?? []).join(",")} uses ${license}`);
+  }
+}
+
+if (licenseGroups.length === 0) {
+  if (report.error) {
+    throw new Error(`pnpm licenses failed: ${JSON.stringify(report.error)}`);
+  }
+  throw new Error(
+    `pnpm licenses output did not contain any license package groups. Top-level keys: ${Object.keys(
+      report,
+    )
+      .slice(0, 10)
+      .join(", ")}`,
+  );
+}
+
+if (violations.length > 0) {
+  console.error("Blocked npm packages with unapproved licenses:");
+  for (const violation of violations.sort()) {
+    console.error(`  - ${violation}`);
+  }
+  process.exit(1);
+}
+
+console.log("All npm dependency licenses match config/dependency-policy.json.");
+
+function runLicenseList() {
+  const report = readLicenseReport();
+  if (report.error?.code === "ERR_PNPM_MISSING_PACKAGE_INDEX_FILE") {
+    runInstall();
+    return readLicenseReport();
+  }
+
+  return report;
+}
+
+function readLicenseReport() {
+  const result = runPnpm(["licenses", "list", "--recursive", "--json"]);
+
+  if (result.error) {
+    throw result.error;
+  }
+  const output = result.stdout.trim();
+  if (!output) {
+    if (result.status === 0) {
+      return {};
+    }
+    throw new Error(result.stderr || "pnpm licenses produced no JSON output.");
+  }
+
+  return parseJsonOutput(output);
+}
+
+function runInstall() {
+  const result = runPnpm(["install", "--frozen-lockfile", "--force"]);
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout || "pnpm install failed.");
+  }
+}
+
+function runPnpm(args) {
+  const result = spawnSync("corepack", ["pnpm", ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error?.code !== "ENOENT") {
+    return result;
+  }
+
+  return spawnSync("pnpm", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function parseJsonOutput(output) {
+  const jsonStart = findJsonStart(output);
+  if (jsonStart === -1) {
+    throw new Error(`pnpm licenses did not emit JSON output:\n${output}`);
+  }
+
+  return JSON.parse(output.slice(jsonStart));
+}
+
+function findJsonStart(output) {
+  let offset = 0;
+  for (const line of output.split(/(?<=\n)/)) {
+    const firstContent = line.search(/\S/);
+    if (firstContent !== -1) {
+      const firstChar = line[firstContent];
+      if (firstChar === "{" || firstChar === "[") {
+        return offset + firstContent;
+      }
+    }
+    offset += line.length;
+  }
+
+  return -1;
+}
+
+function collectPackages(group) {
+  if (Array.isArray(group)) {
+    return group;
+  }
+  if (!group || typeof group !== "object") {
+    return null;
+  }
+  if (Array.isArray(group.packages)) {
+    return group.packages;
+  }
+
+  const values = Object.values(group);
+  if (values.length > 0 && values.every(isPackageEntry)) {
+    return values;
+  }
+
+  return null;
+}
+
+function collectLicenseGroups(node) {
+  if (!node || typeof node !== "object" || Array.isArray(node)) {
+    return [];
+  }
+
+  const groups = [];
+  for (const [license, group] of Object.entries(node)) {
+    const packages = collectPackages(group);
+    if (packages) {
+      groups.push({ license, packages });
+      continue;
+    }
+    groups.push(...collectLicenseGroups(group));
+  }
+
+  return groups;
+}
+
+function isPackageEntry(value) {
+  return Boolean(value && typeof value === "object" && "name" in value);
+}


### PR DESCRIPTION
## Summary
- add Cargo and npm dependency policy gates to CI
- document the approved advisory/license policy
- add scripts for npm advisory and license enforcement

Closes #120.

## Validation
- node scripts/check-npm-advisories.mjs
- node scripts/check-npm-licenses.mjs
- cargo audit --deny warnings
- cargo deny check licenses
- vp run check:ts
- git diff --check