### PR TITLE
ci: enforce benchmark regression thresholds

### DIFF
--- a/.github/scripts/compare-pr-benchmark.mjs
+++ b/.github/scripts/compare-pr-benchmark.mjs
@@ -7,7 +7,7 @@ import { join } from "node:path";
 const runnerTemp = requiredEnv("RUNNER_TEMP");
 const commentPath = join(runnerTemp, "benchmark-comment.md");
 
-run("node", [
+const status = run("node", [
   "benchmarks/bundle-size/compare-pr-benchmark.mjs",
   "--base",
   join(runnerTemp, "benchmark-base.json"),
@@ -27,6 +27,10 @@ run("node", [
 
 if (process.env.GITHUB_STEP_SUMMARY) {
   appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${readFileSync(commentPath, "utf8")}\n`);
+}
+
+if (status !== 0) {
+  process.exit(status);
 }
 
 /**
@@ -52,7 +56,5 @@ function run(command, args) {
   if (result.error) {
     throw result.error;
   }
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
-  }
+  return result.status ?? 1;
 }

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -66,6 +66,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          OX_CONTENT_BENCHMARK_ALLOW_REGRESSION: ${{ contains(github.event.pull_request.labels.*.name, 'benchmark-regression-accepted') && '1' || '0' }}
         working-directory: .benchmark/head
         run: node "$GITHUB_WORKSPACE/.github/scripts/compare-pr-benchmark.mjs"
 

--- a/benchmarks/bundle-size/compare-pr-benchmark.mjs
+++ b/benchmarks/bundle-size/compare-pr-benchmark.mjs
@@ -6,6 +6,9 @@ const COMMENT_MARKER = "<!-- ox-content-benchmark-report -->";
 const TARGET_NAMES = new Set(["@ox-content/napi", "@ox-content/napi (async)"]);
 const COMMENT_SIZE_NAMES = new Set(["large"]);
 const NOISE_THRESHOLD_PERCENT = 5;
+const RUNTIME_REGRESSION_THRESHOLD_PERCENT = -10;
+const BUNDLE_REGRESSION_THRESHOLD_PERCENT = 5;
+const BENCHMARK_OVERRIDE_ENV = "OX_CONTENT_BENCHMARK_ALLOW_REGRESSION";
 const BUNDLE_APP_ORDER = [
   "ox-content (bare)",
   "ox-content (default)",
@@ -33,6 +36,10 @@ if (options.outputPath) {
 }
 
 console.log(body);
+
+if (body.includes("<!-- ox-content-benchmark-regression -->")) {
+  process.exitCode = 1;
+}
 
 function parseOptions(args) {
   const parsed = {
@@ -125,6 +132,8 @@ function buildComment({ basePath, headPath, baseBundlePath, headBundlePath, base
       ? compareBundleReports(readJson(baseBundlePath), readJson(headBundlePath))
       : [];
   const summary = summarizeRows(runtimeRows, bundleRows);
+  const regressions = collectRegressions(runtimeRows, bundleRows);
+  const overrideEnabled = process.env[BENCHMARK_OVERRIDE_ENV] === "1";
   const compareText =
     baseSha && headSha
       ? `Comparing base \`${shortSha(baseSha)}\` to head \`${shortSha(headSha)}\`.`
@@ -181,6 +190,35 @@ function buildComment({ basePath, headPath, baseBundlePath, headBundlePath, base
       "Bundle size uses gzipped JS/CSS/HTML/JSON assets. Requests estimate index.html plus referenced local initial assets. Lower is better.",
       "",
     );
+  }
+
+  lines.push(
+    "### Regression Gate",
+    "",
+    `Runtime regressions fail when head throughput is more than ${Math.abs(RUNTIME_REGRESSION_THRESHOLD_PERCENT)}% slower than base. Bundle regressions fail when gzipped size grows by more than ${BUNDLE_REGRESSION_THRESHOLD_PERCENT}%. Maintainers can intentionally override by applying the \`benchmark-regression-accepted\` PR label, which sets \`${BENCHMARK_OVERRIDE_ENV}=1\`.`,
+    "",
+  );
+
+  if (regressions.length === 0) {
+    lines.push("No threshold regressions found.", "");
+  } else {
+    if (!overrideEnabled) {
+      lines.push("<!-- ox-content-benchmark-regression -->");
+    }
+    lines.push(
+      overrideEnabled
+        ? "Threshold regressions were found, but the maintainer override is active."
+        : "Threshold regressions were found and this check should fail.",
+      "",
+      "| Metric | Target | Delta | Threshold |",
+      "| --- | --- | ---: | ---: |",
+    );
+    for (const regression of regressions) {
+      lines.push(
+        `| ${regression.metric} | ${regression.target} | ${formatDelta(regression.deltaPercent)} | ${formatDelta(regression.thresholdPercent)} |`,
+      );
+    }
+    lines.push("");
   }
 
   return lines.join("\n");
@@ -339,6 +377,40 @@ function summarizeRows(runtimeRows, bundleRows) {
   }
 
   return `${parts.join(" and ")} compared.`;
+}
+
+function collectRegressions(runtimeRows, bundleRows) {
+  const regressions = [];
+
+  for (const row of runtimeRows) {
+    if (
+      Number.isFinite(row.deltaPercent) &&
+      row.deltaPercent < RUNTIME_REGRESSION_THRESHOLD_PERCENT
+    ) {
+      regressions.push({
+        metric: `${row.suiteLabel} runtime`,
+        target: `${row.sizeName} / ${row.targetName}`,
+        deltaPercent: row.deltaPercent,
+        thresholdPercent: RUNTIME_REGRESSION_THRESHOLD_PERCENT,
+      });
+    }
+  }
+
+  for (const row of bundleRows) {
+    if (
+      Number.isFinite(row.deltaPercent) &&
+      row.deltaPercent > BUNDLE_REGRESSION_THRESHOLD_PERCENT
+    ) {
+      regressions.push({
+        metric: "Bundle gzip",
+        target: row.name,
+        deltaPercent: row.deltaPercent,
+        thresholdPercent: BUNDLE_REGRESSION_THRESHOLD_PERCENT,
+      });
+    }
+  }
+
+  return regressions;
 }
 
 function formatNumber(value) {


### PR DESCRIPTION
## Summary
- fail the benchmark comparison check when runtime or bundle regressions exceed policy thresholds
- document threshold results in the benchmark PR comment
- allow intentional regressions with the benchmark-regression-accepted PR label

Closes #124.

## Validation
- local compare script smoke for pass, fail, and override cases
- local GitHub wrapper smoke with override enabled
- git diff --check