### PR TITLE
feat(docs): filter internal declarations

### DIFF
--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -166,19 +166,27 @@ pub enum DocItemKind {
 pub struct DocExtractor {
     /// Include private items.
     include_private: bool,
+    /// Include internal items.
+    include_internal: bool,
 }
 
 impl DocExtractor {
     /// Creates a new documentation extractor.
     #[must_use]
     pub fn new() -> Self {
-        Self { include_private: false }
+        Self { include_private: false, include_internal: false }
     }
 
     /// Creates a new extractor that includes private items.
     #[must_use]
     pub fn with_private(include_private: bool) -> Self {
-        Self { include_private }
+        Self { include_private, include_internal: false }
+    }
+
+    /// Creates a new extractor with explicit visibility options.
+    #[must_use]
+    pub fn with_visibility(include_private: bool, include_internal: bool) -> Self {
+        Self { include_private, include_internal }
     }
 
     /// Extracts documentation from a source file.
@@ -214,7 +222,13 @@ impl DocExtractor {
         let comments: Vec<Comment> = ret.program.comments.iter().copied().collect();
         let jsdoc_cache = build_jsdoc_cache(source, &comments);
 
-        let mut visitor = DocVisitor::new(source, file_path, self.include_private, jsdoc_cache);
+        let mut visitor = DocVisitor::new(
+            source,
+            file_path,
+            self.include_private,
+            self.include_internal,
+            jsdoc_cache,
+        );
         if let Some(module_item) = visitor.extract_module_entry(&comments) {
             visitor.items.push(module_item);
         }
@@ -308,6 +322,7 @@ struct DocVisitor<'a> {
     source: &'a str,
     file_path: &'a str,
     include_private: bool,
+    include_internal: bool,
     jsdoc_cache: FxHashMap<u32, ParsedJsdoc>,
     line_starts: Vec<usize>,
     items: Vec<DocItem>,
@@ -320,6 +335,7 @@ impl<'a> DocVisitor<'a> {
         source: &'a str,
         file_path: &'a str,
         include_private: bool,
+        include_internal: bool,
         jsdoc_cache: FxHashMap<u32, ParsedJsdoc>,
     ) -> Self {
         let mut line_starts = vec![0];
@@ -334,6 +350,7 @@ impl<'a> DocVisitor<'a> {
             source,
             file_path,
             include_private,
+            include_internal,
             jsdoc_cache,
             line_starts,
             items: Vec::new(),
@@ -792,6 +809,15 @@ impl<'a> DocVisitor<'a> {
         tags.iter().any(|tag| tag.tag == "private")
     }
 
+    fn has_internal_tag(tags: &[DocTag]) -> bool {
+        tags.iter().any(|tag| tag.tag == "internal")
+    }
+
+    fn should_skip_by_visibility(&self, tags: &[DocTag]) -> bool {
+        (!self.include_private && Self::has_private_tag(tags))
+            || (!self.include_internal && Self::has_internal_tag(tags))
+    }
+
     fn split_leading_jsdoc_type(value: &str) -> (Option<String>, &str) {
         let value = value.trim_start();
         let Some(rest) = value.strip_prefix('{') else {
@@ -1124,7 +1150,7 @@ impl<'a> DocVisitor<'a> {
     ) -> Option<DocItem> {
         let name = func.id.as_ref()?.name.to_string();
         let (jsdoc, doc, tags) = self.extract_jsdoc(attached_to)?;
-        if !self.include_private && Self::has_private_tag(&tags) {
+        if self.should_skip_by_visibility(&tags) {
             return None;
         }
         let (line, end_line) = self.span_lines(attached_to, func.span.end);
@@ -1160,7 +1186,7 @@ impl<'a> DocVisitor<'a> {
         attached_to: u32,
     ) -> Option<DocItem> {
         let (jsdoc, doc, tags) = self.extract_jsdoc(attached_to)?;
-        if !self.include_private && Self::has_private_tag(&tags) {
+        if self.should_skip_by_visibility(&tags) {
             return None;
         }
         let (line, end_line) = self.span_lines(attached_to, class.span.end);
@@ -1188,7 +1214,7 @@ impl<'a> DocVisitor<'a> {
                     else {
                         continue;
                     };
-                    if !self.include_private && Self::has_private_tag(&method_tags) {
+                    if self.should_skip_by_visibility(&method_tags) {
                         continue;
                     }
                     let (method_line, method_end_line) =
@@ -1228,7 +1254,7 @@ impl<'a> DocVisitor<'a> {
                     else {
                         continue;
                     };
-                    if !self.include_private && Self::has_private_tag(&prop_tags) {
+                    if self.should_skip_by_visibility(&prop_tags) {
                         continue;
                     }
                     let (prop_line, prop_end_line) =
@@ -1352,7 +1378,7 @@ impl<'a> DocVisitor<'a> {
                 let Some((jsdoc, doc, tags)) = self.extract_jsdoc(attached_to) else {
                     return;
                 };
-                if !self.include_private && Self::has_private_tag(&tags) {
+                if self.should_skip_by_visibility(&tags) {
                     return;
                 }
                 let (line, end_line) = self.span_lines(attached_to, var_decl.span.end);
@@ -1449,7 +1475,7 @@ impl<'a> DocVisitor<'a> {
                 let Some((jsdoc, doc, tags)) = self.extract_jsdoc(attached_to) else {
                     return;
                 };
-                if !self.include_private && Self::has_private_tag(&tags) {
+                if self.should_skip_by_visibility(&tags) {
                     return;
                 }
                 let (line, end_line) = self.span_lines(attached_to, type_alias.span.end);
@@ -1475,7 +1501,7 @@ impl<'a> DocVisitor<'a> {
                 let Some((jsdoc, doc, tags)) = self.extract_jsdoc(attached_to) else {
                     return;
                 };
-                if !self.include_private && Self::has_private_tag(&tags) {
+                if self.should_skip_by_visibility(&tags) {
                     return;
                 }
                 let (line, end_line) = self.span_lines(attached_to, interface.span.end);
@@ -1498,7 +1524,7 @@ impl<'a> DocVisitor<'a> {
                             else {
                                 continue;
                             };
-                            if !self.include_private && Self::has_private_tag(&prop_tags) {
+                            if self.should_skip_by_visibility(&prop_tags) {
                                 continue;
                             }
                             let (prop_line, prop_end_line) =
@@ -1539,7 +1565,7 @@ impl<'a> DocVisitor<'a> {
                             else {
                                 continue;
                             };
-                            if !self.include_private && Self::has_private_tag(&method_tags) {
+                            if self.should_skip_by_visibility(&method_tags) {
                                 continue;
                             }
                             let (method_line, method_end_line) =
@@ -1597,7 +1623,7 @@ impl<'a> DocVisitor<'a> {
                 let Some((jsdoc, doc, tags)) = self.extract_jsdoc(attached_to) else {
                     return;
                 };
-                if !self.include_private && Self::has_private_tag(&tags) {
+                if self.should_skip_by_visibility(&tags) {
                     return;
                 }
                 let (line, end_line) = self.span_lines(attached_to, enum_decl.span.end);
@@ -1837,5 +1863,30 @@ export { value } from './value';
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].name, "runtime");
         assert_eq!(items[0].kind, DocItemKind::Module);
+    }
+
+    #[test]
+    fn test_internal_items_are_excluded_by_default() {
+        let source = r"
+/** Public command. */
+export function publicCommand(): void {}
+
+/**
+ * Internal helper.
+ * @internal
+ */
+export function internalHelper(): void {}
+";
+
+        let public_only =
+            DocExtractor::new().extract_source(source, "visibility.ts", SourceType::ts()).unwrap();
+        assert_eq!(public_only.len(), 1);
+        assert_eq!(public_only[0].name, "publicCommand");
+
+        let with_internal = DocExtractor::with_visibility(false, true)
+            .extract_source(source, "visibility.ts", SourceType::ts())
+            .unwrap();
+        assert_eq!(with_internal.len(), 2);
+        assert_eq!(with_internal[1].name, "internalHelper");
     }
 }

--- a/crates/ox_content_docs/src/graph.rs
+++ b/crates/ox_content_docs/src/graph.rs
@@ -41,6 +41,8 @@ pub struct EntryPointDocsOptions {
     pub graph: GraphOptions,
     /// Include `@private` docs.
     pub include_private: bool,
+    /// Include `@internal` docs.
+    pub include_internal: bool,
 }
 
 /// Resolved export graph.
@@ -211,7 +213,8 @@ pub fn extract_docs_from_entry_points(
     options: &EntryPointDocsOptions,
 ) -> Result<Vec<EntrypointDocsModule>, GraphError> {
     let graph = build_export_graph(entrypoints, &options.graph)?;
-    let extractor = DocExtractor::with_private(options.include_private);
+    let extractor =
+        DocExtractor::with_visibility(options.include_private, options.include_internal);
     let mut docs_cache: FxHashMap<PathBuf, Vec<NormalizedDocEntry>> =
         FxHashMap::with_hasher(FxBuildHasher);
     let mut modules = Vec::with_capacity(graph.entrypoints.len());
@@ -739,7 +742,11 @@ export function label(value: string): string {
 
         let docs = extract_docs_from_entry_points(
             &entrypoints,
-            &EntryPointDocsOptions { graph: graph_options, include_private: false },
+            &EntryPointDocsOptions {
+                graph: graph_options,
+                include_private: false,
+                include_internal: false,
+            },
         )
         .unwrap();
         let names = docs[0].entries.iter().map(|entry| entry.name.as_str()).collect::<Vec<_>>();

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -58,10 +58,10 @@ export declare function externalizeSsgAssets(pages: Array<JsSsgGeneratedHtmlPage
 export declare function extractDocsFromEntryPoints(entryPoints: Array<JsEntryPointSpec>, options?: JsEntryPointDocsOptions | undefined | null): Array<JsEntrypointDocsModule>
 
 /** Extracts normalized documentation entries from a JavaScript/TypeScript file using Oxc. */
-export declare function extractFileDocEntries(filePath: string, includePrivate?: boolean | undefined | null): Array<JsDocEntry>
+export declare function extractFileDocEntries(filePath: string, includePrivate?: boolean | undefined | null, includeInternal?: boolean | undefined | null): Array<JsDocEntry>
 
 /** Extracts documented declarations from a JavaScript/TypeScript file using Oxc. */
-export declare function extractFileDocs(filePath: string, includePrivate?: boolean | undefined | null): Array<JsSourceDocItem>
+export declare function extractFileDocs(filePath: string, includePrivate?: boolean | undefined | null, includeInternal?: boolean | undefined | null): Array<JsSourceDocItem>
 
 /**
  * Extracts searchable content from Markdown source.
@@ -276,6 +276,7 @@ export interface JsEntryPointDocsOptions {
   root?: string
   tsconfig?: string
   private?: boolean
+  internal?: boolean
 }
 
 /** Public entry point module. */

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -262,6 +262,7 @@ pub struct JsEntryPointDocsOptions {
     pub root: Option<String>,
     pub tsconfig: Option<String>,
     pub private: Option<bool>,
+    pub internal: Option<bool>,
 }
 
 /// Export source metadata.
@@ -610,6 +611,7 @@ fn convert_entrypoint_docs_options(
             tsconfig: options.tsconfig.map(PathBuf::from),
         },
         include_private: options.private.unwrap_or(false),
+        include_internal: options.internal.unwrap_or(false),
     }
 }
 
@@ -740,8 +742,12 @@ fn convert_markdown_module(module: JsDocsMarkdownModule) -> ApiDocModule {
 pub fn extract_file_docs(
     file_path: String,
     include_private: Option<bool>,
+    include_internal: Option<bool>,
 ) -> Result<Vec<JsSourceDocItem>> {
-    let extractor = DocExtractor::with_private(include_private.unwrap_or(false));
+    let extractor = DocExtractor::with_visibility(
+        include_private.unwrap_or(false),
+        include_internal.unwrap_or(false),
+    );
     let items = extractor
         .extract_file(Path::new(&file_path))
         .map_err(|err| Error::from_reason(err.to_string()))?;
@@ -754,8 +760,12 @@ pub fn extract_file_docs(
 pub fn extract_file_doc_entries(
     file_path: String,
     include_private: Option<bool>,
+    include_internal: Option<bool>,
 ) -> Result<Vec<JsDocEntry>> {
-    let extractor = DocExtractor::with_private(include_private.unwrap_or(false));
+    let extractor = DocExtractor::with_visibility(
+        include_private.unwrap_or(false),
+        include_internal.unwrap_or(false),
+    );
     let items = extractor
         .extract_file(Path::new(&file_path))
         .map_err(|err| Error::from_reason(err.to_string()))?;

--- a/npm/vite-plugin-ox-content/src/docs.test.ts
+++ b/npm/vite-plugin-ox-content/src/docs.test.ts
@@ -256,6 +256,82 @@ export interface Options {
     expect(docs[0]?.entries.map((entry) => entry.name)).toEqual(["sum", "Options"]);
   });
 
+  it("excludes internal docs unless explicitly included", async () => {
+    const srcDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-docs-src-"));
+    tempDirs.push(srcDir);
+
+    await fs.writeFile(
+      path.join(srcDir, "visibility.ts"),
+      `/** Public command. */
+export function publicCommand(): void {}
+
+/**
+ * Internal helper.
+ * @internal
+ */
+export function internalHelper(): void {}
+`,
+      "utf-8",
+    );
+
+    const publicOnly = await extractDocs([srcDir], resolveDocsOptions({ include: ["**/*.ts"] })!);
+    expect(publicOnly[0]?.entries.map((entry) => entry.name)).toEqual(["publicCommand"]);
+
+    const withInternal = await extractDocs(
+      [srcDir],
+      resolveDocsOptions({ include: ["**/*.ts"], internal: true })!,
+    );
+    expect(withInternal[0]?.entries.map((entry) => entry.name)).toEqual([
+      "publicCommand",
+      "internalHelper",
+    ]);
+  });
+
+  it("applies internal filtering to public API entry points", async () => {
+    const srcDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-docs-src-"));
+    tempDirs.push(srcDir);
+
+    await fs.writeFile(
+      path.join(srcDir, "index.ts"),
+      `export { publicCommand, internalHelper } from "./commands";
+`,
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(srcDir, "commands.ts"),
+      `/** Public command. */
+export function publicCommand(): void {}
+
+/**
+ * Internal helper.
+ * @internal
+ */
+export function internalHelper(): void {}
+`,
+      "utf-8",
+    );
+
+    const publicOnly = await extractDocs(
+      [],
+      resolveDocsOptions({
+        entryPoints: [{ path: path.join(srcDir, "index.ts"), name: "default" }],
+      })!,
+    );
+    expect(publicOnly[0]?.entries.map((entry) => entry.name)).toEqual(["publicCommand"]);
+
+    const withInternal = await extractDocs(
+      [],
+      resolveDocsOptions({
+        entryPoints: [{ path: path.join(srcDir, "index.ts"), name: "default" }],
+        internal: true,
+      })!,
+    );
+    expect(withInternal[0]?.entries.map((entry) => entry.name)).toEqual([
+      "publicCommand",
+      "internalHelper",
+    ]);
+  });
+
   it("extracts and renders highlighted interface signatures with generics", async () => {
     const srcDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-docs-src-"));
     tempDirs.push(srcDir);

--- a/npm/vite-plugin-ox-content/src/docs.ts
+++ b/npm/vite-plugin-ox-content/src/docs.ts
@@ -144,7 +144,7 @@ export async function extractDocs(
       napi as {
         extractDocsFromEntryPoints?: (
           entryPoints: ResolvedDocsEntryPoint[],
-          options?: { root?: string; private?: boolean },
+          options?: { root?: string; private?: boolean; internal?: boolean },
         ) => Array<{ file: string; entries: DocEntry[] }>;
       }
     ).extractDocsFromEntryPoints;
@@ -158,11 +158,18 @@ export async function extractDocs(
     return extractDocsFromEntryPoints(options.entryPoints, {
       root: process.cwd(),
       private: options.private,
+      internal: options.internal,
     }).map((doc) => ({ file: doc.file, entries: doc.entries }));
   }
 
   const extractFileDocEntries = (
-    napi as { extractFileDocEntries?: (filePath: string, includePrivate?: boolean) => DocEntry[] }
+    napi as {
+      extractFileDocEntries?: (
+        filePath: string,
+        includePrivate?: boolean,
+        includeInternal?: boolean,
+      ) => DocEntry[];
+    }
   ).extractFileDocEntries;
 
   if (!extractFileDocEntries) {
@@ -175,7 +182,7 @@ export async function extractDocs(
     const files = napi.collectDocsSourceFiles(srcDir, options.include, options.exclude);
 
     for (const file of files) {
-      const entries = extractFileDocEntries(file, options.private);
+      const entries = extractFileDocEntries(file, options.private, options.internal);
 
       if (entries.length > 0) {
         results.push({ file, entries });
@@ -317,6 +324,7 @@ export function resolveDocsOptions(
     ),
     format: opts.format ?? "markdown",
     private: opts.private ?? false,
+    internal: opts.internal ?? false,
     toc: false,
     groupBy: opts.groupBy ?? "file",
     githubUrl: opts.githubUrl,

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -736,6 +736,12 @@ export interface DocsOptions {
   private?: boolean;
 
   /**
+   * Include internal members in documentation.
+   * @default false
+   */
+  internal?: boolean;
+
+  /**
    * Generate table of contents for each file.
    * @default true
    */
@@ -773,6 +779,7 @@ export interface ResolvedDocsOptions {
   entryPoints?: ResolvedDocsEntryPoint[];
   format: "markdown" | "json" | "html";
   private: boolean;
+  internal: boolean;
   toc: boolean;
   groupBy: "file" | "category";
   githubUrl?: string;


### PR DESCRIPTION
## Summary

- Add `@internal` visibility filtering alongside the existing `@private` extractor path.
- Thread the new include option through NAPI and the Vite docs options.
- Cover Rust extraction and Vite docs behavior with focused tests.

Closes #152

## Validation

- `cargo test -p ox_content_docs`
- `cargo test -p ox_content_napi javascript_wrapper_and_declarations_cover_expected_exports`
- `cargo clippy -p ox_content_docs -p ox_content_napi --all-targets -- -D warnings`
- `cargo fmt --all -- --check`