### PR TITLE
feat(docs): expose and render API members

### DIFF
--- a/crates/ox_content_docs/src/data.rs
+++ b/crates/ox_content_docs/src/data.rs
@@ -1,12 +1,13 @@
 use serde_json::{json, Map, Value};
 
-use crate::markdown::{ApiDocEntry, ApiDocModule, ApiParamDoc, ApiReturnDoc};
+use crate::markdown::{ApiDocEntry, ApiDocMember, ApiDocModule, ApiParamDoc, ApiReturnDoc};
 
 const DOC_KIND_ORDER: [&str; 6] = ["function", "class", "interface", "type", "variable", "module"];
 
 #[derive(Default)]
 struct EntryStats {
     entries: u32,
+    members: u32,
     params: u32,
     returns: u32,
     examples: u32,
@@ -38,6 +39,7 @@ fn build_docs_summary(docs: &[ApiDocModule]) -> Value {
             stats.entries += 1;
             let count = stats.by_kind.get(&entry.kind).and_then(Value::as_u64).unwrap_or(0) + 1;
             stats.by_kind.insert(entry.kind.clone(), json!(count));
+            stats.members += entry.members.len() as u32;
             stats.params += entry.params.len() as u32;
             stats.returns += u32::from(entry.returns.is_some());
             stats.examples += entry.examples.len() as u32;
@@ -56,6 +58,7 @@ fn build_docs_summary(docs: &[ApiDocModule]) -> Value {
         "modules": docs.len(),
         "entries": stats.entries,
         "byKind": by_kind,
+        "members": stats.members,
         "params": stats.params,
         "returns": stats.returns,
         "examples": stats.examples,
@@ -96,6 +99,12 @@ fn entry_to_json(entry: &ApiDocEntry) -> Value {
             ),
         );
     }
+    if !entry.members.is_empty() {
+        value.insert(
+            "members".to_string(),
+            Value::Array(entry.members.iter().map(member_to_json).collect()),
+        );
+    }
     if entry.private {
         value.insert("private".to_string(), json!(true));
     }
@@ -106,6 +115,52 @@ fn entry_to_json(entry: &ApiDocEntry) -> Value {
     if let Some(signature) = &entry.signature {
         value.insert("signature".to_string(), json!(signature));
     }
+
+    Value::Object(value)
+}
+
+fn member_to_json(member: &ApiDocMember) -> Value {
+    let mut value = Map::new();
+    value.insert("name".to_string(), json!(member.name));
+    value.insert("kind".to_string(), json!(member.kind));
+    value.insert("description".to_string(), json!(member.description));
+    if let Some(signature) = &member.signature {
+        value.insert("signature".to_string(), json!(signature));
+    }
+    if let Some(type_annotation) = &member.type_annotation {
+        value.insert("type".to_string(), json!(type_annotation));
+    }
+    if !member.params.is_empty() {
+        value.insert(
+            "params".to_string(),
+            Value::Array(member.params.iter().map(param_to_json).collect()),
+        );
+    }
+    if let Some(returns) = &member.returns {
+        value.insert("returns".to_string(), return_to_json(returns));
+    }
+    if member.optional {
+        value.insert("optional".to_string(), json!(true));
+    }
+    if member.readonly {
+        value.insert("readonly".to_string(), json!(true));
+    }
+    if member.r#static {
+        value.insert("static".to_string(), json!(true));
+    }
+    if member.private {
+        value.insert("private".to_string(), json!(true));
+    }
+    if !member.tags.is_empty() {
+        value.insert(
+            "tags".to_string(),
+            Value::Object(
+                member.tags.iter().map(|tag| (tag.tag.clone(), json!(tag.value))).collect(),
+            ),
+        );
+    }
+    value.insert("line".to_string(), json!(member.line));
+    value.insert("endLine".to_string(), json!(member.end_line));
 
     Value::Object(value)
 }
@@ -172,6 +227,7 @@ mod tests {
                 line: 10,
                 end_line: 10,
                 signature: Some("export function clamp(value: number): number".to_string()),
+                members: vec![],
             }],
         }];
 
@@ -180,6 +236,7 @@ mod tests {
 
         assert_eq!(value["summary"]["modules"], 1);
         assert_eq!(value["summary"]["byKind"]["function"], 1);
+        assert_eq!(value["summary"]["members"], 0);
         assert_eq!(value["summary"]["params"], 1);
         assert_eq!(value["summary"]["deprecated"], 1);
         assert_eq!(value["modules"][0]["file"], "src/math.ts");

--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -60,6 +60,15 @@ pub struct DocItem {
     pub exported: bool,
     /// Type signature (if applicable).
     pub signature: Option<String>,
+    /// Whether the item is optional.
+    #[serde(default)]
+    pub optional: bool,
+    /// Whether the item is readonly.
+    #[serde(default)]
+    pub readonly: bool,
+    /// Whether the item is static.
+    #[serde(default)]
+    pub r#static: bool,
     /// Parameters (for functions/methods).
     pub params: Vec<ParamDoc>,
     /// Return type (for functions/methods).
@@ -160,6 +169,9 @@ pub enum DocItemKind {
     Getter,
     /// Setter.
     Setter,
+    /// Enum member.
+    #[serde(rename = "enumMember")]
+    EnumMember,
 }
 
 /// Documentation extractor.
@@ -403,6 +415,9 @@ impl<'a> DocVisitor<'a> {
             jsdoc: Some(raw),
             exported: true,
             signature: None,
+            optional: false,
+            readonly: false,
+            r#static: false,
             params: Vec::new(),
             return_type: None,
             children: Vec::new(),
@@ -1170,6 +1185,9 @@ impl<'a> DocVisitor<'a> {
                 func.id.as_ref()?.name.as_str(),
                 exported,
             )),
+            optional: false,
+            readonly: false,
+            r#static: false,
             params: self.extract_params(func, &tags),
             return_type: self.extract_return_type(func, &tags),
             children: Vec::new(),
@@ -1209,11 +1227,11 @@ impl<'a> DocVisitor<'a> {
                         oxc_ast::ast::MethodDefinitionKind::Method => DocItemKind::Method,
                     };
 
-                    let Some((method_jsdoc, method_doc, method_tags)) =
-                        self.extract_jsdoc(method.span.start)
-                    else {
-                        continue;
-                    };
+                    let (method_jsdoc, method_doc, method_tags) = self
+                        .extract_jsdoc(method.span.start)
+                        .map_or((None, None, Vec::new()), |(jsdoc, doc, tags)| {
+                            (Some(jsdoc), (!doc.is_empty()).then_some(doc), tags)
+                        });
                     if self.should_skip_by_visibility(&method_tags) {
                         continue;
                     }
@@ -1221,22 +1239,29 @@ impl<'a> DocVisitor<'a> {
                         self.span_lines(method.span.start, method.span.end);
 
                     children.push(DocItem {
-                        name: method_name,
+                        name: method_name.clone(),
                         kind,
-                        doc: if method_doc.is_empty() { None } else { Some(method_doc) },
+                        doc: method_doc,
                         source_path: self.file_path.to_string(),
                         line: method_line,
                         end_line: method_end_line,
                         column: self.column_number(method.span.start),
-                        jsdoc: Some(method_jsdoc),
+                        jsdoc: method_jsdoc,
                         exported: false,
                         signature: Some(self.format_assigned_function_signature(
-                            "",
+                            if kind == DocItemKind::Constructor {
+                                "constructor"
+                            } else {
+                                &method_name
+                            },
                             method.value.r#async,
                             method.value.type_parameters.as_ref(),
                             &method.value.params,
                             method.value.return_type.as_ref(),
                         )),
+                        optional: method.optional,
+                        readonly: false,
+                        r#static: method.r#static,
                         params: self.extract_params(&method.value, &method_tags),
                         return_type: self.extract_return_type(&method.value, &method_tags),
                         children: Vec::new(),
@@ -1249,11 +1274,11 @@ impl<'a> DocVisitor<'a> {
                         _ => continue,
                     };
 
-                    let Some((prop_jsdoc, prop_doc, prop_tags)) =
-                        self.extract_jsdoc(prop.span.start)
-                    else {
-                        continue;
-                    };
+                    let (prop_jsdoc, prop_doc, prop_tags) = self
+                        .extract_jsdoc(prop.span.start)
+                        .map_or((None, None, Vec::new()), |(jsdoc, doc, tags)| {
+                            (Some(jsdoc), (!doc.is_empty()).then_some(doc), tags)
+                        });
                     if self.should_skip_by_visibility(&prop_tags) {
                         continue;
                     }
@@ -1268,14 +1293,17 @@ impl<'a> DocVisitor<'a> {
                     children.push(DocItem {
                         name: prop_name,
                         kind: DocItemKind::Property,
-                        doc: if prop_doc.is_empty() { None } else { Some(prop_doc) },
+                        doc: prop_doc,
                         source_path: self.file_path.to_string(),
                         line: prop_line,
                         end_line: prop_end_line,
                         column: self.column_number(prop.span.start),
-                        jsdoc: Some(prop_jsdoc),
+                        jsdoc: prop_jsdoc,
                         exported: false,
                         signature: type_annotation,
+                        optional: prop.optional,
+                        readonly: prop.readonly,
+                        r#static: prop.r#static,
                         params: Vec::new(),
                         return_type: None,
                         children: Vec::new(),
@@ -1297,11 +1325,120 @@ impl<'a> DocVisitor<'a> {
             jsdoc: Some(jsdoc),
             exported,
             signature: Some(self.format_class_signature(class, name, exported)),
+            optional: false,
+            readonly: false,
+            r#static: false,
             params: Vec::new(),
             return_type: None,
             children,
             tags,
         })
+    }
+
+    fn extract_ts_signature_members(&self, signatures: &[TSSignature<'a>]) -> Vec<DocItem> {
+        let mut children = Vec::new();
+
+        for sig in signatures {
+            match sig {
+                TSSignature::TSPropertySignature(prop) => {
+                    let prop_name = match &prop.key {
+                        oxc_ast::ast::PropertyKey::StaticIdentifier(id) => id.name.to_string(),
+                        _ => continue,
+                    };
+
+                    let (prop_jsdoc, prop_doc, prop_tags) = self
+                        .extract_jsdoc(prop.span.start)
+                        .map_or((None, None, Vec::new()), |(jsdoc, doc, tags)| {
+                            (Some(jsdoc), (!doc.is_empty()).then_some(doc), tags)
+                        });
+                    if self.should_skip_by_visibility(&prop_tags) {
+                        continue;
+                    }
+                    let (prop_line, prop_end_line) =
+                        self.span_lines(prop.span.start, prop.span.end);
+
+                    let type_annotation = prop
+                        .type_annotation
+                        .as_ref()
+                        .map(|t| self.format_ts_type(&t.type_annotation));
+
+                    children.push(DocItem {
+                        name: prop_name,
+                        kind: DocItemKind::Property,
+                        doc: prop_doc,
+                        source_path: self.file_path.to_string(),
+                        line: prop_line,
+                        end_line: prop_end_line,
+                        column: self.column_number(prop.span.start),
+                        jsdoc: prop_jsdoc,
+                        exported: false,
+                        signature: type_annotation,
+                        optional: prop.optional,
+                        readonly: prop.readonly,
+                        r#static: false,
+                        params: Vec::new(),
+                        return_type: None,
+                        children: Vec::new(),
+                        tags: prop_tags,
+                    });
+                }
+                TSSignature::TSMethodSignature(method) => {
+                    let method_name = match &method.key {
+                        oxc_ast::ast::PropertyKey::StaticIdentifier(id) => id.name.to_string(),
+                        _ => continue,
+                    };
+
+                    let (method_jsdoc, method_doc, method_tags) = self
+                        .extract_jsdoc(method.span.start)
+                        .map_or((None, None, Vec::new()), |(jsdoc, doc, tags)| {
+                            (Some(jsdoc), (!doc.is_empty()).then_some(doc), tags)
+                        });
+                    if self.should_skip_by_visibility(&method_tags) {
+                        continue;
+                    }
+                    let (method_line, method_end_line) =
+                        self.span_lines(method.span.start, method.span.end);
+
+                    let kind = match method.kind {
+                        oxc_ast::ast::TSMethodSignatureKind::Method => DocItemKind::Method,
+                        oxc_ast::ast::TSMethodSignatureKind::Get => DocItemKind::Getter,
+                        oxc_ast::ast::TSMethodSignatureKind::Set => DocItemKind::Setter,
+                    };
+
+                    children.push(DocItem {
+                        name: method_name.clone(),
+                        kind,
+                        doc: method_doc,
+                        source_path: self.file_path.to_string(),
+                        line: method_line,
+                        end_line: method_end_line,
+                        column: self.column_number(method.span.start),
+                        jsdoc: method_jsdoc,
+                        exported: false,
+                        signature: Some(self.format_assigned_function_signature(
+                            &method_name,
+                            false,
+                            method.type_parameters.as_ref(),
+                            &method.params,
+                            method.return_type.as_ref(),
+                        )),
+                        optional: method.optional,
+                        readonly: false,
+                        r#static: false,
+                        params: self.extract_params_from_formals(&method.params, &method_tags),
+                        return_type: self.extract_return_type_from_annotation(
+                            method.return_type.as_ref(),
+                            &method_tags,
+                        ),
+                        children: Vec::new(),
+                        tags: method_tags,
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        children
     }
 }
 
@@ -1410,6 +1547,9 @@ impl<'a> DocVisitor<'a> {
                                         &arrow.params,
                                         arrow.return_type.as_ref(),
                                     )),
+                                    optional: false,
+                                    readonly: false,
+                                    r#static: false,
                                     params: self.extract_params_from_formals(&arrow.params, &tags),
                                     return_type: self.extract_return_type_from_annotation(
                                         arrow.return_type.as_ref(),
@@ -1437,6 +1577,9 @@ impl<'a> DocVisitor<'a> {
                                         &func_expr.params,
                                         func_expr.return_type.as_ref(),
                                     )),
+                                    optional: false,
+                                    readonly: false,
+                                    r#static: false,
                                     params: self.extract_params(func_expr, &tags),
                                     return_type: self.extract_return_type(func_expr, &tags),
                                     children: Vec::new(),
@@ -1461,6 +1604,9 @@ impl<'a> DocVisitor<'a> {
                                         declarator.type_annotation.as_deref(),
                                         Some(other),
                                     )),
+                                    optional: false,
+                                    readonly: false,
+                                    r#static: false,
                                     params: Vec::new(),
                                     return_type: None,
                                     children: Vec::new(),
@@ -1479,6 +1625,12 @@ impl<'a> DocVisitor<'a> {
                     return;
                 }
                 let (line, end_line) = self.span_lines(attached_to, type_alias.span.end);
+                let children = match &type_alias.type_annotation {
+                    TSType::TSTypeLiteral(type_literal) => {
+                        self.extract_ts_signature_members(&type_literal.members)
+                    }
+                    _ => Vec::new(),
+                };
 
                 self.items.push(DocItem {
                     name: type_alias.id.name.to_string(),
@@ -1491,9 +1643,12 @@ impl<'a> DocVisitor<'a> {
                     jsdoc: Some(jsdoc),
                     exported,
                     signature: Some(self.format_type_alias_signature(type_alias, exported)),
+                    optional: false,
+                    readonly: false,
+                    r#static: false,
                     params: Vec::new(),
                     return_type: None,
-                    children: Vec::new(),
+                    children,
                     tags,
                 });
             }
@@ -1506,101 +1661,7 @@ impl<'a> DocVisitor<'a> {
                 }
                 let (line, end_line) = self.span_lines(attached_to, interface.span.end);
 
-                let mut children = Vec::new();
-
-                // Extract interface members
-                for sig in &interface.body.body {
-                    match sig {
-                        TSSignature::TSPropertySignature(prop) => {
-                            let prop_name = match &prop.key {
-                                oxc_ast::ast::PropertyKey::StaticIdentifier(id) => {
-                                    id.name.to_string()
-                                }
-                                _ => continue,
-                            };
-
-                            let Some((prop_jsdoc, prop_doc, prop_tags)) =
-                                self.extract_jsdoc(prop.span.start)
-                            else {
-                                continue;
-                            };
-                            if self.should_skip_by_visibility(&prop_tags) {
-                                continue;
-                            }
-                            let (prop_line, prop_end_line) =
-                                self.span_lines(prop.span.start, prop.span.end);
-
-                            let type_annotation = prop
-                                .type_annotation
-                                .as_ref()
-                                .map(|t| self.format_ts_type(&t.type_annotation));
-
-                            children.push(DocItem {
-                                name: prop_name,
-                                kind: DocItemKind::Property,
-                                doc: if prop_doc.is_empty() { None } else { Some(prop_doc) },
-                                source_path: self.file_path.to_string(),
-                                line: prop_line,
-                                end_line: prop_end_line,
-                                column: self.column_number(prop.span.start),
-                                jsdoc: Some(prop_jsdoc),
-                                exported: false,
-                                signature: type_annotation,
-                                params: Vec::new(),
-                                return_type: None,
-                                children: Vec::new(),
-                                tags: prop_tags,
-                            });
-                        }
-                        TSSignature::TSMethodSignature(method) => {
-                            let method_name = match &method.key {
-                                oxc_ast::ast::PropertyKey::StaticIdentifier(id) => {
-                                    id.name.to_string()
-                                }
-                                _ => continue,
-                            };
-
-                            let Some((method_jsdoc, method_doc, method_tags)) =
-                                self.extract_jsdoc(method.span.start)
-                            else {
-                                continue;
-                            };
-                            if self.should_skip_by_visibility(&method_tags) {
-                                continue;
-                            }
-                            let (method_line, method_end_line) =
-                                self.span_lines(method.span.start, method.span.end);
-
-                            children.push(DocItem {
-                                name: method_name.clone(),
-                                kind: DocItemKind::Method,
-                                doc: if method_doc.is_empty() { None } else { Some(method_doc) },
-                                source_path: self.file_path.to_string(),
-                                line: method_line,
-                                end_line: method_end_line,
-                                column: self.column_number(method.span.start),
-                                jsdoc: Some(method_jsdoc),
-                                exported: false,
-                                signature: Some(self.format_assigned_function_signature(
-                                    &method_name,
-                                    false,
-                                    method.type_parameters.as_ref(),
-                                    &method.params,
-                                    method.return_type.as_ref(),
-                                )),
-                                params: self
-                                    .extract_params_from_formals(&method.params, &method_tags),
-                                return_type: self.extract_return_type_from_annotation(
-                                    method.return_type.as_ref(),
-                                    &method_tags,
-                                ),
-                                children: Vec::new(),
-                                tags: method_tags,
-                            });
-                        }
-                        _ => {}
-                    }
-                }
+                let children = self.extract_ts_signature_members(&interface.body.body);
 
                 self.items.push(DocItem {
                     name: interface.id.name.to_string(),
@@ -1613,6 +1674,9 @@ impl<'a> DocVisitor<'a> {
                     jsdoc: Some(jsdoc),
                     exported,
                     signature: Some(self.format_interface_signature(interface, exported)),
+                    optional: false,
+                    readonly: false,
+                    r#static: false,
                     params: Vec::new(),
                     return_type: None,
                     children,
@@ -1632,7 +1696,7 @@ impl<'a> DocVisitor<'a> {
                     .body
                     .members
                     .iter()
-                    .map(|member| {
+                    .filter_map(|member| {
                         let member_name = match &member.id {
                             oxc_ast::ast::TSEnumMemberName::Identifier(id) => id.name.to_string(),
                             oxc_ast::ast::TSEnumMemberName::String(s) => s.value.to_string(),
@@ -1643,24 +1707,37 @@ impl<'a> DocVisitor<'a> {
                                 self.slice(template.span.start, template.span.end)
                             }
                         };
+                        let (member_jsdoc, member_doc, member_tags) = self
+                            .extract_jsdoc(member.span.start)
+                            .map_or((None, None, Vec::new()), |(jsdoc, doc, tags)| {
+                                (Some(jsdoc), (!doc.is_empty()).then_some(doc), tags)
+                            });
+                        if self.should_skip_by_visibility(&member_tags) {
+                            return None;
+                        }
                         let (member_line, member_end_line) =
                             self.span_lines(member.span.start, member.span.end);
-                        DocItem {
+                        Some(DocItem {
                             name: member_name,
-                            kind: DocItemKind::Property,
-                            doc: None,
+                            kind: DocItemKind::EnumMember,
+                            doc: member_doc,
                             source_path: self.file_path.to_string(),
                             line: member_line,
                             end_line: member_end_line,
                             column: self.column_number(member.span.start),
-                            jsdoc: None,
+                            jsdoc: member_jsdoc,
                             exported: false,
-                            signature: None,
+                            signature: member.initializer.as_ref().map(|initializer| {
+                                self.slice(initializer.span().start, initializer.span().end)
+                            }),
+                            optional: false,
+                            readonly: false,
+                            r#static: false,
                             params: Vec::new(),
                             return_type: None,
                             children: Vec::new(),
-                            tags: Vec::new(),
-                        }
+                            tags: member_tags,
+                        })
                     })
                     .collect();
 
@@ -1675,6 +1752,9 @@ impl<'a> DocVisitor<'a> {
                     jsdoc: Some(jsdoc),
                     exported,
                     signature: None,
+                    optional: false,
+                    readonly: false,
+                    r#static: false,
                     params: Vec::new(),
                     return_type: None,
                     children,
@@ -1736,6 +1816,80 @@ export interface User {
         assert_eq!(items[0].name, "User");
         assert_eq!(items[0].kind, DocItemKind::Interface);
         assert_eq!(items[0].children.len(), 2);
+    }
+
+    #[test]
+    fn type_alias_object_literal_emits_property_children() {
+        let source = r"
+/**
+ * Command options.
+ */
+export type CommandOptions = {
+    name: string;
+    aliases?: string[];
+};
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "options.ts", SourceType::ts()).unwrap();
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].name, "CommandOptions");
+        assert_eq!(items[0].children.len(), 2);
+        assert_eq!(items[0].children[0].name, "name");
+        assert_eq!(items[0].children[0].kind, DocItemKind::Property);
+        assert_eq!(items[0].children[0].signature.as_deref(), Some("string"));
+        assert!(!items[0].children[0].optional);
+        assert_eq!(items[0].children[1].name, "aliases");
+        assert_eq!(items[0].children[1].signature.as_deref(), Some("string[]"));
+        assert!(items[0].children[1].optional);
+    }
+
+    #[test]
+    fn type_alias_object_literal_with_method_signature() {
+        let source = r"
+/**
+ * Command options.
+ */
+export type CommandOptions = {
+    /**
+     * Runs the command.
+     * @param ctx - Runtime context
+     */
+    run(ctx: Context): void;
+};
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "options.ts", SourceType::ts()).unwrap();
+        let member = &items[0].children[0];
+
+        assert_eq!(member.name, "run");
+        assert_eq!(member.kind, DocItemKind::Method);
+        assert_eq!(member.signature.as_deref(), Some("run(ctx: Context): void"));
+        assert_eq!(member.params.len(), 1);
+        assert_eq!(member.params[0].description.as_deref(), Some("Runtime context"));
+    }
+
+    #[test]
+    fn type_alias_intersection_falls_back_to_signature_only() {
+        let source = r"
+/**
+ * Command options.
+ */
+export type CommandOptions = BaseOptions & {
+    /** Command name. */
+    name: string;
+};
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "options.ts", SourceType::ts()).unwrap();
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].name, "CommandOptions");
+        assert!(items[0].children.is_empty());
+        assert!(items[0].signature.as_deref().unwrap().contains("BaseOptions &"));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/lib.rs
+++ b/crates/ox_content_docs/src/lib.rs
@@ -25,11 +25,11 @@ pub use graph::{
     GraphOptions, PublicExport, ResolvedModule,
 };
 pub use markdown::{
-    generate_markdown, ApiDocEntry, ApiDocModule, ApiDocTag, ApiParamDoc, ApiReturnDoc,
-    MarkdownDocsOptions,
+    generate_markdown, ApiDocEntry, ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc,
+    ApiReturnDoc, MarkdownDocsOptions,
 };
 pub use nav::{generate_nav_code, generate_nav_metadata, DocsNavItem};
 pub use normalize::{
     normalize_doc_item, normalize_doc_items, NormalizedDocEntry, NormalizedDocKind,
-    NormalizedParamDoc, NormalizedReturnDoc,
+    NormalizedMember, NormalizedMemberKind, NormalizedParamDoc, NormalizedReturnDoc,
 };

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -46,6 +46,48 @@ pub struct ApiDocEntry {
     pub end_line: u32,
     /// Full source signature.
     pub signature: Option<String>,
+    /// Members belonging to class/interface/type/enum entries.
+    #[serde(default)]
+    pub members: Vec<ApiDocMember>,
+}
+
+/// Documentation for a member of a class/interface/type/enum entry.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ApiDocMember {
+    /// Member name.
+    pub name: String,
+    /// Member kind.
+    pub kind: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Full member signature.
+    pub signature: Option<String>,
+    /// Property or enum member type/value annotation.
+    pub type_annotation: Option<String>,
+    /// Parameters.
+    #[serde(default)]
+    pub params: Vec<ApiParamDoc>,
+    /// Return documentation.
+    pub returns: Option<ApiReturnDoc>,
+    /// Whether the member is optional.
+    #[serde(default)]
+    pub optional: bool,
+    /// Whether the member is readonly.
+    #[serde(default)]
+    pub readonly: bool,
+    /// Whether the member is static.
+    #[serde(default)]
+    pub r#static: bool,
+    /// Whether the member is private.
+    #[serde(default)]
+    pub private: bool,
+    /// Custom JSDoc tags, kept in source insertion order.
+    #[serde(default)]
+    pub tags: Vec<ApiDocTag>,
+    /// Declaration start line.
+    pub line: u32,
+    /// Declaration end line.
+    pub end_line: u32,
 }
 
 /// Parameter documentation.
@@ -100,6 +142,7 @@ impl Default for MarkdownDocsOptions {
 struct EntryStats {
     entries: usize,
     by_kind: BTreeMap<String, usize>,
+    members: usize,
     params: usize,
     returns: usize,
     examples: usize,
@@ -461,6 +504,7 @@ fn summarize_entries<'a>(entries: impl IntoIterator<Item = &'a ApiDocEntry>) -> 
     for entry in entries {
         stats.entries += 1;
         *stats.by_kind.entry(entry.kind.clone()).or_default() += 1;
+        stats.members += entry.members.len();
         stats.params += entry.params.len();
         stats.returns += usize::from(entry.returns.is_some());
         stats.examples += entry.examples.len();
@@ -487,6 +531,9 @@ fn render_stats_html(stats: &EntryStats, module_count: Option<usize>) -> String 
 
     if stats.params > 0 {
         items.push(("parameters".to_string(), stats.params, None));
+    }
+    if stats.members > 0 {
+        items.push(("members".to_string(), stats.members, None));
     }
     if stats.returns > 0 {
         items.push(("returns".to_string(), stats.returns, None));
@@ -653,6 +700,12 @@ fn get_entry_badges(entry: &ApiDocEntry) -> Vec<EntryBadge> {
     if !entry.params.is_empty() {
         badges.push(EntryBadge {
             label: format_count_label(entry.params.len(), "param", Some("params")),
+            tone: None,
+        });
+    }
+    if !entry.members.is_empty() {
+        badges.push(EntryBadge {
+            label: format_count_label(entry.members.len(), "member", Some("members")),
             tone: None,
         });
     }
@@ -834,6 +887,192 @@ fn render_tag_list_html(tags: &[ApiDocTag]) -> String {
     )
 }
 
+fn render_member_flags(member: &ApiDocMember) -> String {
+    let mut flags = Vec::new();
+    if member.optional {
+        flags.push("optional");
+    }
+    if member.readonly {
+        flags.push("readonly");
+    }
+    if member.r#static {
+        flags.push("static");
+    }
+    if member.private {
+        flags.push("private");
+    }
+
+    let mut html = String::new();
+    for flag in flags {
+        write!(html, "<span class=\"ox-api-badge\">{flag}</span>").unwrap();
+    }
+    html
+}
+
+fn render_member_type_html(member: &ApiDocMember) -> String {
+    let value = member
+        .signature
+        .as_deref()
+        .or(member.type_annotation.as_deref())
+        .or_else(|| member.returns.as_ref().map(|returns| returns.type_annotation.as_str()));
+
+    value.map_or_else(String::new, |value| {
+        render_highlighted_inline_code_html(value, "ox-api-entry__member-type", "typescript")
+    })
+}
+
+fn render_member_description_html(member: &ApiDocMember) -> String {
+    let mut blocks = Vec::new();
+
+    if !member.description.is_empty() {
+        blocks.push(format!(
+            "<div class=\"ox-api-entry__member-description\">{}</div>",
+            render_inline_html(&member.description)
+        ));
+    }
+
+    if !member.params.is_empty() {
+        let mut params = String::new();
+        for param in &member.params {
+            let mut description = param.description.clone();
+            if param.optional {
+                if description.is_empty() {
+                    description.push_str("optional");
+                } else {
+                    description.push_str(" - optional");
+                }
+            }
+            write!(
+                params,
+                "<li><code>{}</code>{}</li>",
+                escape_html(&param.name),
+                if description.is_empty() {
+                    String::new()
+                } else {
+                    format!(" {}", render_inline_html(&description))
+                }
+            )
+            .unwrap();
+        }
+        blocks.push(format!("<ul class=\"ox-api-entry__member-params\">{params}</ul>"));
+    }
+
+    if let Some(returns) = &member.returns {
+        if !returns.description.is_empty() {
+            blocks.push(format!(
+                "<div class=\"ox-api-entry__member-return\"><span>Returns</span> {}</div>",
+                render_inline_html(&returns.description)
+            ));
+        }
+    }
+
+    blocks.join("")
+}
+
+fn render_member_table_html(title: &str, members: &[&ApiDocMember]) -> String {
+    if members.is_empty() {
+        return String::new();
+    }
+
+    let rows = members
+        .iter()
+        .map(|member| {
+            format!(
+                "<tr>
+  <td><code>{}</code>{}</td>
+  <td><span class=\"ox-api-entry__member-kind\">{}</span></td>
+  <td>{}</td>
+  <td>{}</td>
+</tr>",
+                escape_html(&member.name),
+                render_member_flags(member),
+                escape_html(&member.kind),
+                render_member_type_html(member),
+                render_member_description_html(member)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        "<div class=\"ox-api-entry__member-group\">
+<h5>{}</h5>
+<table class=\"ox-api-entry__members-table\">
+<thead><tr><th>Name</th><th>Kind</th><th>Type</th><th>Description</th></tr></thead>
+<tbody>
+{rows}
+</tbody>
+</table>
+</div>",
+        escape_html(title)
+    )
+}
+
+fn render_members_table_html(members: &[ApiDocMember], entry_kind: &str) -> String {
+    if members.is_empty() {
+        return String::new();
+    }
+
+    let constructors =
+        members.iter().filter(|member| member.kind == "constructor").collect::<Vec<_>>();
+    let static_methods = members
+        .iter()
+        .filter(|member| {
+            member.r#static && matches!(member.kind.as_str(), "method" | "getter" | "setter")
+        })
+        .collect::<Vec<_>>();
+    let methods = members
+        .iter()
+        .filter(|member| {
+            !member.r#static && matches!(member.kind.as_str(), "method" | "getter" | "setter")
+        })
+        .collect::<Vec<_>>();
+    let static_properties = members
+        .iter()
+        .filter(|member| member.r#static && member.kind == "property")
+        .collect::<Vec<_>>();
+    let properties = members
+        .iter()
+        .filter(|member| !member.r#static && member.kind == "property")
+        .collect::<Vec<_>>();
+    let enum_members =
+        members.iter().filter(|member| member.kind == "enumMember").collect::<Vec<_>>();
+
+    let mut groups = Vec::new();
+    match entry_kind {
+        "class" => {
+            groups.push(render_member_table_html("Constructors", &constructors));
+            groups.push(render_member_table_html("Static Methods", &static_methods));
+            groups.push(render_member_table_html("Methods", &methods));
+            groups.push(render_member_table_html("Static Properties", &static_properties));
+            groups.push(render_member_table_html("Properties", &properties));
+        }
+        "interface" => {
+            groups.push(render_member_table_html("Properties", &properties));
+            groups.push(render_member_table_html("Methods", &methods));
+        }
+        "type" => {
+            groups.push(render_member_table_html("Properties", &properties));
+            groups.push(render_member_table_html("Methods", &methods));
+            groups.push(render_member_table_html("Enum Members", &enum_members));
+        }
+        _ => groups.push(render_member_table_html("Members", &members.iter().collect::<Vec<_>>())),
+    }
+
+    let groups = groups.into_iter().filter(|group| !group.is_empty()).collect::<Vec<_>>();
+    if groups.is_empty() {
+        return String::new();
+    }
+
+    format!(
+        "<div class=\"ox-api-entry__section ox-api-entry__section--members\">
+<h4>Members</h4>
+{}
+</div>",
+        groups.join("\n")
+    )
+}
+
 fn generate_entry_markdown(
     entry: &ApiDocEntry,
     options: &MarkdownDocsOptions,
@@ -872,6 +1111,11 @@ fn generate_entry_markdown(
             "<p class=\"ox-api-entry__source\"><a href=\"{}\">View source</a></p>\n",
             escape_html(&source_href)
         ));
+    }
+
+    if !entry.members.is_empty() {
+        body.push_str(&render_members_table_html(&entry.members, &entry.kind));
+        body.push('\n');
     }
 
     if !entry.params.is_empty() {
@@ -1230,5 +1474,86 @@ fn capitalize_ascii(value: &str) -> String {
     match chars.next() {
         Some(first) => format!("{}{}", first.to_ascii_uppercase(), chars.as_str()),
         None => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_interface_members_table() {
+        let docs = vec![ApiDocModule {
+            file: "/repo/src/command.ts".to_string(),
+            entries: vec![ApiDocEntry {
+                name: "Command".to_string(),
+                kind: "interface".to_string(),
+                description: "Runtime command.".to_string(),
+                params: vec![],
+                returns: None,
+                examples: vec![],
+                tags: vec![],
+                private: false,
+                file: "/repo/src/command.ts".to_string(),
+                line: 1,
+                end_line: 10,
+                signature: Some("export interface Command".to_string()),
+                members: vec![
+                    ApiDocMember {
+                        name: "name".to_string(),
+                        kind: "property".to_string(),
+                        description: "Command name.".to_string(),
+                        signature: None,
+                        type_annotation: Some("string".to_string()),
+                        params: vec![],
+                        returns: None,
+                        optional: false,
+                        readonly: true,
+                        r#static: false,
+                        private: false,
+                        tags: vec![],
+                        line: 5,
+                        end_line: 5,
+                    },
+                    ApiDocMember {
+                        name: "run".to_string(),
+                        kind: "method".to_string(),
+                        description: "Runs the command.".to_string(),
+                        signature: Some("run(ctx: Context): Promise<void>".to_string()),
+                        type_annotation: None,
+                        params: vec![ApiParamDoc {
+                            name: "ctx".to_string(),
+                            type_annotation: "Context".to_string(),
+                            description: "Runtime context.".to_string(),
+                            optional: false,
+                            default_value: None,
+                        }],
+                        returns: Some(ApiReturnDoc {
+                            type_annotation: "Promise".to_string(),
+                            description: "Run result.".to_string(),
+                        }),
+                        optional: false,
+                        readonly: false,
+                        r#static: false,
+                        private: false,
+                        tags: vec![],
+                        line: 7,
+                        end_line: 7,
+                    },
+                ],
+            }],
+        }];
+
+        let markdown = generate_markdown(&docs, &MarkdownDocsOptions::default());
+        let page = markdown.get("command.md").unwrap();
+
+        assert!(page.contains("<h4>Members</h4>"));
+        assert!(page.contains("<h5>Properties</h5>"));
+        assert!(page.contains("<code>name</code>"));
+        assert!(page.contains("readonly"));
+        assert!(page.contains("Command name."));
+        assert!(page.contains("<h5>Methods</h5>"));
+        assert!(page.contains("run(ctx: Context): Promise&lt;void&gt;"));
+        assert!(page.contains("Runtime context."));
     }
 }

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -45,7 +45,8 @@ impl NormalizedDocKind {
             | DocItemKind::Property
             | DocItemKind::Constructor
             | DocItemKind::Getter
-            | DocItemKind::Setter => None,
+            | DocItemKind::Setter
+            | DocItemKind::EnumMember => None,
         }
     }
 
@@ -59,6 +60,60 @@ impl NormalizedDocKind {
             Self::Type => "type",
             Self::Variable => "variable",
             Self::Module => "module",
+        }
+    }
+}
+
+/// Documentation item kind supported for class/interface/type/enum members.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NormalizedMemberKind {
+    /// Object or class property.
+    Property,
+    /// Method signature.
+    Method,
+    /// Class constructor.
+    Constructor,
+    /// Getter accessor.
+    Getter,
+    /// Setter accessor.
+    Setter,
+    /// Enum member.
+    #[serde(rename = "enumMember")]
+    EnumMember,
+}
+
+impl NormalizedMemberKind {
+    /// Converts extractor-level member kinds into public member kinds.
+    #[must_use]
+    pub fn from_doc_item_kind(kind: DocItemKind) -> Option<Self> {
+        match kind {
+            DocItemKind::Property => Some(Self::Property),
+            DocItemKind::Method => Some(Self::Method),
+            DocItemKind::Constructor => Some(Self::Constructor),
+            DocItemKind::Getter => Some(Self::Getter),
+            DocItemKind::Setter => Some(Self::Setter),
+            DocItemKind::EnumMember => Some(Self::EnumMember),
+            DocItemKind::Module
+            | DocItemKind::Function
+            | DocItemKind::Class
+            | DocItemKind::Interface
+            | DocItemKind::Type
+            | DocItemKind::Enum
+            | DocItemKind::Variable => None,
+        }
+    }
+
+    /// Returns the JavaScript-facing string for this kind.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Property => "property",
+            Self::Method => "method",
+            Self::Constructor => "constructor",
+            Self::Getter => "getter",
+            Self::Setter => "setter",
+            Self::EnumMember => "enumMember",
         }
     }
 }
@@ -85,6 +140,45 @@ pub struct NormalizedReturnDoc {
     pub type_annotation: String,
     /// Return value description.
     pub description: String,
+}
+
+/// Normalized documentation for a member of a class/interface/type/enum entry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NormalizedMember {
+    /// Member name.
+    pub name: String,
+    /// Member kind.
+    pub kind: NormalizedMemberKind,
+    /// Human-readable description.
+    pub description: String,
+    /// Full member signature, for callable members.
+    pub signature: Option<String>,
+    /// Property or enum member type/value annotation.
+    pub type_annotation: Option<String>,
+    /// Parameters, if any.
+    #[serde(default)]
+    pub params: Vec<NormalizedParamDoc>,
+    /// Return documentation, if any.
+    pub returns: Option<NormalizedReturnDoc>,
+    /// Whether the member is optional.
+    #[serde(default)]
+    pub optional: bool,
+    /// Whether the member is readonly.
+    #[serde(default)]
+    pub readonly: bool,
+    /// Whether the member is static.
+    #[serde(default)]
+    pub r#static: bool,
+    /// Whether the member is marked private.
+    #[serde(default)]
+    pub private: bool,
+    /// Custom JSDoc tags.
+    #[serde(default)]
+    pub tags: BTreeMap<String, String>,
+    /// Declaration start line.
+    pub line: u32,
+    /// Declaration end line.
+    pub end_line: u32,
 }
 
 /// Normalized documentation entry consumed by generated API docs.
@@ -114,6 +208,9 @@ pub struct NormalizedDocEntry {
     pub end_line: u32,
     /// Signature text.
     pub signature: Option<String>,
+    /// Members belonging to class/interface/type/enum entries.
+    #[serde(default)]
+    pub members: Vec<NormalizedMember>,
 }
 
 /// Normalizes extracted documentation items into API reference entries.
@@ -127,13 +224,76 @@ pub fn normalize_doc_items(items: Vec<DocItem>) -> Vec<NormalizedDocEntry> {
 pub fn normalize_doc_item(item: DocItem) -> Option<NormalizedDocEntry> {
     let kind = NormalizedDocKind::from_doc_item_kind(item.kind)?;
 
+    let mut metadata = normalize_doc_metadata(&item.tags);
+    merge_extracted_params(&mut metadata.params, item.params);
+    merge_extracted_return(&mut metadata.returns, item.return_type);
+    let members = item.children.into_iter().filter_map(normalize_member).collect();
+
+    Some(NormalizedDocEntry {
+        name: item.name,
+        kind,
+        description: item.doc.unwrap_or_default(),
+        params: metadata.params,
+        returns: metadata.returns,
+        examples: metadata.examples,
+        tags: metadata.tags,
+        private: metadata.private,
+        file: item.source_path,
+        line: item.line,
+        end_line: item.end_line,
+        signature: item.signature,
+        members,
+    })
+}
+
+fn normalize_member(item: DocItem) -> Option<NormalizedMember> {
+    let kind = NormalizedMemberKind::from_doc_item_kind(item.kind)?;
+    let mut metadata = normalize_doc_metadata(&item.tags);
+    merge_extracted_params(&mut metadata.params, item.params);
+    merge_extracted_return(&mut metadata.returns, item.return_type);
+
+    let (signature, type_annotation) = match kind {
+        NormalizedMemberKind::Property | NormalizedMemberKind::EnumMember => (None, item.signature),
+        NormalizedMemberKind::Method
+        | NormalizedMemberKind::Constructor
+        | NormalizedMemberKind::Getter
+        | NormalizedMemberKind::Setter => (item.signature, None),
+    };
+
+    Some(NormalizedMember {
+        name: item.name,
+        kind,
+        description: item.doc.unwrap_or_default(),
+        signature,
+        type_annotation,
+        params: metadata.params,
+        returns: metadata.returns,
+        optional: item.optional,
+        readonly: item.readonly,
+        r#static: item.r#static,
+        private: metadata.private,
+        tags: metadata.tags,
+        line: item.line,
+        end_line: item.end_line,
+    })
+}
+
+struct NormalizedDocMetadata {
+    params: Vec<NormalizedParamDoc>,
+    returns: Option<NormalizedReturnDoc>,
+    examples: Vec<String>,
+    tags: BTreeMap<String, String>,
+    private: bool,
+}
+
+fn normalize_doc_metadata(tags: &[DocTag]) -> NormalizedDocMetadata {
     let mut params = Vec::new();
     let mut returns = None;
     let mut examples = Vec::new();
-    let mut tags = BTreeMap::new();
-    let mut is_private = false;
+    let mut normalized_tags = BTreeMap::new();
+    let mut private = false;
 
-    for tag in &item.tags {
+    for tag in tags {
         match tag.tag.as_str() {
             tag_name if PARAM_TAG_NAMES.contains(&tag_name) => {
                 if let Some(param) = normalized_param_from_tag(tag) {
@@ -151,21 +311,25 @@ pub fn normalize_doc_item(item: DocItem) -> Option<NormalizedDocEntry> {
                 }
             }
             PRIVATE_TAG_NAME => {
-                is_private = true;
+                private = true;
             }
             tag_name => {
-                tags.entry(tag_name.to_string()).or_insert_with(|| tag.value.clone());
+                normalized_tags.entry(tag_name.to_string()).or_insert_with(|| tag.value.clone());
             }
         }
     }
 
-    for param in item.params {
-        if is_placeholder_param(&params, &param) {
+    NormalizedDocMetadata { params, returns, examples, tags: normalized_tags, private }
+}
+
+fn merge_extracted_params(params: &mut Vec<NormalizedParamDoc>, extracted_params: Vec<ParamDoc>) {
+    for param in extracted_params {
+        if is_placeholder_param(params, &param) {
             continue;
         }
 
         merge_param(
-            &mut params,
+            params,
             NormalizedParamDoc {
                 name: param.name,
                 type_annotation: param.type_annotation.unwrap_or_else(|| UNKNOWN_TYPE.to_string()),
@@ -175,33 +339,20 @@ pub fn normalize_doc_item(item: DocItem) -> Option<NormalizedDocEntry> {
             },
         );
     }
+}
 
-    if let Some(return_type) = item.return_type {
-        match &mut returns {
+fn merge_extracted_return(returns: &mut Option<NormalizedReturnDoc>, return_type: Option<String>) {
+    if let Some(return_type) = return_type {
+        match returns {
             Some(current) => current.type_annotation = return_type,
             None => {
-                returns = Some(NormalizedReturnDoc {
+                *returns = Some(NormalizedReturnDoc {
                     type_annotation: return_type,
                     description: String::new(),
                 });
             }
         }
     }
-
-    Some(NormalizedDocEntry {
-        name: item.name,
-        kind,
-        description: item.doc.unwrap_or_default(),
-        params,
-        returns,
-        examples,
-        tags,
-        private: is_private,
-        file: item.source_path,
-        line: item.line,
-        end_line: item.end_line,
-        signature: item.signature,
-    })
 }
 
 fn is_placeholder_param(existing_params: &[NormalizedParamDoc], param: &ParamDoc) -> bool {
@@ -353,5 +504,172 @@ export enum Mode {
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].kind, NormalizedDocKind::Type);
+    }
+
+    #[test]
+    fn interface_with_properties_emits_members() {
+        let source = r"
+/**
+ * Runtime command.
+ */
+export interface Command {
+    /** Command name. */
+    readonly name: string;
+    /** Positional arguments. */
+    args?: string[];
+}
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "command.ts", SourceType::ts()).unwrap();
+        let entries = normalize_doc_items(items);
+        let members = &entries[0].members;
+
+        assert_eq!(members.len(), 2);
+        assert_eq!(members[0].name, "name");
+        assert_eq!(members[0].kind, NormalizedMemberKind::Property);
+        assert_eq!(members[0].type_annotation.as_deref(), Some("string"));
+        assert_eq!(members[0].description, "Command name.");
+        assert!(members[0].readonly);
+        assert!(!members[0].optional);
+        assert_eq!(members[1].name, "args");
+        assert_eq!(members[1].type_annotation.as_deref(), Some("string[]"));
+        assert!(members[1].optional);
+    }
+
+    #[test]
+    fn interface_with_method_signatures_emits_method_members() {
+        let source = r"
+/**
+ * Runtime command.
+ */
+export interface Command {
+    /**
+     * Runs the command.
+     * @param ctx - Runtime context
+     * @returns Run result
+     */
+    run(ctx: Context): Promise<void>;
+}
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "command.ts", SourceType::ts()).unwrap();
+        let entries = normalize_doc_items(items);
+        let member = &entries[0].members[0];
+
+        assert_eq!(member.name, "run");
+        assert_eq!(member.kind, NormalizedMemberKind::Method);
+        assert_eq!(member.signature.as_deref(), Some("run(ctx: Context): Promise<void>"));
+        assert_eq!(member.params.len(), 1);
+        assert_eq!(member.params[0].name, "ctx");
+        assert_eq!(member.params[0].type_annotation, "Context");
+        assert_eq!(member.params[0].description, "Runtime context");
+        assert_eq!(
+            member.returns,
+            Some(NormalizedReturnDoc {
+                type_annotation: "Promise".to_string(),
+                description: "Run result".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn class_emits_constructor_static_method_and_property_members() {
+        let source = r"
+/**
+ * Registry.
+ */
+export class Registry {
+    /** Creates a registry. */
+    constructor(name: string) {}
+    /** Default registry. */
+    static defaultName: string;
+    /** Registers a value. */
+    register(value: string): void {}
+}
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "registry.ts", SourceType::ts()).unwrap();
+        let entries = normalize_doc_items(items);
+        let members = &entries[0].members;
+
+        assert_eq!(
+            members.iter().map(|member| member.name.as_str()).collect::<Vec<_>>(),
+            ["constructor", "defaultName", "register"]
+        );
+        assert_eq!(members[0].kind, NormalizedMemberKind::Constructor);
+        assert_eq!(members[0].params[0].type_annotation, "string");
+        assert_eq!(members[1].kind, NormalizedMemberKind::Property);
+        assert!(members[1].r#static);
+        assert_eq!(members[1].type_annotation.as_deref(), Some("string"));
+        assert_eq!(members[2].kind, NormalizedMemberKind::Method);
+    }
+
+    #[test]
+    fn enum_emits_enum_members_in_declaration_order() {
+        let source = r"
+/**
+ * Available modes.
+ */
+export enum Mode {
+    Fast = 'fast',
+    Slow = 'slow',
+}
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "mode.ts", SourceType::ts()).unwrap();
+        let entries = normalize_doc_items(items);
+        let members = &entries[0].members;
+
+        assert_eq!(
+            members.iter().map(|member| member.name.as_str()).collect::<Vec<_>>(),
+            ["Fast", "Slow"]
+        );
+        assert!(members.iter().all(|member| member.kind == NormalizedMemberKind::EnumMember));
+        assert_eq!(members[0].type_annotation.as_deref(), Some("'fast'"));
+    }
+
+    #[test]
+    fn member_visibility_tags_are_filtered_by_extractor_options() {
+        let source = r"
+/**
+ * Runtime command.
+ */
+export interface Command {
+    /** Command name. */
+    name: string;
+    /**
+     * Internal token.
+     * @internal
+     */
+    token: string;
+    /**
+     * Private secret.
+     * @private
+     */
+    secret: string;
+}
+";
+
+        let public_items =
+            DocExtractor::new().extract_source(source, "command.ts", SourceType::ts()).unwrap();
+        let public_entries = normalize_doc_items(public_items);
+        assert_eq!(
+            public_entries[0].members.iter().map(|member| member.name.as_str()).collect::<Vec<_>>(),
+            ["name"]
+        );
+
+        let all_items = DocExtractor::with_visibility(true, true)
+            .extract_source(source, "command.ts", SourceType::ts())
+            .unwrap();
+        let all_entries = normalize_doc_items(all_items);
+        assert_eq!(
+            all_entries[0].members.iter().map(|member| member.name.as_str()).collect::<Vec<_>>(),
+            ["name", "token", "secret"]
+        );
+        assert!(all_entries[0].members[2].private);
     }
 }

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -196,6 +196,25 @@ export interface JsDocEntry {
   line: number
   endLine: number
   signature?: string
+  members?: Array<JsDocMember>
+}
+
+/** Normalized member documentation used by generated API docs. */
+export interface JsDocMember {
+  name: string
+  kind: string
+  description: string
+  signature?: string
+  type?: string
+  params?: Array<JsDocParam>
+  returns?: JsDocReturn
+  optional?: boolean
+  readonly?: boolean
+  static?: boolean
+  private?: boolean
+  tags?: Record<string, string>
+  line: number
+  endLine: number
 }
 
 /** Normalized parameter documentation used by generated API docs. */
@@ -227,6 +246,7 @@ export interface JsDocsMarkdownEntry {
   line: number
   endLine: number
   signature?: string
+  members?: Array<JsDocMember>
 }
 
 /** Extracted docs for one source file used by generated API Markdown. */
@@ -614,6 +634,7 @@ export interface JsSourceDocItem {
   signature?: string
   params: Array<JsSourceDocParam>
   returnType?: string
+  members?: Array<JsSourceDocItem>
   tags: Array<JsSourceDocTag>
 }
 

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -21,11 +21,11 @@ use std::process::Command;
 use ox_content_allocator::Allocator;
 use ox_content_docs::{
     build_export_graph, extract_docs_from_entry_points, generate_docs_data_json, generate_markdown,
-    generate_nav_code, generate_nav_metadata, normalize_doc_items, ApiDocEntry, ApiDocModule,
-    ApiDocTag, ApiParamDoc, ApiReturnDoc, DocExtractor, DocItem, DocItemKind, DocTag, DocsNavItem,
-    EntryPointDocsOptions, EntryPointSpec, ExportGraph, ExportKind, ExportSource, GraphOptions,
-    MarkdownDocsOptions, NormalizedDocEntry, NormalizedParamDoc, NormalizedReturnDoc, ParamDoc,
-    PublicExport,
+    generate_nav_code, generate_nav_metadata, normalize_doc_items, ApiDocEntry, ApiDocMember,
+    ApiDocModule, ApiDocTag, ApiParamDoc, ApiReturnDoc, DocExtractor, DocItem, DocItemKind, DocTag,
+    DocsNavItem, EntryPointDocsOptions, EntryPointSpec, ExportGraph, ExportKind, ExportSource,
+    GraphOptions, MarkdownDocsOptions, NormalizedDocEntry, NormalizedMember, NormalizedParamDoc,
+    NormalizedReturnDoc, ParamDoc, PublicExport,
 };
 use ox_content_parser::{Parser, ParserOptions};
 use ox_content_renderer::HtmlRenderer;
@@ -148,6 +148,7 @@ pub struct JsSourceDocItem {
     pub signature: Option<String>,
     pub params: Vec<JsSourceDocParam>,
     pub return_type: Option<String>,
+    pub members: Option<Vec<JsSourceDocItem>>,
     pub tags: Vec<JsSourceDocTag>,
 }
 
@@ -170,6 +171,26 @@ pub struct JsDocReturn {
     pub description: String,
 }
 
+/// Normalized member documentation used by generated API docs.
+#[napi(object)]
+#[derive(Clone)]
+pub struct JsDocMember {
+    pub name: String,
+    pub kind: String,
+    pub description: String,
+    pub signature: Option<String>,
+    pub r#type: Option<String>,
+    pub params: Option<Vec<JsDocParam>>,
+    pub returns: Option<JsDocReturn>,
+    pub optional: Option<bool>,
+    pub readonly: Option<bool>,
+    pub r#static: Option<bool>,
+    pub private: Option<bool>,
+    pub tags: Option<HashMap<String, String>>,
+    pub line: u32,
+    pub end_line: u32,
+}
+
 /// Normalized documentation entry used by generated API docs.
 #[napi(object)]
 #[derive(Clone)]
@@ -186,6 +207,7 @@ pub struct JsDocEntry {
     pub line: u32,
     pub end_line: u32,
     pub signature: Option<String>,
+    pub members: Option<Vec<JsDocMember>>,
 }
 
 /// Navigation item emitted for generated documentation.
@@ -221,6 +243,7 @@ pub struct JsDocsMarkdownEntry {
     pub line: u32,
     pub end_line: u32,
     pub signature: Option<String>,
+    pub members: Option<Vec<JsDocMember>>,
 }
 
 /// Extracted docs for one source file used by generated API Markdown.
@@ -518,6 +541,7 @@ fn doc_item_kind_to_string(kind: DocItemKind) -> String {
         DocItemKind::Constructor => "constructor",
         DocItemKind::Getter => "getter",
         DocItemKind::Setter => "setter",
+        DocItemKind::EnumMember => "enumMember",
     }
     .to_string()
 }
@@ -537,6 +561,9 @@ fn map_param_doc(param: ParamDoc) -> JsSourceDocParam {
 }
 
 fn map_doc_item(item: DocItem) -> JsSourceDocItem {
+    let members =
+        (!item.children.is_empty()).then(|| item.children.into_iter().map(map_doc_item).collect());
+
     JsSourceDocItem {
         name: item.name,
         kind: doc_item_kind_to_string(item.kind),
@@ -549,6 +576,7 @@ fn map_doc_item(item: DocItem) -> JsSourceDocItem {
         signature: item.signature,
         params: item.params.into_iter().map(map_param_doc).collect(),
         return_type: item.return_type,
+        members,
         tags: item.tags.into_iter().map(map_doc_tag).collect(),
     }
 }
@@ -567,6 +595,26 @@ fn map_normalized_return_doc(return_doc: NormalizedReturnDoc) -> JsDocReturn {
     JsDocReturn { r#type: return_doc.type_annotation, description: return_doc.description }
 }
 
+fn map_normalized_member(member: NormalizedMember) -> JsDocMember {
+    JsDocMember {
+        name: member.name,
+        kind: member.kind.as_str().to_string(),
+        description: member.description,
+        signature: member.signature,
+        r#type: member.type_annotation,
+        params: (!member.params.is_empty())
+            .then(|| member.params.into_iter().map(map_normalized_param_doc).collect()),
+        returns: member.returns.map(map_normalized_return_doc),
+        optional: member.optional.then_some(true),
+        readonly: member.readonly.then_some(true),
+        r#static: member.r#static.then_some(true),
+        private: member.private.then_some(true),
+        tags: (!member.tags.is_empty()).then(|| member.tags.into_iter().collect()),
+        line: member.line,
+        end_line: member.end_line,
+    }
+}
+
 fn map_normalized_doc_entry(entry: NormalizedDocEntry) -> JsDocEntry {
     JsDocEntry {
         name: entry.name,
@@ -582,6 +630,8 @@ fn map_normalized_doc_entry(entry: NormalizedDocEntry) -> JsDocEntry {
         line: entry.line,
         end_line: entry.end_line,
         signature: entry.signature,
+        members: (!entry.members.is_empty())
+            .then(|| entry.members.into_iter().map(map_normalized_member).collect()),
     }
 }
 
@@ -713,6 +763,30 @@ fn convert_markdown_tag(tag: JsDocsMarkdownTag) -> ApiDocTag {
     ApiDocTag { tag: tag.tag, value: tag.value }
 }
 
+fn convert_markdown_member(member: JsDocMember) -> ApiDocMember {
+    ApiDocMember {
+        name: member.name,
+        kind: member.kind,
+        description: member.description,
+        signature: member.signature,
+        type_annotation: member.r#type,
+        params: member.params.unwrap_or_default().into_iter().map(convert_markdown_param).collect(),
+        returns: member.returns.map(convert_markdown_return),
+        optional: member.optional.unwrap_or(false),
+        readonly: member.readonly.unwrap_or(false),
+        r#static: member.r#static.unwrap_or(false),
+        private: member.private.unwrap_or(false),
+        tags: member
+            .tags
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(tag, value)| ApiDocTag { tag, value })
+            .collect(),
+        line: member.line,
+        end_line: member.end_line,
+    }
+}
+
 fn convert_markdown_entry(entry: JsDocsMarkdownEntry) -> ApiDocEntry {
     ApiDocEntry {
         name: entry.name,
@@ -727,6 +801,12 @@ fn convert_markdown_entry(entry: JsDocsMarkdownEntry) -> ApiDocEntry {
         line: entry.line,
         end_line: entry.end_line,
         signature: entry.signature,
+        members: entry
+            .members
+            .unwrap_or_default()
+            .into_iter()
+            .map(convert_markdown_member)
+            .collect(),
     }
 }
 
@@ -2675,12 +2755,16 @@ pub fn extract_translation_keys(
 
 #[cfg(test)]
 mod tests {
+    use ox_content_docs::{
+        NormalizedDocEntry, NormalizedDocKind, NormalizedMember, NormalizedMemberKind,
+    };
     use serde_json::json;
+    use std::collections::BTreeMap;
     use std::fs;
     use std::process::Command;
 
-    use super::get_git_last_updated;
     use super::transformer::parse_frontmatter;
+    use super::{get_git_last_updated, map_normalized_doc_entry};
 
     #[test]
     fn parses_nested_yaml_frontmatter() {
@@ -2713,6 +2797,49 @@ mod tests {
 
         assert_eq!(content, "Body");
         assert!(frontmatter.is_empty());
+    }
+
+    #[test]
+    fn normalized_doc_entry_maps_members_to_js_shape() {
+        let entry = NormalizedDocEntry {
+            name: "Command".to_string(),
+            kind: NormalizedDocKind::Interface,
+            description: "Runtime command.".to_string(),
+            params: vec![],
+            returns: None,
+            examples: vec![],
+            tags: BTreeMap::new(),
+            private: false,
+            file: "command.ts".to_string(),
+            line: 1,
+            end_line: 8,
+            signature: Some("export interface Command".to_string()),
+            members: vec![NormalizedMember {
+                name: "name".to_string(),
+                kind: NormalizedMemberKind::Property,
+                description: "Command name.".to_string(),
+                signature: None,
+                type_annotation: Some("string".to_string()),
+                params: vec![],
+                returns: None,
+                optional: true,
+                readonly: true,
+                r#static: false,
+                private: false,
+                tags: BTreeMap::new(),
+                line: 4,
+                end_line: 4,
+            }],
+        };
+
+        let js_entry = map_normalized_doc_entry(entry);
+        let member = &js_entry.members.as_ref().unwrap()[0];
+
+        assert_eq!(member.name, "name");
+        assert_eq!(member.kind, "property");
+        assert_eq!(member.r#type.as_deref(), Some("string"));
+        assert_eq!(member.optional, Some(true));
+        assert_eq!(member.readonly, Some(true));
     }
 
     #[test]

--- a/npm/vite-plugin-ox-content/src/docs.test.ts
+++ b/npm/vite-plugin-ox-content/src/docs.test.ts
@@ -214,6 +214,79 @@ export function label(value, maxLength = 20) {
     });
   });
 
+  it("extracts and renders members from documented TypeScript entries", async () => {
+    const srcDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-docs-src-"));
+    tempDirs.push(srcDir);
+
+    await fs.writeFile(
+      path.join(srcDir, "command.ts"),
+      `type Context = { cwd: string };
+
+/**
+ * Runtime command.
+ */
+export interface Command {
+  readonly name: string;
+  args?: string[];
+  run(ctx: Context): Promise<void>;
+}
+
+/**
+ * Command options.
+ */
+export type CommandOptions = {
+  name: string;
+  run(ctx: Context): void;
+};
+`,
+      "utf-8",
+    );
+
+    const docs = await extractDocs([srcDir], resolveDocsOptions({ include: ["**/*.ts"] })!);
+    const command = docs[0]?.entries.find((entry) => entry.name === "Command");
+    const options = docs[0]?.entries.find((entry) => entry.name === "CommandOptions");
+
+    expect(command?.members).toMatchObject([
+      {
+        name: "name",
+        kind: "property",
+        type: "string",
+        readonly: true,
+      },
+      {
+        name: "args",
+        kind: "property",
+        type: "string[]",
+        optional: true,
+      },
+      {
+        name: "run",
+        kind: "method",
+        signature: "run(ctx: Context): Promise<void>",
+      },
+    ]);
+    expect(options?.members).toMatchObject([
+      {
+        name: "name",
+        kind: "property",
+        type: "string",
+      },
+      {
+        name: "run",
+        kind: "method",
+        signature: "run(ctx: Context): void",
+      },
+    ]);
+
+    const markdown = generateMarkdown(docs, resolveDocsOptions({})!);
+
+    expect(markdown["command.md"]).toContain("<h4>Members</h4>");
+    expect(markdown["command.md"]).toContain("<h5>Properties</h5>");
+    expect(markdown["command.md"]).toContain("<code>name</code>");
+    expect(markdown["command.md"]).toContain("readonly");
+    expect(markdown["command.md"]).toContain("run(ctx: Context): Promise&lt;void&gt;");
+  });
+
   it("groups docs by public API entry points", async () => {
     const srcDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-docs-src-"));
     tempDirs.push(srcDir);

--- a/npm/vite-plugin-ox-content/src/docs.ts
+++ b/npm/vite-plugin-ox-content/src/docs.ts
@@ -297,6 +297,7 @@ function toRustDocsModules(docs: ExtractedDocs[]) {
       line: entry.line,
       endLine: entry.endLine,
       signature: entry.signature,
+      members: entry.members,
     })),
   }));
 }

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -802,6 +802,27 @@ export interface DocEntry {
   line: number;
   endLine: number;
   signature?: string; // Full function/type signature (for functions and type aliases)
+  members?: DocMember[];
+}
+
+/**
+ * A member belonging to a class, interface, type alias, or enum entry.
+ */
+export interface DocMember {
+  name: string;
+  kind: "property" | "method" | "constructor" | "getter" | "setter" | "enumMember";
+  description: string;
+  signature?: string;
+  type?: string;
+  params?: ParamDoc[];
+  returns?: ReturnDoc;
+  optional?: boolean;
+  readonly?: boolean;
+  static?: boolean;
+  private?: boolean;
+  tags?: Record<string, string>;
+  line: number;
+  endLine: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Expose API members for interfaces, classes, type aliases, and enums through normalized docs and NAPI.
- Extract object-literal type alias members and enum member metadata.
- Render member tables in generated Markdown and preserve members in docs.json and the Vite plugin mapper.

Closes #147

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [x] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.
