### PR TITLE
docs: update architecture overview

### DIFF
--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -1,562 +1,244 @@
 # Architecture
 
-This document provides a deep dive into the architecture and design decisions of Ox Content.
+Ox Content is a Rust-powered documentation system and Markdown toolkit. The
+core engine is small: parse Markdown into an arena-allocated AST, then render or
+serialize it. The rest of the repository packages that engine for Vite, Node.js,
+WebAssembly, generated API docs, search, OG images, i18n, and editor tooling.
 
-## Overview
+This page is the map. It intentionally avoids API reference details and
+performance results so the major boundaries stay visible.
 
-Ox Content is designed as a modular, high-performance Markdown processing toolkit. The architecture follows the Oxc philosophy of prioritizing speed, memory efficiency, and correctness.
+## Current Shape
+
+Ox Content has three layers:
+
+1. **Core Markdown engine**: Rust crates for allocation, AST nodes, parsing, and
+   rendering.
+2. **Product features**: Rust and TypeScript modules for SSG, search, generated
+   API docs, embeds, OG images, i18n checks, and editor previews.
+3. **Distribution surfaces**: npm packages, N-API bindings, WebAssembly, Vite
+   plugins, framework integrations, and editor adapters.
 
 ```mermaid
-graph TB
-    subgraph UserApps["User Applications"]
-        App[Your App]
-        DocSite[Documentation Site]
-        Blog[Blog]
+flowchart TB
+    subgraph Apps["User-facing entry points"]
+        Vite["@ox-content/vite-plugin"]
+        Napi["@ox-content/napi"]
+        Wasm["@ox-content/wasm"]
+        Editors["VS Code / Zed / Neovim"]
     end
 
-    subgraph JSPackages["JavaScript Packages"]
-        VitePlugin["@ox-content/vite-plugin"]
-        ViteVue["@ox-content/vite-plugin-vue"]
-        ViteReact["@ox-content/vite-plugin-react"]
+    subgraph Features["Documentation features"]
+        SSG["Static site generation"]
+        Search["Search index"]
+        SourceDocs["JSDoc / TypeScript docs"]
+        OG["OG images"]
+        I18n["i18n checks and runtime"]
+        Preview["Editor preview"]
     end
 
-    subgraph NAPI["Node.js Bindings"]
-        NAPIPackage["@ox-content/napi"]
+    subgraph Bridge["Runtime bridge"]
+        NAPI["ox_content_napi"]
+        WASMBinding["ox_content_wasm"]
     end
 
-    subgraph RustCore["Rust Core"]
-        Renderer[ox_content_renderer]
-        Parser[ox_content_parser]
-        AST[ox_content_ast]
-        Allocator[ox_content_allocator]
+    subgraph Core["Core Markdown engine"]
+        Parser["ox_content_parser"]
+        Renderer["ox_content_renderer"]
+        AST["ox_content_ast"]
+        Allocator["ox_content_allocator"]
     end
 
-    UserApps --> JSPackages
-    JSPackages --> NAPI
-    NAPI --> RustCore
-    Renderer --> AST
+    Vite --> Features
+    Vite --> NAPI
+    Napi --> NAPI
+    Wasm --> WASMBinding
+    Editors --> Preview
+    Preview --> Core
+    Features --> NAPI
+    NAPI --> Core
+    WASMBinding --> Core
     Parser --> AST
+    Renderer --> AST
     AST --> Allocator
 ```
 
-## Crate Structure
+The important distinction is that the parser is not the whole product. It is the
+lowest layer used by the docs site, package APIs, authoring tools, and checks.
 
-```
-ox-content/
-├── crates/
-│   ├── ox_content_allocator/   # Foundation: Arena allocator
-│   ├── ox_content_ast/         # Core: AST definitions
-│   ├── ox_content_parser/      # Core: Markdown parser
-│   ├── ox_content_renderer/    # Core: HTML renderer
-│   ├── ox_content_search/      # Core: Full-text search engine
-│   ├── ox_content_ssg/         # Core: Static site generation
-│   ├── ox_content_napi/        # Bindings: Node.js via napi-rs
-│   ├── ox_content_wasm/        # Bindings: WebAssembly
-│   ├── ox_content_vite/        # Integration: Vite plugin
-│   ├── ox_content_og_image/    # Feature: OG image generation
-│   └── ox_content_docs/        # Feature: Source code documentation
-├── playground/                 # Interactive playground
-└── docs/                       # Documentation (self-hosted)
-```
+## Entry Points
 
-## Memory Management
+| Entry point                      | Use it for                                                                         | Primary implementation                           |
+| -------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `@ox-content/vite-plugin`        | Docs sites, Markdown transforms, SSG, theme, search, OG images, generated API docs | TypeScript orchestration plus `@ox-content/napi` |
+| `@ox-content/napi`               | Node.js scripts, custom tools, direct parse/render/search/docs APIs                | `crates/ox_content_napi`                         |
+| `@ox-content/wasm`               | Browser, Web Worker, or sandboxed JavaScript hosts                                 | `crates/ox_content_wasm`                         |
+| `@ox-content/vite-plugin-vue`    | Vue component islands in Markdown                                                  | Base Vite plugin plus Vue runtime                |
+| `@ox-content/vite-plugin-react`  | React component islands in Markdown                                                | Base Vite plugin plus React runtime              |
+| `@ox-content/vite-plugin-svelte` | Svelte component islands in Markdown                                               | Base Vite plugin plus Svelte runtime             |
+| `@ox-content/unplugin`           | Non-Vite bundlers such as Rollup, webpack, or esbuild                              | Universal plugin wrapper                         |
+| Editor integrations              | Completion, diagnostics, snippets, preview, i18n authoring                         | `ox-content-lsp` plus editor adapters            |
 
-### Arena Allocation with bumpalo
+For most documentation projects, start with the Vite plugin. It already depends
+on the native package it needs, so `@ox-content/napi` is usually only installed
+directly when you are building a custom Node.js tool.
 
-Ox Content uses [bumpalo](https://docs.rs/bumpalo) for arena-based allocation. This is the key to our performance advantage.
+## Markdown Engine
 
-#### How Arena Allocation Works
+The core Markdown path is deliberately narrow.
 
 ```mermaid
-graph LR
-    subgraph Traditional["Traditional Allocation"]
-        A1[A] --> H1[Heap]
-        B1[B] --> H2[Heap]
-        C1[C] --> H3[Heap]
-    end
+flowchart LR
+    Source["Markdown source"]
+    Options["Parser / renderer options"]
+    Parser["ox_content_parser"]
+    Arena["ox_content_allocator"]
+    AST["ox_content_ast"]
+    Renderer["ox_content_renderer"]
+    Output["HTML or serialized data"]
 
-    subgraph Arena["Arena Allocation"]
-        A2[A] --> CM
-        B2[B] --> CM
-        C2[C] --> CM[Contiguous Memory]
-    end
-```
-
-**Traditional**: 4 separate heap allocations, 4 separate deallocations
-
-**Arena**: 1 contiguous region, 1 deallocation (drop arena)
-
-#### Benefits
-
-1. **Fast Allocation** - Just bump a pointer, no free list traversal
-2. **Zero-Copy Parsing** - AST nodes can reference source slices directly
-3. **Efficient Deallocation** - Drop the entire arena at once
-4. **Cache-Friendly** - Related data stored contiguously in memory
-5. **No Fragmentation** - Memory is allocated linearly
-
-#### Implementation
-
-```rust
-// ox_content_allocator/src/lib.rs
-
-use bumpalo::Bump;
-
-/// Arena allocator for AST nodes.
-pub struct Allocator {
-    bump: Bump,
-}
-
-impl Allocator {
-    /// Creates a new allocator with default capacity.
-    pub fn new() -> Self {
-        Self { bump: Bump::new() }
-    }
-
-    /// Allocates a value in the arena.
-    pub fn alloc<T>(&self, value: T) -> &mut T {
-        self.bump.alloc(value)
-    }
-
-    /// Allocates a string slice in the arena.
-    pub fn alloc_str(&self, s: &str) -> &str {
-        self.bump.alloc_str(s)
-    }
-
-    /// Creates a new Vec in the arena.
-    pub fn new_vec<T>(&self) -> Vec<'_, T> {
-        Vec::new_in(&self.bump)
-    }
-}
-
-// Re-export arena-aware types with standard names
-pub type Box<'a, T> = bumpalo::boxed::Box<'a, T>;
-pub type Vec<'a, T> = bumpalo::collections::Vec<'a, T>;
-pub type String<'a> = bumpalo::collections::String<'a>;
-```
-
-#### Usage Pattern
-
-```rust
-fn process_markdown(source: &str) -> String {
-    // Create arena - all allocations happen here
-    let allocator = Allocator::new();
-
-    // Parse document - AST allocated in arena
-    let parser = Parser::new(&allocator, source);
-    let document = parser.parse().unwrap();
-
-    // Render to HTML - output is owned String
-    let mut renderer = HtmlRenderer::new();
-    let html = renderer.render(&document);
-
-    html
-    // allocator dropped here - all AST memory freed at once
-}
-```
-
-## AST Design
-
-### mdast Specification
-
-The AST follows the [mdast](https://github.com/syntax-tree/mdast) specification, which is part of the [unified](https://unifiedjs.com/) ecosystem. This ensures compatibility with existing tools and plugins.
-
-### Node Hierarchy
-
-```
-Document (root)
-├── Block Nodes
-│   ├── Paragraph
-│   │   └── Inline Nodes...
-│   ├── Heading (depth: 1-6)
-│   │   └── Inline Nodes...
-│   ├── CodeBlock (lang, meta, value)
-│   ├── BlockQuote
-│   │   └── Block Nodes...
-│   ├── List (ordered, start, spread)
-│   │   └── ListItem (checked)
-│   │       └── Block Nodes...
-│   ├── Table
-│   │   └── TableRow
-│   │       └── TableCell
-│   │           └── Inline Nodes...
-│   ├── ThematicBreak
-│   └── Html (raw)
-│
-└── Inline Nodes
-    ├── Text (value)
-    ├── Emphasis
-    │   └── Inline Nodes...
-    ├── Strong
-    │   └── Inline Nodes...
-    ├── InlineCode (value)
-    ├── Link (url, title)
-    │   └── Inline Nodes...
-    ├── Image (url, alt, title)
-    ├── Break
-    ├── Delete (GFM)
-    │   └── Inline Nodes...
-    └── FootnoteReference (identifier)
-```
-
-### Span Information
-
-Every node includes source location information:
-
-```rust
-/// Source span (byte offsets).
-#[derive(Debug, Clone, Copy)]
-pub struct Span {
-    /// Start byte offset (inclusive).
-    pub start: u32,
-    /// End byte offset (exclusive).
-    pub end: u32,
-}
-
-impl Span {
-    pub fn new(start: u32, end: u32) -> Self {
-        Self { start, end }
-    }
-}
-```
-
-This enables:
-
-- Error messages with precise source locations
-- Source maps for debugging
-- Syntax highlighting in editors
-- Incremental re-parsing
-
-### Visitor Pattern
-
-The AST can be traversed using the visitor pattern:
-
-```rust
-/// Trait for visiting AST nodes.
-pub trait Visit<'a> {
-    fn visit_document(&mut self, document: &Document<'a>) {
-        for node in &document.children {
-            self.visit_node(node);
-        }
-    }
-
-    fn visit_node(&mut self, node: &Node<'a>) {
-        match node {
-            Node::Paragraph(n) => self.visit_paragraph(n),
-            Node::Heading(n) => self.visit_heading(n),
-            Node::CodeBlock(n) => self.visit_code_block(n),
-            // ... other variants
-        }
-    }
-
-    fn visit_paragraph(&mut self, paragraph: &Paragraph<'a>) {
-        for child in &paragraph.children {
-            self.visit_node(child);
-        }
-    }
-
-    fn visit_heading(&mut self, heading: &Heading<'a>) {
-        for child in &heading.children {
-            self.visit_node(child);
-        }
-    }
-
-    // ... other visit methods with default implementations
-}
-```
-
-#### Example: Table of Contents Generator
-
-```rust
-use ox_content_ast::{Visit, Document, Heading, Node, Text};
-
-struct TocGenerator {
-    entries: Vec<TocEntry>,
-}
-
-struct TocEntry {
-    depth: u8,
-    text: String,
-    id: String,
-}
-
-impl<'a> Visit<'a> for TocGenerator {
-    fn visit_heading(&mut self, heading: &Heading<'a>) {
-        let mut text = String::new();
-        for child in &heading.children {
-            if let Node::Text(t) = child {
-                text.push_str(t.value);
-            }
-        }
-
-        let id = slugify(&text);
-        self.entries.push(TocEntry {
-            depth: heading.depth,
-            text,
-            id,
-        });
-    }
-}
-
-fn generate_toc(document: &Document<'_>) -> Vec<TocEntry> {
-    let mut generator = TocGenerator { entries: vec![] };
-    generator.visit_document(document);
-    generator.entries
-}
-```
-
-## Parser Design
-
-### Architecture
-
-```mermaid
-graph TB
-    Source["Source Text<br/>(Markdown)"]
-    Lexer["Lexer<br/>Tokenizes input (logos crate)"]
-    Parser["Parser<br/>Builds AST from tokens"]
-    AST["AST<br/>Arena-allocated nodes"]
-
-    Source --> Lexer
-    Lexer --> Parser
+    Source --> Parser
+    Options --> Parser
     Parser --> AST
+    Parser --> Arena
+    AST --> Renderer
+    Options --> Renderer
+    Renderer --> Output
 ```
 
-### Parser Options
+Key properties:
 
-```rust
-/// Parser configuration options.
-#[derive(Debug, Clone, Default)]
-pub struct ParserOptions {
-    /// Enable GFM (GitHub Flavored Markdown) extensions.
-    pub gfm: bool,
-    /// Enable footnotes.
-    pub footnotes: bool,
-    /// Enable task lists.
-    pub task_lists: bool,
-    /// Enable tables.
-    pub tables: bool,
-    /// Enable strikethrough.
-    pub strikethrough: bool,
-    /// Enable autolinks.
-    pub autolinks: bool,
-    /// Maximum nesting depth for block elements.
-    pub max_nesting_depth: usize,
-}
+- Each parse operation owns an `Allocator`, usually sized from the input length.
+- AST nodes borrow from the source text and arena, which keeps parsing fast and
+  avoids unnecessary string copies.
+- Rendering produces owned output such as HTML, JSON data, or JavaScript module
+  code before crossing into Node.js, WebAssembly, or a browser.
+- Parser options control GFM, footnotes, tables, task lists, strikethrough,
+  autolinks, and nesting limits.
+- Renderer options add documentation-site behavior such as `.md` link
+  conversion, base URLs, line annotations, code block metadata, and TOC depth.
 
-impl ParserOptions {
-    /// Creates options with all GFM extensions enabled.
-    pub fn gfm() -> Self {
-        Self {
-            gfm: true,
-            footnotes: true,
-            task_lists: true,
-            tables: true,
-            strikethrough: true,
-            autolinks: true,
-            max_nesting_depth: 100,
-        }
-    }
-}
-```
+## Vite And SSG Pipeline
 
-### Parsing Strategy
-
-1. **Block-First** - Parse block structure first (paragraphs, headings, etc.)
-2. **Inline Later** - Parse inline content within blocks
-3. **Lazy Evaluation** - Only parse what's needed
-4. **Error Recovery** - Continue parsing after errors when possible
-
-### CommonMark Compliance
-
-The parser follows the [CommonMark spec](https://spec.commonmark.org/):
-
-- ATX headings (`# Heading`)
-- Setext headings (underlined)
-- Fenced code blocks (``` or ~~~)
-- Indented code blocks
-- Block quotes (`>`)
-- Lists (ordered and unordered)
-- Thematic breaks (`---`, `***`, `___`)
-- Emphasis and strong emphasis
-- Links and images
-- Hard and soft line breaks
-
-## Renderer Design
-
-### HTML Renderer
-
-```rust
-/// HTML renderer with customizable options.
-pub struct HtmlRenderer {
-    options: HtmlRendererOptions,
-    output: String,
-}
-
-/// Renderer configuration.
-#[derive(Debug, Clone)]
-pub struct HtmlRendererOptions {
-    /// Use XHTML-style self-closing tags.
-    pub xhtml: bool,
-    /// Soft break string.
-    pub soft_break: String,
-    /// Hard break string.
-    pub hard_break: String,
-    /// Enable syntax highlighting.
-    pub highlight: bool,
-    /// Sanitize HTML output.
-    pub sanitize: bool,
-}
-```
-
-### Renderer Trait
-
-Custom renderers can be implemented:
-
-```rust
-/// Trait for rendering AST to output format.
-pub trait Renderer {
-    type Output;
-
-    fn render(&mut self, document: &Document<'_>) -> RenderResult<Self::Output>;
-}
-```
-
-### HTML Escaping
-
-The renderer properly escapes HTML entities:
-
-| Character | Entity   |
-| --------- | -------- |
-| `&`       | `&amp;`  |
-| `<`       | `&lt;`   |
-| `>`       | `&gt;`   |
-| `"`       | `&quot;` |
-| `'`       | `&#39;`  |
-
-URL encoding is also handled for link/image URLs.
-
-## NAPI Bindings
-
-### Architecture
+The Vite plugin is the main product surface. It turns Markdown-like files into
+importable modules during development and into static HTML during build.
 
 ```mermaid
-graph TB
-    JS["JavaScript / TypeScript"]
-    NPM["@ox-content/napi<br/>TypeScript types + JS wrapper"]
-    NAPI["ox_content_napi<br/>Rust NAPI binding layer"]
-    Core["ox_content_*<br/>Core Rust crates"]
+flowchart TB
+    Content["content/**/*.md, .markdown, .mdx"]
+    SourceTS["TypeScript source files"]
+    Transform["transformMarkdown"]
+    NAPI["@ox-content/napi"]
+    Core["Rust core"]
+    Module["ES module<br/>html, frontmatter, toc"]
+    SSG["buildSsg"]
+    Theme["Theme and navigation"]
+    Search["Search index"]
+    OG["OG image generation"]
+    Dist["dist/docs"]
 
-    JS --> NPM
-    NPM --> NAPI
-    NAPI --> Core
+    SourceTS --> Docs["Generated API docs"] --> Content
+    Content --> Transform --> NAPI --> Core
+    Transform --> Module
+    Module --> SSG
+    Theme --> SSG
+    Content --> Search
+    SSG --> OG
+    SSG --> Dist
+    Search --> Dist
+    OG --> Dist
 ```
 
-### Data Transfer
+During dev, Markdown imports are transformed to modules and HMR sends
+`ox-content:update` events for changed files. During build, the SSG step collects
+Markdown files, resolves routes, builds navigation, generates HTML pages, writes
+the search index, and optionally generates per-page OG images.
 
-- AST is serialized to JSON for JavaScript interop
-- HTML rendering happens in Rust for maximum performance
-- Async support for large documents
+The docs generator is part of the same build graph: it extracts TypeScript/JSDoc
+metadata and writes Markdown files under the configured docs output directory
+before the site build consumes them.
 
-### Thread Safety
+## Rust Crates
 
-The NAPI bindings are designed to be thread-safe:
+| Layer            | Crates                                                                               | Responsibility                                                          |
+| ---------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| Core Markdown    | `ox_content_allocator`, `ox_content_ast`, `ox_content_parser`, `ox_content_renderer` | Parse and render Markdown with arena-backed data structures             |
+| Runtime bridges  | `ox_content_napi`, `ox_content_wasm`, `ox_content_vite`                              | Expose the core to Node.js, WebAssembly, and Vite-oriented runtime code |
+| Site features    | `ox_content_ssg`, `ox_content_search`, `ox_content_docs`, `ox_content_og_image`      | Generate static pages, search data, source docs, and image assets       |
+| Authoring checks | `ox_content_i18n`, `ox_content_i18n_checker`, `ox_content_mdc_checker`               | Validate dictionaries, translation key usage, and MDC component syntax  |
+| Language servers | `ox_content_lsp`, `ox_content_i18n_lsp`                                              | Provide completion, diagnostics, previews, and i18n authoring features  |
+| Profiling        | `ox_content_profiler`, `ox_content_profile_cli`                                      | Measure allocations and timing spans for parser and renderer work       |
+| CLIs             | `ox_content_i18n_cli`, `ox_content_profile_cli`, `ox_content_mdc_checker`            | Run checks and profiling outside the Vite plugin                        |
 
-- Each parse operation creates its own allocator
-- No shared mutable state between calls
+The crates are published from a single Cargo workspace. Internal dependencies
+use workspace versions and local paths so the repository can be developed as one
+system while still publishing individual crates.
 
-## Vite Integration
+## JavaScript Packages
 
-### Environment API
+| Package                          | Role                                                                             |
+| -------------------------------- | -------------------------------------------------------------------------------- |
+| `@ox-content/napi`               | Native Node.js package backed by `ox_content_napi` and platform binding packages |
+| `@ox-content/vite-plugin`        | Main Vite plugin and public TypeScript API                                       |
+| `@ox-content/vite-plugin-vue`    | Vue island runtime and transform integration                                     |
+| `@ox-content/vite-plugin-react`  | React island runtime and transform integration                                   |
+| `@ox-content/vite-plugin-svelte` | Svelte island runtime and transform integration                                  |
+| `@ox-content/islands`            | Framework-agnostic island registration and hydration primitives                  |
+| `@ox-content/unplugin`           | Universal bundler plugin wrapper                                                 |
+| `vscode-ox-content`              | VS Code extension that talks to the local LSP server                             |
 
-Ox Content integrates with Vite's Environment API for SSG:
+The framework packages wrap the base plugin instead of replacing it. That keeps
+Markdown parsing, SSG, search, generated docs, and theme behavior centralized in
+`@ox-content/vite-plugin`.
 
-```typescript
-// Creates a server-side environment for Markdown processing
-const mdEnv = new Environment("markdown", {
-  // Custom module resolution for .md files
-  resolve: {
-    extensions: [".md"],
-  },
-  // Transform .md to JS modules
-  transform: async (code, id) => {
-    if (id.endsWith(".md")) {
-      const result = await parseAndRender(code);
-      return `export default ${JSON.stringify(result)}`;
-    }
-  },
-});
+## Authoring Tooling
+
+Editor integrations are built around a unified language server:
+
+```mermaid
+flowchart LR
+    Editor["Editor client"]
+    Extension["Adapter<br/>VS Code, Zed, Neovim"]
+    LSP["ox-content-lsp"]
+    Markdown["Markdown / MDC diagnostics"]
+    Frontmatter["Frontmatter schema"]
+    I18n["i18n keys"]
+    Preview["Preview HTML"]
+
+    Editor --> Extension --> LSP
+    LSP --> Markdown
+    LSP --> Frontmatter
+    LSP --> I18n
+    LSP --> Preview
 ```
 
-### Hot Module Replacement
+The LSP shares the same parser and renderer concepts as the site pipeline, but
+its output is optimized for authoring: diagnostics, snippets, completion,
+go-to-definition, hover, inlay hints, and preview HTML.
 
-The Vite plugin supports HMR for Markdown files:
+## Boundaries And Invariants
 
-1. File change detected
-2. Re-parse changed file
-3. Send update to client
-4. Update rendered content without full reload
+- **Rust owns parsing correctness.** JavaScript orchestration should call into
+  N-API or WASM instead of reimplementing Markdown behavior.
+- **TypeScript owns integration shape.** Vite plugins, virtual modules,
+  framework adapters, and dev server behavior live in npm packages.
+- **Generated site features are build-time first.** Search, GitHub cards, Open
+  Graph cards, source docs, and OG images are generated statically where
+  possible.
+- **Editor features reuse the same domain model.** Diagnostics and previews
+  should stay aligned with the parser, renderer, frontmatter, MDC, and i18n
+  crates.
+- **Cross-runtime data is owned.** Borrowed AST data stays inside Rust; JSON,
+  HTML, or module code crosses runtime boundaries.
 
-## Performance Characteristics
+## Where To Go Next
 
-### Memory Usage
-
-| Content Size | Traditional Parser | Ox Content    |
-| ------------ | ------------------ | ------------- |
-| 1 KB         | ~50 KB heap        | ~8 KB arena   |
-| 10 KB        | ~500 KB heap       | ~80 KB arena  |
-| 100 KB       | ~5 MB heap         | ~800 KB arena |
-
-### Parse and Render Speed
-
-Latest local benchmark sweep on 2026-05-25 with Node `v24.15.0` on Apple M5 Pro. The tables below show median results from 7 local runs of the benchmark harness for the large 48.7 KB case.
-
-| Library             | Parse Only (48.7 KB) | Parse + Render (48.7 KB) |
-| ------------------- | -------------------: | -----------------------: |
-| `@ox-content/napi`  |         4207 ops/sec |             4503 ops/sec |
-| `Bun.markdown.html` |                    - |             4225 ops/sec |
-| `md4x (napi)`       |         1231 ops/sec |             4014 ops/sec |
-| `md4w (md4c)`       |         1143 ops/sec |             2653 ops/sec |
-| `markdown-it`       |         1035 ops/sec |              840 ops/sec |
-| `marked`            |          530 ops/sec |              470 ops/sec |
-| `micromark`         |                    - |               45 ops/sec |
-| `remark`            |           44 ops/sec |               36 ops/sec |
-
-`@ox-content/napi` now leads both the parse-only and parse+render columns. This benchmark uses `node benchmarks/bundle-size/parse-benchmark.mjs`. The comparison set includes `md4w (md4c)` and `md4x (napi)` by default, and `Bun.markdown.html` is measured automatically when `bun` is available on the host.
-
-## Security Considerations
-
-### HTML Sanitization
-
-When rendering untrusted Markdown, enable sanitization:
-
-```rust
-let options = HtmlRendererOptions {
-    sanitize: true,
-    ..Default::default()
-};
-let mut renderer = HtmlRenderer::with_options(options);
-```
-
-### Nesting Limits
-
-The parser enforces maximum nesting depth to prevent stack overflow:
-
-```rust
-let options = ParserOptions {
-    max_nesting_depth: 50,  // Limit nesting
-    ..Default::default()
-};
-```
-
-### Input Validation
-
-- Maximum input size limits
-- Invalid UTF-8 handling
-- Malformed Markdown graceful handling
-
-## Future Directions
-
-- **Incremental Parsing** - Re-parse only changed portions
-- **Streaming Parser** - Parse large documents in chunks
-- **WASM Build** - Run in browsers without NAPI
-- **Custom Syntax Extensions** - Plugin system for custom blocks
-- **Source Maps** - Full source map generation
+- [Getting Started](./getting-started.md) chooses the right entry point.
+- [@ox-content/vite-plugin](./packages/vite-plugin-ox-content.md) documents the
+  site and transform API.
+- [Performance](./performance.md) contains benchmark results and reproduction
+  commands.
+- [@ox-content/napi](./packages/napi.md) documents the Node.js API.
+- [@ox-content/wasm](./packages/wasm.md) covers browser and WebAssembly usage.
+- [Development Setup](./development-setup.md) explains local builds,
+  contributor commands, and test workflows.

--- a/docs/content/development-setup.md
+++ b/docs/content/development-setup.md
@@ -168,7 +168,7 @@ vp run bench:parse
 vp run bench:bundle
 ```
 
-The latest published benchmark snapshot lives on the home page under [Benchmarks](./index.md#benchmarks).
+The latest published benchmark snapshot lives on [Performance](./performance.md).
 
 ## Troubleshooting
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -47,7 +47,7 @@ features:
   - icon: "mdi:puzzle-outline"
     title: High-Performance Markdown Engine
     details: The parser, renderer, and plugin system are reusable as a Markdown library, not just internals behind the default docs theme.
-    link: architecture.md
+    link: performance.md
   - icon: "mdi:connection"
     title: Vue, Svelte, React Integrations
     details: First-party integrations let you embed framework components into Markdown without giving up the core pipeline.
@@ -82,6 +82,7 @@ Under the hood, Ox Content is not only a docs theme. It also exposes the Markdow
 - [Getting Started](./getting-started.md) - Installation and first steps
 - [Development Setup](./development-setup.md) - Build ox-content itself and work on the repo
 - [Architecture](./architecture.md) - Deep dive into the design
+- [Performance](./performance.md) - Benchmark results and reproduction commands
 - [unplugin mdast Bridge Example](./examples/unplugin-mdast-bridge.md) - Native parser plus unified-compatible mdast plugins
 - [unplugin markdown-it Token Bridge](./examples/unplugin-markdown-it-token-bridge.md) - `markdown-it` plugins plus downstream unified token access
 - [Theming](./theming.md) - Customize your documentation site
@@ -91,43 +92,3 @@ Under the hood, Ox Content is not only a docs theme. It also exposes the Markdow
 ## Community Credits
 
 Special thanks to [kazupon](https://github.com/kazupon) for substantial community contributions around JSDoc support, including the API docs generation pipeline and documentation quality.
-
-## Benchmarks
-
-Ox Content is positioned both as a document generator and as a high-performance Markdown toolkit. The numbers below focus on the Markdown engine side.
-
-Latest local benchmark sweep on 2026-05-25 with Node `v24.15.0` on Apple M5 Pro. The tables below show median results from 7 local runs of the benchmark harness for the large 48.7 KB case.
-
-### Parse Only (48.7 KB)
-
-| Library            | ops/sec | avg time |  throughput |
-| ------------------ | ------: | -------: | ----------: |
-| `@ox-content/napi` |    4207 |  0.24 ms | 200.20 MB/s |
-| `md4x (napi)`      |    1231 |  0.81 ms |  58.56 MB/s |
-| `md4w (md4c)`      |    1143 |  0.87 ms |  54.41 MB/s |
-| `markdown-it`      |    1035 |  0.97 ms |  49.24 MB/s |
-| `marked`           |     530 |  1.89 ms |  25.23 MB/s |
-| `remark`           |      44 | 22.74 ms |   2.09 MB/s |
-
-### Parse + Render (48.7 KB)
-
-| Library             | ops/sec | avg time |  throughput |
-| ------------------- | ------: | -------: | ----------: |
-| `@ox-content/napi`  |    4503 |  0.22 ms | 214.26 MB/s |
-| `Bun.markdown.html` |    4225 |  0.24 ms | 201.06 MB/s |
-| `md4x (napi)`       |    4014 |  0.25 ms | 191.02 MB/s |
-| `md4w (md4c)`       |    2653 |  0.38 ms | 126.23 MB/s |
-| `markdown-it`       |     840 |  1.19 ms |  39.96 MB/s |
-| `marked`            |     470 |  2.13 ms |  22.36 MB/s |
-| `micromark`         |      45 | 22.35 ms |   2.13 MB/s |
-| `remark`            |      36 | 28.16 ms |   1.69 MB/s |
-
-In this latest local release-build sweep, Ox Content leads every comparison: 3.4× ahead of the next-fastest native parser (`md4x (napi)`) on parse-only and 1.07× ahead of `Bun.markdown.html` on parse+render, while remaining the native core that drives the full documentation pipeline. Margins widen further on small documents — see `node benchmarks/bundle-size/parse-benchmark.mjs` for the full sweep across small, medium, and large inputs.
-
-Reproduce with:
-
-```bash
-node benchmarks/bundle-size/parse-benchmark.mjs
-```
-
-The benchmark includes `md4w (md4c)` and `md4x (napi)` by default and adds `Bun.markdown.html` automatically when `bun` is available.

--- a/docs/content/packages/napi.md
+++ b/docs/content/packages/napi.md
@@ -217,43 +217,9 @@ const doc = extractSearchContent(markdown, "hello", "/hello", { gfm: true });
 
 ## Performance
 
-Ox Content is positioned both as a document generator and as a high-performance Markdown toolkit. The numbers below focus on the Markdown engine side.
-
-Latest local benchmark sweep on 2026-05-25 with Node `v24.15.0` on Apple M5 Pro. The tables below show median results from 7 local runs of the benchmark harness for the large 48.7 KB case.
-
-### Parse Only (48.7 KB)
-
-| Library            | ops/sec | avg time |  throughput |
-| ------------------ | ------: | -------: | ----------: |
-| `@ox-content/napi` |    4207 |  0.24 ms | 200.20 MB/s |
-| `md4x (napi)`      |    1231 |  0.81 ms |  58.56 MB/s |
-| `md4w (md4c)`      |    1143 |  0.87 ms |  54.41 MB/s |
-| `markdown-it`      |    1035 |  0.97 ms |  49.24 MB/s |
-| `marked`           |     530 |  1.89 ms |  25.23 MB/s |
-| `remark`           |      44 | 22.74 ms |   2.09 MB/s |
-
-### Parse + Render (48.7 KB)
-
-| Library             | ops/sec | avg time |  throughput |
-| ------------------- | ------: | -------: | ----------: |
-| `@ox-content/napi`  |    4503 |  0.22 ms | 214.26 MB/s |
-| `Bun.markdown.html` |    4225 |  0.24 ms | 201.06 MB/s |
-| `md4x (napi)`       |    4014 |  0.25 ms | 191.02 MB/s |
-| `md4w (md4c)`       |    2653 |  0.38 ms | 126.23 MB/s |
-| `markdown-it`       |     840 |  1.19 ms |  39.96 MB/s |
-| `marked`            |     470 |  2.13 ms |  22.36 MB/s |
-| `micromark`         |      45 | 22.35 ms |   2.13 MB/s |
-| `remark`            |      36 | 28.16 ms |   1.69 MB/s |
-
-Reproduce with:
-
-```bash
-node benchmarks/bundle-size/parse-benchmark.mjs
-```
-
-In this latest local release-build sweep, Ox Content leads every comparison: 3.4× ahead of the next-fastest native parser (`md4x (napi)`) on parse-only and 1.07× ahead of `Bun.markdown.html` on parse+render, while remaining the native core that drives the full documentation pipeline. Margins widen further on small documents — see `node benchmarks/bundle-size/parse-benchmark.mjs` for the full sweep across small, medium, and large inputs.
-
-The benchmark includes `md4w (md4c)` and `md4x (napi)` by default and adds `Bun.markdown.html` automatically when `bun` is available.
+The current parser and renderer benchmark snapshot lives on
+[Performance](../performance.md). This package page keeps only N-API-specific
+micro-benchmarking notes.
 
 ### mdast Transfer Micro-benchmark
 

--- a/docs/content/performance.md
+++ b/docs/content/performance.md
@@ -1,0 +1,67 @@
+# Performance
+
+This page tracks benchmark results and reproduction commands for Ox Content.
+Architecture and package pages should describe boundaries and APIs; measured
+performance belongs here.
+
+For allocation and span-level investigation while developing parser or renderer
+changes, use [Profiling Mode](./profiling.md). Profiling answers "where is the
+work happening?" Benchmarking answers "how fast is this workload?"
+
+## Latest Benchmark Snapshot
+
+Ox Content is positioned both as a document generator and as a high-performance
+Markdown toolkit. The numbers below focus on the Markdown engine side.
+
+Latest local benchmark sweep on 2026-05-25 with Node `v24.15.0` on Apple M5 Pro.
+The tables below show median results from 7 local runs of the benchmark harness
+for the large 48.7 KB case.
+
+### Parse Only (48.7 KB)
+
+| Library            | ops/sec | avg time |  throughput |
+| ------------------ | ------: | -------: | ----------: |
+| `@ox-content/napi` |    4207 |  0.24 ms | 200.20 MB/s |
+| `md4x (napi)`      |    1231 |  0.81 ms |  58.56 MB/s |
+| `md4w (md4c)`      |    1143 |  0.87 ms |  54.41 MB/s |
+| `markdown-it`      |    1035 |  0.97 ms |  49.24 MB/s |
+| `marked`           |     530 |  1.89 ms |  25.23 MB/s |
+| `remark`           |      44 | 22.74 ms |   2.09 MB/s |
+
+### Parse + Render (48.7 KB)
+
+| Library             | ops/sec | avg time |  throughput |
+| ------------------- | ------: | -------: | ----------: |
+| `@ox-content/napi`  |    4503 |  0.22 ms | 214.26 MB/s |
+| `Bun.markdown.html` |    4225 |  0.24 ms | 201.06 MB/s |
+| `md4x (napi)`       |    4014 |  0.25 ms | 191.02 MB/s |
+| `md4w (md4c)`       |    2653 |  0.38 ms | 126.23 MB/s |
+| `markdown-it`       |     840 |  1.19 ms |  39.96 MB/s |
+| `marked`            |     470 |  2.13 ms |  22.36 MB/s |
+| `micromark`         |      45 | 22.35 ms |   2.13 MB/s |
+| `remark`            |      36 | 28.16 ms |   1.69 MB/s |
+
+In this latest local release-build sweep, Ox Content leads every comparison:
+3.4x ahead of the next-fastest native parser (`md4x (napi)`) on parse-only and
+1.07x ahead of `Bun.markdown.html` on parse+render, while remaining the native
+core that drives the full documentation pipeline.
+
+## Reproduce
+
+Run the JavaScript benchmark harness from the repository root:
+
+```bash
+node benchmarks/bundle-size/parse-benchmark.mjs
+```
+
+The benchmark includes `md4w (md4c)` and `md4x (napi)` by default and adds
+`Bun.markdown.html` automatically when `bun` is available.
+
+For Rust-side parser benchmarks, use:
+
+```bash
+cargo bench -p ox_content_parser
+```
+
+For N-API transfer-format micro-benchmarks, see
+[@ox-content/napi](./packages/napi.md#mdast-transfer-micro-benchmark).


### PR DESCRIPTION
## Summary

- Rewrites the architecture page as a current high-level map instead of a mixed deep-dive implementation note.
- Separates entry points, Markdown engine flow, Vite/SSG pipeline, Rust crates, JavaScript packages, and authoring tooling.
- Moves benchmark tables into a dedicated Performance page and links architecture, home, development setup, and N-API docs to that page.
- Removes stale future-direction content from the architecture page.

## Impact

Readers should be able to understand repository structure, product boundaries, and performance data from separate pages instead of one mixed architecture document.

## Validation

- `vp build` from `docs/`
- Local preview at `/ox-content/architecture/index.html`
- Local preview at `/ox-content/performance/index.html`
- Browser check confirmed Performance title, headings, navigation, tables, and no console warnings/errors
- `git diff --check -- docs/content/architecture.md docs/content/development-setup.md docs/content/index.md docs/content/packages/napi.md docs/content/performance.md`

Note: this local environment does not have `mmdc`, so Mermaid static rendering was skipped during build, matching the existing fallback behavior.