### PR TITLE
fix: render docs assets in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,8 +228,10 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - name: Install Chromium for mermaid-cli
-        run: vp exec --filter @ox-content/vite-plugin -- puppeteer browsers install chrome-headless-shell
+      - name: Install browsers for docs rendering
+        run: |
+          vp exec --filter @ox-content/vite-plugin -- playwright install --with-deps chromium
+          vp exec --filter @ox-content/vite-plugin -- puppeteer browsers install chrome-headless-shell
 
       - name: Build
         run: vp build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,8 +41,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Install Chromium for mermaid-cli
-        run: vp exec --filter @ox-content/vite-plugin -- puppeteer browsers install chrome-headless-shell
+      - name: Install browsers for docs rendering
+        run: |
+          vp exec --filter @ox-content/vite-plugin -- playwright install --with-deps chromium
+          vp exec --filter @ox-content/vite-plugin -- puppeteer browsers install chrome-headless-shell
 
       - name: Build
         run: vp build

--- a/npm/vite-plugin-ox-content/src/og-image/browser.ts
+++ b/npm/vite-plugin-ox-content/src/og-image/browser.ts
@@ -10,6 +10,11 @@
 import type { Page } from "playwright";
 import { renderHtmlToPng } from "./renderer";
 
+const PLAYWRIGHT_BROWSER_INSTALL_HINT =
+  "Install Playwright browsers with `npx playwright install chromium` to enable OG image generation.";
+
+let chromiumUnavailableWarned = false;
+
 /**
  * A browser session that can render HTML pages to PNG.
  * Implements AsyncDisposable for automatic cleanup via `await using`.
@@ -66,10 +71,38 @@ export async function openBrowser(): Promise<OgBrowserSession | null> {
       },
     };
   } catch (err) {
-    console.warn(
-      "[ox-content:og-image] Chromium not available, skipping OG image generation.",
-      err instanceof Error ? err.message : err,
-    );
+    warnChromiumUnavailableOnce(err);
     return null;
   }
+}
+
+function warnChromiumUnavailableOnce(err: unknown): void {
+  if (chromiumUnavailableWarned) {
+    return;
+  }
+
+  chromiumUnavailableWarned = true;
+  console.warn(
+    `[ox-content:og-image] Chromium not available, skipping OG image generation. ${formatChromiumUnavailableDetail(
+      err,
+    )}`,
+  );
+}
+
+function formatChromiumUnavailableDetail(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err);
+
+  if (
+    message.includes("Executable doesn't exist") ||
+    message.includes("Please run the following command to download new browsers")
+  ) {
+    return PLAYWRIGHT_BROWSER_INSTALL_HINT;
+  }
+
+  return (
+    message
+      .split(/\r?\n/)
+      .find((line) => line.trim())
+      ?.trim() ?? "Unknown launch error."
+  );
 }

--- a/npm/vite-plugin-ox-content/src/plugins/mermaid.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/mermaid.ts
@@ -41,28 +41,25 @@ async function loadNapi() {
 }
 
 let cachedMmdcPath: string | null | undefined;
+let missingMmdcWarned = false;
 
 function resolveMmdcPath(): string | null {
   if (cachedMmdcPath !== undefined) return cachedMmdcPath;
 
-  // 1. Resolve via Node's CJS resolver. createRequire(process.cwd()) gives
-  //    us a resolver anchored at the consumer project, which is what we want
-  //    in pnpm strict mode. Using `require.resolve` instead of
-  //    `import.meta.resolve` keeps this code working in the CJS bundle —
-  //    rolldown would otherwise warn that `import.meta` is replaced with `{}`.
-  try {
-    const require = createRequire(join(process.cwd(), "noop.js"));
-    const entry = require.resolve("@mermaid-js/mermaid-cli");
-    const cliPath = join(dirname(entry), "cli.js");
-    if (existsSync(cliPath)) {
-      cachedMmdcPath = cliPath;
-      return cachedMmdcPath;
+  for (const resolver of createMmdcResolvers()) {
+    try {
+      const entry = resolver.resolve("@mermaid-js/mermaid-cli");
+      const cliPath = join(dirname(entry), "cli.js");
+      if (existsSync(cliPath)) {
+        cachedMmdcPath = cliPath;
+        return cachedMmdcPath;
+      }
+    } catch {
+      // Try the next resolver.
     }
-  } catch {
-    // not resolvable
   }
 
-  // 2. Fallback: node_modules/.bin/mmdc relative to cwd
+  // Fallback: node_modules/.bin/mmdc relative to cwd
   const binPath = join(process.cwd(), "node_modules", ".bin", "mmdc");
   if (existsSync(binPath)) {
     cachedMmdcPath = binPath;
@@ -71,6 +68,23 @@ function resolveMmdcPath(): string | null {
 
   cachedMmdcPath = null;
   return null;
+}
+
+function createMmdcResolvers(): NodeJS.Require[] {
+  // Resolve from the consumer first, then from this package. The second lookup
+  // matters under pnpm strict linking: docs apps can depend on the plugin
+  // without directly depending on mermaid-cli.
+  const consumerRequire = createRequire(join(process.cwd(), "noop.js"));
+  const resolvers = [consumerRequire];
+
+  try {
+    resolvers.push(createRequire(consumerRequire.resolve("@ox-content/vite-plugin")));
+  } catch {
+    // If the package is used from source without its package name resolvable,
+    // the consumer resolver and bin fallback still cover direct installs.
+  }
+
+  return resolvers;
 }
 
 /**
@@ -88,7 +102,7 @@ export async function transformMermaidStatic(
 
   const mmdcPath = resolveMmdcPath();
   if (!mmdcPath) {
-    console.warn("[ox-content] mmdc not found, skipping mermaid rendering");
+    warnMissingMmdcOnce();
     return html;
   }
 
@@ -102,6 +116,15 @@ export async function transformMermaidStatic(
     console.warn("[ox-content] Mermaid transform error:", err);
     return html;
   }
+}
+
+function warnMissingMmdcOnce(): void {
+  if (missingMmdcWarned) {
+    return;
+  }
+
+  missingMmdcWarned = true;
+  console.warn("[ox-content] mmdc not found; skipping Mermaid rendering.");
 }
 
 /**


### PR DESCRIPTION
## Summary
- install Playwright Chromium before CI/deploy docs builds so OG images are generated instead of skipped
- keep the existing Puppeteer browser install for mermaid-cli rendering
- resolve mermaid-cli from the plugin dependency under pnpm strict linking and collapse fallback warnings to one line

## Validation
- vp check
- vp run build:npm
- vp build from docs/ after installing Playwright Chromium and Puppeteer chrome-headless-shell; confirmed OG image generation ran and the mmdc/Chromium skip warnings did not appear