### PR TITLE
docs: separate user guide and advanced docs

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -77,16 +77,26 @@ Under the hood, Ox Content is not only a docs theme. It also exposes the Markdow
 - [React Integration Example](./examples/integ-react.md) - Use React islands inside Markdown pages
 - [Svelte Integration Example](./examples/integ-svelte.md) - Bring Svelte components into the same pipeline
 
-## Quick Links
+## User Guide
 
 - [Getting Started](./getting-started.md) - Installation and first steps
-- [Development Setup](./development-setup.md) - Build ox-content itself and work on the repo
+- [Theming](./theming.md) - Customize your documentation site
+- [Examples](./examples/index.md) - Integration, source docs, OG image, and SSG examples
+
+## Advanced Docs
+
 - [Architecture](./architecture.md) - Deep dive into the design
 - [Performance](./performance.md) - Benchmark results and reproduction commands
+- [Profiling Mode](./profiling.md) - Allocation and span-level investigation
 - [unplugin mdast Bridge Example](./examples/unplugin-mdast-bridge.md) - Native parser plus unified-compatible mdast plugins
 - [unplugin markdown-it Token Bridge](./examples/unplugin-markdown-it-token-bridge.md) - `markdown-it` plugins plus downstream unified token access
-- [Theming](./theming.md) - Customize your documentation site
+- [Development Setup](./development-setup.md) - Build ox-content itself and work on the repo
+
+## Reference
+
 - [API Reference](./api/index.md) - Generated API docs for the public surface
+- [Vite Plugin](./packages/vite-plugin-ox-content.md) - Main docs pipeline package
+- [Packages](./packages/napi.md) - Node.js, WebAssembly, framework, and i18n package docs
 - [GitHub](https://github.com/ubugeeei/ox-content) - Source code and issues
 
 ## Community Credits

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -58,6 +58,47 @@ export default defineConfig(({ mode }) => {
                 'Released under the <a href="https://opensource.org/licenses/MIT">MIT License</a>.',
               copyright: `Copyright © 2024-${new Date().getFullYear()} ubugeeei`,
             },
+            sidebar: [
+              {
+                text: "Guide",
+                items: [
+                  { text: "Getting Started", link: "/getting-started.md" },
+                  { text: "Theming", link: "/theming.md" },
+                  { text: "Examples", link: "/examples/index.md" },
+                ],
+              },
+              {
+                text: "Advanced",
+                items: [
+                  { text: "Architecture", link: "/architecture.md" },
+                  { text: "Performance", link: "/performance.md" },
+                  { text: "Profiling Mode", link: "/profiling.md" },
+                  { text: "mdast Bridge Example", link: "/examples/unplugin-mdast-bridge.md" },
+                  {
+                    text: "markdown-it Token Bridge",
+                    link: "/examples/unplugin-markdown-it-token-bridge.md",
+                  },
+                  { text: "Development Setup", link: "/development-setup.md" },
+                ],
+              },
+              {
+                text: "Reference",
+                collapsed: true,
+                items: [
+                  { text: "API Reference", link: "/api/index.md" },
+                  { text: "Vite Plugin", link: "/packages/vite-plugin-ox-content.md" },
+                  { text: "N-API", link: "/packages/napi.md" },
+                  { text: "WebAssembly", link: "/packages/wasm.md" },
+                  { text: "Vue Integration", link: "/packages/vite-plugin-ox-content-vue.md" },
+                  { text: "React Integration", link: "/packages/vite-plugin-ox-content-react.md" },
+                  {
+                    text: "Svelte Integration",
+                    link: "/packages/vite-plugin-ox-content-svelte.md",
+                  },
+                  { text: "i18n Package", link: "/packages/i18n.md" },
+                ],
+              },
+            ],
             css: `
               .content h1,
               .hero-name {


### PR DESCRIPTION
## Summary
- Split the docs home quick links into User Guide, Advanced Docs, and Reference sections.
- Add an explicit theme sidebar so Guide, Advanced, and Reference paths are separated consistently.
- Keep parser bridge examples under Advanced while keeping package/API docs under Reference.

## Validation
- `vp fmt docs/vite.config.ts docs/content/index.md`
- `vp check docs/vite.config.ts`
- `vp build` from `docs/`
- Browser verification at `http://127.0.0.1:4173/ox-content/` with no console errors
- `vp run workspace:ci`