### PR TITLE
fix: remove panic-prone runtime paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ cargo = { level = "warn", priority = -1 }
 dbg_macro = "warn"
 print_stdout = "warn"
 print_stderr = "warn"
+format_push_string = "deny"
 
 # Allow
-format_push_string = "allow"
 match_same_arms = "allow"
 option_if_let_else = "allow"
 case_sensitive_file_extension_comparisons = "allow"

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -1,6 +1,7 @@
 //! Markdown rendering for generated API reference documentation.
 
 use std::collections::{BTreeMap, HashMap};
+use std::fmt::Write as _;
 use std::path::Path;
 use std::sync::OnceLock;
 
@@ -13,6 +14,18 @@ type RegexCache = OnceLock<Option<Regex>>;
 
 fn cached_regex(cache: &'static RegexCache, pattern: &'static str) -> Option<&'static Regex> {
     cache.get_or_init(|| Regex::new(pattern).ok()).as_ref()
+}
+
+fn push_fmt(output: &mut String, args: std::fmt::Arguments<'_>) {
+    if output.write_fmt(args).is_err() {
+        output.push_str("[formatting failed]");
+    }
+}
+
+fn fmt_args(args: std::fmt::Arguments<'_>) -> String {
+    let mut output = String::new();
+    push_fmt(&mut output, args);
+    output
 }
 
 /// Extracted docs for one source module.
@@ -262,7 +275,11 @@ fn truncate_summary_text(text: &str, max_length: usize) -> String {
     }
 
     let truncated: String = text.chars().take(max_length.saturating_sub(1)).collect();
-    format!("{}…", truncated.trim_end())
+    let trimmed = truncated.trim_end();
+    let mut value = String::with_capacity(trimmed.len() + "…".len());
+    value.push_str(trimmed);
+    value.push('…');
+    value
 }
 
 fn render_inline_html(text: &str) -> String {
@@ -284,17 +301,23 @@ fn render_inline_html(text: &str) -> String {
         html.push_str(&escape_html(&text[last_index..mat.start()]));
 
         if let Some(code) = captures.get(1) {
-            html.push_str(&format!("<code>{}</code>", escape_html(code.as_str())));
+            push_fmt(&mut html, format_args!("<code>{}</code>", escape_html(code.as_str())));
         } else if let (Some(label), Some(href)) = (captures.get(2), captures.get(3)) {
-            html.push_str(&format!(
-                "<a href=\"{}\">{}</a>",
-                escape_html(href.as_str()),
-                render_inline_html(label.as_str())
-            ));
+            push_fmt(
+                &mut html,
+                format_args!(
+                    "<a href=\"{}\">{}</a>",
+                    escape_html(href.as_str()),
+                    render_inline_html(label.as_str())
+                ),
+            );
         } else if let Some(strong) = captures.get(4).or_else(|| captures.get(5)) {
-            html.push_str(&format!("<strong>{}</strong>", render_inline_html(strong.as_str())));
+            push_fmt(
+                &mut html,
+                format_args!("<strong>{}</strong>", render_inline_html(strong.as_str())),
+            );
         } else if let Some(emphasis) = captures.get(6).or_else(|| captures.get(7)) {
-            html.push_str(&format!("<em>{}</em>", render_inline_html(emphasis.as_str())));
+            push_fmt(&mut html, format_args!("<em>{}</em>", render_inline_html(emphasis.as_str())));
         }
 
         last_index = mat.end();
@@ -628,18 +651,22 @@ fn generate_file_markdown(
     symbol_map: &HashMap<String, SymbolLocation>,
 ) -> String {
     let display_name = file_name(&doc.file);
-    let mut markdown = format!("# {display_name}\n\n");
+    let mut markdown = String::new();
+    push_fmt(&mut markdown, format_args!("# {display_name}\n\n"));
 
     if let Some(github_url) = &options.github_url {
         markdown.push_str(&generate_source_link(&doc.file, github_url, None, None));
         markdown.push_str("\n\n");
     }
 
-    markdown.push_str(&format!(
-        "> {} documented symbol{}. ",
-        doc.entries.len(),
-        if doc.entries.len() == 1 { "" } else { "s" }
-    ));
+    push_fmt(
+        &mut markdown,
+        format_args!(
+            "> {} documented symbol{}. ",
+            doc.entries.len(),
+            if doc.entries.len() == 1 { "" } else { "s" }
+        ),
+    );
     markdown.push_str(
         "Read the signatures first, then expand each item for parameters, return types, and examples.\n\n",
     );
@@ -701,7 +728,7 @@ fn format_kind_label(kind: &str) -> &str {
 
 fn format_count_label(count: usize, singular: &str, plural: Option<&str>) -> String {
     let label = if count == 1 { singular } else { plural.unwrap_or(singular) };
-    format!("{count} {label}")
+    fmt_args(format_args!("{count} {label}"))
 }
 
 fn entry_tag_value<'a>(entry: &'a ApiDocEntry, tag_name: &str) -> Option<&'a str> {
@@ -727,8 +754,10 @@ fn get_entry_badges(entry: &ApiDocEntry) -> Vec<EntryBadge> {
         });
     }
     if let Some(returns) = &entry.returns {
-        badges
-            .push(EntryBadge { label: format!("returns {}", returns.type_annotation), tone: None });
+        badges.push(EntryBadge {
+            label: fmt_args(format_args!("returns {}", returns.type_annotation)),
+            tone: None,
+        });
     }
     if !entry.examples.is_empty() {
         badges.push(EntryBadge {
@@ -737,7 +766,7 @@ fn get_entry_badges(entry: &ApiDocEntry) -> Vec<EntryBadge> {
         });
     }
     if let Some(since) = entry_tag_value(entry, "since") {
-        badges.push(EntryBadge { label: format!("since {since}"), tone: None });
+        badges.push(EntryBadge { label: fmt_args(format_args!("since {since}")), tone: None });
     }
     if entry.private {
         badges.push(EntryBadge { label: "private".to_string(), tone: Some("warning") });
@@ -754,15 +783,20 @@ fn render_entry_badges_html(entry: &ApiDocEntry, class_name: &str) -> String {
 
     let mut rendered = String::new();
     for badge in badges {
-        let tone_class = badge.tone.map_or(String::new(), |tone| format!(" ox-api-badge--{tone}"));
-        rendered.push_str(&format!(
-            "<span class=\"ox-api-badge{}\">{}</span>",
-            tone_class,
-            escape_html(&badge.label)
-        ));
+        let tone_class = badge
+            .tone
+            .map_or(String::new(), |tone| fmt_args(format_args!(" ox-api-badge--{tone}")));
+        push_fmt(
+            &mut rendered,
+            format_args!(
+                "<span class=\"ox-api-badge{}\">{}</span>",
+                tone_class,
+                escape_html(&badge.label)
+            ),
+        );
     }
 
-    format!("<span class=\"{class_name}\">{rendered}</span>")
+    fmt_args(format_args!("<span class=\"{class_name}\">{rendered}</span>"))
 }
 
 fn parse_example_block(example: &str) -> (String, String) {
@@ -886,7 +920,7 @@ fn render_params_list_html(params: &[ApiParamDoc]) -> String {
 fn render_tag_list_html(tags: &[ApiDocTag]) -> String {
     let mut items = String::new();
     for tag in tags {
-        items.push_str(&format!(
+        push_fmt(&mut items, format_args!(
             "<li><span class=\"ox-api-entry__tag-name\">@{}</span><span class=\"ox-api-entry__tag-value\">{}</span></li>",
             escape_html(&tag.tag),
             render_inline_html(&tag.value)
@@ -918,7 +952,7 @@ fn render_member_flags(member: &ApiDocMember) -> String {
 
     let mut html = String::new();
     for flag in flags {
-        html.push_str(&format!("<span class=\"ox-api-badge\">{flag}</span>"));
+        push_fmt(&mut html, format_args!("<span class=\"ox-api-badge\">{flag}</span>"));
     }
     html
 }
@@ -956,15 +990,18 @@ fn render_member_description_html(member: &ApiDocMember) -> String {
                     description.push_str(" - optional");
                 }
             }
-            params.push_str(&format!(
-                "<li><code>{}</code>{}</li>",
-                escape_html(&param.name),
-                if description.is_empty() {
-                    String::new()
-                } else {
-                    format!(" {}", render_inline_html(&description))
-                }
-            ));
+            push_fmt(
+                &mut params,
+                format_args!(
+                    "<li><code>{}</code>{}</li>",
+                    escape_html(&param.name),
+                    if description.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" {}", render_inline_html(&description))
+                    }
+                ),
+            );
         }
         blocks.push(format!("<ul class=\"ox-api-entry__member-params\">{params}</ul>"));
     }
@@ -1109,17 +1146,20 @@ fn generate_entry_markdown(
     }
 
     if let Some(signature) = &entry.signature {
-        body.push_str(&format!(
-            "<div class=\"ox-api-entry__section ox-api-entry__section--signature\">
+        push_fmt(
+            &mut body,
+            format_args!(
+                "<div class=\"ox-api-entry__section ox-api-entry__section--signature\">
 <h4>Signature</h4>
 {}
 </div>\n",
-            render_code_block_html(signature, "typescript")
-        ));
+                render_code_block_html(signature, "typescript")
+            ),
+        );
     }
 
     if let Some(source_href) = source_href {
-        body.push_str(&format!(
+        push_fmt(&mut body, format_args!(
             "<p class=\"ox-api-entry__source\"><a class=\"ox-api-entry__source-link\" href=\"{}\" target=\"_blank\" rel=\"noopener noreferrer\">View source<span class=\"ox-api-entry__source-icon\" aria-hidden=\"true\"></span></a></p>\n",
             escape_html(&source_href)
         ));
@@ -1136,24 +1176,27 @@ fn generate_entry_markdown(
     }
 
     if let Some(returns) = &entry.returns {
-        body.push_str(&format!(
-            "<div class=\"ox-api-entry__section ox-api-entry__section--returns\">
+        push_fmt(
+            &mut body,
+            format_args!(
+                "<div class=\"ox-api-entry__section ox-api-entry__section--returns\">
 <h4>Returns</h4>
 <div class=\"ox-api-entry__return\">
   <code class=\"ox-api-entry__return-type\">{}</code>
   {}
 </div>
 </div>\n",
-            escape_html(&returns.type_annotation),
-            if returns.description.is_empty() {
-                String::new()
-            } else {
-                format!(
-                    "<p class=\"ox-api-entry__return-description\">{}</p>",
-                    render_inline_html(&returns.description)
-                )
-            }
-        ));
+                escape_html(&returns.type_annotation),
+                if returns.description.is_empty() {
+                    String::new()
+                } else {
+                    format!(
+                        "<p class=\"ox-api-entry__return-description\">{}</p>",
+                        render_inline_html(&returns.description)
+                    )
+                }
+            ),
+        );
     }
 
     if !entry.examples.is_empty() {
@@ -1175,12 +1218,15 @@ fn generate_entry_markdown(
             .collect::<Vec<_>>()
             .join("\n");
 
-        body.push_str(&format!(
-            "<div class=\"ox-api-entry__section ox-api-entry__section--examples\">
+        push_fmt(
+            &mut body,
+            format_args!(
+                "<div class=\"ox-api-entry__section ox-api-entry__section--examples\">
 <h4>Examples</h4>
 {examples_html}
 </div>\n"
-        ));
+            ),
+        );
     }
 
     if !entry.tags.is_empty() {
@@ -1266,13 +1312,15 @@ fn generate_index(docs: &[ApiDocModule], doc_to_file: Option<&HashMap<String, St
             file_name = "index-module".to_string();
         }
 
-        let count_label = format!(
+        let count_label = fmt_args(format_args!(
             "{} symbol{}",
             doc.entries.len(),
             if doc.entries.len() == 1 { "" } else { "s" }
-        );
-        markdown.push_str(&format!(
-            "<details class=\"ox-api-module\">
+        ));
+        push_fmt(
+            &mut markdown,
+            format_args!(
+                "<details class=\"ox-api-module\">
   <summary>
     <span class=\"ox-api-module__title\"><a href=\"./{file_name}.md\">{}</a></span>
     <span class=\"ox-api-module__count\">{count_label}</span>
@@ -1280,17 +1328,21 @@ fn generate_index(docs: &[ApiDocModule], doc_to_file: Option<&HashMap<String, St
   <div class=\"ox-api-module__body\">
     <ul class=\"ox-api-module__list\">
 ",
-            escape_html(&display_name)
-        ));
+                escape_html(&display_name)
+            ),
+        );
 
         for entry in &doc.entries {
-            markdown.push_str(&format!(
-                "      {}\n",
-                render_overview_html_item(
-                    entry,
-                    &format!("./{file_name}.md#{}", entry_anchor(&entry.name))
-                )
-            ));
+            push_fmt(
+                &mut markdown,
+                format_args!(
+                    "      {}\n",
+                    render_overview_html_item(
+                        entry,
+                        &fmt_args(format_args!("./{file_name}.md#{}", entry_anchor(&entry.name)))
+                    )
+                ),
+            );
         }
 
         markdown.push_str(
@@ -1311,19 +1363,25 @@ fn generate_category_markdown(
     options: &MarkdownDocsOptions,
     symbol_map: &HashMap<String, SymbolLocation>,
 ) -> String {
-    let category_file_name = format!("{kind}s");
-    let mut markdown = format!("# {}s\n\n", capitalize_ascii(kind));
-    markdown.push_str(&format!(
-        "> {} documented {kind}{} collected across modules.\n\n",
-        entries.len(),
-        if entries.len() == 1 { "" } else { "s" }
-    ));
+    let category_file_name = fmt_args(format_args!("{kind}s"));
+    let mut markdown = fmt_args(format_args!("# {}s\n\n", capitalize_ascii(kind)));
+    push_fmt(
+        &mut markdown,
+        format_args!(
+            "> {} documented {kind}{} collected across modules.\n\n",
+            entries.len(),
+            if entries.len() == 1 { "" } else { "s" }
+        ),
+    );
     markdown.push_str(&render_stats_html(&summarize_entries(entries), None));
     markdown.push_str("\n\n");
 
     markdown.push_str("## Overview\n\n");
     for entry in entries {
-        markdown.push_str(&render_overview_line(entry, &format!("#{}", entry_anchor(&entry.name))));
+        markdown.push_str(&render_overview_line(
+            entry,
+            &fmt_args(format_args!("#{}", entry_anchor(&entry.name))),
+        ));
     }
     markdown.push_str("\n## Reference\n\n");
     if entries.len() > 1 {
@@ -1353,18 +1411,21 @@ fn generate_category_index(by_kind: &BTreeMap<String, Vec<ApiDocEntry>>) -> Stri
     markdown.push_str("\n\n");
 
     for (kind, entries) in by_kind {
-        let kind_title = format!("{}s", capitalize_ascii(kind));
-        markdown.push_str(&format!("## [{kind_title}](./{kind}s.md)\n\n"));
-        markdown.push_str(&format!(
-            "> {} item{}.\n\n",
-            entries.len(),
-            if entries.len() == 1 { "" } else { "s" }
-        ));
+        let kind_title = fmt_args(format_args!("{}s", capitalize_ascii(kind)));
+        push_fmt(&mut markdown, format_args!("## [{kind_title}](./{kind}s.md)\n\n"));
+        push_fmt(
+            &mut markdown,
+            format_args!(
+                "> {} item{}.\n\n",
+                entries.len(),
+                if entries.len() == 1 { "" } else { "s" }
+            ),
+        );
 
         for entry in entries {
             markdown.push_str(&render_overview_line(
                 entry,
-                &format!("./{kind}s.md#{}", entry_anchor(&entry.name)),
+                &fmt_args(format_args!("./{kind}s.md#{}", entry_anchor(&entry.name))),
             ));
         }
         markdown.push('\n');
@@ -1402,13 +1463,16 @@ fn convert_symbol_links(
 
         result.push_str(&text[last_index..mat.start()]);
         if location.file_name == current_file_name {
-            result.push_str(&format!("[{symbol_name}](#{})", symbol_name.to_lowercase()));
+            push_fmt(&mut result, format_args!("[{symbol_name}](#{})", symbol_name.to_lowercase()));
         } else {
-            result.push_str(&format!(
-                "[{symbol_name}](./{}.md#{})",
-                location.file_name,
-                symbol_name.to_lowercase()
-            ));
+            push_fmt(
+                &mut result,
+                format_args!(
+                    "[{symbol_name}](./{}.md#{})",
+                    location.file_name,
+                    symbol_name.to_lowercase()
+                ),
+            );
         }
         last_index = mat.end();
     }

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -1,7 +1,6 @@
 //! Markdown rendering for generated API reference documentation.
 
 use std::collections::{BTreeMap, HashMap};
-use std::fmt::Write as _;
 use std::path::Path;
 use std::sync::OnceLock;
 
@@ -9,6 +8,12 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 const DOC_KIND_ORDER: [&str; 6] = ["function", "class", "interface", "type", "variable", "module"];
+
+type RegexCache = OnceLock<Option<Regex>>;
+
+fn cached_regex(cache: &'static RegexCache, pattern: &'static str) -> Option<&'static Regex> {
+    cache.get_or_init(|| Regex::new(pattern).ok()).as_ref()
+}
 
 /// Extracted docs for one source module.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -225,45 +230,57 @@ fn entry_anchor(name: &str) -> String {
 }
 
 fn clean_summary_text(text: &str, max_length: usize) -> String {
-    static MARKDOWN_LINK_RE: OnceLock<Regex> = OnceLock::new();
-    static BRACKET_LINK_RE: OnceLock<Regex> = OnceLock::new();
-    static WHITESPACE_RE: OnceLock<Regex> = OnceLock::new();
+    static MARKDOWN_LINK_RE: RegexCache = OnceLock::new();
+    static BRACKET_LINK_RE: RegexCache = OnceLock::new();
+    static WHITESPACE_RE: RegexCache = OnceLock::new();
 
     if text.is_empty() {
         return String::new();
     }
 
-    let markdown_link_re =
-        MARKDOWN_LINK_RE.get_or_init(|| Regex::new(r"\[([^\]]+)\]\([^)]+\)").unwrap());
-    let bracket_link_re = BRACKET_LINK_RE.get_or_init(|| Regex::new(r"\[([^\]]+)\]").unwrap());
-    let whitespace_re = WHITESPACE_RE.get_or_init(|| Regex::new(r"\s+").unwrap());
+    let fallback = || text.split_whitespace().collect::<Vec<_>>().join(" ");
+    let Some(markdown_link_re) = cached_regex(&MARKDOWN_LINK_RE, r"\[([^\]]+)\]\([^)]+\)") else {
+        return truncate_summary_text(&fallback(), max_length);
+    };
+    let Some(bracket_link_re) = cached_regex(&BRACKET_LINK_RE, r"\[([^\]]+)\]") else {
+        return truncate_summary_text(&fallback(), max_length);
+    };
+    let Some(whitespace_re) = cached_regex(&WHITESPACE_RE, r"\s+") else {
+        return truncate_summary_text(&fallback(), max_length);
+    };
 
     let collapsed = markdown_link_re.replace_all(text, "$1").to_string();
     let collapsed = bracket_link_re.replace_all(&collapsed, "$1").to_string();
     let collapsed = whitespace_re.replace_all(&collapsed, " ").trim().to_string();
 
-    if collapsed.chars().count() <= max_length {
-        return collapsed;
+    truncate_summary_text(&collapsed, max_length)
+}
+
+fn truncate_summary_text(text: &str, max_length: usize) -> String {
+    if text.chars().count() <= max_length {
+        return text.to_string();
     }
 
-    let truncated: String = collapsed.chars().take(max_length.saturating_sub(1)).collect();
+    let truncated: String = text.chars().take(max_length.saturating_sub(1)).collect();
     format!("{}…", truncated.trim_end())
 }
 
 fn render_inline_html(text: &str) -> String {
-    static TOKEN_RE: OnceLock<Regex> = OnceLock::new();
+    static TOKEN_RE: RegexCache = OnceLock::new();
 
-    let token_re = TOKEN_RE.get_or_init(|| {
-        Regex::new(
-            r"`([^`]+)`|\[([^\]]+)\]\(([^)]+)\)|\*\*([^*]+)\*\*|__([^_]+)__|\*([^*]+)\*|_([^_]+)_",
-        )
-        .unwrap()
-    });
+    let Some(token_re) = cached_regex(
+        &TOKEN_RE,
+        r"`([^`]+)`|\[([^\]]+)\]\(([^)]+)\)|\*\*([^*]+)\*\*|__([^_]+)__|\*([^*]+)\*|_([^_]+)_",
+    ) else {
+        return escape_html(text).replace('\n', "<br>");
+    };
     let mut html = String::new();
     let mut last_index = 0;
 
     for captures in token_re.captures_iter(text) {
-        let mat = captures.get(0).expect("token match");
+        let Some(mat) = captures.get(0) else {
+            continue;
+        };
         html.push_str(&escape_html(&text[last_index..mat.start()]));
 
         if let Some(code) = captures.get(1) {
@@ -288,18 +305,18 @@ fn render_inline_html(text: &str) -> String {
 }
 
 fn is_fence_start(line: &str) -> Option<String> {
-    static FENCE_RE: OnceLock<Regex> = OnceLock::new();
+    static FENCE_RE: RegexCache = OnceLock::new();
 
-    let fence_re = FENCE_RE.get_or_init(|| Regex::new(r"^```([\w-]+)?\s*$").unwrap());
+    let fence_re = cached_regex(&FENCE_RE, r"^```([\w-]+)?\s*$")?;
     fence_re
         .captures(line.trim())
         .map(|captures| captures.get(1).map_or("text", |value| value.as_str()).to_string())
 }
 
 fn heading_match(line: &str) -> Option<(usize, String)> {
-    static HEADING_RE: OnceLock<Regex> = OnceLock::new();
+    static HEADING_RE: RegexCache = OnceLock::new();
 
-    let heading_re = HEADING_RE.get_or_init(|| Regex::new(r"^(#{1,6})\s+(.*)$").unwrap());
+    let heading_re = cached_regex(&HEADING_RE, r"^(#{1,6})\s+(.*)$")?;
     heading_re.captures(line.trim()).map(|captures| {
         (
             captures.get(1).map_or(1, |value| value.as_str().len()).min(6),
@@ -309,18 +326,18 @@ fn heading_match(line: &str) -> Option<(usize, String)> {
 }
 
 fn ordered_list_item(line: &str) -> Option<String> {
-    static ORDERED_RE: OnceLock<Regex> = OnceLock::new();
+    static ORDERED_RE: RegexCache = OnceLock::new();
 
-    let ordered_re = ORDERED_RE.get_or_init(|| Regex::new(r"^\d+\.\s+(.*)$").unwrap());
+    let ordered_re = cached_regex(&ORDERED_RE, r"^\d+\.\s+(.*)$")?;
     ordered_re
         .captures(line.trim())
         .and_then(|captures| captures.get(1).map(|value| value.as_str().to_string()))
 }
 
 fn unordered_list_item(line: &str) -> Option<String> {
-    static UNORDERED_RE: OnceLock<Regex> = OnceLock::new();
+    static UNORDERED_RE: RegexCache = OnceLock::new();
 
-    let unordered_re = UNORDERED_RE.get_or_init(|| Regex::new(r"^[-*+]\s+(.*)$").unwrap());
+    let unordered_re = cached_regex(&UNORDERED_RE, r"^[-*+]\s+(.*)$")?;
     unordered_re
         .captures(line.trim())
         .and_then(|captures| captures.get(1).map(|value| value.as_str().to_string()))
@@ -334,17 +351,15 @@ fn is_markdown_block_start(line: &str) -> bool {
 }
 
 fn render_markdown_blocks_html(text: &str) -> String {
-    static ORDERED_CONTINUATION_RE: OnceLock<Regex> = OnceLock::new();
-    static UNORDERED_CONTINUATION_RE: OnceLock<Regex> = OnceLock::new();
+    static ORDERED_CONTINUATION_RE: RegexCache = OnceLock::new();
+    static UNORDERED_CONTINUATION_RE: RegexCache = OnceLock::new();
 
     let lines: Vec<&str> =
         text.split('\n').map(|line| line.strip_suffix('\r').unwrap_or(line)).collect();
     let mut blocks = Vec::new();
     let mut index = 0;
-    let ordered_continuation_re =
-        ORDERED_CONTINUATION_RE.get_or_init(|| Regex::new(r"^ {0,1}\d+\.\s+").unwrap());
-    let unordered_continuation_re =
-        UNORDERED_CONTINUATION_RE.get_or_init(|| Regex::new(r"^[-*+]\s+").unwrap());
+    let ordered_continuation_re = cached_regex(&ORDERED_CONTINUATION_RE, r"^ {0,1}\d+\.\s+");
+    let unordered_continuation_re = cached_regex(&UNORDERED_CONTINUATION_RE, r"^[-*+]\s+");
 
     while index < lines.len() {
         let line = lines[index];
@@ -397,7 +412,8 @@ fn render_markdown_blocks_html(text: &str) -> String {
 
                     if continuation_trimmed.is_empty()
                         || is_markdown_block_start(continuation)
-                        || ordered_continuation_re.is_match(continuation_trimmed)
+                        || ordered_continuation_re
+                            .is_some_and(|re| re.is_match(continuation_trimmed))
                     {
                         break;
                     }
@@ -436,7 +452,8 @@ fn render_markdown_blocks_html(text: &str) -> String {
 
                     if continuation_trimmed.is_empty()
                         || is_markdown_block_start(continuation)
-                        || unordered_continuation_re.is_match(continuation_trimmed)
+                        || unordered_continuation_re
+                            .is_some_and(|re| re.is_match(continuation_trimmed))
                     {
                         break;
                     }
@@ -738,24 +755,23 @@ fn render_entry_badges_html(entry: &ApiDocEntry, class_name: &str) -> String {
     let mut rendered = String::new();
     for badge in badges {
         let tone_class = badge.tone.map_or(String::new(), |tone| format!(" ox-api-badge--{tone}"));
-        write!(
-            rendered,
+        rendered.push_str(&format!(
             "<span class=\"ox-api-badge{}\">{}</span>",
             tone_class,
             escape_html(&badge.label)
-        )
-        .unwrap();
+        ));
     }
 
     format!("<span class=\"{class_name}\">{rendered}</span>")
 }
 
 fn parse_example_block(example: &str) -> (String, String) {
-    static FENCE_RE: OnceLock<Regex> = OnceLock::new();
+    static FENCE_RE: RegexCache = OnceLock::new();
 
     let trimmed = example.trim();
-    let fence_re =
-        FENCE_RE.get_or_init(|| Regex::new(r"(?s)^```([\w-]+)?[^\n]*\n(.*?)\n?```$").unwrap());
+    let Some(fence_re) = cached_regex(&FENCE_RE, r"(?s)^```([\w-]+)?[^\n]*\n(.*?)\n?```$") else {
+        return (trimmed.to_string(), "ts".to_string());
+    };
 
     if let Some(captures) = fence_re.captures(trimmed) {
         let language = captures.get(1).map_or("ts", |value| value.as_str()).to_string();
@@ -870,13 +886,11 @@ fn render_params_list_html(params: &[ApiParamDoc]) -> String {
 fn render_tag_list_html(tags: &[ApiDocTag]) -> String {
     let mut items = String::new();
     for tag in tags {
-        write!(
-            items,
+        items.push_str(&format!(
             "<li><span class=\"ox-api-entry__tag-name\">@{}</span><span class=\"ox-api-entry__tag-value\">{}</span></li>",
             escape_html(&tag.tag),
             render_inline_html(&tag.value)
-        )
-        .unwrap();
+        ));
     }
 
     format!(
@@ -904,7 +918,7 @@ fn render_member_flags(member: &ApiDocMember) -> String {
 
     let mut html = String::new();
     for flag in flags {
-        write!(html, "<span class=\"ox-api-badge\">{flag}</span>").unwrap();
+        html.push_str(&format!("<span class=\"ox-api-badge\">{flag}</span>"));
     }
     html
 }
@@ -942,8 +956,7 @@ fn render_member_description_html(member: &ApiDocMember) -> String {
                     description.push_str(" - optional");
                 }
             }
-            write!(
-                params,
+            params.push_str(&format!(
                 "<li><code>{}</code>{}</li>",
                 escape_html(&param.name),
                 if description.is_empty() {
@@ -951,8 +964,7 @@ fn render_member_description_html(member: &ApiDocMember) -> String {
                 } else {
                     format!(" {}", render_inline_html(&description))
                 }
-            )
-            .unwrap();
+            ));
         }
         blocks.push(format!("<ul class=\"ox-api-entry__member-params\">{params}</ul>"));
     }
@@ -1366,9 +1378,11 @@ fn convert_symbol_links(
     current_file_name: &str,
     symbol_map: &HashMap<String, SymbolLocation>,
 ) -> String {
-    static SYMBOL_RE: OnceLock<Regex> = OnceLock::new();
+    static SYMBOL_RE: RegexCache = OnceLock::new();
 
-    let symbol_re = SYMBOL_RE.get_or_init(|| Regex::new(r"\[([A-Z_]\w*)\]").unwrap());
+    let Some(symbol_re) = cached_regex(&SYMBOL_RE, r"\[([A-Z_]\w*)\]") else {
+        return text.to_string();
+    };
     let mut result = String::new();
     let mut last_index = 0;
 

--- a/crates/ox_content_i18n_lsp/src/backend.rs
+++ b/crates/ox_content_i18n_lsp/src/backend.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer};
@@ -177,9 +179,13 @@ impl LanguageServer for Backend {
             return Ok(None);
         }
 
-        let mut md = format!("**`{key}`**\n\n| Locale | Translation |\n|--------|-------------|\n");
+        let mut md = String::new();
+        push_fmt(
+            &mut md,
+            format_args!("**`{key}`**\n\n| Locale | Translation |\n|--------|-------------|\n"),
+        );
         for (locale, value) in &translations {
-            md.push_str(&format!("| `{locale}` | {value} |\n"));
+            push_fmt(&mut md, format_args!("| `{locale}` | {value} |\n"));
         }
 
         Ok(Some(Hover {
@@ -265,5 +271,11 @@ impl LanguageServer for Backend {
         }
 
         Ok(Some(hints))
+    }
+}
+
+fn push_fmt(output: &mut String, args: std::fmt::Arguments<'_>) {
+    if output.write_fmt(args).is_err() {
+        output.push_str("[formatting failed]");
     }
 }

--- a/crates/ox_content_lsp/src/backend/features.rs
+++ b/crates/ox_content_lsp/src/backend/features.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use tower_lsp::lsp_types::*;
 
 use crate::document::is_markdown_path;
@@ -68,10 +70,13 @@ impl Backend {
                 return None;
             }
 
-            let mut value =
-                format!("**`{key}`**\n\n| Locale | Translation |\n|--------|-------------|\n");
+            let mut value = String::new();
+            push_fmt(
+                &mut value,
+                format_args!("**`{key}`**\n\n| Locale | Translation |\n|--------|-------------|\n"),
+            );
             for (locale, translation) in &translations {
-                value.push_str(&format!("| `{locale}` | {translation} |\n"));
+                push_fmt(&mut value, format_args!("| `{locale}` | {translation} |\n"));
             }
 
             return Some(Hover {
@@ -177,5 +182,11 @@ impl Backend {
             Ok(symbols) if !symbols.is_empty() => Some(DocumentSymbolResponse::Nested(symbols)),
             _ => None,
         }
+    }
+}
+
+fn push_fmt(output: &mut String, args: std::fmt::Arguments<'_>) {
+    if output.write_fmt(args).is_err() {
+        output.push_str("[formatting failed]");
     }
 }

--- a/crates/ox_content_lsp/src/preview/symbols.rs
+++ b/crates/ox_content_lsp/src/preview/symbols.rs
@@ -65,7 +65,11 @@ fn symbol_for_heading(
     #[allow(deprecated)]
     DocumentSymbol {
         name: heading_text(heading),
-        detail: Some(format!("h{}", heading.depth)),
+        detail: Some({
+            let mut detail = String::from("h");
+            detail.push_str(&heading.depth.to_string());
+            detail
+        }),
         kind: SymbolKind::STRING,
         range,
         selection_range: range,
@@ -78,21 +82,27 @@ fn symbol_for_heading(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fmt::Write as _;
 
     fn outline(symbols: &[DocumentSymbol]) -> String {
         let mut out = String::new();
         for symbol in symbols {
             let detail = symbol.detail.as_deref().unwrap_or("?");
             let range = symbol.range;
-            out.push_str(&format!(
-                "{} [{}:{}..{}:{}] {}\n",
+            if writeln!(
+                &mut out,
+                "{} [{}:{}..{}:{}] {}",
                 detail,
                 range.start.line,
                 range.start.character,
                 range.end.line,
                 range.end.character,
                 symbol.name,
-            ));
+            )
+            .is_err()
+            {
+                out.push_str("[formatting failed]\n");
+            }
         }
         out
     }

--- a/crates/ox_content_napi/src/lint.rs
+++ b/crates/ox_content_napi/src/lint.rs
@@ -11,30 +11,30 @@ use unicode_normalization::UnicodeNormalization;
 const SUPPORTED_MARKDOWN_LINT_LANGUAGES: [&str; 6] = ["en", "ja", "zh", "fr", "de", "pl"];
 const DEFAULT_LANGUAGES: [&str; 1] = ["en"];
 
-static HEADING_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^\s{0,3}(#{1,6})[ \t]+(.+?)\s*#*\s*$").unwrap());
-static FENCE_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^\s{0,3}(`{3,}|~{3,})").unwrap());
-static LIST_PREFIX_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^\s{0,3}(?:#{1,6}[ \t]+|>\s?|(?:[-*+]|(?:\d+[.)]))[ \t]+)").unwrap()
-});
-static REFERENCE_DEFINITION_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^\s{0,3}\[[^\]]+\]:").unwrap());
-static URL_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?iu)\b(?:https?://|mailto:|www\.)\S+").unwrap());
-static HTML_TAG_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?u)</?[\p{L}!][^>]*>").unwrap());
-static FOOTNOTE_PATTERN: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\[\^[^\]]+\]").unwrap());
-static LATIN_WORD_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?u)\p{Latin}+(?:['’-]\p{Latin}+)*").unwrap());
-static CJK_RUN_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?u)[\p{Han}\p{Hiragana}\p{Katakana}ー]+").unwrap());
+static HEADING_PATTERN: LazyLock<Option<Regex>> =
+    LazyLock::new(|| Regex::new(r"^\s{0,3}(#{1,6})[ \t]+(.+?)\s*#*\s*$").ok());
+static FENCE_PATTERN: LazyLock<Option<Regex>> =
+    LazyLock::new(|| Regex::new(r"^\s{0,3}(`{3,}|~{3,})").ok());
+static LIST_PREFIX_PATTERN: LazyLock<Option<Regex>> =
+    LazyLock::new(|| Regex::new(r"^\s{0,3}(?:#{1,6}[ \t]+|>\s?|(?:[-*+]|(?:\d+[.)]))[ \t]+)").ok());
+static REFERENCE_DEFINITION_PATTERN: LazyLock<Option<Regex>> =
+    LazyLock::new(|| Regex::new(r"^\s{0,3}\[[^\]]+\]:").ok());
+static URL_PATTERN: LazyLock<Option<Regex>> =
+    LazyLock::new(|| Regex::new(r"(?iu)\b(?:https?://|mailto:|www\.)\S+").ok());
+static HTML_TAG_PATTERN: LazyLock<Option<Regex>> =
+    LazyLock::new(|| Regex::new(r"(?u)</?[\p{L}!][^>]*>").ok());
+static FOOTNOTE_PATTERN: LazyLock<Option<Regex>> =
+    LazyLock::new(|| Regex::new(r"\[\^[^\]]+\]").ok());
+static LATIN_WORD_PATTERN: LazyLock<Option<Regex>> =
+    LazyLock::new(|| Regex::new(r"(?u)\p{Latin}+(?:['’-]\p{Latin}+)*").ok());
+static CJK_RUN_PATTERN: LazyLock<Option<Regex>> =
+    LazyLock::new(|| Regex::new(r"(?u)[\p{Han}\p{Hiragana}\p{Katakana}ー]+").ok());
 
-static LINT_DICTIONARY_DATA: LazyLock<LintDictionaryData> = LazyLock::new(|| {
+static LINT_DICTIONARY_DATA: LazyLock<Option<LintDictionaryData>> = LazyLock::new(|| {
     serde_json::from_str(include_str!(
         "../../../npm/vite-plugin-ox-content/src/lint-dictionaries.json"
     ))
-    .expect("lint dictionaries JSON should be valid")
+    .ok()
 });
 
 #[derive(Deserialize)]
@@ -44,6 +44,7 @@ struct LintDictionaryData {
     by_language: HashMap<String, Vec<String>>,
 }
 
+#[derive(Default)]
 struct PreparedLintDictionaryData {
     global_words: HashSet<String>,
     by_language: HashMap<String, PreparedLanguageDictionary>,
@@ -62,7 +63,11 @@ struct SegmentWord {
 }
 
 static PREPARED_LINT_DICTIONARY_DATA: LazyLock<PreparedLintDictionaryData> = LazyLock::new(|| {
-    let global_words = LINT_DICTIONARY_DATA
+    let Some(dictionary_data) = LINT_DICTIONARY_DATA.as_ref() else {
+        return PreparedLintDictionaryData::default();
+    };
+
+    let global_words = dictionary_data
         .global
         .iter()
         .map(|word| normalize_word_for_set(word))
@@ -72,7 +77,7 @@ static PREPARED_LINT_DICTIONARY_DATA: LazyLock<PreparedLintDictionaryData> = Laz
     let by_language = SUPPORTED_MARKDOWN_LINT_LANGUAGES
         .iter()
         .map(|language| {
-            let words = LINT_DICTIONARY_DATA
+            let words = dictionary_data
                 .by_language
                 .get(*language)
                 .into_iter()
@@ -349,13 +354,15 @@ fn collect_markdown_lint_state(
             continue;
         }
 
-        if let Some(fence_match) = FENCE_PATTERN.find(line) {
-            let fence = &line[fence_match.start()..fence_match.end()];
-            in_fence = true;
-            fence_char = fence.chars().next().unwrap_or('\0');
-            fence_length = fence.chars().count();
-            masked_lines.push(create_skipped_line_mask(line));
-            continue;
+        if let Some(fence_pattern) = FENCE_PATTERN.as_ref() {
+            if let Some(fence_match) = fence_pattern.find(line) {
+                let fence = &line[fence_match.start()..fence_match.end()];
+                in_fence = true;
+                fence_char = fence.chars().next().unwrap_or('\0');
+                fence_length = fence.chars().count();
+                masked_lines.push(create_skipped_line_mask(line));
+                continue;
+            }
         }
 
         if normalized_options.rules.trailing_spaces {
@@ -398,7 +405,8 @@ fn collect_markdown_lint_state(
 
         blank_line_streak = 0;
 
-        if let Some(captures) = HEADING_PATTERN.captures(line) {
+        if let Some(captures) = HEADING_PATTERN.as_ref().and_then(|pattern| pattern.captures(line))
+        {
             let depth = captures.get(1).map_or(0, |value| value.as_str().chars().count());
             let heading_text = captures
                 .get(2)
@@ -440,7 +448,9 @@ fn collect_markdown_lint_state(
             }
         }
 
-        if REFERENCE_DEFINITION_PATTERN.is_match(line) || is_indented_code_block_line(line) {
+        if REFERENCE_DEFINITION_PATTERN.as_ref().is_some_and(|pattern| pattern.is_match(line))
+            || is_indented_code_block_line(line)
+        {
             masked_lines.push(create_skipped_line_mask(line));
             continue;
         }
@@ -648,9 +658,11 @@ fn collect_tokens(
     let latin_tokens = collect_latin_tokens(masked_line, languages, dictionary);
     let mut cjk_tokens = Vec::new();
 
-    for value in CJK_RUN_PATTERN.find_iter(masked_line) {
-        let start = byte_to_char_index(masked_line, value.start());
-        cjk_tokens.extend(collect_cjk_tokens(value.as_str(), start, languages, dictionary));
+    if let Some(cjk_run_pattern) = CJK_RUN_PATTERN.as_ref() {
+        for value in cjk_run_pattern.find_iter(masked_line) {
+            let start = byte_to_char_index(masked_line, value.start());
+            cjk_tokens.extend(collect_cjk_tokens(value.as_str(), start, languages, dictionary));
+        }
     }
 
     merge_tokens(latin_tokens, cjk_tokens)
@@ -698,11 +710,13 @@ fn collect_latin_tokens(
     let fallback_language = latin_languages[0].clone();
     let mut tokens = Vec::new();
 
-    for value in LATIN_WORD_PATTERN.find_iter(masked_line) {
-        let text = value.as_str().to_string();
-        let start = byte_to_char_index(masked_line, value.start());
-        let end = start + count_code_points(value.as_str());
-        tokens.push(Token { end, language: fallback_language.clone(), start, text });
+    if let Some(latin_word_pattern) = LATIN_WORD_PATTERN.as_ref() {
+        for value in latin_word_pattern.find_iter(masked_line) {
+            let text = value.as_str().to_string();
+            let start = byte_to_char_index(masked_line, value.start());
+            let end = start + count_code_points(value.as_str());
+            tokens.push(Token { end, language: fallback_language.clone(), start, text });
+        }
     }
 
     assign_latin_languages(tokens, &latin_languages, dictionary, &fallback_language)
@@ -1171,24 +1185,33 @@ fn mask_markdown_line(line: &str) -> String {
     let line_chars = line.chars().collect::<Vec<_>>();
     let mut chars = line_chars.clone();
 
-    if let Some(prefix_match) = LIST_PREFIX_PATTERN.find(line) {
-        let (start, end) = byte_range_to_char_range(line, prefix_match.start(), prefix_match.end());
-        blank_range(&mut chars, start, end);
+    if let Some(list_prefix_pattern) = LIST_PREFIX_PATTERN.as_ref() {
+        if let Some(prefix_match) = list_prefix_pattern.find(line) {
+            let (start, end) =
+                byte_range_to_char_range(line, prefix_match.start(), prefix_match.end());
+            blank_range(&mut chars, start, end);
+        }
     }
 
-    for value in FOOTNOTE_PATTERN.find_iter(line) {
-        let (start, end) = byte_range_to_char_range(line, value.start(), value.end());
-        blank_range(&mut chars, start, end);
+    if let Some(footnote_pattern) = FOOTNOTE_PATTERN.as_ref() {
+        for value in footnote_pattern.find_iter(line) {
+            let (start, end) = byte_range_to_char_range(line, value.start(), value.end());
+            blank_range(&mut chars, start, end);
+        }
     }
 
-    for value in URL_PATTERN.find_iter(line) {
-        let (start, end) = byte_range_to_char_range(line, value.start(), value.end());
-        blank_range(&mut chars, start, end);
+    if let Some(url_pattern) = URL_PATTERN.as_ref() {
+        for value in url_pattern.find_iter(line) {
+            let (start, end) = byte_range_to_char_range(line, value.start(), value.end());
+            blank_range(&mut chars, start, end);
+        }
     }
 
-    for value in HTML_TAG_PATTERN.find_iter(line) {
-        let (start, end) = byte_range_to_char_range(line, value.start(), value.end());
-        blank_range(&mut chars, start, end);
+    if let Some(html_tag_pattern) = HTML_TAG_PATTERN.as_ref() {
+        for value in html_tag_pattern.find_iter(line) {
+            let (start, end) = byte_range_to_char_range(line, value.start(), value.end());
+            blank_range(&mut chars, start, end);
+        }
     }
 
     mask_inline_code(&line_chars, &mut chars);
@@ -1410,14 +1433,10 @@ fn levenshtein(left: &str, right: &str) -> usize {
 
         for (right_index, right_value) in right_chars.iter().enumerate() {
             let substitution_cost = usize::from(left_value != right_value);
-            current_row[right_index + 1] = *[
-                current_row[right_index] + 1,
-                previous_row[right_index + 1] + 1,
-                previous_row[right_index] + substitution_cost,
-            ]
-            .iter()
-            .min()
-            .unwrap();
+            let insertion = current_row[right_index] + 1;
+            let deletion = previous_row[right_index + 1] + 1;
+            let substitution = previous_row[right_index] + substitution_cost;
+            current_row[right_index + 1] = insertion.min(deletion).min(substitution);
         }
 
         previous_row.clone_from(&current_row);

--- a/crates/ox_content_napi/src/mdast.rs
+++ b/crates/ox_content_napi/src/mdast.rs
@@ -316,7 +316,7 @@ impl MdastJsonSerializer {
             if let Some(escaped) = escaped {
                 self.output.push_str(escaped);
             } else {
-                self.output.push_str(&format!("\\u{byte:04x}"));
+                push_json_byte_escape(&mut self.output, byte);
             }
             start = idx + 1;
         }
@@ -326,6 +326,13 @@ impl MdastJsonSerializer {
         }
         self.output.push('"');
     }
+}
+
+fn push_json_byte_escape(output: &mut String, byte: u8) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    output.push_str("\\u00");
+    output.push(char::from(HEX[usize::from((byte >> 4) & 0x0f)]));
+    output.push(char::from(HEX[usize::from(byte & 0x0f)]));
 }
 
 #[cfg(test)]

--- a/crates/ox_content_napi/src/mdast_raw.rs
+++ b/crates/ox_content_napi/src/mdast_raw.rs
@@ -111,7 +111,7 @@ pub fn to_mdast_raw_with_sections(
     extra_sections: Vec<(u32, Vec<u8>)>,
 ) -> napi::Result<Uint8Array> {
     let mut serializer = MdastRawSerializer::default();
-    let root_index = serializer.write_document(document);
+    let root_index = serializer.write_document(document)?;
     serializer.finish(root_index, extra_sections)
 }
 
@@ -157,13 +157,13 @@ impl MdastRawSerializer {
         builder.finish()
     }
 
-    fn write_document(&mut self, document: &Document<'_>) -> u32 {
+    fn write_document(&mut self, document: &Document<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_ROOT, document.span);
-        self.write_child_nodes(&mut record, &document.children);
+        self.write_child_nodes(&mut record, &document.children)?;
         self.push_record(record)
     }
 
-    fn write_node(&mut self, node: &Node<'_>) -> u32 {
+    fn write_node(&mut self, node: &Node<'_>) -> napi::Result<u32> {
         match node {
             Node::Paragraph(node) => self.write_paragraph(node),
             Node::Heading(node) => self.write_heading(node),
@@ -188,32 +188,32 @@ impl MdastRawSerializer {
         }
     }
 
-    fn write_paragraph(&mut self, node: &Paragraph<'_>) -> u32 {
+    fn write_paragraph(&mut self, node: &Paragraph<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_PARAGRAPH, node.span);
-        self.write_child_nodes(&mut record, &node.children);
+        self.write_child_nodes(&mut record, &node.children)?;
         self.push_record(record)
     }
 
-    fn write_heading(&mut self, node: &Heading<'_>) -> u32 {
+    fn write_heading(&mut self, node: &Heading<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_HEADING, node.span);
-        self.write_child_nodes(&mut record, &node.children);
+        self.write_child_nodes(&mut record, &node.children)?;
         record.num0 = u32::from(node.depth);
         self.push_record(record)
     }
 
-    fn write_thematic_break(&mut self, node: &ThematicBreak) -> u32 {
+    fn write_thematic_break(&mut self, node: &ThematicBreak) -> napi::Result<u32> {
         self.push_record(RawNodeRecord::new(KIND_THEMATIC_BREAK, node.span))
     }
 
-    fn write_block_quote(&mut self, node: &BlockQuote<'_>) -> u32 {
+    fn write_block_quote(&mut self, node: &BlockQuote<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_BLOCKQUOTE, node.span);
-        self.write_child_nodes(&mut record, &node.children);
+        self.write_child_nodes(&mut record, &node.children)?;
         self.push_record(record)
     }
 
-    fn write_list(&mut self, node: &List<'_>) -> u32 {
+    fn write_list(&mut self, node: &List<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_LIST, node.span);
-        self.write_child_list_items(&mut record, &node.children);
+        self.write_child_list_items(&mut record, &node.children)?;
         if node.ordered {
             record.flags |= FLAG_ORDERED;
         }
@@ -224,9 +224,9 @@ impl MdastRawSerializer {
         self.push_record(record)
     }
 
-    fn write_list_item(&mut self, node: &ListItem<'_>) -> u32 {
+    fn write_list_item(&mut self, node: &ListItem<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_LIST_ITEM, node.span);
-        self.write_child_nodes(&mut record, &node.children);
+        self.write_child_nodes(&mut record, &node.children)?;
         if node.spread {
             record.flags |= FLAG_SPREAD;
         }
@@ -239,23 +239,23 @@ impl MdastRawSerializer {
         self.push_record(record)
     }
 
-    fn write_code_block(&mut self, node: &CodeBlock<'_>) -> u32 {
+    fn write_code_block(&mut self, node: &CodeBlock<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_CODE, node.span);
-        self.write_string_into_slot(&mut record, 0, node.lang);
-        self.write_string_into_slot(&mut record, 1, node.meta);
-        self.write_string_into_slot(&mut record, 2, Some(node.value));
+        self.write_string_into_slot(&mut record, 0, node.lang)?;
+        self.write_string_into_slot(&mut record, 1, node.meta)?;
+        self.write_string_into_slot(&mut record, 2, Some(node.value))?;
         self.push_record(record)
     }
 
-    fn write_html(&mut self, node: &Html<'_>) -> u32 {
+    fn write_html(&mut self, node: &Html<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_HTML, node.span);
-        self.write_string_into_slot(&mut record, 0, Some(node.value));
+        self.write_string_into_slot(&mut record, 0, Some(node.value))?;
         self.push_record(record)
     }
 
-    fn write_table(&mut self, node: &Table<'_>) -> u32 {
+    fn write_table(&mut self, node: &Table<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_TABLE, node.span);
-        self.write_child_table_rows(&mut record, &node.children);
+        self.write_child_table_rows(&mut record, &node.children)?;
         let align_start = self.aligns.len();
         for align in &node.align {
             self.aligns.push(match align {
@@ -265,155 +265,163 @@ impl MdastRawSerializer {
                 AlignKind::Right => ALIGN_RIGHT,
             });
         }
-        record.num0 = as_u32(align_start).expect("align overflow");
-        record.num1 = as_u32(node.align.len()).expect("align overflow");
+        record.num0 = as_u32(align_start)?;
+        record.num1 = as_u32(node.align.len())?;
         self.push_record(record)
     }
 
-    fn write_table_row(&mut self, node: &TableRow<'_>) -> u32 {
+    fn write_table_row(&mut self, node: &TableRow<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_TABLE_ROW, node.span);
-        self.write_child_table_cells(&mut record, &node.children);
+        self.write_child_table_cells(&mut record, &node.children)?;
         self.push_record(record)
     }
 
-    fn write_table_cell(&mut self, node: &TableCell<'_>) -> u32 {
+    fn write_table_cell(&mut self, node: &TableCell<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_TABLE_CELL, node.span);
-        self.write_child_nodes(&mut record, &node.children);
+        self.write_child_nodes(&mut record, &node.children)?;
         self.push_record(record)
     }
 
-    fn write_text(&mut self, node: &Text<'_>) -> u32 {
+    fn write_text(&mut self, node: &Text<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_TEXT, node.span);
-        self.write_string_into_slot(&mut record, 0, Some(node.value));
+        self.write_string_into_slot(&mut record, 0, Some(node.value))?;
         self.push_record(record)
     }
 
-    fn write_emphasis(&mut self, node: &Emphasis<'_>) -> u32 {
+    fn write_emphasis(&mut self, node: &Emphasis<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_EMPHASIS, node.span);
-        self.write_child_nodes(&mut record, &node.children);
+        self.write_child_nodes(&mut record, &node.children)?;
         self.push_record(record)
     }
 
-    fn write_strong(&mut self, node: &Strong<'_>) -> u32 {
+    fn write_strong(&mut self, node: &Strong<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_STRONG, node.span);
-        self.write_child_nodes(&mut record, &node.children);
+        self.write_child_nodes(&mut record, &node.children)?;
         self.push_record(record)
     }
 
-    fn write_inline_code(&mut self, node: &InlineCode<'_>) -> u32 {
+    fn write_inline_code(&mut self, node: &InlineCode<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_INLINE_CODE, node.span);
-        self.write_string_into_slot(&mut record, 0, Some(node.value));
+        self.write_string_into_slot(&mut record, 0, Some(node.value))?;
         self.push_record(record)
     }
 
-    fn write_break(&mut self, node: &Break) -> u32 {
+    fn write_break(&mut self, node: &Break) -> napi::Result<u32> {
         self.push_record(RawNodeRecord::new(KIND_BREAK, node.span))
     }
 
-    fn write_link(&mut self, node: &Link<'_>) -> u32 {
+    fn write_link(&mut self, node: &Link<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_LINK, node.span);
-        self.write_child_nodes(&mut record, &node.children);
-        self.write_string_into_slot(&mut record, 0, Some(node.url));
-        self.write_string_into_slot(&mut record, 1, node.title);
+        self.write_child_nodes(&mut record, &node.children)?;
+        self.write_string_into_slot(&mut record, 0, Some(node.url))?;
+        self.write_string_into_slot(&mut record, 1, node.title)?;
         self.push_record(record)
     }
 
-    fn write_image(&mut self, node: &Image<'_>) -> u32 {
+    fn write_image(&mut self, node: &Image<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_IMAGE, node.span);
-        self.write_string_into_slot(&mut record, 0, Some(node.url));
-        self.write_string_into_slot(&mut record, 1, Some(node.alt));
-        self.write_string_into_slot(&mut record, 2, node.title);
+        self.write_string_into_slot(&mut record, 0, Some(node.url))?;
+        self.write_string_into_slot(&mut record, 1, Some(node.alt))?;
+        self.write_string_into_slot(&mut record, 2, node.title)?;
         self.push_record(record)
     }
 
-    fn write_delete(&mut self, node: &Delete<'_>) -> u32 {
+    fn write_delete(&mut self, node: &Delete<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_DELETE, node.span);
-        self.write_child_nodes(&mut record, &node.children);
+        self.write_child_nodes(&mut record, &node.children)?;
         self.push_record(record)
     }
 
-    fn write_footnote_reference(&mut self, node: &FootnoteReference<'_>) -> u32 {
+    fn write_footnote_reference(&mut self, node: &FootnoteReference<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_FOOTNOTE_REFERENCE, node.span);
-        self.write_string_into_slot(&mut record, 0, Some(node.identifier));
-        self.write_string_into_slot(&mut record, 1, node.label);
+        self.write_string_into_slot(&mut record, 0, Some(node.identifier))?;
+        self.write_string_into_slot(&mut record, 1, node.label)?;
         self.push_record(record)
     }
 
-    fn write_definition(&mut self, node: &Definition<'_>) -> u32 {
+    fn write_definition(&mut self, node: &Definition<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_DEFINITION, node.span);
-        self.write_string_into_slot(&mut record, 0, Some(node.identifier));
-        self.write_string_into_slot(&mut record, 1, node.label);
-        self.write_string_into_slot(&mut record, 2, Some(node.url));
-        self.write_string_into_slot(&mut record, 3, node.title);
+        self.write_string_into_slot(&mut record, 0, Some(node.identifier))?;
+        self.write_string_into_slot(&mut record, 1, node.label)?;
+        self.write_string_into_slot(&mut record, 2, Some(node.url))?;
+        self.write_string_into_slot(&mut record, 3, node.title)?;
         self.push_record(record)
     }
 
-    fn write_footnote_definition(&mut self, node: &FootnoteDefinition<'_>) -> u32 {
+    fn write_footnote_definition(&mut self, node: &FootnoteDefinition<'_>) -> napi::Result<u32> {
         let mut record = RawNodeRecord::new(KIND_FOOTNOTE_DEFINITION, node.span);
-        self.write_child_nodes(&mut record, &node.children);
-        self.write_string_into_slot(&mut record, 0, Some(node.identifier));
-        self.write_string_into_slot(&mut record, 1, node.label);
+        self.write_child_nodes(&mut record, &node.children)?;
+        self.write_string_into_slot(&mut record, 0, Some(node.identifier))?;
+        self.write_string_into_slot(&mut record, 1, node.label)?;
         self.push_record(record)
     }
 
-    fn write_child_nodes(&mut self, record: &mut RawNodeRecord, children: &ArenaVec<'_, Node<'_>>) {
+    fn write_child_nodes(
+        &mut self,
+        record: &mut RawNodeRecord,
+        children: &ArenaVec<'_, Node<'_>>,
+    ) -> napi::Result<()> {
         let mut direct_children = Vec::with_capacity(children.len());
         for child in children {
-            let index = self.write_node(child);
+            let index = self.write_node(child)?;
             direct_children.push(index);
         }
         let child_start = self.child_indices.len();
         self.child_indices.extend(direct_children);
-        record.child_start = as_u32(child_start).expect("child overflow");
-        record.child_len = as_u32(self.child_indices.len() - child_start).expect("child overflow");
+        record.child_start = as_u32(child_start)?;
+        record.child_len = as_u32(self.child_indices.len() - child_start)?;
+        Ok(())
     }
 
     fn write_child_list_items(
         &mut self,
         record: &mut RawNodeRecord,
         children: &ArenaVec<'_, ListItem<'_>>,
-    ) {
+    ) -> napi::Result<()> {
         let mut direct_children = Vec::with_capacity(children.len());
         for child in children {
-            let index = self.write_list_item(child);
+            let index = self.write_list_item(child)?;
             direct_children.push(index);
         }
         let child_start = self.child_indices.len();
         self.child_indices.extend(direct_children);
-        record.child_start = as_u32(child_start).expect("child overflow");
-        record.child_len = as_u32(self.child_indices.len() - child_start).expect("child overflow");
+        record.child_start = as_u32(child_start)?;
+        record.child_len = as_u32(self.child_indices.len() - child_start)?;
+        Ok(())
     }
 
     fn write_child_table_rows(
         &mut self,
         record: &mut RawNodeRecord,
         children: &ArenaVec<'_, TableRow<'_>>,
-    ) {
+    ) -> napi::Result<()> {
         let mut direct_children = Vec::with_capacity(children.len());
         for child in children {
-            let index = self.write_table_row(child);
+            let index = self.write_table_row(child)?;
             direct_children.push(index);
         }
         let child_start = self.child_indices.len();
         self.child_indices.extend(direct_children);
-        record.child_start = as_u32(child_start).expect("child overflow");
-        record.child_len = as_u32(self.child_indices.len() - child_start).expect("child overflow");
+        record.child_start = as_u32(child_start)?;
+        record.child_len = as_u32(self.child_indices.len() - child_start)?;
+        Ok(())
     }
 
     fn write_child_table_cells(
         &mut self,
         record: &mut RawNodeRecord,
         children: &ArenaVec<'_, TableCell<'_>>,
-    ) {
+    ) -> napi::Result<()> {
         let mut direct_children = Vec::with_capacity(children.len());
         for child in children {
-            let index = self.write_table_cell(child);
+            let index = self.write_table_cell(child)?;
             direct_children.push(index);
         }
         let child_start = self.child_indices.len();
         self.child_indices.extend(direct_children);
-        record.child_start = as_u32(child_start).expect("child overflow");
-        record.child_len = as_u32(self.child_indices.len() - child_start).expect("child overflow");
+        record.child_start = as_u32(child_start)?;
+        record.child_len = as_u32(self.child_indices.len() - child_start)?;
+        Ok(())
     }
 
     fn write_string_into_slot(
@@ -421,15 +429,15 @@ impl MdastRawSerializer {
         record: &mut RawNodeRecord,
         slot: usize,
         value: Option<&str>,
-    ) {
+    ) -> napi::Result<()> {
         let Some(value) = value else {
-            return;
+            return Ok(());
         };
 
         let offset = self.strings.len();
         self.strings.extend_from_slice(value.as_bytes());
-        let offset = as_u32(offset).expect("string overflow");
-        let len = as_u32(value.len()).expect("string overflow");
+        let offset = as_u32(offset)?;
+        let len = as_u32(value.len())?;
 
         match slot {
             0 => {
@@ -448,14 +456,20 @@ impl MdastRawSerializer {
                 record.str3_offset = offset;
                 record.str3_len = len;
             }
-            _ => unreachable!(),
+            _ => {
+                return Err(napi::Error::from_reason(format!(
+                    "invalid raw mdast string slot: {slot}"
+                )));
+            }
         }
+        Ok(())
     }
 
-    fn push_record(&mut self, record: RawNodeRecord) -> u32 {
+    fn push_record(&mut self, record: RawNodeRecord) -> napi::Result<u32> {
         let index = self.nodes.len();
+        let index = as_u32(index)?;
         self.nodes.push(record);
-        as_u32(index).expect("node overflow")
+        Ok(index)
     }
 }
 

--- a/crates/ox_content_napi/src/mdast_raw.rs
+++ b/crates/ox_content_napi/src/mdast_raw.rs
@@ -457,9 +457,9 @@ impl MdastRawSerializer {
                 record.str3_len = len;
             }
             _ => {
-                return Err(napi::Error::from_reason(format!(
-                    "invalid raw mdast string slot: {slot}"
-                )));
+                let mut message = String::from("invalid raw mdast string slot: ");
+                message.push_str(&slot.to_string());
+                return Err(napi::Error::from_reason(message));
             }
         }
         Ok(())

--- a/crates/ox_content_napi/src/transfer.rs
+++ b/crates/ox_content_napi/src/transfer.rs
@@ -1,5 +1,3 @@
-use std::ptr;
-
 use napi::bindgen_prelude::Uint8Array;
 
 pub const TRANSFER_MAGIC: u32 = u32::from_le_bytes(*b"OXTR");
@@ -53,10 +51,13 @@ impl TransferBufferBuilder {
     }
 
     pub fn finish(self) -> napi::Result<Uint8Array> {
-        let section_table_len = self.sections.len() * TRANSFER_SECTION_RECORD_LEN;
-        let body_offset = TRANSFER_HEADER_LEN + section_table_len;
-        let body_len = self.sections.iter().map(|section| section.bytes.len()).sum::<usize>();
-        let total_len = body_offset + body_len;
+        let section_table_len =
+            checked_mul(self.sections.len(), TRANSFER_SECTION_RECORD_LEN, "section table length")?;
+        let body_offset = checked_add(TRANSFER_HEADER_LEN, section_table_len, "body offset")?;
+        let body_len = self.sections.iter().try_fold(0usize, |total, section| {
+            checked_add(total, section.bytes.len(), "body length")
+        })?;
+        let total_len = checked_add(body_offset, body_len, "total length")?;
         let mut buffer = Vec::with_capacity(total_len);
 
         push_u32(&mut buffer, TRANSFER_MAGIC);
@@ -72,7 +73,8 @@ impl TransferBufferBuilder {
             push_u32(&mut buffer, section.id);
             push_u32(&mut buffer, as_u32(next_section_offset)?);
             push_u32(&mut buffer, as_u32(section.bytes.len())?);
-            next_section_offset += section.bytes.len();
+            next_section_offset =
+                checked_add(next_section_offset, section.bytes.len(), "section offset")?;
         }
 
         for section in self.sections {
@@ -81,12 +83,24 @@ impl TransferBufferBuilder {
 
         debug_assert_eq!(buffer.len(), total_len);
 
-        into_external_uint8_array(buffer)
+        Ok(Uint8Array::new(buffer))
     }
 }
 
 pub fn as_u32(value: usize) -> napi::Result<u32> {
     u32::try_from(value).map_err(|_| napi::Error::from_reason("transfer buffer overflow"))
+}
+
+fn checked_add(left: usize, right: usize, context: &str) -> napi::Result<usize> {
+    left.checked_add(right).ok_or_else(|| transfer_size_error(context))
+}
+
+fn checked_mul(left: usize, right: usize, context: &str) -> napi::Result<usize> {
+    left.checked_mul(right).ok_or_else(|| transfer_size_error(context))
+}
+
+fn transfer_size_error(context: &str) -> napi::Error {
+    napi::Error::from_reason(format!("transfer buffer is too large while calculating {context}"))
 }
 
 fn push_u16(buffer: &mut Vec<u8>, value: u16) {
@@ -95,19 +109,6 @@ fn push_u16(buffer: &mut Vec<u8>, value: u16) {
 
 fn push_u32(buffer: &mut Vec<u8>, value: u32) {
     buffer.extend_from_slice(&value.to_le_bytes());
-}
-
-#[allow(unsafe_code)]
-fn into_external_uint8_array(buffer: Vec<u8>) -> napi::Result<Uint8Array> {
-    let len = buffer.len();
-    let ptr = Box::into_raw(buffer.into_boxed_slice()).cast::<u8>();
-    let array = unsafe {
-        Uint8Array::with_external_data(ptr, len, move |ptr, len| {
-            let slice = ptr::slice_from_raw_parts_mut(ptr, len);
-            drop(Box::from_raw(slice));
-        })
-    };
-    Ok(array)
 }
 
 #[cfg(test)]

--- a/crates/ox_content_napi/src/transfer.rs
+++ b/crates/ox_content_napi/src/transfer.rs
@@ -100,7 +100,9 @@ fn checked_mul(left: usize, right: usize, context: &str) -> napi::Result<usize> 
 }
 
 fn transfer_size_error(context: &str) -> napi::Error {
-    napi::Error::from_reason(format!("transfer buffer is too large while calculating {context}"))
+    let mut message = String::from("transfer buffer is too large while calculating ");
+    message.push_str(context);
+    napi::Error::from_reason(message)
 }
 
 fn push_u16(buffer: &mut Vec<u8>, value: u16) {

--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -1115,7 +1115,9 @@ impl<'a> Parser<'a> {
             }
         }
 
-        let fence_char = self.peek().unwrap();
+        let Some(fence_char) = self.peek() else {
+            return Err(ParseError::UnexpectedEof { span: Span::new(start as u32, start as u32) });
+        };
         let mut fence_len = 0;
 
         while self.peek() == Some(fence_char) {

--- a/crates/ox_content_profile_cli/src/main.rs
+++ b/crates/ox_content_profile_cli/src/main.rs
@@ -22,6 +22,7 @@
 //! Without a `<FILE>` the embedded corpus is used so the binary stays
 //! useful in CI / first-time setup.
 
+use std::fmt::Write as _;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -94,10 +95,9 @@ fn parser_options(cli: &Cli) -> ParserOptions {
 }
 
 fn parse_error(err: impl std::fmt::Display) -> std::io::Error {
-    std::io::Error::new(
-        std::io::ErrorKind::InvalidData,
-        format!("failed to parse Markdown input for profiling: {err}"),
-    )
+    let mut message = String::from("failed to parse Markdown input for profiling: ");
+    push_fmt(&mut message, format_args!("{err}"));
+    std::io::Error::new(std::io::ErrorKind::InvalidData, message)
 }
 
 fn run(cli: &Cli) -> std::io::Result<()> {
@@ -114,11 +114,13 @@ fn run(cli: &Cli) -> std::io::Result<()> {
     let total_iters = cli.warmup + cli.iters;
     let config = ReportConfig { input_bytes: Some(bytes), warmup: cli.warmup, max_span_rows: 24 };
 
-    let label = match &cli.cmd {
-        Cmd::Parse { .. } => format!("parse ({label_input}, {bytes} bytes)"),
-        Cmd::Render { .. } => format!("render ({label_input}, {bytes} bytes)"),
-        Cmd::Pipeline { .. } => format!("pipeline ({label_input}, {bytes} bytes)"),
+    let label_prefix = match &cli.cmd {
+        Cmd::Parse { .. } => "parse",
+        Cmd::Render { .. } => "render",
+        Cmd::Pipeline { .. } => "pipeline",
     };
+    let mut label = String::new();
+    push_fmt(&mut label, format_args!("{label_prefix} ({label_input}, {bytes} bytes)"));
 
     let mut recorder = Recorder::new(label).with_config(config);
 
@@ -175,6 +177,12 @@ fn run(cli: &Cli) -> std::io::Result<()> {
         println!("{}", report.render_table());
     }
     Ok(())
+}
+
+fn push_fmt(output: &mut String, args: std::fmt::Arguments<'_>) {
+    if output.write_fmt(args).is_err() {
+        output.push_str("[formatting failed]");
+    }
 }
 
 fn main() -> ExitCode {

--- a/crates/ox_content_profile_cli/src/main.rs
+++ b/crates/ox_content_profile_cli/src/main.rs
@@ -93,6 +93,13 @@ fn parser_options(cli: &Cli) -> ParserOptions {
     }
 }
 
+fn parse_error(err: impl std::fmt::Display) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        format!("failed to parse Markdown input for profiling: {err}"),
+    )
+}
+
 fn run(cli: &Cli) -> std::io::Result<()> {
     CountingAllocator::enable();
     scope::enable();
@@ -118,11 +125,12 @@ fn run(cli: &Cli) -> std::io::Result<()> {
     match &cli.cmd {
         Cmd::Parse { .. } => {
             for _ in 0..total_iters {
-                recorder.record(|| {
+                recorder.record(|| -> std::io::Result<()> {
                     let alloc = Allocator::new();
                     let parser = Parser::with_options(&alloc, &source, parser_options(cli));
-                    let _ = parser.parse();
-                });
+                    let _ = parser.parse().map_err(parse_error)?;
+                    Ok(())
+                })?;
             }
         }
         Cmd::Render { .. } => {
@@ -132,7 +140,7 @@ fn run(cli: &Cli) -> std::io::Result<()> {
             for _ in 0..total_iters {
                 let alloc = Allocator::new();
                 let parser = Parser::with_options(&alloc, &source, parser_options(cli));
-                let doc = parser.parse().expect("parser failure during profile");
+                let doc = parser.parse().map_err(parse_error)?;
                 recorder.record(|| {
                     let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions::new());
                     let _ = renderer.render(&doc);
@@ -141,13 +149,14 @@ fn run(cli: &Cli) -> std::io::Result<()> {
         }
         Cmd::Pipeline { .. } => {
             for _ in 0..total_iters {
-                recorder.record(|| {
+                recorder.record(|| -> std::io::Result<()> {
                     let alloc = Allocator::new();
                     let parser = Parser::with_options(&alloc, &source, parser_options(cli));
-                    let doc = parser.parse().expect("parser failure during profile");
+                    let doc = parser.parse().map_err(parse_error)?;
                     let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions::new());
                     let _ = renderer.render(&doc);
-                });
+                    Ok(())
+                })?;
             }
         }
     }

--- a/crates/ox_content_profiler/src/report.rs
+++ b/crates/ox_content_profiler/src/report.rs
@@ -11,6 +11,7 @@
 //! Rendering is intentionally string-based and lock-free so that printing
 //! the report does not itself perturb the global allocator counters by much.
 
+use std::fmt::Write as _;
 use std::time::Duration;
 
 use crate::alloc::AllocDelta;
@@ -107,30 +108,36 @@ impl Report {
         let mut out = String::with_capacity(4096);
         let ruler = "─".repeat(78);
 
-        out.push_str(&format!("\n{ruler}\n"));
-        out.push_str(&format!(" Profile: {}\n", self.label));
-        out.push_str(&format!(
-            " Iterations measured: {} (warmup: {})\n",
-            self.timing.samples, self.config.warmup
-        ));
-        out.push_str(&format!("{ruler}\n"));
+        push_fmt(&mut out, format_args!("\n{ruler}\n"));
+        push_fmt(&mut out, format_args!(" Profile: {}\n", self.label));
+        push_fmt(
+            &mut out,
+            format_args!(
+                " Iterations measured: {} (warmup: {})\n",
+                self.timing.samples, self.config.warmup
+            ),
+        );
+        push_fmt(&mut out, format_args!("{ruler}\n"));
 
         out.push_str("\n Timing\n");
-        out.push_str(&format!(
-            "   min   {}\n   p50   {}\n   p95   {}\n   p99   {}\n   max   {}\n   mean  {}\n",
-            fmt_duration(self.timing.min),
-            fmt_duration(self.timing.p50),
-            fmt_duration(self.timing.p95),
-            fmt_duration(self.timing.p99),
-            fmt_duration(self.timing.max),
-            fmt_duration(self.timing.mean),
-        ));
+        push_fmt(
+            &mut out,
+            format_args!(
+                "   min   {}\n   p50   {}\n   p95   {}\n   p99   {}\n   max   {}\n   mean  {}\n",
+                fmt_duration(self.timing.min),
+                fmt_duration(self.timing.p50),
+                fmt_duration(self.timing.p95),
+                fmt_duration(self.timing.p99),
+                fmt_duration(self.timing.max),
+                fmt_duration(self.timing.mean),
+            ),
+        );
         if let Some(throughput) = self.timing.throughput_mb_s {
-            out.push_str(&format!("   throughput   {throughput:>8.2} MB/s\n"));
+            push_fmt(&mut out, format_args!("   throughput   {throughput:>8.2} MB/s\n"));
         }
 
         out.push_str("\n Allocations (per iteration)\n");
-        out.push_str(&format!(
+        push_fmt(&mut out, format_args!(
             "   count       {:>12.1}\n   bytes       {:>12}\n   peak (max)  {:>12}\n   largest     {:>12}\n",
             self.allocs.mean_allocations,
             fmt_bytes_f(self.allocs.mean_bytes),
@@ -140,28 +147,37 @@ impl Report {
 
         if !self.spans.is_empty() {
             out.push_str("\n Spans (sorted by total inclusive time)\n");
-            out.push_str(&format!(
-                "   {:<32} {:>8} {:>12} {:>12} {:>6}   {:>10} {:>10}\n",
-                "name", "hits", "self", "inclusive", "share", "allocs", "bytes",
-            ));
-            out.push_str(&format!("   {}\n", "·".repeat(74)));
+            push_fmt(
+                &mut out,
+                format_args!(
+                    "   {:<32} {:>8} {:>12} {:>12} {:>6}   {:>10} {:>10}\n",
+                    "name", "hits", "self", "inclusive", "share", "allocs", "bytes",
+                ),
+            );
+            push_fmt(&mut out, format_args!("   {}\n", "·".repeat(74)));
             for span in self.spans.iter().take(self.config.max_span_rows) {
-                out.push_str(&format!(
-                    "   {:<32} {:>8} {:>12} {:>12} {:>5.1}%   {:>10} {:>10}\n",
-                    truncate(span.name, 32),
-                    span.hits,
-                    fmt_duration(span.total_self),
-                    fmt_duration(span.total_inclusive),
-                    span.share_of_total * 100.0,
-                    span.total_allocs,
-                    fmt_bytes(span.total_bytes),
-                ));
+                push_fmt(
+                    &mut out,
+                    format_args!(
+                        "   {:<32} {:>8} {:>12} {:>12} {:>5.1}%   {:>10} {:>10}\n",
+                        truncate(span.name, 32),
+                        span.hits,
+                        fmt_duration(span.total_self),
+                        fmt_duration(span.total_inclusive),
+                        span.share_of_total * 100.0,
+                        span.total_allocs,
+                        fmt_bytes(span.total_bytes),
+                    ),
+                );
             }
             if self.spans.len() > self.config.max_span_rows {
-                out.push_str(&format!(
-                    "   …and {} more spans\n",
-                    self.spans.len() - self.config.max_span_rows
-                ));
+                push_fmt(
+                    &mut out,
+                    format_args!(
+                        "   …and {} more spans\n",
+                        self.spans.len() - self.config.max_span_rows
+                    ),
+                );
             }
         }
 
@@ -176,12 +192,12 @@ impl Report {
                 for (label, count) in last.allocs.size_class_buckets.iter_nonempty() {
                     let bar_len = ((count as f64).log2().max(0.0) * 2.0) as usize;
                     let bar = "▏".repeat(bar_len.min(40));
-                    out.push_str(&format!("   {label:>10}  {count:>8}  {bar}\n"));
+                    push_fmt(&mut out, format_args!("   {label:>10}  {count:>8}  {bar}\n"));
                 }
             }
         }
 
-        out.push_str(&format!("\n{ruler}\n"));
+        push_fmt(&mut out, format_args!("\n{ruler}\n"));
         out
     }
 
@@ -210,18 +226,21 @@ impl Report {
         write_kv_dur(&mut s, "mean_ns", self.timing.mean);
         if let Some(t) = self.timing.throughput_mb_s {
             s.push(',');
-            s.push_str(&format!("\"throughput_mb_s\":{t}"));
+            push_fmt(&mut s, format_args!("\"throughput_mb_s\":{t}"));
         }
         s.push('}');
         s.push(',');
         s.push_str("\"allocs\":{");
-        s.push_str(&format!(
-            "\"mean_count\":{:.3},\"mean_bytes\":{:.3},\"max_peak\":{},\"largest\":{}",
-            self.allocs.mean_allocations,
-            self.allocs.mean_bytes,
-            self.allocs.max_peak_above_baseline,
-            self.allocs.largest_single_alloc
-        ));
+        push_fmt(
+            &mut s,
+            format_args!(
+                "\"mean_count\":{:.3},\"mean_bytes\":{:.3},\"max_peak\":{},\"largest\":{}",
+                self.allocs.mean_allocations,
+                self.allocs.mean_bytes,
+                self.allocs.max_peak_above_baseline,
+                self.allocs.largest_single_alloc
+            ),
+        );
         s.push('}');
         s.push(',');
         s.push_str("\"spans\":[");
@@ -362,13 +381,13 @@ fn aggregate_spans(iters: &[&IterationRecord]) -> Vec<SpanAggregate> {
 fn fmt_duration(d: Duration) -> String {
     let ns = d.as_nanos();
     if ns < 1_000 {
-        format!("{ns} ns")
+        fmt_args(format_args!("{ns} ns"))
     } else if ns < 1_000_000 {
-        format!("{:.2} µs", ns as f64 / 1_000.0)
+        fmt_args(format_args!("{:.2} µs", ns as f64 / 1_000.0))
     } else if ns < 1_000_000_000 {
-        format!("{:.2} ms", ns as f64 / 1_000_000.0)
+        fmt_args(format_args!("{:.2} ms", ns as f64 / 1_000_000.0))
     } else {
-        format!("{:.3} s", d.as_secs_f64())
+        fmt_args(format_args!("{:.3} s", d.as_secs_f64()))
     }
 }
 
@@ -385,9 +404,9 @@ fn fmt_bytes_f(b: f64) -> String {
         unit += 1;
     }
     if unit == 0 {
-        format!("{value:.0} {}", UNITS[unit])
+        fmt_args(format_args!("{value:.0} {}", UNITS[unit]))
     } else {
-        format!("{value:.2} {}", UNITS[unit])
+        fmt_args(format_args!("{value:.2} {}", UNITS[unit]))
     }
 }
 
@@ -410,7 +429,7 @@ fn write_kv_str(s: &mut String, k: &str, v: &str) {
         match ch {
             '"' => s.push_str("\\\""),
             '\\' => s.push_str("\\\\"),
-            c if (c as u32) < 0x20 => s.push_str(&format!("\\u{:04x}", c as u32)),
+            c if (c as u32) < 0x20 => push_json_control_escape(s, c as u32),
             c => s.push(c),
         }
     }
@@ -426,6 +445,26 @@ fn write_kv_u64(s: &mut String, k: &str, v: u64) {
 
 fn write_kv_dur(s: &mut String, k: &str, v: Duration) {
     write_kv_u64(s, k, v.as_nanos() as u64);
+}
+
+fn push_fmt(output: &mut String, args: std::fmt::Arguments<'_>) {
+    if output.write_fmt(args).is_err() {
+        output.push_str("[formatting failed]");
+    }
+}
+
+fn fmt_args(args: std::fmt::Arguments<'_>) -> String {
+    let mut output = String::new();
+    push_fmt(&mut output, args);
+    output
+}
+
+fn push_json_control_escape(output: &mut String, value: u32) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    output.push_str("\\u00");
+    let low = (value & 0xff) as usize;
+    output.push(char::from(HEX[(low >> 4) & 0xf]));
+    output.push(char::from(HEX[low & 0xf]));
 }
 
 #[cfg(test)]

--- a/crates/ox_content_renderer/src/html.rs
+++ b/crates/ox_content_renderer/src/html.rs
@@ -1524,9 +1524,12 @@ impl HtmlRenderer {
                     i = name_end;
                 }
                 _ => {
-                    let ch = html[i..].chars().next().expect("valid UTF-8");
-                    output.push(ch);
-                    i += ch.len_utf8();
+                    if let Some(ch) = html[i..].chars().next() {
+                        output.push(ch);
+                        i += ch.len_utf8();
+                    } else {
+                        break;
+                    }
                 }
             }
         }

--- a/crates/ox_content_search/src/query.rs
+++ b/crates/ox_content_search/src/query.rs
@@ -169,12 +169,10 @@ impl SearchIndex {
         let body_lower = body.to_lowercase();
 
         // Find the first match position
-        let mut first_match_pos = None;
+        let mut first_match_pos: Option<usize> = None;
         for term in matches {
             if let Some(pos) = body_lower.find(term) {
-                if first_match_pos.is_none() || pos < first_match_pos.unwrap() {
-                    first_match_pos = Some(pos);
-                }
+                first_match_pos = Some(first_match_pos.map_or(pos, |current| current.min(pos)));
             }
         }
 

--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -1,5 +1,7 @@
 //! HTML page generation for SSG.
 
+use std::fmt::Write as _;
+
 use askama::Template;
 use serde::{Deserialize, Serialize};
 
@@ -1171,17 +1173,20 @@ fn generate_nav_html(nav_groups: &[NavGroup], current_path: &str) -> String {
     for group in nav_groups {
         if group.collapsed.is_some() {
             let open = if group.collapsed == Some(true) { "" } else { " open" };
-            html.push_str(&format!(
+            push_fmt(&mut html, format_args!(
                 "<details class=\"nav-section nav-section--collapsible\"{open}>\n  <summary class=\"nav-title nav-title--summary\">{}</summary>\n",
                 escape_html(&group.title)
             ));
             render_nav_list(&mut html, &group.items, current_path, false);
             html.push_str("</details>\n");
         } else {
-            html.push_str(&format!(
-                "<div class=\"nav-section\">\n  <div class=\"nav-title\">{}</div>\n",
-                escape_html(&group.title)
-            ));
+            push_fmt(
+                &mut html,
+                format_args!(
+                    "<div class=\"nav-section\">\n  <div class=\"nav-title\">{}</div>\n",
+                    escape_html(&group.title)
+                ),
+            );
             render_nav_list(&mut html, &group.items, current_path, false);
             html.push_str("</div>\n");
         }
@@ -1191,7 +1196,7 @@ fn generate_nav_html(nav_groups: &[NavGroup], current_path: &str) -> String {
 
 fn render_nav_list(html: &mut String, items: &[NavItem], current_path: &str, nested: bool) {
     let class_name = if nested { "nav-list nav-list--nested" } else { "nav-list" };
-    html.push_str(&format!("  <ul class=\"{class_name}\">\n"));
+    push_fmt(html, format_args!("  <ul class=\"{class_name}\">\n"));
     for item in items {
         render_nav_item(html, item, current_path);
     }
@@ -1203,14 +1208,14 @@ fn render_nav_item(html: &mut String, item: &NavItem, current_path: &str) {
     let title = escape_html(&item.title);
     let active_class = if item.path == current_path { " active" } else { "" };
     if item.children.is_empty() {
-        html.push_str(&format!(
+        push_fmt(html, format_args!(
             "    <li class=\"nav-item\"><a href=\"{href}\" class=\"nav-link{active_class}\">{title}</a></li>\n"
         ));
         return;
     }
 
     let open = if item.collapsed == Some(true) { "" } else { " open" };
-    html.push_str(&format!(
+    push_fmt(html, format_args!(
         "    <li class=\"nav-item nav-item--group\"><details class=\"nav-details\"{open}><summary class=\"nav-summary\"><a href=\"{href}\" class=\"nav-link nav-link--summary{active_class}\">{title}</a></summary>\n"
     ));
     render_nav_list(html, &item.children, current_path, true);
@@ -1227,6 +1232,12 @@ fn safe_nav_href(href: &str) -> String {
         return "#".to_string();
     }
     escape_html(trimmed)
+}
+
+fn push_fmt(output: &mut String, args: std::fmt::Arguments<'_>) {
+    if output.write_fmt(args).is_err() {
+        output.push_str("[formatting failed]");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Replace runtime unwrap/expect paths in parser, search, renderer, and profile CLI with explicit branching or Result propagation.
- Make NAPI raw transfer/mdast serialization return clear errors for overflow and avoid project-local unsafe buffer construction.
- Make generated docs and markdown lint regex/dictionary setup non-panicking with graceful fallbacks.
- Deny `clippy::format_push_string` and remove existing `push_str(&format!(...))` sites to avoid avoidable temporary allocations.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -W clippy::unwrap_used -W clippy::expect_used -W clippy::panic -W clippy::unimplemented -W clippy::todo -W unsafe_code`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `vp run test`
- `vp run check:ts`
