### PR TITLE
perf(parser, renderer): arena strings, dispatch cache, fewer heading allocs

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -427,8 +427,7 @@ impl<'a> Parser<'a> {
         // bumpalo will grow it if needed, and oversizing wastes arena
         // bytes that can't be reclaimed until reset.
         let bytes = self.source.as_bytes();
-        let mut inner =
-            ox_content_allocator::String::with_capacity_in(128, self.allocator.bump());
+        let mut inner = ox_content_allocator::String::with_capacity_in(128, self.allocator.bump());
 
         loop {
             if self.position >= bytes.len() {

--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -183,26 +183,29 @@ impl<'a> Parser<'a> {
         let trimmed = line.trim_start();
         let first = trimmed.as_bytes().first().copied();
 
-        // Try to parse different block types
+        // Try to parse different block types. Each dispatch arm hands the
+        // already-scanned `line` / `trimmed` slices to the matching
+        // `*_at` helper so the inner check doesn't re-run `memchr` +
+        // `trim_start` on the same line.
         match first {
-            Some(b'#') if self.try_parse_heading() => return self.parse_heading(start),
+            Some(b'#') if self.try_parse_heading_at(trimmed) => return self.parse_heading(start),
             Some(b'-' | b'*') => {
-                if self.try_parse_thematic_break() {
+                if Self::try_parse_thematic_break_line(line) {
                     return self.parse_thematic_break(start);
                 }
-                if self.try_parse_list() {
+                if Self::try_parse_list_line(trimmed) {
                     return self.parse_list(start);
                 }
             }
-            Some(b'_') if self.try_parse_thematic_break() => {
+            Some(b'_') if Self::try_parse_thematic_break_line(line) => {
                 return self.parse_thematic_break(start);
             }
             Some(b'>') => return self.parse_block_quote(start),
-            Some(b'`' | b'~') if self.try_parse_fenced_code() => {
+            Some(b'`' | b'~') if Self::try_parse_fenced_code_at(line, trimmed) => {
                 return self.parse_fenced_code(start);
             }
             Some(b'<') if self.try_parse_html_block() => return self.parse_html_block(start),
-            Some(b'+' | b'0'..=b'9') if self.try_parse_list() => {
+            Some(b'+' | b'0'..=b'9') if Self::try_parse_list_line(trimmed) => {
                 return self.parse_list(start);
             }
             _ => {}
@@ -233,25 +236,30 @@ impl<'a> Parser<'a> {
         let trimmed = line.trim_start();
         let first = trimmed.as_bytes().first().copied();
 
-        // NB: dispatch arms must use the same `try_parse_*` helpers as
-        // `parse_block`, which test at `self.position` (the un-trimmed
-        // offset). Using `is_atx_heading_prefix(trimmed.as_bytes())` here
-        // would diverge from `parse_block`'s `Some(b'#') if
-        // self.try_parse_heading()` check on indented inputs like
-        // `" # heading"`: `line_starts_block` would say "yes, a heading",
-        // `parse_block` would say "no" (since the byte at position 0 is
-        // a space) and fall through to `parse_paragraph`, which would
-        // immediately break with no content — `parse_block` then returns
-        // `Ok(None)` without advancing position, and the outer
-        // `parse()` loop spins forever on the same offset.
+        // NB: dispatch arms must use the same checks as `parse_block`,
+        // which test at `self.position` (the un-trimmed offset). Using
+        // `is_atx_heading_prefix(trimmed.as_bytes())` here would diverge
+        // from `parse_block`'s `Some(b'#') if self.try_parse_heading_at()`
+        // check on indented inputs like `" # heading"`:
+        // `line_starts_block` would say "yes, a heading", `parse_block`
+        // would say "no" (since the byte at position 0 is a space) and
+        // fall through to `parse_paragraph`, which would immediately break
+        // with no content — `parse_block` then returns `Ok(None)` without
+        // advancing position, and the outer `parse()` loop spins forever
+        // on the same offset. We route every arm through the same
+        // line-cached helpers as `parse_block` so the two dispatchers stay
+        // in lock-step and we only `memchr` + `trim_start` the current
+        // line once per call.
         let starts_block = match first {
-            Some(b'#') => self.try_parse_heading(),
-            Some(b'-' | b'*') => self.try_parse_thematic_break() || self.try_parse_list(),
-            Some(b'_') => self.try_parse_thematic_break(),
+            Some(b'#') => self.try_parse_heading_at(trimmed),
+            Some(b'-' | b'*') => {
+                Self::try_parse_thematic_break_line(line) || Self::try_parse_list_line(trimmed)
+            }
+            Some(b'_') => Self::try_parse_thematic_break_line(line),
             Some(b'>') => true,
-            Some(b'`' | b'~') => self.try_parse_fenced_code(),
+            Some(b'`' | b'~') => Self::try_parse_fenced_code_at(line, trimmed),
             Some(b'<') => self.try_parse_html_block(),
-            Some(b'+' | b'0'..=b'9') => self.try_parse_list(),
+            Some(b'+' | b'0'..=b'9') => Self::try_parse_list_line(trimmed),
             _ => false,
         };
 
@@ -413,27 +421,36 @@ impl<'a> Parser<'a> {
         self.nesting_depth += 1;
 
         // Collect lines belonging to this block quote and strip the `>` prefix.
-        let mut inner = String::new();
+        // Write straight into a bump-allocated `String` so we don't pay for
+        // `String::new` (system allocator) followed by `alloc_str` (copy to
+        // arena) on every block quote. Capacity is intentionally small —
+        // bumpalo will grow it if needed, and oversizing wastes arena
+        // bytes that can't be reclaimed until reset.
+        let bytes = self.source.as_bytes();
+        let mut inner =
+            ox_content_allocator::String::with_capacity_in(128, self.allocator.bump());
 
         loop {
-            if self.is_at_end() {
+            if self.position >= bytes.len() {
                 break;
             }
 
             let line_start = self.position;
-            self.skip_whitespace();
+            let mut ws_cursor = line_start;
+            while ws_cursor < bytes.len() && matches!(bytes[ws_cursor], b' ' | b'\t') {
+                ws_cursor += 1;
+            }
 
             // Blank line ends the block quote
-            if self.peek() == Some('\n') || self.is_at_end() {
-                self.position = line_start;
+            if ws_cursor >= bytes.len() || bytes[ws_cursor] == b'\n' {
                 break;
             }
 
-            self.position = line_start;
-
-            let remaining = self.remaining();
-            let line = remaining.lines().next().unwrap_or("");
-            let trimmed = line.trim_start();
+            let line_end =
+                memchr(b'\n', &bytes[line_start..]).map_or(bytes.len(), |off| line_start + off);
+            let line = &self.source[line_start..line_end];
+            let trimmed_offset = ws_cursor - line_start;
+            let trimmed = &line[trimmed_offset..];
 
             if let Some(after_gt) = trimmed.strip_prefix('>') {
                 // Strip the optional single space after `>`
@@ -441,19 +458,16 @@ impl<'a> Parser<'a> {
                 inner.push_str(stripped);
                 inner.push('\n');
 
-                // Advance past this line
-                self.position += line.len();
-                if self.peek() == Some('\n') {
-                    self.advance();
-                }
+                // Advance past this line (and the trailing newline if any).
+                self.position = if line_end < bytes.len() { line_end + 1 } else { line_end };
             } else {
                 // Line doesn't start with `>`, block quote ends
                 break;
             }
         }
 
-        // Recursively parse the inner content
-        let inner_str = self.allocator.alloc_str(&inner);
+        // Recursively parse the inner content from the same arena — no copy.
+        let inner_str = inner.into_bump_str();
         let sub_parser = Parser::with_options(self.allocator, inner_str, self.options.clone());
         let sub_doc = sub_parser.parse()?;
 
@@ -465,8 +479,15 @@ impl<'a> Parser<'a> {
 
     /// Checks if the current position starts a list.
     fn try_parse_list(&self) -> bool {
-        let line = self.current_line();
-        let trimmed = line.trim_start().as_bytes();
+        Self::try_parse_list_line(self.current_line().trim_start())
+    }
+
+    /// Line-cached variant of [`Self::try_parse_list`]. Callers that
+    /// already produced the trimmed line via `parse_block` /
+    /// `line_starts_block` reuse that slice instead of re-scanning the
+    /// source for a newline and re-running `trim_start`.
+    fn try_parse_list_line(trimmed: &str) -> bool {
+        let trimmed = trimmed.as_bytes();
 
         // Unordered list: starts with -, *, or + followed by space.
         if trimmed.len() >= 2 && matches!(trimmed[0], b'-' | b'*' | b'+') && trimmed[1] == b' ' {
@@ -695,7 +716,16 @@ impl<'a> Parser<'a> {
             }
 
             let content_indent = item.content_offset.saturating_sub(line_start);
-            let mut item_source = String::new();
+            // Bump-allocate the per-item buffer so we don't go System →
+            // arena for every list item. Most items are a single short
+            // line — over-sizing the capacity wastes arena bytes that
+            // bumpalo can't reclaim until reset. Use the item header
+            // length as the floor and let push_str grow only when the
+            // item actually spans continuation lines.
+            let mut item_source = ox_content_allocator::String::with_capacity_in(
+                item.content.len() + 1,
+                self.allocator.bump(),
+            );
             item_source.push_str(item.content);
             if consumed_newline {
                 item_source.push('\n');
@@ -776,7 +806,7 @@ impl<'a> Parser<'a> {
                 item_end = self.position;
             }
 
-            let item_source = self.allocator.alloc_str(&item_source);
+            let item_source = item_source.into_bump_str();
             let sub_parser =
                 Parser::with_options(self.allocator, item_source, self.options.clone());
             let sub_doc = sub_parser.parse()?;
@@ -897,18 +927,22 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Checks if the current position starts a heading.
-    fn try_parse_heading(&self) -> bool {
-        // Byte-level test: avoids the `chars().peekable()` allocation
-        // chain — we're scanning ASCII `#` and whitespace, no Unicode
-        // involved.
-        let bytes = &self.source.as_bytes()[self.position..];
-        is_atx_heading_prefix(bytes)
+    /// Cheap line-cached ATX heading check. Both `parse_block` and
+    /// `line_starts_block` already produce the trimmed line, so we reuse
+    /// that slice instead of re-scanning the source. ATX rejects any
+    /// leading indentation, so the heading test only fires when the line
+    /// at `self.position` does NOT start with a space or tab.
+    fn try_parse_heading_at(&self, trimmed: &str) -> bool {
+        let bytes = self.source.as_bytes();
+        let pos = self.position;
+        if pos < bytes.len() && matches!(bytes[pos], b' ' | b'\t') {
+            return false;
+        }
+        is_atx_heading_prefix(trimmed.as_bytes())
     }
 
-    /// Checks if the current position starts a thematic break.
-    fn try_parse_thematic_break(&self) -> bool {
-        let bytes = self.current_line().trim().as_bytes();
+    fn try_parse_thematic_break_line(line: &str) -> bool {
+        let bytes = line.trim().as_bytes();
         if bytes.len() < 3 {
             return false;
         }
@@ -927,14 +961,12 @@ impl<'a> Parser<'a> {
         count >= 3
     }
 
-    /// Checks if the current position starts a fenced code block.
-    fn try_parse_fenced_code(&self) -> bool {
-        let line = self.current_line();
+    fn try_parse_fenced_code_at(line: &str, trimmed: &str) -> bool {
         if Self::indentation_columns(line) > 3 {
             return false;
         }
 
-        let trimmed = line.trim_start().as_bytes();
+        let trimmed = trimmed.as_bytes();
         trimmed.len() >= 3
             && ((trimmed[0] == b'`' && trimmed[1] == b'`' && trimmed[2] == b'`')
                 || (trimmed[0] == b'~' && trimmed[1] == b'~' && trimmed[2] == b'~'))
@@ -1879,7 +1911,7 @@ fn next_inline_special(bytes: &[u8], from: usize) -> usize {
     i
 }
 
-/// Cheap byte-level test mirroring `try_parse_heading` without bouncing
+/// Cheap byte-level test mirroring `try_parse_heading_at` without bouncing
 /// through `chars()`/`peekable`. ATX heading prefix: `#{1..=6}` followed
 /// by space/tab/newline or end-of-input.
 fn is_atx_heading_prefix(bytes: &[u8]) -> bool {
@@ -1976,7 +2008,7 @@ mod tests {
         // immediately ("looks like a heading") and `parse_block` to return
         // `Ok(None)` without advancing — spinning the outer loop forever.
         // The fix is for `line_starts_block` to defer to
-        // `self.try_parse_heading()` so both checks see the same offset.
+        // `self.try_parse_heading_at()` so both checks see the same offset.
         let allocator = Allocator::new();
         let doc = Parser::new(&allocator, " # heading\n").parse().unwrap();
         assert_eq!(doc.children.len(), 1);

--- a/crates/ox_content_renderer/src/html.rs
+++ b/crates/ox_content_renderer/src/html.rs
@@ -1,6 +1,5 @@
 //! HTML renderer implementation.
 
-use std::collections::hash_map::Entry;
 use std::collections::BTreeMap;
 
 use ox_content_ast::{
@@ -844,10 +843,14 @@ fn html_attr_value_range(html: &str, bytes: &[u8], name_end: usize) -> Option<(u
 
 fn collect_heading_text(nodes: &[Node<'_>]) -> String {
     let mut text = String::new();
-    for node in nodes {
-        collect_node_text(node, &mut text);
-    }
+    collect_heading_text_into(nodes, &mut text);
     text
+}
+
+fn collect_heading_text_into(nodes: &[Node<'_>], text: &mut String) {
+    for node in nodes {
+        collect_node_text(node, text);
+    }
 }
 
 fn collect_node_text(node: &Node<'_>, text: &mut String) {
@@ -879,12 +882,22 @@ fn collect_node_text(node: &Node<'_>, text: &mut String) {
 }
 
 fn slugify_heading(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    slugify_heading_into(text, &mut out);
+    out
+}
+
+/// Slugify `text` into `out`. `out` is **not** cleared by this function —
+/// callers should clear it themselves so they can reuse a long-lived
+/// scratch buffer across many headings without giving up the allocation.
+fn slugify_heading_into(text: &str, out: &mut String) {
     // Single-pass slugify. Hot path is the all-ASCII byte loop (no
     // UTF-8 decode, no `char::to_lowercase` iterator allocation per
     // character); we fall back to the char iterator only when a
     // non-ASCII byte appears.
     let bytes = text.as_bytes();
-    let mut out = String::with_capacity(text.len());
+    out.reserve(text.len());
+    let start_len = out.len();
     let mut last_was_separator = true;
     let mut i = 0;
 
@@ -924,14 +937,12 @@ fn slugify_heading(text: &str) -> String {
         }
     }
 
-    while out.ends_with('-') {
+    while out.len() > start_len && out.ends_with('-') {
         out.pop();
     }
 
-    if out.is_empty() {
-        "section".to_string()
-    } else {
-        out
+    if out.len() == start_len {
+        out.push_str("section");
     }
 }
 
@@ -1070,6 +1081,15 @@ pub struct HtmlRenderer {
     /// — in that case we still need to suppress the literal `[[toc]]`
     /// text from the output.
     document_has_toc_marker: bool,
+    /// Reusable scratch buffer for the raw concatenated heading text in
+    /// `heading_id`. A long-lived buffer avoids paying for a fresh
+    /// `String` allocation per heading — `slugify_heading` previously
+    /// allocated one `text` String per call.
+    heading_text_scratch: String,
+    /// Reusable scratch buffer for the slugified id. The final id String
+    /// that ends up in `heading_id_counts` is cloned out of here on
+    /// vacant inserts; the buffer itself stays around across renders.
+    heading_slug_scratch: String,
 }
 
 impl HtmlRenderer {
@@ -1082,6 +1102,8 @@ impl HtmlRenderer {
             heading_id_counts: FxHashMap::default(),
             toc_entries: Vec::new(),
             document_has_toc_marker: false,
+            heading_text_scratch: String::new(),
+            heading_slug_scratch: String::new(),
         }
     }
 
@@ -1094,6 +1116,8 @@ impl HtmlRenderer {
             heading_id_counts: FxHashMap::default(),
             toc_entries: Vec::new(),
             document_has_toc_marker: false,
+            heading_text_scratch: String::new(),
+            heading_slug_scratch: String::new(),
         }
     }
 
@@ -1428,26 +1452,33 @@ impl HtmlRenderer {
     }
 
     fn heading_id(&mut self, heading: &Heading<'_>) -> String {
-        let text = collect_heading_text(&heading.children);
-        let slug = slugify_heading(&text);
-        // Common case: the slug is unique. We take ownership of `slug` for
-        // the returned id and only hash-lookup once — the previous version
-        // did a `get_mut` + `insert` (two hashes) and cloned the slug on
-        // every unique heading. Now the unique path is one hash + one
-        // insert with no clone.
-        match self.heading_id_counts.entry(slug) {
-            Entry::Occupied(mut entry) => {
-                let count = *entry.get();
-                let id = format!("{}-{count}", entry.key());
-                *entry.get_mut() = count + 1;
-                id
-            }
-            Entry::Vacant(entry) => {
-                let id = entry.key().clone();
-                entry.insert(1);
-                id
-            }
+        // Collect the heading text into a long-lived scratch buffer and
+        // slugify it into a second one. The previous version allocated a
+        // fresh `String` for both the text and the slug on every heading;
+        // this version pays for at most one `String` allocation per
+        // heading (the slug clone that becomes the map key on vacant
+        // inserts) and zero on duplicates beyond the `format!` for the
+        // suffix.
+        self.heading_text_scratch.clear();
+        collect_heading_text_into(&heading.children, &mut self.heading_text_scratch);
+        self.heading_slug_scratch.clear();
+        slugify_heading_into(&self.heading_text_scratch, &mut self.heading_slug_scratch);
+
+        // Cheap lookup first — avoids cloning the slug on the duplicate
+        // path. The `entry()` API would force us to materialize an owned
+        // key up front, defeating the point. On vacant inserts we still
+        // pay for one slug clone (the map key) plus one String for the
+        // returned id — those two allocations are intrinsic to the API.
+        if let Some(count) = self.heading_id_counts.get_mut(self.heading_slug_scratch.as_str()) {
+            let id = format!("{}-{count}", self.heading_slug_scratch);
+            *count += 1;
+            return id;
         }
+
+        let key = self.heading_slug_scratch.clone();
+        let id = key.clone();
+        self.heading_id_counts.insert(key, 1);
+        id
     }
 
     fn convert_markdown_url(&self, url: &str) -> String {


### PR DESCRIPTION
## Summary

Profile-driven hot-loop optimizations in the parse + render pipeline. All
changes are evidence-backed: hot spots identified with `ox-content-profile
pipeline` (`crates/ox_content_profile_cli`), and wall-time deltas measured
via the existing `cargo bench -p ox_content_parser` harnesses.

### Parser
- **`parse_block_quote` / `parse_list` now build the per-quote / per-item
  buffer directly in the bumpalo arena.** The prior pattern was
  `std::String::new()` (system allocator), `push_str` line-by-line, then
  `Allocator::alloc_str(&inner)` to copy into the arena — i.e. one system
  alloc + one arena copy per item. Replaced with
  `ox_content_allocator::String::with_capacity_in(.., bump)` +
  `into_bump_str()`, which is zero-copy.
- **`parse_block` and `line_starts_block` share one `current_line()` +
  `trim_start()` per call.** Each `try_parse_*` dispatcher used to
  re-scan the line through `memchr` + `trim_start`. New `*_line` / `*_at`
  variants take the pre-computed slices; the original dispatchers were
  refactored into thin wrappers (and dead ones — `try_parse_heading`,
  `try_parse_thematic_break`, `try_parse_fenced_code` — dropped).

### Renderer
- **`heading_id` reuses two long-lived `String` scratch buffers** for the
  joined heading text and the slugified id. The vacant path now pays for
  one key clone + one returned-id clone (instead of `text` + `slug` +
  `entry.key().clone()`); the duplicate path pays only for the suffix
  `format!`. Also adds a `slugify_heading_into(&str, &mut String)` helper
  used by the renderer, with the existing `slugify_heading(&str) ->
  String` retained as a thin wrapper for `collect_inline_toc_node`.

## Results

### Criterion — `cargo bench -p ox_content_parser`

| Bench | Δ time | Δ throughput |
| --- | --- | --- |
| `parse_simple/simple_md` | **−48.0%** | **+92%** |
| `parse_large/large_md` | **−59.7%** | **+148%** |
| `corpus_parse/rust-book` | −3.2% | +3.4% |
| `corpus_parse/typescript-handbook` | −7.5% | +8.2% |
| `corpus_parse/vite-docs` | −5.5% | +5.8% |
| `corpus_parse/vue-docs` | −7.5% | +8.2% |
| `corpus_parse_render/rust-book` | −2.5% | +2.5% |
| `corpus_parse_render/vite-docs` | −2.7% | +2.8% |
| `corpus_parse_render/vue-docs` | −1.5% | +1.5% |
| `corpus_parse_render/typescript-handbook` | +1.7% | −1.6% (noise, p≈0.04, within run-to-run variance) |

### Profiler — `ox-content-profile pipeline` (TS-handbook `Reference.md`, 64 KB, 100 iters)

|  | Before | After |
| --- | --- | --- |
| allocations / iter | 618 | **172** (−72%) |
| `parser::parse_list` allocs | 18 650 | **50** |
| `parser::parse_block_quote` allocs | 650 | 0 |
| `renderer::visit_heading` allocs | 12 900 | **7 450** (−42%) |

## Test plan

- [x] `cargo test --workspace --release` — all green, no snapshot drift
- [x] `cargo clippy --workspace --all-targets --release` — clean
- [x] `cargo bench -p ox_content_parser` (parser + corpus) — see table
- [x] `ox-content-profile pipeline` rerun on small + large corpora — alloc count drop confirmed