### PR TITLE
chore: add actrun local ci config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ binding-packages/
 crates/ox_content_wasm/pkg/
 
 # Build artifacts
+/_build/
 /dist
 **/dist/
 **/.astro/

--- a/actrun.toml
+++ b/actrun.toml
@@ -1,0 +1,17 @@
+# Run GitHub Actions locally against the current workspace.
+workspace_mode = "local"
+
+# Use the toolchain and dependencies already installed on the machine.
+local_skip_actions = [
+  "actions/checkout",
+  "actions/setup-node",
+  "actions/setup-python",
+  "actions/setup-go",
+  "actions-rust-lang/setup-rust-toolchain",
+  "dtolnay/rust-toolchain",
+  "Swatinem/rust-cache",
+  "voidzero-dev/setup-vp",
+]
+
+# Avoid slow nix develop wrapping for fast local CI feedback.
+nix_mode = "off"


### PR DESCRIPTION
## Summary
- add actrun.toml for fast local CI runs against the current workspace
- skip setup actions that are covered by the local toolchain
- ignore actrun _build run state

## Validation
- actrun lint .github/workflows/ci.yml
- actrun workflow run .github/workflows/ci.yml --job rustfmt
- actrun workflow run .github/workflows/ci.yml --job typecheck
