### PR TITLE
chore: add actrun vp task

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -155,6 +155,7 @@ export default defineConfig({
       }),
 
       "workspace:ci": noopTask(["fmt:rust-check", "lint:rust", "check:ts", "workspace:test"]),
+      actrun: uncachedTask("actrun workflow run .github/workflows/ci.yml --trust"),
       "workspace:ready": noopTask(["workspace:fmt", "workspace:lint", "workspace:test"]),
       coverage: uncachedTask("cargo llvm-cov --workspace --html"),
       setup: uncachedTask(


### PR DESCRIPTION
## Summary
- add an uncached Vite+ `actrun` task for running the local CI workflow
- keep the command open to forwarded actrun flags such as `--dry-run` and `--job rustfmt`

## Validation
- `vp run actrun --dry-run`
- `vp run actrun --job rustfmt`
- `vp run fmt:ts-check`
- `vp run check:ts`
