### PR TITLE
perf(renderer): avoid duplicate toc slug clones

### DIFF
--- a/crates/ox_content_renderer/src/html.rs
+++ b/crates/ox_content_renderer/src/html.rs
@@ -1068,13 +1068,22 @@ fn collect_inline_toc_node(
 ) {
     match node {
         Node::Heading(heading) => {
+            let include_heading = heading.depth <= max_depth;
             let text = collect_heading_text(&heading.children);
             let slug = slugify_heading(&text);
-            let count = counts.entry(slug.clone()).or_insert(0);
-            let id = if *count == 0 { slug } else { format!("{slug}-{count}") };
-            *count += 1;
+            let id = if let Some(count) = counts.get_mut(slug.as_str()) {
+                let suffix = *count;
+                *count += 1;
+                include_heading.then(|| format!("{slug}-{suffix}"))
+            } else if include_heading {
+                counts.insert(slug.clone(), 1);
+                Some(slug)
+            } else {
+                counts.insert(slug, 1);
+                None
+            };
 
-            if heading.depth <= max_depth {
+            if let Some(id) = id {
                 entries.push(InlineTocEntry { depth: heading.depth, text, id });
             }
         }


### PR DESCRIPTION
## Summary
- avoid pre-cloning inline TOC slugs before checking whether a heading id was seen
- skip duplicate id string construction for headings filtered out of the rendered TOC
- keep skipped headings in the count map so later visible entries still link to the same rendered ids

## Local validation
- `cargo fmt --all -- --check`
- `cargo test -p ox_content_renderer`
- `cargo clippy -p ox_content_renderer --all-targets -- -D warnings`
- `actrun workflow run .github/workflows/ci.yml --trust --job rustfmt`
- `actrun workflow run .github/workflows/ci.yml --trust --job clippy`
- `cargo run --release -p ox_content_profile_cli -- --warmup 20 --iters 100 --gfm pipeline /tmp/ox-content-toc.md`

## Profile notes
- TOC pipeline allocations on local sample: 2002/iter -> 1642/iter
- TOC pipeline p50 on local sample: 731.83 us -> 648.54 us
