### PR TITLE
perf(renderer): write duplicate toc id suffixes in place

### DIFF
--- a/crates/ox_content_renderer/src/html.rs
+++ b/crates/ox_content_renderer/src/html.rs
@@ -1066,15 +1066,22 @@ fn collect_inline_toc_node(
     counts: &mut FxHashMap<String, usize>,
     entries: &mut Vec<InlineTocEntry>,
 ) {
+    use std::fmt::Write as _;
+
     match node {
         Node::Heading(heading) => {
             let include_heading = heading.depth <= max_depth;
             let text = collect_heading_text(&heading.children);
-            let slug = slugify_heading(&text);
+            let mut slug = slugify_heading(&text);
             let id = if let Some(count) = counts.get_mut(slug.as_str()) {
                 let suffix = *count;
                 *count += 1;
-                include_heading.then(|| format!("{slug}-{suffix}"))
+                if include_heading {
+                    let _ = write!(slug, "-{suffix}");
+                    Some(slug)
+                } else {
+                    None
+                }
             } else if include_heading {
                 counts.insert(slug.clone(), 1);
                 Some(slug)


### PR DESCRIPTION
## Summary
- write duplicate inline TOC id suffixes into the existing slug buffer
- avoid allocating a separate formatted id string for repeated headings

## Local validation
- `cargo fmt --all -- --check`
- `cargo test -p ox_content_renderer`
- `cargo clippy -p ox_content_renderer --all-targets -- -D warnings`
- `actrun workflow run .github/workflows/ci.yml --trust --job rustfmt`
- `actrun workflow run .github/workflows/ci.yml --trust --job clippy`
- `cargo run --release -p ox_content_profile_cli -- --warmup 20 --iters 100 --gfm pipeline /tmp/ox-content-toc.md`

## Profile notes
- TOC pipeline allocations on local sample: 1642/iter -> 1282/iter
- TOC pipeline p50 on local sample: 648.54 us -> 646.17 us
