### PR TITLE
perf(renderer): write numeric attrs without strings

### DIFF
--- a/crates/ox_content_renderer/src/html.rs
+++ b/crates/ox_content_renderer/src/html.rs
@@ -1,6 +1,7 @@
 //! HTML renderer implementation.
 
 use std::collections::BTreeMap;
+use std::fmt::{Display, Write as _};
 
 use ox_content_ast::{
     BlockQuote, Break, CodeBlock, Definition, Delete, Document, Emphasis, FootnoteDefinition,
@@ -1222,6 +1223,10 @@ impl HtmlRenderer {
         self.output.push_str(s);
     }
 
+    fn write_display(&mut self, value: impl Display) {
+        write!(self.output, "{value}").expect("writing to String should not fail");
+    }
+
     fn write_escaped(&mut self, s: &str) {
         profile_span!("renderer::write_escaped");
         write_escaped_into(&mut self.output, s);
@@ -1464,12 +1469,12 @@ impl HtmlRenderer {
             self.write("<span class=\"");
             self.write(&class_names.join(" "));
             self.write("\" data-line=\"");
-            self.write(&line_number.to_string());
+            self.write_display(line_number);
             self.write("\"");
 
             if let Some(start) = state.line_numbers_start {
                 self.write(" data-line-number=\"");
-                self.write(&(start + index).to_string());
+                self.write_display(start + index);
                 self.write("\"");
             }
 
@@ -1831,7 +1836,7 @@ impl<'a> Visit<'a> for HtmlRenderer {
             if let Some(start) = list.start {
                 if start != 1 {
                     self.write("<ol start=\"");
-                    self.write(&start.to_string());
+                    self.write_display(start);
                     self.write("\">\n");
                 } else {
                     self.write("<ol>\n");
@@ -1903,7 +1908,7 @@ impl<'a> Visit<'a> for HtmlRenderer {
         }
         if let Some(start) = state.line_numbers_start {
             self.write(" data-line-numbers=\"true\" data-line-number-start=\"");
-            self.write(&start.to_string());
+            self.write_display(start);
             self.write("\"");
         }
         self.write("><code");


### PR DESCRIPTION
## Summary

- Add a small renderer helper for writing `Display` values directly into the HTML output buffer.
- Use it for numeric attributes in ordered lists and annotated code blocks.
- Avoid allocating temporary `String`s for line numbers and `start` attributes.

## Profiling

Temporary render-only profile with `code_annotations: true`, VitePress line numbers, and a 1200-line code block:

- base: 8441 allocations/iter, 822.32 KB/iter, p50 693.96 us
- head: 6038 allocations/iter, 815.07 KB/iter, p50 674.83 us
- `renderer::visit_code_block`: 8436 allocations/iter -> 6033 allocations/iter

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ox_content_renderer`
- `cargo clippy -p ox_content_renderer --all-targets -- -D warnings`
- `actrun workflow run .github/workflows/ci.yml --trust --include-dirty --run-root /tmp/actrun-numeric-rustfmt --job rustfmt`
- `actrun workflow run .github/workflows/ci.yml --trust --include-dirty --run-root /tmp/actrun-numeric-clippy --job clippy`
