### PR TITLE
perf(renderer): scan safe urls in chunks

### DIFF
--- a/crates/ox_content_renderer/src/html.rs
+++ b/crates/ox_content_renderer/src/html.rs
@@ -749,6 +749,26 @@ static ESCAPE_FLAG: [u8; 256] = {
     t
 };
 
+static URL_ESCAPE_TABLE: [&str; 256] = {
+    let mut table: [&str; 256] = [""; 256];
+    table[b'&' as usize] = "&amp;";
+    table[b'<' as usize] = "%3C";
+    table[b'>' as usize] = "%3E";
+    table[b'"' as usize] = "%22";
+    table[b' ' as usize] = "%20";
+    table
+};
+
+static URL_ESCAPE_FLAG: [u8; 256] = {
+    let mut t = [0u8; 256];
+    t[b'&' as usize] = 1;
+    t[b'<' as usize] = 1;
+    t[b'>' as usize] = 1;
+    t[b'"' as usize] = 1;
+    t[b' ' as usize] = 1;
+    t
+};
+
 #[inline]
 fn write_escaped_into(out: &mut String, s: &str) {
     let bytes = s.as_bytes();
@@ -812,28 +832,57 @@ fn write_escaped_into(out: &mut String, s: &str) {
 
 fn write_url_escaped_into(out: &mut String, s: &str) {
     let bytes = s.as_bytes();
-    let mut start = 0;
+    let mut start = 0usize;
+    let mut i = 0usize;
 
-    for (idx, byte) in bytes.iter().copied().enumerate() {
-        let escaped = match byte {
-            b'&' => Some("&amp;"),
-            b'<' => Some("%3C"),
-            b'>' => Some("%3E"),
-            b'"' => Some("%22"),
-            b' ' => Some("%20"),
-            _ => None,
-        };
-
-        if let Some(escaped) = escaped {
-            if start < idx {
-                out.push_str(&s[start..idx]);
-            }
-            out.push_str(escaped);
-            start = idx + 1;
+    while i + 8 <= bytes.len() {
+        let chunk = &bytes[i..i + 8];
+        let mask = URL_ESCAPE_FLAG[chunk[0] as usize]
+            | URL_ESCAPE_FLAG[chunk[1] as usize]
+            | URL_ESCAPE_FLAG[chunk[2] as usize]
+            | URL_ESCAPE_FLAG[chunk[3] as usize]
+            | URL_ESCAPE_FLAG[chunk[4] as usize]
+            | URL_ESCAPE_FLAG[chunk[5] as usize]
+            | URL_ESCAPE_FLAG[chunk[6] as usize]
+            | URL_ESCAPE_FLAG[chunk[7] as usize];
+        if mask == 0 {
+            i += 8;
+            continue;
         }
+        break;
     }
 
-    if start < s.len() {
+    while i < bytes.len() {
+        let b = bytes[i];
+        if URL_ESCAPE_FLAG[b as usize] != 0 {
+            if start < i {
+                out.push_str(&s[start..i]);
+            }
+            out.push_str(URL_ESCAPE_TABLE[b as usize]);
+            i += 1;
+            start = i;
+            while i + 8 <= bytes.len() {
+                let chunk = &bytes[i..i + 8];
+                let mask = URL_ESCAPE_FLAG[chunk[0] as usize]
+                    | URL_ESCAPE_FLAG[chunk[1] as usize]
+                    | URL_ESCAPE_FLAG[chunk[2] as usize]
+                    | URL_ESCAPE_FLAG[chunk[3] as usize]
+                    | URL_ESCAPE_FLAG[chunk[4] as usize]
+                    | URL_ESCAPE_FLAG[chunk[5] as usize]
+                    | URL_ESCAPE_FLAG[chunk[6] as usize]
+                    | URL_ESCAPE_FLAG[chunk[7] as usize];
+                if mask == 0 {
+                    i += 8;
+                    continue;
+                }
+                break;
+            }
+            continue;
+        }
+        i += 1;
+    }
+
+    if start < bytes.len() {
         out.push_str(&s[start..]);
     }
 }


### PR DESCRIPTION
## Summary

- Add URL escape lookup tables for rendered HTML attributes.
- Reuse the renderer's 8-byte fast-skip shape so safe URL runs avoid byte-by-byte branching.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ox_content_renderer`
- `cargo clippy -p ox_content_renderer --all-targets -- -D warnings`
- `actrun workflow run .github/workflows/ci.yml --trust --include-dirty --run-root /tmp/actrun-url-escape-rustfmt --job rustfmt`
- `actrun workflow run .github/workflows/ci.yml --trust --include-dirty --run-root /tmp/actrun-url-escape-clippy --job clippy`

## Profiling

Synthetic 568 KB Markdown fixture with 9,600 links/images, rendered with `ox_content_profile_cli --gfm --warmup 10 --iters 120 render`:

- base: p50 2.42 ms, mean 2.50 ms, 223.43 MB/s
- head: p50 2.08 ms, mean 2.14 ms, 259.77 MB/s
