### PR TITLE
perf(parser): reuse parsed list lines

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -539,6 +539,14 @@ impl<'a> Parser<'a> {
     fn parse_list_item_line(&self, line_start: usize) -> Option<ParsedListItem<'a>> {
         let remaining = &self.source[line_start..];
         let line = remaining.lines().next().unwrap_or("");
+        self.parse_list_item_line_from_line(line_start, line)
+    }
+
+    fn parse_list_item_line_from_line(
+        &self,
+        line_start: usize,
+        line: &'a str,
+    ) -> Option<ParsedListItem<'a>> {
         let trimmed = line.trim_start();
         let trimmed_offset = line_start + (line.len() - trimmed.len());
 
@@ -699,7 +707,7 @@ impl<'a> Parser<'a> {
             // Check if it's a list item
             let remaining = self.remaining();
             let line = remaining.lines().next().unwrap_or("");
-            let Some(item) = self.parse_list_item_line(line_start) else {
+            let Some(item) = self.parse_list_item_line_from_line(line_start, line) else {
                 break;
             };
             if item.ordered != ordered {


### PR DESCRIPTION
## Summary

- Add a list-item helper that accepts the current line slice.
- Reuse the line already read in the list parser instead of scanning the same source range twice.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ox_content_parser`
- `cargo clippy -p ox_content_parser --all-targets -- -D warnings`
- `actrun workflow run .github/workflows/ci.yml --trust --include-dirty --run-root /tmp/actrun-list-line-rustfmt --job rustfmt`
- `actrun workflow run .github/workflows/ci.yml --trust --include-dirty --run-root /tmp/actrun-list-line-clippy --job clippy`

## Profiling

Synthetic 597 KB list-heavy Markdown fixture, parsed with `ox_content_profile_cli --gfm --warmup 10 --iters 120 parse`:

- base: p50 7.37 ms, mean 7.43 ms, 77.26 MB/s
- head: p50 7.25 ms, mean 7.23 ms, 78.47 MB/s
- `parser::parse_list` self time: 181.30 ms -> 165.42 ms over the measured run
