### PR TITLE
refactor: move VitePress frontmatter normalization to Rust

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -989,6 +989,9 @@ export interface Mf2ValidateResult {
   astJson?: string
 }
 
+/** Normalizes VitePress-specific frontmatter into ox-content's entry-page shape. */
+export declare function normalizeVitePressFrontmatter(frontmatter: any): any
+
 /**
  * Parses Markdown source into an AST.
  *

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -105,6 +105,7 @@ module.exports.matchesSearchScopes = binding.matchesSearchScopes;
 module.exports.generateSearchModule = binding.generateSearchModule;
 module.exports.generateSearchModuleFromOptions = binding.generateSearchModuleFromOptions;
 module.exports.collectSearchMarkdownFiles = binding.collectSearchMarkdownFiles;
+module.exports.normalizeVitePressFrontmatter = binding.normalizeVitePressFrontmatter;
 module.exports.generateSsgHtml = binding.generateSsgHtml;
 module.exports.generateSsgBareHtml = binding.generateSsgBareHtml;
 module.exports.getGitLastUpdated = binding.getGitLastUpdated;

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -2142,6 +2142,12 @@ pub fn format_ssg_title(name: String) -> String {
     ox_content_ssg::format_title(&name)
 }
 
+/// Normalizes VitePress-specific frontmatter into ox-content's entry-page shape.
+#[napi(js_name = "normalizeVitePressFrontmatter")]
+pub fn normalize_vitepress_frontmatter(frontmatter: serde_json::Value) -> serde_json::Value {
+    ox_content_ssg::normalize_vitepress_frontmatter(frontmatter)
+}
+
 /// Builds SSG navigation groups from markdown files.
 #[napi(js_name = "buildSsgNavItems")]
 pub fn build_ssg_nav_items(
@@ -2902,6 +2908,7 @@ mod tests {
             "loadDictionariesFlat",
             "matchesSearchScopes",
             "mergeHighlightedCodeBlocks",
+            "normalizeVitePressFrontmatter",
             "parse",
             "parseAndRender",
             "parseAndRenderAsync",

--- a/crates/ox_content_ssg/src/lib.rs
+++ b/crates/ox_content_ssg/src/lib.rs
@@ -54,6 +54,7 @@
 mod assets;
 mod html;
 mod routes;
+mod vitepress;
 
 pub use assets::{
     externalize_shared_page_assets, ExternalizedAssets, GeneratedHtmlPage, SharedAsset,
@@ -70,3 +71,4 @@ pub use routes::{
     resolve_navigation_groups, resolve_route_paths, ManualNavigationGroup, ManualNavigationItem,
     RoutePaths, SidebarItem,
 };
+pub use vitepress::normalize_vitepress_frontmatter;

--- a/crates/ox_content_ssg/src/vitepress.rs
+++ b/crates/ox_content_ssg/src/vitepress.rs
@@ -1,0 +1,186 @@
+//! VitePress migration helpers.
+
+use serde_json::{Map, Number, Value};
+
+/// Normalizes VitePress frontmatter into the ox-content entry-page shape.
+pub fn normalize_vitepress_frontmatter(frontmatter: Value) -> Value {
+    let Value::Object(mut next) = frontmatter else {
+        return frontmatter;
+    };
+
+    if next.get("layout").and_then(Value::as_str) == Some("home") {
+        next.insert("layout".to_string(), Value::String("entry".to_string()));
+    }
+
+    if let Some(Value::Object(hero)) = next.get("hero") {
+        if let Some(image) = hero.get("image").and_then(normalize_hero_image) {
+            let mut next_hero = hero.clone();
+            next_hero.insert("image".to_string(), image);
+            next.insert("hero".to_string(), Value::Object(next_hero));
+        }
+    }
+
+    Value::Object(next)
+}
+
+fn normalize_hero_image(value: &Value) -> Option<Value> {
+    if let Some(src) = value.as_str() {
+        return Some(Value::Object(Map::from_iter([(
+            "src".to_string(),
+            Value::String(src.to_string()),
+        )])));
+    }
+
+    let Value::Object(image) = value else {
+        return None;
+    };
+
+    let src = non_empty_string(image, "src")
+        .or_else(|| non_empty_string(image, "light"))
+        .or_else(|| non_empty_string(image, "dark"))?;
+
+    let mut normalized = Map::new();
+    normalized.insert("src".to_string(), Value::String(src.to_string()));
+
+    if let Some(light_src) =
+        non_empty_string(image, "lightSrc").or_else(|| non_empty_string(image, "light"))
+    {
+        normalized.insert("lightSrc".to_string(), Value::String(light_src.to_string()));
+    }
+
+    if let Some(dark_src) =
+        non_empty_string(image, "darkSrc").or_else(|| non_empty_string(image, "dark"))
+    {
+        normalized.insert("darkSrc".to_string(), Value::String(dark_src.to_string()));
+    }
+
+    if let Some(alt) = image.get("alt").and_then(Value::as_str) {
+        normalized.insert("alt".to_string(), Value::String(alt.to_string()));
+    }
+
+    if let Some(width) = to_number(image.get("width")) {
+        normalized.insert("width".to_string(), Value::Number(width));
+    }
+
+    if let Some(height) = to_number(image.get("height")) {
+        normalized.insert("height".to_string(), Value::Number(height));
+    }
+
+    Some(Value::Object(normalized))
+}
+
+fn non_empty_string<'a>(map: &'a Map<String, Value>, key: &str) -> Option<&'a str> {
+    map.get(key).and_then(Value::as_str).filter(|value| !value.is_empty())
+}
+
+fn to_number(value: Option<&Value>) -> Option<Number> {
+    match value? {
+        Value::Number(number) => Some(number.clone()),
+        Value::String(value) => value
+            .chars()
+            .all(|ch| ch.is_ascii_digit())
+            .then_some(value)
+            .filter(|value| !value.is_empty())
+            .and_then(|value| value.parse::<u64>().ok())
+            .map(Number::from),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::normalize_vitepress_frontmatter;
+
+    #[test]
+    fn normalizes_vitepress_home_frontmatter() {
+        let frontmatter = normalize_vitepress_frontmatter(json!({
+            "layout": "home",
+            "hero": {
+                "name": "Docs",
+                "image": {
+                    "light": "/logo-light.svg",
+                    "dark": "/logo-dark.svg",
+                    "width": "120",
+                    "height": 80
+                }
+            }
+        }));
+
+        assert_eq!(
+            frontmatter,
+            json!({
+                "layout": "entry",
+                "hero": {
+                    "name": "Docs",
+                    "image": {
+                        "src": "/logo-light.svg",
+                        "lightSrc": "/logo-light.svg",
+                        "darkSrc": "/logo-dark.svg",
+                        "width": 120,
+                        "height": 80
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn preserves_ox_content_hero_image_theme_sources() {
+        let frontmatter = normalize_vitepress_frontmatter(json!({
+            "layout": "entry",
+            "hero": {
+                "name": "Ox Content",
+                "image": {
+                    "src": "oxcontent-dark.svg",
+                    "lightSrc": "oxcontent-dark.svg",
+                    "darkSrc": "oxcontent-light.svg",
+                    "alt": "Ox Content wordmark"
+                }
+            }
+        }));
+
+        assert_eq!(
+            frontmatter,
+            json!({
+                "layout": "entry",
+                "hero": {
+                    "name": "Ox Content",
+                    "image": {
+                        "src": "oxcontent-dark.svg",
+                        "lightSrc": "oxcontent-dark.svg",
+                        "darkSrc": "oxcontent-light.svg",
+                        "alt": "Ox Content wordmark"
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn preserves_hero_when_image_has_no_source() {
+        let frontmatter = normalize_vitepress_frontmatter(json!({
+            "layout": "home",
+            "hero": {
+                "name": "Docs",
+                "image": {
+                    "alt": "Logo"
+                }
+            }
+        }));
+
+        assert_eq!(
+            frontmatter,
+            json!({
+                "layout": "entry",
+                "hero": {
+                    "name": "Docs",
+                    "image": {
+                        "alt": "Logo"
+                    }
+                }
+            })
+        );
+    }
+}

--- a/npm/vite-plugin-ox-content/src/vitepress.ts
+++ b/npm/vite-plugin-ox-content/src/vitepress.ts
@@ -1,3 +1,4 @@
+import { importNapiModuleSync } from "./napi";
 import { defineTheme, mergeThemes, type ThemeConfig } from "./theme";
 import type { OxContentOptions, SsgNavigationGroup, SsgNavigationItem } from "./types";
 
@@ -503,74 +504,11 @@ function formatObjectKey(key: string): string {
   return /^[A-Za-z_$][\w$]*$/.test(key) ? key : JSON.stringify(key);
 }
 
-function toNumber(value: unknown): number | undefined {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
-  }
-
-  if (typeof value === "string" && /^\d+$/.test(value)) {
-    return Number(value);
-  }
-
-  return undefined;
-}
-
-function normalizeHeroImage(value: unknown): Record<string, unknown> | undefined {
-  if (typeof value === "string") {
-    return { src: value };
-  }
-
-  if (!isRecord(value)) {
-    return undefined;
-  }
-
-  const src =
-    (typeof value.src === "string" && value.src) ||
-    (typeof value.light === "string" && value.light) ||
-    (typeof value.dark === "string" && value.dark);
-
-  if (!src) {
-    return undefined;
-  }
-
-  const lightSrc =
-    (typeof value.lightSrc === "string" && value.lightSrc) ||
-    (typeof value.light === "string" && value.light);
-  const darkSrc =
-    (typeof value.darkSrc === "string" && value.darkSrc) ||
-    (typeof value.dark === "string" && value.dark);
-
-  return {
-    src,
-    ...(lightSrc ? { lightSrc } : {}),
-    ...(darkSrc ? { darkSrc } : {}),
-    ...(typeof value.alt === "string" ? { alt: value.alt } : {}),
-    ...(toNumber(value.width) !== undefined ? { width: toNumber(value.width) } : {}),
-    ...(toNumber(value.height) !== undefined ? { height: toNumber(value.height) } : {}),
-  };
-}
-
 /**
  * Normalizes VitePress-specific frontmatter into ox-content's entry-page shape.
  */
 export function normalizeVitePressFrontmatter(
   frontmatter: Record<string, unknown>,
 ): Record<string, unknown> {
-  const next = { ...frontmatter };
-
-  if (frontmatter.layout === "home") {
-    next.layout = "entry";
-  }
-
-  if (isRecord(frontmatter.hero)) {
-    const image = normalizeHeroImage(frontmatter.hero.image);
-    if (image) {
-      next.hero = {
-        ...frontmatter.hero,
-        image,
-      };
-    }
-  }
-
-  return next;
+  return importNapiModuleSync().normalizeVitePressFrontmatter(frontmatter);
 }


### PR DESCRIPTION
## Summary
- Move VitePress frontmatter normalization into `ox_content_ssg`.
- Expose the helper through `@ox-content/napi` as `normalizeVitePressFrontmatter`.
- Replace the TypeScript implementation in the Vite plugin with a NAPI call.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p ox_content_ssg -p ox_content_napi`
- `cargo clippy -p ox_content_ssg -p ox_content_napi --all-targets -- -D warnings`
- `corepack pnpm --filter @ox-content/napi build`
- `corepack pnpm exec vp exec --filter @ox-content/vite-plugin -- vp test src/vitepress.test.ts`

## Note
- `corepack pnpm exec vp exec --filter @ox-content/vite-plugin -- vp run typecheck` currently fails on existing package-wide test/lint typing issues unrelated to this change.