### PR TITLE
feat(lsp): preview HMR push channel

### DIFF
--- a/crates/ox_content_lsp/src/backend.rs
+++ b/crates/ox_content_lsp/src/backend.rs
@@ -34,6 +34,11 @@ impl Backend {
         if is_markdown_path(&path) {
             self.state.upsert_document(uri.clone(), text.clone()).await;
             self.publish_diagnostics_for(uri).await;
+            // HMR: any subscribed preview panel needs the rendered HTML
+            // pushed to it; this replaces the polling
+            // `onDidChangeTextDocument` refresh editors used to do. The
+            // helper short-circuits silently when no client is listening.
+            self.push_preview_update(uri).await;
         }
 
         let path_str = path.to_string_lossy().to_string();

--- a/crates/ox_content_lsp/src/backend/commands.rs
+++ b/crates/ox_content_lsp/src/backend/commands.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 
 use tower_lsp::jsonrpc::{Error, ErrorCode, Result};
 use tower_lsp::lsp_types::{
-    CodeAction, CodeActionKind, CodeActionOrCommand, Command, Position, Range, TextEdit, Url,
-    WorkspaceEdit,
+    CodeAction, CodeActionKind, CodeActionOrCommand, Command, MessageType, Position, Range,
+    TextEdit, Url, WorkspaceEdit,
 };
 
 use crate::preview;
@@ -14,6 +14,14 @@ pub(super) const COMMAND_INSERT_TABLE: &str = "oxContent.insertTable";
 pub(super) const COMMAND_INSERT_CODE_FENCE: &str = "oxContent.insertCodeFence";
 pub(super) const COMMAND_INSERT_CALLOUT: &str = "oxContent.insertCallout";
 pub(super) const COMMAND_PREVIEW_HTML: &str = "oxContent.previewHtml";
+pub(super) const COMMAND_PREVIEW_SUBSCRIBE: &str = "oxContent.previewSubscribe";
+pub(super) const COMMAND_PREVIEW_UNSUBSCRIBE: &str = "oxContent.previewUnsubscribe";
+
+/// Notification method pushed to the client whenever a subscribed
+/// document's text changes. Payload matches `preview::PreviewPayload`
+/// plus the originating URI so the client can route updates to the
+/// right webview/panel.
+pub(super) const NOTIFICATION_PREVIEW_DID_CHANGE: &str = "oxContent/previewDidChange";
 
 #[derive(serde::Deserialize)]
 struct EditCommandPayload {
@@ -76,6 +84,89 @@ impl Backend {
 
         serde_json::to_value(payload).map(Some).map_err(|_| Error::internal_error())
     }
+
+    /// Register the URI as a preview subscriber. Subsequent text
+    /// changes will be pushed via
+    /// [`NOTIFICATION_PREVIEW_DID_CHANGE`] until the client
+    /// unsubscribes or closes the document. The current snapshot is
+    /// returned so the client can paint the panel immediately without
+    /// a follow-up `oxContent.previewHtml` round trip.
+    pub(super) async fn preview_subscribe(
+        &self,
+        arguments: Vec<serde_json::Value>,
+    ) -> Result<Option<serde_json::Value>> {
+        let uri = parse_uri_argument(&arguments)?;
+        self.state.subscribe_preview(uri.clone()).await;
+        // Return the initial payload so the client can render before
+        // the first push notification arrives.
+        self.preview_html(arguments).await
+    }
+
+    pub(super) async fn preview_unsubscribe(
+        &self,
+        arguments: Vec<serde_json::Value>,
+    ) -> Result<Option<serde_json::Value>> {
+        let uri = parse_uri_argument(&arguments)?;
+        self.state.unsubscribe_preview(&uri).await;
+        Ok(None)
+    }
+
+    /// Re-render and push a preview update to any client that
+    /// subscribed to this URI. No-op when no subscriber is listening,
+    /// when the document is gone, or when the document is not
+    /// renderable Markdown. Failures are logged through the client
+    /// channel rather than surfaced — pushing diagnostics for an
+    /// in-flight edit would only add noise.
+    pub(super) async fn push_preview_update(&self, uri: &Url) {
+        if !self.state.is_preview_subscribed(uri).await {
+            return;
+        }
+        let Some(document) = self.state.document(uri).await else {
+            return;
+        };
+
+        let payload = match preview::render_preview(document.text()) {
+            Ok(payload) => payload,
+            Err(error) => {
+                self.client
+                    .log_message(
+                        MessageType::WARNING,
+                        format!("ox-content preview render failed for {uri}: {error}"),
+                    )
+                    .await;
+                return;
+            }
+        };
+
+        let notification = PreviewDidChangeParams { uri: uri.to_string(), payload };
+        self.client.send_notification::<PreviewDidChangeNotification>(notification).await;
+    }
+}
+
+fn parse_uri_argument(arguments: &[serde_json::Value]) -> Result<Url> {
+    let raw = arguments
+        .first()
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| Error::invalid_params("Missing preview URI"))?;
+    Url::parse(raw).map_err(|_| Error::invalid_params("Invalid preview URI"))
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub(super) struct PreviewDidChangeParams {
+    pub uri: String,
+    #[serde(flatten)]
+    pub payload: preview::PreviewPayload,
+}
+
+/// Strongly-typed `tower_lsp` notification handle. Splitting it out as
+/// a dedicated zero-sized type keeps the method name centralized in
+/// [`NOTIFICATION_PREVIEW_DID_CHANGE`] and makes it trivial to swap
+/// transport details (e.g. payload version) later.
+pub(super) enum PreviewDidChangeNotification {}
+
+impl tower_lsp::lsp_types::notification::Notification for PreviewDidChangeNotification {
+    type Params = PreviewDidChangeParams;
+    const METHOD: &'static str = NOTIFICATION_PREVIEW_DID_CHANGE;
 }
 
 pub(super) fn insert_actions(uri: &Url, position: Position) -> Vec<CodeActionOrCommand> {

--- a/crates/ox_content_lsp/src/backend/handlers.rs
+++ b/crates/ox_content_lsp/src/backend/handlers.rs
@@ -6,7 +6,7 @@ use crate::document::is_markdown_path;
 
 use super::commands::{
     insert_actions, COMMAND_INSERT_CALLOUT, COMMAND_INSERT_CODE_FENCE, COMMAND_INSERT_TABLE,
-    COMMAND_PREVIEW_HTML,
+    COMMAND_PREVIEW_HTML, COMMAND_PREVIEW_SUBSCRIBE, COMMAND_PREVIEW_UNSUBSCRIBE,
 };
 use super::Backend;
 
@@ -62,6 +62,8 @@ impl LanguageServer for Backend {
                         COMMAND_INSERT_CODE_FENCE.into(),
                         COMMAND_INSERT_CALLOUT.into(),
                         COMMAND_PREVIEW_HTML.into(),
+                        COMMAND_PREVIEW_SUBSCRIBE.into(),
+                        COMMAND_PREVIEW_UNSUBSCRIBE.into(),
                     ],
                     ..Default::default()
                 }),
@@ -162,6 +164,8 @@ impl LanguageServer for Backend {
                 self.insert_template(&params.command, params.arguments).await
             }
             COMMAND_PREVIEW_HTML => self.preview_html(params.arguments).await,
+            COMMAND_PREVIEW_SUBSCRIBE => self.preview_subscribe(params.arguments).await,
+            COMMAND_PREVIEW_UNSUBSCRIBE => self.preview_unsubscribe(params.arguments).await,
             _ => Ok(None),
         }
     }

--- a/crates/ox_content_lsp/src/preview.rs
+++ b/crates/ox_content_lsp/src/preview.rs
@@ -3,5 +3,5 @@ mod render;
 mod symbols;
 mod text;
 
-pub use render::render_preview;
+pub use render::{render_preview, PreviewPayload};
 pub use symbols::document_symbols;

--- a/crates/ox_content_lsp/src/preview/render.rs
+++ b/crates/ox_content_lsp/src/preview/render.rs
@@ -1,14 +1,14 @@
 use ox_content_allocator::Allocator;
 use ox_content_parser::{ParseError, Parser, ParserOptions};
 use ox_content_renderer::HtmlRenderer;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::document::TextDocumentState;
 use crate::frontmatter::parse_frontmatter;
 use crate::preview::html::wrap_preview_html;
 use crate::preview::text::preview_title;
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PreviewPayload {
     pub html: String,
     pub title: String,

--- a/crates/ox_content_lsp/src/state.rs
+++ b/crates/ox_content_lsp/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -18,6 +18,11 @@ struct Inner {
     documents: HashMap<Url, TextDocumentState>,
     root: Option<PathBuf>,
     init_options: InitializationOptions,
+    /// Set of document URIs the client has subscribed to preview updates
+    /// for. When a subscribed document changes, the backend re-renders
+    /// and pushes a `oxContent/previewDidChange` notification, replacing
+    /// the polling-style refresh editors used to do client-side.
+    preview_subscriptions: HashSet<Url>,
 }
 
 impl LspState {
@@ -54,16 +59,98 @@ impl LspState {
     pub async fn remove_document(&self, uri: &Url) {
         let mut inner = self.inner.write().await;
         inner.documents.remove(uri);
+        // A closed document cannot push preview updates anymore. Drop
+        // the subscription so the client doesn't leak state into the
+        // next session for the same URI.
+        inner.preview_subscriptions.remove(uri);
     }
 
     pub async fn document(&self, uri: &Url) -> Option<TextDocumentState> {
         let inner = self.inner.read().await;
         inner.documents.get(uri).cloned()
     }
+
+    /// Mark `uri` as receiving preview push notifications. Returns the
+    /// previous subscription state so callers can distinguish "newly
+    /// subscribed" from "already subscribed".
+    pub async fn subscribe_preview(&self, uri: Url) -> bool {
+        let mut inner = self.inner.write().await;
+        inner.preview_subscriptions.insert(uri)
+    }
+
+    /// Drop a preview subscription. Returns whether the URI was actually
+    /// subscribed (so callers can no-op silently on double-unsubscribe).
+    pub async fn unsubscribe_preview(&self, uri: &Url) -> bool {
+        let mut inner = self.inner.write().await;
+        inner.preview_subscriptions.remove(uri)
+    }
+
+    pub async fn is_preview_subscribed(&self, uri: &Url) -> bool {
+        let inner = self.inner.read().await;
+        inner.preview_subscriptions.contains(uri)
+    }
+
+    #[cfg(test)]
+    pub async fn preview_subscription_count(&self) -> usize {
+        let inner = self.inner.read().await;
+        inner.preview_subscriptions.len()
+    }
 }
 
 impl Default for LspState {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp::lsp_types::Url;
+
+    fn uri(path: &str) -> Url {
+        Url::parse(&format!("file://{path}")).expect("valid file url")
+    }
+
+    #[tokio::test]
+    async fn subscribe_preview_is_idempotent() {
+        let state = LspState::new();
+        let u = uri("/tmp/a.md");
+
+        assert!(state.subscribe_preview(u.clone()).await, "first subscribe should report insert");
+        assert!(
+            !state.subscribe_preview(u.clone()).await,
+            "second subscribe should report no-change",
+        );
+        assert!(state.is_preview_subscribed(&u).await);
+        assert_eq!(state.preview_subscription_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_preview_returns_previous_state() {
+        let state = LspState::new();
+        let u = uri("/tmp/b.md");
+
+        assert!(!state.unsubscribe_preview(&u).await, "unsubscribe on empty set is a no-op");
+        state.subscribe_preview(u.clone()).await;
+        assert!(state.unsubscribe_preview(&u).await);
+        assert!(!state.is_preview_subscribed(&u).await);
+        assert_eq!(state.preview_subscription_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn close_document_drops_preview_subscription() {
+        let state = LspState::new();
+        let u = uri("/tmp/c.md");
+
+        state.upsert_document(u.clone(), "# hi".into()).await;
+        state.subscribe_preview(u.clone()).await;
+        assert!(state.is_preview_subscribed(&u).await);
+
+        state.remove_document(&u).await;
+        assert!(
+            !state.is_preview_subscribed(&u).await,
+            "removing a document must also drop its preview subscription",
+        );
     }
 }

--- a/docs/content/editor-extension-roadmap.md
+++ b/docs/content/editor-extension-roadmap.md
@@ -31,16 +31,16 @@ must not depend on a later one in the list.
 
 ## Feature Matrix
 
-| #   | Feature                                         | LSP                       | CLI                          | VS Code                   | Neovim                      | Status             |
-| --- | ----------------------------------------------- | ------------------------- | ---------------------------- | ------------------------- | --------------------------- | ------------------ |
-| 1   | Markdown preview (HMR)                          | partial — polling refresh | none                         | webview, debounced reload | external browser, on-demand | needs HMR + CLI    |
-| 2   | i18n preview / completion                       | present                   | `ox-content-i18n`            | present                   | present                     | shipped            |
-| 3   | MDC completion + type check                     | completion + diagnostics  | `ox-content-mdc-check`       | completion + diagnostics  | completion + diagnostics    | shipped            |
-| 4   | Vue / React props completion + jump + typecheck | none                      | none                         | none                      | none                        | new (corsa_client) |
-| 5   | Asset path completion + diagnostics             | completion provider       | via link checker             | completion + diagnostics  | completion + diagnostics    | shipped            |
-| 6   | Dead link checker                               | diagnostics               | `ox-content-link-check`      | diagnostics               | diagnostics                 | local: shipped     |
-| 7   | textlint integration                            | on-save diagnostics       | via configured command       | enabled per setting       | enabled per setting         | shipped (opt-in)   |
-| 8   | Frontmatter schema completion + diagnostics     | present                   | none (validated through LSP) | present                   | present                     | needs CLI          |
+| #   | Feature                                         | LSP                      | CLI                          | VS Code                  | Neovim                      | Status             |
+| --- | ----------------------------------------------- | ------------------------ | ---------------------------- | ------------------------ | --------------------------- | ------------------ |
+| 1   | Markdown preview (HMR)                          | push channel             | none                         | subscribed webview       | external browser, on-demand | needs CLI + nvim   |
+| 2   | i18n preview / completion                       | present                  | `ox-content-i18n`            | present                  | present                     | shipped            |
+| 3   | MDC completion + type check                     | completion + diagnostics | `ox-content-mdc-check`       | completion + diagnostics | completion + diagnostics    | shipped            |
+| 4   | Vue / React props completion + jump + typecheck | none                     | none                         | none                     | none                        | new (corsa_client) |
+| 5   | Asset path completion + diagnostics             | completion provider      | via link checker             | completion + diagnostics | completion + diagnostics    | shipped            |
+| 6   | Dead link checker                               | diagnostics              | `ox-content-link-check`      | diagnostics              | diagnostics                 | local: shipped     |
+| 7   | textlint integration                            | on-save diagnostics      | via configured command       | enabled per setting      | enabled per setting         | shipped (opt-in)   |
+| 8   | Frontmatter schema completion + diagnostics     | present                  | none (validated through LSP) | present                  | present                     | needs CLI          |
 
 ## PR Sequence
 
@@ -74,14 +74,19 @@ Foundation PR. Tightens the existing extension before adding features.
 
 Replace the polling refresh path with an explicit push channel.
 
-- New LSP notification `oxContent/previewDidChange` payload `{ uri, html, title }`.
-- VS Code webview subscribes to the notification instead of debouncing on
+- ✅ LSP notification `oxContent/previewDidChange` with `{ uri, html, title }` payload
+  (shipped, see `crates/ox_content_lsp/src/backend/commands.rs`).
+- ✅ `oxContent.previewSubscribe` / `oxContent.previewUnsubscribe`
+  execute-command handlers.
+- ✅ VS Code webview subscribes on open, unsubscribes on dispose, and
+  listens for `oxContent/previewDidChange` instead of debouncing on
   `onDidChangeTextDocument`.
-- New CLI `ox-content-preview` that hosts an SSE endpoint backed by the same
-  renderer; useful for `--watch` workflows and for the Neovim browser
-  preview.
-- Neovim preview opens the SSE URL instead of writing a temp file when
-  `auto_refresh = true`.
+- Pending follow-up: CLI `ox-content-preview` that hosts an SSE endpoint
+  backed by the same renderer (useful for `--watch` workflows and for the
+  Neovim browser preview). Tracked as a separate PR so this one stays
+  focused on the LSP push channel.
+- Pending follow-up: Neovim preview opens the SSE URL instead of writing
+  a temp file when `auto_refresh = true`.
 
 ### 3. `feat(link-checker): new crate, LSP integration, CLI`
 

--- a/npm/vscode-ox-content/README.md
+++ b/npm/vscode-ox-content/README.md
@@ -8,7 +8,9 @@ Features:
 - frontmatter schema completion and diagnostics
 - i18n key completion, hover, definition, diagnostics, and inlay hints for JS/TS
 - command palette actions for table/code fence/callout insertion
-- Ox Content HTML preview
+- Ox Content HTML preview with **HMR**: opening the preview subscribes
+  the document with the LSP, and the panel reloads on every
+  `oxContent/previewDidChange` notification (no client-side polling)
 - `.mdc` files associated with Markdown and component tag diagnostics
 
 ## Configuration
@@ -23,6 +25,22 @@ The environment variable `OX_CONTENT_LSP_PATH` is honored as an override
 between `oxContent.server.path` and the local-binary probe. CI and the
 integration test runner use it so they can point at a freshly built
 `target/release/ox-content-lsp` without writing per-workspace settings.
+
+## Preview HMR
+
+`oxContent.openPreview` opens a webview that subscribes to LSP push
+updates instead of debouncing on `onDidChangeTextDocument`. The flow is:
+
+1. The extension calls `oxContent.previewSubscribe` with the document
+   URI; the LSP returns the initial rendered HTML.
+2. Every text change to that document triggers
+   `oxContent/previewDidChange` from the LSP, which the panel applies
+   directly.
+3. Disposing the webview (or closing the document) sends
+   `oxContent.previewUnsubscribe`.
+
+Set `oxContent.preview.autoRefresh: false` to opt out — the panel
+still opens but stops at the initial render.
 
 ## Testing
 

--- a/npm/vscode-ox-content/src/client.ts
+++ b/npm/vscode-ox-content/src/client.ts
@@ -91,3 +91,19 @@ export async function sendServerCommand<T = unknown>(
     arguments: args,
   });
 }
+
+/**
+ * Subscribe to an LSP notification routed through the active client.
+ * Returns a Disposable so the caller can detach on panel teardown.
+ * Throws when no client is running — callers should only invoke this
+ * after `startClient` resolves.
+ */
+export function onServerNotification<T>(
+  method: string,
+  handler: (params: T) => void,
+): vscode.Disposable {
+  if (!client) {
+    throw new Error("Ox Content language client is not running.");
+  }
+  return client.onNotification(method, handler);
+}

--- a/npm/vscode-ox-content/src/constants.ts
+++ b/npm/vscode-ox-content/src/constants.ts
@@ -3,3 +3,9 @@ export const COMMAND_INSERT_CODE_FENCE = "oxContent.insertCodeFence";
 export const COMMAND_INSERT_CALLOUT = "oxContent.insertCallout";
 export const COMMAND_OPEN_PREVIEW = "oxContent.openPreview";
 export const SERVER_COMMAND_PREVIEW_HTML = "oxContent.previewHtml";
+export const SERVER_COMMAND_PREVIEW_SUBSCRIBE = "oxContent.previewSubscribe";
+export const SERVER_COMMAND_PREVIEW_UNSUBSCRIBE = "oxContent.previewUnsubscribe";
+
+/** Notification pushed by the LSP whenever a subscribed document
+ * changes. Replaces the polling refresh path. */
+export const NOTIFICATION_PREVIEW_DID_CHANGE = "oxContent/previewDidChange";

--- a/npm/vscode-ox-content/src/extension.ts
+++ b/npm/vscode-ox-content/src/extension.ts
@@ -2,10 +2,14 @@ import * as vscode from "vscode";
 
 import { COMMAND_OPEN_PREVIEW } from "./constants";
 import { restartClient, startClient, stopClient } from "./client";
-import { openPreview, refreshAllPreviews, schedulePreviewRefresh } from "./preview";
+import { openPreview, refreshAllPreviews, registerPreviewListeners } from "./preview";
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   await startClient(context);
+  // Wire the `oxContent/previewDidChange` push channel as soon as the
+  // client is up. The handler is re-registered after every restart so
+  // it survives `oxContent` configuration changes.
+  registerPreviewListeners(context);
 
   // The insertion commands (`oxContent.insertTable`, etc.) are registered
   // by `vscode-languageclient` from the server's
@@ -13,18 +17,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // the client middleware (see `client.ts`). The extension only adds the
   // commands the server does not advertise — notably `oxContent.openPreview`,
   // which is a webview-only operation.
+  //
+  // Preview HMR is server-driven: opening the preview subscribes the URI
+  // with the LSP, the LSP pushes `oxContent/previewDidChange` on every
+  // text change, and the panel reapplies the HTML. The extension no
+  // longer needs `onDidChangeTextDocument` debouncing.
   context.subscriptions.push(
     vscode.commands.registerCommand(COMMAND_OPEN_PREVIEW, async () => {
       await openPreview(context);
-    }),
-    vscode.workspace.onDidChangeTextDocument((event) => {
-      schedulePreviewRefresh(event.document);
-    }),
-    vscode.workspace.onDidSaveTextDocument((document) => {
-      schedulePreviewRefresh(document);
-    }),
-    vscode.workspace.onDidCloseTextDocument((document) => {
-      schedulePreviewRefresh(document, true);
     }),
     vscode.workspace.onDidChangeConfiguration(async (event) => {
       if (!event.affectsConfiguration("oxContent")) {
@@ -32,6 +32,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
 
       await restartClient(context);
+      registerPreviewListeners(context);
       await refreshAllPreviews();
     }),
   );

--- a/npm/vscode-ox-content/src/preview.ts
+++ b/npm/vscode-ox-content/src/preview.ts
@@ -2,13 +2,43 @@ import * as path from "node:path";
 import * as vscode from "vscode";
 
 import { getConfig } from "./config";
-import { SERVER_COMMAND_PREVIEW_HTML } from "./constants";
-import { sendServerCommand } from "./client";
+import {
+  NOTIFICATION_PREVIEW_DID_CHANGE,
+  SERVER_COMMAND_PREVIEW_HTML,
+  SERVER_COMMAND_PREVIEW_SUBSCRIBE,
+  SERVER_COMMAND_PREVIEW_UNSUBSCRIBE,
+} from "./constants";
+import { onServerNotification, sendServerCommand } from "./client";
 import { errorHtml } from "./internal/preview-html";
 import type { PreviewEntry, PreviewPayload } from "./types";
 
 const previewEntries = new Map<string, PreviewEntry>();
-const refreshTimers = new Map<string, NodeJS.Timeout>();
+let notificationSubscription: vscode.Disposable | undefined;
+
+type PreviewDidChangeParams = PreviewPayload & { uri: string };
+
+/**
+ * Register the `oxContent/previewDidChange` notification handler against
+ * the currently running LSP client. Safe to call after every
+ * (re)startClient: the previous handler is disposed first so we never
+ * stack listeners across restarts.
+ */
+export function registerPreviewListeners(context: vscode.ExtensionContext): void {
+  notificationSubscription?.dispose();
+  try {
+    notificationSubscription = onServerNotification<PreviewDidChangeParams>(
+      NOTIFICATION_PREVIEW_DID_CHANGE,
+      (params) => applyPushedPreview(params),
+    );
+    context.subscriptions.push({
+      dispose: () => notificationSubscription?.dispose(),
+    });
+  } catch {
+    // The client may not be ready yet (e.g. tests that don't activate
+    // the extension fully). Subscriptions will be re-registered on the
+    // next startClient cycle.
+  }
+}
 
 export async function openPreview(context: vscode.ExtensionContext): Promise<void> {
   const editor = vscode.window.activeTextEditor;
@@ -21,7 +51,7 @@ export async function openPreview(context: vscode.ExtensionContext): Promise<voi
   const existing = previewEntries.get(documentUri);
   if (existing) {
     existing.panel.reveal(vscode.ViewColumn.Beside, true);
-    await updatePreview(existing.panel, editor.document);
+    await renderInitialPreview(existing.panel, editor.document);
     return;
   }
 
@@ -34,59 +64,37 @@ export async function openPreview(context: vscode.ExtensionContext): Promise<voi
 
   previewEntries.set(documentUri, { documentUri, panel });
   panel.onDidDispose(() => disposePreview(documentUri), null, context.subscriptions);
-  await updatePreview(panel, editor.document);
+  await renderInitialPreview(panel, editor.document);
 }
 
-export function schedulePreviewRefresh(document: vscode.TextDocument, dispose = false): void {
-  const key = document.uri.toString();
-  if (dispose) {
-    disposePreview(key);
-    return;
-  }
-
-  if (
-    !getConfig().get<boolean>("preview.autoRefresh", true) ||
-    document.languageId !== "markdown"
-  ) {
-    return;
-  }
-
-  const entry = previewEntries.get(key);
-  if (!entry) {
-    return;
-  }
-
-  clearTimer(key);
-  refreshTimers.set(
-    key,
-    setTimeout(() => {
-      void updatePreview(entry.panel, document);
-    }, 150),
-  );
-}
-
+/**
+ * Force every open preview panel to re-fetch its HTML. Called after a
+ * config change restarts the LSP — the previous subscriptions are gone
+ * and the new server hasn't pushed anything yet, so we reseed each panel
+ * by re-subscribing.
+ */
 export async function refreshAllPreviews(): Promise<void> {
   for (const entry of previewEntries.values()) {
     const document = await vscode.workspace.openTextDocument(vscode.Uri.parse(entry.documentUri));
-    await updatePreview(entry.panel, document);
+    await renderInitialPreview(entry.panel, document);
   }
 }
 
-async function updatePreview(
+async function renderInitialPreview(
   panel: vscode.WebviewPanel,
   document: vscode.TextDocument,
 ): Promise<void> {
+  const command = previewAutoRefreshEnabled()
+    ? SERVER_COMMAND_PREVIEW_SUBSCRIBE
+    : SERVER_COMMAND_PREVIEW_HTML;
+
   try {
-    const payload = await sendServerCommand<PreviewPayload>(SERVER_COMMAND_PREVIEW_HTML, [
-      document.uri.toString(),
-    ]);
+    const payload = await sendServerCommand<PreviewPayload>(command, [document.uri.toString()]);
     if (!payload) {
       panel.webview.html = errorHtml("Preview payload was empty.");
       return;
     }
-
-    panel.title = payload.title || `${path.basename(document.fileName) || "Untitled"} Preview`;
-    panel.webview.html = payload.html;
+    applyPayload(panel, document, payload);
   } catch (error) {
     panel.webview.html = errorHtml(
       error instanceof Error ? error.message : "Failed to render preview.",
@@ -94,15 +102,34 @@ async function updatePreview(
   }
 }
 
-function disposePreview(key: string): void {
-  previewEntries.delete(key);
-  clearTimer(key);
+function applyPushedPreview(params: PreviewDidChangeParams): void {
+  const entry = previewEntries.get(params.uri);
+  if (!entry) {
+    return;
+  }
+  entry.panel.title = params.title || entry.panel.title;
+  entry.panel.webview.html = params.html;
 }
 
-function clearTimer(key: string): void {
-  const timer = refreshTimers.get(key);
-  if (timer) {
-    clearTimeout(timer);
+function applyPayload(
+  panel: vscode.WebviewPanel,
+  document: vscode.TextDocument,
+  payload: PreviewPayload,
+): void {
+  panel.title = payload.title || `${path.basename(document.fileName) || "Untitled"} Preview`;
+  panel.webview.html = payload.html;
+}
+
+function disposePreview(key: string): void {
+  const entry = previewEntries.get(key);
+  previewEntries.delete(key);
+  if (entry && previewAutoRefreshEnabled()) {
+    // Best-effort unsubscribe; the LSP also drops subscriptions on
+    // `did_close`, so an error here is not user-visible.
+    void sendServerCommand(SERVER_COMMAND_PREVIEW_UNSUBSCRIBE, [key]).catch(() => undefined);
   }
-  refreshTimers.delete(key);
+}
+
+function previewAutoRefreshEnabled(): boolean {
+  return getConfig().get<boolean>("preview.autoRefresh", true);
 }

--- a/npm/vscode-ox-content/src/test/integration/extension.test.ts
+++ b/npm/vscode-ox-content/src/test/integration/extension.test.ts
@@ -27,6 +27,14 @@ const EXPECTED_COMMANDS = [
   "oxContent.openPreview",
 ];
 
+// HMR-flow commands. The LSP advertises them in its
+// `execute_command_provider` capability, so vscode-languageclient
+// registers them as VS Code commands once the server starts — but
+// they have no `onCommand:` activation event because they are only
+// dispatched by the extension itself (preview subscribe / unsubscribe
+// on panel lifecycle).
+const EXPECTED_LSP_COMMANDS = ["oxContent.previewSubscribe", "oxContent.previewUnsubscribe"];
+
 const EDITOR_GUARDED_COMMANDS = [
   "oxContent.insertTable",
   "oxContent.insertCodeFence",
@@ -142,7 +150,7 @@ suite("vscode-ox-content extension surface", () => {
     }
     const registered = await vscode.commands.getCommands(true);
     const oxCommands = registered.filter((id) => id.startsWith("oxContent."));
-    for (const id of EXPECTED_COMMANDS) {
+    for (const id of [...EXPECTED_COMMANDS, ...EXPECTED_LSP_COMMANDS]) {
       assert.ok(
         registered.includes(id),
         `command ${id} not registered. registered oxContent.* commands: ${oxCommands.join(", ")}`,


### PR DESCRIPTION
Roadmap step 2 (see [editor extension roadmap](https://github.com/ubugeeei/ox-content/blob/main/docs/content/editor-extension-roadmap.md)).

Replaces the client-side polling refresh in VS Code with an LSP-driven push channel.

## What changed

### Server (`crates/ox_content_lsp`)

- New notification `oxContent/previewDidChange` with `{ uri, html, title }` payload. Sent whenever a *subscribed* document changes.
- New execute-command handlers:
  - `oxContent.previewSubscribe` — registers the URI; also returns the current rendered payload so the client paints the first frame without a follow-up round trip.
  - `oxContent.previewUnsubscribe` — drops the subscription.
- Subscription state lives on `LspState`; `remove_document` also drops the matching subscription so a closed buffer can never receive pushed updates.
- `on_change` calls `push_preview_update` for any subscribed Markdown URI. Render failures are logged through `client.log_message` instead of surfaced as diagnostics — pushing diagnostics for an in-flight keystroke would only add noise.

### Client (`npm/vscode-ox-content`)

- New `client.onServerNotification(method, handler)` helper exposes the LSP notification API to the rest of the extension.
- `preview.registerPreviewListeners(context)` registers a `oxContent/previewDidChange` handler and is invoked from `activate()` and from the post-restart path in the config-change watcher so the subscription survives `oxContent.*` setting changes.
- `openPreview` issues `previewSubscribe` (or `previewHtml` when `oxContent.preview.autoRefresh: false`); the panel's `onDidDispose` issues `previewUnsubscribe`.
- The `onDidChangeTextDocument` / `onDidSaveTextDocument` / `onDidCloseTextDocument` debounce path is gone.

## Tests

- 3 new tokio tests on `LspState` covering subscribe idempotency, unsubscribe-on-empty, and the close-document-drops-subscription guarantee.
- Existing VS Code integration test extended to assert `oxContent.previewSubscribe` and `oxContent.previewUnsubscribe` appear in the registered command list after activation.

Verified locally end-to-end against the real release LSP:

```
cargo test -p ox_content_lsp     ✓  19 tests
vscode-test                       ✓   5 tests (includes new HMR command check)
vp run check                      ✓
```

## Docs

- [docs/content/editor-extension-roadmap.md](https://github.com/ubugeeei/ox-content/blob/feat/preview-hmr/docs/content/editor-extension-roadmap.md) marks the LSP push channel as shipped and pulls the CLI + Neovim items out as follow-up PRs.
- [npm/vscode-ox-content/README.md](https://github.com/ubugeeei/ox-content/blob/feat/preview-hmr/npm/vscode-ox-content/README.md) documents the subscribe/notify flow and the `autoRefresh: false` opt-out.

## Out of scope (follow-up PRs)

- `ox-content-preview` CLI hosting SSE for browser-based watch workflows.
- Neovim preview opening the SSE URL instead of writing a temp file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)