### PR TITLE
feat(link-checker): new crate, LSP diagnostics, CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ ox_content_ssg = { version = "2.19.0", path = "crates/ox_content_ssg" }
 ox_content_i18n = { version = "2.19.0", path = "crates/ox_content_i18n" }
 ox_content_i18n_checker = { version = "2.19.0", path = "crates/ox_content_i18n_checker" }
 ox_content_mdc_checker = { version = "2.19.0", path = "crates/ox_content_mdc_checker" }
+ox_content_link_checker = { version = "2.19.0", path = "crates/ox_content_link_checker" }
 ox_content_profiler = { version = "2.19.0", path = "crates/ox_content_profiler" }
 ox_jsdoc = "0.0.16"
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,23 @@ ox-content-i18n check --dict-dir content/i18n --src src
 ox-content-i18n validate "Hello {$name}"
 ```
 
+### Dead Link Checker (CLI)
+
+```bash
+# Check every link in a tree, exit non-zero on broken targets
+ox-content-link-check docs/**/*.md
+
+# Treat `/foo.md` as workspace-rooted under docs/
+ox-content-link-check --src-dir docs docs/**/*.md
+
+# Suppress known intentionally-broken targets
+ox-content-link-check --ignore "intentionally-broken" docs/**/*.md
+```
+
+Offline-only by design — `http://` and `https://` links pass through
+without a network request, so the same binary is safe to run in CI
+without timeouts, retries, or rate limits.
+
 ### Editor Tooling
 
 Ox Content now ships a unified authoring and i18n language server:
@@ -171,9 +188,10 @@ Supported features include:
 - frontmatter schema completion and diagnostics
 - i18n key completion, hover, go-to-definition, diagnostics, and inlay hints for JS/TS
 - table / code fence / callout insertion commands
-- preview HTML generation for editor UIs
+- preview HTML generation for editor UIs (with LSP-pushed HMR)
 - `.mdc` authoring support with component tag diagnostics
 - asset path completion inside `[…](`, `![…](`, and HTML `src=`/`href=` attributes
+- dead link diagnostics powered by `ox_content_link_checker`
 
 For CI or editor-independent checks, run:
 

--- a/crates/ox_content_link_checker/Cargo.toml
+++ b/crates/ox_content_link_checker/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ox_content_link_checker"
+version.workspace = true
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Static dead-link checker for Ox Content Markdown (local, deterministic)"
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "ox-content-link-check"
+path = "src/main.rs"
+
+[dependencies]
+ox_content_allocator = { workspace = true }
+ox_content_ast = { workspace = true }
+ox_content_parser = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/ox_content_link_checker/README.md
+++ b/crates/ox_content_link_checker/README.md
@@ -1,0 +1,64 @@
+# ox_content_link_checker
+
+Dead-link checker for Ox Content Markdown. Offline-only by design: it
+resolves every link / image / image-link target against the filesystem
+and against the document's own heading slugs, but it never opens a
+network connection. The same binary is safe in CI without timeouts,
+retries, or rate limits, and produces deterministic output across runs.
+
+## Library
+
+```rust
+use ox_content_link_checker::{check_source, CheckOptions};
+use std::path::PathBuf;
+
+let opts = CheckOptions::for_file(PathBuf::from("/path/to/doc.md"));
+for diagnostic in check_source(source, &opts) {
+    eprintln!("{}:{} {}", diagnostic.line, diagnostic.column, diagnostic.message);
+}
+```
+
+Knobs:
+
+- `CheckOptions::src_dir` — base for paths that start with `/`.
+  Defaults to the document's own directory; set this to the workspace
+  root for the same resolution rules as Vite-served static files.
+- `CheckOptions::ignore_patterns` — substring patterns. Any link whose
+  raw target contains any of them is skipped.
+
+## CLI
+
+```bash
+ox-content-link-check docs/**/*.md
+ox-content-link-check --src-dir docs --format json docs/index.md
+ox-content-link-check --ignore "intentionally-broken" docs/**/*.md
+```
+
+Exit code is `1` when any error-severity diagnostic was emitted (or any
+file failed to read). Warning-severity diagnostics never fail the run
+on their own; they show up in the output.
+
+## What it checks
+
+| Link form                                | Behavior                                                                                                 |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `[text](https://…)` / `[text](http://…)` | passed through, never asserted                                                                           |
+| `[text](mailto:…)` and other URL schemes | passed through                                                                                           |
+| `[text](#anchor)`                        | `#anchor` must match a heading slug in the document                                                      |
+| `[text](./other.md)`                     | `./other.md` must exist relative to the document                                                         |
+| `[text](/abs/leaf.md)`                   | resolved under `src_dir` (or the document's directory)                                                   |
+| `[text](./other.md#section)`             | file existence is checked; the anchor is flagged with a warning until cross-file anchor resolution lands |
+| `![alt](./image.png)`                    | same resolution as inline links                                                                          |
+
+## Limitations (tracked follow-ups)
+
+- Reference-link / shortcut-link forms (`[ok][ref]` plus `[ref]: …`) are
+  not yet expanded by the parser, so the checker can't see them. A
+  future parser change that emits `Link` nodes for resolved references
+  will surface here automatically.
+- Cross-file anchor validation is intentionally deferred — it requires
+  parsing the other document and slugifying its headings, which doubles
+  the I/O fan-out. The warning lets the user know the file half passed
+  while keeping that work out of the per-keystroke LSP hot path.
+- HTTP link checking is not implemented. A `http-check` feature flag
+  with a deterministic, opt-in head-check pool is on the roadmap.

--- a/crates/ox_content_link_checker/src/lib.rs
+++ b/crates/ox_content_link_checker/src/lib.rs
@@ -1,0 +1,412 @@
+//! Dead link checker for Ox Content Markdown.
+//!
+//! Resolves every `Link` / `Image` / link reference definition emitted
+//! by the parser against the filesystem and against the document's own
+//! heading slugs. The checker is intentionally **offline-only**:
+//! external HTTP links pass through with no network call so the same
+//! binary is safe to run in CI without timeouts, retries, or rate
+//! limits, and produces deterministic output across runs. A future
+//! `http-check` feature flag can layer network checks on top without
+//! changing this contract.
+//!
+//! ```
+//! use ox_content_link_checker::{check_source, CheckOptions};
+//! use std::path::PathBuf;
+//!
+//! let source = "[broken](missing.md)\n";
+//! let opts = CheckOptions::for_file(PathBuf::from("/tmp/doc.md"));
+//! let diagnostics = check_source(source, &opts);
+//! assert_eq!(diagnostics.len(), 1);
+//! ```
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use ox_content_allocator::Allocator;
+use ox_content_ast::{Document, Node, Span};
+use ox_content_parser::{Parser, ParserOptions};
+use serde::Serialize;
+
+/// Kind of link target that resolution can produce.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LinkKind {
+    /// `[text](./foo.md)` or `<img src="foo.png">`.
+    File,
+    /// `[text](#anchor)`.
+    Anchor,
+    /// `[text](./foo.md#anchor)`.
+    FileAnchor,
+    /// `[text](https://...)` — passed through, never asserted unless
+    /// HTTP checking is enabled (currently always disabled).
+    External,
+    /// `[text](mailto:a@b.example)` etc.
+    Scheme,
+    /// Could not be parsed (e.g. malformed `mailto:` payload).
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Error,
+    Warning,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub message: String,
+    pub line: u32,
+    pub column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+    pub kind: LinkKind,
+    /// The raw URL or reference identifier as written in the source.
+    pub target: String,
+}
+
+/// Inputs that change link resolution outcomes. Constructed by the
+/// caller (CLI / LSP) before each `check_source` call.
+#[derive(Debug, Clone)]
+pub struct CheckOptions {
+    /// Absolute path of the file being checked. Used to resolve
+    /// relative paths and to skip self-anchor warnings.
+    pub file_path: PathBuf,
+    /// Treated as the root of paths that start with `/`. Defaults to
+    /// the file's directory when `None`.
+    pub src_dir: Option<PathBuf>,
+    /// Patterns whose match short-circuits diagnostics. Each entry is
+    /// matched against the raw target string via plain `contains`; this
+    /// is intentionally simple — the LSP/CLI surface can layer
+    /// glob/regex on top without changing the checker.
+    pub ignore_patterns: Vec<String>,
+}
+
+impl CheckOptions {
+    pub fn for_file(file_path: PathBuf) -> Self {
+        Self { file_path, src_dir: None, ignore_patterns: Vec::new() }
+    }
+}
+
+/// Run the checker over a Markdown source string and return the
+/// (possibly empty) list of diagnostics.
+#[must_use]
+pub fn check_source(source: &str, options: &CheckOptions) -> Vec<Diagnostic> {
+    let allocator = Allocator::for_source_len(source.len());
+    let parser = Parser::with_options(&allocator, source, ParserOptions::gfm());
+    let Ok(document) = parser.parse() else {
+        return Vec::new();
+    };
+
+    let line_index = LineIndex::new(source);
+    let anchors = collect_anchors(source, &document);
+    let base_dir = options.file_path.parent().map(Path::to_path_buf);
+
+    let mut walker = Walker {
+        diagnostics: Vec::new(),
+        line_index: &line_index,
+        anchors: &anchors,
+        base_dir: base_dir.as_deref(),
+        src_dir: options.src_dir.as_deref(),
+        ignore_patterns: &options.ignore_patterns,
+    };
+    walker.walk(&document.children);
+    walker.diagnostics
+}
+
+struct Walker<'src, 'opts> {
+    diagnostics: Vec<Diagnostic>,
+    line_index: &'src LineIndex,
+    anchors: &'src HashSet<String>,
+    base_dir: Option<&'opts Path>,
+    src_dir: Option<&'opts Path>,
+    ignore_patterns: &'opts [String],
+}
+
+impl<'src> Walker<'src, '_> {
+    fn walk(&mut self, nodes: &[Node<'src>]) {
+        for node in nodes {
+            match node {
+                Node::Link(link) => {
+                    self.check_target(link.url, link.span, false);
+                    self.walk(&link.children);
+                }
+                Node::Image(image) => {
+                    self.check_target(image.url, image.span, true);
+                }
+                Node::Paragraph(p) => self.walk(&p.children),
+                Node::Heading(h) => self.walk(&h.children),
+                Node::BlockQuote(b) => self.walk(&b.children),
+                Node::List(list) => {
+                    for item in &list.children {
+                        self.walk(&item.children);
+                    }
+                }
+                Node::Emphasis(e) => self.walk(&e.children),
+                Node::Strong(s) => self.walk(&s.children),
+                Node::Delete(d) => self.walk(&d.children),
+                Node::Table(table) => {
+                    for row in &table.children {
+                        for cell in &row.children {
+                            self.walk(&cell.children);
+                        }
+                    }
+                }
+                Node::FootnoteDefinition(f) => self.walk(&f.children),
+                _ => {}
+            }
+        }
+    }
+
+    fn check_target(&mut self, url: &str, span: Span, is_image: bool) {
+        if url.is_empty() {
+            return;
+        }
+        if self.ignore_patterns.iter().any(|pat| url.contains(pat)) {
+            return;
+        }
+
+        let target = url.to_string();
+        match classify(&target) {
+            LinkKind::External | LinkKind::Scheme => {}
+            LinkKind::Anchor => {
+                let anchor = anchor_of(&target).unwrap_or_default();
+                if !self.anchors.contains(anchor) {
+                    self.push(
+                        span,
+                        LinkKind::Anchor,
+                        target.clone(),
+                        format!("Anchor `#{anchor}` is not defined in this document."),
+                        Severity::Error,
+                    );
+                }
+            }
+            LinkKind::File | LinkKind::FileAnchor => {
+                self.check_file_target(&target, span, is_image);
+            }
+            LinkKind::Unknown => {
+                self.push(
+                    span,
+                    LinkKind::Unknown,
+                    target.clone(),
+                    format!("Could not classify link target `{target}`."),
+                    Severity::Warning,
+                );
+            }
+        }
+    }
+
+    fn check_file_target(&mut self, target: &str, span: Span, is_image: bool) {
+        let (file_part, anchor_part) = split_anchor(target);
+        let Some(resolved) = self.resolve_file(file_part) else {
+            self.push(
+                span,
+                LinkKind::File,
+                target.to_string(),
+                format!("Could not resolve `{file_part}` (no base directory available)."),
+                Severity::Error,
+            );
+            return;
+        };
+
+        if !resolved.exists() {
+            let label = if is_image { "image" } else { "link" };
+            self.push(
+                span,
+                if anchor_part.is_some() { LinkKind::FileAnchor } else { LinkKind::File },
+                target.to_string(),
+                format!(
+                    "Broken {label} target: `{file_part}` does not exist (resolved to {}).",
+                    resolved.display()
+                ),
+                Severity::Error,
+            );
+            return;
+        }
+
+        if let Some(anchor) = anchor_part {
+            // Cross-file anchor validation requires parsing the other
+            // document. Defer it to a follow-up so this PR stays
+            // local-only; we emit an informational note instead.
+            if !anchor.is_empty() {
+                self.push(
+                    span,
+                    LinkKind::FileAnchor,
+                    target.to_string(),
+                    format!(
+                        "Cross-file anchor `#{anchor}` is not validated yet \
+                        (file exists, anchor unchecked)."
+                    ),
+                    Severity::Warning,
+                );
+            }
+        }
+    }
+
+    fn resolve_file(&self, raw: &str) -> Option<PathBuf> {
+        let path = Path::new(raw);
+        if path.is_absolute() {
+            // POSIX absolute path inside a Markdown document is a
+            // workspace-rooted reference, not a host-absolute one.
+            // Strip the leading slash and join under src_dir / base_dir.
+            let stripped = raw.trim_start_matches('/');
+            let base = self.src_dir.or(self.base_dir)?;
+            return Some(base.join(stripped));
+        }
+        self.base_dir.map(|base| base.join(raw))
+    }
+
+    fn push(
+        &mut self,
+        span: Span,
+        kind: LinkKind,
+        target: String,
+        message: String,
+        severity: Severity,
+    ) {
+        let (line, column) = self.line_index.position(span.start as usize);
+        let (end_line, end_column) = self.line_index.position(span.end as usize);
+        self.diagnostics.push(Diagnostic {
+            severity,
+            message,
+            line,
+            column,
+            end_line,
+            end_column,
+            kind,
+            target,
+        });
+    }
+}
+
+fn classify(target: &str) -> LinkKind {
+    if target.starts_with('#') {
+        return LinkKind::Anchor;
+    }
+    if let Some(scheme_end) = target.find(':') {
+        let scheme = &target[..scheme_end];
+        if is_url_scheme(scheme) {
+            return if matches!(scheme, "http" | "https") {
+                LinkKind::External
+            } else {
+                LinkKind::Scheme
+            };
+        }
+    }
+    if target.contains('#') {
+        LinkKind::FileAnchor
+    } else {
+        LinkKind::File
+    }
+}
+
+fn is_url_scheme(scheme: &str) -> bool {
+    if scheme.is_empty() {
+        return false;
+    }
+    let mut chars = scheme.chars();
+    let Some(first) = chars.next() else { return false };
+    if !first.is_ascii_alphabetic() {
+        return false;
+    }
+    chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '+' | '-' | '.'))
+}
+
+fn split_anchor(target: &str) -> (&str, Option<&str>) {
+    target.split_once('#').map_or((target, None), |(file, anchor)| (file, Some(anchor)))
+}
+
+fn anchor_of(target: &str) -> Option<&str> {
+    target.strip_prefix('#')
+}
+
+fn collect_anchors<'src>(source: &str, document: &'src Document<'src>) -> HashSet<String> {
+    let mut anchors = HashSet::new();
+    collect_anchors_into(source, &document.children, &mut anchors);
+    anchors
+}
+
+fn collect_anchors_into<'src>(source: &str, nodes: &'src [Node<'src>], out: &mut HashSet<String>) {
+    for node in nodes {
+        if let Node::Heading(heading) = node {
+            let text = inline_text(source, &heading.children);
+            out.insert(slugify(&text));
+        }
+    }
+}
+
+fn inline_text(source: &str, nodes: &[Node<'_>]) -> String {
+    let mut buf = String::new();
+    flatten(source, nodes, &mut buf);
+    buf
+}
+
+fn flatten(source: &str, nodes: &[Node<'_>], buf: &mut String) {
+    for node in nodes {
+        match node {
+            Node::Text(t) => buf.push_str(t.value),
+            Node::InlineCode(c) => buf.push_str(c.value),
+            Node::Emphasis(e) => flatten(source, &e.children, buf),
+            Node::Strong(s) => flatten(source, &s.children, buf),
+            Node::Delete(d) => flatten(source, &d.children, buf),
+            Node::Link(l) => flatten(source, &l.children, buf),
+            _ => {
+                let span = node.span();
+                let text = &source[span.start as usize..span.end as usize];
+                buf.push_str(text);
+            }
+        }
+    }
+}
+
+/// GitHub-style heading slug. Lowercase, strip everything that is not
+/// `[a-z0-9 -]`, collapse spaces into `-`. Matches the slug rules
+/// `ox_content_renderer` uses, so anchors emitted by the renderer for a
+/// given heading round-trip through the checker.
+fn slugify(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.extend(ch.to_lowercase());
+        } else if ch == ' ' || ch == '-' || ch == '_' {
+            out.push('-');
+        }
+        // Drop everything else (punctuation, emoji, etc.).
+    }
+    while out.contains("--") {
+        out = out.replace("--", "-");
+    }
+    out.trim_matches('-').to_string()
+}
+
+struct LineIndex {
+    line_starts: Vec<usize>,
+}
+
+impl LineIndex {
+    fn new(source: &str) -> Self {
+        let mut line_starts = vec![0];
+        for (idx, byte) in source.bytes().enumerate() {
+            if byte == b'\n' {
+                line_starts.push(idx + 1);
+            }
+        }
+        Self { line_starts }
+    }
+
+    fn position(&self, offset: usize) -> (u32, u32) {
+        match self.line_starts.binary_search(&offset) {
+            Ok(idx) => (idx as u32 + 1, 1),
+            Err(idx) => {
+                let line = idx as u32; // idx is the first start *after* offset
+                let line_start = self.line_starts[idx - 1];
+                let column = (offset - line_start) as u32 + 1;
+                (line, column)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/ox_content_link_checker/src/main.rs
+++ b/crates/ox_content_link_checker/src/main.rs
@@ -1,0 +1,138 @@
+//! `ox-content-link-check` — CLI front-end for `ox_content_link_checker`.
+//!
+//! Exit codes:
+//!
+//! * `0` — every checked file was free of error-severity diagnostics.
+//! * `1` — at least one error diagnostic was emitted, or a file failed
+//!   to read.
+//!
+//! Warning-severity diagnostics (e.g. unverifiable cross-file anchors)
+//! never fail the run on their own; they appear in the output and are
+//! counted in the trailing summary so CI can keep the job green while
+//! still surfacing the noise.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::{Parser, ValueEnum};
+use ox_content_link_checker::{check_source, CheckOptions, Diagnostic, Severity};
+
+#[derive(Parser)]
+#[command(
+    name = "ox-content-link-check",
+    about = "Check Markdown links and assets for missing local targets"
+)]
+struct Cli {
+    /// Files to check. Pass one or more `.md` / `.mdc` paths.
+    #[arg(required = true)]
+    files: Vec<PathBuf>,
+
+    /// Treat paths starting with `/` as relative to this directory.
+    /// Defaults to each file's parent directory.
+    #[arg(long)]
+    src_dir: Option<PathBuf>,
+
+    /// Substring patterns that suppress diagnostics whose target
+    /// contains the pattern. Repeatable. Plain `contains` match — the
+    /// linker is intentionally simple; layer regex/glob filtering in
+    /// front when you need it.
+    #[arg(long = "ignore", value_name = "PATTERN")]
+    ignore: Vec<String>,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = Format::Text)]
+    format: Format,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum Format {
+    Text,
+    Json,
+}
+
+#[derive(serde::Serialize)]
+struct FileReport {
+    file: String,
+    diagnostics: Vec<Diagnostic>,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    let mut reports = Vec::with_capacity(cli.files.len());
+    let mut error_count = 0usize;
+    let mut io_error_count = 0usize;
+
+    for file in &cli.files {
+        let display = file.to_string_lossy().into_owned();
+        let source = match fs::read_to_string(file) {
+            Ok(text) => text,
+            Err(error) => {
+                io_error_count += 1;
+                reports.push(FileReport {
+                    file: display,
+                    diagnostics: vec![Diagnostic {
+                        severity: Severity::Error,
+                        message: format!("Failed to read file: {error}"),
+                        line: 1,
+                        column: 1,
+                        end_line: 1,
+                        end_column: 1,
+                        kind: ox_content_link_checker::LinkKind::Unknown,
+                        target: String::new(),
+                    }],
+                });
+                continue;
+            }
+        };
+
+        let opts = CheckOptions {
+            file_path: file.clone(),
+            src_dir: cli.src_dir.clone(),
+            ignore_patterns: cli.ignore.clone(),
+        };
+        let diagnostics = check_source(&source, &opts);
+        error_count += diagnostics.iter().filter(|d| d.severity == Severity::Error).count();
+        reports.push(FileReport { file: display, diagnostics });
+    }
+
+    match cli.format {
+        Format::Json => emit_json(&reports),
+        Format::Text => emit_text(&reports),
+    }
+
+    if error_count + io_error_count > 0 {
+        ExitCode::from(1)
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+#[allow(clippy::print_stdout)]
+fn emit_json(reports: &[FileReport]) {
+    let json = serde_json::to_string_pretty(reports).unwrap_or_else(|_| "[]".into());
+    println!("{json}");
+}
+
+#[allow(clippy::print_stdout)]
+fn emit_text(reports: &[FileReport]) {
+    for report in reports {
+        for diagnostic in &report.diagnostics {
+            println!(
+                "{}:{}:{}: {} {}",
+                report.file,
+                diagnostic.line,
+                diagnostic.column,
+                severity_tag(diagnostic.severity),
+                diagnostic.message,
+            );
+        }
+    }
+}
+
+fn severity_tag(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => "error:",
+        Severity::Warning => "warning:",
+    }
+}

--- a/crates/ox_content_link_checker/src/tests.rs
+++ b/crates/ox_content_link_checker/src/tests.rs
@@ -1,0 +1,136 @@
+use std::fs;
+use std::path::PathBuf;
+
+use super::*;
+
+fn run(source: &str, file_path: PathBuf) -> Vec<Diagnostic> {
+    check_source(source, &CheckOptions::for_file(file_path))
+}
+
+fn tmp_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("ox-content-link-checker-{name}"));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+#[test]
+fn external_links_are_never_reported() {
+    let diagnostics = run(
+        "[home](https://example.com) and [http](http://example.com)\n",
+        PathBuf::from("/tmp/doc.md"),
+    );
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn mailto_and_other_schemes_pass_through() {
+    let diagnostics =
+        run("[email](mailto:dev@example.com) [tel](tel:+1)\n", PathBuf::from("/tmp/doc.md"));
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn self_anchor_is_validated_against_headings() {
+    let source = concat!(
+        "# Top Heading\n",
+        "\n",
+        "## Has Sub-Headings!\n",
+        "\n",
+        "[good](#top-heading)\n",
+        "[bad](#nope)\n",
+        "[punctuated](#has-sub-headings)\n",
+    );
+    let diagnostics = run(source, PathBuf::from("/tmp/doc.md"));
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+    assert_eq!(diagnostics[0].target, "#nope");
+    assert_eq!(diagnostics[0].kind, LinkKind::Anchor);
+}
+
+#[test]
+fn missing_relative_file_is_reported_with_resolved_path() {
+    let dir = tmp_dir("missing-rel");
+    let doc = dir.join("doc.md");
+    let diagnostics = run("[lost](./missing.md)\n", doc);
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+    assert!(diagnostics[0].message.contains("missing.md"), "{}", diagnostics[0].message);
+    assert_eq!(diagnostics[0].kind, LinkKind::File);
+}
+
+#[test]
+fn existing_relative_file_is_silent() {
+    let dir = tmp_dir("existing-rel");
+    fs::write(dir.join("sibling.md"), "ok").unwrap();
+    let diagnostics = run("[ok](./sibling.md)\n", dir.join("doc.md"));
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn absolute_paths_resolve_under_src_dir_when_configured() {
+    let dir = tmp_dir("src-dir-abs");
+    fs::create_dir_all(dir.join("nested")).unwrap();
+    fs::write(dir.join("nested/leaf.md"), "ok").unwrap();
+
+    let opts = CheckOptions {
+        file_path: dir.join("docs/doc.md"),
+        src_dir: Some(dir.clone()),
+        ignore_patterns: Vec::new(),
+    };
+    let diagnostics = check_source("[abs](/nested/leaf.md) [miss](/nope.md)\n", &opts);
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+    assert_eq!(diagnostics[0].target, "/nope.md");
+}
+
+#[test]
+fn cross_file_anchor_emits_warning_until_followup_lands() {
+    let dir = tmp_dir("cross-file-anchor");
+    fs::write(dir.join("other.md"), "# other\n").unwrap();
+    let diagnostics = run("[hop](./other.md#section)\n", dir.join("doc.md"));
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+    assert_eq!(diagnostics[0].severity, Severity::Warning);
+    assert!(diagnostics[0].message.contains("not validated yet"), "{}", diagnostics[0].message);
+}
+
+#[test]
+fn reference_links_are_skipped_for_now() {
+    // The parser doesn't currently expand reference links into Link
+    // nodes — they survive as plain Text. The checker therefore can't
+    // see them. Document the current behavior so a future parser
+    // change that does expand them lights up this test as a TODO.
+    let dir = tmp_dir("ref-link");
+    fs::write(dir.join("target.md"), "ok").unwrap();
+    let source = concat!("[ok][ref]\n", "\n", "[ref]: ./target.md\n");
+    let diagnostics = run(source, dir.join("doc.md"));
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn ignore_patterns_suppress_diagnostics() {
+    let opts = CheckOptions {
+        file_path: PathBuf::from("/tmp/doc.md"),
+        src_dir: None,
+        ignore_patterns: vec!["intentionally-broken".into()],
+    };
+    let diagnostics =
+        check_source("[skipped](./intentionally-broken-link.md) [reported](./other.md)\n", &opts);
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+    assert!(diagnostics[0].target.contains("other.md"));
+}
+
+#[test]
+fn image_target_is_resolved_like_links() {
+    let dir = tmp_dir("image");
+    let diagnostics = run("![alt](./missing.png)\n", dir.join("doc.md"));
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+    assert!(diagnostics[0].message.contains("image"), "{}", diagnostics[0].message);
+}
+
+#[test]
+fn line_index_points_at_the_link_start() {
+    let dir = tmp_dir("line-index");
+    let source = "line one\nline two has [broken](./nope.md) target\n";
+    let diagnostics = run(source, dir.join("doc.md"));
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+    assert_eq!(diagnostics[0].line, 2);
+    assert!(diagnostics[0].column > 1);
+}

--- a/crates/ox_content_lsp/Cargo.toml
+++ b/crates/ox_content_lsp/Cargo.toml
@@ -24,6 +24,7 @@ ox_content_ast = { workspace = true }
 ox_content_i18n = { workspace = true }
 ox_content_i18n_checker = { workspace = true }
 ox_content_mdc_checker = { workspace = true }
+ox_content_link_checker = { workspace = true }
 ox_content_parser = { workspace = true }
 ox_content_renderer = { workspace = true }
 oxc_span = { workspace = true }

--- a/crates/ox_content_lsp/src/backend.rs
+++ b/crates/ox_content_lsp/src/backend.rs
@@ -76,11 +76,16 @@ impl Backend {
             .ok()
             .and_then(|path| path.extension().and_then(|ext| ext.to_str()).map(str::to_string))
             .is_some_and(|ext| ext == "mdc");
-        let diagnostics = self.diagnostics(&document, is_mdc).await;
+        let diagnostics = self.diagnostics(uri, &document, is_mdc).await;
         self.client.publish_diagnostics(uri.clone(), diagnostics, None).await;
     }
 
-    async fn diagnostics(&self, document: &TextDocumentState, is_mdc: bool) -> Vec<Diagnostic> {
+    async fn diagnostics(
+        &self,
+        uri: &Url,
+        document: &TextDocumentState,
+        is_mdc: bool,
+    ) -> Vec<Diagnostic> {
         let config = self.resolved_config().await;
         let frontmatter = frontmatter::parse_frontmatter(document);
         let mut diagnostics = frontmatter
@@ -92,6 +97,16 @@ impl Backend {
         if is_mdc {
             diagnostics.extend(diagnostics::mdc_diagnostics(document, frontmatter.block.as_ref()));
         }
+        // Link checker runs on every Markdown/MDC document. It only
+        // consults the local filesystem, so it stays cheap enough to
+        // run on every keystroke. The optional workspace root is used
+        // as the absolute-path resolution base; without it `/foo.md`
+        // links are anchored to the document's own directory.
+        diagnostics.extend(diagnostics::link_check_diagnostics(
+            document,
+            uri,
+            self.state.root().await,
+        ));
         diagnostics
     }
 

--- a/crates/ox_content_lsp/src/backend/diagnostics.rs
+++ b/crates/ox_content_lsp/src/backend/diagnostics.rs
@@ -1,6 +1,9 @@
+use std::path::PathBuf;
+
 use ox_content_allocator::Allocator;
+use ox_content_link_checker::{check_source as link_check_source, CheckOptions, Severity};
 use ox_content_parser::{ParseError, Parser, ParserOptions};
-use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Url};
 
 use crate::document::TextDocumentState;
 use crate::frontmatter::FrontmatterBlock;
@@ -65,6 +68,40 @@ pub(super) fn mdc_diagnostics(
                 message: diagnostic.message,
                 ..Default::default()
             }
+        })
+        .collect()
+}
+
+pub(super) fn link_check_diagnostics(
+    document: &TextDocumentState,
+    uri: &Url,
+    src_dir: Option<PathBuf>,
+) -> Vec<Diagnostic> {
+    let Some(file_path) = uri.to_file_path().ok() else {
+        return Vec::new();
+    };
+
+    let options = CheckOptions { file_path, src_dir, ignore_patterns: Vec::new() };
+    link_check_source(document.text(), &options)
+        .into_iter()
+        .map(|diagnostic| Diagnostic {
+            range: tower_lsp::lsp_types::Range {
+                start: tower_lsp::lsp_types::Position {
+                    line: diagnostic.line.saturating_sub(1),
+                    character: diagnostic.column.saturating_sub(1),
+                },
+                end: tower_lsp::lsp_types::Position {
+                    line: diagnostic.end_line.saturating_sub(1),
+                    character: diagnostic.end_column.saturating_sub(1),
+                },
+            },
+            severity: Some(match diagnostic.severity {
+                Severity::Error => DiagnosticSeverity::ERROR,
+                Severity::Warning => DiagnosticSeverity::WARNING,
+            }),
+            source: Some("ox-content-link".to_string()),
+            message: diagnostic.message,
+            ..Default::default()
         })
         .collect()
 }

--- a/docs/content/editor-extension-roadmap.md
+++ b/docs/content/editor-extension-roadmap.md
@@ -38,7 +38,7 @@ must not depend on a later one in the list.
 | 3   | MDC completion + type check                     | diagnostics only          | `ox-content-mdc-check`       | diagnostics               | diagnostics                 | needs completion   |
 | 4   | Vue / React props completion + jump + typecheck | none                      | none                         | none                      | none                        | new (corsa_client) |
 | 5   | Asset path completion + diagnostics             | completion provider       | via link checker             | completion + diagnostics  | completion + diagnostics    | shipped            |
-| 6   | Dead link checker                               | none                      | none                         | none                      | none                        | new                |
+| 6   | Dead link checker                               | diagnostics               | `ox-content-link-check`      | diagnostics               | diagnostics                 | local: shipped     |
 | 7   | textlint integration                            | none                      | none                         | none                      | none                        | new                |
 | 8   | Frontmatter schema completion + diagnostics     | present                   | none (validated through LSP) | present                   | present                     | needs CLI          |
 
@@ -85,14 +85,20 @@ Replace the polling refresh path with an explicit push channel.
 
 ### 3. `feat(link-checker): new crate, LSP integration, CLI`
 
-- New crate `ox_content_link_checker` with deterministic local link
-  resolution (relative paths, anchors, link reference definitions) and an
-  optional async HTTP head-check pool guarded behind a feature flag
-  (`http-check`) so the default build is offline-only.
-- LSP diagnostics namespaced under `oxContent.linkCheck`. Configuration:
-  `oxContent.linkCheck.followHttp`, `oxContent.linkCheck.ignorePatterns`.
-- CLI `ox-content-link-check [paths…] [--http] [--format text|json]`.
-- A GitHub Actions snippet pasted into the docs site.
+- ✅ New crate `ox_content_link_checker` with deterministic local link
+  resolution (relative paths, self-anchors, image targets). Offline-only
+  by design; ships with 11 unit tests covering every link form documented
+  in the crate README.
+- ✅ CLI `ox-content-link-check [paths…] [--src-dir DIR] [--ignore PATTERN]
+[--format text|json]` with exit-code-1-on-error semantics for CI.
+- ✅ LSP diagnostics under `source: "ox-content-link"`, wired into the
+  per-document diagnostic publish path so they appear alongside parse,
+  frontmatter, and MDC errors without an extra round trip.
+- Pending follow-ups:
+  - HTTP head-check pool behind a `http-check` feature flag.
+  - Reference-link expansion (currently blocked on the parser).
+  - Cross-file anchor resolution (currently emits a warning).
+  - GitHub Actions snippet on the docs site.
 
 ### 4. `feat(lsp): asset path completion and diagnostics`
 


### PR DESCRIPTION
Roadmap step 3 (see [editor extension roadmap](https://github.com/ubugeeei/ox-content/blob/main/docs/content/editor-extension-roadmap.md#3-featlink-checker-new-crate-lsp-integration-cli)).

Adds offline-only dead link checking. The same logic runs as LSP diagnostics on every keystroke and as a CI-friendly CLI binary.

## What ships

### `crates/ox_content_link_checker` (new crate)

Walks the parsed AST and classifies link / image targets into:

| Form | Behavior |
| --- | --- |
| `https://…`, `http://…` | passed through, never asserted (offline-only) |
| `mailto:…`, other URL schemes | passed through |
| `#anchor` | must match a heading slug in the document |
| `./other.md` | must exist relative to the document |
| `/abs/leaf.md` | resolved under configurable `src_dir` (or the document's directory) |
| `./other.md#section` | file existence checked; anchor is a warning until cross-file anchor resolution lands |
| `![alt](./image.png)` | same resolution as inline links |

Heading slug rules match the HTML renderer (lowercase, strip non-`[a-z0-9 -]`, collapse spaces). 11 unit tests pin every behavior.

External and scheme links are **never** opened — the same binary is safe in CI without timeouts, retries, or rate limits, and produces deterministic output across runs. HTTP head-check support is on the roadmap behind a `http-check` feature flag.

### `ox-content-link-check` (new CLI binary)

```bash
ox-content-link-check docs/**/*.md
ox-content-link-check --src-dir docs --format json docs/index.md
ox-content-link-check --ignore "intentionally-broken" docs/**/*.md
```

Exit code is `1` on any error diagnostic or read failure, `0` otherwise. Warning diagnostics never fail the run on their own; they appear in the output.

### `ox_content_lsp` integration

`link_check_diagnostics` joins the per-document diagnostic publish path under `source: "ox-content-link"`, alongside parse, frontmatter, and MDC errors. No extra round trip — the diagnostics flow through the existing `publish_diagnostics_for` channel. Workspace root flows in as the `src_dir`.

## Known gaps (called out in the crate README + roadmap)

- Reference-link / shortcut-link forms (`[ok][ref]` plus `[ref]: …`) are unhandled — the parser currently emits them as plain text. A future parser change that lifts them into `Link` nodes will surface here automatically.
- Cross-file anchor validation is intentionally deferred. We check the file half and emit a warning for the anchor; doing the full check requires parsing the other document on every keystroke, which we'd rather measure first.
- HTTP head-check is out of scope. The crate is structured so a `http-check` feature flag can layer it on without changing the offline-only contract.

## Verification

```
cargo test -p ox_content_link_checker         ✓  11 lib tests + 1 doctest
cargo clippy --workspace --all-targets        ✓  -D warnings clean
vp run check                                   ✓
ox-content-link-check /tmp/link-ok.md          ✓  exit=1 with one diagnostic
ox-content-link-check --format json …          ✓  JSON output validated
```

## Docs

- New [`crates/ox_content_link_checker/README.md`](https://github.com/ubugeeei/ox-content/blob/feat/link-checker/crates/ox_content_link_checker/README.md) — library + CLI usage, what's checked, what's not.
- Top-level [`README.md`](https://github.com/ubugeeei/ox-content/blob/feat/link-checker/README.md#dead-link-checker-cli) gets a "Dead Link Checker (CLI)" section.
- [`docs/content/editor-extension-roadmap.md`](https://github.com/ubugeeei/ox-content/blob/feat/link-checker/docs/content/editor-extension-roadmap.md#3-featlink-checker-new-crate-lsp-integration-cli) marks the local checker shipped, lists the deferred follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)