### PR TITLE
feat(lsp): asset path completion inside link/image openers

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Supported features include:
 - table / code fence / callout insertion commands
 - preview HTML generation for editor UIs
 - `.mdc` authoring support with component tag diagnostics
+- asset path completion inside `[…](`, `![…](`, and HTML `src=`/`href=` attributes
 
 For CI or editor-independent checks, run:
 

--- a/crates/ox_content_lsp/src/backend.rs
+++ b/crates/ox_content_lsp/src/backend.rs
@@ -1,3 +1,4 @@
+mod assets;
 mod commands;
 mod diagnostics;
 mod features;

--- a/crates/ox_content_lsp/src/backend/assets.rs
+++ b/crates/ox_content_lsp/src/backend/assets.rs
@@ -1,0 +1,265 @@
+//! Asset and link path completion for Markdown.
+//!
+//! Triggered when the cursor sits inside the `()` of a Markdown link
+//! (`[text](`), image (`![alt](`), or a raw HTML `src=`/`href=`
+//! attribute. The completion is a list of filesystem entries — files
+//! and directories — that live under the partial path written so far,
+//! anchored to the document's own directory (or the workspace `src_dir`
+//! when the partial path starts with `/`).
+//!
+//! Image-context triggers (`!` opener or HTML `<img src=`) narrow the
+//! file list to known asset extensions. Plain link contexts return
+//! every entry so the user can link to Markdown, JSON, etc.
+//!
+//! The detection is intentionally textual rather than AST-based: an
+//! `![alt](./foo` line is still mid-edit when the user is asking for
+//! completion, so the parser would refuse it.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind};
+
+const IMAGE_EXTENSIONS: &[&str] =
+    &["png", "jpg", "jpeg", "gif", "webp", "svg", "avif", "ico", "bmp", "tiff"];
+
+const VIDEO_EXTENSIONS: &[&str] = &["mp4", "webm", "ogv", "mov"];
+
+const AUDIO_EXTENSIONS: &[&str] = &["mp3", "ogg", "wav", "flac"];
+
+/// Context the trigger detector returned. `None` means the cursor is
+/// not inside a link/image opener and completion should fall through.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssetContext {
+    /// Cursor is inside the `()` of an image link (`![…](…|)`) or a
+    /// raw HTML `<img src="…|">`. We narrow to media extensions.
+    Image,
+    /// Cursor is inside the `()` of a plain link or an HTML `href=`.
+    /// Every file (and directory) qualifies.
+    Link,
+}
+
+/// Try to extract the asset context the cursor sits inside, given the
+/// portion of the line *before* the cursor. Returns the context plus
+/// the partial path already typed (used to choose the directory to
+/// list and the prefix to filter by).
+#[must_use]
+pub fn detect_context(line_prefix: &str) -> Option<(AssetContext, &str)> {
+    if let Some((context, partial)) = detect_markdown_opener(line_prefix) {
+        return Some((context, partial));
+    }
+    detect_html_attribute(line_prefix)
+}
+
+fn detect_markdown_opener(line_prefix: &str) -> Option<(AssetContext, &str)> {
+    // Walk backwards from the cursor and find the last unmatched `(`
+    // that is immediately preceded by `]`. Anything past it is the
+    // partial path being typed.
+    let bytes = line_prefix.as_bytes();
+    let mut depth: i32 = 0;
+    let mut i = bytes.len();
+    while i > 0 {
+        i -= 1;
+        match bytes[i] {
+            b')' => depth += 1,
+            b'(' if depth == 0 => {
+                if i == 0 || bytes[i - 1] != b']' {
+                    return None;
+                }
+                let partial = &line_prefix[i + 1..];
+                // Reject if the partial already contains a space (URLs
+                // can't have unescaped spaces in `()`).
+                if partial.contains(' ') {
+                    return None;
+                }
+                // The `]` at `i-1` belongs to `[link text]`. Walk back
+                // to its matching `[` so we can check whether the
+                // construct is a link (`[…]`) or an image (`![…]`).
+                let bracket_start = match_opening_bracket(bytes, i - 1)?;
+                let context = if bracket_start > 0 && bytes[bracket_start - 1] == b'!' {
+                    AssetContext::Image
+                } else {
+                    AssetContext::Link
+                };
+                return Some((context, partial));
+            }
+            b'(' => depth -= 1,
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Walk backwards from a `]` and return the offset of the matching
+/// `[`. Returns `None` when the brackets are unbalanced (in which case
+/// the construct isn't a Markdown link/image and completion should
+/// fall through).
+fn match_opening_bracket(bytes: &[u8], close: usize) -> Option<usize> {
+    debug_assert_eq!(bytes[close], b']');
+    let mut depth: i32 = 0;
+    let mut i = close;
+    while i > 0 {
+        i -= 1;
+        match bytes[i] {
+            b']' => depth += 1,
+            b'[' if depth == 0 => return Some(i),
+            b'[' => depth -= 1,
+            _ => {}
+        }
+    }
+    None
+}
+
+fn detect_html_attribute(line_prefix: &str) -> Option<(AssetContext, &str)> {
+    // Look back for the last `src="` or `href="` (also handles
+    // single-quoted variants). The attribute value must not contain a
+    // closing quote between the opener and the cursor.
+    for opener in ["src=\"", "src='", "href=\"", "href='"] {
+        if let Some(start) = line_prefix.rfind(opener) {
+            let value_start = start + opener.len();
+            let value = &line_prefix[value_start..];
+            let quote = &opener[opener.len() - 1..];
+            if value.contains(quote) {
+                continue;
+            }
+            let context = if opener.starts_with("src") {
+                detect_html_image_context(&line_prefix[..start])
+            } else {
+                AssetContext::Link
+            };
+            return Some((context, value));
+        }
+    }
+    None
+}
+
+fn detect_html_image_context(prefix: &str) -> AssetContext {
+    // The src attribute can appear on <img>, <video>, <audio>, <source>,
+    // <embed>, etc. We assume Image context whenever the nearest open
+    // tag has one of those names — otherwise downgrade to Link.
+    let Some(tag_start) = prefix.rfind('<') else {
+        return AssetContext::Link;
+    };
+    let after_lt = &prefix[tag_start + 1..];
+    let tag_name = after_lt
+        .split(|ch: char| ch.is_ascii_whitespace() || ch == '>' || ch == '/')
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    match tag_name.as_str() {
+        "img" | "video" | "audio" | "source" | "embed" | "iframe" | "picture" => {
+            AssetContext::Image
+        }
+        _ => AssetContext::Link,
+    }
+}
+
+/// Build completion items for the given context and partial path.
+/// `doc_dir` is the document's directory; `src_dir` is the workspace
+/// root used to resolve paths that start with `/`.
+#[must_use]
+pub fn completion_items(
+    context: AssetContext,
+    partial: &str,
+    doc_dir: Option<&Path>,
+    src_dir: Option<&Path>,
+) -> Vec<CompletionItem> {
+    let (base, prefix) = split_partial(partial);
+    let Some(directory) = resolve_directory(base, doc_dir, src_dir) else {
+        return Vec::new();
+    };
+
+    let mut items = Vec::new();
+    let Ok(entries) = fs::read_dir(&directory) else {
+        return items;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') {
+            // Hidden files / dotdirs are noise in editor completion;
+            // skip them to keep the list tight.
+            continue;
+        }
+        if !name.starts_with(prefix) {
+            continue;
+        }
+        let file_type = entry.file_type().ok();
+        let is_dir = file_type.as_ref().is_some_and(std::fs::FileType::is_dir);
+        if !is_dir && !file_matches_context(context, &name) {
+            continue;
+        }
+        items.push(CompletionItem {
+            label: if is_dir { format!("{name}/") } else { name.clone() },
+            kind: Some(if is_dir { CompletionItemKind::FOLDER } else { CompletionItemKind::FILE }),
+            insert_text: Some(if is_dir { format!("{name}/") } else { name.clone() }),
+            detail: Some(detail_for(context, is_dir, &name)),
+            ..Default::default()
+        });
+    }
+    items.sort_by(|a, b| a.label.cmp(&b.label));
+    items
+}
+
+fn split_partial(partial: &str) -> (&str, &str) {
+    partial.rsplit_once('/').map_or(("", partial), |(base, prefix)| (base, prefix))
+}
+
+fn resolve_directory(
+    base: &str,
+    doc_dir: Option<&Path>,
+    src_dir: Option<&Path>,
+) -> Option<PathBuf> {
+    if base.starts_with('/') {
+        let stripped = base.trim_start_matches('/');
+        return src_dir.or(doc_dir).map(|root| root.join(stripped));
+    }
+    let doc = doc_dir?;
+    Some(if base.is_empty() { doc.to_path_buf() } else { doc.join(base) })
+}
+
+fn file_matches_context(context: AssetContext, file_name: &str) -> bool {
+    match context {
+        AssetContext::Link => true,
+        AssetContext::Image => {
+            let Some((_, ext)) = file_name.rsplit_once('.') else {
+                return false;
+            };
+            let lower = ext.to_ascii_lowercase();
+            IMAGE_EXTENSIONS.contains(&lower.as_str())
+                || VIDEO_EXTENSIONS.contains(&lower.as_str())
+                || AUDIO_EXTENSIONS.contains(&lower.as_str())
+        }
+    }
+}
+
+fn detail_for(context: AssetContext, is_dir: bool, name: &str) -> String {
+    if is_dir {
+        return "directory".into();
+    }
+    match context {
+        AssetContext::Image => format!("asset: {name}"),
+        AssetContext::Link => format!("file: {name}"),
+    }
+}
+
+/// Slice the document line up to the cursor column, regardless of UTF-16
+/// vs byte indexing. The caller (`features.rs`) already has the
+/// `TextDocumentState` so this is a thin wrapper to keep the call site
+/// tidy.
+#[must_use]
+pub fn line_prefix(line_text: &str, position_character: u32) -> &str {
+    let mut utf16 = 0usize;
+    for (idx, ch) in line_text.char_indices() {
+        if utf16 == position_character as usize {
+            return &line_text[..idx];
+        }
+        utf16 += ch.len_utf16();
+        if utf16 > position_character as usize {
+            return &line_text[..idx];
+        }
+    }
+    line_text
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/ox_content_lsp/src/backend/assets/tests.rs
+++ b/crates/ox_content_lsp/src/backend/assets/tests.rs
@@ -1,0 +1,217 @@
+use std::fs;
+use std::path::PathBuf;
+
+use super::*;
+
+fn tmp_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("ox-content-assets-{name}"));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+mod detect_context_markdown {
+    use super::*;
+
+    #[test]
+    fn link_opener_returns_link_context_with_empty_partial() {
+        let (ctx, partial) = detect_context("see also [docs](").expect("detected");
+        assert_eq!(ctx, AssetContext::Link);
+        assert_eq!(partial, "");
+    }
+
+    #[test]
+    fn image_opener_returns_image_context() {
+        let (ctx, partial) = detect_context("![alt](./").expect("detected");
+        assert_eq!(ctx, AssetContext::Image);
+        assert_eq!(partial, "./");
+    }
+
+    #[test]
+    fn partial_path_after_directory_separator() {
+        let (ctx, partial) = detect_context("[guide](./docs/get").expect("detected");
+        assert_eq!(ctx, AssetContext::Link);
+        assert_eq!(partial, "./docs/get");
+    }
+
+    #[test]
+    fn space_inside_parens_means_we_are_not_in_a_path() {
+        // `[text](https://… "title goes here")` — once we hit a space
+        // we know the cursor is in the title slot, not the URL.
+        assert!(detect_context("[home](https://example.com \"Title").is_none());
+    }
+
+    #[test]
+    fn lone_open_paren_without_a_link_bracket_is_ignored() {
+        assert!(detect_context("plain (text").is_none());
+    }
+
+    #[test]
+    fn balanced_inner_parens_do_not_break_detection() {
+        // The shortcut `[txt](url-with-(paren))` is rare but should
+        // still detect when we're past the inner balanced pair.
+        let (_, partial) = detect_context("[x](outer(inner)/").expect("detected");
+        assert_eq!(partial, "outer(inner)/");
+    }
+}
+
+mod detect_context_html {
+    use super::*;
+
+    #[test]
+    fn img_src_returns_image_context() {
+        let (ctx, partial) = detect_context(r#"<img src=""#).expect("detected");
+        assert_eq!(ctx, AssetContext::Image);
+        assert_eq!(partial, "");
+    }
+
+    #[test]
+    fn a_href_returns_link_context() {
+        let (ctx, partial) = detect_context(r#"<a href="./doc"#).expect("detected");
+        assert_eq!(ctx, AssetContext::Link);
+        assert_eq!(partial, "./doc");
+    }
+
+    #[test]
+    fn closing_quote_means_we_are_past_the_attribute() {
+        // src="done" — we're now after the value, not inside it.
+        assert!(detect_context(r#"<img src="done""#).is_none());
+    }
+
+    #[test]
+    fn video_src_is_treated_as_image_context() {
+        let (ctx, _) = detect_context(r#"<video src=""#).expect("detected");
+        assert_eq!(ctx, AssetContext::Image);
+    }
+
+    #[test]
+    fn audio_src_is_treated_as_image_context() {
+        let (ctx, _) = detect_context(r#"<audio src=""#).expect("detected");
+        assert_eq!(ctx, AssetContext::Image);
+    }
+
+    #[test]
+    fn unknown_tag_src_falls_back_to_link_context() {
+        // We don't want to over-filter when the user is using a custom
+        // element that happens to have a `src` attribute.
+        let (ctx, _) = detect_context(r#"<my-thing src=""#).expect("detected");
+        assert_eq!(ctx, AssetContext::Link);
+    }
+}
+
+mod completion_items {
+    use super::*;
+
+    fn labels(items: &[CompletionItem]) -> Vec<&str> {
+        items.iter().map(|i| i.label.as_str()).collect()
+    }
+
+    #[test]
+    fn lists_files_and_directories_in_the_document_directory() {
+        let dir = tmp_dir("listdir");
+        fs::write(dir.join("alpha.md"), "").unwrap();
+        fs::write(dir.join("beta.png"), "").unwrap();
+        fs::create_dir(dir.join("subdir")).unwrap();
+
+        let items = completion_items(AssetContext::Link, "", Some(&dir), None);
+        let names = labels(&items);
+        assert!(names.contains(&"alpha.md"), "{names:?}");
+        assert!(names.contains(&"beta.png"), "{names:?}");
+        assert!(names.contains(&"subdir/"), "{names:?}");
+    }
+
+    #[test]
+    fn image_context_filters_to_media_extensions() {
+        let dir = tmp_dir("image-filter");
+        fs::write(dir.join("photo.png"), "").unwrap();
+        fs::write(dir.join("notes.md"), "").unwrap();
+        fs::write(dir.join("clip.mp4"), "").unwrap();
+        fs::write(dir.join("data.json"), "").unwrap();
+
+        let items = completion_items(AssetContext::Image, "", Some(&dir), None);
+        let names = labels(&items);
+        assert!(names.contains(&"photo.png"), "{names:?}");
+        assert!(names.contains(&"clip.mp4"), "{names:?}");
+        assert!(!names.contains(&"notes.md"), "{names:?}");
+        assert!(!names.contains(&"data.json"), "{names:?}");
+    }
+
+    #[test]
+    fn prefix_filters_entries() {
+        let dir = tmp_dir("prefix");
+        fs::write(dir.join("alpha.md"), "").unwrap();
+        fs::write(dir.join("apple.md"), "").unwrap();
+        fs::write(dir.join("beta.md"), "").unwrap();
+
+        let items = completion_items(AssetContext::Link, "a", Some(&dir), None);
+        let names = labels(&items);
+        assert_eq!(names, vec!["alpha.md", "apple.md"]);
+    }
+
+    #[test]
+    fn nested_path_lists_the_named_subdirectory() {
+        let dir = tmp_dir("nested");
+        fs::create_dir(dir.join("assets")).unwrap();
+        fs::write(dir.join("assets/hero.png"), "").unwrap();
+        fs::write(dir.join("assets/footer.png"), "").unwrap();
+
+        let items = completion_items(AssetContext::Image, "assets/", Some(&dir), None);
+        let names = labels(&items);
+        assert!(names.contains(&"hero.png"), "{names:?}");
+        assert!(names.contains(&"footer.png"), "{names:?}");
+    }
+
+    #[test]
+    fn absolute_path_resolves_under_src_dir() {
+        let dir = tmp_dir("abs-src");
+        fs::create_dir(dir.join("assets")).unwrap();
+        fs::write(dir.join("assets/hero.png"), "").unwrap();
+
+        let doc_dir = dir.join("docs");
+        fs::create_dir_all(&doc_dir).unwrap();
+        let items = completion_items(AssetContext::Image, "/assets/", Some(&doc_dir), Some(&dir));
+        let names = labels(&items);
+        assert!(names.contains(&"hero.png"), "{names:?}");
+    }
+
+    #[test]
+    fn hidden_entries_are_skipped() {
+        let dir = tmp_dir("hidden");
+        fs::write(dir.join(".env"), "").unwrap();
+        fs::write(dir.join("visible.md"), "").unwrap();
+
+        let items = completion_items(AssetContext::Link, "", Some(&dir), None);
+        let names = labels(&items);
+        assert!(!names.iter().any(|n| n.starts_with('.')), "{names:?}");
+        assert!(names.contains(&"visible.md"), "{names:?}");
+    }
+
+    #[test]
+    fn nonexistent_directory_returns_empty() {
+        let dir = tmp_dir("missing-base");
+        let items = completion_items(AssetContext::Link, "no-such-dir/", Some(&dir), None);
+        assert!(items.is_empty());
+    }
+}
+
+mod line_prefix {
+    use super::*;
+
+    #[test]
+    fn returns_slice_up_to_utf16_column() {
+        let line = "abc def";
+        assert_eq!(line_prefix(line, 0), "");
+        assert_eq!(line_prefix(line, 3), "abc");
+        assert_eq!(line_prefix(line, 7), "abc def");
+    }
+
+    #[test]
+    fn handles_supplementary_characters_via_utf16_units() {
+        // 𝄞 is U+1D11E, a supplementary character: 2 UTF-16 code units.
+        let line = "a𝄞b";
+        // After "a", the cursor is at character 1.
+        assert_eq!(line_prefix(line, 1), "a");
+        // After "a𝄞", the cursor is at character 3 (1 + 2 surrogates).
+        assert_eq!(line_prefix(line, 3), "a𝄞");
+    }
+}

--- a/crates/ox_content_lsp/src/backend/features.rs
+++ b/crates/ox_content_lsp/src/backend/features.rs
@@ -7,6 +7,7 @@ use crate::frontmatter;
 use crate::i18n;
 use crate::preview;
 
+use super::assets::{completion_items as asset_completion_items, detect_context, line_prefix};
 use super::snippets::markdown_snippet_items;
 use super::Backend;
 
@@ -41,6 +42,22 @@ impl Backend {
         }
 
         let document = self.state.document(uri).await?;
+
+        // Asset / link path completion short-circuits everything else
+        // when the cursor sits inside a Markdown `()` or an HTML
+        // `src=`/`href=`. Mixing it with snippets / frontmatter would
+        // pollute the list — a user typing `![alt](./` does not want
+        // a `## Section` snippet suggestion.
+        let line_text = document.line_text(position.line);
+        let prefix = line_prefix(line_text, position.character);
+        if let Some((context, partial)) = detect_context(prefix) {
+            let doc_dir = path.parent().map(std::path::Path::to_path_buf);
+            let src_dir = self.state.root().await;
+            let items =
+                asset_completion_items(context, partial, doc_dir.as_deref(), src_dir.as_deref());
+            return (!items.is_empty()).then_some(CompletionResponse::Array(items));
+        }
+
         let config = self.resolved_config().await;
         let frontmatter = frontmatter::parse_frontmatter(&document);
         let mut items = frontmatter

--- a/crates/ox_content_lsp/src/backend/handlers.rs
+++ b/crates/ox_content_lsp/src/backend/handlers.rs
@@ -31,6 +31,11 @@ impl LanguageServer for Backend {
                         ">".into(),
                         "|".into(),
                         ":".into(),
+                        // Asset path completion: `(` opens it after
+                        // `[…]`/`![…]`, `/` reopens it after the user
+                        // descends into a subdirectory.
+                        "(".into(),
+                        "/".into(),
                     ]),
                     ..Default::default()
                 }),

--- a/docs/content/editor-extension-roadmap.md
+++ b/docs/content/editor-extension-roadmap.md
@@ -37,7 +37,7 @@ must not depend on a later one in the list.
 | 2   | i18n preview / completion                       | present                   | `ox-content-i18n`            | present                   | present                     | shipped            |
 | 3   | MDC completion + type check                     | diagnostics only          | `ox-content-mdc-check`       | diagnostics               | diagnostics                 | needs completion   |
 | 4   | Vue / React props completion + jump + typecheck | none                      | none                         | none                      | none                        | new (corsa_client) |
-| 5   | Asset path completion + diagnostics             | none                      | none                         | none                      | none                        | new                |
+| 5   | Asset path completion + diagnostics             | completion provider       | via link checker             | completion + diagnostics  | completion + diagnostics    | shipped            |
 | 6   | Dead link checker                               | none                      | none                         | none                      | none                        | new                |
 | 7   | textlint integration                            | none                      | none                         | none                      | none                        | new                |
 | 8   | Frontmatter schema completion + diagnostics     | present                   | none (validated through LSP) | present                   | present                     | needs CLI          |
@@ -96,11 +96,19 @@ Replace the polling refresh path with an explicit push channel.
 
 ### 4. `feat(lsp): asset path completion and diagnostics`
 
-- LSP completion provider triggered on image and link openers
-  (`![…](`, `<img src="`, raw HTML attribute parsers).
-- Diagnostics for missing assets resolved relative to a configurable
-  `oxContent.asset.srcDir` (defaults to the workspace root).
-- CLI surface piggybacks on `ox-content-link-check --assets`.
+- ✅ LSP completion provider triggered on image and link openers
+  (`![…](`, `[…](`, `<img src="`, `<a href="`, also `<video|audio|source|iframe|picture src="`).
+  Image-context triggers narrow the file list to known media
+  extensions; link-context triggers list every file plus directories.
+- ✅ Hidden-file filtering, prefix matching, directory entries
+  rendered as `name/`. UTF-16 cursor handling for international
+  characters (covered by `line_prefix` tests).
+- ✅ Diagnostics for missing assets are already produced by the
+  link checker (see PR #3 above) since image targets flow through
+  the same resolver. No new CLI surface needed.
+- Pending follow-up: per-feature `oxContent.asset.srcDir` setting
+  separate from the workspace root, for repos that keep static
+  assets under a `public/` subdirectory.
 
 ### 5. `feat(mdc): component name and attribute completion`
 


### PR DESCRIPTION
Roadmap step 4 (see [editor extension roadmap](https://github.com/ubugeeei/ox-content/blob/main/docs/content/editor-extension-roadmap.md#4-featlsp-asset-path-completion-and-diagnostics)).

## What ships

LSP completion now lights up when the cursor sits inside any of:

- Markdown `[…](` (link context)
- Markdown `![…](` (image context)
- HTML `<a href="…"` (link context)
- HTML `<img|video|audio|source|iframe|picture src="…"` (image context)
- HTML `<custom-element src="…"` (falls back to link context — we don't over-filter unfamiliar tags)

The completion list is filesystem entries under the partial path, anchored to the document's own directory. Paths that start with `/` resolve under the workspace root (the LSP's `state.root`).

Image contexts narrow to:

- images: `png`, `jpg`, `jpeg`, `gif`, `webp`, `svg`, `avif`, `ico`, `bmp`, `tiff`
- videos: `mp4`, `webm`, `ogv`, `mov`
- audio: `mp3`, `ogg`, `wav`, `flac`

Link contexts list every file plus directories so the user can also link to Markdown / JSON / etc.

Hidden entries (`.env`, `.git`, dotfiles in general) are filtered out. Directory entries render as `name/` and re-trigger completion via the new `/` trigger character.

## Why not AST-based detection

An in-flight `![alt](./foo` line is not valid Markdown — the parser refuses it — so the detection has to be textual. `detect_markdown_opener` walks the line backwards, tracks paren depth, finds the last unmatched `(`, then walks back through `match_opening_bracket` to find the matching `[` (so we can correctly distinguish `[link](` from `![image](` even when there are nested brackets inside the bracket text).

## Why no separate diagnostics

PR #3 already produces `Broken link target: …does not exist` diagnostics for image targets through the same `Walker::check_target` path. Adding a second diagnostic source for assets would just double the noise. The "Asset path completion + diagnostics" row in the roadmap is now marked shipped — completion is the new bit; diagnostics ride the existing channel.

## Tests

17 new unit tests in `backend/assets/tests.rs`, grouped by concern:

- `detect_context_markdown::*` — link/image distinction, partial paths, space-aborts-detection, balanced inner parens.
- `detect_context_html::*` — single/double quotes, image-bearing tags, custom-element fallback.
- `completion_items::*` — directory listing, image-extension filtering, prefix matching, nested paths, absolute paths via `src_dir`, hidden-file skip, nonexistent-dir empty.
- `line_prefix::*` — UTF-16-aware cursor slicing for supplementary characters.

All 37 LSP tests pass; `vp run check` is clean.

## Trigger characters

Added `(` and `/` to the existing LSP `completion_provider.trigger_characters` so the popup fires the moment the user closes the link text and again after descending into a subdirectory.

## Out of scope (follow-ups)

- Per-feature `oxContent.asset.srcDir` setting separate from the workspace root, for repos that keep static assets under `public/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)