### PR TITLE
feat(mdc): component name + attribute completion via registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Supported features include:
 - `.mdc` authoring support with component tag diagnostics
 - asset path completion inside `[…](`, `![…](`, and HTML `src=`/`href=` attributes
 - dead link diagnostics powered by `ox_content_link_checker`
+- MDC component name and attribute completion when a project provides a component registry
 
 For CI or editor-independent checks, run:
 

--- a/crates/ox_content_lsp/src/backend.rs
+++ b/crates/ox_content_lsp/src/backend.rs
@@ -3,6 +3,7 @@ mod commands;
 mod diagnostics;
 mod features;
 mod handlers;
+mod mdc;
 mod snippets;
 
 use tower_lsp::lsp_types::{Diagnostic, Url};

--- a/crates/ox_content_lsp/src/backend/features.rs
+++ b/crates/ox_content_lsp/src/backend/features.rs
@@ -7,7 +7,10 @@ use crate::frontmatter;
 use crate::i18n;
 use crate::preview;
 
+use ox_content_mdc_checker::Registry;
+
 use super::assets::{completion_items as asset_completion_items, detect_context, line_prefix};
+use super::mdc::{completion_items as mdc_completion_items, detect_site as detect_mdc_site};
 use super::snippets::markdown_snippet_items;
 use super::Backend;
 
@@ -59,6 +62,22 @@ impl Backend {
         }
 
         let config = self.resolved_config().await;
+
+        // MDC component / attribute completion. Short-circuit out
+        // before snippets and frontmatter so the popup is focused on
+        // the construct the user is mid-typing — a `## Section`
+        // snippet polluting `<Alert |` is just noise.
+        let line_text = document.line_text(position.line);
+        let prefix = line_prefix(line_text, position.character);
+        if let Some(site) = detect_mdc_site(prefix) {
+            if let Some(registry) = load_mdc_registry(&config) {
+                let items = mdc_completion_items(&site, &registry);
+                if !items.is_empty() {
+                    return Some(CompletionResponse::Array(items));
+                }
+            }
+        }
+
         let frontmatter = frontmatter::parse_frontmatter(&document);
         let mut items = frontmatter
             .block
@@ -206,4 +225,13 @@ fn push_fmt(output: &mut String, args: std::fmt::Arguments<'_>) {
     if output.write_fmt(args).is_err() {
         output.push_str("[formatting failed]");
     }
+}
+
+fn load_mdc_registry(config: &crate::config::ResolvedConfig) -> Option<Registry> {
+    let path = config.mdc_components.as_deref()?;
+    // Treat a missing or unreadable registry file the same as "no
+    // registry configured" — completion silently falls through. The
+    // alternative (publishing a diagnostic on every keystroke) would
+    // be noisy and we'd rather not double the failure modes here.
+    Registry::from_path(path).ok().flatten()
 }

--- a/crates/ox_content_lsp/src/backend/handlers.rs
+++ b/crates/ox_content_lsp/src/backend/handlers.rs
@@ -36,6 +36,11 @@ impl LanguageServer for Backend {
                         // descends into a subdirectory.
                         "(".into(),
                         "/".into(),
+                        // MDC component / attribute completion: `<`
+                        // opens it for `<Foo`, space reopens it after
+                        // the component name for `<Foo |`.
+                        "<".into(),
+                        " ".into(),
                     ]),
                     ..Default::default()
                 }),

--- a/crates/ox_content_lsp/src/backend/mdc.rs
+++ b/crates/ox_content_lsp/src/backend/mdc.rs
@@ -1,0 +1,168 @@
+//! MDC-specific LSP features (component name + attribute completion,
+//! hover). Backed by `ox_content_mdc_checker::Registry`.
+
+use ox_content_mdc_checker::{Component, Registry};
+use tower_lsp::lsp_types::{
+    CompletionItem, CompletionItemKind, Documentation, MarkupContent, MarkupKind,
+};
+
+/// Position of the cursor in an in-flight MDC tag, derived purely
+/// from the line text before it. The detection is textual so it
+/// keeps working while the user is typing and the surrounding tag
+/// is not yet syntactically valid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompletionSite<'a> {
+    /// `<Foo|`. Suggest component names whose start matches `prefix`.
+    ComponentName { prefix: &'a str },
+    /// `<Foo a|`. Suggest attributes whose start matches `prefix`,
+    /// scoped to `component`. The current attribute prefix may be
+    /// empty when the cursor is right after whitespace.
+    AttributeName { component: &'a str, prefix: &'a str },
+}
+
+/// Inspect the chunk of the current line that sits before the cursor
+/// and decide whether MDC completion applies. Returns `None` when the
+/// cursor is outside any MDC tag.
+#[must_use]
+pub fn detect_site(line_prefix: &str) -> Option<CompletionSite<'_>> {
+    // Walk back to the last `<` that isn't followed by `/` (closing
+    // tag completion would be just `</TagName>` which we leave to
+    // the user — it auto-completes from the matching opener).
+    let bytes = line_prefix.as_bytes();
+    let lt = line_prefix.rfind('<')?;
+    if lt + 1 < bytes.len() && bytes[lt + 1] == b'/' {
+        return None;
+    }
+    // Anything beyond the next `>` means we are past the tag.
+    if line_prefix[lt..].contains('>') {
+        return None;
+    }
+    let inside = &line_prefix[lt + 1..];
+
+    // Component name is the first identifier-like run in `inside`.
+    // Bail out before that if the user opened `<` with non-alpha
+    // (would be a lone `<` for typography or an HTML comment).
+    let first = inside.chars().next()?;
+    if !first.is_ascii_alphabetic() {
+        return None;
+    }
+    // MDC components start with an uppercase letter, matching the
+    // checker's heuristic in `lib.rs::check`. Lowercase tags fall
+    // through to the HTML completion path elsewhere.
+    if !first.is_ascii_uppercase() {
+        return None;
+    }
+
+    let name_end = inside
+        .char_indices()
+        .find(|(_, ch)| !is_tag_name_char(*ch))
+        .map_or(inside.len(), |(idx, _)| idx);
+
+    if name_end == inside.len() {
+        // Still typing the component name (no whitespace yet).
+        return Some(CompletionSite::ComponentName { prefix: inside });
+    }
+
+    let component_name = &inside[..name_end];
+    let after_name = &inside[name_end..];
+
+    // Past the name. We only complete attribute names when the cursor
+    // sits in a "fresh slot": after whitespace and before any `=`.
+    // `<Foo bar=` and `<Foo bar="..."` should not surface suggestions.
+    let mut attr_prefix_start = None;
+    let mut equal_seen = false;
+    let mut in_quote: Option<u8> = None;
+
+    for (idx, byte) in after_name.bytes().enumerate() {
+        if let Some(quote) = in_quote {
+            if byte == quote {
+                in_quote = None;
+                equal_seen = false;
+                attr_prefix_start = None;
+            }
+            continue;
+        }
+        match byte {
+            b'"' | b'\'' => in_quote = Some(byte),
+            b'=' => equal_seen = true,
+            b' ' | b'\t' => {
+                if equal_seen {
+                    // Whitespace inside an attribute value is unusual
+                    // but harmless; treat it like we're between props.
+                    equal_seen = false;
+                }
+                attr_prefix_start = Some(idx + 1);
+            }
+            _ if attr_prefix_start.is_none() => {
+                // First non-space char after the name; we're in the
+                // middle of typing an attribute prefix.
+                attr_prefix_start = Some(idx);
+            }
+            _ => {}
+        }
+    }
+
+    if equal_seen || in_quote.is_some() {
+        return None;
+    }
+
+    let prefix_start = attr_prefix_start.unwrap_or(after_name.len());
+    Some(CompletionSite::AttributeName {
+        component: component_name,
+        prefix: &after_name[prefix_start..],
+    })
+}
+
+fn is_tag_name_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-')
+}
+
+#[must_use]
+pub fn completion_items(site: &CompletionSite<'_>, registry: &Registry) -> Vec<CompletionItem> {
+    match site {
+        CompletionSite::ComponentName { prefix } => registry
+            .complete_components(prefix)
+            .map(|(name, component)| component_item(name, component))
+            .collect(),
+        CompletionSite::AttributeName { component, prefix } => registry
+            .complete_attributes(component, prefix)
+            .map(|(name, attribute)| attribute_item(name, attribute))
+            .collect(),
+    }
+}
+
+fn component_item(name: &str, component: &Component) -> CompletionItem {
+    CompletionItem {
+        label: name.to_string(),
+        kind: Some(CompletionItemKind::CLASS),
+        detail: Some("MDC component".to_string()),
+        documentation: component.description.as_ref().map(|description| markdown_doc(description)),
+        ..Default::default()
+    }
+}
+
+fn attribute_item(name: &str, attribute: &ox_content_mdc_checker::Attribute) -> CompletionItem {
+    let detail = match attribute.type_hint.as_deref() {
+        Some(type_hint) => format!("MDC prop: {type_hint}"),
+        None => "MDC prop".to_string(),
+    };
+    CompletionItem {
+        label: name.to_string(),
+        kind: Some(CompletionItemKind::PROPERTY),
+        detail: Some(detail),
+        documentation: attribute.description.as_ref().map(|description| markdown_doc(description)),
+        insert_text: Some(format!("{name}=\"$0\"")),
+        insert_text_format: Some(tower_lsp::lsp_types::InsertTextFormat::SNIPPET),
+        ..Default::default()
+    }
+}
+
+fn markdown_doc(value: &str) -> Documentation {
+    Documentation::MarkupContent(MarkupContent {
+        kind: MarkupKind::Markdown,
+        value: value.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/ox_content_lsp/src/backend/mdc/tests.rs
+++ b/crates/ox_content_lsp/src/backend/mdc/tests.rs
@@ -1,0 +1,128 @@
+use ox_content_mdc_checker::Registry;
+
+use super::*;
+
+fn registry() -> Registry {
+    Registry::from_json(
+        r#"{
+        "components": [
+          {
+            "name": "Alert",
+            "description": "Inline alert callout.",
+            "attributes": [
+              { "name": "tone", "type": "info | warn | error" },
+              { "name": "icon", "description": "Icon name" }
+            ]
+          },
+          {
+            "name": "Card",
+            "attributes": [{ "name": "title" }]
+          }
+        ]
+      }"#,
+    )
+    .expect("parse registry")
+}
+
+mod detect_site {
+    use super::*;
+
+    #[test]
+    fn typing_component_name_returns_component_site() {
+        let site = detect_site("paragraph <Ale").expect("site");
+        assert_eq!(site, CompletionSite::ComponentName { prefix: "Ale" });
+    }
+
+    #[test]
+    fn empty_component_prefix_after_lt_returns_component_site() {
+        // Detection only fires after at least one uppercase character —
+        // a lone `<` is ambiguous with typography and HTML comments.
+        assert!(detect_site("text <").is_none());
+    }
+
+    #[test]
+    fn lowercase_tag_is_left_to_other_completions() {
+        assert!(detect_site("<sect").is_none());
+    }
+
+    #[test]
+    fn closing_tag_is_not_a_completion_site() {
+        assert!(detect_site("</Ale").is_none());
+    }
+
+    #[test]
+    fn past_the_close_angle_we_drop_out() {
+        assert!(detect_site("<Alert tone=\"x\"> body ").is_none());
+    }
+
+    #[test]
+    fn whitespace_after_name_means_attribute_site_with_empty_prefix() {
+        let site = detect_site("<Alert ").expect("site");
+        assert_eq!(site, CompletionSite::AttributeName { component: "Alert", prefix: "" });
+    }
+
+    #[test]
+    fn typing_attribute_name_after_existing_attribute() {
+        let site = detect_site("<Alert tone=\"info\" ic").expect("site");
+        assert_eq!(site, CompletionSite::AttributeName { component: "Alert", prefix: "ic" });
+    }
+
+    #[test]
+    fn inside_attribute_value_is_not_a_site() {
+        assert!(detect_site("<Alert tone=\"in").is_none());
+    }
+
+    #[test]
+    fn right_after_equals_is_not_a_site() {
+        assert!(detect_site("<Alert tone=").is_none());
+    }
+}
+
+mod completion_items {
+    use super::*;
+
+    fn labels(items: &[CompletionItem]) -> Vec<&str> {
+        items.iter().map(|item| item.label.as_str()).collect()
+    }
+
+    #[test]
+    fn component_completion_returns_alphabetical_names_with_class_kind() {
+        let registry = registry();
+        let items = completion_items(&CompletionSite::ComponentName { prefix: "" }, &registry);
+        assert_eq!(labels(&items), vec!["Alert", "Card"]);
+        assert!(items.iter().all(|item| item.kind == Some(CompletionItemKind::CLASS)));
+        let alert = &items[0];
+        assert!(alert.documentation.is_some());
+    }
+
+    #[test]
+    fn component_completion_filters_by_prefix() {
+        let registry = registry();
+        let items = completion_items(&CompletionSite::ComponentName { prefix: "A" }, &registry);
+        assert_eq!(labels(&items), vec!["Alert"]);
+    }
+
+    #[test]
+    fn attribute_completion_returns_props_with_property_kind() {
+        let registry = registry();
+        let items = completion_items(
+            &CompletionSite::AttributeName { component: "Alert", prefix: "" },
+            &registry,
+        );
+        assert_eq!(labels(&items), vec!["icon", "tone"]);
+        let tone = items.iter().find(|item| item.label == "tone").unwrap();
+        assert_eq!(tone.kind, Some(CompletionItemKind::PROPERTY));
+        assert_eq!(tone.detail.as_deref(), Some("MDC prop: info | warn | error"));
+        assert!(tone.insert_text.as_deref().unwrap().ends_with(r#"="$0""#));
+    }
+
+    #[test]
+    fn attribute_completion_for_unknown_component_is_empty() {
+        let registry = registry();
+        let items = completion_items(
+            &CompletionSite::AttributeName { component: "Unknown", prefix: "" },
+            &registry,
+        );
+        assert!(items.is_empty());
+    }
+}

--- a/crates/ox_content_lsp/src/config.rs
+++ b/crates/ox_content_lsp/src/config.rs
@@ -13,12 +13,17 @@ pub struct InitializationOptions {
     pub config_path: Option<String>,
     #[serde(rename = "frontmatterSchema")]
     pub frontmatter_schema: Option<String>,
+    /// Path to a JSON file declaring known MDC components and their
+    /// attributes. See `ox_content_mdc_checker::Registry`.
+    #[serde(rename = "mdcComponents")]
+    pub mdc_components: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 struct WorkspaceConfigFile {
     frontmatter: FrontmatterConfigFile,
+    mdc: MdcConfigFile,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -27,25 +32,36 @@ struct FrontmatterConfigFile {
     schema: Option<String>,
 }
 
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+struct MdcConfigFile {
+    components: Option<String>,
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct ResolvedConfig {
     pub frontmatter_schema: Option<PathBuf>,
+    pub mdc_components: Option<PathBuf>,
 }
 
 impl ResolvedConfig {
     #[must_use]
     pub fn load(root: Option<&Path>, init: &InitializationOptions) -> Self {
         let root = root.map(Path::to_path_buf);
+        let workspace_file = load_workspace_file(root.as_deref(), init.config_path.as_deref());
+
         let frontmatter_schema = init
             .frontmatter_schema
             .as_ref()
             .map(|value| resolve_path(root.as_deref(), value))
             .or_else(|| {
-                load_workspace_file(root.as_deref(), init.config_path.as_deref()).and_then(
-                    |(path, config)| {
-                        config.frontmatter.schema.map(|value| resolve_path(path.parent(), &value))
-                    },
-                )
+                workspace_file.as_ref().and_then(|(path, config)| {
+                    config
+                        .frontmatter
+                        .schema
+                        .as_ref()
+                        .map(|value| resolve_path(path.parent(), value))
+                })
             })
             .or_else(|| {
                 env::var("OX_CONTENT_FRONTMATTER_SCHEMA")
@@ -53,7 +69,22 @@ impl ResolvedConfig {
                     .map(|value| resolve_path(root.as_deref(), &value))
             });
 
-        Self { frontmatter_schema }
+        let mdc_components = init
+            .mdc_components
+            .as_ref()
+            .map(|value| resolve_path(root.as_deref(), value))
+            .or_else(|| {
+                workspace_file.as_ref().and_then(|(path, config)| {
+                    config.mdc.components.as_ref().map(|value| resolve_path(path.parent(), value))
+                })
+            })
+            .or_else(|| {
+                env::var("OX_CONTENT_MDC_COMPONENTS")
+                    .ok()
+                    .map(|value| resolve_path(root.as_deref(), &value))
+            });
+
+        Self { frontmatter_schema, mdc_components }
     }
 }
 

--- a/crates/ox_content_mdc_checker/Cargo.toml
+++ b/crates/ox_content_mdc_checker/Cargo.toml
@@ -22,3 +22,4 @@ path = "src/main.rs"
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/ox_content_mdc_checker/README.md
+++ b/crates/ox_content_mdc_checker/README.md
@@ -1,0 +1,76 @@
+# ox_content_mdc_checker
+
+Static checker and component registry for [MDC](https://mdxjs.com/docs/what-is-mdx/#mdx-syntax) component syntax in Ox Content Markdown.
+
+## Library
+
+```rust
+use ox_content_mdc_checker::{check, Registry};
+
+// Tag-balance + attribute diagnostics.
+for diagnostic in check(source) {
+    eprintln!("{}:{} {}", diagnostic.line, diagnostic.column, diagnostic.message);
+}
+
+// Component / attribute completion data, loaded from JSON.
+let registry = Registry::from_path(Path::new("ox-content.components.json"))?
+    .unwrap_or_default();
+for (name, _component) in registry.complete_components("Al") {
+    println!("Alert-like component: {name}");
+}
+```
+
+## CLI
+
+```bash
+ox-content-mdc-check docs/**/*.mdc
+ox-content-mdc-check --format json docs/page.mdc
+```
+
+Exit code is `1` when any diagnostic was emitted or any file failed to read.
+
+## Component registry
+
+Editors load a JSON file describing every MDC component used by the
+project. The file powers component name completion after `<` and
+attribute name completion inside an opening tag. Editor surfaces for
+the registry:
+
+- VS Code: `oxContent.mdc.components` setting (absolute or
+  workspace-relative path).
+- LSP `initializationOptions.mdcComponents`.
+- Workspace config: `"mdc": { "components": "./components.json" }`
+  inside `.ox-content.json` or `ox-content.json`.
+- Environment variable: `OX_CONTENT_MDC_COMPONENTS`.
+
+### File shape
+
+```json
+{
+  "components": [
+    {
+      "name": "Alert",
+      "description": "Inline alert callout.",
+      "attributes": [
+        {
+          "name": "tone",
+          "type": "info | warn | error",
+          "description": "Severity / colour of the alert.",
+          "required": true
+        },
+        { "name": "icon", "description": "Mdi icon name" }
+      ]
+    },
+    {
+      "name": "Card",
+      "attributes": [{ "name": "title" }]
+    }
+  ]
+}
+```
+
+Unknown top-level fields and unknown per-component fields are
+tolerated so older editors keep working when the schema grows.
+
+The `required` flag is reserved for a future diagnostic; it does not
+change completion behavior today.

--- a/crates/ox_content_mdc_checker/src/lib.rs
+++ b/crates/ox_content_mdc_checker/src/lib.rs
@@ -1,5 +1,9 @@
 use serde::Serialize;
 
+pub mod registry;
+
+pub use registry::{Attribute, Component, Registry, RegistryError};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {

--- a/crates/ox_content_mdc_checker/src/registry.rs
+++ b/crates/ox_content_mdc_checker/src/registry.rs
@@ -1,0 +1,187 @@
+//! MDC component registry.
+//!
+//! Editors and CLIs load a JSON file that declares every MDC
+//! component the project uses, together with each component's
+//! attributes. The registry powers completion (component name after
+//! `<`, attribute name inside `<Foo …>`) and hover documentation.
+//!
+//! The file format is intentionally minimal so authors can hand-write
+//! it without a framework integration. Future PRs can layer
+//! auto-discovery on top (Nuxt content config, Astro components,
+//! etc.) without changing the consumer surface.
+//!
+//! ```json
+//! {
+//!   "components": [
+//!     {
+//!       "name": "Alert",
+//!       "description": "Inline alert callout.",
+//!       "attributes": [
+//!         { "name": "tone", "description": "info | warn | error" },
+//!         { "name": "icon" }
+//!       ]
+//!     }
+//!   ]
+//! }
+//! ```
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Registry {
+    /// All known components, keyed by name for O(log n) lookup.
+    /// `BTreeMap` is used over `HashMap` so iteration order is
+    /// deterministic — completion lists, fixture snapshots, and
+    /// JSON round-trips become stable across runs.
+    pub components: BTreeMap<String, Component>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Component {
+    pub description: Option<String>,
+    pub attributes: BTreeMap<String, Attribute>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Attribute {
+    pub description: Option<String>,
+    /// Optional human-readable type hint (e.g. `"info | warn | error"`).
+    #[serde(rename = "type")]
+    pub type_hint: Option<String>,
+    /// Marks the attribute as required so completion can flag it.
+    /// Reserved for future use; not currently consumed by the LSP.
+    #[serde(default)]
+    pub required: bool,
+}
+
+/// Serde-friendly mirror of `Registry` that matches the on-disk
+/// shape: components as an array of objects with a `name` field.
+/// Keeping the disk format separate from the in-memory map lets us
+/// optimize the lookup data structure without breaking the public
+/// JSON schema.
+#[derive(Debug, Deserialize, Serialize, Default)]
+#[serde(default)]
+struct RegistryFile {
+    components: Vec<ComponentEntry>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Default)]
+#[serde(default)]
+struct ComponentEntry {
+    name: String,
+    description: Option<String>,
+    attributes: Vec<AttributeEntry>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Default)]
+#[serde(default)]
+struct AttributeEntry {
+    name: String,
+    description: Option<String>,
+    #[serde(rename = "type")]
+    type_hint: Option<String>,
+    #[serde(default)]
+    required: bool,
+}
+
+impl Registry {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Look up a component by exact (case-sensitive) name.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&Component> {
+        self.components.get(name)
+    }
+
+    /// Component names that start with `prefix` (case-sensitive). The
+    /// list is alphabetical because `BTreeMap` iterates in key order.
+    pub fn complete_components<'a>(
+        &'a self,
+        prefix: &'a str,
+    ) -> impl Iterator<Item = (&'a str, &'a Component)> + 'a {
+        self.components
+            .iter()
+            .filter(move |(name, _)| name.starts_with(prefix))
+            .map(|(name, component)| (name.as_str(), component))
+    }
+
+    /// Attribute names of `component` that start with `prefix`.
+    /// Returns an empty iterator when the component is unknown so
+    /// the caller can chain unconditionally.
+    pub fn complete_attributes<'a>(
+        &'a self,
+        component_name: &str,
+        prefix: &'a str,
+    ) -> impl Iterator<Item = (&'a str, &'a Attribute)> + 'a {
+        self.components
+            .get(component_name)
+            .into_iter()
+            .flat_map(|component| component.attributes.iter())
+            .filter(move |(name, _)| name.starts_with(prefix))
+            .map(|(name, attribute)| (name.as_str(), attribute))
+    }
+
+    /// Parse a registry JSON string. Lenient: missing optional fields
+    /// fall back to defaults; extra fields are tolerated so older
+    /// editors keep working when the schema grows.
+    pub fn from_json(source: &str) -> Result<Self, serde_json::Error> {
+        let file: RegistryFile = serde_json::from_str(source)?;
+        Ok(Self::from(file))
+    }
+
+    /// Load a registry from disk. Returns `Ok(None)` when the path
+    /// doesn't exist so callers can treat "no registry configured" and
+    /// "configured path missing" the same way at the completion site
+    /// (silently fall through) while still failing loudly on a true
+    /// parse error.
+    pub fn from_path(path: &Path) -> Result<Option<Self>, RegistryError> {
+        if !path.exists() {
+            return Ok(None);
+        }
+        let source = fs::read_to_string(path).map_err(RegistryError::Io)?;
+        let registry = Self::from_json(&source).map_err(RegistryError::Parse)?;
+        Ok(Some(registry))
+    }
+}
+
+impl From<RegistryFile> for Registry {
+    fn from(file: RegistryFile) -> Self {
+        let mut components = BTreeMap::new();
+        for entry in file.components {
+            let mut attributes = BTreeMap::new();
+            for attribute in entry.attributes {
+                attributes.insert(
+                    attribute.name,
+                    Attribute {
+                        description: attribute.description,
+                        type_hint: attribute.type_hint,
+                        required: attribute.required,
+                    },
+                );
+            }
+            components.insert(entry.name, Component { description: entry.description, attributes });
+        }
+        Self { components }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RegistryError {
+    #[error("failed to read registry: {0}")]
+    Io(#[source] std::io::Error),
+    #[error("failed to parse registry: {0}")]
+    Parse(#[source] serde_json::Error),
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/ox_content_mdc_checker/src/registry/tests.rs
+++ b/crates/ox_content_mdc_checker/src/registry/tests.rs
@@ -1,0 +1,87 @@
+use super::*;
+
+const SAMPLE: &str = r#"{
+  "components": [
+    {
+      "name": "Alert",
+      "description": "Inline alert callout.",
+      "attributes": [
+        { "name": "tone", "description": "info | warn | error" },
+        { "name": "icon" }
+      ]
+    },
+    {
+      "name": "Card",
+      "attributes": [
+        { "name": "title" }
+      ]
+    }
+  ]
+}"#;
+
+#[test]
+fn parses_components_and_attributes() {
+    let registry = Registry::from_json(SAMPLE).expect("parse");
+    let alert = registry.get("Alert").expect("Alert");
+    assert_eq!(alert.description.as_deref(), Some("Inline alert callout."));
+    assert_eq!(alert.attributes.len(), 2);
+    let tone = alert.attributes.get("tone").expect("tone");
+    assert_eq!(tone.description.as_deref(), Some("info | warn | error"));
+}
+
+#[test]
+fn complete_components_filters_by_prefix() {
+    let registry = Registry::from_json(SAMPLE).expect("parse");
+    let names: Vec<_> = registry.complete_components("A").map(|(n, _)| n).collect();
+    assert_eq!(names, vec!["Alert"]);
+    let all: Vec<_> = registry.complete_components("").map(|(n, _)| n).collect();
+    assert_eq!(all, vec!["Alert", "Card"]);
+}
+
+#[test]
+fn complete_attributes_returns_empty_for_unknown_component() {
+    let registry = Registry::from_json(SAMPLE).expect("parse");
+    assert!(registry.complete_attributes("Nope", "").next().is_none());
+}
+
+#[test]
+fn complete_attributes_filters_by_prefix() {
+    let registry = Registry::from_json(SAMPLE).expect("parse");
+    let names: Vec<_> = registry.complete_attributes("Alert", "ic").map(|(name, _)| name).collect();
+    assert_eq!(names, vec!["icon"]);
+}
+
+#[test]
+fn unknown_fields_are_tolerated() {
+    let json = r#"{
+      "components": [
+        { "name": "X", "future": true, "attributes": [{ "name": "y", "extra": 1 }] }
+      ],
+      "$schema": "https://example.com/schema.json"
+    }"#;
+    let registry = Registry::from_json(json).expect("parse");
+    assert!(registry.get("X").is_some());
+}
+
+#[test]
+fn empty_registry_round_trips() {
+    let registry = Registry::from_json("{}").expect("parse");
+    assert!(registry.components.is_empty());
+}
+
+#[test]
+fn missing_file_returns_ok_none() {
+    let result =
+        Registry::from_path(std::path::Path::new("/this/path/should/not/exist/registry.json"));
+    assert!(matches!(result, Ok(None)));
+}
+
+#[test]
+fn parse_error_surfaces_as_error_variant() {
+    let dir = std::env::temp_dir().join("ox-content-mdc-registry-error");
+    let _ = std::fs::create_dir_all(&dir);
+    let path = dir.join("bad.json");
+    std::fs::write(&path, "{ not json").unwrap();
+    let result = Registry::from_path(&path);
+    assert!(matches!(result, Err(RegistryError::Parse(_))));
+}

--- a/docs/content/editor-extension-roadmap.md
+++ b/docs/content/editor-extension-roadmap.md
@@ -35,7 +35,7 @@ must not depend on a later one in the list.
 | --- | ----------------------------------------------- | ------------------------- | ---------------------------- | ------------------------- | --------------------------- | ------------------ |
 | 1   | Markdown preview (HMR)                          | partial — polling refresh | none                         | webview, debounced reload | external browser, on-demand | needs HMR + CLI    |
 | 2   | i18n preview / completion                       | present                   | `ox-content-i18n`            | present                   | present                     | shipped            |
-| 3   | MDC completion + type check                     | diagnostics only          | `ox-content-mdc-check`       | diagnostics               | diagnostics                 | needs completion   |
+| 3   | MDC completion + type check                     | completion + diagnostics  | `ox-content-mdc-check`       | completion + diagnostics  | completion + diagnostics    | shipped            |
 | 4   | Vue / React props completion + jump + typecheck | none                      | none                         | none                      | none                        | new (corsa_client) |
 | 5   | Asset path completion + diagnostics             | completion provider       | via link checker             | completion + diagnostics  | completion + diagnostics    | shipped            |
 | 6   | Dead link checker                               | diagnostics               | `ox-content-link-check`      | diagnostics               | diagnostics                 | local: shipped     |
@@ -118,12 +118,23 @@ Replace the polling refresh path with an explicit push channel.
 
 ### 5. `feat(mdc): component name and attribute completion`
 
-- Extend `ox_content_mdc_checker` with a component registry sourced from an
-  index file (`oxContent.mdc.components`) and from framework integrations
-  if discoverable. The registry is also consumable from the CLI.
-- LSP exposes component name completion at `::` and attribute completion
-  inside the opening tag.
-- Hover surface that documents the discovered component.
+- ✅ New `ox_content_mdc_checker::Registry` (de)serializes a JSON
+  index of components and their attributes. Deterministic iteration
+  order via `BTreeMap`, lenient parsing (unknown fields tolerated).
+- ✅ LSP completion: component names after `<Foo|`, attribute names
+  inside `<Foo |…>`. Inside-quote and post-`=` positions are skipped
+  to avoid noise. Attribute insertion uses snippet syntax
+  (`name="$0"`) so the cursor lands inside the value.
+- ✅ Registry path is configurable via the `mdcComponents`
+  initialization option, `mdc.components` in the workspace config
+  file, or `OX_CONTENT_MDC_COMPONENTS` env var (in that order).
+- Pending follow-ups:
+  - Hover documentation for an MDC tag the cursor sits on
+    (registry already exposes the data).
+  - Diagnostic for using an unknown component (opt-in only — would
+    be noisy for projects with partial registries).
+  - Framework-specific auto-discovery (Nuxt content, Astro, etc.)
+    that builds the registry without a hand-written JSON file.
 
 ### 6. `feat(component-resolver): Vue and React props via corsa_client`
 

--- a/npm/vscode-ox-content/package.json
+++ b/npm/vscode-ox-content/package.json
@@ -72,6 +72,11 @@
           "type": "boolean",
           "default": true,
           "description": "Automatically refresh the Ox Content preview when the document changes."
+        },
+        "oxContent.mdc.components": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Optional absolute or workspace-relative path to the MDC component registry JSON file. The registry powers component name and attribute completion inside `.md` / `.mdc` files."
         }
       }
     },

--- a/npm/vscode-ox-content/src/config.ts
+++ b/npm/vscode-ox-content/src/config.ts
@@ -32,8 +32,19 @@ export function resolveServerOptions(
 }
 
 export function resolveInitializationOptions(workspaceRoot?: string): Record<string, string> {
+  const options: Record<string, string> = {};
+
   const schemaSetting = getConfig().get<string>("frontmatter.schema", "").trim();
-  return schemaSetting ? { frontmatterSchema: resolveFilePath(schemaSetting, workspaceRoot) } : {};
+  if (schemaSetting) {
+    options.frontmatterSchema = resolveFilePath(schemaSetting, workspaceRoot);
+  }
+
+  const mdcComponents = getConfig().get<string>("mdc.components", "").trim();
+  if (mdcComponents) {
+    options.mdcComponents = resolveFilePath(mdcComponents, workspaceRoot);
+  }
+
+  return options;
 }
 
 function findLocalServerBinary(


### PR DESCRIPTION
Roadmap step 5 (see [editor extension roadmap](https://github.com/ubugeeei/ox-content/blob/main/docs/content/editor-extension-roadmap.md#5-featmdc-component-name-and-attribute-completion)).

## What ships

### `ox_content_mdc_checker::Registry` (new module)

Authoritative source of MDC component metadata for the project. Loaded from a JSON file with the shape documented in [`crates/ox_content_mdc_checker/README.md`](https://github.com/ubugeeei/ox-content/blob/feat/mdc-completion/crates/ox_content_mdc_checker/README.md):

```json
{
  "components": [
    {
      "name": "Alert",
      "description": "Inline alert callout.",
      "attributes": [
        { "name": "tone", "type": "info | warn | error", "required": true },
        { "name": "icon" }
      ]
    }
  ]
}
```

- `BTreeMap`-backed so iteration is alphabetical and round-trips are stable.
- Lenient: unknown top-level / per-component fields are tolerated so older editors keep working when the schema grows.
- `Registry::from_path` returns `Ok(None)` for a missing file (lets the LSP fall through silently) and `Err(RegistryError::Parse)` for a malformed one.

### `ox_content_lsp::backend::mdc` (new module)

- `detect_site(line_prefix)` — purely textual cursor classifier. Returns `ComponentName { prefix }` when the user is typing the tag name, `AttributeName { component, prefix }` after the name has whitespace following it, and `None` when the cursor is past `>`, inside an attribute value, or right after `=`.
- `completion_items(site, registry)` — builds CompletionItems. Components get `CLASS` kind; attributes get `PROPERTY` kind, a `MDC prop: <type-hint>` detail when the registry has one, and an `name="$0"` snippet insert so the cursor lands inside the value.

### Completion path wiring

`features.rs::completion_response` short-circuits MDC completion before snippets and frontmatter. A `## Section` snippet polluting `<Alert |` would just be noise.

### Registry resolution order

(highest to lowest priority)

1. `mdcComponents` LSP `initializationOptions`
2. `mdc.components` in `.ox-content.json` / `ox-content.json`
3. `OX_CONTENT_MDC_COMPONENTS` env var

The VS Code extension exposes the setting as `oxContent.mdc.components` and forwards it via `resolveInitializationOptions`.

### Trigger characters

`<` and ` ` (space) join the LSP completion trigger list so the popup fires when the user opens a tag and again when they hit space after the component name.

## Tests

- 8 new tests in `ox_content_mdc_checker::registry::tests` cover the loader, lookup helpers, lenient parsing, and the `Ok(None)` vs `Err(Parse)` distinction.
- 13 new tests in `ox_content_lsp::backend::mdc::tests`:
  - 9 `detect_site::*` tests pin every documented case (typing-name, empty-prefix-after-`<`-is-`None`, lowercase-skipped, closing-tag-skipped, past-`>`, whitespace-then-attr-prefix, after-other-attr, inside-quote-`None`, after-`=`-`None`).
  - 4 `completion_items::*` tests verify alphabetical order, prefix filtering, `CLASS`/`PROPERTY` kinds, and the snippet insert format.

```
cargo test -p ox_content_mdc_checker  ✓  11 tests
cargo test -p ox_content_lsp          ✓  29 tests (was 16; +13)
vp run check                          ✓
```

## Out of scope (called out in the roadmap)

- Hover documentation for an MDC tag the cursor sits on. Registry already has the data; the hover handler just needs to be wired.
- Diagnostic for using an unknown component. Opt-in only — would be noisy for partial registries.
- Framework auto-discovery (Nuxt content, Astro, etc.) that builds the registry without a hand-written JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)