### PR TITLE
ci: use blacksmith runners

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   benchmark:
     name: Benchmark
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     env:
       CARGO_TARGET_DIR: /tmp/ox-content-cargo-target
     steps:
@@ -80,7 +80,7 @@ jobs:
 
   comment:
     name: Comment
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: benchmark
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   rustfmt:
     name: Rustfmt
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -35,7 +35,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -54,7 +54,7 @@ jobs:
 
   typecheck:
     name: TypeScript check
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -72,7 +72,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -99,7 +99,7 @@ jobs:
 
   vscode-test:
     name: VS Code extension tests
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -134,7 +134,7 @@ jobs:
 
   dependency-policy:
     name: Dependency policy
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -170,7 +170,7 @@ jobs:
 
   package-dry-run:
     name: Package dry-run
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -204,7 +204,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+          - blacksmith-2vcpu-ubuntu-2404
+          - blacksmith-6vcpu-macos-latest
+          - blacksmith-2vcpu-windows-2025
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -244,7 +247,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -73,7 +73,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: build
     permissions:
       pages: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,15 +19,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          - os: blacksmith-6vcpu-macos-latest
             target: x86_64-apple-darwin
-          - os: macos-latest
+          - os: blacksmith-6vcpu-macos-latest
             target: aarch64-apple-darwin
-          - os: ubuntu-latest
+          - os: blacksmith-2vcpu-ubuntu-2404
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-latest
+          - os: blacksmith-2vcpu-ubuntu-2404
             target: aarch64-unknown-linux-gnu
-          - os: windows-latest
+          - os: blacksmith-2vcpu-windows-2025
             target: x86_64-pc-windows-msvc
 
     steps:
@@ -70,7 +70,7 @@ jobs:
 
   publish-napi:
     name: Publish @ox-content/napi
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: build-napi
     environment: npm
     permissions:
@@ -186,7 +186,7 @@ jobs:
 
   publish-packages:
     name: Publish npm packages
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: publish-napi
     environment: npm
     permissions:
@@ -331,7 +331,7 @@ jobs:
 
   publish-crates:
     name: Publish to crates.io
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
       id-token: write
@@ -372,7 +372,7 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: [publish-packages, publish-crates]
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ Special thanks to [kazupon](https://github.com/kazupon) for substantial communit
 
 ## Sponsor
 
+CI/CD for this repository is sponsored by [Blacksmith](https://www.blacksmith.sh/), which provides the GitHub Actions runners used by this project.
+
 If you find Ox Content useful, please consider [sponsoring](https://github.com/sponsors/ubugeeei) the project.
 
 ## License

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -103,3 +103,9 @@ Under the hood, Ox Content is not only a docs theme. It also exposes the Markdow
 ## Community Credits
 
 Special thanks to [kazupon](https://github.com/kazupon) for substantial community contributions around JSDoc support, including the API docs generation pipeline and documentation quality.
+
+## Sponsor
+
+CI/CD for this repository is sponsored by [Blacksmith](https://www.blacksmith.sh/), which provides the GitHub Actions runners used by this project.
+
+If you find Ox Content useful, please consider [sponsoring](https://github.com/sponsors/ubugeeei) the project.


### PR DESCRIPTION
## Summary

- Move GitHub Actions workflows to Blacksmith runner labels for CI, benchmark, deploy, and publish jobs.
- Map Linux, Windows, and macOS matrix jobs to the current Blacksmith runner labels.
- Add Blacksmith as a CI/CD sponsor in the README and docs homepage.

## Validation

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- `vp fmt --check .github/workflows README.md docs/content/index.md`
- `git diff --check`

Note: full `vp run fmt:check` also reports a pre-existing formatting issue in `.claude/settings.local.json`, which is outside this PR's diff.