### PR TITLE
ci: switch to github-hosted runners

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   benchmark:
     name: Benchmark
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     env:
       CARGO_TARGET_DIR: /tmp/ox-content-cargo-target
     steps:
@@ -80,7 +80,7 @@ jobs:
 
   comment:
     name: Comment
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: benchmark
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo
+        if: runner.os != 'Windows'
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build local NAPI binding

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   rustfmt:
     name: Rustfmt
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -35,7 +35,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -54,7 +54,7 @@ jobs:
 
   typecheck:
     name: TypeScript check
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -72,7 +72,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -99,7 +99,7 @@ jobs:
 
   vscode-test:
     name: VS Code extension tests
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -134,7 +134,7 @@ jobs:
 
   dependency-policy:
     name: Dependency policy
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -170,7 +170,7 @@ jobs:
 
   package-dry-run:
     name: Package dry-run
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -205,9 +205,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - blacksmith-2vcpu-ubuntu-2404
-          - blacksmith-6vcpu-macos-latest
-          - blacksmith-2vcpu-windows-2025
+          - ubuntu-24.04
+          - macos-latest
+          - windows-2025
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -247,7 +247,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -73,7 +73,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: build
     permissions:
       pages: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,15 +19,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: blacksmith-6vcpu-macos-latest
+          - os: macos-latest
             target: x86_64-apple-darwin
-          - os: blacksmith-6vcpu-macos-latest
+          - os: macos-latest
             target: aarch64-apple-darwin
-          - os: blacksmith-2vcpu-ubuntu-2404
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
-          - os: blacksmith-2vcpu-ubuntu-2404
+          - os: ubuntu-24.04
             target: aarch64-unknown-linux-gnu
-          - os: blacksmith-2vcpu-windows-2025
+          - os: windows-2025
             target: x86_64-pc-windows-msvc
 
     steps:
@@ -70,7 +70,7 @@ jobs:
 
   publish-napi:
     name: Publish @ox-content/napi
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: build-napi
     environment: npm
     permissions:
@@ -186,7 +186,7 @@ jobs:
 
   publish-packages:
     name: Publish npm packages
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: publish-napi
     environment: npm
     permissions:
@@ -331,7 +331,7 @@ jobs:
 
   publish-crates:
     name: Publish to crates.io
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write
@@ -372,7 +372,7 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: [publish-packages, publish-crates]
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -266,8 +266,6 @@ Special thanks to [kazupon](https://github.com/kazupon) for substantial communit
 
 ## Sponsor
 
-CI/CD for this repository is sponsored by [Blacksmith](https://www.blacksmith.sh/), which provides the GitHub Actions runners used by this project.
-
 If you find Ox Content useful, please consider [sponsoring](https://github.com/sponsors/ubugeeei) the project.
 
 ## License

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -106,6 +106,4 @@ Special thanks to [kazupon](https://github.com/kazupon) for substantial communit
 
 ## Sponsor
 
-CI/CD for this repository is sponsored by [Blacksmith](https://www.blacksmith.sh/), which provides the GitHub Actions runners used by this project.
-
 If you find Ox Content useful, please consider [sponsoring](https://github.com/sponsors/ubugeeei) the project.


### PR DESCRIPTION
## Summary

- Replace Blacksmith runner labels with GitHub-hosted runner labels across CI, benchmark, deploy, and publish workflows.
- Skip the Rust cache step for the Windows NAPI smoke job because the GitHub-hosted Windows runner failed before reaching the actual smoke build/test.
- Remove the Blacksmith CI/CD sponsor note from the README and docs index while the project is not using those runners.

## Why

Blacksmith runners appear unavailable, so this temporarily moves workflows back to GitHub-hosted runners.

## Impact

Pull request CI and release/deploy workflows should queue on standard GitHub-hosted runners instead of Blacksmith runners. The Windows NAPI smoke job still builds and runs; it just avoids the failing cache restore on GitHub-hosted Windows.

## Validation

- `rg -n "blacksmith|Blacksmith" .github README.md docs/content/index.md`
- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts "ok #{file}" }' .github/workflows/benchmark.yml .github/workflows/ci.yml .github/workflows/deploy.yml .github/workflows/publish.yml`
- PR checks passed: CI and Benchmark workflows.