### PR TITLE
feat(renderer): autolink bare URLs in text

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -984,6 +984,22 @@ export interface JsTransformOptions {
   codeAnnotationSyntax?: string
   /** Enable line numbers for all code blocks by default. */
   codeAnnotationDefaultLineNumbers?: boolean
+  /**
+   * Auto-link bare URLs in text. When enabled, the renderer wraps any
+   * text occurrence starting with a registered pattern (default `http://`
+   * and `https://`) in an `<a>` tag.
+   */
+  autolinkUrls?: boolean
+  /**
+   * URL prefix patterns for [`Self::autolink_urls`]. Overrides the
+   * default `["http://", "https://"]` when set.
+   */
+  autolinkPatterns?: Array<string>
+  /**
+   * Add `target="_blank" rel="noopener noreferrer"` to auto-linked URLs.
+   * Defaults to true; ignored when [`Self::autolink_urls`] is off.
+   */
+  autolinkTargetBlank?: boolean
 }
 
 export declare function lintMarkdown(source: string, options?: JsMarkdownLintOptions | undefined | null): JsMarkdownLintResult

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -422,6 +422,16 @@ pub struct JsTransformOptions {
     pub code_annotation_syntax: Option<String>,
     /// Enable line numbers for all code blocks by default.
     pub code_annotation_default_line_numbers: Option<bool>,
+    /// Auto-link bare URLs in text. When enabled, the renderer wraps any
+    /// text occurrence starting with a registered pattern (default `http://`
+    /// and `https://`) in an `<a>` tag.
+    pub autolink_urls: Option<bool>,
+    /// URL prefix patterns for [`Self::autolink_urls`]. Overrides the
+    /// default `["http://", "https://"]` when set.
+    pub autolink_patterns: Option<Vec<String>>,
+    /// Add `target="_blank" rel="noopener noreferrer"` to auto-linked URLs.
+    /// Defaults to true; ignored when [`Self::autolink_urls`] is off.
+    pub autolink_target_blank: Option<bool>,
 }
 
 /// Source preparation options for JavaScript.

--- a/crates/ox_content_napi/src/transformer.rs
+++ b/crates/ox_content_napi/src/transformer.rs
@@ -348,6 +348,15 @@ fn transform_options_to_renderer_options(opts: &JsTransformOptions) -> HtmlRende
     if let Some(v) = opts.code_annotation_default_line_numbers {
         options.code_annotation_default_line_numbers = v;
     }
+    if let Some(v) = opts.autolink_urls {
+        options.autolink_urls = v;
+    }
+    if let Some(v) = &opts.autolink_patterns {
+        options.autolink_patterns.clone_from(v);
+    }
+    if let Some(v) = opts.autolink_target_blank {
+        options.autolink_target_blank = v;
+    }
 
     options
 }

--- a/crates/ox_content_renderer/src/html.rs
+++ b/crates/ox_content_renderer/src/html.rs
@@ -45,6 +45,18 @@ pub struct HtmlRendererOptions {
     pub code_annotation_default_line_numbers: bool,
     /// Maximum heading depth included in inline TOCs.
     pub toc_max_depth: u8,
+    /// Auto-link bare URLs in text. When enabled, any occurrence in a text
+    /// node that starts with one of [`Self::autolink_patterns`] is wrapped
+    /// in an `<a>` tag. Auto-linking is suppressed inside an existing link.
+    pub autolink_urls: bool,
+    /// URL prefix patterns recognised by [`Self::autolink_urls`]. Defaults
+    /// to `["http://", "https://"]`. Register additional schemes (e.g.
+    /// `"ftp://"`, `"mailto:"`) by pushing onto this vec.
+    pub autolink_patterns: Vec<String>,
+    /// When auto-linking, emit `target="_blank" rel="noopener noreferrer"`.
+    /// Independent from the existing markdown-link behaviour, which always
+    /// adds the attributes for http/https hrefs.
+    pub autolink_target_blank: bool,
 }
 
 impl HtmlRendererOptions {
@@ -65,6 +77,9 @@ impl HtmlRendererOptions {
             code_annotation_syntax: CodeAnnotationSyntax::Attribute,
             code_annotation_default_line_numbers: false,
             toc_max_depth: 3,
+            autolink_urls: false,
+            autolink_patterns: vec!["http://".to_string(), "https://".to_string()],
+            autolink_target_blank: true,
         }
     }
 }
@@ -888,6 +903,91 @@ fn write_url_escaped_into(out: &mut String, s: &str) {
     }
 }
 
+/// Scans `s` from `from` for the next position that begins one of the
+/// registered URL prefixes at a word boundary, and returns the
+/// `(match_start, url_end)` byte range with trailing punctuation trimmed.
+///
+/// The boundary rule mirrors common autolinkers: a match is only accepted
+/// when the preceding byte (if any) is not an ASCII alphanumeric — so
+/// `"see http://x"` matches but `"shttp://x"` doesn't. The URL extends to
+/// the next whitespace, `<`, `>`, `"`, `'`, or backtick, and we then strip
+/// trailing `.,;:!?` plus an unbalanced `)`, `]`, or `}`.
+fn find_autolink_match(s: &str, from: usize, patterns: &[String]) -> Option<(usize, usize)> {
+    let bytes = s.as_bytes();
+    let mut i = from;
+    while i < bytes.len() {
+        // Word boundary: the previous byte must not be ASCII alphanumeric.
+        let is_boundary = i == 0 || !bytes[i - 1].is_ascii_alphanumeric();
+        if is_boundary {
+            for pat in patterns {
+                let pat_bytes = pat.as_bytes();
+                if pat_bytes.is_empty() {
+                    continue;
+                }
+                if i + pat_bytes.len() <= bytes.len()
+                    && bytes[i..i + pat_bytes.len()].eq_ignore_ascii_case(pat_bytes)
+                {
+                    let url_start = i;
+                    let mut url_end = i + pat_bytes.len();
+                    while url_end < bytes.len() && is_url_byte(bytes[url_end]) {
+                        url_end += 1;
+                    }
+                    // Require at least one byte beyond the scheme/prefix
+                    // so `"http://"` on its own isn't auto-linked.
+                    if url_end == i + pat_bytes.len() {
+                        continue;
+                    }
+                    url_end = trim_trailing_punct(bytes, url_start, url_end);
+                    return Some((url_start, url_end));
+                }
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+#[inline]
+fn is_url_byte(byte: u8) -> bool {
+    !matches!(byte, b' ' | b'\t' | b'\n' | b'\r' | b'<' | b'>' | b'"' | b'\'' | b'`')
+}
+
+fn trim_trailing_punct(bytes: &[u8], start: usize, mut end: usize) -> usize {
+    while end > start {
+        let b = bytes[end - 1];
+        match b {
+            b'.' | b',' | b';' | b':' | b'!' | b'?' => end -= 1,
+            b')' | b']' | b'}' => {
+                let (open, close) = match b {
+                    b')' => (b'(', b')'),
+                    b']' => (b'[', b']'),
+                    _ => (b'{', b'}'),
+                };
+                // Strip the closing bracket only when it has no unmatched
+                // partner inside the URL — a single pass over the slice is
+                // simpler than two `filter().count()` walks and avoids the
+                // `naive_bytecount` clippy lint.
+                let mut opens = 0usize;
+                let mut closes = 0usize;
+                for &x in &bytes[start..end - 1] {
+                    if x == open {
+                        opens += 1;
+                    } else if x == close {
+                        closes += 1;
+                    }
+                }
+                if closes >= opens {
+                    end -= 1;
+                } else {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+    end
+}
+
 fn is_html_attr_start(byte: u8) -> bool {
     byte.is_ascii_alphabetic()
 }
@@ -1194,6 +1294,12 @@ pub struct HtmlRenderer {
     /// that ends up in `heading_id_counts` is cloned out of here on
     /// vacant inserts; the buffer itself stays around across renders.
     heading_slug_scratch: String,
+    /// Suppresses URL auto-linking while we're already inside an `<a>` so
+    /// the builtin can't nest anchors. Tracked manually rather than via
+    /// the AST because `visit_text` can be reached through many parents
+    /// (paragraphs, headings, emphasis, …) and only the link case needs
+    /// to mask it out.
+    in_link: bool,
 }
 
 impl HtmlRenderer {
@@ -1219,6 +1325,7 @@ impl HtmlRenderer {
             // live for the renderer's lifetime regardless).
             heading_text_scratch: String::with_capacity(64),
             heading_slug_scratch: String::with_capacity(64),
+            in_link: false,
         }
     }
 
@@ -1283,6 +1390,42 @@ impl HtmlRenderer {
     fn write_escaped(&mut self, s: &str) {
         profile_span!("renderer::write_escaped");
         write_escaped_into(&mut self.output, s);
+    }
+
+    /// Walks `s` and emits an `<a>` tag for each registered URL pattern
+    /// match, escaping the non-URL spans the normal way. Caller is expected
+    /// to have already gated this on the autolink flag — the function does
+    /// no flag checks of its own.
+    fn write_text_with_autolinks(&mut self, s: &str) {
+        profile_span!("renderer::write_text_with_autolinks");
+        let bytes = s.as_bytes();
+        let mut cursor = 0usize;
+        while cursor < bytes.len() {
+            let Some((match_start, url_end)) =
+                find_autolink_match(s, cursor, &self.options.autolink_patterns)
+            else {
+                break;
+            };
+            // Emit the literal text preceding the URL.
+            if match_start > cursor {
+                write_escaped_into(&mut self.output, &s[cursor..match_start]);
+            }
+            let url = &s[match_start..url_end];
+            self.output.push_str("<a href=\"");
+            write_url_escaped_into(&mut self.output, url);
+            self.output.push('"');
+            if self.options.autolink_target_blank {
+                self.output.push_str(" target=\"_blank\" rel=\"noopener noreferrer\"");
+            }
+            self.output.push('>');
+            // The visible text is the URL itself; escape it like any text.
+            write_escaped_into(&mut self.output, url);
+            self.output.push_str("</a>");
+            cursor = url_end;
+        }
+        if cursor < bytes.len() {
+            write_escaped_into(&mut self.output, &s[cursor..]);
+        }
     }
 
     fn write_url_escaped(&mut self, s: &str) {
@@ -1560,7 +1703,22 @@ impl HtmlRenderer {
         // `visit_text` wrapper, both of which are the only thing
         // `visit_text` would do anyway (escape into `self.output`).
         match node {
-            Node::Text(text) => write_escaped_into(&mut self.output, text.value),
+            Node::Text(text) => {
+                // The autolink builtin lives on this hot path too: when
+                // the flag is on (and we're not already inside an `<a>`)
+                // we have to scan the text for URLs before escaping. The
+                // common case — flag off — collapses back to the original
+                // single `write_escaped_into` call thanks to the early
+                // boolean check.
+                if self.options.autolink_urls
+                    && !self.in_link
+                    && !self.options.autolink_patterns.is_empty()
+                {
+                    self.write_text_with_autolinks(text.value);
+                } else {
+                    write_escaped_into(&mut self.output, text.value);
+                }
+            }
             Node::Html(html) => self.write_html_value(html.value),
             _ => self.visit_node(node),
         }
@@ -2010,7 +2168,12 @@ impl<'a> Visit<'a> for HtmlRenderer {
 
     fn visit_text(&mut self, text: &Text<'a>) {
         profile_span!("renderer::visit_text");
-        self.write_escaped(text.value);
+        if self.options.autolink_urls && !self.in_link && !self.options.autolink_patterns.is_empty()
+        {
+            self.write_text_with_autolinks(text.value);
+        } else {
+            self.write_escaped(text.value);
+        }
     }
 
     fn visit_emphasis(&mut self, emphasis: &Emphasis<'a>) {
@@ -2056,9 +2219,14 @@ impl<'a> Visit<'a> for HtmlRenderer {
             self.write("\"");
         }
         self.write(">");
+        // Suppress URL auto-linking inside the anchor — children text nodes
+        // may contain literal URLs that we must not wrap in a nested <a>.
+        let prev_in_link = self.in_link;
+        self.in_link = true;
         for child in &link.children {
             self.visit_inline_node(child);
         }
+        self.in_link = prev_in_link;
         self.write("</a>");
     }
 
@@ -2679,6 +2847,146 @@ mod tests {
         assert!(
             html.contains("href=\"../../guide/index.html\""),
             "Expected ../../guide/index.html but got: {html}"
+        );
+    }
+
+    #[test]
+    fn test_autolink_disabled_by_default() {
+        let allocator = Allocator::new();
+        let doc = Parser::new(&allocator, "see http://example.com here").parse().unwrap();
+        let mut renderer = HtmlRenderer::new();
+        let html = renderer.render(&doc);
+        // No <a> tag is emitted unless the flag is on.
+        assert!(!html.contains("<a "), "unexpected autolink in: {html}");
+        assert!(html.contains("http://example.com"));
+    }
+
+    #[test]
+    fn test_autolink_basic_http_and_https() {
+        let allocator = Allocator::new();
+        let doc = Parser::new(&allocator, "see http://example.com and https://example.org")
+            .parse()
+            .unwrap();
+        let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
+            autolink_urls: true,
+            ..Default::default()
+        });
+        let html = renderer.render(&doc);
+        assert!(
+            html.contains(
+                "<a href=\"http://example.com\" target=\"_blank\" rel=\"noopener noreferrer\">http://example.com</a>"
+            ),
+            "missing http autolink in: {html}"
+        );
+        assert!(
+            html.contains(
+                "<a href=\"https://example.org\" target=\"_blank\" rel=\"noopener noreferrer\">https://example.org</a>"
+            ),
+            "missing https autolink in: {html}"
+        );
+    }
+
+    #[test]
+    fn test_autolink_target_blank_can_be_disabled() {
+        let allocator = Allocator::new();
+        let doc = Parser::new(&allocator, "go to https://example.com now").parse().unwrap();
+        let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
+            autolink_urls: true,
+            autolink_target_blank: false,
+            ..Default::default()
+        });
+        let html = renderer.render(&doc);
+        assert!(
+            html.contains("<a href=\"https://example.com\">https://example.com</a>"),
+            "expected bare anchor in: {html}"
+        );
+        assert!(!html.contains("target=\"_blank\""), "blank attr leaked: {html}");
+    }
+
+    #[test]
+    fn test_autolink_strips_trailing_punctuation() {
+        let allocator = Allocator::new();
+        let doc = Parser::new(
+            &allocator,
+            "find it at https://example.com. or (https://example.org) maybe",
+        )
+        .parse()
+        .unwrap();
+        let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
+            autolink_urls: true,
+            ..Default::default()
+        });
+        let html = renderer.render(&doc);
+        assert!(html.contains(">https://example.com</a>."), "period leaked: {html}");
+        assert!(html.contains("(<a href=\"https://example.org\""), "open paren lost: {html}");
+        assert!(html.contains(">https://example.org</a>)"), "close paren lost: {html}");
+    }
+
+    #[test]
+    fn test_autolink_word_boundary_required() {
+        let allocator = Allocator::new();
+        // "shttp://x" must not match — the prefix is glued to a word char.
+        let doc = Parser::new(&allocator, "shttp://x and http://y").parse().unwrap();
+        let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
+            autolink_urls: true,
+            ..Default::default()
+        });
+        let html = renderer.render(&doc);
+        assert!(!html.contains("href=\"http://x\""), "unexpected glued autolink: {html}");
+        assert!(html.contains("href=\"http://y\""), "missing real autolink: {html}");
+    }
+
+    #[test]
+    fn test_autolink_custom_pattern_registration() {
+        let allocator = Allocator::new();
+        let doc = Parser::new(&allocator, "email mailto:foo@example.com please").parse().unwrap();
+        let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
+            autolink_urls: true,
+            autolink_patterns: vec!["mailto:".to_string()],
+            ..Default::default()
+        });
+        let html = renderer.render(&doc);
+        assert!(
+            html.contains("<a href=\"mailto:foo@example.com\""),
+            "missing custom-pattern autolink: {html}"
+        );
+    }
+
+    #[test]
+    fn test_autolink_does_not_nest_inside_existing_link() {
+        let allocator = Allocator::new();
+        // The text inside the explicit markdown link contains a URL — the
+        // builtin must not wrap that URL in a second <a>.
+        let doc =
+            Parser::new(&allocator, "[visit https://example.com here](/page)").parse().unwrap();
+        let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
+            autolink_urls: true,
+            ..Default::default()
+        });
+        let html = renderer.render(&doc);
+        assert_eq!(html.matches("<a ").count(), 1, "nested anchor in: {html}");
+        assert!(html.contains("href=\"/page\""), "outer link lost: {html}");
+        assert!(html.contains("visit https://example.com here"), "inner text lost: {html}");
+    }
+
+    #[test]
+    fn test_autolink_escapes_query_string_safely() {
+        let allocator = Allocator::new();
+        // `&` inside the URL must be escaped both as href and as visible
+        // text — otherwise the output would be parser-ambiguous HTML.
+        let doc = Parser::new(&allocator, "see http://a.test/?q=foo&r=bar now").parse().unwrap();
+        let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
+            autolink_urls: true,
+            ..Default::default()
+        });
+        let html = renderer.render(&doc);
+        assert!(
+            html.contains("href=\"http://a.test/?q=foo&amp;r=bar\""),
+            "href not escaped: {html}"
+        );
+        assert!(
+            html.contains(">http://a.test/?q=foo&amp;r=bar</a>"),
+            "visible text not escaped: {html}"
         );
     }
 }

--- a/crates/ox_content_wasm/src/lib.rs
+++ b/crates/ox_content_wasm/src/lib.rs
@@ -39,6 +39,9 @@ pub struct WasmParserOptions {
     strikethrough: bool,
     autolinks: bool,
     toc_max_depth: u8,
+    autolink_urls: bool,
+    autolink_patterns: Vec<String>,
+    autolink_target_blank: bool,
 }
 
 #[wasm_bindgen]
@@ -53,6 +56,9 @@ impl WasmParserOptions {
             strikethrough: false,
             autolinks: false,
             toc_max_depth: 3,
+            autolink_urls: false,
+            autolink_patterns: vec!["http://".to_string(), "https://".to_string()],
+            autolink_target_blank: true,
         }
     }
 
@@ -90,6 +96,27 @@ impl WasmParserOptions {
     pub fn set_toc_max_depth(&mut self, value: u8) {
         self.toc_max_depth = value;
     }
+
+    /// Enables the renderer's URL auto-linking builtin. Bare URLs matching
+    /// any registered pattern are wrapped in an `<a>` tag.
+    #[wasm_bindgen(setter = autolinkUrls)]
+    pub fn set_autolink_urls(&mut self, value: bool) {
+        self.autolink_urls = value;
+    }
+
+    /// Replaces the URL prefix patterns used by auto-linking. Pass a JS
+    /// array of strings such as `["http://", "https://", "ftp://"]`.
+    #[wasm_bindgen(setter = autolinkPatterns)]
+    pub fn set_autolink_patterns(&mut self, value: Vec<String>) {
+        self.autolink_patterns = value;
+    }
+
+    /// Toggles `target="_blank" rel="noopener noreferrer"` on auto-linked
+    /// URLs. Has no effect when `autolinkUrls` is off.
+    #[wasm_bindgen(setter = autolinkTargetBlank)]
+    pub fn set_autolink_target_blank(&mut self, value: bool) {
+        self.autolink_target_blank = value;
+    }
 }
 
 impl From<&WasmParserOptions> for ParserOptions {
@@ -119,6 +146,9 @@ pub fn parse_and_render(source: &str, options: Option<WasmParserOptions>) -> JsV
         Ok(doc) => {
             let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
                 toc_max_depth: opts.toc_max_depth,
+                autolink_urls: opts.autolink_urls,
+                autolink_patterns: opts.autolink_patterns.clone(),
+                autolink_target_blank: opts.autolink_target_blank,
                 ..Default::default()
             });
             let html = renderer.render(&doc);
@@ -159,6 +189,9 @@ pub fn transform(source: &str, options: Option<WasmParserOptions>) -> JsValue {
             // Render to HTML
             let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
                 toc_max_depth,
+                autolink_urls: opts.autolink_urls,
+                autolink_patterns: opts.autolink_patterns.clone(),
+                autolink_target_blank: opts.autolink_target_blank,
                 ..Default::default()
             });
             let html = renderer.render(&doc);


### PR DESCRIPTION
## Summary

- Add an opt-in builtin to the HTML renderer that wraps bare URLs in text nodes with `<a target=\"_blank\">` tags. Off by default to preserve existing output.
- New options on `HtmlRendererOptions`:
  - `autolink_urls: bool` — master flag.
  - `autolink_patterns: Vec<String>` — registrable URL prefix list, defaults to `[\"http://\", \"https://\"]`. Push more (e.g. `\"ftp://\"`, `\"mailto:\"`) to extend.
  - `autolink_target_blank: bool` — emits `target=\"_blank\" rel=\"noopener noreferrer\"` on generated anchors (default true).
- Wired identical knobs through the NAPI (`autolinkUrls`, `autolinkPatterns`, `autolinkTargetBlank` on `JsTransformOptions`) and WASM (`WasmParserOptions` setters with the same camelCase JS names) bindings.

### Implementation notes

- A new `in_link: bool` field on `HtmlRenderer` masks autolinking while we walk a markdown link's children, so we never produce nested `<a>` tags.
- The scanner enforces a word boundary at match start (`shttp://x` does not match), extends the URL until whitespace or `<>\"'\`` , then strips trailing `.,;:!?` and unbalanced `)`/`]`/`}`.
- Wired into both `visit_text` and the `visit_inline_node` perf fast-path so the flag stays effective on the hot path; the flag-off case collapses back to a single `write_escaped_into` call.
- Both the `href` and the visible text are routed through the existing escape helpers, so `&` and friends round-trip safely.

### Usage

Rust:
```rust
let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
    autolink_urls: true,
    autolink_patterns: vec![\"http://\".into(), \"https://\".into(), \"mailto:\".into()],
    autolink_target_blank: true,
    ..Default::default()
});
```

JS (NAPI / WASM):
```ts
transform(src, {
  autolinkUrls: true,
  autolinkPatterns: [\"http://\", \"https://\", \"ftp://\"],
  autolinkTargetBlank: true,
});
```

## Risk

- Risk level: low
- User or production impact: none unless the new flag is opted in — default `autolink_urls = false` preserves byte-for-byte output for existing callers, and no existing API was renamed or removed.
- Rollback plan: revert this commit; no migrations or data shape changes.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_renderer -p ox_content_napi -p ox_content_wasm` (renderer 43 + napi 29 + wasm 21, all green), `cargo fmt --all -- --check`, `cargo clippy -p ox_content_renderer -p ox_content_napi -p ox_content_wasm --no-deps -- -D warnings`.
- [x] Manual verification completed: 8 new renderer tests cover the off-by-default behaviour, http/https matches, target-blank toggle, trailing-punctuation handling, word boundary, custom-pattern registration, no-nesting-inside-link, and `&` escaping in query strings.
- [x] Edge cases or failure modes considered: URLs inside an existing markdown link (no nesting), URLs at start of text (boundary check at index 0), unbalanced parens at URL tail, custom non-default patterns replacing the defaults, `&` escaping in href and visible text.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed — option doc comments cover the public surface; user-facing docs can follow once the API stabilises.
- [x] Configuration, migration, or environment changes documented, or not needed — pure additive options with safe defaults.
- [x] Observability, logging, and alerting impact considered, or not needed — no new logs or metrics.
- [x] Security, privacy, and dependency impact considered, or not needed — no new deps; auto-linked URLs go through the same escape and (when enabled) sanitize paths as explicit markdown links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)