### PR TITLE
ci: add zizmor security analysis workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,32 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/**
+  pull_request:
+    branches: ["**"]
+    paths:
+      - .github/workflows/**
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          inputs: .github/workflows/


### PR DESCRIPTION
## Summary

This PR is supply change attack prevent.

Add a new `.github/workflows/zizmor.yml` that runs [zizmor](https://github.com/zizmorcore/zizmor) static analysis on `.github/workflows/**` whenever workflow files change.

Findings are uploaded as SARIF to GitHub Code Scanning by `zizmorcore/zizmor-action`.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.
