### PR TITLE
fix(docs): support typedoc markdown paths

### DIFF
--- a/crates/ox_content_docs/src/lib.rs
+++ b/crates/ox_content_docs/src/lib.rs
@@ -31,9 +31,11 @@ pub use graph::{
 };
 pub use markdown::{
     generate_markdown, ApiDocEntry, ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc,
-    ApiReturnDoc, MarkdownDocsOptions, MarkdownLinkStyle,
+    ApiReturnDoc, MarkdownDocsOptions, MarkdownLinkStyle, MarkdownPathStrategy,
 };
-pub use nav::{generate_nav_code, generate_nav_metadata, DocsNavItem};
+pub use nav::{
+    generate_nav_code, generate_nav_metadata, generate_nav_metadata_from_docs, DocsNavItem,
+};
 pub use normalize::{
     normalize_doc_item, normalize_doc_items, NormalizedDocEntry, NormalizedDocKind,
     NormalizedMember, NormalizedMemberKind, NormalizedParamDoc, NormalizedReturnDoc,

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -156,6 +156,9 @@ pub struct MarkdownDocsOptions {
     /// Optional absolute route prefix for generated documentation links.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_path: Option<String>,
+    /// Output path strategy.
+    #[serde(default)]
+    pub path_strategy: MarkdownPathStrategy,
 }
 
 /// Internal documentation link style.
@@ -169,6 +172,17 @@ pub enum MarkdownLinkStyle {
     Clean,
 }
 
+/// Generated Markdown output path strategy.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum MarkdownPathStrategy {
+    /// Keep the historical flat module/category files with entry anchors.
+    #[default]
+    Flat,
+    /// Emit TypeDoc-style module/kind/symbol pages.
+    TypeDoc,
+}
+
 impl Default for MarkdownDocsOptions {
     fn default() -> Self {
         Self {
@@ -176,6 +190,7 @@ impl Default for MarkdownDocsOptions {
             github_url: None,
             link_style: MarkdownLinkStyle::Markdown,
             base_path: None,
+            path_strategy: MarkdownPathStrategy::Flat,
         }
     }
 }
@@ -203,15 +218,17 @@ struct EntryBadge {
 
 #[derive(Debug, Clone)]
 struct SymbolLocation {
+    module_name: String,
     file_name: String,
-    anchor: String,
+    anchor: Option<String>,
 }
 
 #[derive(Debug, Clone)]
 struct MarkdownLinkContext<'a> {
     options: &'a MarkdownDocsOptions,
     current_file_name: &'a str,
-    symbol_map: &'a HashMap<String, SymbolLocation>,
+    current_module_name: &'a str,
+    symbol_map: &'a HashMap<String, Vec<SymbolLocation>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -239,13 +256,14 @@ pub fn generate_markdown(
     let symbol_map = build_symbol_map(&sorted_docs, options);
 
     if options.group_by == "file" {
+        if options.path_strategy == MarkdownPathStrategy::TypeDoc {
+            return generate_typedoc_markdown(&sorted_docs, options, &symbol_map);
+        }
+
         let mut doc_to_file = HashMap::new();
 
         for doc in &sorted_docs {
-            let mut file_name = file_stem(&doc.file);
-            if file_name == "index" {
-                file_name = "index-module".to_string();
-            }
+            let file_name = module_file_name(&doc.file);
             doc_to_file.insert(doc.file.clone(), file_name.clone());
 
             let markdown = generate_file_markdown(doc, options, &file_name, &symbol_map);
@@ -286,7 +304,23 @@ pub fn generate_markdown(
 }
 
 fn doc_page_href(options: &MarkdownDocsOptions, file_name: &str, anchor: Option<&str>) -> String {
+    doc_page_href_from(options, "", file_name, anchor)
+}
+
+fn doc_page_href_from(
+    options: &MarkdownDocsOptions,
+    current_file_name: &str,
+    target_file_name: &str,
+    anchor: Option<&str>,
+) -> String {
+    if target_file_name == current_file_name {
+        if let Some(anchor) = anchor.filter(|anchor| !anchor.is_empty()) {
+            return format!("#{anchor}");
+        }
+    }
+
     let mut href = String::new();
+    let target_file_name = route_file_name(options, target_file_name);
 
     if let Some(base_path) =
         options.base_path.as_deref().map(str::trim).filter(|base| !base.is_empty())
@@ -296,11 +330,11 @@ fn doc_page_href(options: &MarkdownDocsOptions, file_name: &str, anchor: Option<
             href.push_str(&base_path);
         }
         href.push('/');
+        href.push_str(&target_file_name);
     } else {
-        href.push_str("./");
+        href.push_str(&relative_doc_href_path(current_file_name, &target_file_name));
     }
 
-    href.push_str(file_name);
     if options.link_style == MarkdownLinkStyle::Markdown {
         href.push_str(".md");
     }
@@ -310,6 +344,41 @@ fn doc_page_href(options: &MarkdownDocsOptions, file_name: &str, anchor: Option<
     }
 
     href
+}
+
+fn route_file_name(options: &MarkdownDocsOptions, file_name: &str) -> String {
+    if options.link_style == MarkdownLinkStyle::Clean {
+        file_name.strip_suffix("/index").unwrap_or(file_name).to_string()
+    } else {
+        file_name.to_string()
+    }
+}
+
+fn relative_doc_href_path(current_file_name: &str, target_file_name: &str) -> String {
+    let current_dir =
+        current_file_name.rsplit_once('/').map_or("", |(directory, _)| directory).trim_matches('/');
+    let current_parts = current_dir.split('/').filter(|part| !part.is_empty()).collect::<Vec<_>>();
+    let target_parts =
+        target_file_name.split('/').filter(|part| !part.is_empty()).collect::<Vec<_>>();
+
+    let mut common = 0;
+    while current_parts.get(common) == target_parts.get(common) {
+        if current_parts.get(common).is_none() {
+            break;
+        }
+        common += 1;
+    }
+
+    let mut parts = Vec::new();
+    parts.extend(std::iter::repeat_n("..", current_parts.len().saturating_sub(common)));
+    parts.extend(target_parts.iter().skip(common).copied());
+
+    let path = if parts.is_empty() { target_file_name.to_string() } else { parts.join("/") };
+    if path.starts_with("../") {
+        path
+    } else {
+        format!("./{path}")
+    }
 }
 
 fn normalize_base_path(base_path: &str) -> String {
@@ -339,16 +408,122 @@ fn entry_anchor(name: &str) -> String {
     name.to_lowercase()
 }
 
-fn member_anchor(entry_name: &str, member_name: &str) -> String {
-    format!("{}-{}", entry_anchor(entry_name), entry_anchor(member_name))
+fn member_anchor(
+    entry_name: &str,
+    member: &ApiDocMember,
+    path_strategy: MarkdownPathStrategy,
+) -> String {
+    match path_strategy {
+        MarkdownPathStrategy::Flat => {
+            format!("{}-{}", entry_anchor(entry_name), entry_anchor(&member.name))
+        }
+        MarkdownPathStrategy::TypeDoc => {
+            let prefix = match member.kind.as_str() {
+                "constructor" => return "constructor".to_string(),
+                "method" => "method",
+                "getter" | "setter" => "accessor",
+                "enumMember" => "enumeration-member",
+                _ => "property",
+            };
+            format!("{prefix}-{}", entry_anchor(&member.name))
+        }
+    }
+}
+
+fn module_file_name(file_path: &str) -> String {
+    let mut file_name = file_stem(file_path);
+    if file_name == "index" {
+        file_name = "index-module".to_string();
+    }
+    sanitize_doc_path_segment(&file_name)
+}
+
+fn typedoc_kind_segment(kind: &str) -> &'static str {
+    match kind {
+        "function" => "functions",
+        "class" => "classes",
+        "interface" => "interfaces",
+        "type" => "type-aliases",
+        "variable" | "const" => "variables",
+        "module" => "modules",
+        _ => "symbols",
+    }
+}
+
+fn typedoc_kind_title(kind: &str) -> &'static str {
+    match kind {
+        "function" => "Functions",
+        "class" => "Classes",
+        "interface" => "Interfaces",
+        "type" => "Type Aliases",
+        "variable" | "const" => "Variables",
+        "module" => "Modules",
+        _ => "Symbols",
+    }
+}
+
+fn typedoc_entry_file_name(module_name: &str, entry: &ApiDocEntry) -> String {
+    format!(
+        "{}/{}/{}",
+        module_name,
+        typedoc_kind_segment(&entry.kind),
+        sanitize_doc_path_segment(&entry.name)
+    )
+}
+
+fn typedoc_module_index_file_name(module_name: &str) -> String {
+    format!("{module_name}/index")
+}
+
+fn sanitize_doc_path_segment(value: &str) -> String {
+    let sanitized = value
+        .chars()
+        .map(|ch| match ch {
+            '/' | '\\' | '?' | '#' | '[' | ']' | '<' | '>' | ':' | '"' | '|' | '*' => '-',
+            _ => ch,
+        })
+        .collect::<String>();
+    if sanitized.is_empty() {
+        "symbol".to_string()
+    } else {
+        sanitized
+    }
 }
 
 fn format_symbol_href(context: &MarkdownLinkContext<'_>, location: &SymbolLocation) -> String {
     if location.file_name == context.current_file_name {
-        format!("#{}", location.anchor)
+        if let Some(anchor) = location.anchor.as_deref().filter(|anchor| !anchor.is_empty()) {
+            format!("#{anchor}")
+        } else {
+            doc_page_href_from(
+                context.options,
+                context.current_file_name,
+                &location.file_name,
+                None,
+            )
+        }
     } else {
-        doc_page_href(context.options, &location.file_name, Some(&location.anchor))
+        doc_page_href_from(
+            context.options,
+            context.current_file_name,
+            &location.file_name,
+            location.anchor.as_deref(),
+        )
     }
+}
+
+fn resolve_symbol_location<'a>(
+    symbol_name: &str,
+    context: &'a MarkdownLinkContext<'_>,
+) -> Option<&'a SymbolLocation> {
+    let locations = context.symbol_map.get(symbol_name)?;
+    locations
+        .iter()
+        .find(|location| location.module_name == context.current_module_name)
+        .or_else(|| {
+            locations.iter().find(|location| location.file_name == context.current_file_name)
+        })
+        .or_else(|| locations.first())
 }
 
 fn resolve_jsdoc_link_target(
@@ -361,7 +536,7 @@ fn resolve_jsdoc_link_target(
     }
 
     let context = context?;
-    context.symbol_map.get(target).map(|location| format_symbol_href(context, location))
+    resolve_symbol_location(target, context).map(|location| format_symbol_href(context, location))
 }
 
 fn parse_jsdoc_inline_link_body(body: &str) -> Option<(&str, Option<&str>)> {
@@ -873,7 +1048,7 @@ fn generate_file_markdown(
     doc: &ApiDocModule,
     options: &MarkdownDocsOptions,
     current_file_name: &str,
-    symbol_map: &HashMap<String, SymbolLocation>,
+    symbol_map: &HashMap<String, Vec<SymbolLocation>>,
 ) -> String {
     let display_name = file_name(&doc.file);
     let mut markdown = String::new();
@@ -910,11 +1085,188 @@ fn generate_file_markdown(
             entry,
             options,
             Some(current_file_name),
+            Some(current_file_name),
             Some(symbol_map),
         ));
     }
 
     markdown
+}
+
+fn generate_typedoc_markdown(
+    docs: &[ApiDocModule],
+    options: &MarkdownDocsOptions,
+    symbol_map: &HashMap<String, Vec<SymbolLocation>>,
+) -> BTreeMap<String, String> {
+    let mut result = BTreeMap::new();
+
+    result.insert("index.md".to_string(), generate_typedoc_root_index(docs, options, symbol_map));
+
+    for doc in docs {
+        let module_name = module_file_name(&doc.file);
+        let module_index_file_name = typedoc_module_index_file_name(&module_name);
+        result.insert(
+            format!("{module_index_file_name}.md"),
+            generate_typedoc_module_index(doc, options, &module_name, symbol_map),
+        );
+
+        for entry in &doc.entries {
+            let entry_file_name = typedoc_entry_file_name(&module_name, entry);
+            result.insert(
+                format!("{entry_file_name}.md"),
+                generate_typedoc_entry_page(
+                    entry,
+                    options,
+                    &module_name,
+                    &entry_file_name,
+                    symbol_map,
+                ),
+            );
+        }
+    }
+
+    result
+}
+
+fn generate_typedoc_root_index(
+    docs: &[ApiDocModule],
+    options: &MarkdownDocsOptions,
+    symbol_map: &HashMap<String, Vec<SymbolLocation>>,
+) -> String {
+    let link_context = MarkdownLinkContext {
+        options,
+        current_file_name: "index",
+        current_module_name: "",
+        symbol_map,
+    };
+    let mut markdown = "# API Documentation\n\n".to_string();
+    markdown.push_str("Generated by [Ox Content](https://github.com/ubugeeei/ox-content)\n\n");
+    markdown.push_str(&render_stats_html(
+        &summarize_entries(docs.iter().flat_map(|doc| doc.entries.iter())),
+        Some(docs.len()),
+    ));
+    markdown.push_str("\n\n## Modules\n\n");
+
+    for doc in docs {
+        let module_name = module_file_name(&doc.file);
+        let href = doc_page_href_from(
+            options,
+            "index",
+            &typedoc_module_index_file_name(&module_name),
+            None,
+        );
+        let summary = clean_summary_text(
+            &doc.entries.first().map_or_else(String::new, |entry| {
+                process_doc_text(&entry.description, Some(&link_context))
+            }),
+            88,
+        );
+        if summary.is_empty() {
+            push_fmt(
+                &mut markdown,
+                format_args!("- [{}]({href})\n", capitalize_ascii(&module_name)),
+            );
+        } else {
+            push_fmt(
+                &mut markdown,
+                format_args!("- [{}]({href}) - {summary}\n", capitalize_ascii(&module_name)),
+            );
+        }
+    }
+
+    markdown
+}
+
+fn generate_typedoc_module_index(
+    doc: &ApiDocModule,
+    options: &MarkdownDocsOptions,
+    module_name: &str,
+    symbol_map: &HashMap<String, Vec<SymbolLocation>>,
+) -> String {
+    let current_file_name = typedoc_module_index_file_name(module_name);
+    let link_context = MarkdownLinkContext {
+        options,
+        current_file_name: &current_file_name,
+        current_module_name: module_name,
+        symbol_map,
+    };
+    let mut markdown = fmt_args(format_args!("# {}\n\n", capitalize_ascii(module_name)));
+
+    if let Some(github_url) = &options.github_url {
+        markdown.push_str(&generate_source_link(&doc.file, github_url, None, None));
+        markdown.push_str("\n\n");
+    }
+
+    markdown.push_str(&render_stats_html(&summarize_entries(&doc.entries), None));
+    markdown.push_str("\n\n");
+
+    for kind in ordered_entry_kinds(&doc.entries) {
+        let entries = doc.entries.iter().filter(|entry| entry.kind == kind).collect::<Vec<_>>();
+        if entries.is_empty() {
+            continue;
+        }
+
+        push_fmt(&mut markdown, format_args!("## {}\n\n", typedoc_kind_title(&kind)));
+        for entry in entries {
+            let href = doc_page_href_from(
+                options,
+                &current_file_name,
+                &typedoc_entry_file_name(module_name, entry),
+                None,
+            );
+            markdown.push_str(&render_overview_line(entry, &href, Some(&link_context)));
+        }
+        markdown.push('\n');
+    }
+
+    markdown
+}
+
+fn generate_typedoc_entry_page(
+    entry: &ApiDocEntry,
+    options: &MarkdownDocsOptions,
+    module_name: &str,
+    current_file_name: &str,
+    symbol_map: &HashMap<String, Vec<SymbolLocation>>,
+) -> String {
+    let link_context = MarkdownLinkContext {
+        options,
+        current_file_name,
+        current_module_name: module_name,
+        symbol_map,
+    };
+    let body = render_entry_body_html(entry, options, Some(&link_context));
+    let mut markdown = fmt_args(format_args!("# {}\n\n", entry.name));
+    push_fmt(
+        &mut markdown,
+        format_args!(
+            "<div id=\"{}\" class=\"ox-api-entry ox-api-entry--page\">
+{}
+</div>
+",
+            entry_anchor(&entry.name),
+            body
+        ),
+    );
+    markdown
+}
+
+fn ordered_entry_kinds(entries: &[ApiDocEntry]) -> Vec<String> {
+    let mut kinds = Vec::new();
+    for kind in DOC_KIND_ORDER {
+        if entries.iter().any(|entry| entry.kind == kind) {
+            kinds.push(kind.to_string());
+        }
+    }
+    let mut extra = entries
+        .iter()
+        .map(|entry| entry.kind.clone())
+        .filter(|kind| !DOC_KIND_ORDER.contains(&kind.as_str()))
+        .collect::<Vec<_>>();
+    extra.sort();
+    extra.dedup();
+    kinds.extend(extra);
+    kinds
 }
 
 fn normalize_signature(signature: Option<&str>) -> Option<String> {
@@ -1277,7 +1629,13 @@ fn render_member_table_html(
   <td>{}</td>
   <td>{}</td>
 </tr>",
-                escape_html(&member_anchor(entry_name, &member.name)),
+                escape_html(&member_anchor(
+                    entry_name,
+                    member,
+                    context.map_or(MarkdownPathStrategy::Flat, |context| context
+                        .options
+                        .path_strategy),
+                )),
                 escape_html(&member.name),
                 render_member_flags(member),
                 escape_html(&member.kind),
@@ -1399,18 +1757,12 @@ fn render_members_table_html(
     )
 }
 
-fn generate_entry_markdown(
+fn render_entry_body_html(
     entry: &ApiDocEntry,
     options: &MarkdownDocsOptions,
-    current_file_name: Option<&str>,
-    symbol_map: Option<&HashMap<String, SymbolLocation>>,
+    link_context: Option<&MarkdownLinkContext<'_>>,
 ) -> String {
-    let link_context = current_file_name.zip(symbol_map).map(|(current_file_name, symbol_map)| {
-        MarkdownLinkContext { options, current_file_name, symbol_map }
-    });
-    let link_context = link_context.as_ref();
     let processed_description = process_doc_text(&entry.description, link_context);
-    let summary_signature = normalize_signature(entry.signature.as_deref());
     let source_href = options.github_url.as_ref().map(|github_url| {
         generate_source_href(&entry.file, github_url, Some(entry.line), Some(entry.end_line))
     });
@@ -1510,6 +1862,29 @@ fn generate_entry_markdown(
         body.push('\n');
     }
 
+    body.trim().to_string()
+}
+
+fn generate_entry_markdown(
+    entry: &ApiDocEntry,
+    options: &MarkdownDocsOptions,
+    current_file_name: Option<&str>,
+    current_module_name: Option<&str>,
+    symbol_map: Option<&HashMap<String, Vec<SymbolLocation>>>,
+) -> String {
+    let link_context = current_file_name.zip(current_module_name).zip(symbol_map).map(
+        |((current_file_name, current_module_name), symbol_map)| MarkdownLinkContext {
+            options,
+            current_file_name,
+            current_module_name,
+            symbol_map,
+        },
+    );
+    let link_context = link_context.as_ref();
+    let processed_description = process_doc_text(&entry.description, link_context);
+    let summary_signature = normalize_signature(entry.signature.as_deref());
+    let body = render_entry_body_html(entry, options, link_context);
+
     let summary_description = clean_summary_text(
         &processed_description,
         if summary_signature.is_some() { 80 } else { 120 },
@@ -1554,7 +1929,7 @@ fn generate_entry_markdown(
 ",
         entry_anchor(&entry.name),
         summary_parts.join(""),
-        body.trim()
+        body
     )
 }
 
@@ -1562,11 +1937,12 @@ fn generate_index(
     docs: &[ApiDocModule],
     options: &MarkdownDocsOptions,
     doc_to_file: Option<&HashMap<String, String>>,
-    symbol_map: Option<&HashMap<String, SymbolLocation>>,
+    symbol_map: Option<&HashMap<String, Vec<SymbolLocation>>>,
 ) -> String {
     let link_context = symbol_map.map(|symbol_map| MarkdownLinkContext {
         options,
         current_file_name: "index",
+        current_module_name: "",
         symbol_map,
     });
     let mut markdown = "# API Documentation\n\n".to_string();
@@ -1646,11 +2022,15 @@ fn generate_category_markdown(
     kind: &str,
     entries: &[ApiDocEntry],
     options: &MarkdownDocsOptions,
-    symbol_map: &HashMap<String, SymbolLocation>,
+    symbol_map: &HashMap<String, Vec<SymbolLocation>>,
 ) -> String {
     let category_file_name = fmt_args(format_args!("{kind}s"));
-    let link_context =
-        MarkdownLinkContext { options, current_file_name: &category_file_name, symbol_map };
+    let link_context = MarkdownLinkContext {
+        options,
+        current_file_name: &category_file_name,
+        current_module_name: "",
+        symbol_map,
+    };
     let mut markdown = fmt_args(format_args!("# {}s\n\n", capitalize_ascii(kind)));
     push_fmt(
         &mut markdown,
@@ -1682,6 +2062,7 @@ fn generate_category_markdown(
             entry,
             options,
             Some(&category_file_name),
+            Some(""),
             Some(symbol_map),
         ));
     }
@@ -1692,9 +2073,14 @@ fn generate_category_markdown(
 fn generate_category_index(
     by_kind: &BTreeMap<String, Vec<ApiDocEntry>>,
     options: &MarkdownDocsOptions,
-    symbol_map: &HashMap<String, SymbolLocation>,
+    symbol_map: &HashMap<String, Vec<SymbolLocation>>,
 ) -> String {
-    let link_context = MarkdownLinkContext { options, current_file_name: "index", symbol_map };
+    let link_context = MarkdownLinkContext {
+        options,
+        current_file_name: "index",
+        current_module_name: "",
+        symbol_map,
+    };
     let mut markdown = "# API Documentation\n\n".to_string();
     markdown.push_str("Generated by [Ox Content](https://github.com/ubugeeei/ox-content)\n\n");
     markdown.push_str(&render_stats_html(
@@ -1752,7 +2138,7 @@ fn convert_symbol_links(text: &str, context: &MarkdownLinkContext<'_>) -> String
         }
 
         let symbol_name = captures.get(1).map_or("", |value| value.as_str());
-        let Some(location) = context.symbol_map.get(symbol_name) else {
+        let Some(location) = resolve_symbol_location(symbol_name, context) else {
             continue;
         };
 
@@ -1775,30 +2161,38 @@ fn convert_symbol_links(text: &str, context: &MarkdownLinkContext<'_>) -> String
 fn build_symbol_map(
     docs: &[ApiDocModule],
     options: &MarkdownDocsOptions,
-) -> HashMap<String, SymbolLocation> {
+) -> HashMap<String, Vec<SymbolLocation>> {
     let mut map = HashMap::new();
 
     for doc in docs {
+        let module_name = module_file_name(&doc.file);
         for entry in &doc.entries {
-            let mut file_name = if options.group_by == "category" {
-                fmt_args(format_args!("{}s", entry.kind))
-            } else {
-                file_stem(&doc.file)
+            let (file_name, anchor) = match (options.group_by.as_str(), options.path_strategy) {
+                ("file", MarkdownPathStrategy::TypeDoc) => {
+                    (typedoc_entry_file_name(&module_name, entry), None)
+                }
+                ("category", _) => {
+                    (fmt_args(format_args!("{}s", entry.kind)), Some(entry_anchor(&entry.name)))
+                }
+                _ => (module_name.clone(), Some(entry_anchor(&entry.name))),
             };
-            if file_name == "index" {
-                file_name = "index-module".to_string();
-            }
-
-            map.insert(
+            insert_symbol_location(
+                &mut map,
                 entry.name.clone(),
-                SymbolLocation { file_name: file_name.clone(), anchor: entry_anchor(&entry.name) },
+                SymbolLocation {
+                    module_name: module_name.clone(),
+                    file_name: file_name.clone(),
+                    anchor,
+                },
             );
             for member in &entry.members {
-                map.insert(
+                insert_symbol_location(
+                    &mut map,
                     fmt_args(format_args!("{}.{}", entry.name, member.name)),
                     SymbolLocation {
+                        module_name: module_name.clone(),
                         file_name: file_name.clone(),
-                        anchor: member_anchor(&entry.name, &member.name),
+                        anchor: Some(member_anchor(&entry.name, member, options.path_strategy)),
                     },
                 );
             }
@@ -1806,6 +2200,14 @@ fn build_symbol_map(
     }
 
     map
+}
+
+fn insert_symbol_location(
+    map: &mut HashMap<String, Vec<SymbolLocation>>,
+    symbol_name: String,
+    location: SymbolLocation,
+) {
+    map.entry(symbol_name).or_default().push(location);
 }
 
 fn generate_source_href(
@@ -2084,6 +2486,139 @@ mod tests {
         assert!(command_page.contains("<tr id=\"command-args\">"));
         assert!(command_page.contains("<a href=\"#command-args\"><code>Command.args</code></a>"));
         assert!(index.contains("Builds command metadata."));
+    }
+
+    #[test]
+    fn typedoc_path_strategy_emits_per_symbol_pages_and_links() {
+        let docs = vec![ApiDocModule {
+            file: "default".to_string(),
+            entries: vec![
+                ApiDocEntry {
+                    name: "cli".to_string(),
+                    kind: "function".to_string(),
+                    description:
+                        "Run with {@link CliOptions} and {@linkcode CliOptions.usageSilent}."
+                            .to_string(),
+                    params: vec![],
+                    returns: None,
+                    examples: vec![],
+                    tags: vec![],
+                    private: false,
+                    file: "/repo/src/cli.ts".to_string(),
+                    line: 1,
+                    end_line: 10,
+                    signature: Some("export function cli(options: CliOptions): void".to_string()),
+                    members: vec![],
+                },
+                ApiDocEntry {
+                    name: "CliOptions".to_string(),
+                    kind: "interface".to_string(),
+                    description: "CLI options.".to_string(),
+                    params: vec![],
+                    returns: None,
+                    examples: vec![],
+                    tags: vec![],
+                    private: false,
+                    file: "/repo/src/types.ts".to_string(),
+                    line: 1,
+                    end_line: 20,
+                    signature: Some("export interface CliOptions".to_string()),
+                    members: vec![ApiDocMember {
+                        name: "usageSilent".to_string(),
+                        kind: "property".to_string(),
+                        description: "Suppress usage output.".to_string(),
+                        signature: None,
+                        type_annotation: Some("boolean".to_string()),
+                        params: vec![],
+                        returns: None,
+                        optional: true,
+                        readonly: false,
+                        r#static: false,
+                        private: false,
+                        tags: vec![],
+                        line: 5,
+                        end_line: 5,
+                    }],
+                },
+                test_entry("Plugin", "type", "/repo/src/plugin.ts", "Plugin type."),
+                test_entry(
+                    "CLI_OPTIONS_DEFAULT",
+                    "variable",
+                    "/repo/src/constants.ts",
+                    "Default options.",
+                ),
+            ],
+        }];
+
+        let markdown = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let cli_page = markdown.get("default/functions/cli.md").unwrap();
+        let options_page = markdown.get("default/interfaces/CliOptions.md").unwrap();
+        let module_index = markdown.get("default/index.md").unwrap();
+
+        assert!(markdown.contains_key("index.md"));
+        assert!(markdown.contains_key("default/type-aliases/Plugin.md"));
+        assert!(markdown.contains_key("default/variables/CLI_OPTIONS_DEFAULT.md"));
+        assert!(module_index.contains("[`cli`](./functions/cli.md)"));
+        assert!(module_index.contains("[`CliOptions`](./interfaces/CliOptions.md)"));
+        assert!(cli_page.contains("<a href=\"../interfaces/CliOptions.md\">CliOptions</a>"));
+        assert!(cli_page.contains(
+            "<a href=\"../interfaces/CliOptions.md#property-usagesilent\"><code>CliOptions.usageSilent</code></a>"
+        ));
+        assert!(options_page.contains("<tr id=\"property-usagesilent\">"));
+    }
+
+    #[test]
+    fn typedoc_path_strategy_uses_clean_base_path_and_module_scope() {
+        let docs = vec![
+            ApiDocModule {
+                file: "default".to_string(),
+                entries: vec![
+                    test_entry("Command", "interface", "/repo/src/default.ts", "Default command."),
+                    test_entry(
+                        "runDefault",
+                        "function",
+                        "/repo/src/default.ts",
+                        "Runs {@link Command}.",
+                    ),
+                ],
+            },
+            ApiDocModule {
+                file: "plugin".to_string(),
+                entries: vec![
+                    test_entry("Command", "interface", "/repo/src/plugin.ts", "Plugin command."),
+                    test_entry(
+                        "runPlugin",
+                        "function",
+                        "/repo/src/plugin.ts",
+                        "Runs {@link Command}.",
+                    ),
+                ],
+            },
+        ];
+
+        let markdown = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                link_style: MarkdownLinkStyle::Clean,
+                base_path: Some("/api".to_string()),
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let default_page = markdown.get("default/functions/runDefault.md").unwrap();
+        let plugin_page = markdown.get("plugin/functions/runPlugin.md").unwrap();
+        let index = markdown.get("index.md").unwrap();
+
+        assert!(index.contains("[Default](/api/default)"));
+        assert!(default_page.contains("<a href=\"/api/default/interfaces/Command\">Command</a>"));
+        assert!(plugin_page.contains("<a href=\"/api/plugin/interfaces/Command\">Command</a>"));
+        assert!(!default_page.contains(".md"));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/nav.rs
+++ b/crates/ox_content_docs/src/nav.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
+use crate::markdown::{ApiDocEntry, ApiDocModule, MarkdownPathStrategy};
+
 const DEFAULT_BASE_PATH: &str = "/api";
 const DEFAULT_EXPORT_NAME: &str = "apiNav";
 const OVERVIEW_TITLE: &str = "Overview";
@@ -37,6 +39,74 @@ pub fn generate_nav_metadata(files: &[String], base_path: Option<&str>) -> Vec<D
         .collect()
 }
 
+/// Generates sidebar navigation metadata from extracted docs and the output path strategy.
+pub fn generate_nav_metadata_from_docs(
+    docs: &[ApiDocModule],
+    base_path: Option<&str>,
+    path_strategy: MarkdownPathStrategy,
+) -> Vec<DocsNavItem> {
+    match path_strategy {
+        MarkdownPathStrategy::Flat => {
+            let files = docs.iter().map(|doc| doc.file.clone()).collect::<Vec<_>>();
+            generate_nav_metadata(&files, base_path)
+        }
+        MarkdownPathStrategy::TypeDoc => generate_typedoc_nav_metadata(docs, base_path),
+    }
+}
+
+fn generate_typedoc_nav_metadata(
+    docs: &[ApiDocModule],
+    base_path: Option<&str>,
+) -> Vec<DocsNavItem> {
+    let base_path = normalize_base_path(base_path.unwrap_or(DEFAULT_BASE_PATH));
+    let mut docs = docs.to_vec();
+    docs.sort_by_key(|doc| module_file_name(&doc.file));
+
+    docs.into_iter()
+        .map(|doc| {
+            let module_name = module_file_name(&doc.file);
+            let mut children = Vec::new();
+            for kind in ordered_entry_kinds(&doc.entries) {
+                let entries =
+                    doc.entries.iter().filter(|entry| entry.kind == kind).collect::<Vec<_>>();
+                if entries.is_empty() {
+                    continue;
+                }
+
+                let kind_segment = typedoc_kind_segment(&kind);
+                let kind_path =
+                    nav_route_path(&base_path, &format!("{module_name}/{kind_segment}"));
+                let entry_children = entries
+                    .into_iter()
+                    .map(|entry| DocsNavItem {
+                        title: entry.name.clone(),
+                        path: nav_route_path(
+                            &base_path,
+                            &format!(
+                                "{module_name}/{kind_segment}/{}",
+                                sanitize_doc_path_segment(&entry.name)
+                            ),
+                        ),
+                        children: None,
+                    })
+                    .collect::<Vec<_>>();
+
+                children.push(DocsNavItem {
+                    title: typedoc_kind_title(&kind).to_string(),
+                    path: kind_path,
+                    children: Some(entry_children),
+                });
+            }
+
+            DocsNavItem {
+                title: format_doc_title(&module_name),
+                path: nav_route_path(&base_path, &format!("{module_name}/index")),
+                children: if children.is_empty() { None } else { Some(children) },
+            }
+        })
+        .collect()
+}
+
 fn normalize_base_path(base_path: &str) -> String {
     let base_path = base_path.trim().trim_end_matches('/');
 
@@ -48,6 +118,15 @@ fn normalize_base_path(base_path: &str) -> String {
         base_path.to_string()
     } else {
         format!("/{base_path}")
+    }
+}
+
+fn nav_route_path(base_path: &str, file_name: &str) -> String {
+    let file_name = file_name.strip_suffix("/index").unwrap_or(file_name);
+    if base_path.is_empty() {
+        format!("/{file_name}")
+    } else {
+        format!("{base_path}/{file_name}")
     }
 }
 
@@ -86,6 +165,74 @@ fn get_doc_display_name(file_path: &str) -> String {
 
 fn get_doc_file_name(file_path: &str) -> String {
     file_stem(file_path)
+}
+
+fn module_file_name(file_path: &str) -> String {
+    let mut file_name = file_stem(file_path);
+    if file_name == "index" {
+        file_name = "index-module".to_string();
+    }
+    sanitize_doc_path_segment(&file_name)
+}
+
+fn ordered_entry_kinds(entries: &[ApiDocEntry]) -> Vec<String> {
+    const DOC_KIND_ORDER: [&str; 6] =
+        ["function", "class", "interface", "type", "variable", "module"];
+
+    let mut kinds = Vec::new();
+    for kind in DOC_KIND_ORDER {
+        if entries.iter().any(|entry| entry.kind == kind) {
+            kinds.push(kind.to_string());
+        }
+    }
+    let mut extra = entries
+        .iter()
+        .map(|entry| entry.kind.clone())
+        .filter(|kind| !DOC_KIND_ORDER.contains(&kind.as_str()))
+        .collect::<Vec<_>>();
+    extra.sort();
+    extra.dedup();
+    kinds.extend(extra);
+    kinds
+}
+
+fn typedoc_kind_segment(kind: &str) -> &'static str {
+    match kind {
+        "function" => "functions",
+        "class" => "classes",
+        "interface" => "interfaces",
+        "type" => "type-aliases",
+        "variable" | "const" => "variables",
+        "module" => "modules",
+        _ => "symbols",
+    }
+}
+
+fn typedoc_kind_title(kind: &str) -> &'static str {
+    match kind {
+        "function" => "Functions",
+        "class" => "Classes",
+        "interface" => "Interfaces",
+        "type" => "Type Aliases",
+        "variable" | "const" => "Variables",
+        "module" => "Modules",
+        _ => "Symbols",
+    }
+}
+
+fn sanitize_doc_path_segment(value: &str) -> String {
+    let sanitized = value
+        .chars()
+        .map(|ch| match ch {
+            '/' | '\\' | '?' | '#' | '[' | ']' | '<' | '>' | ':' | '"' | '|' | '*' => '-',
+            _ => ch,
+        })
+        .collect::<String>();
+    if sanitized.is_empty() {
+        "symbol".to_string()
+    } else {
+        sanitized
+    }
 }
 
 fn file_stem(file_path: &str) -> String {
@@ -161,6 +308,60 @@ mod tests {
         let nav = generate_nav_metadata(&["/repo/src/context.ts".to_string()], Some("api-ox/"));
 
         assert_eq!(nav[0].path, "/api-ox/context");
+    }
+
+    #[test]
+    fn generates_typedoc_nav_metadata_from_docs() {
+        let docs = vec![ApiDocModule {
+            file: "default".to_string(),
+            entries: vec![
+                ApiDocEntry {
+                    name: "cli".to_string(),
+                    kind: "function".to_string(),
+                    description: String::new(),
+                    params: vec![],
+                    returns: None,
+                    examples: vec![],
+                    tags: vec![],
+                    private: false,
+                    file: "cli.ts".to_string(),
+                    line: 1,
+                    end_line: 1,
+                    signature: None,
+                    members: vec![],
+                },
+                ApiDocEntry {
+                    name: "Command".to_string(),
+                    kind: "interface".to_string(),
+                    description: String::new(),
+                    params: vec![],
+                    returns: None,
+                    examples: vec![],
+                    tags: vec![],
+                    private: false,
+                    file: "types.ts".to_string(),
+                    line: 1,
+                    end_line: 1,
+                    signature: None,
+                    members: vec![],
+                },
+            ],
+        }];
+
+        let nav =
+            generate_nav_metadata_from_docs(&docs, Some("/api"), MarkdownPathStrategy::TypeDoc);
+
+        assert_eq!(nav[0].title, "Default");
+        assert_eq!(nav[0].path, "/api/default");
+        let children = nav[0].children.as_ref().unwrap();
+        assert_eq!(children[0].title, "Functions");
+        assert_eq!(children[0].path, "/api/default/functions");
+        assert_eq!(children[0].children.as_ref().unwrap()[0].path, "/api/default/functions/cli");
+        assert_eq!(children[1].title, "Interfaces");
+        assert_eq!(
+            children[1].children.as_ref().unwrap()[0].path,
+            "/api/default/interfaces/Command"
+        );
     }
 
     #[test]

--- a/crates/ox_content_docs/src/output.rs
+++ b/crates/ox_content_docs/src/output.rs
@@ -7,8 +7,8 @@ use std::path::Path;
 use thiserror::Error;
 
 use crate::data::generate_docs_data_json;
-use crate::markdown::ApiDocModule;
-use crate::nav::{generate_nav_code, generate_nav_metadata};
+use crate::markdown::{ApiDocModule, MarkdownPathStrategy};
+use crate::nav::{generate_nav_code, generate_nav_metadata_from_docs};
 
 const DOCS_MANIFEST_FILE: &str = ".ox-content-docs-manifest.json";
 const DOCS_DATA_FILE: &str = "docs.json";
@@ -27,6 +27,8 @@ pub struct DocsOutputOptions {
     pub generated_at: String,
     /// Base path used for navigation links. Defaults to `/api` when `None`.
     pub base_path: Option<String>,
+    /// Output path strategy used for navigation metadata.
+    pub path_strategy: MarkdownPathStrategy,
 }
 
 /// Error returned while writing generated docs.
@@ -66,14 +68,21 @@ pub fn write_docs_output(
     remove_stale_files(out_dir, &generated_files)?;
 
     for (file_name, content) in docs {
-        fs::write(out_dir.join(file_name), content)?;
+        let output_path = out_dir.join(file_name);
+        if let Some(parent) = output_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(output_path, content)?;
     }
 
     if let Some(extracted_docs) = extracted_docs {
         if options.generate_nav && options.group_by == "file" {
-            let files = extracted_docs.iter().map(|doc| doc.file.clone()).collect::<Vec<_>>();
             let base_path = options.base_path.as_deref().unwrap_or(DOCS_NAV_BASE_PATH);
-            let nav_items = generate_nav_metadata(&files, Some(base_path));
+            let nav_items = generate_nav_metadata_from_docs(
+                extracted_docs,
+                Some(base_path),
+                options.path_strategy,
+            );
             fs::write(
                 out_dir.join(DOCS_NAV_FILE),
                 generate_nav_code(&nav_items, Some(DOCS_NAV_EXPORT_NAME)),
@@ -104,14 +113,31 @@ fn remove_stale_files(out_dir: &Path, generated_files: &[String]) -> DocsOutputR
             continue;
         }
 
-        match fs::remove_file(out_dir.join(stale_file)) {
-            Ok(()) => {}
+        let stale_path = out_dir.join(stale_file);
+        match fs::remove_file(&stale_path) {
+            Ok(()) => remove_empty_parent_dirs(out_dir, stale_path.parent())?,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
             Err(error) => return Err(error.into()),
         }
     }
 
     Ok(())
+}
+
+fn remove_empty_parent_dirs(out_dir: &Path, parent: Option<&Path>) -> DocsOutputResult<()> {
+    let Some(parent) = parent else {
+        return Ok(());
+    };
+    if parent == out_dir || !parent.starts_with(out_dir) {
+        return Ok(());
+    }
+
+    match fs::remove_dir(parent) {
+        Ok(()) => remove_empty_parent_dirs(out_dir, parent.parent()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::DirectoryNotEmpty => Ok(()),
+        Err(error) => Err(error.into()),
+    }
 }
 
 #[cfg(test)]
@@ -134,6 +160,7 @@ mod tests {
             group_by: "file".to_string(),
             generated_at: "2026-01-01T00:00:00.000Z".to_string(),
             base_path: None,
+            path_strategy: MarkdownPathStrategy::Flat,
         }
     }
 
@@ -155,6 +182,28 @@ mod tests {
         assert!(!out_dir.join("alpha.md").exists());
         assert!(fs::read_to_string(out_dir.join("beta.md")).unwrap().contains("updated"));
         assert!(fs::read_to_string(out_dir.join("manual.md")).unwrap().contains("Manual"));
+
+        fs::remove_dir_all(out_dir).unwrap();
+    }
+
+    #[test]
+    fn writes_and_removes_stale_nested_docs_output() {
+        let out_dir = temp_dir();
+        let mut docs = BTreeMap::new();
+        docs.insert("default/functions/cli.md".to_string(), "# cli".to_string());
+        docs.insert("default/interfaces/Command.md".to_string(), "# Command".to_string());
+
+        write_docs_output(&docs, &out_dir, None, &options()).unwrap();
+
+        assert!(out_dir.join("default/functions/cli.md").exists());
+        assert!(out_dir.join("default/interfaces/Command.md").exists());
+
+        docs.remove("default/functions/cli.md");
+        write_docs_output(&docs, &out_dir, None, &options()).unwrap();
+
+        assert!(!out_dir.join("default/functions/cli.md").exists());
+        assert!(!out_dir.join("default/functions").exists());
+        assert!(out_dir.join("default/interfaces/Command.md").exists());
 
         fs::remove_dir_all(out_dir).unwrap();
     }

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -274,6 +274,7 @@ export interface JsDocsMarkdownOptions {
   githubUrl?: string
   linkStyle?: 'markdown' | 'clean'
   basePath?: string
+  pathStrategy?: 'flat' | 'typedoc'
 }
 
 /** Ordered JSDoc tag used by generated API Markdown. */
@@ -295,6 +296,7 @@ export interface JsDocsOutputOptions {
   groupBy?: string
   generatedAt?: string
   basePath?: string
+  pathStrategy?: 'flat' | 'typedoc'
 }
 
 /** Entry page configuration. */

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -26,8 +26,9 @@ use ox_content_docs::{
     ApiParamDoc, ApiReturnDoc, DocExtractor, DocItem, DocItemKind, DocTag, DocsDiagnostic,
     DocsDiagnosticCode, DocsNavItem, DocsOutputOptions, EntryPointDocsOptions, EntryPointSpec,
     ExportGraph, ExportKind, ExportSource, ExternalDocsOptions, ExternalPackageSource,
-    ExtractedDocModule, GraphOptions, MarkdownDocsOptions, MarkdownLinkStyle, NormalizedDocEntry,
-    NormalizedMember, NormalizedParamDoc, NormalizedReturnDoc, ParamDoc, PublicExport,
+    ExtractedDocModule, GraphOptions, MarkdownDocsOptions, MarkdownLinkStyle, MarkdownPathStrategy,
+    NormalizedDocEntry, NormalizedMember, NormalizedParamDoc, NormalizedReturnDoc, ParamDoc,
+    PublicExport,
 };
 use ox_content_parser::{Parser, ParserOptions};
 use ox_content_renderer::HtmlRenderer;
@@ -268,6 +269,8 @@ pub struct JsDocsMarkdownOptions {
     #[napi(ts_type = "'markdown' | 'clean'")]
     pub link_style: Option<String>,
     pub base_path: Option<String>,
+    #[napi(ts_type = "'flat' | 'typedoc'")]
+    pub path_strategy: Option<String>,
 }
 
 /// Options for writing generated API documentation files.
@@ -278,6 +281,8 @@ pub struct JsDocsOutputOptions {
     pub group_by: Option<String>,
     pub generated_at: Option<String>,
     pub base_path: Option<String>,
+    #[napi(ts_type = "'flat' | 'typedoc'")]
+    pub path_strategy: Option<String>,
 }
 
 /// Entry point used to group generated API docs.
@@ -931,6 +936,7 @@ fn convert_docs_output_options(options: Option<JsDocsOutputOptions>) -> DocsOutp
         group_by: options.group_by.unwrap_or_else(|| "file".to_string()),
         generated_at: options.generated_at.unwrap_or_default(),
         base_path: options.base_path,
+        path_strategy: parse_markdown_path_strategy(options.path_strategy.as_deref()),
     }
 }
 
@@ -1068,6 +1074,7 @@ pub fn generate_docs_markdown(
             github_url: options.github_url,
             link_style: parse_markdown_link_style(options.link_style.as_deref()),
             base_path: options.base_path,
+            path_strategy: parse_markdown_path_strategy(options.path_strategy.as_deref()),
         });
     generate_markdown(&docs.into_iter().map(convert_markdown_module).collect::<Vec<_>>(), &options)
         .into_iter()
@@ -1078,6 +1085,13 @@ fn parse_markdown_link_style(link_style: Option<&str>) -> MarkdownLinkStyle {
     match link_style {
         Some("clean") => MarkdownLinkStyle::Clean,
         _ => MarkdownLinkStyle::Markdown,
+    }
+}
+
+fn parse_markdown_path_strategy(path_strategy: Option<&str>) -> MarkdownPathStrategy {
+    match path_strategy {
+        Some("typedoc") => MarkdownPathStrategy::TypeDoc,
+        _ => MarkdownPathStrategy::Flat,
     }
 }
 
@@ -3046,6 +3060,7 @@ mod tests {
                 github_url: None,
                 link_style: Some("clean".to_string()),
                 base_path: Some("/api-ox".to_string()),
+                path_strategy: None,
             }),
         );
         let index = markdown.get("index.md").unwrap();
@@ -3137,6 +3152,61 @@ mod tests {
         assert!(build_page.contains("<a href=\"https://github.com/unjs/std-env\">std-env</a>"));
         assert!(command_page.contains("<tr id=\"command-args\">"));
         assert!(command_page.contains("<a href=\"#command-args\"><code>Command.args</code></a>"));
+    }
+
+    #[test]
+    fn generate_docs_markdown_accepts_typedoc_path_strategy() {
+        let docs = vec![JsDocsMarkdownModule {
+            file: "default".to_string(),
+            entries: vec![
+                JsDocsMarkdownEntry {
+                    name: "Command".to_string(),
+                    kind: "interface".to_string(),
+                    description: "Runtime command.".to_string(),
+                    params: None,
+                    returns: None,
+                    examples: None,
+                    tags: None,
+                    private: false,
+                    file: "/repo/src/types.ts".to_string(),
+                    line: 1,
+                    end_line: 10,
+                    signature: Some("export interface Command".to_string()),
+                    members: None,
+                },
+                JsDocsMarkdownEntry {
+                    name: "cli".to_string(),
+                    kind: "function".to_string(),
+                    description: "Runs {@link Command}.".to_string(),
+                    params: None,
+                    returns: None,
+                    examples: None,
+                    tags: None,
+                    private: false,
+                    file: "/repo/src/cli.ts".to_string(),
+                    line: 1,
+                    end_line: 10,
+                    signature: Some("export function cli(): void".to_string()),
+                    members: None,
+                },
+            ],
+        }];
+
+        let markdown = generate_docs_markdown(
+            docs,
+            Some(JsDocsMarkdownOptions {
+                group_by: Some("file".to_string()),
+                github_url: None,
+                link_style: Some("clean".to_string()),
+                base_path: Some("/api".to_string()),
+                path_strategy: Some("typedoc".to_string()),
+            }),
+        );
+        let cli_page = markdown.get("default/functions/cli.md").unwrap();
+
+        assert!(markdown.contains_key("default/index.md"));
+        assert!(markdown.contains_key("default/interfaces/Command.md"));
+        assert!(cli_page.contains("<a href=\"/api/default/interfaces/Command\">Command</a>"));
     }
 
     #[test]

--- a/npm/vite-plugin-ox-content/src/docs.test.ts
+++ b/npm/vite-plugin-ox-content/src/docs.test.ts
@@ -200,6 +200,48 @@ describe("generateMarkdown", () => {
     expect(markdown["index.md"]).toContain('href="/api-ox/context#commandcontext"');
     expect(markdown["index.md"]).not.toContain(".md#commandcontext");
   });
+
+  it("emits TypeDoc-style paths when pathStrategy is typedoc", () => {
+    const docs: ExtractedDocs[] = [
+      {
+        file: "default",
+        entries: [
+          {
+            name: "Command",
+            kind: "interface",
+            description: "Runtime command.",
+            file: "/repo/src/types.ts",
+            line: 1,
+            endLine: 1,
+            signature: "export interface Command",
+          },
+          {
+            name: "cli",
+            kind: "function",
+            description: "Runs {@link Command}.",
+            file: "/repo/src/cli.ts",
+            line: 1,
+            endLine: 1,
+            signature: "export function cli(): void",
+          },
+        ],
+      },
+    ];
+
+    const markdown = generateMarkdown(
+      docs,
+      resolveDocsOptions({
+        linkStyle: "clean",
+        basePath: "/api",
+        pathStrategy: "typedoc",
+      })!,
+    );
+
+    expect(markdown["default/index.md"]).toContain("[`cli`](/api/default/functions/cli)");
+    expect(markdown["default/functions/cli.md"]).toContain(
+      'href="/api/default/interfaces/Command"',
+    );
+  });
 });
 
 describe("generateMarkdown extraction", () => {

--- a/npm/vite-plugin-ox-content/src/docs.ts
+++ b/npm/vite-plugin-ox-content/src/docs.ts
@@ -49,7 +49,13 @@
  * ```
  */
 
-import type { ResolvedDocsOptions, ExtractedDocs, DocEntry, ResolvedDocsEntryPoint } from "./types";
+import type {
+  ResolvedDocsOptions,
+  ExtractedDocs,
+  DocEntry,
+  ResolvedDocsEntryPoint,
+  DocsOptions,
+} from "./types";
 import { importNapiModule, importNapiModuleSync } from "./napi";
 
 const DEFAULT_DOCS_INCLUDE = [
@@ -204,6 +210,7 @@ export function generateMarkdown(
     githubUrl: options.githubUrl,
     linkStyle: options.linkStyle,
     basePath: options.basePath,
+    pathStrategy: options.pathStrategy,
   });
 }
 
@@ -233,6 +240,7 @@ export async function writeDocs(
       groupBy: options?.groupBy ?? "file",
       generatedAt: new Date().toISOString(),
       basePath: options?.basePath,
+      pathStrategy: options?.pathStrategy,
     },
   );
 }
@@ -263,8 +271,13 @@ function toRustDocsModules(docs: ExtractedDocs[]) {
 /**
  * Resolves docs options with defaults.
  */
+export function resolveDocsOptions(options: false): false;
+export function resolveDocsOptions(options?: DocsOptions): ResolvedDocsOptions;
 export function resolveDocsOptions(
-  options: import("./types").DocsOptions | false | undefined,
+  options: DocsOptions | false | undefined,
+): ResolvedDocsOptions | false;
+export function resolveDocsOptions(
+  options: DocsOptions | false | undefined,
 ): ResolvedDocsOptions | false {
   if (options === false) {
     return false;
@@ -289,6 +302,7 @@ export function resolveDocsOptions(
     githubUrl: opts.githubUrl,
     linkStyle: opts.linkStyle ?? "markdown",
     basePath: opts.basePath,
+    pathStrategy: opts.pathStrategy ?? "flat",
     generateNav: opts.generateNav ?? true,
   };
 }

--- a/npm/vite-plugin-ox-content/src/lint.ts
+++ b/npm/vite-plugin-ox-content/src/lint.ts
@@ -1,5 +1,5 @@
 import { createRequire } from "node:module";
-import type { CSpellUserSettings, ValidationIssue } from "cspell-lib";
+import type { CSpellUserSettings, SpellCheckFileOptions, ValidationIssue } from "cspell-lib";
 
 const require = createRequire(import.meta.url);
 
@@ -14,12 +14,12 @@ const DEFAULT_RULES = {
   spellcheck: true,
   trailingSpaces: true,
 } as const;
-const DEFAULT_CSPELL_IMPORTS = {
+const DEFAULT_CSPELL_IMPORTS: Partial<Record<MarkdownLintLanguage, string>> = {
   de: "@cspell/dict-de-de/cspell-ext.json",
   en: "@cspell/dict-en_us/cspell-ext.json",
   fr: "@cspell/dict-fr-fr/cspell-ext.json",
   pl: "@cspell/dict-pl_pl/cspell-ext.json",
-} as const satisfies Partial<Record<MarkdownLintLanguage, string>>;
+};
 
 export type MarkdownLintLanguage = (typeof SUPPORTED_MARKDOWN_LINT_LANGUAGES)[number];
 export type MarkdownLintSeverity = "error" | "warning" | "info";
@@ -433,12 +433,19 @@ function stripMaskedDocument(result: NapiMarkdownLintResult): MarkdownLintResult
 }
 
 function normalizeLintOptions(options: MarkdownLintOptions): InternalNormalizedMarkdownLintOptions {
-  const languages = options.languages?.filter((language): language is MarkdownLintLanguage =>
+  const standardDictionary =
+    options.dictionary?.standard && typeof options.dictionary.standard === "object"
+      ? options.dictionary.standard
+      : undefined;
+  const optionLanguages = options.languages?.filter((language): language is MarkdownLintLanguage =>
     SUPPORTED_MARKDOWN_LINT_LANGUAGES.includes(language),
-  ) ??
-    options.dictionary?.standard?.languages?.filter((language): language is MarkdownLintLanguage =>
+  );
+  const standardLanguages = standardDictionary?.languages?.filter(
+    (language): language is MarkdownLintLanguage =>
       SUPPORTED_MARKDOWN_LINT_LANGUAGES.includes(language),
-    ) ?? [...DEFAULT_LANGUAGES];
+  );
+  const languages: MarkdownLintLanguage[] = optionLanguages ??
+    standardLanguages ?? [...DEFAULT_LANGUAGES];
 
   const standard = normalizeStandardDictionaryOptions(options.dictionary?.standard, languages);
 
@@ -519,6 +526,12 @@ async function runStandardSpellcheckDocuments(
     const { spellCheckDocument } = await loadCspellLib();
     const locale = standard.languages.join(",");
     const settings = createStandardSpellcheckSettings(options, locale);
+    const spellCheckOptions = {
+      generateSuggestions: true,
+      noConfigSearch: true,
+      numSuggestions: 3,
+      resolveImportsRelativeTo: standard.resolveImportsRelativeTo,
+    } satisfies SpellCheckFileOptions & { resolveImportsRelativeTo: string | URL };
 
     return Promise.all(
       maskedDocuments.map(async (maskedDocument, index) => {
@@ -533,17 +546,12 @@ async function runStandardSpellcheckDocuments(
             text: maskedDocument,
             uri: `file:///ox-content-lint-${index}.md`,
           },
-          {
-            generateSuggestions: true,
-            noConfigSearch: true,
-            numSuggestions: 3,
-            resolveImportsRelativeTo: standard.resolveImportsRelativeTo,
-          },
+          spellCheckOptions,
           settings,
         );
 
         return result.issues.map((issue) =>
-          mapStandardIssueToDiagnostic(issue, standard.languages),
+          mapStandardIssueToDiagnostic(issue, standard.languages, maskedDocument),
         );
       }),
     );
@@ -584,8 +592,9 @@ async function loadCspellLib(): Promise<typeof import("cspell-lib")> {
 function mapStandardIssueToDiagnostic(
   issue: ValidationIssue,
   languages: MarkdownLintLanguage[],
+  documentText: string,
 ): MarkdownLintDiagnostic {
-  const line = issue.line.position.line + 1;
+  const line = getLineNumberAtOffset(documentText, issue.line.offset);
   const column = issue.offset - issue.line.offset + 1;
   const length = issue.length ?? issue.text.length;
 
@@ -600,6 +609,18 @@ function mapStandardIssueToDiagnostic(
     severity: "warning",
     suggestions: issue.suggestions?.slice(0, 3),
   };
+}
+
+function getLineNumberAtOffset(text: string, offset: number): number {
+  let line = 1;
+
+  for (let index = 0; index < offset && index < text.length; index++) {
+    if (text.charCodeAt(index) === 10) {
+      line++;
+    }
+  }
+
+  return line;
 }
 
 function inferStandardIssueLanguage(

--- a/npm/vite-plugin-ox-content/src/og-image/index.ts
+++ b/npm/vite-plugin-ox-content/src/og-image/index.ts
@@ -6,7 +6,6 @@
  */
 import * as path from "path";
 import * as crypto from "crypto";
-import type {} from "./optional-deps";
 import { openBrowser } from "./browser";
 import type { OgBrowserSession } from "./browser";
 import { getDefaultTemplate } from "./template";

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -773,6 +773,12 @@ export interface DocsOptions {
   basePath?: string;
 
   /**
+   * Generated Markdown output path strategy.
+   * @default 'flat'
+   */
+  pathStrategy?: "flat" | "typedoc";
+
+  /**
    * Generate navigation metadata file.
    * @default true
    */
@@ -797,6 +803,7 @@ export interface ResolvedDocsOptions {
   githubUrl?: string;
   linkStyle: "markdown" | "clean";
   basePath?: string;
+  pathStrategy: "flat" | "typedoc";
   generateNav: boolean;
 }
 

--- a/npm/vite-plugin-ox-content/src/vitepress.test.ts
+++ b/npm/vite-plugin-ox-content/src/vitepress.test.ts
@@ -89,21 +89,27 @@ describe("vitepress migration helpers", () => {
     expect(options.search).toEqual({ placeholder: "Search VitePress docs" });
 
     expect(options.ssg).not.toBe(false);
-    if (options.ssg === false) {
+    if (!options.ssg || options.ssg === true) {
       throw new Error("Expected migrated SSG options");
     }
 
-    expect(options.ssg.siteName).toBe("Docs");
-    expect(options.ssg.navigation).toEqual([
+    const ssg = options.ssg;
+
+    expect(ssg.siteName).toBe("Docs");
+    expect(ssg.navigation).toEqual([
       {
         title: "Guide",
         items: [{ title: "Intro", path: "/intro" }],
       },
     ]);
-    expect(options.ssg.theme?.header?.logo).toBe("/logo.svg");
-    expect(options.ssg.theme?.socialLinks?.github).toBe("https://github.com/ubugeeei/ox-content");
-    expect(options.ssg.theme?.footer?.copyright).toBe("2026");
-    expect(options.ssg.theme?.footer?.message).toBe("Migrated from VitePress");
+    expect(ssg.theme?.header?.logo).toBe("/logo.svg");
+    const socialLinks = ssg.theme?.socialLinks;
+    if (!socialLinks || Array.isArray(socialLinks)) {
+      throw new Error("Expected migrated social links");
+    }
+    expect(socialLinks.github).toBe("https://github.com/ubugeeei/ox-content");
+    expect(ssg.theme?.footer?.copyright).toBe("2026");
+    expect(ssg.theme?.footer?.message).toBe("Migrated from VitePress");
   });
 
   it("generates an editable ox-content options module", () => {

--- a/npm/vite-plugin-ox-content/tsconfig.json
+++ b/npm/vite-plugin-ox-content/tsconfig.json
@@ -10,7 +10,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": ".",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Background
Gunshi currently generates its API reference with TypeDoc + typedoc-plugin-markdown, which creates one Markdown file per exported symbol under module/kind paths such as `default/functions/cli.md` and `default/interfaces/Command.md`.

The ox-content Markdown generator only supported flat entrypoint pages such as `default.md#cli` when groupBy was file. Migrating gunshi to ox-content with that layout would change public URLs, sidebar paths, search indexes, and external symbol links.

## Summary
- Add a flat/typedoc Markdown path strategy and keep flat as the default for compatibility.
- Generate TypeDoc-style nested module/kind/symbol pages for file-grouped API docs.
- Make internal links, member anchors, duplicate symbol resolution, nav metadata, and native output writing follow the selected path strategy.
- Expose pathStrategy through Rust options, NAPI, generated types, and the Vite plugin.
- Fix vite-plugin typecheck issues found while validating the change.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.
