### PR TITLE
ci(deploy): publish docs via Void instead of GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,11 +9,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: pages
+  group: deploy
   cancel-in-progress: false
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -46,39 +46,11 @@ jobs:
           vp exec --filter @ox-content/vite-plugin -- playwright install --with-deps chromium
           vp exec --filter @ox-content/vite-plugin -- puppeteer browsers install chrome-headless-shell
 
-      - name: Build
-        run: vp build
+      - name: Build site
+        run: vp run build:site
 
-      - name: Prepare deployment directory
-        run: |
-          mkdir -p dist
-          # Copy docs site to root
-          cp -r docs/dist/docs/* dist/
-          # Copy Rust API docs
-          cp -r target/doc dist/api
-          # Copy playground
-          cp -r examples/playground/dist dist/playground
-          # Add .nojekyll
-          touch dist/.nojekyll
-
-      - name: Setup Pages
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-        with:
-          path: dist
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-24.04
-    needs: build
-    permissions:
-      pages: write
-      id-token: write
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+      - name: Deploy to Void
+        run: npx -y void deploy --dir dist
+        env:
+          VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
+          VOID_PROJECT: ${{ vars.VOID_PROJECT }}

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ crates/ox_content_wasm/pkg/
 *.dylib
 *.dll
 
+# Void deployment (local project linkage; CI uses VOID_PROJECT)
+.void/
+
 # Test and coverage
 /coverage
 *.lcov

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 </p>
 
 <p align="center">
-  <a href="https://ubugeeei.github.io/ox-content/">Documentation</a> •
-  <a href="https://ubugeeei.github.io/ox-content/getting-started">Getting Started</a> •
-  <a href="https://ubugeeei.github.io/ox-content/playground/">Playground</a> •
+  <a href="https://ox-content.void.app/">Documentation</a> •
+  <a href="https://ox-content.void.app/getting-started">Getting Started</a> •
+  <a href="https://ox-content.void.app/playground/">Playground</a> •
   <a href="./SECURITY.md">Security</a>
 </p>
 
@@ -201,7 +201,7 @@ For CI or editor-independent checks, run:
 cargo run -p ox_content_mdc_checker --bin ox-content-mdc-check -- docs/page.mdc
 ```
 
-**[Read the full documentation →](https://ubugeeei.github.io/ox-content/)**
+**[Read the full documentation →](https://ox-content.void.app/)**
 
 ## Performance
 
@@ -258,7 +258,7 @@ The dev shell is pinned in `flake.nix`, the workspace task graph lives in `vite.
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for branch, commit, PR, testing, and release-note guidance.
 
-See the [documentation](https://ubugeeei.github.io/ox-content/) for more details.
+See the [documentation](https://ox-content.void.app/) for more details.
 
 ## Community Credits
 

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -8,12 +8,11 @@ import { oxContentHighlightTheme } from "./ox-content-highlight-theme";
  * Dogfooding: Using ox-content to build ox-content's own documentation.
  * Uses SSG to generate static HTML from Markdown files.
  */
-export default defineConfig(({ mode }) => {
-  const isProd = mode === "production";
-  const base = isProd ? "/ox-content/" : "/";
+export default defineConfig(() => {
+  // Void serves the site at the domain root (not a subpath like GitHub Pages did).
+  const base = "/";
 
   return {
-    // Site base path (for GitHub Pages in prod, root for dev)
     base,
 
     plugins: [
@@ -28,9 +27,9 @@ export default defineConfig(({ mode }) => {
         // SSG options with theme customization
         ssg: {
           siteName: "Ox Content",
-          siteUrl: "https://ubugeeei.github.io",
+          siteUrl: "https://ox-content.void.app",
           generateOgImage: true,
-          ogImage: "https://ubugeeei.github.io/ox-content/og-image.png",
+          ogImage: "https://ox-content.void.app/og-image.png",
           theme: defineTheme({
             extends: defaultTheme,
             header: {

--- a/scripts/assemble-site.ts
+++ b/scripts/assemble-site.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env -S node --experimental-strip-types
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+
+const DIST = path.join(ROOT, "dist");
+
+// Build outputs produced by `vp build` (build:docs / doc:cargo / build:playground),
+// assembled into a single directory for `void deploy --dir dist`.
+const parts = [
+  { src: path.join(ROOT, "docs", "dist", "docs"), dest: DIST, label: "docs site -> /" },
+  { src: path.join(ROOT, "target", "doc"), dest: path.join(DIST, "api"), label: "rust docs -> /api" },
+  {
+    src: path.join(ROOT, "examples", "playground", "dist"),
+    dest: path.join(DIST, "playground"),
+    label: "playground -> /playground",
+  },
+];
+
+const missing = parts.filter((p) => !fs.existsSync(p.src)).map((p) => path.relative(ROOT, p.src));
+if (missing.length > 0) {
+  console.error(`Missing build output(s): ${missing.join(", ")}\nRun \`vp build\` first.`);
+  process.exit(1);
+}
+
+fs.rmSync(DIST, { recursive: true, force: true });
+fs.mkdirSync(DIST, { recursive: true });
+
+for (const { src, dest, label } of parts) {
+  fs.cpSync(src, dest, { recursive: true });
+  console.log(`assembled ${label}`);
+}
+
+console.log(`site assembled at ${path.relative(ROOT, DIST)}/`);

--- a/scripts/build-wasm-package.ts
+++ b/scripts/build-wasm-package.ts
@@ -68,7 +68,7 @@ function normalizePackageJson(): void {
   pkg.name = "@ox-content/wasm";
   pkg.author = "ubugeeei";
   delete pkg.collaborators;
-  pkg.homepage = "https://ubugeeei.github.io/ox-content/packages/wasm";
+  pkg.homepage = "https://ox-content.void.app/packages/wasm";
   pkg.repository = {
     type: "git",
     url: "https://github.com/ubugeeei/ox-content.git",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -102,6 +102,14 @@ export default defineConfig({
       }),
       "build:wasm": task("node --experimental-strip-types scripts/build-wasm-package.ts"),
 
+      // Assemble docs + Rust API docs + playground into a single `dist/` for deployment.
+      "build:site": uncachedTask("node --experimental-strip-types scripts/assemble-site.ts", {
+        dependsOn: ["build:docs", "doc:cargo", "build:playground"],
+      }),
+      deploy: uncachedTask("npx -y void deploy --dir dist", {
+        dependsOn: ["build:site"],
+      }),
+
       "workspace:test": noopTask(["test:rust", "test:ts"]),
       "test:rust": task("cargo test --workspace"),
       "test:rust-verbose": uncachedTask("cargo test --workspace -- --nocapture"),


### PR DESCRIPTION
## Summary
Migrate the documentation deployment from **GitHub Pages** to VoidZero's [Void](https://void.cloud) platform (`npx void deploy`) — the natural companion to the Vite+ toolchain this repo already uses. The site moves from `https://ubugeeei.github.io/ox-content/` to `https://ox-content.void.app`.

- **[.github/workflows/deploy.yml](.github/workflows/deploy.yml)**: builds the composite site and ships it with `npx void deploy --dir dist`; drops the GitHub Pages permissions/environment, Setup Pages, and upload/deploy-pages steps.
- **vite.config.ts**: adds a `build:site` task (assembles docs + Rust API docs + playground into a single `dist/`) and a `deploy` task, so local (`vp run deploy`) and CI share one path. Previously the composite assembly only existed as inline CI shell, so `void deploy --dir dist` failed locally.
- **scripts/assemble-site.ts**: the composite-`dist/` assembler, extracted from that inline shell.
- **docs/vite.config.ts**: serves at the domain root (`base: "/"` instead of `/ox-content/`, required since Void isn't a subpath) and points `siteUrl`/`ogImage` at the Void domain.
- **README / wasm package homepage**: docs links updated to `https://ox-content.void.app`.
- **.gitignore**: ignores the local `.void/` project-linkage dir (CI resolves the project via `VOID_PROJECT`).

## Required setup (one-time, in repo settings)
- Secret `VOID_TOKEN` — from `npx void auth token`
- Variable `VOID_PROJECT` = `ox-content`

## Test plan
- [x] `vp run build:site` locally produces `dist/` with `/api` + `/playground` and root-relative asset URLs (no `/ox-content/` remnants)
- [x] Workflow YAML validates
- [ ] CI: `Deploy` workflow succeeds on push to `main` once `VOID_TOKEN` / `VOID_PROJECT` are set
- [ ] Verify `https://ox-content.void.app` serves docs, `/api`, and `/playground`

🤖 Generated with [Claude Code](https://claude.com/claude-code)