### PR TITLE
feat(docs): complete typedoc path strategy support

### DIFF
--- a/crates/ox_content_docs/src/data.rs
+++ b/crates/ox_content_docs/src/data.rs
@@ -2,7 +2,8 @@ use serde_json::{json, Map, Value};
 
 use crate::markdown::{ApiDocEntry, ApiDocMember, ApiDocModule, ApiParamDoc, ApiReturnDoc};
 
-const DOC_KIND_ORDER: [&str; 6] = ["function", "class", "interface", "type", "variable", "module"];
+const DOC_KIND_ORDER: [&str; 7] =
+    ["function", "class", "interface", "type", "enum", "variable", "module"];
 
 #[derive(Default)]
 struct EntryStats {

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -8,7 +8,8 @@ use std::sync::OnceLock;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-const DOC_KIND_ORDER: [&str; 6] = ["function", "class", "interface", "type", "variable", "module"];
+const DOC_KIND_ORDER: [&str; 7] =
+    ["function", "class", "interface", "type", "enum", "variable", "module"];
 
 type RegexCache = OnceLock<Option<Regex>>;
 
@@ -157,6 +158,9 @@ pub struct MarkdownDocsOptions {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_path: Option<String>,
     /// Output path strategy.
+    ///
+    /// Only applies when `group_by` is `"file"`. Category grouping always emits
+    /// flat `{kind}s.md` pages regardless of this setting.
     #[serde(default)]
     pub path_strategy: MarkdownPathStrategy,
 }
@@ -444,6 +448,7 @@ fn typedoc_kind_segment(kind: &str) -> &'static str {
         "class" => "classes",
         "interface" => "interfaces",
         "type" => "type-aliases",
+        "enum" => "enumerations",
         "variable" | "const" => "variables",
         "module" => "modules",
         _ => "symbols",
@@ -456,6 +461,7 @@ fn typedoc_kind_title(kind: &str) -> &'static str {
         "class" => "Classes",
         "interface" => "Interfaces",
         "type" => "Type Aliases",
+        "enum" => "Enumerations",
         "variable" | "const" => "Variables",
         "module" => "Modules",
         _ => "Symbols",
@@ -1009,6 +1015,7 @@ fn doc_kind_plural(kind: &str) -> &'static str {
         "class" => "classes",
         "interface" => "interfaces",
         "type" => "types",
+        "enum" => "enumerations",
         "variable" => "variables",
         "module" => "modules",
         _ => "symbols",
@@ -2619,6 +2626,110 @@ mod tests {
         assert!(default_page.contains("<a href=\"/api/default/interfaces/Command\">Command</a>"));
         assert!(plugin_page.contains("<a href=\"/api/plugin/interfaces/Command\">Command</a>"));
         assert!(!default_page.contains(".md"));
+    }
+
+    #[test]
+    fn category_group_ignores_typedoc_path_strategy() {
+        let docs = link_test_docs();
+
+        let category_flat = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                group_by: "category".to_string(),
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let category_typedoc = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                group_by: "category".to_string(),
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+
+        let mut flat_keys = category_flat.keys().cloned().collect::<Vec<_>>();
+        let mut typedoc_keys = category_typedoc.keys().cloned().collect::<Vec<_>>();
+        flat_keys.sort();
+        typedoc_keys.sort();
+        assert_eq!(flat_keys, typedoc_keys);
+
+        assert!(category_typedoc.contains_key("functions.md"));
+        assert!(category_typedoc.contains_key("interfaces.md"));
+        assert!(!category_typedoc.keys().any(|key| key.contains('/')));
+    }
+
+    #[test]
+    fn typedoc_path_strategy_emits_enumerations_directory() {
+        let docs = vec![ApiDocModule {
+            file: "default".to_string(),
+            entries: vec![
+                ApiDocEntry {
+                    name: "Mode".to_string(),
+                    kind: "enum".to_string(),
+                    description: "Execution mode.".to_string(),
+                    params: vec![],
+                    returns: None,
+                    examples: vec![],
+                    tags: vec![],
+                    private: false,
+                    file: "/repo/src/mode.ts".to_string(),
+                    line: 1,
+                    end_line: 5,
+                    signature: Some("export enum Mode".to_string()),
+                    members: vec![ApiDocMember {
+                        name: "Strict".to_string(),
+                        kind: "enumMember".to_string(),
+                        description: "Strict mode.".to_string(),
+                        signature: None,
+                        type_annotation: Some("\"strict\"".to_string()),
+                        params: vec![],
+                        returns: None,
+                        optional: false,
+                        readonly: false,
+                        r#static: false,
+                        private: false,
+                        tags: vec![],
+                        line: 2,
+                        end_line: 2,
+                    }],
+                },
+                ApiDocEntry {
+                    name: "run".to_string(),
+                    kind: "function".to_string(),
+                    description: "Runs in {@link Mode} or {@linkcode Mode.Strict}.".to_string(),
+                    params: vec![],
+                    returns: None,
+                    examples: vec![],
+                    tags: vec![],
+                    private: false,
+                    file: "/repo/src/run.ts".to_string(),
+                    line: 1,
+                    end_line: 5,
+                    signature: Some("export function run(mode: Mode): void".to_string()),
+                    members: vec![],
+                },
+            ],
+        }];
+
+        let markdown = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let mode_page = markdown.get("default/enumerations/Mode.md").unwrap();
+        let run_page = markdown.get("default/functions/run.md").unwrap();
+        let module_index = markdown.get("default/index.md").unwrap();
+
+        assert!(module_index.contains("## Enumerations"));
+        assert!(module_index.contains("[`Mode`](./enumerations/Mode.md)"));
+        assert!(mode_page.contains("<tr id=\"enumeration-member-strict\">"));
+        assert!(run_page.contains("<a href=\"../enumerations/Mode.md\">Mode</a>"));
+        assert!(run_page.contains(
+            "<a href=\"../enumerations/Mode.md#enumeration-member-strict\"><code>Mode.Strict</code></a>"
+        ));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/nav.rs
+++ b/crates/ox_content_docs/src/nav.rs
@@ -176,8 +176,8 @@ fn module_file_name(file_path: &str) -> String {
 }
 
 fn ordered_entry_kinds(entries: &[ApiDocEntry]) -> Vec<String> {
-    const DOC_KIND_ORDER: [&str; 6] =
-        ["function", "class", "interface", "type", "variable", "module"];
+    const DOC_KIND_ORDER: [&str; 7] =
+        ["function", "class", "interface", "type", "enum", "variable", "module"];
 
     let mut kinds = Vec::new();
     for kind in DOC_KIND_ORDER {
@@ -202,6 +202,7 @@ fn typedoc_kind_segment(kind: &str) -> &'static str {
         "class" => "classes",
         "interface" => "interfaces",
         "type" => "type-aliases",
+        "enum" => "enumerations",
         "variable" | "const" => "variables",
         "module" => "modules",
         _ => "symbols",
@@ -214,6 +215,7 @@ fn typedoc_kind_title(kind: &str) -> &'static str {
         "class" => "Classes",
         "interface" => "Interfaces",
         "type" => "Type Aliases",
+        "enum" => "Enumerations",
         "variable" | "const" => "Variables",
         "module" => "Modules",
         _ => "Symbols",
@@ -361,6 +363,39 @@ mod tests {
         assert_eq!(
             children[1].children.as_ref().unwrap()[0].path,
             "/api/default/interfaces/Command"
+        );
+    }
+
+    #[test]
+    fn generates_typedoc_nav_metadata_includes_enumerations() {
+        let docs = vec![ApiDocModule {
+            file: "default".to_string(),
+            entries: vec![ApiDocEntry {
+                name: "Mode".to_string(),
+                kind: "enum".to_string(),
+                description: String::new(),
+                params: vec![],
+                returns: None,
+                examples: vec![],
+                tags: vec![],
+                private: false,
+                file: "mode.ts".to_string(),
+                line: 1,
+                end_line: 1,
+                signature: None,
+                members: vec![],
+            }],
+        }];
+
+        let nav =
+            generate_nav_metadata_from_docs(&docs, Some("/api"), MarkdownPathStrategy::TypeDoc);
+        let children = nav[0].children.as_ref().unwrap();
+
+        assert_eq!(children[0].title, "Enumerations");
+        assert_eq!(children[0].path, "/api/default/enumerations");
+        assert_eq!(
+            children[0].children.as_ref().unwrap()[0].path,
+            "/api/default/enumerations/Mode"
         );
     }
 

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -22,8 +22,10 @@ pub enum NormalizedDocKind {
     Class,
     /// TypeScript interface declaration.
     Interface,
-    /// Type alias or enum.
+    /// Type alias.
     Type,
+    /// Enum declaration.
+    Enum,
     /// Variable declaration.
     Variable,
     /// Module or namespace.
@@ -38,7 +40,8 @@ impl NormalizedDocKind {
             DocItemKind::Function => Some(Self::Function),
             DocItemKind::Class => Some(Self::Class),
             DocItemKind::Interface => Some(Self::Interface),
-            DocItemKind::Type | DocItemKind::Enum => Some(Self::Type),
+            DocItemKind::Type => Some(Self::Type),
+            DocItemKind::Enum => Some(Self::Enum),
             DocItemKind::Variable => Some(Self::Variable),
             DocItemKind::Module => Some(Self::Module),
             DocItemKind::Method
@@ -58,6 +61,7 @@ impl NormalizedDocKind {
             Self::Class => "class",
             Self::Interface => "interface",
             Self::Type => "type",
+            Self::Enum => "enum",
             Self::Variable => "variable",
             Self::Module => "module",
         }
@@ -487,7 +491,7 @@ export function internalHelper(): void {}
     }
 
     #[test]
-    fn maps_enums_to_type_entries() {
+    fn preserves_enum_kind_in_normalized_entries() {
         let source = r"
 /**
  * Available modes.
@@ -503,7 +507,7 @@ export enum Mode {
         let entries = normalize_doc_items(items);
 
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].kind, NormalizedDocKind::Type);
+        assert_eq!(entries[0].kind, NormalizedDocKind::Enum);
     }
 
     #[test]

--- a/crates/ox_content_docs/src/output.rs
+++ b/crates/ox_content_docs/src/output.rs
@@ -142,16 +142,23 @@ fn remove_empty_parent_dirs(out_dir: &Path, parent: Option<&Path>) -> DocsOutput
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::*;
 
     fn temp_dir() -> std::path::PathBuf {
+        // A timestamp alone is not unique enough: under parallel test execution the
+        // system clock resolution can be coarse enough that two tests observe the same
+        // nanosecond value and collide on the same directory. Combine it with a
+        // process-wide atomic counter so every call gets a distinct path.
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system time should be valid")
             .as_nanos();
-        std::env::temp_dir().join(format!("ox-content-docs-output-{nonce}"))
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("ox-content-docs-output-{nonce}-{seq}"))
     }
 
     fn options() -> DocsOutputOptions {
@@ -204,6 +211,102 @@ mod tests {
         assert!(!out_dir.join("default/functions/cli.md").exists());
         assert!(!out_dir.join("default/functions").exists());
         assert!(out_dir.join("default/interfaces/Command.md").exists());
+
+        fs::remove_dir_all(out_dir).unwrap();
+    }
+
+    #[test]
+    fn writes_typedoc_docs_with_consistent_nav_and_data() {
+        use crate::markdown::{
+            generate_markdown, ApiDocEntry, ApiDocMember, MarkdownDocsOptions,
+        };
+
+        let out_dir = temp_dir();
+        let extracted = vec![ApiDocModule {
+            file: "default".to_string(),
+            entries: vec![
+                ApiDocEntry {
+                    name: "cli".to_string(),
+                    kind: "function".to_string(),
+                    description: "Runs the CLI.".to_string(),
+                    params: vec![],
+                    returns: None,
+                    examples: vec![],
+                    tags: vec![],
+                    private: false,
+                    file: "/repo/src/cli.ts".to_string(),
+                    line: 1,
+                    end_line: 5,
+                    signature: Some("export function cli(): void".to_string()),
+                    members: vec![],
+                },
+                ApiDocEntry {
+                    name: "Mode".to_string(),
+                    kind: "enum".to_string(),
+                    description: "Run mode.".to_string(),
+                    params: vec![],
+                    returns: None,
+                    examples: vec![],
+                    tags: vec![],
+                    private: false,
+                    file: "/repo/src/mode.ts".to_string(),
+                    line: 1,
+                    end_line: 4,
+                    signature: Some("export enum Mode".to_string()),
+                    members: vec![ApiDocMember {
+                        name: "Strict".to_string(),
+                        kind: "enumMember".to_string(),
+                        description: "Strict mode.".to_string(),
+                        signature: None,
+                        type_annotation: Some("\"strict\"".to_string()),
+                        params: vec![],
+                        returns: None,
+                        optional: false,
+                        readonly: false,
+                        r#static: false,
+                        private: false,
+                        tags: vec![],
+                        line: 2,
+                        end_line: 2,
+                    }],
+                },
+            ],
+        }];
+
+        let markdown_options = MarkdownDocsOptions {
+            path_strategy: MarkdownPathStrategy::TypeDoc,
+            base_path: Some("/api".to_string()),
+            ..MarkdownDocsOptions::default()
+        };
+        let docs = generate_markdown(&extracted, &markdown_options);
+
+        let output_options = DocsOutputOptions {
+            generate_nav: true,
+            group_by: "file".to_string(),
+            generated_at: "2026-01-01T00:00:00.000Z".to_string(),
+            base_path: Some("/api".to_string()),
+            path_strategy: MarkdownPathStrategy::TypeDoc,
+        };
+        write_docs_output(&docs, &out_dir, Some(&extracted), &output_options).unwrap();
+
+        assert!(out_dir.join("default/index.md").exists());
+        assert!(out_dir.join("default/functions/cli.md").exists());
+        assert!(out_dir.join("default/enumerations/Mode.md").exists());
+
+        let nav = fs::read_to_string(out_dir.join(DOCS_NAV_FILE)).unwrap();
+        assert!(nav.contains("\"path\": \"/api/default\""));
+        assert!(nav.contains("\"path\": \"/api/default/functions/cli\""));
+        assert!(nav.contains("\"path\": \"/api/default/enumerations/Mode\""));
+        assert!(nav.contains("\"title\": \"Enumerations\""));
+
+        let data = fs::read_to_string(out_dir.join(DOCS_DATA_FILE)).unwrap();
+        assert!(data.contains("\"enum\": 1"));
+
+        let manifest = fs::read_to_string(out_dir.join(DOCS_MANIFEST_FILE)).unwrap();
+        assert!(manifest.contains("default/functions/cli.md"));
+        assert!(manifest.contains("default/enumerations/Mode.md"));
+        assert!(manifest.contains(DOCS_NAV_FILE));
+        assert!(manifest.contains(DOCS_DATA_FILE));
 
         fs::remove_dir_all(out_dir).unwrap();
     }

--- a/crates/ox_content_docs/src/output.rs
+++ b/crates/ox_content_docs/src/output.rs
@@ -217,9 +217,7 @@ mod tests {
 
     #[test]
     fn writes_typedoc_docs_with_consistent_nav_and_data() {
-        use crate::markdown::{
-            generate_markdown, ApiDocEntry, ApiDocMember, MarkdownDocsOptions,
-        };
+        use crate::markdown::{generate_markdown, ApiDocEntry, ApiDocMember, MarkdownDocsOptions};
 
         let out_dir = temp_dir();
         let extracted = vec![ApiDocModule {

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -98,6 +98,14 @@ export declare function generateDocsNavCode(navItems: Array<JsDocsNavItem>, expo
 /** Generates sidebar navigation metadata from documentation file paths. */
 export declare function generateDocsNavMetadata(files: Array<string>, basePath?: string | undefined | null): Array<JsDocsNavItem>
 
+/**
+ * Generates sidebar navigation metadata from extracted documentation modules.
+ *
+ * Use this when the output `pathStrategy` is `"typedoc"` so that the navigation
+ * tree mirrors the nested module/category/symbol pages.
+ */
+export declare function generateDocsNavMetadataFromDocs(docs: Array<JsDocsMarkdownModule>, options?: JsDocsNavOptions | undefined | null): Array<JsDocsNavItem>
+
 /** Generates the `virtual:ox-content/i18n` runtime module. */
 export declare function generateI18nModule(dictDir: string, config: JsI18NRuntimeConfig): string
 
@@ -288,6 +296,12 @@ export interface JsDocsNavItem {
   title: string
   path: string
   children?: Array<JsDocsNavItem>
+}
+
+/** Options for generating sidebar navigation metadata from extracted docs. */
+export interface JsDocsNavOptions {
+  basePath?: string
+  pathStrategy?: 'flat' | 'typedoc'
 }
 
 /** Options for writing generated API documentation files. */

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -89,6 +89,7 @@ module.exports.buildExportGraph = binding.buildExportGraph;
 module.exports.extractDocsFromDirectories = binding.extractDocsFromDirectories;
 module.exports.extractDocsFromEntryPoints = binding.extractDocsFromEntryPoints;
 module.exports.generateDocsNavMetadata = binding.generateDocsNavMetadata;
+module.exports.generateDocsNavMetadataFromDocs = binding.generateDocsNavMetadataFromDocs;
 module.exports.generateDocsNavCode = binding.generateDocsNavCode;
 module.exports.collectDocsSourceFiles = binding.collectDocsSourceFiles;
 module.exports.generateDocsDataJson = binding.generateDocsDataJson;

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -22,13 +22,13 @@ use ox_content_allocator::Allocator;
 use ox_content_docs::{
     build_export_graph, extract_docs_from_directories, extract_docs_from_entry_points,
     generate_docs_data_json, generate_markdown, generate_nav_code, generate_nav_metadata,
-    normalize_doc_items, write_docs_output, ApiDocEntry, ApiDocMember, ApiDocModule, ApiDocTag,
-    ApiParamDoc, ApiReturnDoc, DocExtractor, DocItem, DocItemKind, DocTag, DocsDiagnostic,
-    DocsDiagnosticCode, DocsNavItem, DocsOutputOptions, EntryPointDocsOptions, EntryPointSpec,
-    ExportGraph, ExportKind, ExportSource, ExternalDocsOptions, ExternalPackageSource,
-    ExtractedDocModule, GraphOptions, MarkdownDocsOptions, MarkdownLinkStyle, MarkdownPathStrategy,
-    NormalizedDocEntry, NormalizedMember, NormalizedParamDoc, NormalizedReturnDoc, ParamDoc,
-    PublicExport,
+    generate_nav_metadata_from_docs, normalize_doc_items, write_docs_output, ApiDocEntry,
+    ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc, ApiReturnDoc, DocExtractor, DocItem,
+    DocItemKind, DocTag, DocsDiagnostic, DocsDiagnosticCode, DocsNavItem, DocsOutputOptions,
+    EntryPointDocsOptions, EntryPointSpec, ExportGraph, ExportKind, ExportSource,
+    ExternalDocsOptions, ExternalPackageSource, ExtractedDocModule, GraphOptions,
+    MarkdownDocsOptions, MarkdownLinkStyle, MarkdownPathStrategy, NormalizedDocEntry,
+    NormalizedMember, NormalizedParamDoc, NormalizedReturnDoc, ParamDoc, PublicExport,
 };
 use ox_content_parser::{Parser, ParserOptions};
 use ox_content_renderer::HtmlRenderer;
@@ -215,6 +215,15 @@ pub struct JsDocsNavItem {
     pub title: String,
     pub path: String,
     pub children: Option<Vec<JsDocsNavItem>>,
+}
+
+/// Options for generating sidebar navigation metadata from extracted docs.
+#[napi(object)]
+#[derive(Default)]
+pub struct JsDocsNavOptions {
+    pub base_path: Option<String>,
+    #[napi(ts_type = "'flat' | 'typedoc'")]
+    pub path_strategy: Option<String>,
 }
 
 /// Ordered JSDoc tag used by generated API Markdown.
@@ -983,6 +992,24 @@ pub fn generate_docs_nav_metadata(
     base_path: Option<String>,
 ) -> Vec<JsDocsNavItem> {
     generate_nav_metadata(&files, base_path.as_deref()).into_iter().map(map_docs_nav_item).collect()
+}
+
+/// Generates sidebar navigation metadata from extracted documentation modules.
+///
+/// Use this when the output `pathStrategy` is `"typedoc"` so that the navigation
+/// tree mirrors the nested module/category/symbol pages.
+#[napi(js_name = "generateDocsNavMetadataFromDocs")]
+pub fn generate_docs_nav_metadata_from_docs_napi(
+    docs: Vec<JsDocsMarkdownModule>,
+    options: Option<JsDocsNavOptions>,
+) -> Vec<JsDocsNavItem> {
+    let options = options.unwrap_or_default();
+    let strategy = parse_markdown_path_strategy(options.path_strategy.as_deref());
+    let modules = docs.into_iter().map(convert_markdown_module).collect::<Vec<_>>();
+    generate_nav_metadata_from_docs(&modules, options.base_path.as_deref(), strategy)
+        .into_iter()
+        .map(map_docs_nav_item)
+        .collect()
 }
 
 /// Generates TypeScript source code for documentation navigation metadata.
@@ -2951,9 +2978,10 @@ mod tests {
 
     use super::transformer::parse_frontmatter;
     use super::{
-        extract_docs_from_entry_points_napi, generate_docs_markdown, get_git_last_updated,
-        map_normalized_doc_entry, JsDocMember, JsDocParam, JsDocReturn, JsDocsMarkdownEntry,
-        JsDocsMarkdownModule, JsDocsMarkdownOptions, JsDocsMarkdownTag, JsEntryPointDocsOptions,
+        extract_docs_from_entry_points_napi, generate_docs_markdown,
+        generate_docs_nav_metadata_from_docs_napi, get_git_last_updated, map_normalized_doc_entry,
+        JsDocMember, JsDocParam, JsDocReturn, JsDocsMarkdownEntry, JsDocsMarkdownModule,
+        JsDocsMarkdownOptions, JsDocsMarkdownTag, JsDocsNavOptions, JsEntryPointDocsOptions,
         JsEntryPointSpec,
     };
 
@@ -3210,6 +3238,140 @@ mod tests {
     }
 
     #[test]
+    fn generate_docs_nav_metadata_from_docs_returns_typedoc_tree() {
+        let docs = vec![JsDocsMarkdownModule {
+            file: "default".to_string(),
+            entries: vec![
+                JsDocsMarkdownEntry {
+                    name: "cli".to_string(),
+                    kind: "function".to_string(),
+                    description: String::new(),
+                    params: None,
+                    returns: None,
+                    examples: None,
+                    tags: None,
+                    private: false,
+                    file: "/repo/src/cli.ts".to_string(),
+                    line: 1,
+                    end_line: 1,
+                    signature: None,
+                    members: None,
+                },
+                JsDocsMarkdownEntry {
+                    name: "Mode".to_string(),
+                    kind: "enum".to_string(),
+                    description: String::new(),
+                    params: None,
+                    returns: None,
+                    examples: None,
+                    tags: None,
+                    private: false,
+                    file: "/repo/src/mode.ts".to_string(),
+                    line: 1,
+                    end_line: 1,
+                    signature: None,
+                    members: None,
+                },
+            ],
+        }];
+
+        let nav = generate_docs_nav_metadata_from_docs_napi(
+            docs,
+            Some(JsDocsNavOptions {
+                base_path: Some("/api".to_string()),
+                path_strategy: Some("typedoc".to_string()),
+            }),
+        );
+
+        assert_eq!(nav[0].title, "Default");
+        assert_eq!(nav[0].path, "/api/default");
+        let children = nav[0].children.as_ref().unwrap();
+        assert_eq!(children[0].title, "Functions");
+        assert_eq!(children[0].children.as_ref().unwrap()[0].path, "/api/default/functions/cli");
+        assert_eq!(children[1].title, "Enumerations");
+        assert_eq!(
+            children[1].children.as_ref().unwrap()[0].path,
+            "/api/default/enumerations/Mode"
+        );
+    }
+
+    #[test]
+    fn generate_docs_nav_metadata_from_docs_defaults_to_flat() {
+        let docs = vec![JsDocsMarkdownModule {
+            file: "/repo/src/context.ts".to_string(),
+            entries: vec![],
+        }];
+
+        let nav = generate_docs_nav_metadata_from_docs_napi(docs, None);
+
+        assert_eq!(nav.len(), 1);
+        assert_eq!(nav[0].path, "/api/context");
+        assert!(nav[0].children.is_none());
+    }
+
+    #[test]
+    fn write_generated_docs_writes_typedoc_nested_files() {
+        use super::{write_generated_docs, JsDocsOutputOptions};
+
+        let unique =
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos();
+        let out_dir = std::env::temp_dir()
+            .join(format!("ox-content-napi-typedoc-write-{}-{unique}", std::process::id()));
+
+        let extracted = vec![JsDocsMarkdownModule {
+            file: "default".to_string(),
+            entries: vec![JsDocsMarkdownEntry {
+                name: "cli".to_string(),
+                kind: "function".to_string(),
+                description: "Runs the CLI.".to_string(),
+                params: None,
+                returns: None,
+                examples: None,
+                tags: None,
+                private: false,
+                file: "/repo/src/cli.ts".to_string(),
+                line: 1,
+                end_line: 1,
+                signature: Some("export function cli(): void".to_string()),
+                members: None,
+            }],
+        }];
+
+        let markdown = generate_docs_markdown(
+            extracted.clone(),
+            Some(JsDocsMarkdownOptions {
+                group_by: Some("file".to_string()),
+                github_url: None,
+                link_style: Some("clean".to_string()),
+                base_path: Some("/api".to_string()),
+                path_strategy: Some("typedoc".to_string()),
+            }),
+        );
+
+        write_generated_docs(
+            markdown,
+            out_dir.to_string_lossy().to_string(),
+            Some(extracted),
+            Some(JsDocsOutputOptions {
+                generate_nav: Some(true),
+                group_by: Some("file".to_string()),
+                generated_at: Some("2026-01-01T00:00:00.000Z".to_string()),
+                base_path: Some("/api".to_string()),
+                path_strategy: Some("typedoc".to_string()),
+            }),
+        )
+        .unwrap();
+
+        assert!(out_dir.join("default/index.md").exists());
+        assert!(out_dir.join("default/functions/cli.md").exists());
+
+        let nav = fs::read_to_string(out_dir.join("nav.ts")).unwrap();
+        assert!(nav.contains("\"/api/default/functions/cli\""));
+
+        fs::remove_dir_all(&out_dir).unwrap();
+    }
+
+    #[test]
     fn extract_docs_from_entry_points_accepts_external_docs_options() {
         let unique =
             std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos();
@@ -3374,6 +3536,7 @@ export type ExtractArgs<G> = G extends { args: infer A } ? A : never;
             "generateDocsMarkdown",
             "generateDocsNavCode",
             "generateDocsNavMetadata",
+            "generateDocsNavMetadataFromDocs",
             "generateI18nModule",
             "generateOgImageSvg",
             "generateSearchModule",

--- a/npm/vite-plugin-ox-content/src/docs.test.ts
+++ b/npm/vite-plugin-ox-content/src/docs.test.ts
@@ -141,6 +141,44 @@ describe("writeDocs", () => {
       '"path": "/api-ox/context"',
     );
   });
+
+  it("writes typedoc nested files and nav tree when pathStrategy is typedoc", async () => {
+    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-docs-"));
+    tempDirs.push(outDir);
+
+    const extractedDocs: ExtractedDocs[] = [
+      {
+        file: "default",
+        entries: [
+          {
+            name: "cli",
+            kind: "function",
+            description: "Runs the CLI.",
+            file: "/repo/src/cli.ts",
+            line: 1,
+            endLine: 1,
+            signature: "export function cli(): void",
+          },
+        ],
+      },
+    ];
+
+    const options = resolveDocsOptions({
+      generateNav: true,
+      basePath: "/api",
+      pathStrategy: "typedoc",
+      linkStyle: "clean",
+    });
+    const markdown = generateMarkdown(extractedDocs, options);
+
+    await writeDocs(markdown, outDir, extractedDocs, options);
+
+    await expect(fs.access(path.join(outDir, "default/index.md"))).resolves.not.toThrow();
+    await expect(fs.access(path.join(outDir, "default/functions/cli.md"))).resolves.not.toThrow();
+    await expect(fs.readFile(path.join(outDir, "nav.ts"), "utf-8")).resolves.toContain(
+      '"path": "/api/default/functions/cli"',
+    );
+  });
 });
 
 describe("generateMarkdown", () => {

--- a/npm/vite-plugin-ox-content/src/docs.ts
+++ b/npm/vite-plugin-ox-content/src/docs.ts
@@ -245,7 +245,7 @@ export async function writeDocs(
   );
 }
 
-function toRustDocsModules(docs: ExtractedDocs[]) {
+export function toRustDocsModules(docs: ExtractedDocs[]) {
   return docs.map((doc) => ({
     file: doc.file,
     entries: doc.entries.map((entry) => ({

--- a/npm/vite-plugin-ox-content/src/nav-generator.ts
+++ b/npm/vite-plugin-ox-content/src/nav-generator.ts
@@ -12,9 +12,7 @@ export function generateNavMetadata(
   basePathOrOptions: string | GenerateNavMetadataOptions = "/api",
 ): NavItem[] {
   const options: GenerateNavMetadataOptions =
-    typeof basePathOrOptions === "string"
-      ? { basePath: basePathOrOptions }
-      : basePathOrOptions;
+    typeof basePathOrOptions === "string" ? { basePath: basePathOrOptions } : basePathOrOptions;
   const basePath = options.basePath ?? "/api";
   const napi = importNapiModuleSync();
 

--- a/npm/vite-plugin-ox-content/src/nav-generator.ts
+++ b/npm/vite-plugin-ox-content/src/nav-generator.ts
@@ -1,8 +1,31 @@
 import type { ExtractedDocs, NavItem } from "./types";
+import { toRustDocsModules } from "./docs";
 import { importNapiModuleSync } from "./napi";
 
-export function generateNavMetadata(docs: ExtractedDocs[], basePath: string = "/api"): NavItem[] {
-  return importNapiModuleSync().generateDocsNavMetadata(
+export interface GenerateNavMetadataOptions {
+  basePath?: string;
+  pathStrategy?: "flat" | "typedoc";
+}
+
+export function generateNavMetadata(
+  docs: ExtractedDocs[],
+  basePathOrOptions: string | GenerateNavMetadataOptions = "/api",
+): NavItem[] {
+  const options: GenerateNavMetadataOptions =
+    typeof basePathOrOptions === "string"
+      ? { basePath: basePathOrOptions }
+      : basePathOrOptions;
+  const basePath = options.basePath ?? "/api";
+  const napi = importNapiModuleSync();
+
+  if (options.pathStrategy === "typedoc") {
+    return napi.generateDocsNavMetadataFromDocs(toRustDocsModules(docs), {
+      basePath,
+      pathStrategy: "typedoc",
+    });
+  }
+
+  return napi.generateDocsNavMetadata(
     docs.map((doc) => doc.file),
     basePath,
   );

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -812,7 +812,7 @@ export interface ResolvedDocsOptions {
  */
 export interface DocEntry {
   name: string;
-  kind: "function" | "class" | "interface" | "type" | "variable" | "module";
+  kind: "function" | "class" | "interface" | "type" | "enum" | "variable" | "module";
   description: string;
   params?: ParamDoc[];
   returns?: ReturnDoc;


### PR DESCRIPTION
## Background

PR #209 added base TypeDoc-style markdown path support (`pathStrategy: "typedoc"`), but a consumer (gunshi) hit broken output: `enum` symbols were not emitted to their own `enumerations/{Name}.md` pages.

The root cause was in the normalize layer — `DocItemKind::Enum` was collapsed into `NormalizedDocKind::Type` before reaching the renderer, so the enum path/segment mapping never activated.

A few other gaps also blocked a real end-to-end migration.

## Summary

- Enum kind: preserve `enum` through the normalize layer so enums emit to `enumerations/{Name}.md`; thread `enum` through `DOC_KIND_ORDER`, segment/title, and plural mappings in `markdown.rs` / `nav.rs` / `data.rs`.
- NAPI nav export: add `generateDocsNavMetadataFromDocs(docs, { basePath, pathStrategy })` so manual pipelines (e.g. gunshi) can generate typedoc nav trees without the full plugin; declared in `index.d.ts` / `index.js`.
- vite-plugin: `generateNavMetadata` accepts `{ pathStrategy: "typedoc" }`; `DocEntry.kind` union now includes `"enum"`.
- Category behavior: `groupBy: "category"` always emits flat `{kind}s.md` pages and ignores `pathStrategy` (documented + tested).
- E2E coverage: typedoc markdown + nav tree + `docs.json` + manifest verified consistent across Rust, NAPI, and the vite-plugin.
- Flaky test fix: `output.rs` `temp_dir()` helper could collide under parallel runs (coarse clock resolution); now uses an atomic counter suffix.

## Compatibility

Additive minor feature, no breaking changes. `pathStrategy` defaults to `"flat"`,
and the existing `generateDocsNavMetadata(files, basePath)` behavior is unchanged.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.
