### PR TITLE
bench: add satteri to parse/render comparison

### DIFF
--- a/benchmarks/bundle-size/package.json
+++ b/benchmarks/bundle-size/package.json
@@ -18,6 +18,7 @@
     "micromark": "^4.0.1",
     "remark-html": "^16.0.1",
     "remark-parse": "^11.0.0",
+    "satteri": "^0.6.3",
     "showdown": "^2.1.0",
     "unified": "^11.0.5"
   },

--- a/benchmarks/bundle-size/parse-benchmark.mjs
+++ b/benchmarks/bundle-size/parse-benchmark.mjs
@@ -348,8 +348,18 @@ async function runBenchmarks() {
   const { unified } = await import("unified");
   const remarkParse = (await import("remark-parse")).default;
   const remarkHtml = (await import("remark-html")).default;
-  const { markdownToMdast: satteriParse, markdownToHtml: satteriRender } = await import("satteri");
   await initMd4w();
+
+  // satteri is an optional comparison target. It may be missing when the
+  // benchmark runs against an older checkout (e.g. the CI base ref that
+  // predates this dependency), so load it defensively like @ox-content/napi.
+  let satteri = null;
+  try {
+    satteri = await import("satteri");
+    console.log("Using satteri\n");
+  } catch {
+    console.log("satteri not available, skipping satteri comparisons\n");
+  }
 
   // Try to import NAPI
   let napi = null;
@@ -387,8 +397,11 @@ async function runBenchmarks() {
     { name: "md4x (napi)", fn: (input) => md4xParseAST(input) },
     { name: "markdown-it", fn: (input) => md.parse(input, {}) },
     { name: "remark", fn: (input) => remarkParseProcessor.parse(input) },
-    { name: "satteri", fn: (input) => satteriParse(input) },
   );
+
+  if (satteri) {
+    parsers.push({ name: "satteri", fn: (input) => satteri.markdownToMdast(input) });
+  }
 
   // Define renderers (parse + render)
   const renderers = [];
@@ -410,8 +423,11 @@ async function runBenchmarks() {
       name: "remark",
       fn: (input) => remarkFullProcessor.processSync(input).toString(),
     },
-    { name: "satteri", fn: (input) => satteriRender(input) },
   );
+
+  if (satteri) {
+    renderers.push({ name: "satteri", fn: (input) => satteri.markdownToHtml(input) });
+  }
 
   // Define async renderers
   const asyncRenderers = [];

--- a/benchmarks/bundle-size/parse-benchmark.mjs
+++ b/benchmarks/bundle-size/parse-benchmark.mjs
@@ -348,6 +348,7 @@ async function runBenchmarks() {
   const { unified } = await import("unified");
   const remarkParse = (await import("remark-parse")).default;
   const remarkHtml = (await import("remark-html")).default;
+  const { markdownToMdast: satteriParse, markdownToHtml: satteriRender } = await import("satteri");
   await initMd4w();
 
   // Try to import NAPI
@@ -386,6 +387,7 @@ async function runBenchmarks() {
     { name: "md4x (napi)", fn: (input) => md4xParseAST(input) },
     { name: "markdown-it", fn: (input) => md.parse(input, {}) },
     { name: "remark", fn: (input) => remarkParseProcessor.parse(input) },
+    { name: "satteri", fn: (input) => satteriParse(input) },
   );
 
   // Define renderers (parse + render)
@@ -408,6 +410,7 @@ async function runBenchmarks() {
       name: "remark",
       fn: (input) => remarkFullProcessor.processSync(input).toString(),
     },
+    { name: "satteri", fn: (input) => satteriRender(input) },
   );
 
   // Define async renderers

--- a/config/dependency-policy.json
+++ b/config/dependency-policy.json
@@ -201,6 +201,31 @@
         "name": "jszip",
         "license": "(MIT OR GPL-3.0-or-later)",
         "reason": "Dev-only transitive dependency of @vscode/test-electron (extension test harness); MIT branch of the dual license is selected."
+      },
+      {
+        "name": "@bruits/satteri-linux-x64-gnu",
+        "license": "Unknown",
+        "reason": "Optional native binary of satteri (MIT), a benchmark-only Markdown engine comparison target; platform package omits its own license field."
+      },
+      {
+        "name": "@bruits/satteri-darwin-x64",
+        "license": "Unknown",
+        "reason": "Optional native binary of satteri (MIT), a benchmark-only Markdown engine comparison target; platform package omits its own license field."
+      },
+      {
+        "name": "@bruits/satteri-darwin-arm64",
+        "license": "Unknown",
+        "reason": "Optional native binary of satteri (MIT), a benchmark-only Markdown engine comparison target; platform package omits its own license field."
+      },
+      {
+        "name": "@bruits/satteri-win32-x64-msvc",
+        "license": "Unknown",
+        "reason": "Optional native binary of satteri (MIT), a benchmark-only Markdown engine comparison target; platform package omits its own license field."
+      },
+      {
+        "name": "@bruits/satteri-wasm32-wasi",
+        "license": "Unknown",
+        "reason": "Optional native binary of satteri (MIT), a benchmark-only Markdown engine comparison target; platform package omits its own license field."
       }
     ]
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       remark-parse:
         specifier: ^11.0.0
         version: 11.0.0
+      satteri:
+        specifier: ^0.6.3
+        version: 0.6.3
       showdown:
         specifier: ^2.1.0
         version: 2.1.0
@@ -1099,6 +1102,31 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
+  '@bruits/satteri-darwin-arm64@0.6.3':
+    resolution: {integrity: sha512-oKgMfpmNzQ8vaqmkE37PBu8tOyVjoOc4s+DV2tLpWvO6WO467qn/+Nbcirm/ceer7wUM8v4vMLGcZO0gkRzBEg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@bruits/satteri-darwin-x64@0.6.3':
+    resolution: {integrity: sha512-9I5pbwZRWH5LvhoCtwpRr4rYSDe43/dLvps6zO70ipVF2XbH4rJ20T+EfvPcmou5jsWMsq9Ybn5GX3PwlSrBaw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@bruits/satteri-linux-x64-gnu@0.6.3':
+    resolution: {integrity: sha512-aFfw2DL2HpIcAQ8I3ZEtKuz+/GoF0H0sq387jAlvr00Q7buiiFbvARFuQlvTk00N7u3SJIh/3+YkKssTJDT+yQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@bruits/satteri-wasm32-wasi@0.6.3':
+    resolution: {integrity: sha512-DdpfnJ+04Mb4YtHaxAeETUvhdxFKg3URnroGY39FvweJEgeXx8cFNutuF5w904BhqaiblhmF76AoBnJwNLxsXg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@bruits/satteri-win32-x64-msvc@0.6.3':
+    resolution: {integrity: sha512-J/CZqACnBbv77eImx/JeO5RmCuCyliihiC81u3M4VobA8eupsygaPen3/UFFqf3yfeHvMlE3myilouh/2iHMOA==}
+    cpu: [x64]
+    os: [win32]
+
   '@capsizecss/unpack@4.0.0':
     resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
     engines: {node: '>=18'}
@@ -1379,8 +1407,17 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
+  '@emnapi/core@1.9.1':
+    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/runtime@1.9.1':
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+
+  '@emnapi/wasi-threads@1.2.0':
+    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -3128,6 +3165,9 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -6039,6 +6079,9 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  satteri@0.6.3:
+    resolution: {integrity: sha512-iY5xd2tBDQveYRFkL1F0cegkabWSVoXHi64e1p49SiCs1bZDaqTQPGQI+PqEQIaWkz0iqK80CuQQUYvhsssviw==}
+
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -7196,6 +7239,25 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
+  '@bruits/satteri-darwin-arm64@0.6.3':
+    optional: true
+
+  '@bruits/satteri-darwin-x64@0.6.3':
+    optional: true
+
+  '@bruits/satteri-linux-x64-gnu@0.6.3':
+    optional: true
+
+  '@bruits/satteri-wasm32-wasi@0.6.3':
+    dependencies:
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+    optional: true
+
+  '@bruits/satteri-win32-x64-msvc@0.6.3':
+    optional: true
+
   '@capsizecss/unpack@4.0.0':
     dependencies:
       fontkitten: 1.0.3
@@ -7466,7 +7528,23 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.9.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.0
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -8179,6 +8257,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
+    dependencies:
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@napi-rs/wasm-tools-android-arm-eabi@1.0.1':
     optional: true
 
@@ -8879,6 +8964,10 @@ snapshots:
       '@types/ms': 2.1.0
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
 
   '@types/estree@1.0.8': {}
 
@@ -12336,6 +12425,19 @@ snapshots:
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
+
+  satteri@0.6.3:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+    optionalDependencies:
+      '@bruits/satteri-darwin-arm64': 0.6.3
+      '@bruits/satteri-darwin-x64': 0.6.3
+      '@bruits/satteri-linux-x64-gnu': 0.6.3
+      '@bruits/satteri-wasm32-wasi': 0.6.3
+      '@bruits/satteri-win32-x64-msvc': 0.6.3
 
   sax@1.6.0: {}
 


### PR DESCRIPTION
## What

Adds [satteri](https://satteri.bruits.org/) as a comparison target in the parse/render speed benchmark (`benchmarks/bundle-size/parse-benchmark.mjs`).

satteri is a Rust-backed Markdown / MDX engine for the JS world, so it fits naturally alongside the other native parsers (`md4w`, `md4x`, `@ox-content/napi`) already in the sweep.

## Changes

- Add `satteri@^0.6.3` to the benchmark workspace deps
- Register `satteri` in both the **Parse Only** (`markdownToMdast`) and **Parse + Render** (`markdownToHtml`) suites. Both APIs are synchronous and need no init step.

## Verification

`node parse-benchmark.mjs` runs cleanly with satteri appearing in both tables. Local quick run (M-series, default napi build), large input — for orientation only:

| suite          | satteri | @ox-content/napi |
| -------------- | ------: | ---------------: |
| Parse Only     |     ✅ shows up | fastest |
| Parse + Render |     ✅ shows up | fastest |

## Note on the published tables

The result tables in `README.md` / `docs/content/performance.md` are from a dated reference sweep (release build, median of 7 runs on a specific machine). I deliberately did **not** edit those with fabricated satteri numbers — they should be regenerated on the maintainer's reference machine so satteri's figures are real and comparable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)