### PR TITLE
perf(ssg): skip no-op rehype round-trips and redundant per-page work

### DIFF
--- a/npm/vite-plugin-ox-content/src/plugins/mermaid-protect.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/mermaid-protect.ts
@@ -67,9 +67,15 @@ export function protectMermaidSvgs(html: string): MermaidSvgProtection {
  * Restore protected mermaid SVG blocks from placeholders.
  */
 export function restoreMermaidSvgs(html: string, svgs: Map<string, string>): string {
-  let result = html;
-  for (const [placeholder, content] of svgs) {
-    result = result.replace(placeholder, content);
+  if (svgs.size === 0) {
+    return html;
   }
-  return result;
+  // Single pass over the HTML instead of one full `String.replace` scan per
+  // placeholder (O(svgs × html) → O(html)). The function replacer also avoids
+  // the `$`-pattern interpretation that the string form of `replace` applies
+  // to the SVG replacement content.
+  return html.replace(/<!--ox-mermaid-\d+-->/g, (placeholder) => {
+    const content = svgs.get(placeholder);
+    return content !== undefined ? content : placeholder;
+  });
 }

--- a/npm/vite-plugin-ox-content/src/plugins/tabs.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/tabs.ts
@@ -218,6 +218,14 @@ function rehypeTabs() {
  * Transform Tabs components in HTML.
  */
 export async function transformTabs(html: string): Promise<string> {
+  // `rehypeTabs` only acts on `<Tabs>` elements. When the document has none,
+  // the rehype parse/stringify round-trip is wasted work, so skip it. The
+  // marker is a deliberately loose superset of the element name to avoid ever
+  // skipping a page that actually contains a `<Tabs>`.
+  if (!/<tabs/i.test(html)) {
+    return html;
+  }
+
   const result = await unified()
     .use(rehypeParse, { fragment: true })
     .use(rehypeTabs)

--- a/npm/vite-plugin-ox-content/src/plugins/youtube.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/youtube.ts
@@ -167,6 +167,13 @@ function rehypeYouTube(options: Required<YouTubeOptions>) {
  * Transform YouTube components in HTML.
  */
 export async function transformYouTube(html: string, options?: YouTubeOptions): Promise<string> {
+  // `rehypeYouTube` only acts on `<youtube>` elements. Skip the rehype
+  // round-trip entirely when the document has none. The marker is a loose
+  // superset of the element name so a real `<youtube>` is never skipped.
+  if (!/<youtube/i.test(html)) {
+    return html;
+  }
+
   const mergedOptions = { ...defaultOptions, ...options };
 
   const result = await unified()

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -137,6 +137,44 @@ export function generateBareHtmlPage(content: string, title: string): string {
   return importNapiModuleSync().generateSsgBareHtml(content, title);
 }
 
+/** NAPI-facing nav group shape produced from a [`NavGroup`]. */
+interface RustNavGroup {
+  title: string;
+  collapsed?: boolean;
+  items: SsgNavItem[];
+}
+
+/**
+ * Per-build cache for the Rust-facing nav conversion. `navGroups` is the same
+ * `context.navItems` reference for every page in a build, so the deep recursive
+ * copy below only needs to run once per build instead of once per page.
+ */
+const navGroupsForRustCache = new WeakMap<NavGroup[], RustNavGroup[]>();
+
+function toRustNavItem(item: SsgNavItem): SsgNavItem {
+  return {
+    title: item.title,
+    path: item.path,
+    href: item.href,
+    children: item.children?.map(toRustNavItem),
+    collapsed: item.collapsed,
+  };
+}
+
+function convertNavGroupsForRust(navGroups: NavGroup[]): RustNavGroup[] {
+  const cached = navGroupsForRustCache.get(navGroups);
+  if (cached) {
+    return cached;
+  }
+  const converted = navGroups.map((group) => ({
+    title: group.title,
+    collapsed: group.collapsed,
+    items: group.items.map(toRustNavItem),
+  }));
+  navGroupsForRustCache.set(navGroups, converted);
+  return converted;
+}
+
 /**
  * Generates HTML page with navigation using Rust NAPI bindings.
  */
@@ -161,20 +199,8 @@ export async function generateHtmlPage(
   });
   const tocForRust = pageData.toc.map(toRustTocEntry);
 
-  // Convert NavGroup to the format expected by Rust
-  const toRustNavItem = (item: SsgNavItem): SsgNavItem => ({
-    title: item.title,
-    path: item.path,
-    href: item.href,
-    children: item.children?.map(toRustNavItem),
-    collapsed: item.collapsed,
-  });
-
-  const navGroupsForRust = navGroups.map((group) => ({
-    title: group.title,
-    collapsed: group.collapsed,
-    items: group.items.map(toRustNavItem),
-  }));
+  // Convert NavGroup to the format expected by Rust (cached per build).
+  const navGroupsForRust = convertNavGroupsForRust(navGroups);
 
   // Convert theme to NAPI format if provided
   const themeForRust = theme ? themeToNapi(theme) : undefined;


### PR DESCRIPTION
## What

Three **behaviour-preserving** build-time optimizations in the SSG pipeline. All verified by the existing 89 `@ox-content/vite-plugin` tests — including the HTML snapshot tests, which would flag any output drift.

### 1. Skip no-op rehype round-trips for tabs/youtube (biggest win)

`transformTabs` and `transformYouTube` parsed the whole page into a HAST and re-serialized it through `rehype-parse` + `rehype-stringify` on **every page**, even when the page contained no `<tabs>`/`<youtube>` element — i.e. almost every page. They now early-return when a marker isn't present. The marker (`/<tabs/i`, `/<youtube/i`) is a deliberately *loose superset* of the element name, so a page that really contains an embed is never skipped.

Measured on an 18.6 KB no-embed page (release, 2000 iters, median):

| transform | before (round-trip) | after (marker skip) |
| --- | ---: | ---: |
| `transformTabs` | ~1.56 ms/page | ~0.002 ms/page |
| `transformYouTube` | ~1.49 ms/page | ~0.0015 ms/page |

≈ **3 ms saved per plain page** — e.g. ~0.6 s off a 200-page docs build, just from these two transforms.

### 2. Memoize the per-page nav conversion

`generateHtmlPage` rebuilt the entire recursive Rust-facing nav tree (`navGroupsForRust`) once per page, although `context.navItems` is the same array reference for the whole build. The conversion is now memoized in a per-build `WeakMap`, so a site's nav tree is converted once instead of once per page (matters most for large sidebars × many pages). Public signature unchanged.

### 3. Single-pass mermaid SVG restore

`restoreMermaidSvgs` ran one full-document `String.replace` scan per protected SVG (`O(svgs × html)`). It now restores all placeholders in a single regex pass (`O(html)`). The function replacer also sidesteps the `$`-pattern interpretation that the string form of `replace` applies to SVG replacement content.

## Verification

`vp test`: **17 files / 89 tests pass** (incl. `docs.snapshot`, `embed`, `ssg`). `tsgo --noEmit` clean. Snapshots unchanged ⇒ output is byte-identical.

## Not included (deliberately)

The investigation also flagged double-running github/openGraph/mermaid embeds and the serial per-page `await` loop. Those carry real behavioural risk (fetch ordering, idempotence of protect/restore) and are left for a separate, more carefully-tested change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)