### PR TITLE
perf(napi): port the YouTube embed transform to Rust

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -1018,6 +1018,21 @@ export interface JsTransformOptions {
   autolinkTargetBlank?: boolean
 }
 
+/**
+ * Options for [`transform_youtube_embeds`]; all optional, matching the TS
+ * `YouTubeOptions` defaults when omitted.
+ */
+export interface JsYouTubeOptions {
+  /** Use privacy-enhanced mode (youtube-nocookie.com). Default: true. */
+  privacyEnhanced?: boolean
+  /** Default aspect ratio. Default: "16/9". */
+  aspectRatio?: string
+  /** Allow fullscreen. Default: true. */
+  allowFullscreen?: boolean
+  /** Lazy-load the iframe. Default: true. */
+  lazyLoad?: boolean
+}
+
 export declare function lintMarkdown(source: string, options?: JsMarkdownLintOptions | undefined | null): JsMarkdownLintResult
 
 export declare function lintMarkdownDocuments(sources: Array<string>, options?: JsMarkdownLintOptions | undefined | null): Array<JsMarkdownLintResult>
@@ -1196,6 +1211,12 @@ export interface TransformResult {
   /** Parse/render errors, if any. */
   errors: Array<string>
 }
+
+/**
+ * Rewrites `<youtube …>` elements in rendered HTML into responsive,
+ * privacy-enhanced iframe embeds. Rust port of the TS `transformYouTube`.
+ */
+export declare function transformYoutubeEmbeds(html: string, options?: JsYouTubeOptions | undefined | null): string
 
 /**
  * Validates an MF2 message string.

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -9,6 +9,7 @@ mod mdast;
 mod mdast_raw;
 mod transfer;
 mod transformer;
+mod youtube;
 
 use napi::bindgen_prelude::*;
 use napi::Task;
@@ -1157,6 +1158,37 @@ pub fn write_generated_docs(
 #[napi]
 pub fn merge_highlighted_code_blocks(original_html: String, highlighted_html: String) -> String {
     highlight::merge_highlighted_code_blocks(&original_html, &highlighted_html)
+}
+
+/// Options for [`transform_youtube_embeds`]; all optional, matching the TS
+/// `YouTubeOptions` defaults when omitted.
+#[napi(object)]
+pub struct JsYouTubeOptions {
+    /// Use privacy-enhanced mode (youtube-nocookie.com). Default: true.
+    pub privacy_enhanced: Option<bool>,
+    /// Default aspect ratio. Default: "16/9".
+    pub aspect_ratio: Option<String>,
+    /// Allow fullscreen. Default: true.
+    pub allow_fullscreen: Option<bool>,
+    /// Lazy-load the iframe. Default: true.
+    pub lazy_load: Option<bool>,
+}
+
+/// Rewrites `<youtube …>` elements in rendered HTML into responsive,
+/// privacy-enhanced iframe embeds. Rust port of the TS `transformYouTube`.
+#[napi]
+pub fn transform_youtube_embeds(html: String, options: Option<JsYouTubeOptions>) -> String {
+    let defaults = youtube::YouTubeEmbedOptions::default();
+    let resolved = match options {
+        Some(options) => youtube::YouTubeEmbedOptions {
+            privacy_enhanced: options.privacy_enhanced.unwrap_or(defaults.privacy_enhanced),
+            aspect_ratio: options.aspect_ratio.unwrap_or(defaults.aspect_ratio),
+            allow_fullscreen: options.allow_fullscreen.unwrap_or(defaults.allow_fullscreen),
+            lazy_load: options.lazy_load.unwrap_or(defaults.lazy_load),
+        },
+        None => defaults,
+    };
+    youtube::transform_youtube(&html, &resolved)
 }
 
 /// Transforms Markdown source into HTML, frontmatter, and TOC.

--- a/crates/ox_content_napi/src/youtube.rs
+++ b/crates/ox_content_napi/src/youtube.rs
@@ -1,0 +1,375 @@
+//! Static YouTube embed transform (Rust port of the TS `transformYouTube`).
+//!
+//! Rewrites `<youtube …>` elements in already-rendered HTML into a responsive,
+//! privacy-enhanced iframe embed. This replaces a `rehype-parse` +
+//! `rehype-stringify` round-trip on the JS side: the Rust renderer's HTML is a
+//! rehype fixed-point, so rewriting only the `<youtube>` spans and leaving the
+//! surrounding bytes untouched reproduces the previous output byte-for-byte.
+//!
+//! The exact output is pinned by the `embed-transform` characterization tests
+//! in `@ox-content/vite-plugin`.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// Options mirroring the TS `YouTubeOptions`, with the same defaults.
+#[derive(Debug, Clone)]
+pub struct YouTubeEmbedOptions {
+    pub privacy_enhanced: bool,
+    pub aspect_ratio: String,
+    pub allow_fullscreen: bool,
+    pub lazy_load: bool,
+}
+
+impl Default for YouTubeEmbedOptions {
+    fn default() -> Self {
+        Self {
+            privacy_enhanced: true,
+            aspect_ratio: "16/9".to_string(),
+            allow_fullscreen: true,
+            lazy_load: true,
+        }
+    }
+}
+
+static VIDEO_ID: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9_-]{11}$").expect("valid video id regex"));
+static URL_PATTERNS: LazyLock<[Regex; 2]> = LazyLock::new(|| {
+    [
+        Regex::new(
+            r"(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/embed/|youtube\.com/v/)([a-zA-Z0-9_-]{11})",
+        )
+        .expect("valid url regex"),
+        Regex::new(r"youtube\.com/shorts/([a-zA-Z0-9_-]{11})").expect("valid shorts regex"),
+    ]
+});
+
+/// Extract a YouTube video id from a bare id or a watch/share/embed/shorts URL.
+/// Mirrors the TS `extractVideoId`.
+pub fn extract_video_id(input: &str) -> Option<String> {
+    if VIDEO_ID.is_match(input) {
+        return Some(input.to_string());
+    }
+    for pattern in URL_PATTERNS.iter() {
+        if let Some(captures) = pattern.captures(input) {
+            if let Some(id) = captures.get(1) {
+                return Some(id.as_str().to_string());
+            }
+        }
+    }
+    None
+}
+
+/// HTML-escape an attribute value the way `hast-util-to-html` does for the
+/// characters that can occur in titles/urls here.
+fn escape_attribute(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '&' => out.push_str("&#x26;"),
+            '"' => out.push_str("&#x22;"),
+            '<' => out.push_str("&#x3C;"),
+            '>' => out.push_str("&#x3E;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+fn build_embed_url(video_id: &str, options: &YouTubeEmbedOptions) -> String {
+    let domain =
+        if options.privacy_enhanced { "www.youtube-nocookie.com" } else { "www.youtube.com" };
+    format!("https://{domain}/embed/{video_id}")
+}
+
+fn render_embed(video_id: &str, options: &YouTubeEmbedOptions, title: Option<&str>) -> String {
+    let embed_url = build_embed_url(video_id, options);
+    let title_value = match title {
+        Some(title) => title.to_string(),
+        None => format!("YouTube video {video_id}"),
+    };
+    let mut html = String::new();
+    html.push_str("<div class=\"ox-youtube\" style=\"aspect-ratio: ");
+    html.push_str(&options.aspect_ratio);
+    html.push_str(";\"><iframe src=\"");
+    html.push_str(&escape_attribute(&embed_url));
+    html.push_str("\" title=\"");
+    html.push_str(&escape_attribute(&title_value));
+    html.push_str("\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\"");
+    if options.allow_fullscreen {
+        html.push_str(" allowfullscreen");
+    }
+    if options.lazy_load {
+        html.push_str(" loading=\"lazy\"");
+    }
+    html.push_str("></iframe></div>");
+    html
+}
+
+/// A `<youtube …>` element located in the source HTML.
+///
+/// Note: the `start` attribute is intentionally not read. The TS
+/// implementation this ports parsed HTML via hast, which coerces `start`
+/// (a known numeric attribute on `<ol>`) to a number and then dropped it in
+/// its string-only attribute reader — so `start` never reached the embed
+/// URL. Reproducing that exactly keeps this a behaviour-preserving port;
+/// honouring `start` is left to a separate change.
+struct YouTubeElement {
+    /// Byte range of the whole element (open tag through close tag or `/>`).
+    span: (usize, usize),
+    id: Option<String>,
+    url: Option<String>,
+    title: Option<String>,
+}
+
+/// Find the next `<youtube …>` element at or after `from`. Recognises both
+/// `<youtube …></youtube>` and self-closing `<youtube … />` forms.
+fn find_youtube_element(html: &str, from: usize) -> Option<YouTubeElement> {
+    let bytes = html.as_bytes();
+    let mut search = from;
+    loop {
+        let rel = find_ci(html, search, "<youtube")?;
+        let tag_start = rel;
+        let after_name = tag_start + "<youtube".len();
+        // Require an element boundary after the name so `<youtuber>` etc. never
+        // matches.
+        let boundary = bytes.get(after_name).copied();
+        let is_boundary =
+            matches!(boundary, Some(b) if b == b'>' || b == b'/' || b.is_ascii_whitespace());
+        if !is_boundary {
+            search = after_name;
+            continue;
+        }
+
+        // Scan to the end of the start tag, respecting quoted attribute values
+        // so a `>` inside a value doesn't terminate the tag early.
+        let mut i = after_name;
+        let mut quote: Option<u8> = None;
+        let mut tag_end = None;
+        while i < bytes.len() {
+            let b = bytes[i];
+            match quote {
+                Some(q) => {
+                    if b == q {
+                        quote = None;
+                    }
+                }
+                None => {
+                    if b == b'"' || b == b'\'' {
+                        quote = Some(b);
+                    } else if b == b'>' {
+                        tag_end = Some(i);
+                        break;
+                    }
+                }
+            }
+            i += 1;
+        }
+        let tag_end = tag_end?;
+        let self_closing = tag_end > after_name && bytes[tag_end - 1] == b'/';
+
+        let inner_end = if self_closing { tag_end - 1 } else { tag_end };
+        let attrs = parse_attributes(&html[after_name..inner_end]);
+
+        let span_end = if self_closing {
+            tag_end + 1
+        } else {
+            // Find the matching close tag.
+            match find_ci(html, tag_end + 1, "</youtube>") {
+                Some(close_start) => close_start + "</youtube>".len(),
+                None => tag_end + 1,
+            }
+        };
+
+        return Some(YouTubeElement {
+            span: (tag_start, span_end),
+            id: attrs.iter().find(|(n, _)| n == "id").map(|(_, v)| v.clone()),
+            url: attrs.iter().find(|(n, _)| n == "url").map(|(_, v)| v.clone()),
+            title: attrs.iter().find(|(n, _)| n == "title").map(|(_, v)| v.clone()),
+        });
+    }
+}
+
+/// Parse `name="value"` / `name='value'` / `name=value` / bare `name`
+/// attributes from the inside of a start tag. Names are lower-cased.
+fn parse_attributes(inner: &str) -> Vec<(String, String)> {
+    let bytes = inner.as_bytes();
+    let mut attrs = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i >= bytes.len() || bytes[i] == b'/' {
+            break;
+        }
+        let name_start = i;
+        while i < bytes.len()
+            && !bytes[i].is_ascii_whitespace()
+            && bytes[i] != b'='
+            && bytes[i] != b'/'
+        {
+            i += 1;
+        }
+        if name_start == i {
+            break;
+        }
+        let name = inner[name_start..i].to_ascii_lowercase();
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        let value = if i < bytes.len() && bytes[i] == b'=' {
+            i += 1;
+            while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            if i >= bytes.len() {
+                String::new()
+            } else if bytes[i] == b'"' || bytes[i] == b'\'' {
+                let q = bytes[i];
+                i += 1;
+                let vs = i;
+                while i < bytes.len() && bytes[i] != q {
+                    i += 1;
+                }
+                let v = inner[vs..i].to_string();
+                if i < bytes.len() {
+                    i += 1;
+                }
+                v
+            } else {
+                let vs = i;
+                while i < bytes.len() && !bytes[i].is_ascii_whitespace() && bytes[i] != b'/' {
+                    i += 1;
+                }
+                inner[vs..i].to_string()
+            }
+        } else {
+            String::new()
+        };
+        attrs.push((name, value));
+    }
+    attrs
+}
+
+/// Case-insensitive search for `needle` in `haystack[from..]`, returning an
+/// absolute byte offset. `needle` must be ASCII (it always is here).
+fn find_ci(haystack: &str, from: usize, needle: &str) -> Option<usize> {
+    let hay = haystack.as_bytes();
+    let pat = needle.as_bytes();
+    if pat.is_empty() || from > hay.len() || hay.len() - from < pat.len() {
+        return None;
+    }
+    let last = hay.len() - pat.len();
+    for i in from..=last {
+        if hay[i..i + pat.len()].eq_ignore_ascii_case(pat) {
+            return Some(i);
+        }
+    }
+    None
+}
+
+/// Transform every `<youtube …>` element in `html` into an iframe embed.
+/// Elements whose `id`/`url` yield no valid video id are left untouched.
+pub fn transform_youtube(html: &str, options: &YouTubeEmbedOptions) -> String {
+    // Fast path: nothing to do when the marker is absent.
+    if find_ci(html, 0, "<youtube").is_none() {
+        return html.to_string();
+    }
+
+    let mut out = String::with_capacity(html.len());
+    let mut cursor = 0;
+    while let Some(element) = find_youtube_element(html, cursor) {
+        let (start, end) = element.span;
+        out.push_str(&html[cursor..start]);
+
+        let video_id = match &element.id {
+            Some(id) => extract_video_id(id),
+            None => element.url.as_deref().and_then(extract_video_id),
+        };
+
+        match video_id {
+            Some(video_id) => {
+                out.push_str(&render_embed(&video_id, options, element.title.as_deref()));
+            }
+            // No usable id: leave the original element bytes in place.
+            None => out.push_str(&html[start..end]),
+        }
+        cursor = end;
+    }
+    out.push_str(&html[cursor..]);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts() -> YouTubeEmbedOptions {
+        YouTubeEmbedOptions::default()
+    }
+
+    #[test]
+    fn wraps_bare_id_matching_characterization() {
+        let html = transform_youtube(r#"<p><youtube id="dQw4w9WgXcQ"></youtube></p>"#, &opts());
+        assert_eq!(
+            html,
+            r#"<p><div class="ox-youtube" style="aspect-ratio: 16/9;"><iframe src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ" title="YouTube video dQw4w9WgXcQ" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen loading="lazy"></iframe></div></p>"#
+        );
+    }
+
+    #[test]
+    fn extracts_from_url_and_title_ignoring_start() {
+        // `start` is intentionally not applied — see `YouTubeElement` — so the
+        // embed URL has no query string even though the element carries one.
+        let html = transform_youtube(
+            r#"<youtube url="https://youtu.be/dQw4w9WgXcQ" title="Demo" start="30"></youtube>"#,
+            &opts(),
+        );
+        assert_eq!(
+            html,
+            r#"<div class="ox-youtube" style="aspect-ratio: 16/9;"><iframe src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ" title="Demo" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen loading="lazy"></iframe></div>"#
+        );
+    }
+
+    #[test]
+    fn passes_through_when_no_element() {
+        let html = r#"<p>Plain prose with a <a href="/x">link</a> and no embeds.</p>"#;
+        assert_eq!(transform_youtube(html, &opts()), html);
+    }
+
+    #[test]
+    fn leaves_element_untouched_when_id_invalid() {
+        let html = r#"<youtube id="not-a-valid-id"></youtube>"#;
+        assert_eq!(transform_youtube(html, &opts()), html);
+    }
+
+    #[test]
+    fn does_not_match_youtuber() {
+        let html = r#"<youtuber id="dQw4w9WgXcQ"></youtuber>"#;
+        assert_eq!(transform_youtube(html, &opts()), html);
+    }
+
+    #[test]
+    fn handles_self_closing() {
+        let html = transform_youtube(r#"<youtube id="dQw4w9WgXcQ" />"#, &opts());
+        assert!(html.starts_with(r#"<div class="ox-youtube""#));
+        assert!(html.ends_with("></iframe></div>"));
+    }
+
+    #[test]
+    fn non_privacy_and_no_fullscreen_no_lazy() {
+        let options = YouTubeEmbedOptions {
+            privacy_enhanced: false,
+            aspect_ratio: "4/3".to_string(),
+            allow_fullscreen: false,
+            lazy_load: false,
+        };
+        let html = transform_youtube(r#"<youtube id="dQw4w9WgXcQ"></youtube>"#, &options);
+        assert_eq!(
+            html,
+            r#"<div class="ox-youtube" style="aspect-ratio: 4/3;"><iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="YouTube video dQw4w9WgXcQ" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin"></iframe></div>"#
+        );
+    }
+}

--- a/npm/vite-plugin-ox-content/src/plugins/youtube.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/youtube.ts
@@ -1,14 +1,16 @@
 /**
  * YouTube Plugin - Privacy-enhanced iframe embedding
  *
- * Transforms <YouTube> components into responsive iframe embeds
- * using youtube-nocookie.com for enhanced privacy.
+ * Transforms <YouTube> components into responsive iframe embeds using
+ * youtube-nocookie.com for enhanced privacy.
+ *
+ * The HTML rewrite is performed in Rust (`transformYoutubeEmbeds` in
+ * @ox-content/napi), replacing the previous rehype parse/stringify
+ * round-trip. This module keeps the public TS surface and a cheap marker
+ * check so pages without a `<youtube>` element never cross the NAPI boundary.
  */
 
-import { unified } from "unified";
-import rehypeParse from "rehype-parse";
-import rehypeStringify from "rehype-stringify";
-import type { Root, Element, Properties } from "hast";
+import { importNapiModule } from "../napi";
 
 export interface YouTubeOptions {
   /** Use privacy-enhanced mode (youtube-nocookie.com). Default: true */
@@ -19,23 +21,6 @@ export interface YouTubeOptions {
   allowFullscreen?: boolean;
   /** Lazy load iframe. Default: true */
   lazyLoad?: boolean;
-}
-
-const defaultOptions: Required<YouTubeOptions> = {
-  privacyEnhanced: true,
-  aspectRatio: "16/9",
-  allowFullscreen: true,
-  lazyLoad: true,
-};
-
-/**
- * Get element attribute value.
- */
-function getAttribute(el: Element, name: string): string | undefined {
-  const value = el.properties?.[name];
-  if (typeof value === "string") return value;
-  if (Array.isArray(value)) return value.join(" ");
-  return undefined;
 }
 
 /**
@@ -62,125 +47,17 @@ export function extractVideoId(input: string): string | null {
 }
 
 /**
- * Build YouTube embed URL with parameters.
- */
-function buildEmbedUrl(
-  videoId: string,
-  options: Required<YouTubeOptions>,
-  params?: Record<string, string>,
-): string {
-  const domain = options.privacyEnhanced ? "www.youtube-nocookie.com" : "www.youtube.com";
-  const url = new URL(`https://${domain}/embed/${videoId}`);
-
-  // Add any custom parameters
-  if (params) {
-    for (const [key, value] of Object.entries(params)) {
-      url.searchParams.set(key, value);
-    }
-  }
-
-  return url.toString();
-}
-
-/**
- * Create YouTube embed element.
- */
-function createYouTubeElement(
-  videoId: string,
-  options: Required<YouTubeOptions>,
-  title?: string,
-  start?: string,
-): Element {
-  const params: Record<string, string> = {};
-  if (start) {
-    params.start = start;
-  }
-
-  const embedUrl = buildEmbedUrl(videoId, options, params);
-
-  const iframeProps: Properties = {
-    src: embedUrl,
-    title: title || `YouTube video ${videoId}`,
-    allow:
-      "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share",
-    referrerpolicy: "strict-origin-when-cross-origin",
-    allowfullscreen: options.allowFullscreen || undefined,
-    loading: options.lazyLoad ? "lazy" : undefined,
-  };
-
-  const iframe: Element = {
-    type: "element",
-    tagName: "iframe",
-    properties: iframeProps,
-    children: [],
-  };
-
-  return {
-    type: "element",
-    tagName: "div",
-    properties: {
-      className: ["ox-youtube"],
-      style: `aspect-ratio: ${options.aspectRatio};`,
-    },
-    children: [iframe],
-  };
-}
-
-/**
- * Rehype plugin to transform YouTube components.
- */
-function rehypeYouTube(options: Required<YouTubeOptions>) {
-  return (tree: Root) => {
-    const visit = (node: Root | Element) => {
-      if ("children" in node) {
-        for (let i = 0; i < node.children.length; i++) {
-          const child = node.children[i];
-
-          if (child.type === "element") {
-            // Check for <YouTube> component
-            if (child.tagName.toLowerCase() === "youtube") {
-              const id = getAttribute(child, "id");
-              const url = getAttribute(child, "url");
-              const title = getAttribute(child, "title");
-              const start = getAttribute(child, "start");
-
-              // Extract video ID from id or url attribute
-              const videoId = id ? extractVideoId(id) : url ? extractVideoId(url) : null;
-
-              if (videoId) {
-                const youtubeElement = createYouTubeElement(videoId, options, title, start);
-                node.children[i] = youtubeElement;
-              }
-            } else {
-              visit(child);
-            }
-          }
-        }
-      }
-    };
-
-    visit(tree);
-  };
-}
-
-/**
  * Transform YouTube components in HTML.
  */
 export async function transformYouTube(html: string, options?: YouTubeOptions): Promise<string> {
-  // `rehypeYouTube` only acts on `<youtube>` elements. Skip the rehype
-  // round-trip entirely when the document has none. The marker is a loose
-  // superset of the element name so a real `<youtube>` is never skipped.
+  // Cheap marker check: skip the NAPI call entirely when there's no
+  // `<youtube>` element (the common case). The Rust side guards the same way,
+  // but short-circuiting here avoids marshalling the whole document across
+  // the boundary.
   if (!/<youtube/i.test(html)) {
     return html;
   }
 
-  const mergedOptions = { ...defaultOptions, ...options };
-
-  const result = await unified()
-    .use(rehypeParse, { fragment: true })
-    .use(rehypeYouTube, mergedOptions)
-    .use(rehypeStringify)
-    .process(html);
-
-  return String(result);
+  const mod = await importNapiModule();
+  return mod.transformYoutubeEmbeds(html, options);
 }


### PR DESCRIPTION
## What

Ports the `transformYouTube` HTML transform from a JS `rehype-parse` + `rehype-stringify` round-trip to a Rust HTML rewriter, exposed as `transformYoutubeEmbeds` in `@ox-content/napi`.

- New Rust module `crates/ox_content_napi/src/youtube.rs`: scans for `<youtube …>` elements (open/close and self-closing), parses attributes, extracts the video id (bare id or watch/share/embed/shorts URL via `regex`), and emits the responsive privacy-enhanced iframe embed.
- The Rust renderer's HTML is a rehype fixed-point (established in #218), so rewriting **only** the `<youtube>` spans and leaving every other byte untouched reproduces the old output **byte-for-byte**.
- TS `transformYouTube` keeps its public surface (`transformYouTube`, `extractVideoId`, `YouTubeOptions`) and a cheap `/<youtube/i` marker check so embed-less pages never cross the NAPI boundary; the actual rewrite delegates to Rust.

## Why

First step of the TS→Rust transform port. `transformYouTube` was a pure CPU transform (no network), making it the safest, fully-verifiable starting point. On embed pages it replaces a ~1.5 ms/page rehype round-trip with a single linear Rust scan.

## Behaviour preservation

Output is verified identical by:
- the embed-transform **characterization tests** added in #219 (now exercising the Rust path), and
- new Rust unit tests in `youtube.rs` pinning the same strings.

One quirk is preserved deliberately: the `start` attribute is dropped, exactly as the JS did (hast coerced `start` to a numeric attribute that the string-only reader discarded, so it never reached the embed URL). Honouring `start` is left to a separate change to keep this a pure port.

## Verification

- `cargo test -p ox_content_napi youtube`: 7 pass · `cargo clippy` / `cargo fmt --check`: clean
- `vp test`: 18 files / 94 tests pass (incl. characterization)
- `index.d.ts` regenerated (additive only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)