### PR TITLE
perf(parser): skip redundant block dispatch on a paragraph's first line

### DIFF
--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -67,8 +67,23 @@ impl<'a> Parser<'a> {
 
     pub(super) fn parse_paragraph(&mut self, start: usize) -> ParseResult<Option<Node<'a>>> {
         profile_span!("parser::parse_paragraph");
-        let mut content_end = start;
         let bytes = self.source.as_bytes();
+
+        // `parse_block` is the sole caller and only reaches here after
+        // `skip_blank_lines` + its block dispatch — the very checks
+        // `line_starts_block` re-runs — have already classified the current
+        // line as a non-blank, non-block paragraph line. So consume the first
+        // line unconditionally instead of re-deriving that verdict with
+        // another `current_line` memchr + `trim_start` + dispatch (+ table
+        // `memchr`). This also removes the infinite-loop hazard the two
+        // dispatchers guard against: by always advancing past line one we can
+        // never return `Ok(None)` without progress on a non-blank line.
+        let mut content_end = if let Some(off) = memchr(b'\n', &bytes[start..]) {
+            start + off + 1
+        } else {
+            self.source.len()
+        };
+        self.position = content_end;
 
         loop {
             if self.is_at_end() {


### PR DESCRIPTION
## What

`parse_block` only reaches `parse_paragraph` after running `skip_blank_lines` plus its block dispatch — the very checks `line_starts_block` performs. So when we land in `parse_paragraph`, the current line is already known to be a **non-blank, non-block paragraph line**.

The paragraph loop nonetheless re-ran `line_starts_block` on that first line, repeating a `current_line` memchr + `trim_start` + full block dispatch + table-detection memchr whose verdict was already settled.

This change consumes the first line unconditionally and only runs `line_starts_block` on subsequent lines.

## Why it's safe

- `parse_block` is the **sole caller** of `parse_paragraph`, and only via the dispatch fall-through. The two dispatchers are kept in lock-step (see the note in `cursor.rs`), so `line_starts_block` on line one is guaranteed to return `false`.
- As a bonus, this **removes the infinite-loop hazard** those dispatchers guard against: by always advancing past line one, `parse_paragraph` can no longer return `Ok(None)` without progress on a non-blank line.

## Measurement

`cargo bench -p ox_content_parser` (criterion, p < 0.05, statistically significant):

| bench | before | after | change |
|---|---|---|---|
| `parse_simple` | 484 ns (336 MiB/s) | **462 ns (352 MiB/s)** | **−11.3%** |
| `parse_large` | 3.51 µs (691 MiB/s) | **3.24 µs (748 MiB/s)** | **−3.3%** |

Short documents gain most, where the per-paragraph fixed cost dominates — which is the common shape for the small content fragments the SSG processes in bulk. Identified by profiling the full pipeline with `ox_content_profile_cli` (`parser::parse_block` was the top self-time span).

## Testing

- All 49 `ox_content_parser` tests pass
- `cargo fmt` / `cargo clippy --all-targets -- -D warnings` clean