### PR TITLE
perf(napi): SIMD-accelerate the static embed transforms

### DIFF
--- a/crates/ox_content_napi/Cargo.toml
+++ b/crates/ox_content_napi/Cargo.toml
@@ -36,6 +36,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 regex = { workspace = true }
+memchr = { workspace = true }
 unicode-normalization = { workspace = true }
 
 [build-dependencies]

--- a/crates/ox_content_napi/src/html_scan.rs
+++ b/crates/ox_content_napi/src/html_scan.rs
@@ -1,0 +1,90 @@
+//! Small byte-level scanning helpers shared by the static HTML embed transforms
+//! ([`crate::tabs`], [`crate::youtube`]).
+//!
+//! These transforms walk already-rendered HTML looking for a handful of literal
+//! tag markers (`<youtube`, `<tabs`, `</tab>`, …). Every marker begins with `<`,
+//! which is sparse in real documents, so the search is dominated by skipping
+//! over long runs of prose. [`find_ci`] uses SIMD `memchr` to jump straight to
+//! the next candidate `<` instead of running a case-insensitive comparison at
+//! every byte — the same trick the renderer's autolink scanner relies on.
+
+/// Case-insensitive ASCII substring search in `haystack[from..]`, returning an
+/// absolute byte offset.
+///
+/// `needle` must be ASCII (it always is at the call sites). The first byte is
+/// located with `memchr`, so the cost of skipping non-matching bytes is a tight
+/// SIMD scan rather than a per-position `eq_ignore_ascii_case`.
+pub fn find_ci(haystack: &str, from: usize, needle: &str) -> Option<usize> {
+    let hay = haystack.as_bytes();
+    let pat = needle.as_bytes();
+    if pat.is_empty() || from > hay.len() || hay.len() - from < pat.len() {
+        return None;
+    }
+    // Last index at which a full `pat`-length match can still start.
+    let last_start = hay.len() - pat.len();
+    let rest = &pat[1..];
+
+    // Match the first byte case-insensitively. The markers here all begin with
+    // `<` (non-alphabetic, so `lo == hi` and this collapses to a single
+    // `memchr`), but handle the alphabetic case too so the helper stays a
+    // correct case-insensitive search.
+    let lo = pat[0].to_ascii_lowercase();
+    let hi = pat[0].to_ascii_uppercase();
+
+    let mut base = from;
+    while base <= last_start {
+        let window = &hay[base..=last_start];
+        let rel = if lo == hi {
+            memchr::memchr(pat[0], window)
+        } else {
+            memchr::memchr2(lo, hi, window)
+        }?;
+        let i = base + rel;
+        if hay[i + 1..i + pat.len()].eq_ignore_ascii_case(rest) {
+            return Some(i);
+        }
+        base = i + 1;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_ci;
+
+    fn naive(haystack: &str, from: usize, needle: &str) -> Option<usize> {
+        let hay = haystack.as_bytes();
+        let pat = needle.as_bytes();
+        if pat.is_empty() || from > hay.len() || hay.len() - from < pat.len() {
+            return None;
+        }
+        (from..=hay.len() - pat.len()).find(|&i| hay[i..i + pat.len()].eq_ignore_ascii_case(pat))
+    }
+
+    #[test]
+    fn matches_naive_reference_across_cases() {
+        let cases = [
+            ("<p>hi</p><YouTube id>", "<youtube"),
+            ("plain prose, no tags at all", "<tabs"),
+            ("<TABS><TAB>x</TAB></TABS>", "</tab>"),
+            ("a<b<c<youtube>", "<youtube"),
+            ("", "<tabs"),
+            ("<youtube", "<youtube"),
+        ];
+        for (hay, needle) in cases {
+            for from in 0..=hay.len() {
+                assert_eq!(
+                    find_ci(hay, from, needle),
+                    naive(hay, from, needle),
+                    "mismatch for needle {needle:?} in {hay:?} from {from}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn returns_none_when_window_too_small() {
+        assert_eq!(find_ci("<yo", 0, "<youtube"), None);
+        assert_eq!(find_ci("<youtube", 1, "<youtube"), None);
+    }
+}

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -4,6 +4,7 @@
 //! including raw-buffer AST transfer for JavaScript interoperability.
 
 mod highlight;
+mod html_scan;
 mod lint;
 mod mdast;
 mod mdast_raw;

--- a/crates/ox_content_napi/src/tabs.rs
+++ b/crates/ox_content_napi/src/tabs.rs
@@ -13,6 +13,8 @@
 //! itself stays on the JS side. The exact output is pinned by the
 //! `embed-transform` characterization tests in `@ox-content/vite-plugin`.
 
+use crate::html_scan::find_ci;
+
 struct Tab {
     label: String,
     /// Raw inner HTML of the `<tab>` element, copied verbatim.
@@ -37,7 +39,7 @@ pub fn transform_tabs(html: &str, start_group: u32) -> TabsTransform {
     let mut cursor = 0;
     let mut next_group = start_group;
 
-    while let Some(open_at) = find_tag(html, cursor, "tabs") {
+    while let Some(open_at) = find_tag(html, cursor, "<tabs") {
         // Emit everything up to the `<tabs>`.
         out.push_str(&html[cursor..open_at]);
 
@@ -56,7 +58,7 @@ pub fn transform_tabs(html: &str, start_group: u32) -> TabsTransform {
         }
 
         // Find the matching `</tabs>` accounting for nested `<tabs>`.
-        let Some(close_start) = find_matching_close(html, tag.end, "tabs", "</tabs>") else {
+        let Some(close_start) = find_matching_close(html, tag.end, "<tabs", "</tabs>") else {
             out.push_str(&html[open_at..tag.end]);
             cursor = tag.end;
             continue;
@@ -83,7 +85,7 @@ pub fn transform_tabs(html: &str, start_group: u32) -> TabsTransform {
 fn parse_tabs(inner: &str) -> Vec<Tab> {
     let mut tabs = Vec::new();
     let mut cursor = 0;
-    while let Some(open_at) = find_tag(inner, cursor, "tab") {
+    while let Some(open_at) = find_tag(inner, cursor, "<tab") {
         let Some(tag) = scan_start_tag(inner, open_at) else {
             cursor = open_at + 1;
             continue;
@@ -98,7 +100,7 @@ fn parse_tabs(inner: &str) -> Vec<Tab> {
             continue;
         }
 
-        let Some(close_start) = find_matching_close(inner, tag.end, "tab", "</tab>") else {
+        let Some(close_start) = find_matching_close(inner, tag.end, "<tab", "</tab>") else {
             // Unterminated `<tab>`: stop collecting.
             break;
         };
@@ -109,25 +111,29 @@ fn parse_tabs(inner: &str) -> Vec<Tab> {
 }
 
 fn render_tabs(tabs: &[Tab], group: u32) -> String {
+    use std::fmt::Write;
+
+    // The group number is interpolated many times below; format it once and
+    // reuse the string instead of allocating per use. The per-tab index is
+    // written directly into `out` via `write!`, avoiding a temporary `String`
+    // per number.
+    let group_str = group.to_string();
+
     let mut out = String::new();
     out.push_str("<div class=\"ox-tabs-container\"><div class=\"ox-tabs\" data-group=\"");
-    out.push_str(&group.to_string());
+    out.push_str(&group_str);
     out.push_str("\"><div class=\"ox-tabs-header\">");
     for (index, tab) in tabs.iter().enumerate() {
         out.push_str("<input type=\"radio\" name=\"ox-tabs-");
-        out.push_str(&group.to_string());
+        out.push_str(&group_str);
         out.push_str("\" id=\"ox-tab-");
-        out.push_str(&group.to_string());
-        out.push('-');
-        out.push_str(&index.to_string());
+        let _ = write!(out, "{group_str}-{index}");
         out.push('"');
         if index == 0 {
             out.push_str(" checked");
         }
         out.push_str("><label for=\"ox-tab-");
-        out.push_str(&group.to_string());
-        out.push('-');
-        out.push_str(&index.to_string());
+        let _ = write!(out, "{group_str}-{index}");
         out.push_str("\">");
         out.push_str(&escape_text(&tab.label));
         out.push_str("</label>");
@@ -135,7 +141,7 @@ fn render_tabs(tabs: &[Tab], group: u32) -> String {
     out.push_str("</div>");
     for (index, tab) in tabs.iter().enumerate() {
         out.push_str("<div class=\"ox-tab-panel\" data-tab=\"");
-        out.push_str(&index.to_string());
+        let _ = write!(out, "{index}");
         out.push_str("\">");
         out.push_str(&tab.content);
         out.push_str("</div>");
@@ -207,16 +213,15 @@ fn scan_start_tag(html: &str, pos: usize) -> Option<StartTag> {
     Some(StartTag { name_end, inner_end, end: tag_end + 1, self_closing })
 }
 
-/// Find the next `<name` start tag at or after `from` with a proper element
-/// boundary, so `<tab` never matches `<tabs`/`<table` and `<tabs` never matches
-/// `<tabset>`.
-fn find_tag(html: &str, from: usize, name: &str) -> Option<usize> {
-    let needle = format!("<{name}");
+/// Find the next start tag at or after `from` with a proper element boundary.
+/// `open` is the `<name` literal (e.g. `"<tabs"`); the boundary check means
+/// `<tab` never matches `<tabs`/`<table` and `<tabs` never matches `<tabset>`.
+fn find_tag(html: &str, from: usize, open: &str) -> Option<usize> {
     let bytes = html.as_bytes();
     let mut search = from;
     loop {
-        let at = find_ci(html, search, &needle)?;
-        let after = at + needle.len();
+        let at = find_ci(html, search, open)?;
+        let after = at + open.len();
         let boundary = bytes.get(after).copied();
         if matches!(boundary, Some(b) if b == b'>' || b == b'/' || b.is_ascii_whitespace()) {
             return Some(at);
@@ -226,12 +231,12 @@ fn find_tag(html: &str, from: usize, name: &str) -> Option<usize> {
 }
 
 /// Given the position just past a `<name …>` start tag, find the byte offset of
-/// its matching `close` literal, accounting for nested `<name …>` opens.
-fn find_matching_close(html: &str, from: usize, name: &str, close: &str) -> Option<usize> {
+/// its matching `close` literal, accounting for nested `open` (`<name`) tags.
+fn find_matching_close(html: &str, from: usize, open: &str, close: &str) -> Option<usize> {
     let mut depth = 1usize;
     let mut search = from;
     loop {
-        let next_open = find_tag(html, search, name);
+        let next_open = find_tag(html, search, open);
         let next_close = find_ci(html, search, close);
         match (next_open, next_close) {
             (Some(open_at), Some(close_at)) if open_at < close_at => {
@@ -327,22 +332,6 @@ fn escape_text(value: &str) -> String {
         }
     }
     out
-}
-
-/// Case-insensitive ASCII substring search in `haystack[from..]`.
-fn find_ci(haystack: &str, from: usize, needle: &str) -> Option<usize> {
-    let hay = haystack.as_bytes();
-    let pat = needle.as_bytes();
-    if pat.is_empty() || from > hay.len() || hay.len() - from < pat.len() {
-        return None;
-    }
-    let last = hay.len() - pat.len();
-    for i in from..=last {
-        if hay[i..i + pat.len()].eq_ignore_ascii_case(pat) {
-            return Some(i);
-        }
-    }
-    None
 }
 
 #[cfg(test)]

--- a/crates/ox_content_napi/src/youtube.rs
+++ b/crates/ox_content_napi/src/youtube.rs
@@ -13,6 +13,8 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
+use crate::html_scan::find_ci;
+
 /// Options mirroring the TS `YouTubeOptions`, with the same defaults.
 #[derive(Debug, Clone)]
 pub struct YouTubeEmbedOptions {
@@ -170,7 +172,19 @@ fn find_youtube_element(html: &str, from: usize) -> Option<YouTubeElement> {
         let self_closing = tag_end > after_name && bytes[tag_end - 1] == b'/';
 
         let inner_end = if self_closing { tag_end - 1 } else { tag_end };
-        let attrs = parse_attributes(&html[after_name..inner_end]);
+
+        // Pull out the three attributes we care about in a single pass, keeping
+        // the first occurrence of each (matching hast's first-wins semantics)
+        // and moving the values out instead of cloning them.
+        let (mut id, mut url, mut title) = (None, None, None);
+        for (name, value) in parse_attributes(&html[after_name..inner_end]) {
+            match name.as_str() {
+                "id" if id.is_none() => id = Some(value),
+                "url" if url.is_none() => url = Some(value),
+                "title" if title.is_none() => title = Some(value),
+                _ => {}
+            }
+        }
 
         let span_end = if self_closing {
             tag_end + 1
@@ -182,12 +196,7 @@ fn find_youtube_element(html: &str, from: usize) -> Option<YouTubeElement> {
             }
         };
 
-        return Some(YouTubeElement {
-            span: (tag_start, span_end),
-            id: attrs.iter().find(|(n, _)| n == "id").map(|(_, v)| v.clone()),
-            url: attrs.iter().find(|(n, _)| n == "url").map(|(_, v)| v.clone()),
-            title: attrs.iter().find(|(n, _)| n == "title").map(|(_, v)| v.clone()),
-        });
+        return Some(YouTubeElement { span: (tag_start, span_end), id, url, title });
     }
 }
 
@@ -251,23 +260,6 @@ fn parse_attributes(inner: &str) -> Vec<(String, String)> {
         attrs.push((name, value));
     }
     attrs
-}
-
-/// Case-insensitive search for `needle` in `haystack[from..]`, returning an
-/// absolute byte offset. `needle` must be ASCII (it always is here).
-fn find_ci(haystack: &str, from: usize, needle: &str) -> Option<usize> {
-    let hay = haystack.as_bytes();
-    let pat = needle.as_bytes();
-    if pat.is_empty() || from > hay.len() || hay.len() - from < pat.len() {
-        return None;
-    }
-    let last = hay.len() - pat.len();
-    for i in from..=last {
-        if hay[i..i + pat.len()].eq_ignore_ascii_case(pat) {
-            return Some(i);
-        }
-    }
-    None
 }
 
 /// Transform every `<youtube …>` element in `html` into an iframe embed.


### PR DESCRIPTION
## Summary

Optimizes the hot paths of the static embed transforms (`#220` YouTube / `#221` tabs) that were ported to Rust in the last 72 hours. The output is **byte-for-byte identical** to before.

These transforms located their tag markers (`<youtube` / `<tabs` / `</tab>` …) in the rendered HTML with a hand-rolled `find_ci`, which ran a **case-insensitive comparison at every byte** of the document — a naive O(n·m) scan. In particular, the leading no-op probe that checks whether a marker is even present runs a full scan on **every page during SSG**.

## Changes

- **Added a shared `html_scan::find_ci` used by both transforms.** It skips to the marker's first byte (`<`) with SIMD `memchr` and only compares the full needle at real candidates — the same technique as the renderer's autolink scanner. The two duplicated `find_ci` implementations are also merged.
- **`find_tag` no longer allocates a `String` via `format!("<{name}")` on every call** (it was being rebuilt inside the nested-close matching loop). Callers pass the literal instead.
- **`render_tabs`** formats the group number once and reuses it, and writes per-tab indices straight into the buffer via `write!` (eliminating a `to_string()` allocation per use).
- **`youtube::find_youtube_element`** extracts id/url/title in a single pass, moving the values out instead of cloning and scanning the attribute list 3×.

## Validation

- The `find_ci` rewrite is cross-checked against the original naive scan across all cases and all start positions (added in `html_scan::tests`).
- The existing characterization tests (`tabs::tests` / `youtube::tests`) pin the emitted HTML byte-for-byte and all pass.
- `cargo test -p ox_content_napi` ✅ / `cargo clippy -p ox_content_napi` no warnings ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)