### PR TITLE
perf(renderer): build the autolink first-byte index once per render

### DIFF
--- a/crates/ox_content_renderer/src/html.rs
+++ b/crates/ox_content_renderer/src/html.rs
@@ -1426,13 +1426,12 @@ impl HtmlRenderer {
         // Build the autolink first-byte index once per render (it depends only
         // on the immutable pattern list) so `write_text_with_autolinks` can
         // reuse it instead of rebuilding a 256-byte table per text node.
-        self.autolink_index = if self.options.autolink_urls
-            && !self.options.autolink_patterns.is_empty()
-        {
-            Some(FirstByteIndex::from_patterns(&self.options.autolink_patterns))
-        } else {
-            None
-        };
+        self.autolink_index =
+            if self.options.autolink_urls && !self.options.autolink_patterns.is_empty() {
+                Some(FirstByteIndex::from_patterns(&self.options.autolink_patterns))
+            } else {
+                None
+            };
         // HTML output is typically 2×–3× the markdown source (every
         // `**bold**` becomes `<strong>...</strong>` etc.) so the prior
         // 1.5× estimate kept undersizing the buffer and forcing 1–2

--- a/crates/ox_content_renderer/src/html.rs
+++ b/crates/ox_content_renderer/src/html.rs
@@ -1370,6 +1370,13 @@ pub struct HtmlRenderer {
     /// (paragraphs, headings, emphasis, …) and only the link case needs
     /// to mask it out.
     in_link: bool,
+    /// First-byte skip index for the autolink scanner. It depends only on
+    /// `options.autolink_patterns`, which is immutable for the duration of a
+    /// render, so it is built once at `render()` entry and reused for every
+    /// text node instead of being rebuilt per node (the prior behaviour zeroed
+    /// and filled a 256-byte table on the hottest inline path). `None` when
+    /// autolinking is disabled or there are no patterns.
+    autolink_index: Option<FirstByteIndex>,
 }
 
 impl HtmlRenderer {
@@ -1396,6 +1403,7 @@ impl HtmlRenderer {
             heading_text_scratch: String::with_capacity(64),
             heading_slug_scratch: String::with_capacity(64),
             in_link: false,
+            autolink_index: None,
         }
     }
 
@@ -1415,6 +1423,16 @@ impl HtmlRenderer {
             collect_inline_toc_entries(document, self.options.toc_max_depth, &mut self.toc_entries);
         }
         self.heading_id_counts.clear();
+        // Build the autolink first-byte index once per render (it depends only
+        // on the immutable pattern list) so `write_text_with_autolinks` can
+        // reuse it instead of rebuilding a 256-byte table per text node.
+        self.autolink_index = if self.options.autolink_urls
+            && !self.options.autolink_patterns.is_empty()
+        {
+            Some(FirstByteIndex::from_patterns(&self.options.autolink_patterns))
+        } else {
+            None
+        };
         // HTML output is typically 2×–3× the markdown source (every
         // `**bold**` becomes `<strong>...</strong>` etc.) so the prior
         // 1.5× estimate kept undersizing the buffer and forcing 1–2
@@ -1469,35 +1487,43 @@ impl HtmlRenderer {
     fn write_text_with_autolinks(&mut self, s: &str) {
         profile_span!("renderer::write_text_with_autolinks");
         let bytes = s.as_bytes();
-        // Build the first-byte skip index once per text node, then reuse it
-        // for every cursor advance below.
-        let index = FirstByteIndex::from_patterns(&self.options.autolink_patterns);
+        // Reuse the per-render first-byte index (see `autolink_index`). If it's
+        // absent the caller's gating slipped — fall back to emitting the text
+        // verbatim rather than rebuilding the index here.
+        let Some(index) = self.autolink_index.as_ref() else {
+            write_escaped_into(&mut self.output, s);
+            return;
+        };
+        // Borrow the relevant fields disjointly so the URL scan (which only
+        // reads `options`/`autolink_index`) and the output writes can coexist.
+        let patterns = &self.options.autolink_patterns;
+        let target_blank = self.options.autolink_target_blank;
+        let out = &mut self.output;
         let mut cursor = 0usize;
         while cursor < bytes.len() {
-            let Some((match_start, url_end)) =
-                find_autolink_match(s, cursor, &self.options.autolink_patterns, &index)
+            let Some((match_start, url_end)) = find_autolink_match(s, cursor, patterns, index)
             else {
                 break;
             };
             // Emit the literal text preceding the URL.
             if match_start > cursor {
-                write_escaped_into(&mut self.output, &s[cursor..match_start]);
+                write_escaped_into(out, &s[cursor..match_start]);
             }
             let url = &s[match_start..url_end];
-            self.output.push_str("<a href=\"");
-            write_url_escaped_into(&mut self.output, url);
-            self.output.push('"');
-            if self.options.autolink_target_blank {
-                self.output.push_str(" target=\"_blank\" rel=\"noopener noreferrer\"");
+            out.push_str("<a href=\"");
+            write_url_escaped_into(out, url);
+            out.push('"');
+            if target_blank {
+                out.push_str(" target=\"_blank\" rel=\"noopener noreferrer\"");
             }
-            self.output.push('>');
+            out.push('>');
             // The visible text is the URL itself; escape it like any text.
-            write_escaped_into(&mut self.output, url);
-            self.output.push_str("</a>");
+            write_escaped_into(out, url);
+            out.push_str("</a>");
             cursor = url_end;
         }
         if cursor < bytes.len() {
-            write_escaped_into(&mut self.output, &s[cursor..]);
+            write_escaped_into(out, &s[cursor..]);
         }
     }
 


### PR DESCRIPTION
## Summary

When URL autolinking is enabled, `write_text_with_autolinks` rebuilt the `FirstByteIndex` — a 256-byte lookup table plus needle derivation — **for every text node**. Text nodes dominate inline visits, so this zeroed and refilled the table on the hottest path of the renderer, despite `autolink_patterns` being immutable for the whole render.

## Change

- Build the index **once at `render()` entry**, gated on `autolink_urls && !autolink_patterns.is_empty()`, and store it on the renderer (`autolink_index: Option<FirstByteIndex>`).
- `write_text_with_autolinks` reuses the cached index via disjoint field borrows (`autolink_index` read + `output` write), with a verbatim-escape fallback if the cache is absent.

## Impact / risk

- **Impact:** removes a per-text-node table init from the hottest inline path; the index is now built once per document.
- **Risk:** low — same value, just hoisted. The pattern list cannot change mid-render (`render()` takes `&mut self` and runs to completion).

## Validation

- `cargo test -p ox_content_renderer` ✅ (44 tests incl. the 9 autolink cases + insta snapshots)
- `cargo clippy -p ox_content_renderer` no warnings ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)