### PR TITLE
perf(docs): cache sort keys and bucket members lazily

### DIFF
--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -288,7 +288,12 @@ pub fn generate_markdown(
         }
 
         for entries in by_kind.values_mut() {
-            entries.sort_by(|left, right| compare_strings(&left.name, &right.name));
+            // Case-insensitive sort with a case-sensitive tiebreak. Caching the
+            // (lowercase, original) key computes each side's lowercase form once
+            // per entry instead of on every comparison (O(n) vs O(n log n)
+            // allocations); the tuple's lexicographic order reproduces the
+            // previous "lowercase, then original" ordering exactly.
+            entries.sort_by_cached_key(|entry| (entry.name.to_lowercase(), entry.name.clone()));
         }
 
         for (kind, entries) in &by_kind {
@@ -1036,18 +1041,17 @@ fn normalize_doc_file_path(file_path: &str) -> String {
     normalized.trim_start_matches('/').to_string()
 }
 
-fn compare_strings(left: &str, right: &str) -> std::cmp::Ordering {
-    left.to_lowercase().cmp(&right.to_lowercase()).then_with(|| left.cmp(right))
-}
-
 fn sort_extracted_docs(docs: &[ApiDocModule]) -> Vec<ApiDocModule> {
     let mut sorted = docs.to_vec();
 
     for doc in &mut sorted {
-        doc.entries.sort_by(|left, right| compare_strings(&left.name, &right.name));
+        doc.entries.sort_by_cached_key(|entry| (entry.name.to_lowercase(), entry.name.clone()));
     }
 
-    sorted.sort_by(|left, right| compare_strings(&file_name(&left.file), &file_name(&right.file)));
+    sorted.sort_by_cached_key(|module| {
+        let name = file_name(&module.file);
+        (name.to_lowercase(), name)
+    });
     sorted
 }
 
@@ -1675,38 +1679,31 @@ fn render_members_table_html(
         return String::new();
     }
 
-    let constructors =
-        entry.members.iter().filter(|member| member.kind == "constructor").collect::<Vec<_>>();
-    let static_methods = entry
-        .members
-        .iter()
-        .filter(|member| {
-            member.r#static && matches!(member.kind.as_str(), "method" | "getter" | "setter")
-        })
-        .collect::<Vec<_>>();
-    let methods = entry
-        .members
-        .iter()
-        .filter(|member| {
-            !member.r#static && matches!(member.kind.as_str(), "method" | "getter" | "setter")
-        })
-        .collect::<Vec<_>>();
-    let static_properties = entry
-        .members
-        .iter()
-        .filter(|member| member.r#static && member.kind == "property")
-        .collect::<Vec<_>>();
-    let properties = entry
-        .members
-        .iter()
-        .filter(|member| !member.r#static && member.kind == "property")
-        .collect::<Vec<_>>();
-    let enum_members =
-        entry.members.iter().filter(|member| member.kind == "enumMember").collect::<Vec<_>>();
+    // Bucket the members lazily: each `match` arm below only uses a subset of
+    // these groups (the default arm uses none of them), so computing every
+    // bucket up front wasted a full `members` pass + `Vec` per unused group.
+    let members = entry.members.as_slice();
+    let methods = |is_static: bool| {
+        members
+            .iter()
+            .filter(|member| {
+                member.r#static == is_static
+                    && matches!(member.kind.as_str(), "method" | "getter" | "setter")
+            })
+            .collect::<Vec<_>>()
+    };
+    let properties = |is_static: bool| {
+        members
+            .iter()
+            .filter(|member| member.r#static == is_static && member.kind == "property")
+            .collect::<Vec<_>>()
+    };
 
     let mut groups = Vec::new();
     match entry.kind.as_str() {
         "class" => {
+            let constructors =
+                members.iter().filter(|member| member.kind == "constructor").collect::<Vec<_>>();
             groups.push(render_member_table_html(
                 &entry.name,
                 "Constructors",
@@ -1716,25 +1713,42 @@ fn render_members_table_html(
             groups.push(render_member_table_html(
                 &entry.name,
                 "Static Methods",
-                &static_methods,
+                &methods(true),
                 context,
             ));
-            groups.push(render_member_table_html(&entry.name, "Methods", &methods, context));
+            groups.push(render_member_table_html(&entry.name, "Methods", &methods(false), context));
             groups.push(render_member_table_html(
                 &entry.name,
                 "Static Properties",
-                &static_properties,
+                &properties(true),
                 context,
             ));
-            groups.push(render_member_table_html(&entry.name, "Properties", &properties, context));
+            groups.push(render_member_table_html(
+                &entry.name,
+                "Properties",
+                &properties(false),
+                context,
+            ));
         }
         "interface" => {
-            groups.push(render_member_table_html(&entry.name, "Properties", &properties, context));
-            groups.push(render_member_table_html(&entry.name, "Methods", &methods, context));
+            groups.push(render_member_table_html(
+                &entry.name,
+                "Properties",
+                &properties(false),
+                context,
+            ));
+            groups.push(render_member_table_html(&entry.name, "Methods", &methods(false), context));
         }
         "type" => {
-            groups.push(render_member_table_html(&entry.name, "Properties", &properties, context));
-            groups.push(render_member_table_html(&entry.name, "Methods", &methods, context));
+            let enum_members =
+                members.iter().filter(|member| member.kind == "enumMember").collect::<Vec<_>>();
+            groups.push(render_member_table_html(
+                &entry.name,
+                "Properties",
+                &properties(false),
+                context,
+            ));
+            groups.push(render_member_table_html(&entry.name, "Methods", &methods(false), context));
             groups.push(render_member_table_html(
                 &entry.name,
                 "Enum Members",
@@ -1745,7 +1759,7 @@ fn render_members_table_html(
         _ => groups.push(render_member_table_html(
             &entry.name,
             "Members",
-            &entry.members.iter().collect::<Vec<_>>(),
+            &members.iter().collect::<Vec<_>>(),
             context,
         )),
     }

--- a/crates/ox_content_docs/src/nav.rs
+++ b/crates/ox_content_docs/src/nav.rs
@@ -27,7 +27,10 @@ pub fn generate_nav_metadata(files: &[String], base_path: Option<&str>) -> Vec<D
     let base_path = normalize_base_path(base_path.unwrap_or(DEFAULT_BASE_PATH));
     let mut sorted_files = files.to_vec();
 
-    sorted_files.sort_by_key(|file| get_doc_display_name(file));
+    // `sort_by_cached_key` derives each display name once instead of
+    // recomputing it (a `file_stem` + title-format allocation) on every
+    // comparison; the ordering is identical.
+    sorted_files.sort_by_cached_key(|file| get_doc_display_name(file));
 
     sorted_files
         .into_iter()
@@ -60,7 +63,7 @@ fn generate_typedoc_nav_metadata(
 ) -> Vec<DocsNavItem> {
     let base_path = normalize_base_path(base_path.unwrap_or(DEFAULT_BASE_PATH));
     let mut docs = docs.to_vec();
-    docs.sort_by_key(|doc| module_file_name(&doc.file));
+    docs.sort_by_cached_key(|doc| module_file_name(&doc.file));
 
     docs.into_iter()
         .map(|doc| {


### PR DESCRIPTION
## Summary

Three allocation cuts on the docs-generation path. All are **output-identical** (the docs crate's `insta` snapshot tests still pass).

### 1. Cache the case-insensitive sort key
`compare_strings` lowercased **both** operands on every comparison, so a `sort_by` over N symbols allocated `O(n log n)` lowercase `String`s. The entry/module sorts now use `sort_by_cached_key` with a `(lowercase, original)` tuple — each lowercase form is computed once (`O(n)`), and the tuple's lexicographic order reproduces the previous "case-insensitive, then case-sensitive tiebreak" exactly. `compare_strings` is removed.

### 2. Cache nav sort keys
`generate_nav_metadata` / `generate_typedoc_nav_metadata` used `sort_by_key`, which re-derives the display/module name (a `file_stem` + title-format allocation) on every comparison. Switched to `sort_by_cached_key`.

### 3. Bucket members lazily
`render_members_table_html` eagerly built **all six** member buckets (constructors, static/instance methods, static/instance properties, enum members) before matching on `entry.kind` — but the default arm uses *none* of them and `interface`/`type` use only two or three. Each bucket cost a full `members` pass + a `Vec`. Buckets are now derived inside the arms that actually consume them.

## Risk

Low — pure reordering/caching. Sort orderings are provably identical (tuple lexicographic == the old comparator), and the member tables emit the same groups in the same order.

## Validation

- `cargo test -p ox_content_docs` ✅ (47 tests incl. snapshot suites)
- `cargo clippy -p ox_content_docs` no warnings ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)