### PR TITLE
perf(ssg): hoist per-page constant work out of the page loop

### DIFF
--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -176,6 +176,65 @@ function convertNavGroupsForRust(navGroups: NavGroup[]): RustNavGroup[] {
 }
 
 /**
+ * Converts a `TocEntry` tree into the plain shape the Rust binding expects.
+ * Hoisted to module scope so it isn't reallocated for every page; the
+ * per-page `.map` over `pageData.toc` still runs since the TOC is page-specific.
+ */
+function toRustTocEntry(entry: TocEntry): TocEntry {
+  return {
+    depth: entry.depth,
+    text: entry.text,
+    slug: entry.slug,
+    children: entry.children?.map(toRustTocEntry) ?? [],
+  };
+}
+
+/** Rust-facing locale shape. */
+interface RustLocale {
+  code: string;
+  name: string;
+  dir: string;
+}
+
+/**
+ * Per-build cache for the Rust-facing locale list. `i18n.locales` is the same
+ * reference for every page in a build, so this mapping (and the `?? "ltr"`
+ * default) only runs once per build instead of once per page.
+ */
+const rustLocalesCache = new WeakMap<LocaleConfig[], RustLocale[]>();
+
+function toRustLocales(locales: LocaleConfig[]): RustLocale[] {
+  const cached = rustLocalesCache.get(locales);
+  if (cached) {
+    return cached;
+  }
+  const converted = locales.map((locale) => ({
+    code: locale.code,
+    name: locale.name,
+    dir: locale.dir ?? "ltr",
+  }));
+  rustLocalesCache.set(locales, converted);
+  return converted;
+}
+
+/**
+ * Per-build cache for the locale-code list passed to `getSsgPageLocale`. The
+ * `i18n.locales` reference is stable across a build, so the `.map` to codes
+ * runs once instead of once per page.
+ */
+const localeCodesCache = new WeakMap<LocaleConfig[], string[]>();
+
+function localeCodesFor(locales: LocaleConfig[]): string[] {
+  const cached = localeCodesCache.get(locales);
+  if (cached) {
+    return cached;
+  }
+  const codes = locales.map((locale) => locale.code);
+  localeCodesCache.set(locales, codes);
+  return codes;
+}
+
+/**
  * Generates HTML page with navigation using Rust NAPI bindings.
  */
 export async function generateHtmlPage(
@@ -190,13 +249,7 @@ export async function generateHtmlPage(
 ): Promise<string> {
   const mod = await importNapiModule();
 
-  // Convert TocEntry to the format expected by Rust
-  const toRustTocEntry = (entry: TocEntry): TocEntry => ({
-    depth: entry.depth,
-    text: entry.text,
-    slug: entry.slug,
-    children: entry.children?.map(toRustTocEntry) ?? [],
-  });
+  // Convert TocEntry to the format expected by Rust (converter is module-scoped).
   const tocForRust = pageData.toc.map(toRustTocEntry);
 
   // Convert NavGroup to the format expected by Rust (cached per build).
@@ -263,11 +316,7 @@ export async function generateHtmlPage(
       ogImage,
       theme: themeForRust,
       locale,
-      availableLocales: availableLocales?.map((l) => ({
-        code: l.code,
-        name: l.name,
-        dir: l.dir ?? "ltr",
-      })),
+      availableLocales: availableLocales ? toRustLocales(availableLocales) : undefined,
     },
   );
 }
@@ -359,7 +408,7 @@ export function getPageLocale(urlPath: string, i18n: ResolvedOptions["i18n"]): s
     importNapiModuleSync().getSsgPageLocale(
       urlPath,
       i18n.defaultLocale,
-      i18n.locales.map((locale) => locale.code),
+      localeCodesFor(i18n.locales),
     ) ?? undefined
   );
 }


### PR DESCRIPTION
## Summary

Three per-page allocations on the SSG build path depend only on build-constant inputs. They're now computed once per build instead of once per page.

1. **`toRustTocEntry`** was redefined as a fresh closure on every `generateHtmlPage` call. It captures nothing → moved to module scope. (The per-page `.map` over the page's own TOC necessarily stays.)
2. **`availableLocales` remap** — `generateHtmlPage` mapped the locale list to the Rust `{code, name, dir}` shape on every page.
3. **locale-code array** — `getPageLocale` mapped `i18n.locales` to a `code[]` on every page.

For (2) and (3), the locale array is the **same reference for the whole build**, so the mappings are memoized in a `WeakMap` keyed by that array — the same per-build caching pattern already used by `convertNavGroupsForRust`.

## Risk

Low — identical values, just computed once per build. The cache key is the build-stable `i18n.locales` reference.

## Validation

- `tsc --noEmit` ✅
- `vp test src/` shows **no new failures** vs. `main` (both: 83 passed, 11 failed). The 11 failures are pre-existing and require the native NAPI `.node` addon to be built locally — they exercise the embed transforms, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)