### PR TITLE
perf(search): memoize per-doc scopes and the prefix-scan vocabulary

### DIFF
--- a/crates/ox_content_ssg/src/ssg.js
+++ b/crates/ox_content_ssg/src/ssg.js
@@ -206,7 +206,10 @@ const getOxContentScopesForDoc = (doc) => {
 
 const matchesOxContentScopes = (doc, scopes) => {
   if (!scopes.length) return true;
-  const docScopes = new Set(getOxContentScopesForDoc(doc));
+  // A doc's scopes derive only from its (immutable) id/url, but this runs once
+  // per posting per term — the same doc is revisited many times in a query.
+  // Cache the Set on the doc so it's built once for the index's lifetime.
+  const docScopes = doc.__oxScopes || (doc.__oxScopes = new Set(getOxContentScopesForDoc(doc)));
   return scopes.some((scope) => docScopes.has(scope));
 };
 
@@ -276,7 +279,11 @@ const scoreOxContentSearchTerms = (searchIndex, parsedQuery, tokens) => {
       isLast = i === tokens.length - 1;
     const terms =
       isLast && token.length >= 2
-        ? Object.keys(searchIndex.index).filter((term) => term.startsWith(token))
+        ? // Prefix expansion scans the whole vocabulary. Materialize the term
+          // list once and reuse it across keystrokes instead of rebuilding the
+          // `Object.keys` array on every query.
+          (searchIndex.__oxIndexKeys || (searchIndex.__oxIndexKeys = Object.keys(searchIndex.index)))
+            .filter((term) => term.startsWith(token))
         : searchIndex.index[token]
           ? [token]
           : [];

--- a/crates/ox_content_ssg/src/ssg.js
+++ b/crates/ox_content_ssg/src/ssg.js
@@ -282,8 +282,10 @@ const scoreOxContentSearchTerms = (searchIndex, parsedQuery, tokens) => {
         ? // Prefix expansion scans the whole vocabulary. Materialize the term
           // list once and reuse it across keystrokes instead of rebuilding the
           // `Object.keys` array on every query.
-          (searchIndex.__oxIndexKeys || (searchIndex.__oxIndexKeys = Object.keys(searchIndex.index)))
-            .filter((term) => term.startsWith(token))
+          (
+            searchIndex.__oxIndexKeys ||
+            (searchIndex.__oxIndexKeys = Object.keys(searchIndex.index))
+          ).filter((term) => term.startsWith(token))
         : searchIndex.index[token]
           ? [token]
           : [];

--- a/crates/ox_content_wasm/src/lib.rs
+++ b/crates/ox_content_wasm/src/lib.rs
@@ -147,8 +147,8 @@ pub fn parse_and_render(source: &str, options: Option<WasmParserOptions>) -> JsV
             let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
                 toc_max_depth: opts.toc_max_depth,
                 autolink_urls: opts.autolink_urls,
-                autolink_patterns: opts.autolink_patterns.clone(),
                 autolink_target_blank: opts.autolink_target_blank,
+                autolink_patterns: opts.autolink_patterns,
                 ..Default::default()
             });
             let html = renderer.render(&doc);


### PR DESCRIPTION
## Summary

Two allocations in the browser search runtime (`ssg.js`) fired on every keystroke (debounced, so once per query):

1. **Per-doc scopes** — `matchesOxContentScopes` rebuilt a `Set` from `getOxContentScopesForDoc` for **every posting of every term**, revisiting the same docs repeatedly within a query. The scope set derives only from the doc's immutable id/url, so it's now cached on the doc and built once for the index's lifetime.
2. **Prefix-scan vocabulary** — the last-token prefix expansion rebuilt `Object.keys(searchIndex.index)` (the entire term vocabulary) on every query before filtering by prefix. The key array is now materialized once and reused; only the prefix `.filter` (inherently per-query) still runs each time.

Both use lazy caches on the long-lived index/doc objects.

## Risk

Low — identical results; the cached values depend only on immutable index data. The cache properties (`__oxScopes`, `__oxIndexKeys`) are read by field, never enumerated.

## Validation

- `node --check` on the runtime ✅
- `cargo test -p ox_content_ssg` ✅ (21 tests; the runtime is `include_str!`'d into the crate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)