### PR TITLE
perf(parser): SIMD-accelerate inline scanning with memchr

### DIFF
--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -1,3 +1,4 @@
+use memchr::memchr;
 use ox_content_allocator::Vec;
 use ox_content_ast::{Node, Span};
 
@@ -105,7 +106,14 @@ impl<'a> Parser<'a> {
         let mut inner_end = inner_start;
 
         while inner_end + 1 < content.len() {
-            if bytes[inner_end] == b'~' && bytes[inner_end + 1] == b'~' {
+            // Restrict the scan to `..content.len() - 1` so any `~` memchr finds
+            // has a valid `inner_end + 1` byte to test — preserving the original
+            // `inner_end + 1 < content.len()` guard exactly.
+            match memchr(b'~', &bytes[inner_end..content.len() - 1]) {
+                Some(off) => inner_end += off,
+                None => break,
+            }
+            if bytes[inner_end + 1] == b'~' {
                 let inner_children =
                     self.parse_inline(&content[inner_start..inner_end], offset + inner_start)?;
                 let span = Span::new((offset + *pos) as u32, (offset + inner_end + 2) as u32);
@@ -168,9 +176,12 @@ impl<'a> Parser<'a> {
     ) {
         *pos += 1;
         let code_start = *pos;
-        while *pos < content.len() && content.as_bytes()[*pos] != b'`' {
-            *pos += 1;
-        }
+        let bytes = content.as_bytes();
+        // Jump to the closing backtick via SIMD memchr instead of a per-byte loop.
+        *pos = match memchr(b'`', &bytes[code_start..]) {
+            Some(off) => code_start + off,
+            None => content.len(),
+        };
 
         if *pos < content.len() {
             let span = Span::new((offset + code_start - 1) as u32, (offset + *pos + 1) as u32);

--- a/crates/ox_content_parser/src/parser/inline_helpers.rs
+++ b/crates/ox_content_parser/src/parser/inline_helpers.rs
@@ -1,3 +1,4 @@
+use memchr::{memchr, memchr2};
 use ox_content_allocator::Vec;
 use ox_content_ast::{Image, Link, Node, Span, Text};
 
@@ -128,30 +129,40 @@ impl<'a> Parser<'a> {
         min_count: usize,
     ) -> Option<usize> {
         while cursor < bytes.len() {
-            if bytes[cursor] == marker {
-                let count = Self::marker_run_len(bytes, cursor, marker);
-                if count >= min_count {
-                    return Some(cursor);
-                }
-                cursor += count;
-            } else {
-                cursor += 1;
+            // Skip directly to the next marker byte instead of inspecting every
+            // intervening byte; the original `else { cursor += 1 }` arm was a
+            // pure no-op skip, so the marker positions visited are identical.
+            let off = memchr(marker, &bytes[cursor..])?;
+            cursor += off;
+            let count = Self::marker_run_len(bytes, cursor, marker);
+            if count >= min_count {
+                return Some(cursor);
             }
+            cursor += count;
         }
         None
     }
 
     fn scan_balanced(bytes: &[u8], mut cursor: usize, open: u8, close: u8) -> usize {
         let mut depth = 1;
-        while cursor < bytes.len() && depth > 0 {
-            match bytes[cursor] {
-                byte if byte == open => depth += 1,
-                byte if byte == close => depth -= 1,
-                _ => {}
+        while cursor < bytes.len() {
+            // Only `open`/`close` change depth, so jump straight to the next one
+            // via memchr2; the skipped bytes were a no-op in the original loop.
+            let Some(off) = memchr2(open, close, &bytes[cursor..]) else {
+                return bytes.len();
+            };
+            cursor += off;
+            if bytes[cursor] == open {
+                depth += 1;
+            } else {
+                depth -= 1;
+                // Stop AT the closing delimiter (matching the original, which
+                // skipped its trailing `cursor += 1` once depth hit 0).
+                if depth == 0 {
+                    return cursor;
+                }
             }
-            if depth > 0 {
-                cursor += 1;
-            }
+            cursor += 1;
         }
         cursor
     }

--- a/crates/ox_content_parser/src/parser/tests.rs
+++ b/crates/ox_content_parser/src/parser/tests.rs
@@ -125,6 +125,26 @@ fn test_parse_strikethrough() {
 }
 
 #[test]
+fn test_parse_strikethrough_lone_tilde_not_matched() {
+    // A trailing lone `~` (and a single `~` mid-text) must not be treated as a
+    // closing run: the `~~` opener falls back to literal text. This pins the
+    // `inner_end + 1 < len` boundary preserved by the memchr-based scan.
+    let allocator = Allocator::new();
+    for input in ["~~open ~ but no close", "~~trailing tilde~"] {
+        let doc = Parser::with_options(&allocator, input, ParserOptions::gfm()).parse().unwrap();
+        match &doc.children[0] {
+            Node::Paragraph(p) => {
+                assert!(
+                    !p.children.iter().any(|n| matches!(n, Node::Delete(_))),
+                    "{input:?} should not produce a Delete node"
+                );
+            }
+            _ => panic!("expected paragraph"),
+        }
+    }
+}
+
+#[test]
 fn test_parse_hard_break() {
     let allocator = Allocator::new();
     let doc = Parser::new(&allocator, "line 1\\\nline 2").parse().unwrap();


### PR DESCRIPTION
## Summary

Four hot inline scans in the parser advanced one byte at a time — either through the `Option<char>` `peek`/`advance` plumbing or per-byte `match` branches. Each is replaced with a `memchr`/`memchr2` jump straight to the next byte of interest (`memchr` is already a parser dependency, used in `cursor.rs`/`block.rs`).

| Function | Change |
| --- | --- |
| `parse_inline_code` | jump to the closing `` ` `` via `memchr` |
| `parse_strikethrough` | jump to the next `~` via `memchr` |
| `find_marker_run` | jump to the next emphasis/strong marker |
| `scan_balanced` | jump to the next bracket/paren via `memchr2` |

## Correctness

All four skipped-byte regions were pure no-ops in the original loops, so the visited positions, returned offsets, and resulting nodes/spans are **byte-identical**.

The `parse_strikethrough` case is the most delicate: its original guard was `inner_end + 1 < content.len()`. The rewrite restricts the memchr window to `&bytes[inner_end..content.len() - 1]`, so any `~` it finds is guaranteed to have a valid `inner_end + 1` to test — a trailing lone `~` can never match. `scan_balanced` still returns *at* the closing delimiter when depth reaches zero.

## Validation

- `cargo test -p ox_content_parser` + `-p ox_content_renderer` — all pass (incl. `snapshot_inline_strikethrough_gfm`/`_unmatched`, `unmatched_strikethrough_remains_text`, emphasis/strong and link/image nested-paren snapshots).
- Added `test_parse_strikethrough_lone_tilde_not_matched` to pin the preserved boundary.
- `cargo clippy -p ox_content_parser -- -D warnings` clean; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)