### PR TITLE
perf(parser): tighten leaf/list/fenced block scans

### DIFF
--- a/crates/ox_content_parser/src/parser/fenced_code.rs
+++ b/crates/ox_content_parser/src/parser/fenced_code.rs
@@ -133,7 +133,10 @@ impl<'a> Parser<'a> {
 
                 if line_indent <= 3 {
                     self.position = line_start;
-                    let indent_to_skip = self.calc_indentation(line_start).min(3);
+                    // `line_indent` was just computed from the same leading
+                    // whitespace `calc_indentation(line_start)` would re-scan,
+                    // and is already <= 3, so the `.min(3)` was a no-op.
+                    let indent_to_skip = line_indent;
                     for _ in 0..indent_to_skip {
                         if self.peek() == Some(' ') {
                             self.advance();

--- a/crates/ox_content_parser/src/parser/leaf.rs
+++ b/crates/ox_content_parser/src/parser/leaf.rs
@@ -1,3 +1,4 @@
+use memchr::memchr;
 use ox_content_ast::{Node, Span};
 
 use super::Parser;
@@ -61,25 +62,23 @@ impl<'a> Parser<'a> {
     /// Parses a heading.
     pub(super) fn parse_heading(&mut self, start: usize) -> ParseResult<Option<Node<'a>>> {
         profile_span!("parser::parse_heading");
+        let bytes = self.source.as_bytes();
         let mut depth = 0u8;
-        while self.peek() == Some('#') {
+        // `#` is ASCII, so count the leading run with direct byte compares
+        // instead of routing each through `peek()`/`advance()`.
+        while self.position < bytes.len() && bytes[self.position] == b'#' {
             depth += 1;
-            self.advance();
+            self.position += 1;
         }
 
         self.skip_whitespace();
 
         let content_start = self.position;
-        let mut content_end = content_start;
-
-        // Read until end of line
-        while let Some(ch) = self.peek() {
-            if ch == '\n' {
-                break;
-            }
-            self.advance();
-            content_end = self.position;
-        }
+        // The heading content runs to the end of the line; find it in one
+        // memchr scan rather than a per-char peek/advance walk.
+        let content_end = memchr(b'\n', &bytes[content_start..])
+            .map_or(self.source.len(), |off| content_start + off);
+        self.position = content_end;
 
         // Skip trailing hashes and whitespace
         let content = self.source[content_start..content_end].trim_end();
@@ -104,13 +103,10 @@ impl<'a> Parser<'a> {
 
     /// Parses a thematic break.
     pub(super) fn parse_thematic_break(&mut self, start: usize) -> ParseResult<Option<Node<'a>>> {
-        // Skip to end of line
-        while let Some(ch) = self.peek() {
-            self.advance();
-            if ch == '\n' {
-                break;
-            }
-        }
+        // Skip to (and past) the end of the current line. `consume_line`
+        // advances to `line_end + 1`, or to EOF when there's no newline —
+        // exactly the two positions the old peek/advance loop produced.
+        self.consume_line();
 
         let span = Span::new(start as u32, self.position as u32);
         Ok(Some(Node::ThematicBreak(ox_content_ast::ThematicBreak { span })))

--- a/crates/ox_content_parser/src/parser/list.rs
+++ b/crates/ox_content_parser/src/parser/list.rs
@@ -165,8 +165,12 @@ impl<'a> Parser<'a> {
                 }
 
                 if current_indent == baseline_indent {
+                    // Reuse the line already scanned at the top of the loop
+                    // (`continuation_line`) instead of re-finding the newline;
+                    // only `next.ordered` is read, which a trailing `\r` cannot
+                    // affect.
                     if self
-                        .parse_list_item_line(continuation_start)
+                        .parse_list_item_line_from_line(continuation_start, continuation_line)
                         .is_some_and(|next| next.ordered == ordered)
                     {
                         break;


### PR DESCRIPTION
## Summary

Four block-level scans walked character-by-character or re-scanned spans already computed. Each is replaced with single-pass byte/`memchr` work. **Output is byte-identical** (parser + renderer snapshot suites pass).

| Function | Before | After |
| --- | --- | --- |
| `parse_heading` | ~2 `peek`/`advance` per char for the `#` run and the content line | direct `bytes[..] == b'#'` count + one `memchr(b'\n')` for the line end |
| `parse_thematic_break` | per-char `peek`/`advance` loop to EOL | existing `consume_line` (memchr), lands on the same position |
| list continuation | `parse_list_item_line` re-finds the newline | `parse_list_item_line_from_line` reusing the loop's `continuation_line` |
| fenced-code (indented branch) | `calc_indentation(line_start).min(3)` re-scan | reuse the just-computed `line_indent` |

## Correctness notes

- `parse_heading`: `try_parse_heading_at`/`is_atx_heading_prefix` already gate that 1–6 `#` precede a space/tab/newline, so counting `#` bytes yields the same `depth` and leaves `position` at the first non-`#`; the `memchr` end offset equals the old loop's break position.
- `parse_thematic_break`: `consume_line` sets `position = line_end + 1` (past `\n`) or `source.len()` at EOF — the two positions the old loop produced; the node carries no text.
- list continuation: the result is consumed only via `.is_some_and(|n| n.ordered == ordered)`; a trailing `\r` (kept by `line_at` vs stripped by `.lines()`) can't affect marker detection or `ordered`.
- fenced-code: `indentation_columns` and `calc_indentation` are the identical algorithm (space → +1, tab → +4, else break) over the same leading bytes, and the branch only runs when `line_indent <= 3` so `.min(3)` was a no-op.

## Validation

- `cargo test -p ox_content_parser` + `-p ox_content_renderer` — all pass.
- `cargo clippy -p ox_content_parser -- -D warnings` clean; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)