### PR TITLE
perf(docs): cut per-symbol allocations on the generation path

### DIFF
--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -968,14 +968,18 @@ impl<'a> DocVisitor<'a> {
         })
     }
 
-    fn find_param_tag(tags: &[DocTag], name: &str) -> Option<ParsedParamTag> {
-        tags.iter()
-            .filter(|tag| matches!(tag.tag.as_str(), "param" | "arg" | "argument"))
-            .filter_map(Self::parse_param_tag)
-            .find(|tag| {
-                let tag_name = tag.name.trim_start_matches("...");
-                tag_name == name || tag_name.split('.').next() == Some(name)
-            })
+    /// Find the first pre-parsed `@param` tag matching `name`, using the same
+    /// predicate as before (strip a leading `...`, then exact-name or
+    /// dotted-prefix match). Operating on already-parsed tags avoids
+    /// re-parsing every `@param` for each formal parameter.
+    fn find_parsed_param_tag<'t>(
+        parsed: &'t [ParsedParamTag],
+        name: &str,
+    ) -> Option<&'t ParsedParamTag> {
+        parsed.iter().find(|tag| {
+            let tag_name = tag.name.trim_start_matches("...");
+            tag_name == name || tag_name.split('.').next() == Some(name)
+        })
     }
 
     fn parse_return_tag(tag: &DocTag) -> (Option<String>, Option<String>) {
@@ -1114,12 +1118,21 @@ impl<'a> DocVisitor<'a> {
         params: &oxc_ast::ast::FormalParameters<'a>,
         tags: &[DocTag],
     ) -> Vec<ParamDoc> {
+        // Parse the `@param`/`@arg`/`@argument` tags once, in source order,
+        // instead of re-filtering and re-parsing them for every formal
+        // parameter (the old `find_param_tag` did O(P*T) parses).
+        let parsed_param_tags: Vec<ParsedParamTag> = tags
+            .iter()
+            .filter(|tag| matches!(tag.tag.as_str(), "param" | "arg" | "argument"))
+            .filter_map(Self::parse_param_tag)
+            .collect();
+
         let mut docs = params
             .items
             .iter()
             .map(|param| {
                 let name = Self::binding_pattern_name(&param.pattern);
-                let tag = Self::find_param_tag(tags, &name);
+                let tag = Self::find_parsed_param_tag(&parsed_param_tags, &name);
                 let default_value = self
                     .binding_pattern_default_value(&param.pattern)
                     .or_else(|| {
@@ -1128,18 +1141,18 @@ impl<'a> DocVisitor<'a> {
                             .as_ref()
                             .map(|init| self.slice(init.span().start, init.span().end))
                     })
-                    .or_else(|| tag.as_ref().and_then(|tag| tag.default_value.clone()));
+                    .or_else(|| tag.and_then(|tag| tag.default_value.clone()));
 
                 let type_annotation = param
                     .type_annotation
                     .as_ref()
                     .map(|t| self.format_ts_type(&t.type_annotation))
-                    .or_else(|| tag.as_ref().and_then(|tag| tag.type_annotation.clone()));
+                    .or_else(|| tag.and_then(|tag| tag.type_annotation.clone()));
 
                 let optional = param.optional
                     || default_value.is_some()
-                    || tag.as_ref().is_some_and(|tag| tag.optional);
-                let description = tag.and_then(|tag| tag.description);
+                    || tag.is_some_and(|tag| tag.optional);
+                let description = tag.and_then(|tag| tag.description.clone());
 
                 ParamDoc { name, type_annotation, optional, default_value, description }
             })
@@ -1147,19 +1160,19 @@ impl<'a> DocVisitor<'a> {
 
         if let Some(rest) = params.rest.as_ref() {
             let name = Self::binding_pattern_name(&rest.rest.argument);
-            let tag = Self::find_param_tag(tags, &name);
+            let tag = Self::find_parsed_param_tag(&parsed_param_tags, &name);
             let type_annotation = rest
                 .type_annotation
                 .as_ref()
                 .map(|t| self.format_ts_type(&t.type_annotation))
-                .or_else(|| tag.as_ref().and_then(|tag| tag.type_annotation.clone()));
+                .or_else(|| tag.and_then(|tag| tag.type_annotation.clone()));
 
             docs.push(ParamDoc {
                 name,
                 type_annotation,
-                optional: tag.as_ref().is_some_and(|tag| tag.optional),
-                default_value: tag.as_ref().and_then(|tag| tag.default_value.clone()),
-                description: tag.and_then(|tag| tag.description),
+                optional: tag.is_some_and(|tag| tag.optional),
+                default_value: tag.and_then(|tag| tag.default_value.clone()),
+                description: tag.and_then(|tag| tag.description.clone()),
             });
         }
 

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -405,12 +405,25 @@ fn normalize_base_path(base_path: &str) -> String {
 }
 
 fn escape_html(value: &str) -> String {
-    value
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&#39;")
+    // Most inputs (symbol names, type annotations, kind labels) contain none of
+    // these characters, so a single scan with an early-out avoids the five
+    // full-string passes + five intermediate allocations the chained
+    // `replace()` calls performed unconditionally.
+    if !value.bytes().any(|b| matches!(b, b'&' | b'<' | b'>' | b'"' | b'\'')) {
+        return value.to_string();
+    }
+    let mut out = String::with_capacity(value.len() + 16);
+    for ch in value.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(ch),
+        }
+    }
+    out
 }
 
 fn entry_anchor(name: &str) -> String {
@@ -672,12 +685,16 @@ fn clean_summary_text(text: &str, max_length: usize) -> String {
         return truncate_summary_text(&fallback(), max_length);
     };
 
-    let collapsed = markdown_link_re.replace_all(text, "$1").to_string();
-    let collapsed = bracket_link_re.replace_all(&collapsed, "$1").to_string();
-    let collapsed = inline_code_re.replace_all(&collapsed, "$1").to_string();
-    let collapsed = whitespace_re.replace_all(&collapsed, " ").trim().to_string();
+    // `replace_all` returns `Cow::Borrowed` (no allocation) when the pattern
+    // doesn't match — the common case for short summaries. Thread the Cow
+    // through each stage instead of forcing a `String` after every one, and
+    // materialize only at the final `truncate_summary_text` (which takes `&str`).
+    let s1 = markdown_link_re.replace_all(text, "$1");
+    let s2 = bracket_link_re.replace_all(&s1, "$1");
+    let s3 = inline_code_re.replace_all(&s2, "$1");
+    let s4 = whitespace_re.replace_all(&s3, " ");
 
-    truncate_summary_text(&collapsed, max_length)
+    truncate_summary_text(s4.trim(), max_length)
 }
 
 fn truncate_summary_text(text: &str, max_length: usize) -> String {
@@ -738,20 +755,37 @@ fn render_inline_html(text: &str) -> String {
     html.replace('\n', "<br>")
 }
 
-fn is_fence_start(line: &str) -> Option<String> {
+// The four block-start regexes are cached once and shared between the
+// value-returning helpers (which capture a group) and `is_markdown_block_start`
+// (which only needs a boolean and so can use the allocation-free `is_match`).
+fn fence_re() -> Option<&'static Regex> {
     static FENCE_RE: RegexCache = OnceLock::new();
+    cached_regex(&FENCE_RE, r"^```([\w-]+)?\s*$")
+}
 
-    let fence_re = cached_regex(&FENCE_RE, r"^```([\w-]+)?\s*$")?;
-    fence_re
+fn heading_re() -> Option<&'static Regex> {
+    static HEADING_RE: RegexCache = OnceLock::new();
+    cached_regex(&HEADING_RE, r"^(#{1,6})\s+(.*)$")
+}
+
+fn ordered_re() -> Option<&'static Regex> {
+    static ORDERED_RE: RegexCache = OnceLock::new();
+    cached_regex(&ORDERED_RE, r"^\d+\.\s+(.*)$")
+}
+
+fn unordered_re() -> Option<&'static Regex> {
+    static UNORDERED_RE: RegexCache = OnceLock::new();
+    cached_regex(&UNORDERED_RE, r"^[-*+]\s+(.*)$")
+}
+
+fn is_fence_start(line: &str) -> Option<String> {
+    fence_re()?
         .captures(line.trim())
         .map(|captures| captures.get(1).map_or("text", |value| value.as_str()).to_string())
 }
 
 fn heading_match(line: &str) -> Option<(usize, String)> {
-    static HEADING_RE: RegexCache = OnceLock::new();
-
-    let heading_re = cached_regex(&HEADING_RE, r"^(#{1,6})\s+(.*)$")?;
-    heading_re.captures(line.trim()).map(|captures| {
+    heading_re()?.captures(line.trim()).map(|captures| {
         (
             captures.get(1).map_or(1, |value| value.as_str().len()).min(6),
             captures.get(2).map_or("", |value| value.as_str()).trim().to_string(),
@@ -760,28 +794,26 @@ fn heading_match(line: &str) -> Option<(usize, String)> {
 }
 
 fn ordered_list_item(line: &str) -> Option<String> {
-    static ORDERED_RE: RegexCache = OnceLock::new();
-
-    let ordered_re = cached_regex(&ORDERED_RE, r"^\d+\.\s+(.*)$")?;
-    ordered_re
+    ordered_re()?
         .captures(line.trim())
         .and_then(|captures| captures.get(1).map(|value| value.as_str().to_string()))
 }
 
 fn unordered_list_item(line: &str) -> Option<String> {
-    static UNORDERED_RE: RegexCache = OnceLock::new();
-
-    let unordered_re = cached_regex(&UNORDERED_RE, r"^[-*+]\s+(.*)$")?;
-    unordered_re
+    unordered_re()?
         .captures(line.trim())
         .and_then(|captures| captures.get(1).map(|value| value.as_str().to_string()))
 }
 
 fn is_markdown_block_start(line: &str) -> bool {
-    is_fence_start(line).is_some()
-        || heading_match(line).is_some()
-        || ordered_list_item(line).is_some()
-        || unordered_list_item(line).is_some()
+    // Only a boolean is needed, so use `is_match` (no capture allocation) and
+    // trim once. The regexes are `^…$`-anchored, so `is_match(trimmed)` is true
+    // exactly when the corresponding `captures(trimmed)` was `Some`.
+    let trimmed = line.trim();
+    fence_re().is_some_and(|re| re.is_match(trimmed))
+        || heading_re().is_some_and(|re| re.is_match(trimmed))
+        || ordered_re().is_some_and(|re| re.is_match(trimmed))
+        || unordered_re().is_some_and(|re| re.is_match(trimmed))
 }
 
 fn render_markdown_blocks_html(text: &str) -> String {


### PR DESCRIPTION
## Summary

Four **output-identical** allocation cuts on hot doc-generation paths (the `ox_content_docs` snapshot suite is unchanged).

### `is_markdown_block_start` — drop up to 4 Strings + 4 Captures per line
It called four capture-and-allocate helpers (`is_fence_start`, `heading_match`, …) just to test `.is_some()`, on every list/paragraph continuation line. The four cached `^…$`-anchored regexes are now exposed via accessors and tested with allocation-free `is_match`, trimming once. Because the regexes are anchored, `is_match(trimmed)` is true exactly when `captures(trimmed)` was `Some`. The value-returning helpers are unchanged.

### `escape_html` — single pass + no-escape fast path
The five chained `.replace()` calls did five full scans and five allocations *unconditionally*. Replaced with one scan and a fast path returning `value.to_string()` when no special char is present (the common case for symbol names / type annotations / kind labels). Each of the five characters maps independently and the chain never re-processed inserted entities, so the single pass is byte-identical.

### `clean_summary_text` — thread the `Cow`
`replace_all` returns `Cow::Borrowed` (no allocation) on no match. The code forced a `String` after each of four stages anyway; threading the `Cow` avoids per-stage allocations for summaries with no links/inline-code, materializing once via `truncate_summary_text(s4.trim(), …)`.

### `extract_params_from_formals` — parse `@param` tags once
`find_param_tag` re-filtered and re-parsed every `@param` tag for *each* formal parameter (O(P·T) parses, each allocating). The tags are now parsed once into a `Vec<ParsedParamTag>` and matched against via a borrowing `find_parsed_param_tag`, preserving the exact first-match predicate (strip `...`, then exact-name or dotted-prefix).

> The workflow also surfaced a `graph.rs` dedup-key tuple swap; I dropped it because the original `format!` is a single allocation while a `(String, String, u32)` tuple clones twice — it would *increase* allocations, not reduce them.

## Validation

- `cargo test -p ox_content_docs` — 47 pass (incl. snapshot suites).
- `cargo clippy -p ox_content_docs -- -D warnings` clean; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)