### PR TITLE
perf(napi): drop redundant allocations in slugify and the YouTube embed

### DIFF
--- a/crates/ox_content_napi/src/transformer.rs
+++ b/crates/ox_content_napi/src/transformer.rs
@@ -276,13 +276,22 @@ fn collect_text(node: &Node, text: &mut String) {
 }
 
 fn slugify(text: &str) -> String {
-    text.to_lowercase()
+    let mapped: String = text
+        .to_lowercase()
         .chars()
         .map(|c| if c.is_alphanumeric() || c == ' ' || c == '-' { c } else { ' ' })
-        .collect::<String>()
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join("-")
+        .collect();
+    // Join the whitespace-split tokens with '-' directly, skipping the
+    // intermediate `Vec<&str>` and the separate `join` allocation. `mapped.len()`
+    // is a safe upper bound for the slug (separators only shrink it).
+    let mut slug = String::with_capacity(mapped.len());
+    for token in mapped.split_whitespace() {
+        if !slug.is_empty() {
+            slug.push('-');
+        }
+        slug.push_str(token);
+    }
+    slug
 }
 
 fn unique_slug(slug: String, counts: &mut HashMap<String, usize>) -> String {

--- a/crates/ox_content_napi/src/youtube.rs
+++ b/crates/ox_content_napi/src/youtube.rs
@@ -87,9 +87,11 @@ fn build_embed_url(video_id: &str, options: &YouTubeEmbedOptions) -> String {
 
 fn render_embed(video_id: &str, options: &YouTubeEmbedOptions, title: Option<&str>) -> String {
     let embed_url = build_embed_url(video_id, options);
-    let title_value = match title {
-        Some(title) => title.to_string(),
-        None => format!("YouTube video {video_id}"),
+    // Escape the borrowed title directly instead of copying it into an owned
+    // String first (`escape_attribute` already returns an owned String).
+    let escaped_title = match title {
+        Some(title) => escape_attribute(title),
+        None => escape_attribute(&format!("YouTube video {video_id}")),
     };
     let mut html = String::new();
     html.push_str("<div class=\"ox-youtube\" style=\"aspect-ratio: ");
@@ -97,7 +99,7 @@ fn render_embed(video_id: &str, options: &YouTubeEmbedOptions, title: Option<&st
     html.push_str(";\"><iframe src=\"");
     html.push_str(&escape_attribute(&embed_url));
     html.push_str("\" title=\"");
-    html.push_str(&escape_attribute(&title_value));
+    html.push_str(&escaped_title);
     html.push_str("\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\"");
     if options.allow_fullscreen {
         html.push_str(" allowfullscreen");


### PR DESCRIPTION
## Summary

Two byte-identical allocation cuts in the N-API crate.

- **`slugify`** collected the whitespace-split tokens into a `Vec<&str>` purely to `join("-")` them. The tokens are now written straight into one pre-reserved `String`, dropping the `Vec` allocation and the separate join buffer. `[&str].join("-")` and the manual "separator only between tokens" loop produce identical bytes. Runs once per heading during TOC extraction.
- **`render_embed`** copied a provided `<youtube title>` into an owned `String` (`title.to_string()`) and then escaped it — two allocations + copies. It now escapes the borrowed `&str` directly (`escape_attribute` already returns the owned result), removing the first copy in the common titled case.

## Validation

- `cargo test -p ox_content_napi --lib` — 49 pass, including the YouTube characterization tests that pin the emitted `title="…"` byte-for-byte and the TOC slug tests.
- `cargo clippy -p ox_content_napi --lib -- -D warnings` clean; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)