### PR TITLE
perf(renderer): gate text autolinking on the cached autolink_index

### DIFF
--- a/crates/ox_content_renderer/src/html.rs
+++ b/crates/ox_content_renderer/src/html.rs
@@ -1808,10 +1808,10 @@ impl HtmlRenderer {
                 // common case — flag off — collapses back to the original
                 // single `write_escaped_into` call thanks to the early
                 // boolean check.
-                if self.options.autolink_urls
-                    && !self.in_link
-                    && !self.options.autolink_patterns.is_empty()
-                {
+                // `autolink_index` is `Some` iff `autolink_urls` and a non-empty
+                // pattern list (computed once at `render()` entry), so this one
+                // Option check replaces the three field reads.
+                if self.autolink_index.is_some() && !self.in_link {
                     self.write_text_with_autolinks(text.value);
                 } else {
                     write_escaped_into(&mut self.output, text.value);
@@ -2266,8 +2266,9 @@ impl<'a> Visit<'a> for HtmlRenderer {
 
     fn visit_text(&mut self, text: &Text<'a>) {
         profile_span!("renderer::visit_text");
-        if self.options.autolink_urls && !self.in_link && !self.options.autolink_patterns.is_empty()
-        {
+        // See the matching gate in `visit_inline_node`: the cached
+        // `autolink_index` already encodes `autolink_urls && !patterns.is_empty()`.
+        if self.autolink_index.is_some() && !self.in_link {
             self.write_text_with_autolinks(text.value);
         } else {
             self.write_escaped(text.value);


### PR DESCRIPTION
## Summary

The per-text-node autolink gate read three fields on every `Node::Text` (the hottest inline path): `options.autolink_urls`, then `options.autolink_patterns` + a `Vec::is_empty` len load.

`render()` (from #225) already computes `autolink_index = Some(..)` **exactly when** `autolink_urls && !autolink_patterns.is_empty()`. Both gates — `visit_text` and the `visit_inline_node` `Text` arm — now collapse to a single `self.autolink_index.is_some() && !self.in_link` discriminant check.

## Correctness

Term-for-term equivalent: `autolink_index.is_some()` ≡ `autolink_urls && !autolink_patterns.is_empty()` by construction; `&& !self.in_link` is unchanged. `options` is immutable during a render so the cached value can't drift, and `write_text_with_autolinks` already falls back to plain escaping if the index is `None`.

## Validation

- `cargo test -p ox_content_renderer` — 40 pass, including all autolink cases (http/https, target-blank toggle, trailing-punctuation, word-boundary, custom pattern, many-pattern table fallback, no-nesting, query-string escaping).
- `cargo clippy -- -D warnings` clean; `cargo fmt --check` clean.

> Builds on #225 (the `autolink_index` field), already merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)