### PR TITLE
perf(lint): resolve spellcheck issue lines via binary search

### DIFF
--- a/npm/vite-plugin-ox-content/src/lint.ts
+++ b/npm/vite-plugin-ox-content/src/lint.ts
@@ -550,8 +550,18 @@ async function runStandardSpellcheckDocuments(
           settings,
         );
 
+        // Precompute the document's newline offsets once so each issue's line
+        // can be resolved with a binary search instead of a fresh O(N) scan
+        // from offset 0 (which made line resolution O(issues * length)).
+        const newlineOffsets: number[] = [];
+        for (let i = 0; i < maskedDocument.length; i++) {
+          if (maskedDocument.charCodeAt(i) === 10) {
+            newlineOffsets.push(i);
+          }
+        }
+
         return result.issues.map((issue) =>
-          mapStandardIssueToDiagnostic(issue, standard.languages, maskedDocument),
+          mapStandardIssueToDiagnostic(issue, standard.languages, newlineOffsets),
         );
       }),
     );
@@ -592,9 +602,9 @@ async function loadCspellLib(): Promise<typeof import("cspell-lib")> {
 function mapStandardIssueToDiagnostic(
   issue: ValidationIssue,
   languages: MarkdownLintLanguage[],
-  documentText: string,
+  newlineOffsets: number[],
 ): MarkdownLintDiagnostic {
-  const line = getLineNumberAtOffset(documentText, issue.line.offset);
+  const line = getLineNumberAtOffset(newlineOffsets, issue.line.offset);
   const column = issue.offset - issue.line.offset + 1;
   const length = issue.length ?? issue.text.length;
 
@@ -611,16 +621,23 @@ function mapStandardIssueToDiagnostic(
   };
 }
 
-function getLineNumberAtOffset(text: string, offset: number): number {
-  let line = 1;
-
-  for (let index = 0; index < offset && index < text.length; index++) {
-    if (text.charCodeAt(index) === 10) {
-      line++;
+function getLineNumberAtOffset(newlineOffsets: number[], offset: number): number {
+  // Line number = 1 + (count of newline offsets strictly less than `offset`).
+  // This matches the old linear scan exactly: a newline can only exist at an
+  // index < text.length, so counting positions `< offset` over the whole
+  // document gives the same count for every `offset` (including past EOF).
+  let lo = 0;
+  let hi = newlineOffsets.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (newlineOffsets[mid] < offset) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
     }
   }
 
-  return line;
+  return lo + 1;
 }
 
 function inferStandardIssueLanguage(


### PR DESCRIPTION
## Summary

`getLineNumberAtOffset` rescanned the masked document from offset 0 for **every** spellcheck issue. For a document of length N with I flagged words that's **O(I·N)** — quadratic when standard dictionaries flag many words.

Now the document's newline offsets are precomputed once per document (one O(N) pass), and each issue's line is resolved with a binary search over them → **O(N + I·log L)**.

## Correctness

Byte-identical. The old code returned `1 + (count of '\n' at indices in [0, min(offset, length)))`. A newline can only exist at an index `< length`, so counting newline offsets strictly `< offset` over the whole document yields the identical count for every `offset` (including `offset > length`, where both count all newlines). `column`/`endColumn` are untouched.

`mapStandardIssueToDiagnostic`'s third parameter changes from `documentText: string` to `newlineOffsets: number[]`.

> The workflow also flagged a micro-hoist of the `latinLanguages` filter in `inferStandardIssueLanguage`; I deferred it — it filters an ≤6-element array and would require threading an extra parameter through two functions for no measurable gain.

## Validation

- `vp run check:ts` (tsc + format) clean.
- `lint.test.ts` (7) and `lint-files.test.ts` (5) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)