### PR TITLE
test(vite-plugin): cover the JSX runtime and island parser

### DIFF
--- a/npm/vite-plugin-ox-content/src/island/parse.test.ts
+++ b/npm/vite-plugin-ox-content/src/island/parse.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach } from "vite-plus/test";
+import {
+  transformIslands,
+  hasIslands,
+  extractIslandInfo,
+  generateHydrationScript,
+  resetIslandCounter,
+} from "./parse";
+
+describe("island/parse", () => {
+  beforeEach(() => {
+    resetIslandCounter();
+  });
+
+  describe("hasIslands", () => {
+    it("detects <island> regardless of case", () => {
+      expect(hasIslands('<Island load="visible"></Island>')).toBe(true);
+      expect(hasIslands("<island></island>")).toBe(true);
+    });
+
+    it("returns false when no island element is present", () => {
+      expect(hasIslands("<p>plain</p>")).toBe(false);
+      // The boundary check means a longer tag name does not match.
+      expect(hasIslands("<islander></islander>")).toBe(false);
+    });
+  });
+
+  describe("transformIslands", () => {
+    it("rewrites an <Island> into a data-attributed wrapper and collects its info", async () => {
+      const { html, islands } = await transformIslands(
+        '<Island load="visible"><Counter initial={0} /></Island>',
+      );
+
+      expect(islands).toHaveLength(1);
+      expect(islands[0].load).toBe("visible");
+      expect(islands[0].props).toEqual({ initial: 0 });
+
+      expect(html).toContain('id="ox-island-0"');
+      expect(html).toContain('data-ox-load="visible"');
+      expect(html).toContain('class="ox-island"');
+      expect(html).toContain("data-ox-island=");
+    });
+
+    it("defaults the load strategy to eager when omitted", async () => {
+      const { islands } = await transformIslands("<Island><Widget /></Island>");
+      expect(islands).toHaveLength(1);
+      expect(islands[0].load).toBe("eager");
+    });
+
+    it("records a media query when present", async () => {
+      const { html, islands } = await transformIslands(
+        '<Island load="media" media="(min-width: 768px)"><Widget /></Island>',
+      );
+      expect(islands[0].mediaQuery).toBe("(min-width: 768px)");
+      expect(html).toContain('data-ox-media="(min-width: 768px)"');
+    });
+
+    it("parses JSX-style prop values into JS primitives and JSON", async () => {
+      const { islands } = await transformIslands(
+        '<Island><Widget count={42} active={true} label="hi" config={{"a":1}} /></Island>',
+      );
+      expect(islands[0].props).toMatchObject({
+        count: 42,
+        active: true,
+        label: "hi",
+        config: { a: 1 },
+      });
+    });
+
+    it("increments island ids across multiple islands", async () => {
+      const { html, islands } = await transformIslands(
+        "<Island><A /></Island><Island><B /></Island>",
+      );
+      expect(islands).toHaveLength(2);
+      expect(html).toContain('id="ox-island-0"');
+      expect(html).toContain('id="ox-island-1"');
+    });
+
+    it("leaves island-free HTML without any island wrappers", async () => {
+      const { html, islands } = await transformIslands("<p>just prose</p>");
+      expect(islands).toHaveLength(0);
+      expect(html).not.toContain("data-ox-island");
+    });
+  });
+
+  describe("extractIslandInfo", () => {
+    it("returns the island metadata without requiring the caller to read the html", async () => {
+      const islands = await extractIslandInfo('<Island load="idle"><Widget /></Island>');
+      expect(islands).toHaveLength(1);
+      expect(islands[0].load).toBe("idle");
+    });
+  });
+
+  describe("generateHydrationScript", () => {
+    it("returns an empty string when there are no components", () => {
+      expect(generateHydrationScript([])).toBe("");
+    });
+
+    it("imports each component and wires up initIslands", () => {
+      const script = generateHydrationScript(["Counter", "Chart"]);
+      expect(script).toContain("import Counter from './Counter';");
+      expect(script).toContain("import Chart from './Chart';");
+      expect(script).toContain("initIslands(");
+      expect(script).toContain("@ox-content/islands");
+    });
+  });
+});

--- a/npm/vite-plugin-ox-content/src/jsx-runtime.test.ts
+++ b/npm/vite-plugin-ox-content/src/jsx-runtime.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vite-plus/test";
+import { jsx, jsxs, Fragment, renderToString, raw, when, each, type JSXNode } from "./jsx-runtime";
+
+describe("jsx-runtime", () => {
+  describe("jsx — intrinsic elements", () => {
+    it("renders a tag with text children, escaping the text", () => {
+      expect(jsx("p", { children: "a < b & c" }).__html).toBe("<p>a &lt; b &amp; c</p>");
+    });
+
+    it("renders a tag with no children as an empty element", () => {
+      expect(jsx("div", {}).__html).toBe("<div></div>");
+    });
+
+    it("renders numeric children without escaping", () => {
+      expect(jsx("span", { children: 42 }).__html).toBe("<span>42</span>");
+    });
+
+    it("joins array children", () => {
+      expect(
+        jsx("ul", { children: [jsx("li", { children: "a" }), jsx("li", { children: "b" })] })
+          .__html,
+      ).toBe("<ul><li>a</li><li>b</li></ul>");
+    });
+
+    it("inlines nested node children without re-escaping their html", () => {
+      expect(jsx("div", { children: raw("<strong>x</strong>") }).__html).toBe(
+        "<div><strong>x</strong></div>",
+      );
+    });
+
+    it("omits boolean/null/undefined children", () => {
+      expect(jsx("div", { children: true }).__html).toBe("<div></div>");
+      expect(jsx("div", { children: false }).__html).toBe("<div></div>");
+      expect(jsx("div", { children: null }).__html).toBe("<div></div>");
+    });
+  });
+
+  describe("jsx — attributes", () => {
+    it("renders and escapes attribute values", () => {
+      expect(jsx("a", { href: 'x"y', children: "link" }).__html).toBe(
+        '<a href="x&quot;y">link</a>',
+      );
+    });
+
+    it("maps className -> class and htmlFor -> for", () => {
+      expect(jsx("label", { className: "c", htmlFor: "id", children: "L" }).__html).toBe(
+        '<label class="c" for="id">L</label>',
+      );
+    });
+
+    it("kebab-cases data-* and aria-* attributes", () => {
+      expect(jsx("div", { dataFooBar: "1", ariaLabel: "x" }).__html).toBe(
+        '<div data-foo-bar="1" aria-label="x"></div>',
+      );
+    });
+
+    it("renders boolean attributes as bare names when truthy and omits them when falsy", () => {
+      expect(jsx("input", { disabled: true }).__html).toBe("<input disabled />");
+      expect(jsx("input", { disabled: false }).__html).toBe("<input />");
+    });
+
+    it("skips undefined, null, and false attribute values", () => {
+      expect(jsx("div", { title: undefined, lang: null, contentEditable: false }).__html).toBe(
+        "<div></div>",
+      );
+    });
+
+    it("skips the internal key and ref props", () => {
+      expect(jsx("div", { key: "k", ref: "r", id: "real" }).__html).toBe('<div id="real"></div>');
+    });
+
+    it("serializes a style object to a kebab-cased declaration string", () => {
+      expect(jsx("div", { style: { backgroundColor: "red", fontSize: 12 } }).__html).toBe(
+        '<div style="background-color:red;font-size:12"></div>',
+      );
+    });
+  });
+
+  describe("jsx — void elements", () => {
+    it("self-closes void elements and ignores children", () => {
+      expect(jsx("br", {}).__html).toBe("<br />");
+      expect(jsx("img", { src: "a.png", alt: "x" }).__html).toBe('<img src="a.png" alt="x" />');
+    });
+  });
+
+  describe("jsx — function components", () => {
+    it("invokes a function component with merged props and children", () => {
+      const Card = (props: { title: string; children?: unknown }): JSXNode =>
+        jsx("section", { children: [jsx("h2", { children: props.title }), props.children] });
+      expect(jsx(Card, { title: "T", children: raw("<p>body</p>") }).__html).toBe(
+        "<section><h2>T</h2><p>body</p></section>",
+      );
+    });
+  });
+
+  describe("jsxs", () => {
+    it("behaves identically to jsx", () => {
+      expect(jsxs("ul", { children: [jsx("li", { children: "x" })] }).__html).toBe(
+        jsx("ul", { children: [jsx("li", { children: "x" })] }).__html,
+      );
+    });
+  });
+
+  describe("Fragment", () => {
+    it("renders children without a wrapper element", () => {
+      expect(
+        Fragment({ children: [jsx("span", { children: "a" }), jsx("span", { children: "b" })] })
+          .__html,
+      ).toBe("<span>a</span><span>b</span>");
+    });
+
+    it("renders empty for no children", () => {
+      expect(Fragment({}).__html).toBe("");
+    });
+  });
+
+  describe("renderToString", () => {
+    it("returns the node's html", () => {
+      expect(renderToString(jsx("p", { children: "hi" }))).toBe("<p>hi</p>");
+    });
+  });
+
+  describe("raw", () => {
+    it("passes html through unescaped", () => {
+      expect(raw("<em>x</em> & y").__html).toBe("<em>x</em> & y");
+    });
+  });
+
+  describe("when", () => {
+    it("returns the content when the condition is true", () => {
+      expect(when(true, raw("<p>shown</p>")).__html).toBe("<p>shown</p>");
+    });
+
+    it("returns empty when the condition is false", () => {
+      expect(when(false, raw("<p>hidden</p>")).__html).toBe("");
+    });
+  });
+
+  describe("each", () => {
+    it("maps items and concatenates their html, passing the index", () => {
+      expect(
+        each(["a", "b"], (item, index) => jsx("li", { children: `${index}:${item}` })).__html,
+      ).toBe("<li>0:a</li><li>1:b</li>");
+    });
+
+    it("renders empty for an empty array", () => {
+      expect(each([], () => raw("x")).__html).toBe("");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Two pure modules behind the MDX / framework-integration story were **entirely untested**. This adds characterization tests pinning their current behaviour, as groundwork for the framework-integration work.

### `jsx-runtime` — 24 tests
Intrinsic-element rendering; child escaping/number/array/nested-node handling; attribute handling (`className`→`class`, `htmlFor`→`for`, `data-*`/`aria-*` kebab-casing, boolean attributes, `style`-object serialization, skipped `key`/`ref`/`null`/`false`); void-element self-closing; function components; `Fragment`; `renderToString`; `raw`; `when`; `each`.

### `island/parse` — 11 tests
`hasIslands` boundary detection (`<islander>` must not match); `<Island>` → `data-ox-*` wrapper rewriting with collected metadata; default (`eager`) and explicit load strategies; media queries; JSX-style prop parsing (`{42}`→number, `{true}`→boolean, string, `{ {"a":1} }`→JSON); island-id incrementing across multiple islands; island-free passthrough; `extractIslandInfo`; `generateHydrationScript` (empty list + import/`initIslands` wiring).

## Validation

- `vp run check:ts` (tsc + format) clean.
- `vp test` — **35 tests pass** (jsx-runtime 24, island/parse 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)