### PR TITLE
docs(theming): document dark mode, embed slots, social icons, and custom CSS

### DIFF
--- a/docs/content/theming.md
+++ b/docs/content/theming.md
@@ -96,23 +96,10 @@ Configure your `tsconfig.json` for JSX:
 
 ## CSS Variables Reference
 
-All CSS variables use the `--octc-` prefix for namespacing.
-
-## Entry Page Modes
-
-The default theme supports two landing page modes:
-
-- `default` - the more branded, marketing-style entry page
-- `subtle` - a quieter docs.rs-like presentation with tighter spacing and a more restrained hero
-
-```ts
-defineTheme({
-  extends: defaultTheme,
-  entryPage: {
-    mode: "subtle",
-  },
-});
-```
+Every theme color, layout dimension, and font stack is emitted as a
+`--octc-`-prefixed CSS custom property on `:root`. You can set them through the
+theme config (below) or override them directly from [custom CSS](#custom-css-and-javascript)
+— the variable is the single source of truth either way.
 
 ### Colors
 
@@ -142,6 +129,50 @@ defineTheme({
 | ------------ | ------------------ | --------------------- |
 | `fonts.sans` | `--octc-font-sans` | Sans-serif font stack |
 | `fonts.mono` | `--octc-font-mono` | Monospace font stack  |
+
+Only the keys you set are emitted. Omitted colors, fonts, and layout values fall
+back to the [default theme](#default-theme-values), so overriding a single accent
+never forces you to redeclare the rest of the palette.
+
+## Dark Mode
+
+`colors` defines the light palette and `darkColors` defines the dark one; Ox
+Content emits both from a single build and switches between them with two
+selectors:
+
+- `[data-theme="dark"]` — used when the page (or the reader, via the built-in
+  header theme toggle) explicitly opts into dark mode. The toggle persists the
+  choice in `localStorage` so it survives navigation.
+- `@media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) { … } }`
+  — honours the operating-system preference unless the reader has explicitly
+  chosen light.
+
+```ts
+defineTheme({
+  extends: defaultTheme,
+  colors: { primary: "#3b82f6", background: "#ffffff" },
+  darkColors: { primary: "#60a5fa", background: "#060816" },
+});
+```
+
+`darkColors` follows the same key-by-key fallback as `colors`: any key you leave
+out inherits the default dark palette.
+
+## Entry Page Modes
+
+The default theme supports two landing page modes:
+
+- `default` - the more branded, marketing-style entry page
+- `subtle` - a quieter docs.rs-like presentation with tighter spacing and a more restrained hero
+
+```ts
+defineTheme({
+  extends: defaultTheme,
+  entryPage: {
+    mode: "subtle",
+  },
+});
+```
 
 ## Page Props & Hooks
 
@@ -316,7 +347,7 @@ title: Welcome
 
 ## Social Links
 
-Add social links to the header:
+Add social links to the header. The shorthand form covers the common networks:
 
 ```ts
 defineTheme({
@@ -329,41 +360,95 @@ defineTheme({
 });
 ```
 
-## Slots
+For anything else, pass an array of `{ icon, link, label? }` entries. The
+`icon` field accepts several formats:
 
-Inject custom HTML at specific locations:
+| Format                | Example                       | Renders as                               |
+| --------------------- | ----------------------------- | ---------------------------------------- |
+| Iconify `prefix:name` | `"mdi:mastodon"`              | Iconify icon (any set), color-aware      |
+| Lucide                | `"lucide:rss"`                | Lucide icon via Iconify                  |
+| Image URL             | `"https://example.com/x.svg"` | `<img>` with that source                 |
+| Local path            | `"/icons/x.svg"`              | `<img>` resolved against the site `base` |
+| Emoji / text          | `"📡"`                        | Rendered inline as-is                    |
 
 ```ts
 defineTheme({
   extends: defaultTheme,
-  slots: {
+  socialLinks: [
+    { icon: "mdi:mastodon", link: "https://mastodon.social/@you", label: "Mastodon" },
+    { icon: "lucide:rss", link: "/feed.xml", label: "RSS" },
+  ],
+});
+```
+
+Inline SVG passed as an icon is sanitized — `<script>` is stripped — so an icon
+string can never inject executable markup.
+
+## Embedded HTML (Slots)
+
+The `embed` option injects raw HTML at fixed points in the page layout. All nine
+positions are optional:
+
+| Field           | Renders…                                                   |
+| --------------- | ---------------------------------------------------------- |
+| `head`          | inside `<head>` (analytics, `preconnect`, custom `<meta>`) |
+| `headerBefore`  | immediately before the header bar                          |
+| `headerAfter`   | immediately after the header bar                           |
+| `sidebarBefore` | at the top of the sidebar, before the navigation           |
+| `sidebarAfter`  | at the bottom of the sidebar, after the navigation         |
+| `contentBefore` | before the main content (above the article)                |
+| `contentAfter`  | after the main content (below the article)                 |
+| `footerBefore`  | immediately before the footer                              |
+| `footer`        | replaces the default footer entirely                       |
+
+```ts
+defineTheme({
+  extends: defaultTheme,
+  embed: {
     head: '<link rel="preconnect" href="https://fonts.googleapis.com">',
     headerBefore: '<div class="announcement">New version!</div>',
-    headerAfter: "",
-    sidebarBefore: "",
-    sidebarAfter: "",
-    contentBefore: "",
     contentAfter: '<div class="feedback">Was this helpful?</div>',
-    footerBefore: "",
-    footer: '<footer class="custom">...</footer>',
+    footer: '<footer class="custom">© My Project</footer>',
   },
 });
 ```
 
+Embedded HTML is inserted verbatim, so only pass trusted markup.
+
 ## Custom CSS and JavaScript
+
+`css` is appended **after** the generated `--octc-*` variable overrides, so your
+rules win on specificity ties and you can freely read or redefine the variables.
+`js` is injected as an inline script on every page.
 
 ```ts
 defineTheme({
   extends: defaultTheme,
   css: `
+    /* Override a generated variable for every page… */
+    :root {
+      --octc-max-content-width: 1100px;
+    }
+    /* …or target the rendered markup directly. */
     .content h1 {
-      color: #3b82f6;
+      color: var(--octc-color-primary);
       letter-spacing: -0.04em;
     }
   `,
   js: `
     console.log('Page loaded');
   `,
+});
+```
+
+For one-off tweaks you can also pass `css` straight to the `ssg` plugin option
+without defining a full theme — it is merged the same way:
+
+```ts
+oxContent({
+  ssg: {
+    theme: { css: ".hero-name { letter-spacing: -0.04em; }" },
+  },
 });
 ```
 
@@ -420,7 +505,7 @@ import type {
   ThemeHeader,
   ThemeFooter,
   SocialLinks,
-  ThemeSlots,
+  ThemeEmbed,
   ResolvedThemeConfig,
   PageProps,
   BasePageProps,


### PR DESCRIPTION
## Summary

Expands the theming guide and **corrects it against the actual API**.

### Correctness fixes
- The guide documented a `slots:` theme option that **does not exist** — the real field is `embed` (`ThemeEmbed`, `theme.ts:169`). Replaced the "Slots" section with "Embedded HTML (Slots)" using `embed:`.
- Fixed the `ThemeSlots` import in the TypeScript Support list — the exported type is `ThemeEmbed` (verified `ThemeSlots` is exported nowhere).
- Restructured "CSS Variables Reference": the Colors/Layout/Fonts tables were mis-nested under "Entry Page Modes"; they now sit under the reference heading.

### New / expanded content
- **Dark Mode** section: `colors` vs `darkColors`, the `[data-theme="dark"]` selector, the `@media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) }` fallback, the `localStorage`-backed header toggle, and per-key fallback to the default palette.
- **Embedded HTML**: a table enumerating all nine injection points (`head`, `headerBefore/After`, `sidebarBefore/After`, `contentBefore/After`, `footerBefore`, `footer`).
- **Social links**: the icon formats (`mdi:`/`lucide:`/any Iconify `prefix:name`, image URL, local path, emoji), the `<script>`-stripping sanitization, and the array form.
- **Custom CSS**: clarified that `css` is appended *after* the `--octc-*` variable overrides and can be set on the `ssg.theme` option directly.

All facts were checked against `theme.ts` and the Rust `generate_theme_css` (`html.rs`) — exact variable names (`--octc-color-*`, `--octc-font-*`, `--octc-*-width/height`), the dark-mode selectors, and the `render_icon` format list.

## Validation

`vp run fmt:check` clean (markdown reflowed by the formatter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)