### PR TITLE
docs: add JSDoc API-docs and i18n guides

### DIFF
--- a/docs/content/i18n.md
+++ b/docs/content/i18n.md
@@ -1,0 +1,167 @@
+---
+title: Internationalization (i18n)
+description: ICU MessageFormat 2 messages, multi-locale dictionaries, a static checker, a runtime module, and editor tooling.
+---
+
+# Internationalization (i18n)
+
+Ox Content ships a complete i18n toolkit built around **ICU MessageFormat 2
+(MF2)**:
+
+- Multi-locale **dictionaries** loaded from JSON/YAML with nested keys.
+- A hand-written **MF2 parser** (simple messages, `.input`/`.local`
+  declarations, `.match` variants).
+- A build-time **static checker** (missing keys, unused keys, variable
+  mismatches across locales, MF2 syntax errors).
+- A **runtime virtual module** with `t()` and `Intl`-backed formatters.
+- A **CLI** (`ox-content-i18n`) and an **LSP** for editor integration.
+
+## Enable
+
+```ts
+// vite.config.ts
+import { oxContent } from "@ox-content/vite-plugin";
+
+export default {
+  plugins: [
+    oxContent({
+      i18n: {
+        enabled: true,
+        dir: "content/i18n",
+        defaultLocale: "en",
+        locales: [
+          { code: "en", name: "English" },
+          { code: "ja", name: "日本語" },
+          { code: "ar", name: "العربية", dir: "rtl" },
+        ],
+      },
+    }),
+  ],
+};
+```
+
+### Options
+
+| Option              | Default          | Description                                                                                                   |
+| ------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------- |
+| `enabled`           | `false`          | Enable i18n.                                                                                                  |
+| `dir`               | `'content/i18n'` | Dictionary directory, relative to the project root.                                                           |
+| `defaultLocale`     | `'en'`           | Default locale tag (BCP 47).                                                                                  |
+| `locales`           | —                | Available locales: `{ code, name, dir? }` (`dir` is `'ltr'`/`'rtl'`).                                         |
+| `hideDefaultLocale` | `true`           | When true, `/page` serves the default locale and `/ja/page` is prefixed; when false every locale is prefixed. |
+| `check`             | `true`           | Run the static checker during build.                                                                          |
+| `functionNames`     | `['t', '$t']`    | Translation function names to detect when scanning source for used keys.                                      |
+
+## Dictionaries
+
+Each locale is a JSON or YAML file under `dir`. Nested keys are flattened with
+dots, so the dictionary and your call sites share one key space:
+
+```yaml
+# content/i18n/en.yaml
+nav:
+  home: "Home"
+  docs: "Documentation"
+cart:
+  items: "{$count :number} items in your cart"
+```
+
+```jsonc
+// content/i18n/ja.json
+{
+  "nav": { "home": "ホーム", "docs": "ドキュメント" },
+  "cart": { "items": "カートに {$count :number} 件" },
+}
+```
+
+Missing keys in a non-default locale fall back to the default locale at runtime.
+
+## MessageFormat 2 messages
+
+Values are MF2 messages. Beyond plain text:
+
+```text
+# Interpolation with a formatting function
+{$count :number} items
+
+# Declarations + a match (pluralization / selection)
+.input {$count :number}
+.match $count
+  one  {{You have {$count} item.}}
+  *    {{You have {$count} items.}}
+```
+
+Validate a message from the CLI:
+
+```bash
+ox-content-i18n validate "{$count :number} items"
+ox-content-i18n validate ".match {$n}\n one {{1}}\n * {{many}}" --ast
+```
+
+## Static checking
+
+With `check: true`, the build scans your source for used keys and compares them
+against the dictionaries, reporting four classes of problem:
+
+- **Missing keys** — used in code but absent from a locale.
+- **Unused keys** — present in dictionaries but never referenced.
+- **Type mismatches** — a placeholder/variable set differs across locales for
+  the same key.
+- **Syntax errors** — invalid MF2 in a dictionary value.
+
+Run it standalone (also handy in CI — it exits non-zero on findings):
+
+```bash
+ox-content-i18n check --dict-dir content/i18n --src src
+ox-content-i18n check --dict-dir content/i18n --src src --format json
+ox-content-i18n check --dict-dir content/i18n --src src --default-locale en
+```
+
+Keys are collected from TS/JS call sites (`t(...)`, `$t(...)`, `this.t(...)`,
+`i18n.t(...)`) via the OXC parser and from Markdown (`{{t(...)}}`); customize the
+detected function names with `functionNames`.
+
+## Runtime module
+
+Importing the virtual module gives you translation and formatting helpers backed
+by the loaded dictionaries and the platform `Intl` APIs:
+
+```ts
+import {
+  t,
+  localePath,
+  getLocaleFromPath,
+  formatDate,
+  formatNumber,
+  formatRelativeTime,
+  formatList,
+  formatDisplayName,
+  i18nConfig,
+} from "virtual:ox-content/i18n";
+
+t("cart.items", { count: 3 }); // "3 items in your cart"
+t("nav.home", {}, "ja"); // force a locale → "ホーム"
+
+localePath("/docs", "ja"); // "/ja/docs"
+getLocaleFromPath("/ja/docs"); // "ja"
+
+formatNumber(1234.5, "ja"); // "1,234.5"
+formatRelativeTime(-2, "day", "en"); // "2 days ago"
+```
+
+`Intl` formatters are cached per locale, and locale metadata carries the
+optional text direction so RTL locales render correctly.
+
+## Editor tooling
+
+The bundled language server (`ox-content-lsp`) provides dictionary-key
+completion, hover previews of every locale's translation, go-to-definition into
+the dictionary file, inlay hints showing the default-locale value, and the same
+missing/unused-key diagnostics as the checker. It runs over stdio:
+
+```bash
+cargo run -p ox_content_lsp --bin ox-content-lsp
+```
+
+and integrates with VS Code, Zed, and Neovim — see the editor tooling section of
+the project README for wiring instructions.

--- a/docs/content/jsdoc.md
+++ b/docs/content/jsdoc.md
@@ -1,0 +1,137 @@
+---
+title: API Docs from JSDoc
+description: Generate API documentation from JSDoc and TypeScript types, like cargo doc for JavaScript.
+---
+
+# API Docs from JSDoc
+
+Ox Content can generate API documentation directly from your JSDoc comments and
+TypeScript types — "cargo doc for JavaScript". Source files are parsed with the
+[OXC](https://oxc.rs) parser, so extraction is fast and understands real
+TypeScript (generics, overloads, interfaces, enums) without a separate
+type-checker pass.
+
+It produces, in one run:
+
+- **Markdown pages** for each module, with syntax-highlighted signatures,
+  parameter tables, return types, examples, and (optionally) source links.
+- **`docs.json`** — a machine-readable payload of the same data for runtime
+  tooling.
+- **`nav.ts`** — a typed navigation tree you can feed into the sidebar.
+
+## Enable
+
+Docs generation is part of the Vite plugin and is **on by default** (opt-out).
+Point it at your source and pick an output directory:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import { oxContent } from "@ox-content/vite-plugin";
+
+export default defineConfig({
+  plugins: [
+    oxContent({
+      docs: {
+        src: ["./src"],
+        out: "docs/api",
+        githubUrl: "https://github.com/your/repo",
+      },
+    }),
+  ],
+});
+```
+
+To turn it off entirely, set `docs: { enabled: false }`.
+
+## Options
+
+| Option         | Default                                          | Description                                                                   |
+| -------------- | ------------------------------------------------ | ----------------------------------------------------------------------------- |
+| `enabled`      | `true`                                           | Enable/disable docs generation.                                               |
+| `src`          | `['./src']`                                      | Source directories to scan.                                                   |
+| `out`          | `'docs/api'`                                     | Output directory for generated docs.                                          |
+| `include`      | `['**/*.ts', '**/*.tsx', …]`                     | Glob patterns of files to include.                                            |
+| `exclude`      | `['**/*.test.*', '**/*.spec.*', 'node_modules']` | Glob patterns to exclude.                                                     |
+| `entryPoints`  | —                                                | Public API entry points used to group re-exported docs (see below).           |
+| `format`       | `'markdown'`                                     | `'markdown'`, `'json'`, or `'html'`.                                          |
+| `private`      | `false`                                          | Include `@private` members.                                                   |
+| `internal`     | `false`                                          | Include `@internal` members.                                                  |
+| `toc`          | `true`                                           | Emit a table of contents per file.                                            |
+| `groupBy`      | `'file'`                                         | Group output by `'file'` or `'category'`.                                     |
+| `githubUrl`    | —                                                | Repository URL; when set, signatures link to their source lines.              |
+| `linkStyle`    | `'markdown'`                                     | Internal link style: `'markdown'` (`.md` links) or `'clean'` (extensionless). |
+| `basePath`     | `'/api'`                                         | Route prefix for generated links and nav metadata.                            |
+| `pathStrategy` | `'flat'`                                         | Output layout: `'flat'` or `'typedoc'` (see below).                           |
+| `generateNav`  | `true`                                           | Emit the `nav.ts` navigation file.                                            |
+
+## What gets extracted
+
+Each documented declaration becomes an entry with its `kind` (`function`,
+`class`, `interface`, `type`, `enum`, `variable`, or `module`), description,
+signature, and members. The following JSDoc tags are recognised:
+
+| Tag                    | Effect                                                  |
+| ---------------------- | ------------------------------------------------------- |
+| `@param name desc`     | Adds a row to the parameter table (type comes from TS). |
+| `@returns desc`        | Documents the return value.                             |
+| `@example`             | Rendered as a fenced code block.                        |
+| `@default value`       | Shown alongside the parameter/property.                 |
+| `@deprecated [reason]` | Flags the entry as deprecated.                          |
+| `@private`             | Hidden unless `private: true`.                          |
+| `@internal`            | Hidden unless `internal: true`.                         |
+
+Types are read from the TypeScript annotations themselves, so `@param {Type}`
+JSDoc type syntax is not required.
+
+## Entry points and re-exports
+
+By default, docs are grouped by source file. If your package re-exports its
+public API through a barrel (`index.ts`), pass it as an `entryPoint` to group
+the docs by what's actually exported, following the re-export graph:
+
+```ts
+docs: {
+  entryPoints: [
+    "./src/index.ts",
+    { path: "./src/cli.ts", name: "CLI" },
+  ],
+}
+```
+
+A symbol re-exported under a new name is documented under the name it is
+exported as.
+
+## Output layout
+
+`pathStrategy` controls the directory shape of the generated Markdown:
+
+- **`flat`** (default) — one file per module under `out` (e.g.
+  `docs/api/index.md`, `docs/api/parser.md`).
+- **`typedoc`** — a nested, TypeDoc-style tree that splits modules into
+  per-kind subdirectories (`functions/`, `classes/`, `interfaces/`, …), which
+  scales better for large APIs.
+
+Alongside the Markdown, `writeDocs` emits `docs.json` (the structured payload)
+and, when `generateNav` is on, `nav.ts`. A manifest tracks generated files so
+stale pages are cleaned up on the next run.
+
+## Wire the nav into your sidebar
+
+`nav.ts` exports a typed `NavItem[]` you can splice into your theme's sidebar:
+
+```ts
+import { apiNav } from "./docs/api/nav";
+
+// in your ssg theme config
+sidebar: [
+  ...apiNav,
+  // …your hand-written sections
+];
+```
+
+## See also
+
+- [`examples/gen-source-docs`](./examples/gen-source-docs.md) — a runnable setup.
+- The generated [API Reference](./api/index.md) for this project is itself
+  produced by this feature.

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -64,6 +64,8 @@ export default defineConfig(({ mode }) => {
                 items: [
                   { text: "Getting Started", link: "/getting-started.md" },
                   { text: "Theming", link: "/theming.md" },
+                  { text: "API Docs from JSDoc", link: "/jsdoc.md" },
+                  { text: "Internationalization", link: "/i18n.md" },
                   { text: "Examples", link: "/examples/index.md" },
                 ],
               },


### PR DESCRIPTION
## Summary

Two fully-implemented features only had auto-generated API-reference pages and no Guide-level documentation. This adds proper guides and registers them in the sidebar Guide section.

### `jsdoc.md` — API Docs from JSDoc
Covers the `docs` plugin option end to end: enabling/opting out, the **full options table** (`src`, `out`, `include`, `exclude`, `entryPoints`, `format`, `private`, `internal`, `toc`, `groupBy`, `githubUrl`, `linkStyle`, `basePath`, `pathStrategy`, `generateNav`), the recognised JSDoc tags (`@param`/`@returns`/`@example`/`@default`/`@deprecated`/`@private`/`@internal`), entry-point re-export grouping, the `flat` vs `typedoc` output layouts, the `docs.json` + `nav.ts` artifacts, and how to wire `nav.ts` into the sidebar.

### `i18n.md` — Internationalization
Covers the `i18n` option + `locales`, JSON/YAML dictionaries with nested-key flattening, ICU MessageFormat 2 messages (`.input`/`.local`/`.match`), the static checker (missing / unused / type-mismatch / syntax) and the `ox-content-i18n check|validate` CLI, the `virtual:ox-content/i18n` runtime module (`t` + `Intl` formatters + `localePath`/`getLocaleFromPath`), and the LSP.

## Accuracy

All option names and defaults were verified against `types.ts` (`DocsOptions`, `I18nOptions`, `LocaleConfig`) and the i18n crate/CLI/virtual-module surface (from a code map of the feature areas). Both pages added to the Guide sidebar in `docs/vite.config.ts`.

`vp run check:ts` + `fmt:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)