### PR TITLE
docs: add an MDX & Components guide

### DIFF
--- a/docs/content/mdx.md
+++ b/docs/content/mdx.md
@@ -1,0 +1,130 @@
+---
+title: MDX & Components
+description: Embed Vue, React, or Svelte components in Markdown using island hydration.
+---
+
+# MDX & Components
+
+Ox Content lets you embed framework components inside Markdown and `.mdx` files.
+It is worth understanding how this works, because it differs from "classic" MDX:
+
+- **`.md` and `.mdx` are parsed identically** — both go through the same Rust
+  Markdown parser (CommonMark + GFM). The parser does **not** parse JSX. The
+  `.mdx` extension is simply recognised as a content file.
+- **Components are resolved by a framework plugin**, not the parser. The
+  React/Vue/Svelte plugins scan the content for PascalCase component tags,
+  replace them with **island** placeholders, and hydrate them on the client.
+
+So you get Markdown's speed for prose plus real interactive components where you
+need them — without shipping a JavaScript bundle for pages that have none.
+
+## Setup
+
+Add the plugin for your framework alongside its official Vite plugin and point
+it at your components:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { oxContentReact } from "@ox-content/vite-plugin-react";
+
+export default defineConfig({
+  plugins: [
+    react(),
+    oxContentReact({
+      srcDir: "docs",
+      // Auto-discover components by glob…
+      components: "./src/components/*.tsx",
+      // …or map names explicitly:
+      // components: { Counter: "./src/components/Counter.tsx" },
+    }),
+  ],
+});
+```
+
+Vue and Svelte work the same way via `@ox-content/vite-plugin-vue`
+(`oxContentVue`) and `@ox-content/vite-plugin-svelte` (`oxContentSvelte`). When
+`components` is a glob, the component name is the PascalCased file name.
+
+## Authoring components in Markdown
+
+Write components as PascalCase tags in your Markdown — self-closing or with
+children:
+
+```md
+# My Page
+
+Regular **Markdown** prose.
+
+<Counter initial={5} />
+
+<Callout type="tip">
+  This child content is passed to the component.
+</Callout>
+```
+
+Only tags that start with an uppercase letter are treated as components, so your
+ordinary HTML (`<div>`, `<span>`, …) is left untouched. Tags inside fenced code
+blocks are **not** transformed, so you can document component usage without it
+being executed.
+
+### Props
+
+Props use JSX-like syntax. The following forms are recognised:
+
+| Syntax             | Parsed as           |
+| ------------------ | ------------------- |
+| `prop="text"`      | string              |
+| `prop={42}`        | number / JSON value |
+| `prop={true}`      | boolean             |
+| `prop={ {"a":1} }` | object (JSON)       |
+| `prop`             | boolean `true`      |
+
+Props are serialized to a `data-ox-props` attribute on the island element and
+handed to your component at hydration time.
+
+## How islands hydrate
+
+Each component becomes an island wrapper in the generated HTML — a block-level
+component renders as a `<div data-ox-island="Name" …>` and an inline one as a
+`<span data-ox-island="Name" …>`. The matching framework runtime mounts the real
+component into that element on the client.
+
+Hydration timing is controlled by a load strategy (see
+[`@ox-content/islands`](./packages/vite-plugin-ox-content.md)):
+
+| Strategy  | Hydrates…                                                   |
+| --------- | ----------------------------------------------------------- |
+| `eager`   | immediately on load (default)                               |
+| `idle`    | during `requestIdleCallback` (≈200 ms fallback)             |
+| `visible` | when the element scrolls into view (`IntersectionObserver`) |
+| `media`   | when a media query matches (`matchMedia`)                   |
+
+Because the server output is plain HTML, pages render and are readable before
+(or entirely without) hydration; the island JavaScript is only loaded for the
+components a page actually uses.
+
+## Static JSX in themes
+
+Separately from component islands, Ox Content ships a small **static JSX
+runtime** (`jsx`, `jsxs`, `Fragment`, `renderToString`, `raw`, `when`, `each`)
+used to author themes and layouts that render to HTML strings with no
+client-side JavaScript. Configure it in `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "@ox-content/vite-plugin"
+  }
+}
+```
+
+See [Theming](./theming.md) for using it to build a custom layout.
+
+## See also
+
+- [React Integration](./packages/vite-plugin-ox-content-react.md)
+- [Vue Integration](./packages/vite-plugin-ox-content-vue.md)
+- [Svelte Integration](./packages/vite-plugin-ox-content-svelte.md)

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -64,6 +64,7 @@ export default defineConfig(({ mode }) => {
                 items: [
                   { text: "Getting Started", link: "/getting-started.md" },
                   { text: "Theming", link: "/theming.md" },
+                  { text: "MDX & Components", link: "/mdx.md" },
                   { text: "API Docs from JSDoc", link: "/jsdoc.md" },
                   { text: "Internationalization", link: "/i18n.md" },
                   { text: "Examples", link: "/examples/index.md" },


### PR DESCRIPTION
## Summary

The `.mdx` workflow was conflated with `.md` and had no guide. This adds one that explains how it **actually** works (and how it differs from classic MDX), grounded in the framework plugins' source.

- **`.md` and `.mdx` are parsed identically** by the Rust CommonMark+GFM parser — it does not parse JSX. Components are resolved by the **framework plugins**, which detect PascalCase tags and hydrate them as **islands**.
- Setup for the React/Vue/Svelte plugins and the `components` glob/map option.
- Authoring: PascalCase tags (self-closing or with children), the prop forms (`="text"`, `={42}`, `={true}`, `={ {json} }`, bare), code-fence exclusion, and block (`<div>`) vs inline (`<span>`) island wrappers.
- Load strategies (`eager`/`idle`/`visible`/`media`) and the static-HTML-first model.
- A section distinguishing the **theme-authoring static JSX runtime** from component islands, with the `tsconfig` `jsx` settings.

Registered in the Guide sidebar. Authoring details verified against the React plugin's `COMPONENT_REGEX`/`PROP_REGEX` and `injectIslandMarkers`.

## Note on framework tests

The genuinely unit-testable framework surface — the static JSX runtime and the island parser — is covered by #237 (35 tests). The per-framework transform helpers (`parseProps`, `extractFrontmatter`, …) are module-private and the end-to-end transform needs the native NAPI addon, so they aren't unit-tested here without exporting internals.

## Validation

`vp run check:ts` + `fmt:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)