### PR TITLE
fix(bench): restore Bun.markdown row in PR benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,6 +48,16 @@ jobs:
           cache: true
           run-install: false
 
+      # The parse/render benchmark compares against `Bun.markdown.html`, which
+      # only exists in Bun >= 1.3.8. Without an explicit Bun the runner has no
+      # (or too old a) bun, so `loadBunMarkdownBenchmarks` silently drops the
+      # Bun.markdown row. Pin a version that ships the API so the comparison
+      # always includes Bun.
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.14"
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 

--- a/benchmarks/bundle-size/parse-benchmark.mjs
+++ b/benchmarks/bundle-size/parse-benchmark.mjs
@@ -312,7 +312,17 @@ function loadBunMarkdownBenchmarks() {
 
   if (run.status !== 0) {
     const details = run.stderr.trim() || run.stdout.trim();
-    console.warn(`Failed to run Bun benchmark helper: ${details}`);
+    // `Bun.markdown` only exists in Bun >= 1.3.8. On an older bun the helper
+    // throws this exact message; call it out so the missing Bun.markdown row
+    // is traced to the bun version rather than read as a transient failure.
+    if (details.includes("Bun.markdown is not available")) {
+      console.warn(
+        `Bun ${version.stdout.trim()} predates Bun.markdown (added in 1.3.8); ` +
+          "skipping Bun.markdown comparisons. Upgrade bun to include it.",
+      );
+    } else {
+      console.warn(`Failed to run Bun benchmark helper: ${details}`);
+    }
     return null;
   }
 


### PR DESCRIPTION
## Restore the `Bun.markdown` row in the PR benchmark

### Problem
The parse/render benchmark (`benchmarks/bundle-size/parse-benchmark.mjs`) compares against `Bun.markdown.html`, run in a separate `bun` subprocess (`parse-benchmark-bun.mjs`). But the **Benchmark workflow never set up Bun**. On the runner `bun` was missing — or too old to expose `Bun.markdown` (added in **Bun 1.3.8**) — so `loadBunMarkdownBenchmarks()` caught the non-zero exit, emitted a vague warning, and returned `null`. The Bun.markdown row was then **silently dropped** from the comparison table.

That is exactly the reported symptom: Bun's markdown bench "disappeared" and its previously reported numbers vanished.

### Fix
- Add a pinned `oven-sh/setup-bun` (`1.3.14`) step to the Benchmark job so the runner always has a Bun that ships `Bun.markdown`. Pinned by SHA + version comment, matching the repo's other actions (zizmor-friendly).
- Make `loadBunMarkdownBenchmarks()` recognize the `Bun.markdown is not available` failure and warn with the bun version, so a future too-old bun is diagnosable instead of reading as a transient failure.

### Verification
Locally with Bun 1.3.14 the row is back across all sizes:
```
Using Bun.markdown (Bun 1.3.14)
| Bun.markdown.html |     241376 |    0.00ms | 114.41 MB/s |   1.19x |
| Bun.markdown.html |      25658 |    0.04ms | 122.05 MB/s |   1.57x |
| Bun.markdown.html |      ...
```
(With an old bun the new branch prints: `Bun <ver> predates Bun.markdown (added in 1.3.8); skipping…`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
