### PR TITLE
perf(ci): debug-build NAPI smoke and cache rendering browsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,9 +227,14 @@ jobs:
         if: runner.os != 'Windows'
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
+      # Debug build: the smoke test only verifies the binding loads and that
+      # parseAndRender produces correct output — it does not benchmark. A debug
+      # build validates the same ABI/load/correctness path far faster than the
+      # release profile (fat LTO + codegen-units=1). Release artifacts are built
+      # and verified separately in publish.yml.
       - name: Build local NAPI binding
         working-directory: crates/ox_content_napi
-        run: vp exec -- napi build --release
+        run: vp exec -- napi build
 
       - name: Load and parse smoke test
         shell: bash
@@ -266,6 +271,16 @@ jobs:
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Cache rendering browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/.cache/puppeteer
+          key: ${{ runner.os }}-browsers-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-browsers-
 
       - name: Install browsers for docs rendering
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      - name: Cache rendering browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/.cache/puppeteer
+          key: ${{ runner.os }}-browsers-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-browsers-
+
       - name: Install browsers for docs rendering
         run: |
           vp exec --filter @ox-content/vite-plugin -- playwright install --with-deps chromium


### PR DESCRIPTION
## 概要

定常状態の CI クリティカルパス（**Windows の NAPI smoke** ジョブと **Build** ジョブ）を狙った2点の最適化です。直近の warm-cache run の所要時間データに基づきます。

## 変更

### 1. NAPI smoke を debug ビルドに
`napi build --release` → `napi build`

- `release` プロファイル（`lto = "fat"` + `codegen-units = 1`）のコンパイルが Windows で **100秒+**（変動で最大 ~280s）かかり、3 OS 共通の律速になっていた。
- smoke テストはバインディングのロード/ABI/`parseAndRender` の正当性確認のみで性能測定はしないため、debug ビルドで同じ検証経路を大幅に高速化できる。
- リリース成果物は `publish.yml` で別途ビルド・検証済み。

### 2. レンダリング用ブラウザのキャッシュ（Build + Deploy）
`~/.cache/ms-playwright` と `~/.cache/puppeteer` を `pnpm-lock.yaml` ハッシュをキーに `actions/cache` でキャッシュ。

- 毎回約 **27秒** の Playwright/Puppeteer ダウンロードを削減。
- ダウンロード失敗による flakiness も低減。
- キャッシュヒット時も `--with-deps` の apt 部分は走るため、システム依存の整合性は保たれる。

## 期待効果

- **NAPI smoke (windows)**: 約169〜280s → 大幅短縮（最遅ジョブの解消、3 OS とも改善）
- **Build / Deploy**: ブラウザ DL 約27s/回を削減
- CI 全体のウォール時間が短縮

## トレードオフ

- debug ビルド化により、LTO/最適化特有の稀な miscompile は CI smoke では検出できなくなる（リリースビルドは publish.yml でカバー）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782790869&installation_id=136613492&pr_number=263&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F263&signature=f6e452849bfecf53be5feb356688a062304dff961b6642064b13d96d90d864ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->