### PR TITLE
ci(release): publish npm packages on GitHub-hosted runners

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,7 @@ jobs:
 
   publish-napi:
     name: Publish @ox-content/napi
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: build-napi
     environment: npm
     permissions:
@@ -186,7 +186,7 @@ jobs:
 
   publish-packages:
     name: Publish npm packages
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: publish-napi
     environment: npm
     permissions:
@@ -386,4 +386,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REF_NAME: ${{ github.ref_name }}
-        run: gh release create "$GH_REF_NAME" --generate-notes
+        run: |
+          if gh release view "$GH_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GH_REF_NAME already exists; skipping."
+            exit 0
+          fi
+          gh release create "$GH_REF_NAME" --generate-notes


### PR DESCRIPTION
## Summary

- Move npm publish jobs to GitHub-hosted runners so npm provenance verification accepts trusted publishing.
- Keep NAPI build jobs on the existing runner matrix for performance.
- Make the release creation step idempotent so rerunning the publish workflow after a partial release does not fail on an existing GitHub Release.

## Validation

- `git diff --check origin/main...HEAD`
- `vp fmt .github/workflows/publish.yml --check`
- Re-ran the `v2.31.0` Publish workflow from the updated tag to verify the release path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782807567&installation_id=136613492&pr_number=267&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F267&signature=e9e3aa506b9fb9eb0420ae4194d5e538f03ef1bb799dca2e797cd46bec8c1ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->