### PR TITLE
docs: expand built-in feature and Void deploy guides

### DIFF
--- a/docs/content/built-in-features.md
+++ b/docs/content/built-in-features.md
@@ -1,0 +1,182 @@
+---
+title: Built-in Features
+description: Default and opt-in features available in @ox-content/vite-plugin.
+---
+
+# Built-in Features
+
+Ox Content keeps common documentation behavior on by default and keeps
+non-standard Markdown or HTML extensions opt-in.
+
+The defaults below match `@ox-content/vite-plugin`. They are designed for a
+fast static baseline: parsing, static embeds, source docs, and search indexing
+run during transform or build, while extra syntax and runtime behavior must be
+enabled explicitly.
+
+## Default vs Opt-in
+
+| Area             | Option                                                                | Default       | Notes                                               |
+| ---------------- | --------------------------------------------------------------------- | ------------- | --------------------------------------------------- |
+| Markdown base    | `gfm`, `footnotes`, `tables`, `taskLists`, `strikethrough`            | `true`        | Common GitHub-flavored Markdown behavior.           |
+| Page metadata    | `frontmatter`                                                         | `true`        | Parses YAML frontmatter before rendering.           |
+| Navigation       | `toc`, `tocMaxDepth`                                                  | `true`, `3`   | Builds a page table of contents from headings.      |
+| Static site      | `ssg`                                                                 | `{ enabled }` | Generates static HTML pages during build.           |
+| API docs         | `docs`                                                                | `{ enabled }` | Generates package API docs unless set to `false`.   |
+| Search           | `search`                                                              | `{ enabled }` | Builds a static BM25 index for client-side search.  |
+| Syntax highlight | `highlight`                                                           | `false`       | Opt in when the site needs highlighted code blocks. |
+| OG images        | `ogImage`                                                             | `false`       | Opt in because image rendering adds build work.     |
+| Extra syntax     | `wikiLinks`, `emojiShortcodes`, `attrs`, `codeImports`, `cjkEmphasis` | `false`       | Non-standard authoring features are opt-in.         |
+| HTML safety      | `sanitize`                                                            | `false`       | Opt in when rendering untrusted or mixed HTML.      |
+| Editing links    | `editThisPage`                                                        | `false`       | Opt in with a repository URL.                       |
+| Code checks      | `codeAnnotations`, `codeBlockLint`, `codeBlockTypecheck`, `docsTests` | `false`       | Opt in per documentation workflow.                  |
+| Diagrams         | `mermaid`                                                             | `false`       | Opt in for diagram rendering.                       |
+| Custom pipeline  | `transformers`                                                        | `[]`          | Add project-specific Markdown AST transforms.       |
+
+Use explicit options when a site needs non-standard behavior:
+
+```ts
+import { defineConfig } from "vite-plus";
+import { oxContent } from "@ox-content/vite-plugin";
+
+export default defineConfig({
+  plugins: [
+    oxContent({
+      highlight: true,
+      emojiShortcodes: true,
+      codeAnnotations: {
+        notation: "both",
+      },
+      embeds: {
+        pm: { sync: true },
+        twitter: true,
+        bluesky: true,
+      },
+    }),
+  ],
+});
+```
+
+## Emoji Shortcodes
+
+Emoji shortcode expansion is opt-in:
+
+```ts
+oxContent({
+  emojiShortcodes: true,
+});
+```
+
+The built-in table covers hundreds of common GitHub-style aliases such as
+`:rocket:`, `:white_check_mark:`, `:warning:`, `:smile:`, and `:thinking:`.
+Shortcodes expand outside fenced and inline code. Unknown shortcodes are left
+unchanged.
+
+Custom values override the built-in table:
+
+```ts
+oxContent({
+  emojiShortcodes: {
+    custom: {
+      shipit: "ship it",
+    },
+  },
+});
+```
+
+See [Emoji Shortcodes](./examples/emoji-shortcodes.md) for a rendered example.
+
+## Code Annotations
+
+Code annotations are opt-in so ordinary code fences stay literal unless a site
+chooses annotation syntax:
+
+```ts
+oxContent({
+  highlight: true,
+  codeAnnotations: {
+    notation: "both",
+  },
+});
+```
+
+The default notation is the configurable attribute syntax:
+
+````md
+```ts annotate="highlight:1,3;warning:5;error:8"
+const value = load();
+console.warn(value);
+throw new Error("stop");
+```
+````
+
+`notation: "vitepress"` enables VitePress-compatible fence metadata and inline
+comments. `notation: "both"` enables both syntaxes.
+
+Use a standalone escape comment when the next line should render literally even
+if it contains annotation-looking text:
+
+````md
+```ts
+// [!code escape]
+console.warn("literal"); // [!code warning]
+console.warn("annotated"); // [!code warning]
+```
+````
+
+The escape directive is removed from the rendered block, and only the next line
+is escaped.
+
+See [Code Annotations](./examples/code-annotations.md) for the complete syntax.
+
+## Built-in Embeds
+
+`embeds.github` and `embeds.openGraph` are enabled by default because they render
+static HTML at transform time. Non-standard or runtime-heavy embeds are opt-in.
+
+| Embed                         | Default | Authoring form                     | Runtime behavior                          |
+| ----------------------------- | ------- | ---------------------------------- | ----------------------------------------- |
+| GitHub repository/source card | `true`  | `<GitHub repo="owner/name" />`     | Static HTML generated during transform.   |
+| Open Graph link card          | `true`  | `<OgCard url="https://..." />`     | Static HTML generated during transform.   |
+| Package manager tabs          | `false` | `<pm>npm install package</pm>`     | Static HTML; sync mode adds small JS.     |
+| Spotify                       | `false` | `<Spotify url="https://..." />`    | Iframe embed.                             |
+| StackBlitz                    | `false` | `<StackBlitz url="https://..." />` | Iframe embed.                             |
+| Twitter/X                     | `false` | `<Tweet />` or `<XPost />`         | Static privacy-conscious card.            |
+| Bluesky                       | `false` | `<Bluesky />`                      | Static card.                              |
+| WebContainer                  | `false` | `<WebContainer />`                 | Lazy placeholder with isolation metadata. |
+
+Disable every built-in embed with `embeds: false`, or configure only the embeds
+your site needs:
+
+```ts
+oxContent({
+  embeds: {
+    github: {
+      token: process.env.GITHUB_TOKEN,
+      maxSourceLines: 120,
+    },
+    openGraph: {
+      timeout: 5000,
+    },
+    pm: true,
+  },
+});
+```
+
+See [Package Manager Tabs](./examples/package-manager-tabs.md) for a rendered
+tab example, and see the [Vite Plugin embeds reference](./packages/vite-plugin-ox-content.md#embeds)
+for GitHub and Open Graph authoring forms.
+
+## Code Quality Hooks
+
+Documentation-specific checks are also opt-in:
+
+| Option               | Default | Use when...                                                    |
+| -------------------- | ------- | -------------------------------------------------------------- |
+| `codeBlockLint`      | `false` | Code fences should require languages or reject trailing space. |
+| `codeBlockTypecheck` | `false` | TypeScript or TSX fences should be checked with `tsgo`.        |
+| `docsTests`          | `false` | Runnable fences should be extracted for a Vitest harness.      |
+| `sanitize`           | `false` | Raw or third-party HTML should be cleaned before rendering.    |
+| `codeImports`        | `false` | Markdown should import checked source snippets from files.     |
+
+The feature pages under [Examples](./examples/index.md) show each hook in
+isolation, so a site can enable only the pieces it actually uses.

--- a/docs/content/deployment.md
+++ b/docs/content/deployment.md
@@ -1,0 +1,75 @@
+---
+title: Docs Deployment
+description: Deploy the Ox Content documentation site to Void.
+---
+
+# Docs Deployment
+
+The repository exposes a dedicated workspace task for deploying the docs site to
+Void:
+
+```bash
+vp run deploy#docs
+```
+
+The task builds from the local repository before deploying, so the published
+site uses the current Rust crates and local npm workspace packages rather than
+whatever is already published to the registry.
+
+## What the Task Runs
+
+`vp run deploy#docs` executes `scripts/deploy-docs-to-void.mjs`, which runs:
+
+1. `cargo build --workspace`
+2. `napi build --release` in `crates/ox_content_napi`
+3. `vp pack` in `npm/ox-content-islands`
+4. `vp pack` in `npm/vite-plugin-ox-content`
+5. `vp build` in `docs`
+6. `vpx void@0.9.0 deploy`
+
+The deploy command defaults to the Void project and docs output directory used
+by this repository.
+
+| Setting                    | Default                       | Purpose                                     |
+| -------------------------- | ----------------------------- | ------------------------------------------- |
+| `VOID_PROJECT`             | `ox-content`                  | Passed to `void deploy --project`.          |
+| `OX_CONTENT_DOCS_BASE`     | `/`                           | Vite base path for the Void-hosted site.    |
+| `OX_CONTENT_DOCS_SITE_URL` | `https://ox-content.void.app` | Absolute site URL used for metadata and OG. |
+| Deploy directory           | `docs/dist/docs`              | Passed to `void deploy --dir`.              |
+
+Void hosts `https://ox-content.void.app` at the root path, so the deploy task
+sets the docs base to `/` by default. A normal production docs build without
+that override still uses the GitHub Pages base configured in `docs/vite.config.ts`.
+
+## Overrides
+
+Use environment variables for common deployment targets:
+
+```bash
+VOID_PROJECT=ox-content-preview vp run deploy#docs
+```
+
+```bash
+OX_CONTENT_DOCS_BASE=/ \
+OX_CONTENT_DOCS_SITE_URL=https://ox-content.void.app \
+vp run deploy#docs
+```
+
+Extra arguments are forwarded to `void deploy`, so the project or directory can
+also be overridden from the command line:
+
+```bash
+vp run deploy#docs -- --project ox-content-preview --dir docs/dist/docs
+```
+
+## CSS and Asset Paths
+
+If the deployed site loads HTML but misses CSS or client assets, check the base
+path first. Void deployments should build with:
+
+```bash
+OX_CONTENT_DOCS_BASE=/ vp run deploy#docs
+```
+
+The generated HTML should reference root-relative assets such as
+`/assets/index.css`, not `/ox-content/assets/index.css`.

--- a/docs/content/development-setup.md
+++ b/docs/content/development-setup.md
@@ -69,6 +69,7 @@ vp run ready
 # Documentation
 vp run doc:cargo
 vp run doc:cargo-open
+vp run deploy#docs
 
 # Docs and examples
 vp run dev
@@ -158,6 +159,20 @@ vp run playground
 ```
 
 Then open [http://127.0.0.1:4173](http://127.0.0.1:4173) for the docs site and [http://127.0.0.1:5173](http://127.0.0.1:5173) for the playground.
+
+## Deploying the Docs to Void
+
+Deploy the documentation site to Void with:
+
+```bash
+vp run deploy#docs
+```
+
+The task builds the Rust workspace and local npm packages before running
+`void deploy`, and it uses a root base path so assets resolve correctly on
+`https://ox-content.void.app`.
+
+See [Docs Deployment](./deployment.md) for environment variables and overrides.
 
 ## Running Benchmarks
 

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -34,6 +34,7 @@ This is the default entry point for most users.
 
 The Vite plugin gives you the full Ox Content pipeline: Markdown transforms, static site generation, theming, search, OG images, and generated API docs.
 It already brings in the native runtime it needs, so you do not need to install `@ox-content/napi` separately for the Vite-based path.
+Common Markdown behavior is enabled by default, while non-standard authoring features such as emoji shortcodes, code annotations, package-manager tabs, and social embeds are opt-in. See [Built-in Features](./built-in-features.md) when choosing those options.
 
 ### Install
 
@@ -99,6 +100,7 @@ vp install @ox-content/vite-plugin-svelte svelte @sveltejs/vite-plugin-svelte
 Read more:
 
 - [@ox-content/vite-plugin](./packages/vite-plugin-ox-content.md)
+- [Built-in Features](./built-in-features.md)
 - [Vue integration](./packages/vite-plugin-ox-content-vue.md)
 - [React integration](./packages/vite-plugin-ox-content-react.md)
 - [Svelte integration](./packages/vite-plugin-ox-content-svelte.md)

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -80,6 +80,7 @@ Under the hood, Ox Content is not only a docs theme. It also exposes the Markdow
 ## User Guide
 
 - [Getting Started](./getting-started.md) - Installation and first steps
+- [Built-in Features](./built-in-features.md) - Defaults, opt-in features, embeds, emoji shortcodes, and code annotations
 - [Theming](./theming.md) - Customize your documentation site
 - [Examples](./examples/index.md) - Integration, source docs, OG image, and SSG examples
 
@@ -91,6 +92,7 @@ Under the hood, Ox Content is not only a docs theme. It also exposes the Markdow
 - [unplugin mdast Bridge Example](./examples/unplugin-mdast-bridge.md) - Native parser plus unified-compatible mdast plugins
 - [unplugin markdown-it Token Bridge](./examples/unplugin-markdown-it-token-bridge.md) - `markdown-it` plugins plus downstream unified token access
 - [Development Setup](./development-setup.md) - Build ox-content itself and work on the repo
+- [Docs Deployment](./deployment.md) - Deploy the documentation site to Void with `vp run deploy#docs`
 - [Editor Extension Roadmap](./editor-extension-roadmap.md) - VS Code and Neovim plan, PR-by-PR
 
 ## Reference

--- a/docs/content/packages/vite-plugin-ox-content.md
+++ b/docs/content/packages/vite-plugin-ox-content.md
@@ -64,6 +64,9 @@ ox-content's `layout: entry`.
 
 ## Options
 
+For a consolidated default table, including which non-standard features are
+opt-in, see [Built-in Features](../built-in-features.md).
+
 ### srcDir
 
 - Type: `string`
@@ -216,6 +219,8 @@ Generate table of contents.
 
 Built-in static embeds are rendered at transform time, with no client-side JavaScript.
 Non-standard embeds are opt-in.
+See [Built-in Features](../built-in-features.md#built-in-embeds) for the full
+default table.
 
 ```md
 <GitHub repo="ubugeeei-prod/ox-content" />

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -65,6 +65,7 @@ export default defineConfig(({ mode }) => {
                 text: "Guide",
                 items: [
                   { text: "Getting Started", link: "/getting-started.md" },
+                  { text: "Built-in Features", link: "/built-in-features.md" },
                   { text: "Theming", link: "/theming.md" },
                   { text: "MDX & Components", link: "/mdx.md" },
                   { text: "API Docs from JSDoc", link: "/jsdoc.md" },
@@ -84,6 +85,7 @@ export default defineConfig(({ mode }) => {
                     link: "/examples/unplugin-markdown-it-token-bridge.md",
                   },
                   { text: "Development Setup", link: "/development-setup.md" },
+                  { text: "Docs Deployment", link: "/deployment.md" },
                   {
                     text: "Editor Extension Roadmap",
                     link: "/editor-extension-roadmap.md",


### PR DESCRIPTION
## Summary

- Add a Built-in Features guide that separates default behavior from opt-in Markdown, embed, emoji, code annotation, and code quality features.
- Add a Docs Deployment guide for `vp run deploy#docs`, including Void defaults, environment overrides, forwarded CLI args, and root asset path expectations.
- Link the new guides from the docs home page, getting started page, development setup, Vite plugin reference, and docs sidebar.

## Validation

- `vp run fmt:check`
- `vp run check:ts`
- `vp run build:docs`
- `vp run actrun` attempted locally; most jobs passed, but local runner differences failed `build/step_1` (`cache requires with.key`), `vscode-test/step_4` (`xvfb-run: command not found` on macOS), and `dependency-policy/step_5` (`pnpm licenses` local error). GitHub CI is still the source of truth for these jobs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782809285&installation_id=136613492&pr_number=269&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F269&signature=1ca2c5ce1d02559038b7c8ff2cacab7592243c4269ec6f353bc01b841c00612c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->