### PR TITLE
fix(docs): drop source links for external dependency symbols

### DIFF
--- a/crates/ox_content_docs/src/data.rs
+++ b/crates/ox_content_docs/src/data.rs
@@ -111,9 +111,14 @@ fn entry_to_json(entry: &ApiDocEntry) -> Value {
         value.insert("private".to_string(), json!(true));
     }
 
-    value.insert("file".to_string(), json!(normalize_doc_file_path(&entry.file)));
-    value.insert("line".to_string(), json!(entry.line));
-    value.insert("endLine".to_string(), json!(entry.end_line));
+    // An empty `file` means the symbol has no source in the consumer's repo
+    // (e.g. re-exported from an external package): omit the source location
+    // entirely rather than leak an absolute local path.
+    if !entry.file.is_empty() {
+        value.insert("file".to_string(), json!(normalize_doc_file_path(&entry.file)));
+        value.insert("line".to_string(), json!(entry.line));
+        value.insert("endLine".to_string(), json!(entry.end_line));
+    }
     if let Some(signature) = &entry.signature {
         value.insert("signature".to_string(), json!(signature));
     }
@@ -259,5 +264,40 @@ mod tests {
         let value: Value = serde_json::from_str(&json).unwrap();
 
         assert_eq!(value["modules"][0]["description"], "The entry for gunshi context.");
+    }
+
+    #[test]
+    fn entry_without_file_omits_source_location() {
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "/repo/src/combinators.ts".to_string(),
+            entries: vec![ApiDocEntry {
+                name: "Combinator".to_string(),
+                kind: "type".to_string(),
+                description: "A combinator.".to_string(),
+                params: vec![],
+                returns: None,
+                examples: vec![],
+                tags: vec![],
+                private: false,
+                // External-package source: no in-repo location.
+                file: String::new(),
+                line: 15,
+                end_line: 23,
+                signature: Some("type Combinator = unknown".to_string()),
+                members: vec![],
+            }],
+        }];
+
+        let json = generate_docs_data_json(&docs, "2026-05-31T00:00:00.000Z").unwrap();
+        let value: Value = serde_json::from_str(&json).unwrap();
+        let entry = &value["modules"][0]["entries"][0];
+
+        assert_eq!(entry["name"], "Combinator");
+        assert_eq!(entry["signature"], "type Combinator = unknown");
+        // No source location keys, so no absolute local path can leak.
+        assert!(entry.get("file").is_none());
+        assert!(entry.get("line").is_none());
+        assert!(entry.get("endLine").is_none());
     }
 }

--- a/crates/ox_content_docs/src/graph.rs
+++ b/crates/ox_content_docs/src/graph.rs
@@ -339,6 +339,14 @@ pub fn extract_docs_from_entry_points(
                     }
                     let mut entry = entry.clone();
                     entry.name.clone_from(&export.name);
+                    if is_dependency_source(module) {
+                        // Source lives in an installed dependency (under a
+                        // node_modules directory): drop the absolute path so we emit
+                        // no "View source" link and never leak a local absolute path
+                        // (matches TypeDoc's inlined external symbols). Workspace
+                        // sources resolved inside the repo keep their path.
+                        entry.file = String::new();
+                    }
                     entries.push(entry);
                 }
                 matched
@@ -408,6 +416,15 @@ pub fn extract_docs_from_entry_points(
     }
 
     Ok(modules)
+}
+
+/// Returns true when a resolved module path is an installed dependency, i.e. it
+/// lives under a `node_modules` directory. Such sources are not in the consumer's
+/// repository, so generated docs must not link to them or leak their absolute
+/// local path. Workspace sources resolved inside the repo return false and keep
+/// their source location.
+fn is_dependency_source(module: &Path) -> bool {
+    module.components().any(|component| component.as_os_str() == "node_modules")
 }
 
 fn normalized_entries_for_module<'a>(
@@ -1524,7 +1541,9 @@ export { a };
 
         assert_eq!(docs[0].entries[0].name, "parseArgs");
         assert_eq!(docs[0].entries[0].description, "Parse args.");
-        assert!(docs[0].entries[0].file.ends_with("parser-hash.d.ts"));
+        // The alias resolved to a declaration under node_modules, so its absolute
+        // source path is dropped (no "View source" link, no local-path leak).
+        assert!(docs[0].entries[0].file.is_empty());
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -1871,6 +1871,40 @@ mod tests {
     }
 
     #[test]
+    fn entries_without_file_omit_source_link() {
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "mod".to_string(),
+            entries: vec![
+                test_entry("localSym", "function", "packages/x/src/a.ts", "Local symbol."),
+                // Empty file = external-package source: no in-repo source location.
+                test_entry("externalSym", "function", "", "External symbol."),
+            ],
+        }];
+
+        for render_style in [MarkdownRenderStyle::Html, MarkdownRenderStyle::Markdown] {
+            let markdown = generate_markdown(
+                &docs,
+                &MarkdownDocsOptions {
+                    github_url: Some("https://github.com/o/r".to_string()),
+                    path_strategy: MarkdownPathStrategy::TypeDoc,
+                    render_style,
+                    ..MarkdownDocsOptions::default()
+                },
+            );
+
+            let local_page = markdown.get("mod/functions/localSym.md").unwrap();
+            let external_page = markdown.get("mod/functions/externalSym.md").unwrap();
+
+            // The local symbol links to its in-repo source.
+            assert!(local_page.contains("https://github.com/o/r/blob/main/packages/x/src/a.ts"));
+            // The external symbol emits no source link and leaks no path.
+            assert!(!external_page.contains("blob/main"));
+            assert!(!external_page.contains("View source"));
+        }
+    }
+
+    #[test]
     fn typedoc_path_strategy_uses_clean_base_path_and_module_scope() {
         let docs = vec![
             ApiDocModule {

--- a/crates/ox_content_docs/src/markdown/markdown_html.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_html.rs
@@ -747,9 +747,12 @@ fn render_entry_body_html(
     link_context: Option<&MarkdownLinkContext<'_>>,
 ) -> String {
     let processed_description = process_doc_text(&entry.description, link_context);
-    let source_href = options.github_url.as_ref().map(|github_url| {
-        generate_source_href(&entry.file, github_url, Some(entry.line), Some(entry.end_line))
-    });
+    // Entries with an empty `file` (e.g. symbols re-exported from an external
+    // package) have no source in the consumer's repo, so emit no source link.
+    let source_href =
+        options.github_url.as_ref().filter(|_| !entry.file.is_empty()).map(|github_url| {
+            generate_source_href(&entry.file, github_url, Some(entry.line), Some(entry.end_line))
+        });
     let mut body = String::new();
 
     if !processed_description.is_empty() {

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -65,10 +65,18 @@ pub(super) fn render_entry_body_pure(
         push_fmt(&mut out, format_args!("**Signature**\n\n```ts\n{}\n```\n\n", signature.trim()));
     }
 
+    // Entries with an empty `file` (e.g. symbols re-exported from an external
+    // package) have no source in the consumer's repo, so emit no source link.
     if let Some(github_url) = &options.github_url {
-        let href =
-            generate_source_href(&entry.file, github_url, Some(entry.line), Some(entry.end_line));
-        push_fmt(&mut out, format_args!("[View source]({href})\n\n"));
+        if !entry.file.is_empty() {
+            let href = generate_source_href(
+                &entry.file,
+                github_url,
+                Some(entry.line),
+                Some(entry.end_line),
+            );
+            push_fmt(&mut out, format_args!("[View source]({href})\n\n"));
+        }
     }
 
     if !entry.members.is_empty() {


### PR DESCRIPTION
## Background

When `externalDocs: true` resolves external-package re-exports into documentation entries, `@ox-content/napi` builds each symbol's "View source" link by concatenating the configured `githubUrl` with the symbol's `file`: `${githubUrl}/blob/main/${file}`.

For **local** symbols this is correct, `file` is repo-relative (e.g. `packages/gunshi/src/context.ts`). 

But for symbols re-exported from an installed dependency, `file` is the **absolute filesystem path** of the resolved `.d.ts` under `node_modules` (only the leading `/` stripped).

Concatenating that onto `githubUrl` produces a link that:

- (1) points to a path that does not exist in the consumer's repository
- (2) leaks the generator machine's absolute local path into the output, making it non-reproducible across machines/CI. (Reported against gunshi: 40 broken `args-tokens`-sourced links

TypeDoc emits **no** source link for the same inlined external symbols.

## Sumary

Treats symbols whose source resolves into an installed dependency as having no in-repo source.

It drops their `file`, so no "View source" link is emitted and no absolute local path is leaked, matching TypeDoc. Local symbols are completely unchanged.

- Extraction (`graph.rs`): in `extract_docs_from_entry_points`, after computing the dedup key from the original path, clear `entry.file` when the resolved module lives under a `node_modules` directory (`is_dependency_source`).
- Rendering (`markdown_html.rs` / `markdown_pure.rs`): skip the "View source" / `[View source]` link when `entry.file` is empty.
- docs.json (`data.rs`): omit `file` / `line` / `endLine` when `entry.file` is empty, so no source location (and no absolute path) is serialized.

### Why detect by `node_modules`, not "external" or "outside root"

`externalPackageSources` can map an external package name to an **in-repo workspace source** (covered by the existing `external_package_source_mapping_prefers_workspace_source` test).

Those resolve inside the repo and must keep a valid source link.

So keying off `ExportSource::External` would wrongly drop them.

A project-root containment check is also unreliable (`node_modules` lives under the root, and temp-dir symlink canonicalization skews path comparison).

Detecting a `node_modules` path segment precisely targets installed dependencies while preserving workspace-source links.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782809856&installation_id=136613492&pr_number=270&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F270&signature=64e63937939b1d257b1452e6dfb9bf2c2f1a3b80cb4e94c73239c2a35f4a4cc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->