### PR TITLE
feat: add vitest docs test harness

### DIFF
--- a/docs/content/examples/vitest-docs-test.md
+++ b/docs/content/examples/vitest-docs-test.md
@@ -17,6 +17,69 @@ const blocks = await extractDocsTests(markdown, {
 });
 ```
 
+You can turn those blocks into temporary Vitest files and run them from CI:
+
+```ts
+import { runDocsTests } from "@ox-content/vite-plugin";
+
+await runDocsTests({
+  include: ["docs/content/**/*.md"],
+  vitestCommand: "vitest",
+  vitestArgs: ["run"],
+});
+```
+
+To test examples in implementation documentation comments, switch the source to
+`jsdoc`. This path uses the same ox-content source documentation extractor that
+powers generated API docs, then runs the fenced `@example` blocks through the
+Vitest harness.
+
+```ts
+import { runDocsTests } from "@ox-content/vite-plugin";
+
+await runDocsTests({
+  source: "jsdoc",
+  src: ["./src"],
+  include: ["**/*.ts"],
+  ignore: ["**/*.test.ts"],
+  vitestCommand: "vitest",
+  vitestArgs: ["run"],
+});
+```
+
+Like Cargo doctests, runnable fences are examples first: write normal example
+code and assertions inside `@example`, and the harness wraps each fence in a
+generated Vitest `test(...)`. A runnable fence is any configured JavaScript or
+TypeScript language with `test`, `runnable`, `vitest`, or `docs-test` in the
+fence metadata.
+
+````ts
+/**
+ * Adds two values.
+ *
+ * @example
+ * ```ts docs-test
+ * import { expect } from "vitest";
+ * import { add } from "@acme/math";
+ *
+ * expect(add(1, 2)).toBe(3);
+ * ```
+ */
+export function add(left: number, right: number): number {
+  return left + right;
+}
+````
+
+```ts docs-test
+import { expect } from "vitest";
+
+const result = 1 + 1;
+expect(result).toBe(2);
+```
+
+Set `executionMode: "module"` when a snippet already declares its own Vitest
+tests.
+
 ````md
 ```ts test
 import { expect, it } from "vitest";
@@ -26,5 +89,3 @@ it("works", () => {
 });
 ```
 ````
-
-Use the returned block list to generate a Vitest file in your own CI harness.

--- a/npm/vite-plugin-ox-content/src/docs-tests.test.ts
+++ b/npm/vite-plugin-ox-content/src/docs-tests.test.ts
@@ -1,0 +1,179 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vite-plus/test";
+import { collectDocsTests, runDocsTests, writeDocsTestFiles } from "./docs-tests";
+
+const srcDir = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(srcDir, "..");
+const repoRoot = path.resolve(packageRoot, "../..");
+
+describe("docs test harness", () => {
+  it("collects runnable docs fences with source metadata", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "ox-content-docs-tests-"));
+    try {
+      await writeFile(
+        path.join(cwd, "guide.md"),
+        [
+          "# Guide",
+          "",
+          "```ts docs-test",
+          "import { expect, it } from 'vitest';",
+          "it('works', () => expect(1).toBe(1));",
+          "```",
+          "",
+          "```ts",
+          "const ignored = true;",
+          "```",
+        ].join("\n"),
+      );
+
+      const blocks = await collectDocsTests({ cwd, include: ["**/*.md"] });
+
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0]).toMatchObject({
+        language: "ts",
+        meta: "docs-test",
+        relativePath: "guide.md",
+        startLine: 4,
+        endLine: 5,
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("collects runnable JSDoc example fences through docs extraction", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "ox-content-docs-tests-"));
+    try {
+      await mkdir(path.join(cwd, "src"), { recursive: true });
+      await writeFile(
+        path.join(cwd, "src/math.ts"),
+        [
+          "/**",
+          " * Adds two numbers.",
+          " *",
+          " * @example",
+          " * ```ts docs-test",
+          ' * import { expect } from "vitest";',
+          ' * import { add } from "../src/math";',
+          " *",
+          " * expect(add(1, 2)).toBe(3);",
+          " * ```",
+          " */",
+          "export function add(left: number, right: number): number {",
+          "  return left + right;",
+          "}",
+        ].join("\n"),
+      );
+
+      const blocks = await collectDocsTests({
+        cwd,
+        source: "jsdoc",
+        src: ["src"],
+        include: ["**/*.ts"],
+      });
+
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0]).toMatchObject({
+        language: "ts",
+        meta: "docs-test",
+        relativePath: "src/math.ts",
+        startLine: 12,
+        endLine: 14,
+      });
+      expect(blocks[0]?.code).toContain("expect(add(1, 2)).toBe(3);");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("writes generated Vitest files for collected docs blocks", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "ox-content-docs-tests-"));
+    try {
+      await writeFile(
+        path.join(cwd, "guide.md"),
+        [
+          "```tsx runnable",
+          "import { expect } from 'vitest';",
+          "const value = <span />;",
+          "expect(value.type).toBe('span');",
+          "```",
+        ].join("\n"),
+      );
+
+      const result = await writeDocsTestFiles({
+        cwd,
+        include: ["**/*.md"],
+        generatedDir: ".generated",
+        setupCode: "import { expect, it } from 'vitest';",
+      });
+
+      expect(result.files).toHaveLength(1);
+      expect(result.files[0].filePath.endsWith("guide.md-L2-1.test.tsx")).toBe(true);
+      const generated = await readFile(result.files[0].filePath, "utf-8");
+      expect(generated).toContain("Source: guide.md:2-4");
+      expect(generated).toContain('import { test } from "vitest";');
+      expect(generated).toContain("import { expect } from 'vitest';");
+      expect(generated).toContain('test("guide.md:2", async () => {');
+      expect(generated).toContain("  expect(value.type).toBe('span');");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("executes repository docs examples through the Vitest runner", async () => {
+    const result = await runDocsTests({
+      cwd: packageRoot,
+      include: [
+        normalizePath(path.relative(packageRoot, path.join(repoRoot, "docs/content/**/*.md"))),
+      ],
+      generatedDir: ".cache/ox-content-docs-tests",
+      importRewrites: {
+        vitest: "vite-plus/test",
+      },
+      vitestCommand: "vp",
+      vitestArgs: ["test"],
+      env: {
+        VITEST: undefined,
+        VITEST_POOL_ID: undefined,
+        VITEST_WORKER_ID: undefined,
+      },
+    });
+
+    expect(result.files.length).toBeGreaterThan(0);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("executes implementation JSDoc examples through the Vitest runner", async () => {
+    const result = await runDocsTests({
+      cwd: packageRoot,
+      source: "jsdoc",
+      src: ["src"],
+      include: ["**/docs-tests.ts"],
+      docs: {
+        internal: true,
+      },
+      generatedDir: ".cache/ox-content-source-docs-tests",
+      importRewrites: {
+        vitest: "vite-plus/test",
+      },
+      vitestCommand: "vp",
+      vitestArgs: ["test"],
+      env: {
+        VITEST: undefined,
+        VITEST_POOL_ID: undefined,
+        VITEST_WORKER_ID: undefined,
+      },
+    });
+
+    expect(result.files.length).toBeGreaterThan(0);
+    expect(result.blocks[0]?.relativePath).toBe("src/docs-tests.ts");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+function normalizePath(value: string): string {
+  return value.split(path.sep).join("/");
+}

--- a/npm/vite-plugin-ox-content/src/docs-tests.ts
+++ b/npm/vite-plugin-ox-content/src/docs-tests.ts
@@ -1,0 +1,599 @@
+import { spawn } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { glob } from "glob";
+import { extractDocsTests, type DocsTestOptions, type ExtractedCodeBlock } from "./code-blocks";
+import { extractDocs, resolveDocsOptions } from "./docs";
+import type { DocEntry, DocsOptions, ExtractedDocs, ResolvedDocsOptions } from "./types";
+
+export interface CollectedDocsTest extends ExtractedCodeBlock {
+  sourcePath: string;
+  relativePath: string;
+  index: number;
+}
+
+export type DocsTestSource = "markdown" | "jsdoc";
+
+export interface DocsTestHarnessOptions extends DocsTestOptions {
+  /**
+   * Source kind to scan for runnable examples.
+   * - `markdown` scans Markdown files for fenced code blocks.
+   * - `jsdoc` scans JSDoc/TSDoc `@example` blocks through ox-content's docs extractor.
+   * @default "markdown"
+   */
+  source?: DocsTestSource;
+
+  /**
+   * Markdown glob patterns, or source-file include globs when `source` is `jsdoc`.
+   */
+  include?: string | string[];
+
+  /**
+   * Glob patterns to skip. For `jsdoc`, this is passed to docs extraction as `exclude`.
+   */
+  ignore?: string | string[];
+
+  /**
+   * Working directory used for globs and generated test files.
+   * @default process.cwd()
+   */
+  cwd?: string;
+
+  /**
+   * Source directories to scan when `source` is `jsdoc`.
+   * @default ["./src"]
+   */
+  src?: string | string[];
+
+  /**
+   * Additional docs extraction options for `jsdoc` source mode.
+   */
+  docs?: DocsOptions;
+}
+
+export interface DocsTestFileOptions extends DocsTestHarnessOptions {
+  /**
+   * Directory for generated Vitest files.
+   * @default ".cache/ox-content-docs-tests"
+   */
+  generatedDir?: string;
+
+  /**
+   * Remove the generated directory before writing files.
+   * @default true
+   */
+  clean?: boolean;
+
+  /**
+   * Optional code prepended to every generated test file.
+   */
+  setupCode?: string;
+
+  /**
+   * How each generated file should execute the docs block.
+   * - `test` wraps the block in a generated Vitest test, similar to Cargo doctests.
+   * - `module` writes the block as-is for snippets that declare their own tests.
+   * @default "test"
+   */
+  executionMode?: "test" | "module";
+
+  /**
+   * Module used for the generated `test` import.
+   * @default "vitest"
+   */
+  testImport?: string;
+
+  /**
+   * Optional static import specifier rewrites for generated test files.
+   */
+  importRewrites?: Record<string, string>;
+}
+
+export interface WrittenDocsTestFile {
+  filePath: string;
+  sourcePath: string;
+  relativePath: string;
+  startLine: number;
+  endLine: number;
+  language: string;
+}
+
+export interface DocsTestWriteResult {
+  cwd: string;
+  generatedDir: string;
+  blocks: CollectedDocsTest[];
+  files: WrittenDocsTestFile[];
+}
+
+export interface RunDocsTestsOptions extends DocsTestFileOptions {
+  /**
+   * Vitest-compatible command to run.
+   * @default "vitest"
+   */
+  vitestCommand?: string;
+
+  /**
+   * Arguments passed before generated test file paths.
+   * @default ["run"]
+   */
+  vitestArgs?: string[];
+
+  /**
+   * Environment overrides for the Vitest child process.
+   */
+  env?: NodeJS.ProcessEnv;
+
+  /**
+   * Allow a scan that finds no runnable docs tests.
+   * @default false
+   */
+  allowEmpty?: boolean;
+}
+
+export interface DocsTestRunResult extends DocsTestWriteResult {
+  command: string;
+  args: string[];
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export class DocsTestRunError extends Error {
+  readonly result: DocsTestRunResult;
+
+  constructor(result: DocsTestRunResult) {
+    const command = [result.command, ...result.args].join(" ");
+    super(`[ox-content] Docs tests failed with exit code ${result.exitCode}: ${command}`);
+    this.name = "DocsTestRunError";
+    this.result = result;
+  }
+}
+
+export async function collectDocsTests(
+  options: DocsTestHarnessOptions,
+): Promise<CollectedDocsTest[]> {
+  const cwd = path.resolve(options.cwd ?? process.cwd());
+  if ((options.source ?? "markdown") === "jsdoc") {
+    return collectJsdocDocsTests(options, cwd);
+  }
+
+  return collectMarkdownDocsTests(options, cwd);
+}
+
+async function collectMarkdownDocsTests(
+  options: DocsTestHarnessOptions,
+  cwd: string,
+): Promise<CollectedDocsTest[]> {
+  const include = toArray(options.include);
+  const ignore = toArray(options.ignore);
+  const files = new Map<string, string>();
+
+  if (include.length === 0) {
+    throw new Error("[ox-content] Docs test include patterns are required for markdown sources.");
+  }
+
+  for (const pattern of include) {
+    const matches = await glob(pattern, {
+      absolute: true,
+      cwd,
+      ignore,
+      nodir: true,
+    });
+
+    for (const filePath of matches) {
+      const absolutePath = path.resolve(filePath);
+      files.set(absolutePath, normalizePath(path.relative(cwd, absolutePath)));
+    }
+  }
+
+  const blocks: CollectedDocsTest[] = [];
+  let index = 0;
+  for (const [sourcePath, relativePath] of [...files.entries()].sort((left, right) =>
+    left[0].localeCompare(right[0]),
+  )) {
+    const source = await fs.readFile(sourcePath, "utf-8");
+    const extracted = await extractDocsTests(source, {
+      languages: options.languages,
+      requireMeta: options.requireMeta,
+    });
+
+    for (const block of extracted) {
+      blocks.push({
+        ...block,
+        sourcePath,
+        relativePath,
+        index,
+      });
+      index += 1;
+    }
+  }
+
+  return blocks;
+}
+
+async function collectJsdocDocsTests(
+  options: DocsTestHarnessOptions,
+  cwd: string,
+): Promise<CollectedDocsTest[]> {
+  const docsOptions = resolveJsdocDocsOptions(options, cwd);
+  const docs = await extractDocs(docsOptions.src, docsOptions);
+  const blocks: CollectedDocsTest[] = [];
+  let index = 0;
+
+  for (const doc of sortDocs(docs)) {
+    for (const entry of sortEntries(doc.entries)) {
+      for (const example of entry.examples ?? []) {
+        const extracted = await extractDocsTests(example, {
+          languages: options.languages,
+          requireMeta: options.requireMeta,
+        });
+        const sourcePath = resolveEntrySourcePath(entry, doc, cwd);
+        const relativePath = relativeSourcePath(cwd, sourcePath);
+
+        for (const block of extracted) {
+          blocks.push({
+            ...block,
+            sourcePath,
+            relativePath,
+            startLine: entry.line,
+            endLine: entry.endLine,
+            index,
+          });
+          index += 1;
+        }
+      }
+    }
+  }
+
+  return blocks;
+}
+
+function resolveJsdocDocsOptions(
+  options: DocsTestHarnessOptions,
+  cwd: string,
+): ResolvedDocsOptions {
+  const docsOptions: DocsOptions = {
+    ...options.docs,
+  };
+
+  if (options.src !== undefined) {
+    docsOptions.src = toArray(options.src);
+  }
+  if (options.include !== undefined) {
+    docsOptions.include = toArray(options.include);
+  }
+  if (options.ignore !== undefined) {
+    docsOptions.exclude = toArray(options.ignore);
+  }
+
+  const resolved = resolveDocsOptions(docsOptions);
+  return {
+    ...resolved,
+    src: resolved.src.map((sourceDir) => path.resolve(cwd, sourceDir)),
+    entryPoints: resolved.entryPoints?.map((entryPoint) => ({
+      ...entryPoint,
+      path: path.resolve(cwd, entryPoint.path),
+    })),
+  };
+}
+
+function sortDocs(docs: ExtractedDocs[]): ExtractedDocs[] {
+  return [...docs].sort((left, right) => left.file.localeCompare(right.file));
+}
+
+function sortEntries(entries: DocEntry[]): DocEntry[] {
+  return [...entries].sort((left, right) => {
+    const byFile = left.file.localeCompare(right.file);
+    if (byFile !== 0) return byFile;
+    const byLine = left.line - right.line;
+    if (byLine !== 0) return byLine;
+    return left.name.localeCompare(right.name);
+  });
+}
+
+function resolveEntrySourcePath(entry: DocEntry, doc: ExtractedDocs, cwd: string): string {
+  const sourcePath = entry.file || doc.file;
+  return path.isAbsolute(sourcePath) ? path.resolve(sourcePath) : path.resolve(cwd, sourcePath);
+}
+
+function relativeSourcePath(cwd: string, sourcePath: string): string {
+  const relativePath = path.relative(cwd, sourcePath);
+  if (!relativePath.startsWith("..") && !path.isAbsolute(relativePath)) {
+    return normalizePath(relativePath);
+  }
+  return normalizePath(sourcePath);
+}
+
+export async function writeDocsTestFiles(
+  options: DocsTestFileOptions,
+): Promise<DocsTestWriteResult> {
+  const cwd = path.resolve(options.cwd ?? process.cwd());
+  const generatedDir = path.resolve(cwd, options.generatedDir ?? ".cache/ox-content-docs-tests");
+  const clean = options.clean ?? true;
+  const blocks = await collectDocsTests({ ...options, cwd });
+
+  if (clean) {
+    await fs.rm(generatedDir, { recursive: true, force: true });
+  }
+  await fs.mkdir(generatedDir, { recursive: true });
+
+  const files = await Promise.all(
+    blocks.map(async (block) => {
+      const filePath = path.join(generatedDir, docsTestFileName(block));
+      await fs.writeFile(filePath, renderDocsTestFile(block, options), "utf-8");
+      return {
+        filePath,
+        sourcePath: block.sourcePath,
+        relativePath: block.relativePath,
+        startLine: block.startLine,
+        endLine: block.endLine,
+        language: block.language,
+      };
+    }),
+  );
+
+  return {
+    cwd,
+    generatedDir,
+    blocks,
+    files,
+  };
+}
+
+export async function runDocsTests(options: RunDocsTestsOptions): Promise<DocsTestRunResult> {
+  const writeResult = await writeDocsTestFiles(options);
+  const command = options.vitestCommand ?? "vitest";
+  const leadingArgs = options.vitestArgs ?? ["run"];
+  const fileArgs = writeResult.files.map((file) => file.filePath);
+  const args = [...leadingArgs, ...fileArgs];
+
+  if (fileArgs.length === 0) {
+    if (options.allowEmpty) {
+      return {
+        ...writeResult,
+        command,
+        args,
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+      };
+    }
+    throw new Error("[ox-content] No runnable docs test blocks were found.");
+  }
+
+  const result = await runCommand(command, args, {
+    cwd: writeResult.cwd,
+    env: mergeEnv(options.env),
+  });
+  const runResult = {
+    ...writeResult,
+    command,
+    args,
+    ...result,
+  };
+
+  if (runResult.exitCode !== 0) {
+    throw new DocsTestRunError(runResult);
+  }
+
+  return runResult;
+}
+
+function renderDocsTestFile(block: CollectedDocsTest, options: DocsTestFileOptions): string {
+  const parts = [
+    "// Generated by @ox-content/vite-plugin docs test harness.",
+    `// Source: ${block.relativePath}:${block.startLine}-${block.endLine}`,
+    "",
+  ];
+  const setupCode = options.setupCode?.trimEnd();
+  const code = rewriteImports(block.code.trimEnd(), options.importRewrites);
+  if (setupCode) {
+    parts.push(setupCode, "");
+  }
+  if ((options.executionMode ?? "test") === "module") {
+    parts.push(code, "");
+    return parts.join("\n");
+  }
+
+  const { imports, body } = partitionImports(code);
+  parts.push(
+    `import { test } from ${JSON.stringify(
+      rewriteSpecifier(options.testImport ?? "vitest", options.importRewrites),
+    )};`,
+  );
+  if (imports.length > 0) {
+    parts.push(...imports);
+  }
+  parts.push(
+    "",
+    `test(${JSON.stringify(`${block.relativePath}:${block.startLine}`)}, async () => {`,
+  );
+  if (body.trim().length > 0) {
+    parts.push(indentCode(body.trimEnd()));
+  }
+  parts.push("});", "");
+  return parts.join("\n");
+}
+
+function partitionImports(source: string): { imports: string[]; body: string } {
+  const imports: string[] = [];
+  const body: string[] = [];
+  const lines = source.split(/\r?\n/);
+  let currentImport: string[] | undefined;
+
+  for (const line of lines) {
+    if (currentImport) {
+      currentImport.push(line);
+      if (endsImportDeclaration(line)) {
+        imports.push(currentImport.join("\n"));
+        currentImport = undefined;
+      }
+      continue;
+    }
+
+    if (startsStaticImport(line)) {
+      if (endsImportDeclaration(line)) {
+        imports.push(line);
+      } else {
+        currentImport = [line];
+      }
+      continue;
+    }
+
+    body.push(line);
+  }
+
+  if (currentImport) {
+    body.push(...currentImport);
+  }
+
+  return { imports, body: body.join("\n") };
+}
+
+function startsStaticImport(line: string): boolean {
+  const trimmed = line.trimStart();
+  return trimmed.startsWith("import ") && !trimmed.startsWith("import(");
+}
+
+function endsImportDeclaration(line: string): boolean {
+  const trimmed = line.trim();
+  return (
+    trimmed.endsWith(";") ||
+    /^import\s+["'][^"']+["']$/.test(trimmed) ||
+    /\sfrom\s+["'][^"']+["']$/.test(trimmed)
+  );
+}
+
+function indentCode(source: string): string {
+  return source
+    .split("\n")
+    .map((line) => (line.length > 0 ? `  ${line}` : line))
+    .join("\n");
+}
+
+function rewriteImports(source: string, rewrites: Record<string, string> | undefined): string {
+  if (!rewrites) {
+    return source;
+  }
+
+  let result = source;
+  for (const [from, to] of Object.entries(rewrites)) {
+    const escaped = escapeRegExp(from);
+    result = result
+      .replace(new RegExp(`(from\\s+["'])${escaped}(["'])`, "g"), `$1${to}$2`)
+      .replace(new RegExp(`(import\\s+["'])${escaped}(["'])`, "g"), `$1${to}$2`)
+      .replace(new RegExp(`(import\\(\\s*["'])${escaped}(["']\\s*\\))`, "g"), `$1${to}$2`);
+  }
+  return result;
+}
+
+/**
+ * Applies the same import rewrite table to harness-owned imports.
+ *
+ * @internal
+ * @example
+ * ```ts docs-test
+ * import { expect } from "vitest";
+ * import { extractDocsTests } from "../../src/code-blocks";
+ *
+ * const markdown = [
+ *   "```ts docs-test",
+ *   "expect(1 + 1).toBe(2);",
+ *   "```",
+ * ].join("\n");
+ *
+ * const blocks = await extractDocsTests(markdown);
+ *
+ * expect(blocks).toHaveLength(1);
+ * expect(blocks[0]?.code).toContain("1 + 1");
+ * ```
+ */
+function rewriteSpecifier(specifier: string, rewrites: Record<string, string> | undefined): string {
+  return rewrites?.[specifier] ?? specifier;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function docsTestFileName(block: CollectedDocsTest): string {
+  const baseName =
+    block.relativePath
+      .replace(/^\.\//, "")
+      .replace(/[^A-Za-z0-9._-]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "docs-test";
+  return `${baseName}-L${block.startLine}-${block.index + 1}.test.${extensionForLanguage(
+    block.language,
+  )}`;
+}
+
+function extensionForLanguage(language: string): string {
+  switch (language.toLowerCase()) {
+    case "jsx":
+      return "jsx";
+    case "tsx":
+      return "tsx";
+    case "mjs":
+      return "mjs";
+    case "mts":
+      return "mts";
+    case "js":
+      return "js";
+    default:
+      return "ts";
+  }
+}
+
+function toArray(value: string | string[] | undefined): string[] {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function normalizePath(value: string): string {
+  return value.split(path.sep).join("/");
+}
+
+function mergeEnv(overrides: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const [key, value] of Object.entries(overrides ?? {})) {
+    if (value === undefined) {
+      delete env[key];
+    } else {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+function runCommand(
+  command: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+
+    if (child.stdout) {
+      child.stdout.setEncoding("utf-8");
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk;
+      });
+    }
+    if (child.stderr) {
+      child.stderr.setEncoding("utf-8");
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk;
+      });
+    }
+    child.on("error", reject);
+    child.on("close", (exitCode) => {
+      resolve({ exitCode: exitCode ?? 1, stdout, stderr });
+    });
+  });
+}

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -725,6 +725,20 @@ export {
   type ExtractedCodeBlock,
   type TypecheckCodeBlockOptions,
 } from "./code-blocks";
+export {
+  collectDocsTests,
+  DocsTestRunError,
+  runDocsTests,
+  writeDocsTestFiles,
+  type CollectedDocsTest,
+  type DocsTestFileOptions,
+  type DocsTestHarnessOptions,
+  type DocsTestRunResult,
+  type DocsTestSource,
+  type DocsTestWriteResult,
+  type RunDocsTestsOptions,
+  type WrittenDocsTestFile,
+} from "./docs-tests";
 export { extractDocs, generateMarkdown, writeDocs, resolveDocsOptions } from "./docs";
 export { lintMarkdown, lintMarkdownAsync } from "./lint";
 export { lintMarkdownFile, lintMarkdownFiles, shouldLintMarkdownFile } from "./lint-files";

--- a/npm/vite-plugin-ox-content/src/public-exports.test.ts
+++ b/npm/vite-plugin-ox-content/src/public-exports.test.ts
@@ -6,9 +6,12 @@ describe("public export surface", () => {
     const guardedExports = [
       "DEFAULT_HTML_TEMPLATE",
       "DEFAULT_MARKDOWN_EXTENSIONS",
+      "DocsTestRunError",
       "buildSearchIndex",
       "buildSsg",
+      "collectDocsTests",
       "extractDocs",
+      "extractDocsTests",
       "generateMarkdown",
       "isMarkdownFilePath",
       "oxContent",
@@ -17,8 +20,10 @@ describe("public export surface", () => {
       "resolveOgImageOptions",
       "resolveSearchOptions",
       "resolveSsgOptions",
+      "runDocsTests",
       "transformMarkdown",
       "writeDocs",
+      "writeDocsTestFiles",
       "writeSearchIndex",
     ].sort();
 


### PR DESCRIPTION
## Summary

- add a docs-as-tests harness that collects opt-in fenced examples, wraps each block in a generated Vitest `test(...)` by default, and runs a configurable Vitest-compatible command
- support `source: "jsdoc"` so implementation JSDoc/TSDoc `@example` blocks are collected through ox-content's existing source docs extractor
- keep the default execution model close to Cargo doctests while preserving `executionMode: "module"` for snippets that declare their own tests
- export the harness utilities from @ox-content/vite-plugin and document both Markdown and implementation-comment flows

Closes #256

## Validation

- `vp exec --filter @ox-content/vite-plugin -- vp test src/docs-tests.test.ts src/public-exports.test.ts src/code-blocks.test.ts`
- `vp exec --filter @ox-content/vite-plugin -- tsgo --noEmit`
- `vp fmt --check npm/vite-plugin-ox-content/src/docs-tests.ts npm/vite-plugin-ox-content/src/docs-tests.test.ts npm/vite-plugin-ox-content/src/index.ts docs/content/examples/vitest-docs-test.md`
- `vp run test:ts-unit`
- `vp run --filter @ox-content/vite-plugin build`
- `vp run check:ts`
- `vp run --filter ./docs build`
- `actrun workflow run .github/workflows/ci.yml --trust --local --include-dirty --job typecheck`
- `actrun workflow run .github/workflows/ci.yml --trust --local --include-dirty --job test`
- `git diff --check`