### PR TITLE
feat(docs): add opt-in type parameter docs

### DIFF
--- a/crates/ox_content_docs/src/data.rs
+++ b/crates/ox_content_docs/src/data.rs
@@ -1,6 +1,8 @@
 use serde_json::{json, Map, Value};
 
-use crate::model::{ApiDocEntry, ApiDocMember, ApiDocModule, ApiParamDoc, ApiReturnDoc};
+use crate::model::{
+    ApiDocEntry, ApiDocMember, ApiDocModule, ApiParamDoc, ApiReturnDoc, ApiTypeParamDoc,
+};
 
 const DOC_KIND_ORDER: [&str; 7] =
     ["function", "class", "interface", "type", "enum", "variable", "module"];
@@ -81,6 +83,12 @@ fn entry_to_json(entry: &ApiDocEntry) -> Value {
     value.insert("kind".to_string(), json!(entry.kind));
     value.insert("description".to_string(), json!(entry.description));
 
+    if !entry.type_parameters.is_empty() {
+        value.insert(
+            "typeParameters".to_string(),
+            Value::Array(entry.type_parameters.iter().map(type_param_to_json).collect()),
+        );
+    }
     if !entry.params.is_empty() {
         value.insert(
             "params".to_string(),
@@ -193,6 +201,21 @@ fn return_to_json(return_doc: &ApiReturnDoc) -> Value {
     })
 }
 
+fn type_param_to_json(type_param: &ApiTypeParamDoc) -> Value {
+    let mut value = Map::new();
+    value.insert("name".to_string(), json!(type_param.name));
+    if let Some(constraint) = &type_param.constraint {
+        value.insert("constraint".to_string(), json!(constraint));
+    }
+    if let Some(default) = &type_param.default {
+        value.insert("default".to_string(), json!(default));
+    }
+    if !type_param.description.is_empty() {
+        value.insert("description".to_string(), json!(type_param.description));
+    }
+    Value::Object(value)
+}
+
 fn normalize_doc_file_path(file_path: &str) -> String {
     let normalized = file_path.replace('\\', "/");
     for prefix in ["npm/", "packages/", "crates/", "src/"] {
@@ -236,6 +259,7 @@ mod tests {
                 end_line: 10,
                 signature: Some("export function clamp(value: number): number".to_string()),
                 members: vec![],
+                type_parameters: vec![],
             }],
         }];
 
@@ -286,6 +310,7 @@ mod tests {
                 end_line: 23,
                 signature: Some("type Combinator = unknown".to_string()),
                 members: vec![],
+                type_parameters: vec![],
             }],
         }];
 
@@ -299,5 +324,53 @@ mod tests {
         assert!(entry.get("file").is_none());
         assert!(entry.get("line").is_none());
         assert!(entry.get("endLine").is_none());
+    }
+
+    #[test]
+    fn entry_type_parameters_serialize_to_json() {
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "/repo/src/make.ts".to_string(),
+            entries: vec![ApiDocEntry {
+                name: "make".to_string(),
+                kind: "function".to_string(),
+                description: "Make.".to_string(),
+                params: vec![],
+                returns: None,
+                examples: vec![],
+                tags: vec![],
+                private: false,
+                file: "/repo/src/make.ts".to_string(),
+                line: 1,
+                end_line: 1,
+                signature: None,
+                members: vec![],
+                type_parameters: vec![
+                    ApiTypeParamDoc {
+                        name: "G".to_string(),
+                        constraint: Some("Base".to_string()),
+                        default: Some("Default".to_string()),
+                        description: String::new(),
+                    },
+                    ApiTypeParamDoc {
+                        name: "T".to_string(),
+                        constraint: None,
+                        default: None,
+                        description: "Value.".to_string(),
+                    },
+                ],
+            }],
+        }];
+
+        let json = generate_docs_data_json(&docs, "2026-05-31T00:00:00.000Z").unwrap();
+        let value: Value = serde_json::from_str(&json).unwrap();
+        let type_params = &value["modules"][0]["entries"][0]["typeParameters"];
+
+        assert_eq!(type_params[0]["name"], "G");
+        assert_eq!(type_params[0]["constraint"], "Base");
+        assert_eq!(type_params[0]["default"], "Default");
+        assert!(type_params[0].get("description").is_none());
+        assert_eq!(type_params[1]["name"], "T");
+        assert_eq!(type_params[1]["description"], "Value.");
     }
 }

--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -78,6 +78,9 @@ pub struct DocItem {
     pub children: Vec<DocItem>,
     /// JSDoc tags.
     pub tags: Vec<DocTag>,
+    /// Declaration type parameters (`<T extends C = D>`), in declaration order.
+    #[serde(default)]
+    pub type_parameters: Vec<TypeParamDoc>,
 }
 
 /// Parameter documentation.
@@ -93,6 +96,19 @@ pub struct ParamDoc {
     pub default_value: Option<String>,
     /// Description from JSDoc @param tag.
     pub description: Option<String>,
+}
+
+/// Type parameter documentation (`<T extends C = D>`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TypeParamDoc {
+    /// Type parameter name (e.g. `T`).
+    pub name: String,
+    /// Constraint after `extends`, when present.
+    pub constraint: Option<String>,
+    /// Default type after `=`, when present.
+    pub default: Option<String>,
+    /// Description merged from a `@typeParam` / `@template` tag (TSDoc).
+    pub description: String,
 }
 
 /// JSDoc tag.
@@ -453,6 +469,7 @@ impl<'a> DocVisitor<'a> {
             return_type: None,
             children: Vec::new(),
             tags,
+            type_parameters: Vec::new(),
         })
     }
 
@@ -637,6 +654,34 @@ impl<'a> DocVisitor<'a> {
         type_params
             .map(|type_params| self.slice(type_params.span().start, type_params.span().end))
             .unwrap_or_default()
+    }
+
+    /// Extracts structured type parameters (`name`, `extends` constraint, `=`
+    /// default) from a declaration's type-parameter list. Descriptions are filled
+    /// later from `@typeParam` tags during normalization.
+    fn extract_type_parameters(
+        &self,
+        type_params: Option<&oxc_allocator::Box<'a, oxc_ast::ast::TSTypeParameterDeclaration<'a>>>,
+    ) -> Vec<TypeParamDoc> {
+        let Some(type_params) = type_params else {
+            return Vec::new();
+        };
+        type_params
+            .params
+            .iter()
+            .map(|param| TypeParamDoc {
+                name: param.name.name.to_string(),
+                constraint: param
+                    .constraint
+                    .as_ref()
+                    .map(|constraint| self.slice(constraint.span().start, constraint.span().end)),
+                default: param
+                    .default
+                    .as_ref()
+                    .map(|default| self.slice(default.span().start, default.span().end)),
+                description: String::new(),
+            })
+            .collect()
     }
 
     fn format_formal_parameters(&self, params: &oxc_ast::ast::FormalParameters<'a>) -> String {
@@ -1235,6 +1280,7 @@ impl<'a> DocVisitor<'a> {
             return_type: self.extract_return_type(func, &tags),
             children: Vec::new(),
             tags,
+            type_parameters: self.extract_type_parameters(func.type_parameters.as_ref()),
         })
     }
 
@@ -1306,6 +1352,7 @@ impl<'a> DocVisitor<'a> {
                         return_type: self.extract_return_type(&method.value, &method_tags),
                         children: Vec::new(),
                         tags: method_tags,
+                        type_parameters: Vec::new(),
                     });
                 }
                 oxc_ast::ast::ClassElement::PropertyDefinition(prop) => {
@@ -1348,6 +1395,7 @@ impl<'a> DocVisitor<'a> {
                         return_type: None,
                         children: Vec::new(),
                         tags: prop_tags,
+                        type_parameters: Vec::new(),
                     });
                 }
                 _ => {}
@@ -1372,6 +1420,7 @@ impl<'a> DocVisitor<'a> {
             return_type: None,
             children,
             tags,
+            type_parameters: self.extract_type_parameters(class.type_parameters.as_ref()),
         })
     }
 
@@ -1420,6 +1469,7 @@ impl<'a> DocVisitor<'a> {
                         return_type: None,
                         children: Vec::new(),
                         tags: prop_tags,
+                        type_parameters: Vec::new(),
                     });
                 }
                 TSSignature::TSMethodSignature(method) => {
@@ -1472,6 +1522,7 @@ impl<'a> DocVisitor<'a> {
                         ),
                         children: Vec::new(),
                         tags: method_tags,
+                        type_parameters: Vec::new(),
                     });
                 }
                 _ => {}
@@ -1613,6 +1664,7 @@ impl<'a> DocVisitor<'a> {
                         .extract_return_type_from_annotation(arrow.return_type.as_ref(), &tags),
                     children: Vec::new(),
                     tags: tags.clone(),
+                    type_parameters: self.extract_type_parameters(arrow.type_parameters.as_ref()),
                 },
                 Expression::FunctionExpression(func_expr) => DocItem {
                     name: name.clone(),
@@ -1638,6 +1690,8 @@ impl<'a> DocVisitor<'a> {
                     return_type: self.extract_return_type(func_expr, &tags),
                     children: Vec::new(),
                     tags: tags.clone(),
+                    type_parameters: self
+                        .extract_type_parameters(func_expr.type_parameters.as_ref()),
                 },
                 other => DocItem {
                     name: name.clone(),
@@ -1663,6 +1717,7 @@ impl<'a> DocVisitor<'a> {
                     return_type: None,
                     children: Vec::new(),
                     tags: tags.clone(),
+                    type_parameters: Vec::new(),
                 },
             };
             self.items.push(item);
@@ -1704,6 +1759,7 @@ impl<'a> DocVisitor<'a> {
             return_type: None,
             children,
             tags,
+            type_parameters: self.extract_type_parameters(type_alias.type_parameters.as_ref()),
         });
     }
 
@@ -1737,6 +1793,7 @@ impl<'a> DocVisitor<'a> {
             return_type: None,
             children,
             tags,
+            type_parameters: self.extract_type_parameters(interface.type_parameters.as_ref()),
         });
     }
 
@@ -1775,6 +1832,7 @@ impl<'a> DocVisitor<'a> {
             return_type: None,
             children,
             tags,
+            type_parameters: Vec::new(),
         });
     }
 
@@ -1818,6 +1876,7 @@ impl<'a> DocVisitor<'a> {
             return_type: None,
             children: Vec::new(),
             tags: member_tags,
+            type_parameters: Vec::new(),
         })
     }
 }
@@ -2066,6 +2125,27 @@ export function cli(): void {}
         assert_eq!(items[0].doc.as_deref(), Some("Main entry point for the framework."));
         assert!(items[0].tags.iter().any(|tag| tag.tag == "module"));
         assert_eq!(items[1].name, "cli");
+    }
+
+    #[test]
+    fn test_extract_function_type_parameters() {
+        let source = r"
+/** Make a thing. */
+export function make<G extends Base = Default, V>(value: V): G {
+  return value as unknown as G;
+}
+";
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "src/make.ts", SourceType::ts()).unwrap();
+        let func = items.iter().find(|item| item.name == "make").unwrap();
+
+        assert_eq!(func.type_parameters.len(), 2);
+        assert_eq!(func.type_parameters[0].name, "G");
+        assert_eq!(func.type_parameters[0].constraint.as_deref(), Some("Base"));
+        assert_eq!(func.type_parameters[0].default.as_deref(), Some("Default"));
+        assert_eq!(func.type_parameters[1].name, "V");
+        assert_eq!(func.type_parameters[1].constraint, None);
+        assert_eq!(func.type_parameters[1].default, None);
     }
 
     #[test]

--- a/crates/ox_content_docs/src/generator.rs
+++ b/crates/ox_content_docs/src/generator.rs
@@ -154,13 +154,15 @@ pub fn extract_docs_from_directories(
     exclude: &[String],
     include_private: bool,
     include_internal: bool,
+    type_parameters: bool,
 ) -> ExtractResult<Vec<ExtractedDocModule>> {
     let extractor = DocExtractor::with_visibility(include_private, include_internal);
     let mut modules = Vec::new();
 
     for src_dir in src_dirs {
         for file in collect_source_files(src_dir, include, exclude) {
-            let entries = normalize_doc_items(extractor.extract_file(Path::new(&file))?);
+            let entries =
+                normalize_doc_items(extractor.extract_file(Path::new(&file))?, type_parameters);
             if !entries.is_empty() {
                 modules.push(ExtractedDocModule { file, entries });
             }

--- a/crates/ox_content_docs/src/graph.rs
+++ b/crates/ox_content_docs/src/graph.rs
@@ -67,6 +67,10 @@ pub struct EntryPointDocsOptions {
     pub include_private: bool,
     /// Include `@internal` docs.
     pub include_internal: bool,
+    /// Opt in to TSDoc-style type-parameter docs (`@typeParam` / `<T>` table).
+    /// Off by default (JSDoc semantics).
+    #[serde(default)]
+    pub type_parameters: bool,
 }
 
 /// Resolved export graph.
@@ -328,8 +332,12 @@ pub fn extract_docs_from_entry_points(
             }
 
             let matched = {
-                let module_entries =
-                    normalized_entries_for_module(&mut docs_cache, &extractor, module)?;
+                let module_entries = normalized_entries_for_module(
+                    &mut docs_cache,
+                    &extractor,
+                    module,
+                    options.type_parameters,
+                )?;
                 let mut matched = false;
                 for entry in module_entries.iter().filter(|entry| entry.name == *original_name) {
                     matched = true;
@@ -360,6 +368,7 @@ pub fn extract_docs_from_entry_points(
                 &mut all_docs_cache,
                 &all_visibility_extractor,
                 module,
+                options.type_parameters,
             )?;
             if let Some(hidden_entry) =
                 all_module_entries.iter().find(|entry| entry.name == *original_name)
@@ -397,12 +406,16 @@ pub fn extract_docs_from_entry_points(
         // by the extractor as a `Module`-kind entry but is never an export, so it
         // is dropped from `entries` above. Pull it out of the entry file's
         // normalized items and carry it as the module description.
-        let description =
-            normalized_entries_for_module(&mut docs_cache, &extractor, &entrypoint.source_path)?
-                .iter()
-                .find(|entry| entry.kind == NormalizedDocKind::Module)
-                .map(|entry| entry.description.clone())
-                .unwrap_or_default();
+        let description = normalized_entries_for_module(
+            &mut docs_cache,
+            &extractor,
+            &entrypoint.source_path,
+            options.type_parameters,
+        )?
+        .iter()
+        .find(|entry| entry.kind == NormalizedDocKind::Module)
+        .map(|entry| entry.description.clone())
+        .unwrap_or_default();
 
         modules.push(EntrypointDocsModule {
             file: entrypoint.name.clone(),
@@ -431,12 +444,13 @@ fn normalized_entries_for_module<'a>(
     docs_cache: &'a mut FxHashMap<PathBuf, Vec<NormalizedDocEntry>>,
     extractor: &DocExtractor,
     module: &PathBuf,
+    type_parameters: bool,
 ) -> Result<&'a [NormalizedDocEntry], GraphError> {
     if !docs_cache.contains_key(module) {
         let items = extractor
             .extract_file(module)
             .map_err(|source| GraphError::Extract { path: module.clone(), source })?;
-        docs_cache.insert(module.clone(), normalize_doc_items(items));
+        docs_cache.insert(module.clone(), normalize_doc_items(items, type_parameters));
     }
 
     Ok(docs_cache.get(module).expect("normalized docs cache entry").as_slice())
@@ -1231,6 +1245,7 @@ export function label(value: string): string {
                 graph: graph_options,
                 include_private: false,
                 include_internal: false,
+                type_parameters: false,
             },
         )
         .unwrap();
@@ -1300,6 +1315,7 @@ export function plugin(): void {}
                 graph: graph_options,
                 include_private: false,
                 include_internal: false,
+                type_parameters: false,
             },
         )
         .unwrap();
@@ -1349,6 +1365,7 @@ export const CLI_OPTIONS_DEFAULT: CliOptions<DefaultGunshiParams> = {
                 graph: GraphOptions { root: Some(root.clone()), ..GraphOptions::default() },
                 include_private: false,
                 include_internal: false,
+                type_parameters: false,
             },
         )
         .unwrap();
@@ -1403,6 +1420,7 @@ export type ExtractArgs<G> = G extends { args: infer A } ? A : never;
                 graph: GraphOptions { root: Some(root.clone()), ..GraphOptions::default() },
                 include_private: false,
                 include_internal: false,
+                type_parameters: false,
             },
         )
         .unwrap();
@@ -1419,6 +1437,7 @@ export type ExtractArgs<G> = G extends { args: infer A } ? A : never;
                 graph: GraphOptions { root: Some(root.clone()), ..GraphOptions::default() },
                 include_private: false,
                 include_internal: true,
+                type_parameters: false,
             },
         )
         .unwrap();
@@ -1470,6 +1489,7 @@ export interface ExternalThing {
                 graph: graph_options,
                 include_private: false,
                 include_internal: false,
+                type_parameters: false,
             },
         )
         .unwrap();
@@ -1535,6 +1555,7 @@ export { a };
                 graph: graph_options,
                 include_private: false,
                 include_internal: false,
+                type_parameters: false,
             },
         )
         .unwrap();
@@ -1585,6 +1606,7 @@ export function helper(): void {}
                 graph: graph_options,
                 include_private: false,
                 include_internal: false,
+                type_parameters: false,
             },
         )
         .unwrap();

--- a/crates/ox_content_docs/src/lib.rs
+++ b/crates/ox_content_docs/src/lib.rs
@@ -18,7 +18,7 @@ mod output;
 pub use config::DocsConfig;
 pub use data::generate_docs_data_json;
 pub use extractor::{
-    DocExtractor, DocItem, DocItemKind, DocTag, ExtractError, ExtractResult, ParamDoc,
+    DocExtractor, DocItem, DocItemKind, DocTag, ExtractError, ExtractResult, ParamDoc, TypeParamDoc,
 };
 pub use generator::{
     collect_source_files, extract_docs_from_directories, DocsGenerator, ExtractedDocModule,
@@ -34,12 +34,15 @@ pub use markdown::{
     generate_markdown, MarkdownDocsOptions, MarkdownLinkStyle, MarkdownPathStrategy,
     MarkdownRenderStyle,
 };
-pub use model::{ApiDocEntry, ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc, ApiReturnDoc};
+pub use model::{
+    ApiDocEntry, ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc, ApiReturnDoc, ApiTypeParamDoc,
+};
 pub use nav::{
     generate_nav_code, generate_nav_metadata, generate_nav_metadata_from_docs, DocsNavItem,
 };
 pub use normalize::{
     normalize_doc_item, normalize_doc_items, NormalizedDocEntry, NormalizedDocKind,
     NormalizedMember, NormalizedMemberKind, NormalizedParamDoc, NormalizedReturnDoc,
+    NormalizedTypeParam,
 };
 pub use output::{write_docs_output, DocsOutputError, DocsOutputOptions, DocsOutputResult};

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -1368,7 +1368,7 @@ fn capitalize_ascii(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{ApiDocTag, ApiParamDoc, ApiReturnDoc};
+    use crate::model::{ApiDocTag, ApiParamDoc, ApiReturnDoc, ApiTypeParamDoc};
 
     fn test_entry(name: &str, kind: &str, file: &str, description: &str) -> ApiDocEntry {
         ApiDocEntry {
@@ -1385,6 +1385,7 @@ mod tests {
             end_line: 1,
             signature: Some(format!("export function {name}(): void")),
             members: vec![],
+            type_parameters: vec![],
         }
     }
 
@@ -1441,6 +1442,7 @@ mod tests {
                     end_line: 3,
                     signature: Some("export function cli(argv: string[]): void".to_string()),
                     members: vec![],
+                    type_parameters: vec![],
                 },
                 ApiDocEntry {
                     name: "Command".to_string(),
@@ -1471,6 +1473,7 @@ mod tests {
                         line: 6,
                         end_line: 6,
                     }],
+                    type_parameters: vec![],
                 },
             ],
         }]
@@ -1670,6 +1673,7 @@ mod tests {
                         line: 5,
                         end_line: 5,
                     }],
+                    type_parameters: vec![],
                 }],
             },
             ApiDocModule {
@@ -1710,6 +1714,7 @@ mod tests {
                         "export function buildCommand(entry: Command): AgentProfile".to_string(),
                     ),
                     members: vec![],
+                    type_parameters: vec![],
                 }],
             },
         ];
@@ -1755,6 +1760,7 @@ mod tests {
                     end_line: 10,
                     signature: Some("export function cli(options: CliOptions): void".to_string()),
                     members: vec![],
+                    type_parameters: vec![],
                 },
                 ApiDocEntry {
                     name: "CliOptions".to_string(),
@@ -1785,6 +1791,7 @@ mod tests {
                         line: 5,
                         end_line: 5,
                     }],
+                    type_parameters: vec![],
                 },
                 test_entry("Plugin", "type", "/repo/src/plugin.ts", "Plugin type."),
                 test_entry(
@@ -1905,6 +1912,44 @@ mod tests {
     }
 
     #[test]
+    fn type_parameters_render_as_a_section() {
+        let mut entry = test_entry("make", "function", "src/make.ts", "Make a thing.");
+        entry.type_parameters = vec![
+            ApiTypeParamDoc {
+                name: "G".to_string(),
+                constraint: Some("Base".to_string()),
+                default: Some("Default".to_string()),
+                description: String::new(),
+            },
+            ApiTypeParamDoc {
+                name: "T".to_string(),
+                constraint: None,
+                default: None,
+                description: "The value type.".to_string(),
+            },
+        ];
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "mod".to_string(),
+            entries: vec![entry],
+        }];
+
+        let markdown = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                render_style: MarkdownRenderStyle::Markdown,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let page = markdown.get("mod/functions/make.md").unwrap();
+
+        assert!(page.contains("**Type Parameters**"));
+        assert!(page.contains("`G` *extends* `Base` = `Default`"));
+        assert!(page.contains("| `T` | The value type. |"));
+    }
+
+    #[test]
     fn typedoc_path_strategy_uses_clean_base_path_and_module_scope() {
         let docs = vec![
             ApiDocModule {
@@ -2020,6 +2065,7 @@ mod tests {
                         line: 2,
                         end_line: 2,
                     }],
+                    type_parameters: vec![],
                 },
                 ApiDocEntry {
                     name: "run".to_string(),
@@ -2035,6 +2081,7 @@ mod tests {
                     end_line: 5,
                     signature: Some("export function run(mode: Mode): void".to_string()),
                     members: vec![],
+                    type_parameters: vec![],
                 },
             ],
         }];
@@ -2120,6 +2167,7 @@ mod tests {
                         end_line: 7,
                     },
                 ],
+                type_parameters: vec![],
             }],
         }];
 

--- a/crates/ox_content_docs/src/markdown/markdown_html.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_html.rs
@@ -15,7 +15,9 @@ use super::{
     parse_example_block, process_doc_text, push_fmt, EntryStats, MarkdownDocsOptions,
     MarkdownLinkContext, MarkdownPathStrategy, RegexCache, DOC_KIND_ORDER,
 };
-use crate::model::{ApiDocEntry, ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc};
+use crate::model::{
+    ApiDocEntry, ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc, ApiTypeParamDoc,
+};
 
 fn escape_html(value: &str) -> String {
     // Most inputs (symbol names, type annotations, kind labels) contain none of
@@ -479,6 +481,48 @@ fn render_params_list_html(
     )
 }
 
+fn render_type_parameters_html(
+    type_parameters: &[ApiTypeParamDoc],
+    context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    let rows = type_parameters
+        .iter()
+        .map(|type_param| {
+            let mut name = format!("<code>{}</code>", escape_html(&type_param.name));
+            if let Some(constraint) = &type_param.constraint {
+                push_fmt(
+                    &mut name,
+                    format_args!(" <em>extends</em> <code>{}</code>", escape_html(constraint)),
+                );
+            }
+            if let Some(default) = &type_param.default {
+                push_fmt(&mut name, format_args!(" = <code>{}</code>", escape_html(default)));
+            }
+            format!(
+                "<tr>
+  <td>{}</td>
+  <td>{}</td>
+</tr>",
+                name,
+                render_doc_inline_html(&type_param.description, context)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        "<div class=\"ox-api-entry__section ox-api-entry__section--type-parameters\">
+<h4>Type Parameters</h4>
+<table class=\"ox-api-entry__type-parameters-table\">
+<thead><tr><th>Name</th><th>Description</th></tr></thead>
+<tbody>
+{rows}
+</tbody>
+</table>
+</div>"
+    )
+}
+
 fn render_tag_list_html(tags: &[ApiDocTag], context: Option<&MarkdownLinkContext<'_>>) -> String {
     let mut items = String::new();
     for tag in tags {
@@ -778,6 +822,11 @@ fn render_entry_body_html(
             "<p class=\"ox-api-entry__source\"><a class=\"ox-api-entry__source-link\" href=\"{}\" target=\"_blank\" rel=\"noopener noreferrer\">View source<span class=\"ox-api-entry__source-icon\" aria-hidden=\"true\"></span></a></p>\n",
             escape_html(&source_href)
         ));
+    }
+
+    if !entry.type_parameters.is_empty() {
+        body.push_str(&render_type_parameters_html(&entry.type_parameters, link_context));
+        body.push('\n');
     }
 
     if !entry.members.is_empty() {

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -10,7 +10,7 @@ use super::{
     fmt_args, generate_source_href, parse_example_block, process_doc_text, push_fmt, EntryStats,
     MarkdownDocsOptions, MarkdownLinkContext,
 };
-use crate::model::{ApiDocEntry, ApiDocMember};
+use crate::model::{ApiDocEntry, ApiDocMember, ApiTypeParamDoc};
 
 /// Renders the per-page stats summary as a single italic Markdown line.
 pub(super) fn render_stats_markdown(stats: &EntryStats, module_count: Option<usize>) -> String {
@@ -77,6 +77,22 @@ pub(super) fn render_entry_body_pure(
             );
             push_fmt(&mut out, format_args!("[View source]({href})\n\n"));
         }
+    }
+
+    if !entry.type_parameters.is_empty() {
+        out.push_str("**Type Parameters**\n\n");
+        out.push_str("| Name | Description |\n| --- | --- |\n");
+        for type_param in &entry.type_parameters {
+            push_fmt(
+                &mut out,
+                format_args!(
+                    "| {} | {} |\n",
+                    type_param_name_cell(type_param),
+                    table_cell(&inline(&type_param.description, context)),
+                ),
+            );
+        }
+        out.push('\n');
     }
 
     if !entry.members.is_empty() {
@@ -289,4 +305,17 @@ fn code_cell(value: &str) -> String {
     } else {
         fmt_args(format_args!("`{}`", value.replace('|', "\\|")))
     }
+}
+
+/// Builds the Name cell for a type parameter: `` `T` `` plus optional `*extends*`
+/// constraint and `=` default, each rendered as inline code.
+fn type_param_name_cell(type_param: &ApiTypeParamDoc) -> String {
+    let mut cell = code_cell(&type_param.name);
+    if let Some(constraint) = &type_param.constraint {
+        push_fmt(&mut cell, format_args!(" *extends* {}", code_cell(constraint)));
+    }
+    if let Some(default) = &type_param.default {
+        push_fmt(&mut cell, format_args!(" = {}", code_cell(default)));
+    }
+    cell
 }

--- a/crates/ox_content_docs/src/model.rs
+++ b/crates/ox_content_docs/src/model.rs
@@ -50,6 +50,9 @@ pub struct ApiDocEntry {
     /// Members belonging to class/interface/type/enum entries.
     #[serde(default)]
     pub members: Vec<ApiDocMember>,
+    /// Declaration type parameters (opt-in; empty unless enabled).
+    #[serde(default)]
+    pub type_parameters: Vec<ApiTypeParamDoc>,
 }
 
 /// Documentation for a member of a class/interface/type/enum entry.
@@ -112,6 +115,19 @@ pub struct ApiReturnDoc {
     /// Return type.
     pub type_annotation: String,
     /// Return description.
+    pub description: String,
+}
+
+/// Type parameter documentation (`<T extends C = D>`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ApiTypeParamDoc {
+    /// Type parameter name (e.g. `T`).
+    pub name: String,
+    /// Constraint after `extends`, when present.
+    pub constraint: Option<String>,
+    /// Default type after `=`, when present.
+    pub default: Option<String>,
+    /// Description merged from a `@typeParam` / `@template` tag.
     pub description: String,
 }
 

--- a/crates/ox_content_docs/src/nav.rs
+++ b/crates/ox_content_docs/src/nav.rs
@@ -336,6 +336,7 @@ mod tests {
                     end_line: 1,
                     signature: None,
                     members: vec![],
+                    type_parameters: vec![],
                 },
                 ApiDocEntry {
                     name: "Command".to_string(),
@@ -351,6 +352,7 @@ mod tests {
                     end_line: 1,
                     signature: None,
                     members: vec![],
+                    type_parameters: vec![],
                 },
             ],
         }];
@@ -390,6 +392,7 @@ mod tests {
                 end_line: 1,
                 signature: None,
                 members: vec![],
+                type_parameters: vec![],
             }],
         }];
 

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -4,13 +4,14 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::extractor::{DocItem, DocItemKind, DocTag, ParamDoc};
+use crate::extractor::{DocItem, DocItemKind, DocTag, ParamDoc, TypeParamDoc};
 
 const UNKNOWN_TYPE: &str = "unknown";
 const PARAM_TAG_NAMES: [&str; 3] = ["param", "arg", "argument"];
 const RETURN_TAG_NAMES: [&str; 2] = ["returns", "return"];
 const EXAMPLE_TAG_NAME: &str = "example";
 const PRIVATE_TAG_NAME: &str = "private";
+const TYPE_PARAM_TAG_NAMES: [&str; 2] = ["typeParam", "template"];
 
 /// Documentation item kind supported by the generated API reference.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -146,6 +147,19 @@ pub struct NormalizedReturnDoc {
     pub description: String,
 }
 
+/// Normalized type parameter documentation (`<T extends C = D>`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NormalizedTypeParam {
+    /// Type parameter name (e.g. `T`).
+    pub name: String,
+    /// Constraint after `extends`, when present.
+    pub constraint: Option<String>,
+    /// Default type after `=`, when present.
+    pub default: Option<String>,
+    /// Description merged from a `@typeParam` / `@template` tag.
+    pub description: String,
+}
+
 /// Normalized documentation for a member of a class/interface/type/enum entry.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NormalizedMember {
@@ -215,23 +229,37 @@ pub struct NormalizedDocEntry {
     /// Members belonging to class/interface/type/enum entries.
     #[serde(default)]
     pub members: Vec<NormalizedMember>,
+    /// Declaration type parameters. Populated only when type-parameter docs are
+    /// enabled (opt-in); empty otherwise.
+    #[serde(default)]
+    pub type_parameters: Vec<NormalizedTypeParam>,
 }
 
 /// Normalizes extracted documentation items into API reference entries.
 #[must_use]
-pub fn normalize_doc_items(items: Vec<DocItem>) -> Vec<NormalizedDocEntry> {
-    items.into_iter().filter_map(normalize_doc_item).collect()
+pub fn normalize_doc_items(items: Vec<DocItem>, type_parameters: bool) -> Vec<NormalizedDocEntry> {
+    items.into_iter().filter_map(|item| normalize_doc_item(item, type_parameters)).collect()
 }
 
 /// Normalizes a single extracted documentation item into an API reference entry.
+///
+/// `type_parameters` opts in to TSDoc-style type-parameter docs: when `true`,
+/// `@typeParam` / `@template` tags are merged into structured type parameters and
+/// removed from the generic tag map; when `false` they remain generic tags and
+/// `type_parameters` stays empty (default JSDoc behavior).
 #[must_use]
-pub fn normalize_doc_item(item: DocItem) -> Option<NormalizedDocEntry> {
+pub fn normalize_doc_item(item: DocItem, type_parameters: bool) -> Option<NormalizedDocEntry> {
     let kind = NormalizedDocKind::from_doc_item_kind(item.kind)?;
 
-    let mut metadata = normalize_doc_metadata(&item.tags);
+    let mut metadata = normalize_doc_metadata(&item.tags, type_parameters);
     merge_extracted_params(&mut metadata.params, item.params);
     merge_extracted_return(&mut metadata.returns, item.return_type);
     let members = item.children.into_iter().filter_map(normalize_member).collect();
+    let type_parameters = if type_parameters {
+        build_type_parameters(item.type_parameters, &metadata.type_param_descriptions)
+    } else {
+        Vec::new()
+    };
 
     Some(NormalizedDocEntry {
         name: item.name,
@@ -247,12 +275,14 @@ pub fn normalize_doc_item(item: DocItem) -> Option<NormalizedDocEntry> {
         end_line: item.end_line,
         signature: item.signature,
         members,
+        type_parameters,
     })
 }
 
 fn normalize_member(item: DocItem) -> Option<NormalizedMember> {
     let kind = NormalizedMemberKind::from_doc_item_kind(item.kind)?;
-    let mut metadata = normalize_doc_metadata(&item.tags);
+    // Member-level type parameters are out of scope; keep generic-tag behavior.
+    let mut metadata = normalize_doc_metadata(&item.tags, false);
     merge_extracted_params(&mut metadata.params, item.params);
     merge_extracted_return(&mut metadata.returns, item.return_type);
 
@@ -287,14 +317,16 @@ struct NormalizedDocMetadata {
     returns: Option<NormalizedReturnDoc>,
     examples: Vec<String>,
     tags: BTreeMap<String, String>,
+    type_param_descriptions: BTreeMap<String, String>,
     private: bool,
 }
 
-fn normalize_doc_metadata(tags: &[DocTag]) -> NormalizedDocMetadata {
+fn normalize_doc_metadata(tags: &[DocTag], type_parameters: bool) -> NormalizedDocMetadata {
     let mut params = Vec::new();
     let mut returns = None;
     let mut examples = Vec::new();
     let mut normalized_tags = BTreeMap::new();
+    let mut type_param_descriptions = BTreeMap::new();
     let mut private = false;
 
     for tag in tags {
@@ -317,13 +349,84 @@ fn normalize_doc_metadata(tags: &[DocTag]) -> NormalizedDocMetadata {
             PRIVATE_TAG_NAME => {
                 private = true;
             }
+            // TSDoc `@typeParam` / `@template`: only handled specially when opted
+            // in. Otherwise it falls through to the generic tag map (JSDoc default).
+            tag_name if type_parameters && TYPE_PARAM_TAG_NAMES.contains(&tag_name) => {
+                if let Some((name, description)) = parse_type_param_tag(tag) {
+                    type_param_descriptions.entry(name).or_insert(description);
+                }
+            }
             tag_name => {
                 normalized_tags.entry(tag_name.to_string()).or_insert_with(|| tag.value.clone());
             }
         }
     }
 
-    NormalizedDocMetadata { params, returns, examples, tags: normalized_tags, private }
+    NormalizedDocMetadata {
+        params,
+        returns,
+        examples,
+        tags: normalized_tags,
+        type_param_descriptions,
+        private,
+    }
+}
+
+/// Parses a `@typeParam` / `@template` tag into `(name, description)`.
+/// Prefers the structured `name`/`description` from the JSDoc parser; otherwise
+/// splits the raw value as `"<name>[ - ]<description>"`.
+fn parse_type_param_tag(tag: &DocTag) -> Option<(String, String)> {
+    if let Some(name) = tag.name.as_ref().map(|name| name.trim()).filter(|name| !name.is_empty()) {
+        let description = tag.description.clone().unwrap_or_default().trim().to_string();
+        return Some((name.to_string(), description));
+    }
+
+    let value = tag.value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    let mut parts = value.splitn(2, char::is_whitespace);
+    let name = parts.next()?.trim();
+    if name.is_empty() {
+        return None;
+    }
+    let description = parts.next().unwrap_or("").trim().trim_start_matches('-').trim().to_string();
+    Some((name.to_string(), description))
+}
+
+/// Merges `@typeParam` descriptions into the AST-derived type parameters by name.
+/// Descriptions with no matching declaration parameter are appended as
+/// name+description-only entries so they are not lost.
+fn build_type_parameters(
+    ast: Vec<TypeParamDoc>,
+    descriptions: &BTreeMap<String, String>,
+) -> Vec<NormalizedTypeParam> {
+    let mut used = std::collections::BTreeSet::new();
+    let mut result: Vec<NormalizedTypeParam> = ast
+        .into_iter()
+        .map(|param| {
+            used.insert(param.name.clone());
+            NormalizedTypeParam {
+                description: descriptions.get(&param.name).cloned().unwrap_or_default(),
+                name: param.name,
+                constraint: param.constraint,
+                default: param.default,
+            }
+        })
+        .collect();
+
+    for (name, description) in descriptions {
+        if !used.contains(name) {
+            result.push(NormalizedTypeParam {
+                name: name.clone(),
+                constraint: None,
+                default: None,
+                description: description.clone(),
+            });
+        }
+    }
+
+    result
 }
 
 fn merge_extracted_params(params: &mut Vec<NormalizedParamDoc>, extracted_params: Vec<ParamDoc>) {
@@ -446,7 +549,7 @@ export function label(value, maxLength = 20) {
 
         let extractor = DocExtractor::new();
         let items = extractor.extract_source(source, "labels.js", SourceType::mjs()).unwrap();
-        let entries = normalize_doc_items(items);
+        let entries = normalize_doc_items(items, false);
 
         assert_eq!(entries.len(), 1);
         let entry = &entries[0];
@@ -484,7 +587,7 @@ export function internalHelper(): void {}
 
         let extractor = DocExtractor::with_private(true);
         let items = extractor.extract_source(source, "internal.ts", SourceType::ts()).unwrap();
-        let entries = normalize_doc_items(items);
+        let entries = normalize_doc_items(items, false);
 
         assert_eq!(entries.len(), 1);
         assert!(entries[0].private);
@@ -504,7 +607,7 @@ export enum Mode {
 
         let extractor = DocExtractor::new();
         let items = extractor.extract_source(source, "mode.ts", SourceType::ts()).unwrap();
-        let entries = normalize_doc_items(items);
+        let entries = normalize_doc_items(items, false);
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].kind, NormalizedDocKind::Enum);
@@ -526,7 +629,7 @@ export interface Command {
 
         let extractor = DocExtractor::new();
         let items = extractor.extract_source(source, "command.ts", SourceType::ts()).unwrap();
-        let entries = normalize_doc_items(items);
+        let entries = normalize_doc_items(items, false);
         let members = &entries[0].members;
 
         assert_eq!(members.len(), 2);
@@ -559,7 +662,7 @@ export interface Command {
 
         let extractor = DocExtractor::new();
         let items = extractor.extract_source(source, "command.ts", SourceType::ts()).unwrap();
-        let entries = normalize_doc_items(items);
+        let entries = normalize_doc_items(items, false);
         let member = &entries[0].members[0];
 
         assert_eq!(member.name, "run");
@@ -596,7 +699,7 @@ export class Registry {
 
         let extractor = DocExtractor::new();
         let items = extractor.extract_source(source, "registry.ts", SourceType::ts()).unwrap();
-        let entries = normalize_doc_items(items);
+        let entries = normalize_doc_items(items, false);
         let members = &entries[0].members;
 
         assert_eq!(
@@ -625,7 +728,7 @@ export enum Mode {
 
         let extractor = DocExtractor::new();
         let items = extractor.extract_source(source, "mode.ts", SourceType::ts()).unwrap();
-        let entries = normalize_doc_items(items);
+        let entries = normalize_doc_items(items, false);
         let members = &entries[0].members;
 
         assert_eq!(
@@ -660,7 +763,7 @@ export interface Command {
 
         let public_items =
             DocExtractor::new().extract_source(source, "command.ts", SourceType::ts()).unwrap();
-        let public_entries = normalize_doc_items(public_items);
+        let public_entries = normalize_doc_items(public_items, false);
         assert_eq!(
             public_entries[0].members.iter().map(|member| member.name.as_str()).collect::<Vec<_>>(),
             ["name"]
@@ -669,11 +772,43 @@ export interface Command {
         let all_items = DocExtractor::with_visibility(true, true)
             .extract_source(source, "command.ts", SourceType::ts())
             .unwrap();
-        let all_entries = normalize_doc_items(all_items);
+        let all_entries = normalize_doc_items(all_items, false);
         assert_eq!(
             all_entries[0].members.iter().map(|member| member.name.as_str()).collect::<Vec<_>>(),
             ["name", "token", "secret"]
         );
         assert!(all_entries[0].members[2].private);
+    }
+
+    #[test]
+    fn type_parameters_opt_in_merges_typeparam_and_excludes_tag() {
+        let source = r"
+/**
+ * A combinator.
+ * @typeParam T - The parsed value type.
+ * @experimental
+ */
+export type Combinator<T> = { parse: (value: string) => T };
+";
+        let items =
+            DocExtractor::new().extract_source(source, "src/c.ts", SourceType::ts()).unwrap();
+
+        // Opted out (default): `@typeParam` stays a generic tag, no type parameters.
+        let off = normalize_doc_items(items.clone(), false);
+        let off = off.iter().find(|entry| entry.name == "Combinator").unwrap();
+        assert!(off.type_parameters.is_empty());
+        assert_eq!(
+            off.tags.get("typeParam").map(String::as_str),
+            Some("T - The parsed value type.")
+        );
+
+        // Opted in: structured type parameter with merged description; tag removed.
+        let on = normalize_doc_items(items, true);
+        let on = on.iter().find(|entry| entry.name == "Combinator").unwrap();
+        assert_eq!(on.type_parameters.len(), 1);
+        assert_eq!(on.type_parameters[0].name, "T");
+        assert_eq!(on.type_parameters[0].description, "The parsed value type.");
+        assert!(!on.tags.contains_key("typeParam"));
+        assert!(on.tags.contains_key("experimental"));
     }
 }

--- a/crates/ox_content_docs/src/output.rs
+++ b/crates/ox_content_docs/src/output.rs
@@ -240,6 +240,7 @@ mod tests {
                     end_line: 5,
                     signature: Some("export function cli(): void".to_string()),
                     members: vec![],
+                    type_parameters: vec![],
                 },
                 ApiDocEntry {
                     name: "Mode".to_string(),
@@ -270,6 +271,7 @@ mod tests {
                         line: 2,
                         end_line: 2,
                     }],
+                    type_parameters: vec![],
                 },
             ],
         }];

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -58,7 +58,7 @@ export declare function externalizeSsgAssets(pages: Array<JsSsgGeneratedHtmlPage
 export declare function extractCodeBlocks(source: string): Array<JsCodeBlock>
 
 /** Extracts normalized documentation entries from source directories using Oxc. */
-export declare function extractDocsFromDirectories(srcDirs: Array<string>, include: Array<string>, exclude: Array<string>, includePrivate?: boolean | undefined | null, includeInternal?: boolean | undefined | null): Array<JsExtractedDocsModule>
+export declare function extractDocsFromDirectories(srcDirs: Array<string>, include: Array<string>, exclude: Array<string>, includePrivate?: boolean | undefined | null, includeInternal?: boolean | undefined | null, typeParameters?: boolean | undefined | null): Array<JsExtractedDocsModule>
 
 /** Extracts generated API docs grouped by public entry points. */
 export declare function extractDocsFromEntryPoints(entryPoints: Array<JsEntryPointSpec>, options?: JsEntryPointDocsOptions | undefined | null): Array<JsEntrypointDocsModule>
@@ -67,7 +67,7 @@ export declare function extractDocsFromEntryPoints(entryPoints: Array<JsEntryPoi
 export declare function extractDocsTests(source: string, options?: JsDocsTestOptions | undefined | null): Array<JsCodeBlock>
 
 /** Extracts normalized documentation entries from a JavaScript/TypeScript file using Oxc. */
-export declare function extractFileDocEntries(filePath: string, includePrivate?: boolean | undefined | null, includeInternal?: boolean | undefined | null): Array<JsDocEntry>
+export declare function extractFileDocEntries(filePath: string, includePrivate?: boolean | undefined | null, includeInternal?: boolean | undefined | null, typeParameters?: boolean | undefined | null): Array<JsDocEntry>
 
 /** Extracts documented declarations from a JavaScript/TypeScript file using Oxc. */
 export declare function extractFileDocs(filePath: string, includePrivate?: boolean | undefined | null, includeInternal?: boolean | undefined | null): Array<JsSourceDocItem>
@@ -261,6 +261,7 @@ export interface JsDocEntry {
   endLine: number
   signature?: string
   members?: Array<JsDocMember>
+  typeParameters?: Array<JsTypeParam>
 }
 
 /** Normalized member documentation used by generated API docs. */
@@ -321,6 +322,7 @@ export interface JsDocsMarkdownEntry {
   endLine: number
   signature?: string
   members?: Array<JsDocMember>
+  typeParameters?: Array<JsTypeParam>
 }
 
 /** Extracted docs for one source file used by generated API Markdown. */
@@ -429,6 +431,11 @@ export interface JsEntryPointDocsOptions {
   internal?: boolean
   externalDocs?: boolean
   externalPackageSources?: Array<JsExternalPackageSource>
+  /**
+   * Opt in to TSDoc-style type-parameter docs (`@typeParam` / `<T>` table).
+   * Off by default.
+   */
+  typeParameters?: boolean
 }
 
 /** Public entry point module. */
@@ -1183,6 +1190,14 @@ export interface JsTransformOptions {
   sanitize?: JsSanitizeOptions
   /** Opt-in edit-this-page link generation. */
   editThisPage?: JsEditThisPageOptions
+}
+
+/** Type parameter documentation (`<T extends C = D>`) used by generated API docs. */
+export interface JsTypeParam {
+  name: string
+  constraint?: string
+  default?: string
+  description: string
 }
 
 /** Wiki-link transform options. */

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -30,13 +30,13 @@ use ox_content_docs::{
     build_export_graph, extract_docs_from_directories, extract_docs_from_entry_points,
     generate_docs_data_json, generate_markdown, generate_nav_code, generate_nav_metadata,
     generate_nav_metadata_from_docs, normalize_doc_items, write_docs_output, ApiDocEntry,
-    ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc, ApiReturnDoc, DocExtractor, DocItem,
-    DocItemKind, DocTag, DocsDiagnostic, DocsDiagnosticCode, DocsNavItem, DocsOutputOptions,
-    EntryPointDocsOptions, EntryPointSpec, ExportGraph, ExportKind, ExportSource,
-    ExternalDocsOptions, ExternalPackageSource, ExtractedDocModule, GraphOptions,
+    ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc, ApiReturnDoc, ApiTypeParamDoc,
+    DocExtractor, DocItem, DocItemKind, DocTag, DocsDiagnostic, DocsDiagnosticCode, DocsNavItem,
+    DocsOutputOptions, EntryPointDocsOptions, EntryPointSpec, ExportGraph, ExportKind,
+    ExportSource, ExternalDocsOptions, ExternalPackageSource, ExtractedDocModule, GraphOptions,
     MarkdownDocsOptions, MarkdownLinkStyle, MarkdownPathStrategy, MarkdownRenderStyle,
-    NormalizedDocEntry, NormalizedMember, NormalizedParamDoc, NormalizedReturnDoc, ParamDoc,
-    PublicExport,
+    NormalizedDocEntry, NormalizedMember, NormalizedParamDoc, NormalizedReturnDoc,
+    NormalizedTypeParam, ParamDoc, PublicExport,
 };
 use ox_content_parser::{Parser, ParserOptions};
 use ox_content_renderer::HtmlRenderer;
@@ -177,6 +177,16 @@ pub struct JsDocReturn {
     pub description: String,
 }
 
+/// Type parameter documentation (`<T extends C = D>`) used by generated API docs.
+#[napi(object)]
+#[derive(Clone)]
+pub struct JsTypeParam {
+    pub name: String,
+    pub constraint: Option<String>,
+    pub r#default: Option<String>,
+    pub description: String,
+}
+
 /// Normalized member documentation used by generated API docs.
 #[napi(object)]
 #[derive(Clone)]
@@ -214,6 +224,7 @@ pub struct JsDocEntry {
     pub end_line: u32,
     pub signature: Option<String>,
     pub members: Option<Vec<JsDocMember>>,
+    pub type_parameters: Option<Vec<JsTypeParam>>,
 }
 
 /// Navigation item emitted for generated documentation.
@@ -259,6 +270,7 @@ pub struct JsDocsMarkdownEntry {
     pub end_line: u32,
     pub signature: Option<String>,
     pub members: Option<Vec<JsDocMember>>,
+    pub type_parameters: Option<Vec<JsTypeParam>>,
 }
 
 /// Extracted docs for one source file used by generated API Markdown.
@@ -334,6 +346,9 @@ pub struct JsEntryPointDocsOptions {
     pub internal: Option<bool>,
     pub external_docs: Option<bool>,
     pub external_package_sources: Option<Vec<JsExternalPackageSource>>,
+    /// Opt in to TSDoc-style type-parameter docs (`@typeParam` / `<T>` table).
+    /// Off by default.
+    pub type_parameters: Option<bool>,
 }
 
 /// Explicit source entry for an external package.
@@ -891,6 +906,17 @@ fn map_normalized_doc_entry(entry: NormalizedDocEntry) -> JsDocEntry {
         signature: entry.signature,
         members: (!entry.members.is_empty())
             .then(|| entry.members.into_iter().map(map_normalized_member).collect()),
+        type_parameters: (!entry.type_parameters.is_empty())
+            .then(|| entry.type_parameters.into_iter().map(map_normalized_type_param).collect()),
+    }
+}
+
+fn map_normalized_type_param(type_param: NormalizedTypeParam) -> JsTypeParam {
+    JsTypeParam {
+        name: type_param.name,
+        constraint: type_param.constraint,
+        r#default: type_param.default,
+        description: type_param.description,
     }
 }
 
@@ -929,6 +955,7 @@ fn convert_entrypoint_docs_options(
         },
         include_private: options.private.unwrap_or(false),
         include_internal: options.internal.unwrap_or(false),
+        type_parameters: options.type_parameters.unwrap_or(false),
     }
 }
 
@@ -1112,6 +1139,21 @@ fn convert_markdown_entry(entry: JsDocsMarkdownEntry) -> ApiDocEntry {
             .into_iter()
             .map(convert_markdown_member)
             .collect(),
+        type_parameters: entry
+            .type_parameters
+            .unwrap_or_default()
+            .into_iter()
+            .map(convert_markdown_type_param)
+            .collect(),
+    }
+}
+
+fn convert_markdown_type_param(type_param: JsTypeParam) -> ApiTypeParamDoc {
+    ApiTypeParamDoc {
+        name: type_param.name,
+        constraint: type_param.constraint,
+        default: type_param.r#default,
+        description: type_param.description,
     }
 }
 
@@ -1165,6 +1207,7 @@ pub fn extract_file_doc_entries(
     file_path: String,
     include_private: Option<bool>,
     include_internal: Option<bool>,
+    type_parameters: Option<bool>,
 ) -> Result<Vec<JsDocEntry>> {
     let extractor = DocExtractor::with_visibility(
         include_private.unwrap_or(false),
@@ -1174,7 +1217,10 @@ pub fn extract_file_doc_entries(
         .extract_file(Path::new(&file_path))
         .map_err(|err| Error::from_reason(err.to_string()))?;
 
-    Ok(normalize_doc_items(items).into_iter().map(map_normalized_doc_entry).collect())
+    Ok(normalize_doc_items(items, type_parameters.unwrap_or(false))
+        .into_iter()
+        .map(map_normalized_doc_entry)
+        .collect())
 }
 
 /// Generates sidebar navigation metadata from documentation file paths.
@@ -1232,6 +1278,7 @@ pub fn extract_docs_from_directories_napi(
     exclude: Vec<String>,
     include_private: Option<bool>,
     include_internal: Option<bool>,
+    type_parameters: Option<bool>,
 ) -> Result<Vec<JsExtractedDocsModule>> {
     let modules = extract_docs_from_directories(
         &src_dirs,
@@ -1239,6 +1286,7 @@ pub fn extract_docs_from_directories_napi(
         &exclude,
         include_private.unwrap_or(false),
         include_internal.unwrap_or(false),
+        type_parameters.unwrap_or(false),
     )
     .map_err(|err| Error::from_reason(err.to_string()))?;
 
@@ -3305,7 +3353,7 @@ mod tests {
         generate_docs_nav_metadata_from_docs_napi, get_git_last_updated, map_normalized_doc_entry,
         JsDocMember, JsDocParam, JsDocReturn, JsDocsMarkdownEntry, JsDocsMarkdownModule,
         JsDocsMarkdownOptions, JsDocsMarkdownTag, JsDocsNavOptions, JsEntryPointDocsOptions,
-        JsEntryPointSpec,
+        JsEntryPointSpec, JsTypeParam,
     };
 
     #[test]
@@ -3372,6 +3420,7 @@ mod tests {
                 line: 4,
                 end_line: 4,
             }],
+            type_parameters: vec![],
         };
 
         let js_entry = map_normalized_doc_entry(entry);
@@ -3403,6 +3452,7 @@ mod tests {
                 end_line: 1,
                 signature: Some("export interface CommandContext".to_string()),
                 members: None,
+                type_parameters: None,
             }],
         }];
         let markdown = generate_docs_markdown(
@@ -3441,6 +3491,7 @@ mod tests {
                 end_line: 1,
                 signature: Some("export interface CommandContext".to_string()),
                 members: None,
+                type_parameters: None,
             }],
         }];
         let markdown = generate_docs_markdown(
@@ -3497,6 +3548,7 @@ mod tests {
                         line: 5,
                         end_line: 5,
                     }]),
+                    type_parameters: None,
                 }],
             },
             JsDocsMarkdownModule {
@@ -3530,6 +3582,7 @@ mod tests {
                         "export function buildCommand(entry: Command): Command".to_string(),
                     ),
                     members: None,
+                    type_parameters: None,
                 }],
             },
         ];
@@ -3569,6 +3622,7 @@ mod tests {
                     end_line: 10,
                     signature: Some("export interface Command".to_string()),
                     members: None,
+                    type_parameters: None,
                 },
                 JsDocsMarkdownEntry {
                     name: "cli".to_string(),
@@ -3584,6 +3638,7 @@ mod tests {
                     end_line: 10,
                     signature: Some("export function cli(): void".to_string()),
                     members: None,
+                    type_parameters: None,
                 },
             ],
         }];
@@ -3607,6 +3662,52 @@ mod tests {
     }
 
     #[test]
+    fn generate_docs_markdown_renders_type_parameters() {
+        let docs = vec![JsDocsMarkdownModule {
+            description: None,
+            file: "default".to_string(),
+            entries: vec![JsDocsMarkdownEntry {
+                name: "make".to_string(),
+                kind: "function".to_string(),
+                description: "Make a thing.".to_string(),
+                params: None,
+                returns: None,
+                examples: None,
+                tags: None,
+                private: false,
+                file: "/repo/src/make.ts".to_string(),
+                line: 1,
+                end_line: 1,
+                signature: Some("export function make<G>(): G".to_string()),
+                members: None,
+                type_parameters: Some(vec![JsTypeParam {
+                    name: "G".to_string(),
+                    constraint: Some("Base".to_string()),
+                    r#default: Some("Default".to_string()),
+                    description: "The thing type.".to_string(),
+                }]),
+            }],
+        }];
+
+        let markdown = generate_docs_markdown(
+            docs,
+            Some(JsDocsMarkdownOptions {
+                group_by: Some("file".to_string()),
+                github_url: None,
+                link_style: Some("markdown".to_string()),
+                base_path: None,
+                path_strategy: Some("typedoc".to_string()),
+                render_style: Some("markdown".to_string()),
+            }),
+        );
+        let page = markdown.get("default/functions/make.md").unwrap();
+
+        assert!(page.contains("**Type Parameters**"));
+        assert!(page.contains("`G` *extends* `Base` = `Default`"));
+        assert!(page.contains("The thing type."));
+    }
+
+    #[test]
     fn generate_docs_markdown_renders_module_description_in_typedoc_index() {
         let docs = vec![JsDocsMarkdownModule {
             description: Some("The entry for gunshi context.".to_string()),
@@ -3625,6 +3726,7 @@ mod tests {
                 end_line: 10,
                 signature: Some("export function createCommandContext(): void".to_string()),
                 members: None,
+                type_parameters: None,
             }],
         }];
 
@@ -3667,6 +3769,7 @@ mod tests {
                     end_line: 1,
                     signature: None,
                     members: None,
+                    type_parameters: None,
                 },
                 JsDocsMarkdownEntry {
                     name: "Mode".to_string(),
@@ -3682,6 +3785,7 @@ mod tests {
                     end_line: 1,
                     signature: None,
                     members: None,
+                    type_parameters: None,
                 },
             ],
         }];
@@ -3747,6 +3851,7 @@ mod tests {
                 end_line: 1,
                 signature: Some("export function cli(): void".to_string()),
                 members: None,
+                type_parameters: None,
             }],
         }];
 

--- a/npm/vite-plugin-ox-content/src/docs.ts
+++ b/npm/vite-plugin-ox-content/src/docs.ts
@@ -145,7 +145,12 @@ export async function extractDocs(
       napi as {
         extractDocsFromEntryPoints?: (
           entryPoints: ResolvedDocsEntryPoint[],
-          options?: { root?: string; private?: boolean; internal?: boolean },
+          options?: {
+            root?: string;
+            private?: boolean;
+            internal?: boolean;
+            typeParameters?: boolean;
+          },
         ) => Array<{ file: string; entries: DocEntry[] }>;
       }
     ).extractDocsFromEntryPoints;
@@ -160,6 +165,7 @@ export async function extractDocs(
       root: process.cwd(),
       private: options.private,
       internal: options.internal,
+      typeParameters: options.typeParameters,
     }).map((doc) => ({ file: doc.file, entries: doc.entries }));
   }
 
@@ -171,6 +177,7 @@ export async function extractDocs(
         exclude: string[],
         includePrivate?: boolean,
         includeInternal?: boolean,
+        typeParameters?: boolean,
       ) => Array<{ file: string; entries: DocEntry[] }>;
     }
   ).extractDocsFromDirectories;
@@ -187,6 +194,7 @@ export async function extractDocs(
     options.exclude,
     options.private,
     options.internal,
+    options.typeParameters,
   ).map((doc) => ({ file: doc.file, entries: doc.entries }));
 }
 
@@ -305,6 +313,7 @@ export function resolveDocsOptions(
     basePath: opts.basePath,
     pathStrategy: opts.pathStrategy ?? "flat",
     renderStyle: opts.renderStyle ?? "html",
+    typeParameters: opts.typeParameters ?? false,
     generateNav: opts.generateNav ?? true,
   };
 }

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -1023,6 +1023,17 @@ export interface DocsOptions {
   renderStyle?: "html" | "markdown";
 
   /**
+   * Opt in to TSDoc-style type-parameter documentation.
+   *
+   * When enabled, declaration type parameters (`<T extends C = D>`) are
+   * extracted into a structured "Type Parameters" section and `@typeParam` /
+   * `@template` tags are merged in (and removed from the generic tag list).
+   * `@typeParam` is a TSDoc feature, so this is off by default (JSDoc semantics).
+   * @default false
+   */
+  typeParameters?: boolean;
+
+  /**
    * Generate navigation metadata file.
    * @default true
    */
@@ -1049,6 +1060,7 @@ export interface ResolvedDocsOptions {
   basePath?: string;
   pathStrategy: "flat" | "typedoc";
   renderStyle: "html" | "markdown";
+  typeParameters: boolean;
   generateNav: boolean;
 }
 


### PR DESCRIPTION
## Background

`@ox-content/napi` never extracts a declaration's **type parameters** (`<G extends … = …>`) into structured data, so generated API docs differ from TypeDoc in two ways:

- Generics only in the signature: for symbols whose type parameters live in the TS signature (e.g. `createCommandContext`, `cli`, `define`), there is no "Type Parameters" table with `extends` constraints and `= default` types; the generics only appear inside the signature code block.
- `@typeParam` dumped as a generic tag: `@typeParam T - …` lands in the generic `tags` map and renders under a flat "Tags" section instead of a structured table.

## Summary

Adds a `typeParameters` extraction option (default `false`). When enabled, declaration type parameters are extracted from the AST and rendered as a "Type Parameters" section, and `@typeParam` / `@template` descriptions are merged in (and removed from the generic tag list) — matching TypeDoc.

- Option (`typeParameters?: boolean`): on `extractDocsFromEntryPoints` (`JsEntryPointDocsOptions` / `EntryPointDocsOptions`), `extractDocsFromDirectories`, and the vite-plugin `DocsOptions`. Rendering / `docs.json` carry no flag — they react to whether type parameters are present, so a single extraction flag flips markdown and JSON together (true opt-out).
- Extraction (`extractor.rs`): `extract_type_parameters` reads `name` / `extends` constraint / `=` default from `TSTypeParameter` via source spans (no type checker) for functions, type aliases, interfaces, classes, and function-valued consts.
- Gate (`normalize.rs`): a single `type_parameters_enabled` flag decides whether to surface type parameters and merge `@typeParam` (excluding it from `tags`); off → empty + generic-tag behavior preserved. Orphan `@typeParam` (no matching declaration param) is kept as a name+description-only entry.
- Model / NAPI / docs.json / render: new `{ name, constraint?, default?, description }` type threaded through `ApiDocEntry` / `JsDocEntry` / `JsDocsMarkdownEntry` (+ `index.d.ts`); `data.rs` emits `typeParameters`; the Markdown/HTML renderers emit a "Type Parameters" table (name with `*extends*` / `= default`, plus description) after the signature.

Scope: entry-level declarations (member/method type-parameter tables are a follow-up). 

Constraints/defaults are emitted as source text (not normalized/linked like TypeDoc), but carry the same information.

### Why opt-in (default off)

`@typeParam` is a **TSDoc** feature, not JSDoc, and a "Type Parameters" section is a TypeDoc/TSDoc-style output. ox-content is a JSDoc-first extractor, so this whole feature is **off by default** and enabled via a new extraction option.

With it off, output is byte-for-byte unchanged (generics stay in the signature, `@typeParam` stays a generic tag).


## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782814135&installation_id=136613492&pr_number=272&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F272&signature=fed005b557a5eb7030db59d5feadd2b574dc734f8c9cac085dd0b2c489936db2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->