### PR TITLE
fix(docs): render pure markdown sections as sequential headings instead of bold paragraphs

### DIFF
--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -859,7 +859,8 @@ fn generate_typedoc_entry_page(
         symbol_map,
     };
     if options.render_style == MarkdownRenderStyle::Markdown {
-        let body = markdown_pure::render_entry_body_pure(entry, options, Some(&link_context));
+        // Per-symbol page: title is `# {name}` (H1), so sections render at H2.
+        let body = markdown_pure::render_entry_body_pure(entry, options, Some(&link_context), 2);
         let mut markdown = fmt_args(format_args!("# {}\n\n", entry.name));
         if !body.is_empty() {
             markdown.push_str(&body);
@@ -1029,7 +1030,8 @@ fn generate_entry_markdown(
     let link_context = link_context.as_ref();
 
     if options.render_style == MarkdownRenderStyle::Markdown {
-        let body = markdown_pure::render_entry_body_pure(entry, options, link_context);
+        // Flat entry heading is `### {name}` (H3), so sections render at H4.
+        let body = markdown_pure::render_entry_body_pure(entry, options, link_context, 4);
         let mut markdown = fmt_args(format_args!("### {}\n\n", entry.name));
         if !body.is_empty() {
             markdown.push_str(&body);
@@ -1486,6 +1488,33 @@ mod tests {
         assert!(!markdown.contains("ox-api-controls"), "unexpected controls in:\n{markdown}");
     }
 
+    /// Asserts heading levels never increase by more than one (markdownlint
+    /// MD001), ignoring `#` lines inside fenced code blocks.
+    fn assert_no_heading_level_skips(markdown: &str) {
+        let mut previous = 0usize;
+        let mut in_fence = false;
+        for line in markdown.lines() {
+            if line.trim_start().starts_with("```") {
+                in_fence = !in_fence;
+                continue;
+            }
+            if in_fence {
+                continue;
+            }
+            let hashes = line.chars().take_while(|&ch| ch == '#').count();
+            if hashes == 0 || line.as_bytes().get(hashes) != Some(&b' ') {
+                continue;
+            }
+            if previous != 0 {
+                assert!(
+                    hashes <= previous + 1,
+                    "heading level skip {previous} -> {hashes} at: {line}\nin:\n{markdown}"
+                );
+            }
+            previous = hashes;
+        }
+    }
+
     #[test]
     fn render_style_markdown_flat_emits_pure_markdown() {
         let options = MarkdownDocsOptions {
@@ -1498,10 +1527,14 @@ mod tests {
         let page = out.get("cli.md").unwrap();
         assert_no_api_html(page);
         assert!(page.contains("### cli"));
-        assert!(page.contains("**Signature**"));
+        // Flat entry heading is H3, so body sections render at H4.
+        assert!(page.lines().any(|line| line == "#### Signature"));
+        assert!(!page.contains("**Signature**"));
         assert!(page.contains("```ts"));
         assert!(page.contains("| Name | Type | Description |"));
-        assert!(page.contains("**Members**"));
+        // The interface member group is a real heading (no `**Members**` wrapper).
+        assert!(page.lines().any(|line| line == "#### Methods"));
+        assert!(!page.contains("**Members**"));
         assert!(page.contains("| Name | Kind | Type | Description |"));
         assert!(page.contains("[View source](https://github.com/x/y/blob/main/"));
 
@@ -1543,6 +1576,68 @@ mod tests {
         let functions = out.get("functions.md").unwrap();
         assert_no_api_html(functions);
         assert!(functions.contains("### cli"));
+    }
+
+    #[test]
+    fn render_style_markdown_typedoc_sections_are_sequential_headings() {
+        let options = MarkdownDocsOptions {
+            render_style: MarkdownRenderStyle::Markdown,
+            path_strategy: MarkdownPathStrategy::TypeDoc,
+            github_url: Some("https://github.com/x/y".to_string()),
+            ..MarkdownDocsOptions::default()
+        };
+        let out = generate_markdown(&pure_test_docs(), &options);
+
+        // Function page: every section is a real H2 heading under the H1 title,
+        // with no bold-as-header, no skipped levels.
+        let fn_key =
+            out.keys().find(|key| key.ends_with("functions/cli.md")).expect("cli page").clone();
+        let page = out.get(&fn_key).unwrap();
+        assert!(page.starts_with("# cli"));
+        assert!(page.contains("## Signature"));
+        assert!(page.contains("## Parameters"));
+        assert!(page.contains("## Returns"));
+        assert!(page.contains("## Examples"));
+        assert!(page.contains("## Tags"));
+        assert!(!page.contains("**Signature**"));
+        assert!(!page.contains("**Returns**"));
+        assert!(!page.contains("#### "));
+        assert_no_heading_level_skips(page);
+
+        // Returns is its own heading with the value on the following line.
+        let after_returns = page.split("## Returns\n\n").nth(1).expect("returns section");
+        assert!(after_returns.starts_with("`void`"), "returns value on next line:\n{page}");
+
+        // Interface page: member group is a real H2 heading (## Methods), not a
+        // `#### Properties`/`**Members**` mix.
+        let if_key = out
+            .keys()
+            .find(|key| key.ends_with("interfaces/Command.md"))
+            .expect("Command page")
+            .clone();
+        let page = out.get(&if_key).unwrap();
+        assert!(page.contains("## Methods"));
+        assert!(!page.contains("#### "));
+        assert!(!page.contains("**Members**"));
+        assert_no_heading_level_skips(page);
+    }
+
+    #[test]
+    fn render_style_markdown_flat_sections_render_at_h4() {
+        let options = MarkdownDocsOptions {
+            render_style: MarkdownRenderStyle::Markdown,
+            ..MarkdownDocsOptions::default()
+        };
+        let out = generate_markdown(&pure_test_docs(), &options);
+        let page = out.get("cli.md").unwrap();
+
+        // Flat entry heading is H3, so its sections render at H4 (sequential).
+        assert!(page.contains("### cli"));
+        assert!(page.lines().any(|line| line == "#### Signature"));
+        assert!(page.lines().any(|line| line == "#### Parameters"));
+        assert!(page.lines().any(|line| line == "#### Returns"));
+        assert!(!page.lines().any(|line| line == "## Signature"));
+        assert_no_heading_level_skips(page);
     }
 
     #[test]
@@ -1944,7 +2039,8 @@ mod tests {
         );
         let page = markdown.get("mod/functions/make.md").unwrap();
 
-        assert!(page.contains("**Type Parameters**"));
+        assert!(page.contains("## Type Parameters"));
+        assert!(!page.contains("**Type Parameters**"));
         assert!(page.contains("`G` *extends* `Base` = `Default`"));
         assert!(page.contains("| `T` | The value type. |"));
     }

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -43,12 +43,20 @@ pub(super) fn render_stats_markdown(stats: &EntryStats, module_count: Option<usi
 }
 
 /// Renders the body of one entry (everything below its heading) as pure Markdown.
+///
+/// `section_level` is the heading level (number of `#`) for the entry's
+/// top-level sections — `2` under a page `# Title` (typedoc per-symbol pages),
+/// `4` under a flat `### Entry` heading. Sections are emitted as real Markdown
+/// headings (not bold paragraphs) so they appear in the VitePress outline, get
+/// anchors, and keep a sequential level hierarchy (markdownlint MD001).
 pub(super) fn render_entry_body_pure(
     entry: &ApiDocEntry,
     options: &MarkdownDocsOptions,
     context: Option<&MarkdownLinkContext<'_>>,
+    section_level: usize,
 ) -> String {
     let mut out = String::new();
+    let heading = "#".repeat(section_level);
 
     if entry.tags.iter().any(|tag| tag.tag == "deprecated") {
         out.push_str("**Deprecated.**\n\n");
@@ -62,7 +70,10 @@ pub(super) fn render_entry_body_pure(
     }
 
     if let Some(signature) = &entry.signature {
-        push_fmt(&mut out, format_args!("**Signature**\n\n```ts\n{}\n```\n\n", signature.trim()));
+        push_fmt(
+            &mut out,
+            format_args!("{heading} Signature\n\n```ts\n{}\n```\n\n", signature.trim()),
+        );
     }
 
     // Entries with an empty `file` (e.g. symbols re-exported from an external
@@ -80,7 +91,7 @@ pub(super) fn render_entry_body_pure(
     }
 
     if !entry.type_parameters.is_empty() {
-        out.push_str("**Type Parameters**\n\n");
+        push_fmt(&mut out, format_args!("{heading} Type Parameters\n\n"));
         out.push_str("| Name | Description |\n| --- | --- |\n");
         for type_param in &entry.type_parameters {
             push_fmt(
@@ -96,11 +107,11 @@ pub(super) fn render_entry_body_pure(
     }
 
     if !entry.members.is_empty() {
-        out.push_str(&render_members_pure(entry, context));
+        out.push_str(&render_members_pure(entry, context, section_level));
     }
 
     if !entry.params.is_empty() {
-        out.push_str("**Parameters**\n\n");
+        push_fmt(&mut out, format_args!("{heading} Parameters\n\n"));
         out.push_str("| Name | Type | Description |\n| --- | --- | --- |\n");
         for param in &entry.params {
             let mut description = inline(&param.description, context);
@@ -133,7 +144,7 @@ pub(super) fn render_entry_body_pure(
     }
 
     if let Some(returns) = &entry.returns {
-        out.push_str("**Returns** ");
+        push_fmt(&mut out, format_args!("{heading} Returns\n\n"));
         out.push_str(&code_cell(&returns.type_annotation));
         if !returns.description.is_empty() {
             push_fmt(&mut out, format_args!(" — {}", inline(&returns.description, context)));
@@ -142,7 +153,7 @@ pub(super) fn render_entry_body_pure(
     }
 
     if !entry.examples.is_empty() {
-        out.push_str("**Examples**\n\n");
+        push_fmt(&mut out, format_args!("{heading} Examples\n\n"));
         for example in &entry.examples {
             let (code, language) = parse_example_block(example);
             push_fmt(&mut out, format_args!("```{language}\n{code}\n```\n\n"));
@@ -150,7 +161,7 @@ pub(super) fn render_entry_body_pure(
     }
 
     if !entry.tags.is_empty() {
-        out.push_str("**Tags**\n\n");
+        push_fmt(&mut out, format_args!("{heading} Tags\n\n"));
         for tag in &entry.tags {
             let value = inline(&tag.value, context);
             if value.is_empty() {
@@ -166,7 +177,16 @@ pub(super) fn render_entry_body_pure(
 }
 
 /// Renders the member tables for an entry, grouped to match the HTML renderer.
-fn render_members_pure(entry: &ApiDocEntry, context: Option<&MarkdownLinkContext<'_>>) -> String {
+///
+/// Each member group (`Properties`, `Methods`, …) is emitted as a real heading
+/// at `section_level` — the same level as the entry's other sections — matching
+/// TypeDoc, which renders `## Properties` directly rather than nesting member
+/// tables under a separate "Members" heading.
+fn render_members_pure(
+    entry: &ApiDocEntry,
+    context: Option<&MarkdownLinkContext<'_>>,
+    section_level: usize,
+) -> String {
     // Bucket the members lazily: each `match` arm below only uses a subset of
     // these groups (the default arm uses none of them), so computing every
     // bucket up front wasted a full `members` pass + `Vec` per unused group.
@@ -200,16 +220,12 @@ fn render_members_pure(entry: &ApiDocEntry, context: Option<&MarkdownLinkContext
     };
 
     let mut out = String::new();
-    let mut wrote_heading = false;
+    let heading = "#".repeat(section_level);
     for (title, members) in groups {
         if members.is_empty() {
             continue;
         }
-        if !wrote_heading {
-            out.push_str("**Members**\n\n");
-            wrote_heading = true;
-        }
-        push_fmt(&mut out, format_args!("#### {title}\n\n"));
+        push_fmt(&mut out, format_args!("{heading} {title}\n\n"));
         out.push_str("| Name | Kind | Type | Description |\n| --- | --- | --- | --- |\n");
         for member in members {
             push_fmt(

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -3702,7 +3702,8 @@ mod tests {
         );
         let page = markdown.get("default/functions/make.md").unwrap();
 
-        assert!(page.contains("**Type Parameters**"));
+        assert!(page.contains("## Type Parameters"));
+        assert!(!page.contains("**Type Parameters**"));
         assert!(page.contains("`G` *extends* `Base` = `Default`"));
         assert!(page.contains("The thing type."));
     }


### PR DESCRIPTION
## Background

With `generateDocsMarkdown({ renderStyle: 'markdown', pathStrategy: 'typedoc' })`, symbol pages did not render their sections as real Markdown headings.

Instead:

- Almost every section (`Signature`, `Type Parameters`, `Parameters`, `Returns`, `Examples`, `Tags`) was emitted as a **bold paragraph** (`<p><strong>…</strong></p>`), not a heading.
- The member sub-section (`Properties` / `Methods` / `Constructors`) was emitted as `####` (H4) directly under the page `#` (H1) — skipping H2/H3 — and sat below a bold `**Members**` "header", an inverted hierarchy.
- `###` (H3) was never emitted; `## ` only appeared in `index.md` group lists.

This breaks the VitePress "On this page" outline (built from real `h2`–`h3` headings, so symbol pages had an empty outline), produces no section anchors/deep links, and emits non-sequential heading levels (markdownlint MD001).

TypeDoc (`typedoc-plugin-markdown`) renders every section as a real, sequentially-nested heading.

Root cause: the pure-markdown renderer (`markdown_pure.rs`) hard-coded section labels as `**X**` bold paragraphs, and rendered member groups under a `**Members**` wrapper with a fixed `#### {group}` level that is unrelated to the page's heading depth.

## Summary

All changes are in the pure-markdown renderer and its two call sites; the HTML renderer (default `renderStyle: 'html'`), JSON, extractor, and NAPI types are unchanged.

- `render_entry_body_pure` takes a `section_level` and emits every section (`Signature`, `Type Parameters`, `Parameters`, `Returns`, `Examples`, `Tags`) as a real heading at that level. `Returns` becomes its own heading with the value on the following line instead of an inline `**Returns** … — …`. The `**Deprecated.**` notice stays a bold callout (it is not a section).
- `render_members_pure` drops the `**Members**` wrapper and the fixed `####`, emitting each member group (`Properties`, `Methods`, `Constructors`, …) as a real heading at the same level as the other sections — matching TypeDoc, which renders `## Properties` directly.
- Call sites pass the level for their context: typedoc per-symbol pages (`# Title`) use H2; flat/category entries (`### Entry`) use H4. Both keep a sequential hierarchy with no level skips.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782826130&installation_id=136613492&pr_number=275&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F275&signature=6d89ad3453ff2cde0ffaeb7b048d99d20ad3a5e4990c7093ad9d61dcb9cbdcf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->