### PR TITLE
fix(docs): emit one canonical typedoc page per symbol for cross-entrypoint re-exports

### DIFF
--- a/crates/ox_content_docs/src/data.rs
+++ b/crates/ox_content_docs/src/data.rs
@@ -239,6 +239,7 @@ mod tests {
         let docs = vec![ApiDocModule {
             description: String::new(),
             file: "/repo/src/math.ts".to_string(),
+            source_path: String::new(),
             entries: vec![ApiDocEntry {
                 name: "clamp".to_string(),
                 kind: "function".to_string(),
@@ -281,6 +282,7 @@ mod tests {
         let docs = vec![ApiDocModule {
             description: "The entry for gunshi context.".to_string(),
             file: "/repo/src/context.ts".to_string(),
+            source_path: String::new(),
             entries: vec![],
         }];
 
@@ -295,6 +297,7 @@ mod tests {
         let docs = vec![ApiDocModule {
             description: String::new(),
             file: "/repo/src/combinators.ts".to_string(),
+            source_path: String::new(),
             entries: vec![ApiDocEntry {
                 name: "Combinator".to_string(),
                 kind: "type".to_string(),
@@ -331,6 +334,7 @@ mod tests {
         let docs = vec![ApiDocModule {
             description: String::new(),
             file: "/repo/src/make.ts".to_string(),
+            source_path: String::new(),
             entries: vec![ApiDocEntry {
                 name: "make".to_string(),
                 kind: "function".to_string(),

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -712,12 +712,73 @@ fn generate_file_markdown(
     markdown
 }
 
+/// Resolves, for each distinct symbol, the single module that owns its canonical
+/// TypeDoc per-symbol page. A symbol re-exported from several entry points
+/// otherwise produces an identical page under each one; TypeDoc emits one page.
+///
+/// A symbol is keyed by `(name, defining_file)` so that two distinct symbols
+/// sharing a name (different source files) keep separate pages. The owner is:
+///
+/// 1. the module whose own entry-point source (`source_path`) is the symbol's
+///    defining file (i.e. the symbol is declared in that entry point), else
+/// 2. the first module that exports it, in the same order pages are emitted.
+pub struct CanonicalOwners {
+    owners: HashMap<(String, String), String>,
+}
+
+impl CanonicalOwners {
+    pub fn compute(docs: &[ApiDocModule]) -> Self {
+        // Build the owner table in the same deterministic order that pages are
+        // emitted (see `sort_extracted_docs`) so the fallback "first exporter"
+        // rule agrees between the page generator and the nav generator,
+        // regardless of the caller's input order.
+        let mut order: Vec<&ApiDocModule> = docs.iter().collect();
+        order.sort_by_cached_key(|module| {
+            let name = file_name(&module.file);
+            (name.to_lowercase(), name)
+        });
+
+        let mut owners: HashMap<(String, String), String> = HashMap::new();
+        let mut fallback: HashMap<(String, String), String> = HashMap::new();
+        for doc in order {
+            let module_name = module_file_name(&doc.file);
+            for entry in &doc.entries {
+                let key = (entry.name.clone(), entry.file.clone());
+                fallback.entry(key.clone()).or_insert_with(|| module_name.clone());
+                // Rule 1: the defining module wins, if it is itself an entry point.
+                if !entry.file.is_empty() && doc.source_path == entry.file {
+                    owners.entry(key).or_insert_with(|| module_name.clone());
+                }
+            }
+        }
+        // Rule 2: symbols with no defining-module match fall back to the first
+        // module that exported them.
+        for (key, module_name) in fallback {
+            owners.entry(key).or_insert(module_name);
+        }
+
+        Self { owners }
+    }
+
+    /// The module name owning `entry`'s canonical page, if known.
+    fn canonical_module(&self, entry: &ApiDocEntry) -> Option<&str> {
+        self.owners.get(&(entry.name.clone(), entry.file.clone())).map(String::as_str)
+    }
+
+    /// True when `entry` should render its full page under `doc` (rather than be
+    /// a re-export reference to another module's canonical page).
+    pub fn is_canonical(&self, doc: &ApiDocModule, entry: &ApiDocEntry) -> bool {
+        self.canonical_module(entry) == Some(module_file_name(&doc.file).as_str())
+    }
+}
+
 fn generate_typedoc_markdown(
     docs: &[ApiDocModule],
     options: &MarkdownDocsOptions,
     symbol_map: &HashMap<String, Vec<SymbolLocation>>,
 ) -> BTreeMap<String, String> {
     let mut result = BTreeMap::new();
+    let owners = CanonicalOwners::compute(docs);
 
     result.insert("index.md".to_string(), generate_typedoc_root_index(docs, options, symbol_map));
 
@@ -726,10 +787,16 @@ fn generate_typedoc_markdown(
         let module_index_file_name = typedoc_module_index_file_name(&module_name);
         result.insert(
             format!("{module_index_file_name}.md"),
-            generate_typedoc_module_index(doc, options, &module_name, symbol_map),
+            generate_typedoc_module_index(doc, options, &module_name, symbol_map, &owners),
         );
 
         for entry in &doc.entries {
+            // A symbol re-exported from several entry points gets one canonical
+            // page (matching TypeDoc); non-canonical occurrences are surfaced as
+            // re-export references in the module index instead of duplicate pages.
+            if !owners.is_canonical(doc, entry) {
+                continue;
+            }
             let entry_file_name = typedoc_entry_file_name(&module_name, entry);
             result.insert(
                 format!("{entry_file_name}.md"),
@@ -798,6 +865,7 @@ fn generate_typedoc_module_index(
     options: &MarkdownDocsOptions,
     module_name: &str,
     symbol_map: &HashMap<String, Vec<SymbolLocation>>,
+    owners: &CanonicalOwners,
 ) -> String {
     let current_file_name = typedoc_module_index_file_name(module_name);
     let link_context = MarkdownLinkContext {
@@ -824,7 +892,13 @@ fn generate_typedoc_module_index(
     markdown.push_str("\n\n");
 
     for kind in ordered_entry_kinds(&doc.entries) {
-        let entries = doc.entries.iter().filter(|entry| entry.kind == kind).collect::<Vec<_>>();
+        // Only entries whose canonical page lives in this module are listed in
+        // the kind sections; re-exports are collected into "References" below.
+        let entries = doc
+            .entries
+            .iter()
+            .filter(|entry| entry.kind == kind && owners.is_canonical(doc, entry))
+            .collect::<Vec<_>>();
         if entries.is_empty() {
             continue;
         }
@@ -838,6 +912,28 @@ fn generate_typedoc_module_index(
                 None,
             );
             markdown.push_str(&render_overview_line(entry, &href, Some(&link_context)));
+        }
+        markdown.push('\n');
+    }
+
+    // Symbols this module re-exports but does not own: link to the canonical page
+    // instead of emitting a duplicate (matches TypeDoc's "References" section).
+    let references = doc
+        .entries
+        .iter()
+        .filter(|entry| !owners.is_canonical(doc, entry))
+        .filter_map(|entry| owners.canonical_module(entry).map(|owner| (entry, owner)))
+        .collect::<Vec<_>>();
+    if !references.is_empty() {
+        markdown.push_str("## References\n\n");
+        for (entry, owner) in references {
+            let href = doc_page_href_from(
+                options,
+                &current_file_name,
+                &typedoc_entry_file_name(owner, entry),
+                None,
+            );
+            push_fmt(&mut markdown, format_args!("- Re-exports [`{}`]({href})\n", entry.name));
         }
         markdown.push('\n');
     }
@@ -1265,13 +1361,23 @@ fn build_symbol_map(
     options: &MarkdownDocsOptions,
 ) -> HashMap<String, Vec<SymbolLocation>> {
     let mut map = HashMap::new();
+    // In the TypeDoc strategy a re-exported symbol has a single canonical page;
+    // resolve every reference to that owner module so cross-links never point at
+    // a duplicate page that is no longer emitted.
+    let canonical = (options.group_by == "file"
+        && options.path_strategy == MarkdownPathStrategy::TypeDoc)
+        .then(|| CanonicalOwners::compute(docs));
 
     for doc in docs {
         let module_name = module_file_name(&doc.file);
         for entry in &doc.entries {
             let (file_name, anchor) = match (options.group_by.as_str(), options.path_strategy) {
                 ("file", MarkdownPathStrategy::TypeDoc) => {
-                    (typedoc_entry_file_name(&module_name, entry), None)
+                    let owner_module = canonical
+                        .as_ref()
+                        .and_then(|owners| owners.canonical_module(entry))
+                        .unwrap_or(module_name.as_str());
+                    (typedoc_entry_file_name(owner_module, entry), None)
                 }
                 ("category", _) => {
                     (fmt_args(format_args!("{}s", entry.kind)), Some(entry_anchor(&entry.name)))
@@ -1394,6 +1500,7 @@ mod tests {
             ApiDocModule {
                 description: String::new(),
                 file: "/repo/src/context.ts".to_string(),
+                source_path: String::new(),
                 entries: vec![test_entry(
                     "CommandContext",
                     "interface",
@@ -1404,6 +1511,7 @@ mod tests {
             ApiDocModule {
                 description: String::new(),
                 file: "/repo/src/command.ts".to_string(),
+                source_path: String::new(),
                 entries: vec![test_entry(
                     "Command",
                     "function",
@@ -1418,6 +1526,7 @@ mod tests {
         vec![ApiDocModule {
             description: String::new(),
             file: "/repo/src/cli.ts".to_string(),
+            source_path: String::new(),
             entries: vec![
                 ApiDocEntry {
                     name: "cli".to_string(),
@@ -1633,6 +1742,7 @@ mod tests {
             ApiDocModule {
                 description: String::new(),
                 file: "/repo/src/agent.ts".to_string(),
+                source_path: String::new(),
                 entries: vec![test_entry(
                     "AgentProfile",
                     "interface",
@@ -1643,6 +1753,7 @@ mod tests {
             ApiDocModule {
                 description: String::new(),
                 file: "/repo/src/command.ts".to_string(),
+                source_path: String::new(),
                 entries: vec![ApiDocEntry {
                     name: "Command".to_string(),
                     kind: "interface".to_string(),
@@ -1679,6 +1790,7 @@ mod tests {
             ApiDocModule {
                 description: String::new(),
                 file: "/repo/src/build.ts".to_string(),
+                source_path: String::new(),
                 entries: vec![ApiDocEntry {
                     name: "buildCommand".to_string(),
                     kind: "function".to_string(),
@@ -1743,6 +1855,7 @@ mod tests {
         let docs = vec![ApiDocModule {
             description: String::new(),
             file: "default".to_string(),
+            source_path: String::new(),
             entries: vec![
                 ApiDocEntry {
                     name: "cli".to_string(),
@@ -1832,6 +1945,7 @@ mod tests {
             ApiDocModule {
                 description: "The entry for gunshi context.".to_string(),
                 file: "context".to_string(),
+                source_path: String::new(),
                 entries: vec![test_entry(
                     "CommandContextParams",
                     "interface",
@@ -1842,6 +1956,7 @@ mod tests {
             ApiDocModule {
                 description: String::new(),
                 file: "plugin".to_string(),
+                source_path: String::new(),
                 entries: vec![test_entry(
                     "plugin",
                     "function",
@@ -1882,6 +1997,7 @@ mod tests {
         let docs = vec![ApiDocModule {
             description: String::new(),
             file: "mod".to_string(),
+            source_path: String::new(),
             entries: vec![
                 test_entry("localSym", "function", "packages/x/src/a.ts", "Local symbol."),
                 // Empty file = external-package source: no in-repo source location.
@@ -1931,6 +2047,7 @@ mod tests {
         let docs = vec![ApiDocModule {
             description: String::new(),
             file: "mod".to_string(),
+            source_path: String::new(),
             entries: vec![entry],
         }];
 
@@ -1955,6 +2072,7 @@ mod tests {
             ApiDocModule {
                 description: String::new(),
                 file: "default".to_string(),
+                source_path: String::new(),
                 entries: vec![
                     test_entry("Command", "interface", "/repo/src/default.ts", "Default command."),
                     test_entry(
@@ -1968,6 +2086,7 @@ mod tests {
             ApiDocModule {
                 description: String::new(),
                 file: "plugin".to_string(),
+                source_path: String::new(),
                 entries: vec![
                     test_entry("Command", "interface", "/repo/src/plugin.ts", "Plugin command."),
                     test_entry(
@@ -1997,6 +2116,127 @@ mod tests {
         assert!(default_page.contains("<a href=\"/api/default/interfaces/Command\">Command</a>"));
         assert!(plugin_page.contains("<a href=\"/api/plugin/interfaces/Command\">Command</a>"));
         assert!(!default_page.contains(".md"));
+    }
+
+    #[test]
+    fn typedoc_dedupes_cross_entrypoint_reexports_to_canonical_page() {
+        // `createCommandContext` is defined in context.ts and re-exported from
+        // the default and plugin entry points. It must produce a single page
+        // under its defining module (context), with the re-exporters linking to
+        // it via a References section.
+        let docs = vec![
+            ApiDocModule {
+                description: String::new(),
+                file: "context".to_string(),
+                source_path: "/repo/src/context.ts".to_string(),
+                entries: vec![test_entry(
+                    "createCommandContext",
+                    "function",
+                    "/repo/src/context.ts",
+                    "Creates a command context.",
+                )],
+            },
+            ApiDocModule {
+                description: String::new(),
+                file: "default".to_string(),
+                source_path: "/repo/src/index.ts".to_string(),
+                entries: vec![
+                    test_entry(
+                        "createCommandContext",
+                        "function",
+                        "/repo/src/context.ts",
+                        "Creates a command context.",
+                    ),
+                    test_entry(
+                        "runDefault",
+                        "function",
+                        "/repo/src/index.ts",
+                        "Uses {@link createCommandContext}.",
+                    ),
+                ],
+            },
+            ApiDocModule {
+                description: String::new(),
+                file: "plugin".to_string(),
+                source_path: "/repo/src/plugin.ts".to_string(),
+                entries: vec![test_entry(
+                    "createCommandContext",
+                    "function",
+                    "/repo/src/context.ts",
+                    "Creates a command context.",
+                )],
+            },
+        ];
+
+        let out = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+
+        // Exactly one canonical page, placed under the defining module.
+        assert!(out.contains_key("context/functions/createCommandContext.md"));
+        assert!(!out.contains_key("default/functions/createCommandContext.md"));
+        assert!(!out.contains_key("plugin/functions/createCommandContext.md"));
+
+        // The defining module lists it as a real entry; re-exporters reference it.
+        let context_index = out.get("context/index.md").unwrap();
+        assert!(context_index.contains("## Functions"));
+        assert!(!context_index.contains("## References"));
+
+        let default_index = out.get("default/index.md").unwrap();
+        assert!(default_index.contains("## References"));
+        assert!(default_index.contains("Re-exports [`createCommandContext`]"));
+        // The re-export reference and any cross-link resolve to the canonical page.
+        assert!(default_index.contains("context/functions/createCommandContext"));
+
+        let run_default = out.get("default/functions/runDefault.md").unwrap();
+        assert!(run_default.contains("context/functions/createCommandContext"));
+    }
+
+    #[test]
+    fn typedoc_dedupe_without_source_path_uses_first_module() {
+        // `Command` is defined in a non-entry-point file (command.ts), so no
+        // module owns it via source_path; the canonical page falls back to the
+        // first module (sorted) that exports it.
+        let docs = vec![
+            ApiDocModule {
+                description: String::new(),
+                file: "default".to_string(),
+                source_path: "/repo/src/index.ts".to_string(),
+                entries: vec![test_entry(
+                    "Command",
+                    "interface",
+                    "/repo/src/command.ts",
+                    "A command.",
+                )],
+            },
+            ApiDocModule {
+                description: String::new(),
+                file: "plugin".to_string(),
+                source_path: "/repo/src/plugin.ts".to_string(),
+                entries: vec![test_entry(
+                    "Command",
+                    "interface",
+                    "/repo/src/command.ts",
+                    "A command.",
+                )],
+            },
+        ];
+
+        let out = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+
+        assert!(out.contains_key("default/interfaces/Command.md"));
+        assert!(!out.contains_key("plugin/interfaces/Command.md"));
+        assert!(out.get("plugin/index.md").unwrap().contains("Re-exports [`Command`]"));
     }
 
     #[test]
@@ -2035,6 +2275,7 @@ mod tests {
         let docs = vec![ApiDocModule {
             description: String::new(),
             file: "default".to_string(),
+            source_path: String::new(),
             entries: vec![
                 ApiDocEntry {
                     name: "Mode".to_string(),
@@ -2111,6 +2352,7 @@ mod tests {
         let docs = vec![ApiDocModule {
             description: String::new(),
             file: "/repo/src/command.ts".to_string(),
+            source_path: String::new(),
             entries: vec![ApiDocEntry {
                 name: "Command".to_string(),
                 kind: "interface".to_string(),

--- a/crates/ox_content_docs/src/model.rs
+++ b/crates/ox_content_docs/src/model.rs
@@ -16,6 +16,14 @@ pub struct ApiDocModule {
     /// file comment. Empty when the source has no module-level JSDoc.
     #[serde(default)]
     pub description: String,
+    /// Absolute source path of the entry point this module was generated from.
+    ///
+    /// Used by the TypeDoc path strategy to place a re-exported symbol's
+    /// canonical page under its defining module (when that module is itself an
+    /// entry point). Empty when the caller does not supply it; dedup then falls
+    /// back to the first module that exports the symbol.
+    #[serde(default)]
+    pub source_path: String,
     /// Documented entries in the source file.
     pub entries: Vec<ApiDocEntry>,
 }

--- a/crates/ox_content_docs/src/nav.rs
+++ b/crates/ox_content_docs/src/nav.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::markdown::MarkdownPathStrategy;
+use crate::markdown::{CanonicalOwners, MarkdownPathStrategy};
 use crate::model::{ApiDocEntry, ApiDocModule};
 
 const DEFAULT_BASE_PATH: &str = "/api";
@@ -65,14 +65,20 @@ fn generate_typedoc_nav_metadata(
     let base_path = normalize_base_path(base_path.unwrap_or(DEFAULT_BASE_PATH));
     let mut docs = docs.to_vec();
     docs.sort_by_cached_key(|doc| module_file_name(&doc.file));
+    // A re-exported symbol appears in the sidebar only under the module that owns
+    // its canonical page (matching TypeDoc's single-location listing).
+    let owners = CanonicalOwners::compute(&docs);
 
     docs.into_iter()
         .map(|doc| {
             let module_name = module_file_name(&doc.file);
             let mut children = Vec::new();
             for kind in ordered_entry_kinds(&doc.entries) {
-                let entries =
-                    doc.entries.iter().filter(|entry| entry.kind == kind).collect::<Vec<_>>();
+                let entries = doc
+                    .entries
+                    .iter()
+                    .filter(|entry| entry.kind == kind && owners.is_canonical(&doc, entry))
+                    .collect::<Vec<_>>();
                 if entries.is_empty() {
                     continue;
                 }
@@ -321,6 +327,7 @@ mod tests {
         let docs = vec![ApiDocModule {
             description: String::new(),
             file: "default".to_string(),
+            source_path: String::new(),
             entries: vec![
                 ApiDocEntry {
                     name: "cli".to_string(),
@@ -378,6 +385,7 @@ mod tests {
         let docs = vec![ApiDocModule {
             description: String::new(),
             file: "default".to_string(),
+            source_path: String::new(),
             entries: vec![ApiDocEntry {
                 name: "Mode".to_string(),
                 kind: "enum".to_string(),
@@ -405,6 +413,45 @@ mod tests {
         assert_eq!(
             children[0].children.as_ref().unwrap()[0].path,
             "/api/default/enumerations/Mode"
+        );
+    }
+
+    #[test]
+    fn typedoc_nav_omits_reexports_from_non_owner_modules() {
+        let make = |module: &str, source: &str| ApiDocModule {
+            description: String::new(),
+            file: module.to_string(),
+            source_path: source.to_string(),
+            entries: vec![ApiDocEntry {
+                name: "createCommandContext".to_string(),
+                kind: "function".to_string(),
+                description: String::new(),
+                params: vec![],
+                returns: None,
+                examples: vec![],
+                tags: vec![],
+                private: false,
+                file: "/repo/src/context.ts".to_string(),
+                line: 1,
+                end_line: 1,
+                signature: None,
+                members: vec![],
+                type_parameters: vec![],
+            }],
+        };
+        // `context` defines the symbol; `default` only re-exports it.
+        let docs =
+            vec![make("context", "/repo/src/context.ts"), make("default", "/repo/src/index.ts")];
+
+        let nav =
+            generate_nav_metadata_from_docs(&docs, Some("/api"), MarkdownPathStrategy::TypeDoc);
+
+        let context = nav.iter().find(|item| item.path == "/api/context").unwrap();
+        assert!(context.children.is_some(), "owner module keeps the symbol in the sidebar");
+        let default = nav.iter().find(|item| item.path == "/api/default").unwrap();
+        assert!(
+            default.children.is_none(),
+            "re-exporting module omits the symbol from the sidebar"
         );
     }
 

--- a/crates/ox_content_docs/src/output.rs
+++ b/crates/ox_content_docs/src/output.rs
@@ -225,6 +225,7 @@ mod tests {
         let extracted = vec![ApiDocModule {
             description: String::new(),
             file: "default".to_string(),
+            source_path: String::new(),
             entries: vec![
                 ApiDocEntry {
                     name: "cli".to_string(),

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -330,6 +330,12 @@ export interface JsDocsMarkdownModule {
   file: string
   /** Module-level description from the entry file's `@module` / leading JSDoc. */
   description?: string
+  /**
+   * Absolute source path of the entry point (from `extractDocsFromEntryPoints`'
+   * `sourcePath`). Optional; when provided, the TypeDoc path strategy places a
+   * re-exported symbol's canonical page under its defining module.
+   */
+  sourcePath?: string
   entries: Array<JsDocsMarkdownEntry>
 }
 

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -280,6 +280,10 @@ pub struct JsDocsMarkdownModule {
     pub file: String,
     /// Module-level description from the entry file's `@module` / leading JSDoc.
     pub description: Option<String>,
+    /// Absolute source path of the entry point (from `extractDocsFromEntryPoints`'
+    /// `sourcePath`). Optional; when provided, the TypeDoc path strategy places a
+    /// re-exported symbol's canonical page under its defining module.
+    pub source_path: Option<String>,
     pub entries: Vec<JsDocsMarkdownEntry>,
 }
 
@@ -1161,6 +1165,7 @@ fn convert_markdown_module(module: JsDocsMarkdownModule) -> ApiDocModule {
     ApiDocModule {
         file: module.file,
         description: module.description.unwrap_or_default(),
+        source_path: module.source_path.unwrap_or_default(),
         entries: module.entries.into_iter().map(convert_markdown_entry).collect(),
     }
 }
@@ -3438,6 +3443,7 @@ mod tests {
         let docs = vec![JsDocsMarkdownModule {
             description: None,
             file: "/repo/src/context.ts".to_string(),
+            source_path: None,
             entries: vec![JsDocsMarkdownEntry {
                 name: "CommandContext".to_string(),
                 kind: "interface".to_string(),
@@ -3477,6 +3483,7 @@ mod tests {
         let docs = vec![JsDocsMarkdownModule {
             description: None,
             file: "/repo/src/context.ts".to_string(),
+            source_path: None,
             entries: vec![JsDocsMarkdownEntry {
                 name: "CommandContext".to_string(),
                 kind: "interface".to_string(),
@@ -3519,6 +3526,7 @@ mod tests {
             JsDocsMarkdownModule {
                 description: None,
                 file: "/repo/src/command.ts".to_string(),
+                source_path: None,
                 entries: vec![JsDocsMarkdownEntry {
                     name: "Command".to_string(),
                     kind: "interface".to_string(),
@@ -3554,6 +3562,7 @@ mod tests {
             JsDocsMarkdownModule {
                 description: None,
                 file: "/repo/src/build.ts".to_string(),
+                source_path: None,
                 entries: vec![JsDocsMarkdownEntry {
                     name: "buildCommand".to_string(),
                     kind: "function".to_string(),
@@ -3607,6 +3616,7 @@ mod tests {
         let docs = vec![JsDocsMarkdownModule {
             description: None,
             file: "default".to_string(),
+            source_path: None,
             entries: vec![
                 JsDocsMarkdownEntry {
                     name: "Command".to_string(),
@@ -3662,10 +3672,63 @@ mod tests {
     }
 
     #[test]
+    fn generate_docs_markdown_dedupes_cross_entrypoint_reexports() {
+        // The same symbol re-exported from two entry points should yield a single
+        // canonical page placed under its defining module via `sourcePath`.
+        let entry = |name: &str| JsDocsMarkdownEntry {
+            name: name.to_string(),
+            kind: "function".to_string(),
+            description: "Creates a command context.".to_string(),
+            params: None,
+            returns: None,
+            examples: None,
+            tags: None,
+            private: false,
+            file: "/repo/src/context.ts".to_string(),
+            line: 1,
+            end_line: 1,
+            signature: Some("export function createCommandContext(): void".to_string()),
+            members: None,
+            type_parameters: None,
+        };
+        let docs = vec![
+            JsDocsMarkdownModule {
+                description: None,
+                file: "context".to_string(),
+                source_path: Some("/repo/src/context.ts".to_string()),
+                entries: vec![entry("createCommandContext")],
+            },
+            JsDocsMarkdownModule {
+                description: None,
+                file: "default".to_string(),
+                source_path: Some("/repo/src/index.ts".to_string()),
+                entries: vec![entry("createCommandContext")],
+            },
+        ];
+
+        let markdown = generate_docs_markdown(
+            docs,
+            Some(JsDocsMarkdownOptions {
+                group_by: Some("file".to_string()),
+                github_url: None,
+                link_style: Some("markdown".to_string()),
+                base_path: None,
+                path_strategy: Some("typedoc".to_string()),
+                render_style: None,
+            }),
+        );
+
+        assert!(markdown.contains_key("context/functions/createCommandContext.md"));
+        assert!(!markdown.contains_key("default/functions/createCommandContext.md"));
+        assert!(markdown.get("default/index.md").unwrap().contains("Re-exports"));
+    }
+
+    #[test]
     fn generate_docs_markdown_renders_type_parameters() {
         let docs = vec![JsDocsMarkdownModule {
             description: None,
             file: "default".to_string(),
+            source_path: None,
             entries: vec![JsDocsMarkdownEntry {
                 name: "make".to_string(),
                 kind: "function".to_string(),
@@ -3712,6 +3775,7 @@ mod tests {
         let docs = vec![JsDocsMarkdownModule {
             description: Some("The entry for gunshi context.".to_string()),
             file: "context".to_string(),
+            source_path: None,
             entries: vec![JsDocsMarkdownEntry {
                 name: "createCommandContext".to_string(),
                 kind: "function".to_string(),
@@ -3754,6 +3818,7 @@ mod tests {
         let docs = vec![JsDocsMarkdownModule {
             description: None,
             file: "default".to_string(),
+            source_path: None,
             entries: vec![
                 JsDocsMarkdownEntry {
                     name: "cli".to_string(),
@@ -3815,6 +3880,7 @@ mod tests {
         let docs = vec![JsDocsMarkdownModule {
             description: None,
             file: "/repo/src/context.ts".to_string(),
+            source_path: None,
             entries: vec![],
         }];
 
@@ -3837,6 +3903,7 @@ mod tests {
         let extracted = vec![JsDocsMarkdownModule {
             description: None,
             file: "default".to_string(),
+            source_path: None,
             entries: vec![JsDocsMarkdownEntry {
                 name: "cli".to_string(),
                 kind: "function".to_string(),


### PR DESCRIPTION
## Background

Under `generateDocsMarkdown(..., { pathStrategy: 'typedoc' })`, a symbol re-exported from several entry points (a normal barrel pattern) gets a full per-symbol page `{module}/{category}/{Name}.md` under **every** entry point that exports it. 

TypeDoc emits exactly one canonical page per symbol, placed at its defining (or primary) module.

Measured on gunshi (8 entry points): TypeDoc emits 82 symbol pages for 82 names (0 duplicates); ox-content emitted 133 pages for the same 82 names, **51 duplicate pages**.

For example `createCommandContext` (defined in `context.ts`, re-exported from `index`/`definition`/`plugin`) produced 4 identical pages.

The duplication inflates the build output and search index, scatters a symbol across several sidebar locations, and leaves no canonical URL.

Root cause: `generate_typedoc_markdown` unconditionally emits a page for every `(module, entry)` pair, and the same symbol appears in every re-exporting module's `entries`.

The graph layer only dedupes within a single entry point, not across them.

## Summary

The TypeDoc path strategy now emits one canonical page per symbol.

The defining source path of each entry is preserved through the graph (re-exports keep the original `entry.file`), which makes canonical placement possible.

- Canonical owner resolution (`CanonicalOwners`): each distinct symbol, keyed by `(name, defining file)`, is owned by (1) the module whose own entry-point source (`source_path`) is the symbol's defining file — i.e. the symbol is declared in that entry point — else (2) the first module that exports it. Keying by `(name, file)` keeps two distinct same-named symbols as separate pages.
- Pages: only the canonical `(module, entry)` renders a full page; re-export occurrences are skipped. Page count now equals the number of distinct symbols.
- Cross-links: the symbol map resolves every reference to the canonical page, so `{@link}`, overview, and nav links never point at a page that is no longer emitted.
- Module index: a re-exporting module lists the symbol in a `## References` section (`Re-exports [Name](canonical)`) instead of a duplicate page.
- Nav: a re-exported symbol appears in the sidebar only under its owning module (single-location listing, matching TypeDoc).

### Source-path wiring

`ApiDocModule` gains a `source_path`, and `JsDocsMarkdownModule` gains an optional `sourcePath` (already available from `extractDocsFromEntryPoints`).

It is optional and backward-compatible: without it, dedup still collapses duplicates (falling back to the first exporting module); with it, a symbol defined in one entry point but re-exported from an alphabetically-earlier one (e.g. `define` in `definition.ts`, re-exported from `index.ts`) is correctly placed under its defining module, matching TypeDoc.

`docs.json` is unchanged (its JSON is built explicitly).

This is the default for `group_by: 'file'` + `pathStrategy: 'typedoc'`; flat/category strategies, JSON, and the HTML render style are untouched.

## Note for consumers

For canonical placement to match TypeDoc, pass `sourcePath` through to `generateDocsMarkdown` (one line in the generator, mapping `extractDocsFromEntryPoints`' `sourcePath`).

Without it, pages are still deduplicated. Existing per-entry-point duplicate URLs (e.g. `…/default/functions/createCommandContext`) collapse to the canonical URL (`…/context/functions/createCommandContext`).

the TypeDoc-parity behavior this strategy targets.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782872993&installation_id=136613492&pr_number=280&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F280&signature=4fb4b3c3f354c817ff76179900810576230bd8f9f7494e50e6c360af6a024849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->