### PR TITLE
fix(docs): render typedoc module index members as compact tables instead of bullet lists

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ memchr = "2.7"
 
 # Hashing
 rustc-hash = "2"
+phf = { version = "0.13", features = ["macros"] }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/ox_content_docs/Cargo.toml
+++ b/crates/ox_content_docs/Cargo.toml
@@ -25,6 +25,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
+phf = { workspace = true }
 
 # OXC for JS/TS parsing
 oxc_allocator = { workspace = true }

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -374,6 +374,21 @@ fn typedoc_kind_title(kind: &str) -> &'static str {
     }
 }
 
+/// Singular category label used as the first column header of a module index
+/// table (matches TypeDoc, e.g. `Function`, `Type Alias`).
+fn typedoc_kind_singular(kind: &str) -> &'static str {
+    match kind {
+        "function" => "Function",
+        "class" => "Class",
+        "interface" => "Interface",
+        "type" => "Type Alias",
+        "enum" => "Enumeration",
+        "variable" | "const" => "Variable",
+        "module" => "Module",
+        _ => "Symbol",
+    }
+}
+
 fn typedoc_entry_file_name(module_name: &str, entry: &ApiDocEntry) -> String {
     format!(
         "{}/{}/{}",
@@ -543,6 +558,20 @@ fn process_doc_text(text: &str, context: Option<&MarkdownLinkContext<'_>>) -> St
     let text =
         context.map_or_else(|| text.to_string(), |context| convert_symbol_links(text, context));
     convert_jsdoc_inline_links(&text, context)
+}
+
+/// One-line summary for a module index table cell.
+///
+/// Resolves `{@link}`/`{@linkcode}` exactly like the per-symbol pages (keeping
+/// the produced Markdown links and inline code), takes the first paragraph,
+/// collapses it to a single line, and escapes table-cell pipes. Unlike
+/// [`clean_summary_text`] it does not strip links/code, so the index matches
+/// TypeDoc (e.g. `An object that contains [argument schema](…).`).
+fn typedoc_index_summary(description: &str, context: &MarkdownLinkContext<'_>) -> String {
+    let resolved = process_doc_text(description, Some(context));
+    let first_paragraph = resolved.split("\n\n").next().unwrap_or_default();
+    let one_line = first_paragraph.split_whitespace().collect::<Vec<_>>().join(" ");
+    one_line.replace('|', "\\|")
 }
 
 fn clean_summary_text(text: &str, max_length: usize) -> String {
@@ -903,15 +932,31 @@ fn generate_typedoc_module_index(
             continue;
         }
 
+        // Render a compact `Name | Description` table (matching TypeDoc) rather
+        // than a bullet list with the full signature inlined; the signature
+        // stays on the per-symbol page.
         push_fmt(&mut markdown, format_args!("## {}\n\n", typedoc_kind_title(&kind)));
+        push_fmt(
+            &mut markdown,
+            format_args!(
+                "| {} | Description |\n| ------ | ------ |\n",
+                typedoc_kind_singular(&kind)
+            ),
+        );
+        let mut seen = std::collections::HashSet::new();
         for entry in entries {
+            // Overloads share a name (and page); collapse them to one row.
+            if !seen.insert(entry.name.as_str()) {
+                continue;
+            }
             let href = doc_page_href_from(
                 options,
                 &current_file_name,
                 &typedoc_entry_file_name(module_name, entry),
                 None,
             );
-            markdown.push_str(&render_overview_line(entry, &href, Some(&link_context)));
+            let summary = typedoc_index_summary(&entry.description, &link_context);
+            push_fmt(&mut markdown, format_args!("| [{}]({href}) | {summary} |\n", entry.name));
         }
         markdown.push('\n');
     }
@@ -2025,8 +2070,13 @@ mod tests {
         assert!(markdown.contains_key("index.md"));
         assert!(markdown.contains_key("default/type-aliases/Plugin.md"));
         assert!(markdown.contains_key("default/variables/CLI_OPTIONS_DEFAULT.md"));
-        assert!(module_index.contains("[`cli`](./functions/cli.md)"));
-        assert!(module_index.contains("[`CliOptions`](./interfaces/CliOptions.md)"));
+        // The module index lists members as a compact table, not bullets with
+        // the full signature inlined.
+        assert!(module_index.contains("| Function | Description |"));
+        assert!(module_index.contains("| [cli](./functions/cli.md) |"));
+        assert!(module_index.contains("| [CliOptions](./interfaces/CliOptions.md) |"));
+        assert!(!module_index.contains("[`cli`]"));
+        assert!(!module_index.contains("export function cli"));
         assert!(cli_page.contains("<a href=\"../interfaces/CliOptions.md\">CliOptions</a>"));
         assert!(cli_page.contains(
             "<a href=\"../interfaces/CliOptions.md#property-usagesilent\"><code>CliOptions.usageSilent</code></a>"
@@ -2160,6 +2210,115 @@ mod tests {
         assert!(!page.contains("**Type Parameters**"));
         assert!(page.contains("`G` *extends* `Base` = `Default`"));
         assert!(page.contains("| `T` | The value type. |"));
+    }
+
+    #[test]
+    fn typedoc_module_index_renders_member_tables() {
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "default".to_string(),
+            source_path: String::new(),
+            entries: vec![
+                test_entry("cli", "function", "/repo/src/cli.ts", "Run the command."),
+                test_entry("CliOptions", "interface", "/repo/src/types.ts", "CLI options."),
+            ],
+        }];
+
+        let out = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let index = out.get("default/index.md").unwrap();
+
+        assert!(index.contains("## Functions"));
+        assert!(index.contains("| Function | Description |\n| ------ | ------ |"));
+        assert!(index.contains("| [cli](./functions/cli.md) | Run the command. |"));
+        assert!(index.contains("## Interfaces"));
+        assert!(index.contains("| Interface | Description |"));
+        assert!(index.contains("| [CliOptions](./interfaces/CliOptions.md) | CLI options. |"));
+        // No bullet list, no inlined kind label or signature.
+        assert!(!index.contains("- [`cli`]"));
+        assert!(!index.contains("`function`"));
+        assert!(!index.contains("export function cli"));
+    }
+
+    #[test]
+    fn typedoc_module_index_resolves_links_in_table_cells() {
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "default".to_string(),
+            source_path: String::new(),
+            entries: vec![
+                test_entry(
+                    "Args",
+                    "interface",
+                    "/repo/src/args.ts",
+                    "An object that contains {@link ArgSchema | argument schema}.",
+                ),
+                test_entry("ArgSchema", "interface", "/repo/src/args.ts", "A schema."),
+            ],
+        }];
+
+        let out = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let index = out.get("default/index.md").unwrap();
+
+        // The `{@link}` is resolved to a Markdown link inside the cell, not left raw.
+        assert!(index.contains("[argument schema](./interfaces/ArgSchema.md)"));
+        assert!(!index.contains("{@link"));
+    }
+
+    #[test]
+    fn typedoc_module_index_collapses_overloads_to_one_row() {
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "default".to_string(),
+            source_path: String::new(),
+            entries: vec![
+                test_entry("cli", "function", "/repo/src/cli.ts", "Run the command."),
+                test_entry("cli", "function", "/repo/src/cli.ts", "Run the command."),
+            ],
+        }];
+
+        let out = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let index = out.get("default/index.md").unwrap();
+
+        assert_eq!(index.matches("| [cli](./functions/cli.md) |").count(), 1);
+    }
+
+    #[test]
+    fn typedoc_module_index_escapes_pipes_in_table_cells() {
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "default".to_string(),
+            source_path: String::new(),
+            entries: vec![test_entry("toUnion", "function", "/repo/src/u.ts", "Returns A | B.")],
+        }];
+
+        let out = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let index = out.get("default/index.md").unwrap();
+
+        assert!(index.contains("Returns A \\| B."));
     }
 
     #[test]
@@ -2435,7 +2594,8 @@ mod tests {
         let module_index = markdown.get("default/index.md").unwrap();
 
         assert!(module_index.contains("## Enumerations"));
-        assert!(module_index.contains("[`Mode`](./enumerations/Mode.md)"));
+        assert!(module_index.contains("| Enumeration | Description |"));
+        assert!(module_index.contains("| [Mode](./enumerations/Mode.md) |"));
         assert!(mode_page.contains("<tr id=\"enumeration-member-strict\">"));
         assert!(run_page.contains("<a href=\"../enumerations/Mode.md\">Mode</a>"));
         assert!(run_page.contains(

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -5,6 +5,7 @@ use std::fmt::Write as _;
 use std::path::Path;
 use std::sync::OnceLock;
 
+use phf::phf_map;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
@@ -348,45 +349,53 @@ fn module_file_name(file_path: &str) -> String {
     sanitize_doc_path_segment(&file_name)
 }
 
-fn typedoc_kind_segment(kind: &str) -> &'static str {
-    match kind {
-        "function" => "functions",
-        "class" => "classes",
-        "interface" => "interfaces",
-        "type" => "type-aliases",
-        "enum" => "enumerations",
-        "variable" | "const" => "variables",
-        "module" => "modules",
-        _ => "symbols",
-    }
-}
+/// Directory segment for each documentation kind under the TypeDoc path strategy.
+static TYPEDOC_KIND_SEGMENT: phf::Map<&'static str, &'static str> = phf_map! {
+    "function" => "functions",
+    "class" => "classes",
+    "interface" => "interfaces",
+    "type" => "type-aliases",
+    "enum" => "enumerations",
+    "variable" => "variables",
+    "const" => "variables",
+    "module" => "modules",
+};
 
-fn typedoc_kind_title(kind: &str) -> &'static str {
-    match kind {
-        "function" => "Functions",
-        "class" => "Classes",
-        "interface" => "Interfaces",
-        "type" => "Type Aliases",
-        "enum" => "Enumerations",
-        "variable" | "const" => "Variables",
-        "module" => "Modules",
-        _ => "Symbols",
-    }
-}
+/// Plural category heading for each documentation kind.
+static TYPEDOC_KIND_TITLE: phf::Map<&'static str, &'static str> = phf_map! {
+    "function" => "Functions",
+    "class" => "Classes",
+    "interface" => "Interfaces",
+    "type" => "Type Aliases",
+    "enum" => "Enumerations",
+    "variable" => "Variables",
+    "const" => "Variables",
+    "module" => "Modules",
+};
 
 /// Singular category label used as the first column header of a module index
 /// table (matches TypeDoc, e.g. `Function`, `Type Alias`).
+static TYPEDOC_KIND_SINGULAR: phf::Map<&'static str, &'static str> = phf_map! {
+    "function" => "Function",
+    "class" => "Class",
+    "interface" => "Interface",
+    "type" => "Type Alias",
+    "enum" => "Enumeration",
+    "variable" => "Variable",
+    "const" => "Variable",
+    "module" => "Module",
+};
+
+fn typedoc_kind_segment(kind: &str) -> &'static str {
+    TYPEDOC_KIND_SEGMENT.get(kind).copied().unwrap_or("symbols")
+}
+
+fn typedoc_kind_title(kind: &str) -> &'static str {
+    TYPEDOC_KIND_TITLE.get(kind).copied().unwrap_or("Symbols")
+}
+
 fn typedoc_kind_singular(kind: &str) -> &'static str {
-    match kind {
-        "function" => "Function",
-        "class" => "Class",
-        "interface" => "Interface",
-        "type" => "Type Alias",
-        "enum" => "Enumeration",
-        "variable" | "const" => "Variable",
-        "module" => "Module",
-        _ => "Symbol",
-    }
+    TYPEDOC_KIND_SINGULAR.get(kind).copied().unwrap_or("Symbol")
 }
 
 fn typedoc_entry_file_name(module_name: &str, entry: &ApiDocEntry) -> String {

--- a/crates/ox_content_docs/src/nav.rs
+++ b/crates/ox_content_docs/src/nav.rs
@@ -2,6 +2,7 @@
 
 use std::path::Path;
 
+use phf::phf_map;
 use serde::{Deserialize, Serialize};
 
 use crate::markdown::{CanonicalOwners, MarkdownPathStrategy};
@@ -206,30 +207,36 @@ fn ordered_entry_kinds(entries: &[ApiDocEntry]) -> Vec<String> {
     kinds
 }
 
+/// Directory segment for each documentation kind under the TypeDoc path strategy.
+static TYPEDOC_KIND_SEGMENT: phf::Map<&'static str, &'static str> = phf_map! {
+    "function" => "functions",
+    "class" => "classes",
+    "interface" => "interfaces",
+    "type" => "type-aliases",
+    "enum" => "enumerations",
+    "variable" => "variables",
+    "const" => "variables",
+    "module" => "modules",
+};
+
+/// Plural category heading for each documentation kind.
+static TYPEDOC_KIND_TITLE: phf::Map<&'static str, &'static str> = phf_map! {
+    "function" => "Functions",
+    "class" => "Classes",
+    "interface" => "Interfaces",
+    "type" => "Type Aliases",
+    "enum" => "Enumerations",
+    "variable" => "Variables",
+    "const" => "Variables",
+    "module" => "Modules",
+};
+
 fn typedoc_kind_segment(kind: &str) -> &'static str {
-    match kind {
-        "function" => "functions",
-        "class" => "classes",
-        "interface" => "interfaces",
-        "type" => "type-aliases",
-        "enum" => "enumerations",
-        "variable" | "const" => "variables",
-        "module" => "modules",
-        _ => "symbols",
-    }
+    TYPEDOC_KIND_SEGMENT.get(kind).copied().unwrap_or("symbols")
 }
 
 fn typedoc_kind_title(kind: &str) -> &'static str {
-    match kind {
-        "function" => "Functions",
-        "class" => "Classes",
-        "interface" => "Interfaces",
-        "type" => "Type Aliases",
-        "enum" => "Enumerations",
-        "variable" | "const" => "Variables",
-        "module" => "Modules",
-        _ => "Symbols",
-    }
+    TYPEDOC_KIND_TITLE.get(kind).copied().unwrap_or("Symbols")
 }
 
 fn sanitize_doc_path_segment(value: &str) -> String {

--- a/npm/vite-plugin-ox-content/src/docs.test.ts
+++ b/npm/vite-plugin-ox-content/src/docs.test.ts
@@ -306,7 +306,13 @@ describe("generateMarkdown", () => {
       })!,
     );
 
-    expect(markdown["default/index.md"]).toContain("[`cli`](/api/default/functions/cli)");
+    // The module index lists members as a compact table (Name | Description),
+    // with the `{@link}` summary resolved in the cell, not a bullet with the
+    // full signature inlined.
+    expect(markdown["default/index.md"]).toContain("| Function | Description |");
+    expect(markdown["default/index.md"]).toContain(
+      "| [cli](/api/default/functions/cli) | Runs [Command](/api/default/interfaces/Command). |",
+    );
     expect(markdown["default/functions/cli.md"]).toContain(
       'href="/api/default/interfaces/Command"',
     );


### PR DESCRIPTION
## Background

Under `generateDocsMarkdown(..., { pathStrategy: 'typedoc', renderStyle: 'markdown' })`, each module `index.md` listed its members as a **bullet list** that inlined every symbol's **entire type signature**:

```md
## Functions

- [`cli`](/api-ox/default/functions/cli.md) `function` `cli<G extends GunshiParamsConstraint>(args: string[], entry: Command<G> | CommandRunner<G> | LazyCommand<G>, options?: CliOptions<G>): Promise<string | undefined>` - Run the command.
- ... (one bullet per overload)
```

TypeDoc renders the same index as a compact `Name | Description` table, with the signature living only on the per-symbol page:

```md
## Functions

| Function | Description |
| ------ | ------ |
| [cli](functions/cli.md) | Run the command. |
```

The bullet-with-inlined-signature form makes the index extremely long (a single generic signature can span dozens of lines), duplicates the per-symbol signature, and splits overloads across multiple rows.

Root cause: `generate_typedoc_module_index` rendered each category entry via `render_overview_line`, which emits `- [`name`](href) `kind` `signature` - summary`, the shared bullet helper used by the flat/category strategies.

## Summary

The TypeDoc module index now renders each category as a compact Markdown table; all changes are in `markdown.rs` (per-symbol pages, JSON, the HTML render style, and NAPI types are unchanged).

- Each category emits `## <Category>` followed by a `| <Singular> | Description |` table (`Function`, `Class`, `Interface`, `Type Alias`, `Enumeration`, `Variable`).
- One row per symbol, `[name](href)` linking to the per-symbol page; **the signature is no longer inlined** (it stays on the symbol page).
- **Overloads collapse to a single row** (same name → one entry).
- The description column is the symbol's first-paragraph summary, collapsed to one line, with `{@link}`/`{@linkcode}` resolved through the same renderer the per-symbol pages use (so cells show `An object that contains [argument schema](…).`, not raw `{@link}`), and table pipes escaped.
- `render_overview_line` itself is unchanged (still used by the flat/category strategies); the `## References` section (cross-entry-point re-exports) is left as-is.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782874524&installation_id=136613492&pr_number=281&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F281&signature=03122c83edd2065fffe0a2d330aa3010b85d1143ae5b55b70f67390c9ad985d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->