### PR TITLE
fix(docs): format module index references as typedoc-style heading entries

### DIFF
--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -972,24 +972,33 @@ fn generate_typedoc_module_index(
 
     // Symbols this module re-exports but does not own: link to the canonical page
     // instead of emitting a duplicate (matches TypeDoc's "References" section).
+    // Overloads share a name, so collapse them to a single reference.
+    let mut seen_references = std::collections::HashSet::new();
     let references = doc
         .entries
         .iter()
         .filter(|entry| !owners.is_canonical(doc, entry))
         .filter_map(|entry| owners.canonical_module(entry).map(|owner| (entry, owner)))
+        .filter(|(entry, _)| seen_references.insert(entry.name.as_str()))
         .collect::<Vec<_>>();
     if !references.is_empty() {
         markdown.push_str("## References\n\n");
-        for (entry, owner) in references {
+        for (index, (entry, owner)) in references.iter().enumerate() {
+            // TypeDoc separates consecutive reference entries with a thematic break.
+            if index > 0 {
+                markdown.push_str("***\n\n");
+            }
             let href = doc_page_href_from(
                 options,
                 &current_file_name,
                 &typedoc_entry_file_name(owner, entry),
                 None,
             );
-            push_fmt(&mut markdown, format_args!("- Re-exports [`{}`]({href})\n", entry.name));
+            push_fmt(
+                &mut markdown,
+                format_args!("### {}\n\nRe-exports [{}]({href})\n\n", entry.name, entry.name),
+            );
         }
-        markdown.push('\n');
     }
 
     markdown
@@ -2452,12 +2461,104 @@ mod tests {
 
         let default_index = out.get("default/index.md").unwrap();
         assert!(default_index.contains("## References"));
-        assert!(default_index.contains("Re-exports [`createCommandContext`]"));
+        // TypeDoc-style reference entry (heading + "Re-exports" link), not a bullet.
+        assert!(default_index.contains("### createCommandContext"));
+        assert!(default_index.contains("Re-exports [createCommandContext]("));
+        assert!(!default_index.contains("- Re-exports"));
         // The re-export reference and any cross-link resolve to the canonical page.
         assert!(default_index.contains("context/functions/createCommandContext"));
 
         let run_default = out.get("default/functions/runDefault.md").unwrap();
         assert!(run_default.contains("context/functions/createCommandContext"));
+    }
+
+    #[test]
+    fn typedoc_references_section_uses_typedoc_layout() {
+        // Two symbols defined in `context` and re-exported from `default` produce
+        // a TypeDoc-style References section: `### Name` headings, `Re-exports`
+        // links, and a `***` separator between entries.
+        let make = |module: &str, source: &str, entries: Vec<ApiDocEntry>| ApiDocModule {
+            description: String::new(),
+            file: module.to_string(),
+            source_path: source.to_string(),
+            entries,
+        };
+        let docs = vec![
+            make(
+                "context",
+                "/repo/src/context.ts",
+                vec![
+                    test_entry("createCommandContext", "function", "/repo/src/context.ts", "Ctx."),
+                    test_entry("CommandContextParams", "interface", "/repo/src/context.ts", "P."),
+                ],
+            ),
+            make(
+                "default",
+                "/repo/src/index.ts",
+                vec![
+                    test_entry("createCommandContext", "function", "/repo/src/context.ts", "Ctx."),
+                    test_entry("CommandContextParams", "interface", "/repo/src/context.ts", "P."),
+                ],
+            ),
+        ];
+
+        let out = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let default_index = out.get("default/index.md").unwrap();
+
+        assert!(default_index.contains("## References"));
+        assert!(default_index.contains("### CommandContextParams"));
+        // The link resolves to the canonical page under the owner module (context).
+        assert!(default_index.contains(
+            "Re-exports [CommandContextParams](../context/interfaces/CommandContextParams.md)"
+        ));
+        assert!(default_index.contains("### createCommandContext"));
+        // Two references → exactly one thematic-break separator between them.
+        assert_eq!(default_index.matches("\n***\n").count(), 1);
+        assert!(!default_index.contains("- Re-exports"));
+    }
+
+    #[test]
+    fn typedoc_references_collapse_overloads_to_one_entry() {
+        // An overloaded function (two signatures) re-exported from another module
+        // is referenced once, not once per overload.
+        let docs = vec![
+            ApiDocModule {
+                description: String::new(),
+                file: "definition".to_string(),
+                source_path: "/repo/src/definition.ts".to_string(),
+                entries: vec![
+                    test_entry("define", "function", "/repo/src/definition.ts", "Define."),
+                    test_entry("define", "function", "/repo/src/definition.ts", "Define."),
+                ],
+            },
+            ApiDocModule {
+                description: String::new(),
+                file: "default".to_string(),
+                source_path: "/repo/src/index.ts".to_string(),
+                entries: vec![
+                    test_entry("define", "function", "/repo/src/definition.ts", "Define."),
+                    test_entry("define", "function", "/repo/src/definition.ts", "Define."),
+                ],
+            },
+        ];
+
+        let out = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let default_index = out.get("default/index.md").unwrap();
+
+        assert_eq!(default_index.matches("### define").count(), 1);
+        assert_eq!(default_index.matches("Re-exports [define]").count(), 1);
     }
 
     #[test]
@@ -2500,7 +2601,9 @@ mod tests {
 
         assert!(out.contains_key("default/interfaces/Command.md"));
         assert!(!out.contains_key("plugin/interfaces/Command.md"));
-        assert!(out.get("plugin/index.md").unwrap().contains("Re-exports [`Command`]"));
+        let plugin_index = out.get("plugin/index.md").unwrap();
+        assert!(plugin_index.contains("### Command"));
+        assert!(plugin_index.contains("Re-exports [Command]("));
     }
 
     #[test]


### PR DESCRIPTION
## Background

Under `generateDocsMarkdown(..., { pathStrategy: 'typedoc', renderStyle: 'markdown' })`, a module index lists symbols it does not own (cross-entry-point re-exports) under a `## References` section, added in #280.

That section was emitted as a bullet list with backtick-wrapped names, and overloaded re-exports were listed once per overload:

```md
## References

- Re-exports [`createCommandContext`](../context/functions/createCommandContext.md)
- Re-exports [`define`](../definition/functions/define.md)
- Re-exports [`define`](../definition/functions/define.md)   ← one bullet per overload
```

TypeDoc (`typedoc-plugin-markdown`) instead renders each reference as a `### Name` heading followed by a `Re-exports [Name](canonical page)` paragraph, separated by a `***` thematic break, and lists overloaded symbols once.

Root cause: `generate_typedoc_module_index` emitted the References block as bullets and iterated every non-owned entry, so overloads (which share a name) produced duplicate references.

## Summary

All changes are in `markdown.rs`; the owned category tables (#281), canonical page selection (#280), extractor, JSON, and NAPI types are unchanged.

- The `## References` section now renders each reference as `### Name` + `Re-exports [Name](href)`, with a `***` separator between consecutive entries (matching TypeDoc). Links resolve to the symbol's canonical page under its owner module.
- Overloaded re-exports collapse to a single reference (deduped by name; entries are already name-sorted, so order is preserved).

```md
## References

### CommandContextParams

Re-exports [CommandContextParams](../context/interfaces/CommandContextParams.md)

***

### createCommandContext

Re-exports [createCommandContext](../context/functions/createCommandContext.md)
```

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782878706&installation_id=136613492&pr_number=282&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F282&signature=14fb402a51f8b6a2871e4c0d203b066d804b623c53ba753471b515c850ecc788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->