### PR TITLE
fix(docs): preserve typedoc module names

### DIFF
--- a/crates/ox_content_docs/src/graph.rs
+++ b/crates/ox_content_docs/src/graph.rs
@@ -406,22 +406,21 @@ pub fn extract_docs_from_entry_points(
         // by the extractor as a `Module`-kind entry but is never an export, so it
         // is dropped from `entries` above. Pull it out of the entry file's
         // normalized items and carry it as the module description.
-        let description = normalized_entries_for_module(
-            &mut docs_cache,
-            &extractor,
-            &entrypoint.source_path,
-            options.type_parameters,
-        )?
-        .iter()
-        .find(|entry| entry.kind == NormalizedDocKind::Module)
-        .map(|entry| entry.description.clone())
-        .unwrap_or_default();
+        let module_metadata = resolve_entrypoint_module_metadata(
+            &entrypoint.name,
+            normalized_entries_for_module(
+                &mut docs_cache,
+                &extractor,
+                &entrypoint.source_path,
+                options.type_parameters,
+            )?,
+        );
 
         modules.push(EntrypointDocsModule {
-            file: entrypoint.name.clone(),
-            name: entrypoint.name,
+            file: module_metadata.name.clone(),
+            name: module_metadata.name,
             source_path: entrypoint.source_path,
-            description,
+            description: module_metadata.description,
             entries,
             exports: entrypoint.exports,
             diagnostics,
@@ -429,6 +428,35 @@ pub fn extract_docs_from_entry_points(
     }
 
     Ok(modules)
+}
+
+struct EntrypointModuleMetadata {
+    name: String,
+    description: String,
+}
+
+fn resolve_entrypoint_module_metadata(
+    entrypoint_name: &str,
+    entries: &[NormalizedDocEntry],
+) -> EntrypointModuleMetadata {
+    let module_entry = entries.iter().find(|entry| entry.kind == NormalizedDocKind::Module);
+    let explicit_module_name =
+        module_entry.and_then(|entry| explicit_module_name_from_tags(&entry.tags));
+
+    EntrypointModuleMetadata {
+        name: explicit_module_name.unwrap_or(entrypoint_name).to_string(),
+        description: module_entry.map(|entry| entry.description.clone()).unwrap_or_default(),
+    }
+}
+
+fn explicit_module_name_from_tags(
+    tags: &std::collections::BTreeMap<String, String>,
+) -> Option<&str> {
+    tags.get("module")
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .and_then(|value| value.split_whitespace().next())
+        .filter(|value| !value.is_empty())
 }
 
 /// Returns true when a resolved module path is an installed dependency, i.e. it
@@ -1321,13 +1349,89 @@ export function plugin(): void {}
         .unwrap();
 
         let context = docs.iter().find(|module| module.name == "context").unwrap();
+        assert_eq!(context.file, "context");
         assert_eq!(context.description, "The entry for gunshi context.");
         // The module entry itself is not surfaced as a regular export entry.
         assert!(context.entries.iter().all(|entry| entry.kind != NormalizedDocKind::Module));
         assert!(context.entries.iter().any(|entry| entry.name == "createCommandContext"));
 
         let plugin = docs.iter().find(|module| module.name == "plugin").unwrap();
+        assert_eq!(plugin.file, "plugin");
         assert!(plugin.description.is_empty());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn entrypoint_docs_prefers_explicit_module_name() {
+        let root = temp_root();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(
+            root.join("src/index.ts"),
+            r"
+/**
+ * Default entry point.
+ *
+ * @module default
+ */
+/** Runs the CLI. */
+export function cli(): void {}
+",
+        )
+        .unwrap();
+
+        let docs = extract_docs_from_entry_points(
+            &[EntryPointSpec {
+                path: PathBuf::from("src/index.ts"),
+                name: Some("entry".to_string()),
+            }],
+            &EntryPointDocsOptions {
+                graph: GraphOptions { root: Some(root.clone()), ..GraphOptions::default() },
+                include_private: false,
+                include_internal: false,
+                type_parameters: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(docs[0].name, "default");
+        assert_eq!(docs[0].file, "default");
+        assert_eq!(docs[0].description, "Default entry point.");
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn entrypoint_docs_uses_entrypoint_name_without_module_tag() {
+        let root = temp_root();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(
+            root.join("src/agent.ts"),
+            r"
+export function isAiAgent(): boolean {
+  return false;
+}
+",
+        )
+        .unwrap();
+
+        let docs = extract_docs_from_entry_points(
+            &[EntryPointSpec {
+                path: PathBuf::from("src/agent.ts"),
+                name: Some("agent".to_string()),
+            }],
+            &EntryPointDocsOptions {
+                graph: GraphOptions { root: Some(root.clone()), ..GraphOptions::default() },
+                include_private: false,
+                include_internal: false,
+                type_parameters: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(docs[0].name, "agent");
+        assert_eq!(docs[0].file, "agent");
+        assert!(docs[0].description.is_empty());
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -349,6 +349,23 @@ fn module_file_name(file_path: &str) -> String {
     sanitize_doc_path_segment(&file_name)
 }
 
+fn module_route_name(doc: &ApiDocModule) -> String {
+    module_file_name(&doc.file)
+}
+
+fn module_display_name(doc: &ApiDocModule) -> String {
+    if !doc.source_path.is_empty() {
+        return doc.file.clone();
+    }
+
+    let display_name = file_stem(&doc.file);
+    if display_name.is_empty() {
+        doc.file.clone()
+    } else {
+        display_name
+    }
+}
+
 /// Directory segment for each documentation kind under the TypeDoc path strategy.
 static TYPEDOC_KIND_SEGMENT: phf::Map<&'static str, &'static str> = phf_map! {
     "function" => "functions",
@@ -873,7 +890,8 @@ fn generate_typedoc_root_index(
     markdown.push_str("\n\n## Modules\n\n");
 
     for doc in docs {
-        let module_name = module_file_name(&doc.file);
+        let module_name = module_route_name(doc);
+        let display_name = module_display_name(doc);
         let href = doc_page_href_from(
             options,
             "index",
@@ -883,15 +901,9 @@ fn generate_typedoc_root_index(
         let summary =
             clean_summary_text(&process_doc_text(&doc.description, Some(&link_context)), 88);
         if summary.is_empty() {
-            push_fmt(
-                &mut markdown,
-                format_args!("- [{}]({href})\n", capitalize_ascii(&module_name)),
-            );
+            push_fmt(&mut markdown, format_args!("- [{display_name}]({href})\n"));
         } else {
-            push_fmt(
-                &mut markdown,
-                format_args!("- [{}]({href}) - {summary}\n", capitalize_ascii(&module_name)),
-            );
+            push_fmt(&mut markdown, format_args!("- [{display_name}]({href}) - {summary}\n"));
         }
     }
 
@@ -912,7 +924,8 @@ fn generate_typedoc_module_index(
         current_module_name: module_name,
         symbol_map,
     };
-    let mut markdown = fmt_args(format_args!("# {}\n\n", capitalize_ascii(module_name)));
+    let display_name = module_display_name(doc);
+    let mut markdown = fmt_args(format_args!("# {display_name}\n\n"));
 
     let description = process_doc_text(&doc.description, Some(&link_context));
     let description = description.trim();
@@ -2141,6 +2154,10 @@ mod tests {
         // Root module list shows the module-level `@module` description, never a
         // symbol's description, and renders nothing for a module without one.
         let index = markdown.get("index.md").unwrap();
+        assert!(index.contains("[context](./context/index.md)"));
+        assert!(index.contains("[plugin](./plugin/index.md)"));
+        assert!(!index.contains("[Context]"));
+        assert!(!index.contains("[Plugin]"));
         assert!(index.contains("The entry for gunshi context."));
         assert!(!index.contains("Parameters of createCommandContext"));
         assert!(!index.contains("Define a plugin."));
@@ -2150,9 +2167,9 @@ mod tests {
         // empty description emits no paragraph, so the heading is followed
         // directly by the stats line.
         let context_index = markdown.get("context/index.md").unwrap();
-        assert!(context_index.starts_with("# Context\n\nThe entry for gunshi context.\n\n_"));
+        assert!(context_index.starts_with("# context\n\nThe entry for gunshi context.\n\n_"));
         let plugin_index = markdown.get("plugin/index.md").unwrap();
-        assert!(plugin_index.starts_with("# Plugin\n\n_"));
+        assert!(plugin_index.starts_with("# plugin\n\n_"));
     }
 
     #[test]
@@ -2385,7 +2402,7 @@ mod tests {
         let plugin_page = markdown.get("plugin/functions/runPlugin.md").unwrap();
         let index = markdown.get("index.md").unwrap();
 
-        assert!(index.contains("[Default](/api/default)"));
+        assert!(index.contains("[default](/api/default)"));
         assert!(default_page.contains("<a href=\"/api/default/interfaces/Command\">Command</a>"));
         assert!(plugin_page.contains("<a href=\"/api/plugin/interfaces/Command\">Command</a>"));
         assert!(!default_page.contains(".md"));

--- a/crates/ox_content_docs/src/nav.rs
+++ b/crates/ox_content_docs/src/nav.rs
@@ -65,14 +65,15 @@ fn generate_typedoc_nav_metadata(
 ) -> Vec<DocsNavItem> {
     let base_path = normalize_base_path(base_path.unwrap_or(DEFAULT_BASE_PATH));
     let mut docs = docs.to_vec();
-    docs.sort_by_cached_key(|doc| module_file_name(&doc.file));
+    docs.sort_by_cached_key(typedoc_module_route_name);
     // A re-exported symbol appears in the sidebar only under the module that owns
     // its canonical page (matching TypeDoc's single-location listing).
     let owners = CanonicalOwners::compute(&docs);
 
     docs.into_iter()
         .map(|doc| {
-            let module_name = module_file_name(&doc.file);
+            let module_name = typedoc_module_route_name(&doc);
+            let module_title = typedoc_module_display_name(&doc);
             let mut children = Vec::new();
             for kind in ordered_entry_kinds(&doc.entries) {
                 let entries = doc
@@ -110,7 +111,7 @@ fn generate_typedoc_nav_metadata(
             }
 
             DocsNavItem {
-                title: format_doc_title(&module_name),
+                title: module_title,
                 path: nav_route_path(&base_path, &format!("{module_name}/index")),
                 children: if children.is_empty() { None } else { Some(children) },
             }
@@ -184,6 +185,23 @@ fn module_file_name(file_path: &str) -> String {
         file_name = "index-module".to_string();
     }
     sanitize_doc_path_segment(&file_name)
+}
+
+fn typedoc_module_route_name(doc: &ApiDocModule) -> String {
+    module_file_name(&doc.file)
+}
+
+fn typedoc_module_display_name(doc: &ApiDocModule) -> String {
+    if !doc.source_path.is_empty() {
+        return doc.file.clone();
+    }
+
+    let display_name = file_stem(&doc.file);
+    if display_name.is_empty() {
+        doc.file.clone()
+    } else {
+        display_name
+    }
 }
 
 fn ordered_entry_kinds(entries: &[ApiDocEntry]) -> Vec<String> {
@@ -374,7 +392,7 @@ mod tests {
         let nav =
             generate_nav_metadata_from_docs(&docs, Some("/api"), MarkdownPathStrategy::TypeDoc);
 
-        assert_eq!(nav[0].title, "Default");
+        assert_eq!(nav[0].title, "default");
         assert_eq!(nav[0].path, "/api/default");
         let children = nav[0].children.as_ref().unwrap();
         assert_eq!(children[0].title, "Functions");

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -3665,9 +3665,14 @@ mod tests {
             }),
         );
         let cli_page = markdown.get("default/functions/cli.md").unwrap();
+        let root_index = markdown.get("index.md").unwrap();
+        let module_index = markdown.get("default/index.md").unwrap();
 
         assert!(markdown.contains_key("default/index.md"));
         assert!(markdown.contains_key("default/interfaces/Command.md"));
+        assert!(root_index.contains("[default](/api/default)"));
+        assert!(!root_index.contains("[Default]"));
+        assert!(module_index.starts_with("# default\n\n"));
         assert!(cli_page.contains("<a href=\"/api/default/interfaces/Command\">Command</a>"));
     }
 
@@ -3864,7 +3869,7 @@ mod tests {
             }),
         );
 
-        assert_eq!(nav[0].title, "Default");
+        assert_eq!(nav[0].title, "default");
         assert_eq!(nav[0].path, "/api/default");
         let children = nav[0].children.as_ref().unwrap();
         assert_eq!(children[0].title, "Functions");
@@ -3953,9 +3958,48 @@ mod tests {
         assert!(out_dir.join("default/functions/cli.md").exists());
 
         let nav = fs::read_to_string(out_dir.join("nav.ts")).unwrap();
+        assert!(nav.contains(r#""title": "default""#));
         assert!(nav.contains("\"/api/default/functions/cli\""));
 
         fs::remove_dir_all(&out_dir).unwrap();
+    }
+
+    #[test]
+    fn extract_docs_from_entry_points_preserves_explicit_module_name() {
+        let unique =
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos();
+        let root = std::env::temp_dir()
+            .join(format!("ox-content-napi-module-name-{}-{unique}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(
+            root.join("src/index.ts"),
+            r"
+/**
+ * gunshi cli entry point.
+ *
+ * @module default
+ */
+/** Runs the CLI. */
+export function cli(): void {}
+",
+        )
+        .unwrap();
+
+        let modules = extract_docs_from_entry_points_napi(
+            vec![JsEntryPointSpec { path: "src/index.ts".to_string(), name: None }],
+            Some(JsEntryPointDocsOptions {
+                root: Some(root.to_string_lossy().into_owned()),
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(modules[0].name, "default");
+        assert_eq!(modules[0].file, "default");
+        assert_eq!(modules[0].description, "gunshi cli entry point.");
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]


### PR DESCRIPTION
## Background

Gunshi is using ox-content as a TypeDoc-compatible API docs generator and compares the generated output against the existing TypeDoc plus typedoc-plugin-markdown pages.

TypeDoc preserves resolved module names exactly in visible labels, for example agent, combinators, context, default, definition, generator, plugin, and renderer.

ox-content already generated the correct TypeDoc-style lowercase routes for these modules, but the visible module labels were still title-cased in several places.

The root API index rendered labels such as Agent, Combinators, and Default, module index pages used headings such as `# Default`, and generated nav metadata also used title-cased module titles.

The links still worked, but the output no longer matched TypeDoc and created visible migration diffs for Gunshi.

The underlying issue was that route names and display labels were coupled.

The renderer and nav generator reused the sanitized module path segment as the display label, then applied flat-doc title formatting.

Entrypoint extraction also carried the module description from a leading `@module` block, but did not consistently propagate the explicit `@module` name as the public module identity.

## Summary

- Resolve entrypoint module metadata from leading module docs and preserve explicit `@module` names.
- Keep TypeDoc module labels exact in root indexes, module index headings, and generated nav metadata.
- Keep route/path sanitization separate from display labels so existing generated paths stay stable.
- Preserve the existing flat nav title-formatting behavior outside the TypeDoc path strategy.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782892822&installation_id=136613492&pr_number=283&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F283&signature=6210eccc94fb79c36e7d5c63d31c4e6b6674abe3e201c99dcd649ce8ce7e7a44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->