### PR TITLE
feat(docs): add Markdown display formats

### DIFF
--- a/crates/ox_content_docs/src/lib.rs
+++ b/crates/ox_content_docs/src/lib.rs
@@ -31,8 +31,8 @@ pub use graph::{
     PublicExport, ResolvedModule,
 };
 pub use markdown::{
-    generate_markdown, MarkdownDocsOptions, MarkdownLinkStyle, MarkdownPathStrategy,
-    MarkdownRenderStyle,
+    generate_markdown, MarkdownDisplayFormat, MarkdownDocsOptions, MarkdownLinkStyle,
+    MarkdownPathStrategy, MarkdownRenderStyle,
 };
 pub use model::{
     ApiDocEntry, ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc, ApiReturnDoc, ApiTypeParamDoc,

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -59,6 +59,30 @@ pub struct MarkdownDocsOptions {
     /// Rendering style: HTML-laced Markdown (default) or pure Markdown.
     #[serde(default)]
     pub render_style: MarkdownRenderStyle,
+    /// Display format for index items.
+    #[serde(default)]
+    pub index_format: MarkdownDisplayFormat,
+    /// Display format for value and type parameters.
+    #[serde(default)]
+    pub parameters_format: MarkdownDisplayFormat,
+    /// Display format for interface property groups.
+    #[serde(default)]
+    pub interface_properties_format: MarkdownDisplayFormat,
+    /// Display format for class property groups.
+    #[serde(default)]
+    pub class_properties_format: MarkdownDisplayFormat,
+    /// Display format for type alias property groups.
+    #[serde(default)]
+    pub type_alias_properties_format: MarkdownDisplayFormat,
+    /// Display format for enum member groups.
+    #[serde(default)]
+    pub enum_members_format: MarkdownDisplayFormat,
+    /// Display format for property-owned object literal members.
+    #[serde(default)]
+    pub property_members_format: MarkdownDisplayFormat,
+    /// Display format for type declaration members.
+    #[serde(default)]
+    pub type_declaration_format: MarkdownDisplayFormat,
 }
 
 /// Internal documentation link style.
@@ -97,6 +121,19 @@ pub enum MarkdownRenderStyle {
     Markdown,
 }
 
+/// TypeDoc-compatible Markdown display format.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum MarkdownDisplayFormat {
+    /// Use the renderer's default behavior.
+    #[default]
+    None,
+    /// Render supported sections as Markdown lists.
+    List,
+    /// Render supported sections as Markdown tables.
+    Table,
+}
+
 impl Default for MarkdownDocsOptions {
     fn default() -> Self {
         Self {
@@ -106,6 +143,14 @@ impl Default for MarkdownDocsOptions {
             base_path: None,
             path_strategy: MarkdownPathStrategy::Flat,
             render_style: MarkdownRenderStyle::Html,
+            index_format: MarkdownDisplayFormat::None,
+            parameters_format: MarkdownDisplayFormat::None,
+            interface_properties_format: MarkdownDisplayFormat::None,
+            class_properties_format: MarkdownDisplayFormat::None,
+            type_alias_properties_format: MarkdownDisplayFormat::None,
+            enum_members_format: MarkdownDisplayFormat::None,
+            property_members_format: MarkdownDisplayFormat::None,
+            type_declaration_format: MarkdownDisplayFormat::None,
         }
     }
 }
@@ -594,7 +639,11 @@ fn process_doc_text(text: &str, context: Option<&MarkdownLinkContext<'_>>) -> St
 /// [`clean_summary_text`] it does not strip links/code, so the index matches
 /// TypeDoc (e.g. `An object that contains [argument schema](…).`).
 fn typedoc_index_summary(description: &str, context: &MarkdownLinkContext<'_>) -> String {
-    let resolved = process_doc_text(description, Some(context));
+    markdown_index_summary(description, Some(context))
+}
+
+fn markdown_index_summary(description: &str, context: Option<&MarkdownLinkContext<'_>>) -> String {
+    let resolved = process_doc_text(description, context);
     let first_paragraph = resolved.split("\n\n").next().unwrap_or_default();
     let one_line = first_paragraph.split_whitespace().collect::<Vec<_>>().join(" ");
     one_line.replace('|', "\\|")
@@ -716,6 +765,39 @@ fn render_stats(
         MarkdownRenderStyle::Html => markdown_html::render_stats_html(stats, module_count),
         MarkdownRenderStyle::Markdown => markdown_pure::render_stats_markdown(stats, module_count),
     }
+}
+
+fn effective_display_format(
+    options: &MarkdownDocsOptions,
+    format: MarkdownDisplayFormat,
+) -> MarkdownDisplayFormat {
+    match (options.render_style, format) {
+        (MarkdownRenderStyle::Markdown, MarkdownDisplayFormat::None) => MarkdownDisplayFormat::List,
+        (_, format) => format,
+    }
+}
+
+fn effective_index_format(options: &MarkdownDocsOptions) -> MarkdownDisplayFormat {
+    effective_display_format(options, options.index_format)
+}
+
+fn effective_parameters_format(options: &MarkdownDocsOptions) -> MarkdownDisplayFormat {
+    effective_display_format(options, options.parameters_format)
+}
+
+fn effective_members_format(
+    options: &MarkdownDocsOptions,
+    entry_kind: &str,
+    group_title: &str,
+) -> MarkdownDisplayFormat {
+    let format = match (entry_kind, group_title) {
+        ("class", "Properties" | "Static Properties") => options.class_properties_format,
+        ("interface", "Properties") => options.interface_properties_format,
+        ("type", "Properties") => options.type_alias_properties_format,
+        ("enum", "Enum Members") | ("type", "Enum Members") => options.enum_members_format,
+        _ => return MarkdownDisplayFormat::None,
+    };
+    effective_display_format(options, format)
 }
 
 fn generate_file_markdown(
@@ -889,6 +971,23 @@ fn generate_typedoc_root_index(
     ));
     markdown.push_str("\n\n## Modules\n\n");
 
+    if effective_index_format(options) == MarkdownDisplayFormat::Table {
+        markdown.push_str("| Module | Description |\n| ------ | ------ |\n");
+        for doc in docs {
+            let module_name = module_route_name(doc);
+            let display_name = module_display_name(doc);
+            let href = doc_page_href_from(
+                options,
+                "index",
+                &typedoc_module_index_file_name(&module_name),
+                None,
+            );
+            let summary = typedoc_index_summary(&doc.description, &link_context);
+            push_fmt(&mut markdown, format_args!("| [{display_name}]({href}) | {summary} |\n"));
+        }
+        return markdown;
+    }
+
     for doc in docs {
         let module_name = module_route_name(doc);
         let display_name = module_display_name(doc);
@@ -942,6 +1041,7 @@ fn generate_typedoc_module_index(
     markdown.push_str(&render_stats(options, &summarize_entries(&doc.entries), None));
     markdown.push_str("\n\n");
 
+    let index_format = effective_index_format(options);
     for kind in ordered_entry_kinds(&doc.entries) {
         // Only entries whose canonical page lives in this module are listed in
         // the kind sections; re-exports are collected into "References" below.
@@ -954,10 +1054,40 @@ fn generate_typedoc_module_index(
             continue;
         }
 
+        push_fmt(&mut markdown, format_args!("## {}\n\n", typedoc_kind_title(&kind)));
+        let mut seen = std::collections::HashSet::new();
+        if index_format == MarkdownDisplayFormat::List {
+            for entry in entries {
+                // Overloads share a name (and page); collapse them to one row.
+                if !seen.insert(entry.name.as_str()) {
+                    continue;
+                }
+                let href = doc_page_href_from(
+                    options,
+                    &current_file_name,
+                    &typedoc_entry_file_name(module_name, entry),
+                    None,
+                );
+                let summary = clean_summary_text(
+                    &process_doc_text(&entry.description, Some(&link_context)),
+                    88,
+                );
+                if summary.is_empty() {
+                    push_fmt(&mut markdown, format_args!("- [{}]({href})\n", entry.name));
+                } else {
+                    push_fmt(
+                        &mut markdown,
+                        format_args!("- [{}]({href}) - {summary}\n", entry.name),
+                    );
+                }
+            }
+            markdown.push('\n');
+            continue;
+        }
+
         // Render a compact `Name | Description` table (matching TypeDoc) rather
         // than a bullet list with the full signature inlined; the signature
         // stays on the per-symbol page.
-        push_fmt(&mut markdown, format_args!("## {}\n\n", typedoc_kind_title(&kind)));
         push_fmt(
             &mut markdown,
             format_args!(
@@ -965,7 +1095,6 @@ fn generate_typedoc_module_index(
                 typedoc_kind_singular(&kind)
             ),
         );
-        let mut seen = std::collections::HashSet::new();
         for entry in entries {
             // Overloads share a name (and page); collapse them to one row.
             if !seen.insert(entry.name.as_str()) {
@@ -1184,6 +1313,15 @@ fn render_overview_line(
     format!("{}\n", parts.join(" "))
 }
 
+fn render_overview_table_row(
+    entry: &ApiDocEntry,
+    href: &str,
+    context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    let summary = markdown_index_summary(&entry.description, context);
+    fmt_args(format_args!("| [`{}`]({href}) | `{}` | {summary} |\n", entry.name, entry.kind))
+}
+
 fn generate_entry_markdown(
     entry: &ApiDocEntry,
     options: &MarkdownDocsOptions,
@@ -1272,9 +1410,21 @@ fn generate_index(
                     doc_page_href(options, &file_name, None)
                 ),
             );
-            for entry in &doc.entries {
-                let href = doc_page_href(options, &file_name, Some(&entry_anchor(&entry.name)));
-                markdown.push_str(&render_overview_line(entry, &href, link_context.as_ref()));
+            if effective_index_format(options) == MarkdownDisplayFormat::Table {
+                markdown.push_str("| Name | Kind | Description |\n| --- | --- | --- |\n");
+                for entry in &doc.entries {
+                    let href = doc_page_href(options, &file_name, Some(&entry_anchor(&entry.name)));
+                    markdown.push_str(&render_overview_table_row(
+                        entry,
+                        &href,
+                        link_context.as_ref(),
+                    ));
+                }
+            } else {
+                for entry in &doc.entries {
+                    let href = doc_page_href(options, &file_name, Some(&entry_anchor(&entry.name)));
+                    markdown.push_str(&render_overview_line(entry, &href, link_context.as_ref()));
+                }
             }
             markdown.push('\n');
             continue;
@@ -1319,12 +1469,23 @@ fn generate_category_markdown(
     markdown.push_str("\n\n");
 
     markdown.push_str("## Overview\n\n");
-    for entry in entries {
-        markdown.push_str(&render_overview_line(
-            entry,
-            &fmt_args(format_args!("#{}", entry_anchor(&entry.name))),
-            Some(&link_context),
-        ));
+    if effective_index_format(options) == MarkdownDisplayFormat::Table {
+        markdown.push_str("| Name | Kind | Description |\n| --- | --- | --- |\n");
+        for entry in entries {
+            markdown.push_str(&render_overview_table_row(
+                entry,
+                &fmt_args(format_args!("#{}", entry_anchor(&entry.name))),
+                Some(&link_context),
+            ));
+        }
+    } else {
+        for entry in entries {
+            markdown.push_str(&render_overview_line(
+                entry,
+                &fmt_args(format_args!("#{}", entry_anchor(&entry.name))),
+                Some(&link_context),
+            ));
+        }
     }
     markdown.push_str("\n## Reference\n\n");
     if options.render_style == MarkdownRenderStyle::Html && entries.len() > 1 {
@@ -1384,10 +1545,19 @@ fn generate_category_index(
             ),
         );
 
-        for entry in entries {
-            let href =
-                doc_page_href(options, &category_file_name, Some(&entry_anchor(&entry.name)));
-            markdown.push_str(&render_overview_line(entry, &href, Some(&link_context)));
+        if effective_index_format(options) == MarkdownDisplayFormat::Table {
+            markdown.push_str("| Name | Kind | Description |\n| --- | --- | --- |\n");
+            for entry in entries {
+                let href =
+                    doc_page_href(options, &category_file_name, Some(&entry_anchor(&entry.name)));
+                markdown.push_str(&render_overview_table_row(entry, &href, Some(&link_context)));
+            }
+        } else {
+            for entry in entries {
+                let href =
+                    doc_page_href(options, &category_file_name, Some(&entry_anchor(&entry.name)));
+                markdown.push_str(&render_overview_line(entry, &href, Some(&link_context)));
+            }
         }
         markdown.push('\n');
     }
@@ -1716,7 +1886,8 @@ mod tests {
         assert!(page.lines().any(|line| line == "#### Signature"));
         assert!(!page.contains("**Signature**"));
         assert!(page.contains("```ts"));
-        assert!(page.contains("| Name | Type | Description |"));
+        assert!(page.contains("- `argv` (`string[]`) - Arguments."));
+        assert!(!page.contains("| Name | Type | Description |"));
         // The interface member group is a real heading (no `**Members**` wrapper).
         assert!(page.lines().any(|line| line == "#### Methods"));
         assert!(!page.contains("**Members**"));
@@ -2244,7 +2415,103 @@ mod tests {
         assert!(page.contains("## Type Parameters"));
         assert!(!page.contains("**Type Parameters**"));
         assert!(page.contains("`G` *extends* `Base` = `Default`"));
-        assert!(page.contains("| `T` | The value type. |"));
+        assert!(page.contains("- `T` - The value type."));
+    }
+
+    #[test]
+    fn markdown_display_format_options_render_tables() {
+        let mut entry = test_entry("make", "function", "src/make.ts", "Make a thing.");
+        entry.params = vec![ApiParamDoc {
+            name: "value".to_string(),
+            type_annotation: "string".to_string(),
+            description: "Input value.".to_string(),
+            optional: false,
+            default_value: None,
+        }];
+        entry.type_parameters = vec![ApiTypeParamDoc {
+            name: "T".to_string(),
+            constraint: None,
+            default: None,
+            description: "Value type.".to_string(),
+        }];
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "mod".to_string(),
+            source_path: String::new(),
+            entries: vec![entry],
+        }];
+
+        let markdown = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                render_style: MarkdownRenderStyle::Markdown,
+                index_format: MarkdownDisplayFormat::Table,
+                parameters_format: MarkdownDisplayFormat::Table,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let index = markdown.get("mod/index.md").unwrap();
+        let page = markdown.get("mod/functions/make.md").unwrap();
+
+        assert!(index.contains("| Function | Description |"));
+        assert!(page.contains("| Name | Type | Description |"));
+        assert!(page.contains("| `value` | `string` | Input value. |"));
+        assert!(page.contains("| `T` | Value type. |"));
+    }
+
+    #[test]
+    fn markdown_property_display_format_controls_property_groups() {
+        let mut entry = test_entry("Command", "interface", "src/types.ts", "Command options.");
+        entry.members = vec![ApiDocMember {
+            name: "name".to_string(),
+            kind: "property".to_string(),
+            description: "Command name.".to_string(),
+            signature: None,
+            type_annotation: Some("string".to_string()),
+            params: vec![],
+            returns: None,
+            optional: false,
+            readonly: true,
+            r#static: false,
+            private: false,
+            tags: vec![],
+            line: 2,
+            end_line: 2,
+        }];
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "mod".to_string(),
+            source_path: String::new(),
+            entries: vec![entry],
+        }];
+
+        let list_markdown = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                render_style: MarkdownRenderStyle::Markdown,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let list_page = list_markdown.get("mod/interfaces/Command.md").unwrap();
+        assert!(list_page.contains("- `name` _(readonly)_ `property` `string` - Command name."));
+        assert!(!list_page.contains("| Name | Kind | Type | Description |"));
+
+        let table_markdown = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                render_style: MarkdownRenderStyle::Markdown,
+                interface_properties_format: MarkdownDisplayFormat::Table,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let table_page = table_markdown.get("mod/interfaces/Command.md").unwrap();
+        assert!(table_page.contains("| Name | Kind | Type | Description |"));
+        assert!(
+            table_page.contains("| `name` _(readonly)_ | property | `string` | Command name. |")
+        );
     }
 
     #[test]

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -794,7 +794,9 @@ fn effective_members_format(
         ("class", "Properties" | "Static Properties") => options.class_properties_format,
         ("interface", "Properties") => options.interface_properties_format,
         ("type", "Properties") => options.type_alias_properties_format,
-        ("enum", "Enum Members") | ("type", "Enum Members") => options.enum_members_format,
+        ("enum", "Enum Members" | "Members") | ("type", "Enum Members") => {
+            options.enum_members_format
+        }
         _ => return MarkdownDisplayFormat::None,
     };
     effective_display_format(options, format)
@@ -1378,6 +1380,20 @@ fn generate_index(
     markdown.push_str("\n\n");
 
     markdown.push_str("## Modules\n\n");
+    let index_format = effective_index_format(options);
+    if options.render_style == MarkdownRenderStyle::Html
+        && matches!(index_format, MarkdownDisplayFormat::List | MarkdownDisplayFormat::Table)
+    {
+        markdown.push_str(&markdown_html::render_module_index_html(
+            docs,
+            options,
+            doc_to_file,
+            index_format,
+            link_context.as_ref(),
+        ));
+        return markdown;
+    }
+
     if options.render_style == MarkdownRenderStyle::Html && docs.len() > 1 {
         markdown.push_str(&markdown_html::render_details_controls_html(".ox-api-module"));
         markdown.push_str("\n\n");
@@ -2512,6 +2528,169 @@ mod tests {
         assert!(
             table_page.contains("| `name` _(readonly)_ | property | `string` | Command name. |")
         );
+    }
+
+    #[test]
+    fn markdown_member_parameters_follow_parameters_format() {
+        let mut entry = test_entry("Command", "interface", "src/types.ts", "Command options.");
+        entry.members = vec![ApiDocMember {
+            name: "run".to_string(),
+            kind: "method".to_string(),
+            description: "Runs the command.".to_string(),
+            signature: Some("run(ctx: Context): Promise<void>".to_string()),
+            type_annotation: None,
+            params: vec![ApiParamDoc {
+                name: "ctx".to_string(),
+                type_annotation: "Context".to_string(),
+                description: "Runtime context.".to_string(),
+                optional: false,
+                default_value: None,
+            }],
+            returns: None,
+            optional: false,
+            readonly: false,
+            r#static: false,
+            private: false,
+            tags: vec![],
+            line: 2,
+            end_line: 2,
+        }];
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "mod".to_string(),
+            source_path: String::new(),
+            entries: vec![entry],
+        }];
+
+        let list_markdown = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                render_style: MarkdownRenderStyle::Markdown,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let list_page = list_markdown.get("mod/interfaces/Command.md").unwrap();
+        assert!(list_page.contains("### run Parameters"));
+        assert!(list_page.contains("- `ctx` (`Context`) - Runtime context."));
+
+        let table_markdown = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                render_style: MarkdownRenderStyle::Markdown,
+                parameters_format: MarkdownDisplayFormat::Table,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let table_page = table_markdown.get("mod/interfaces/Command.md").unwrap();
+        assert!(table_page.contains("### run Parameters"));
+        assert!(table_page.contains("| Name | Type | Description |"));
+        assert!(table_page.contains("| `ctx` | `Context` | Runtime context. |"));
+    }
+
+    #[test]
+    fn html_display_format_options_switch_explicit_sections() {
+        let mut make = test_entry("make", "function", "src/make.ts", "Make a thing.");
+        make.params = vec![ApiParamDoc {
+            name: "value".to_string(),
+            type_annotation: "string".to_string(),
+            description: "Input value.".to_string(),
+            optional: false,
+            default_value: None,
+        }];
+        make.type_parameters = vec![ApiTypeParamDoc {
+            name: "T".to_string(),
+            constraint: None,
+            default: None,
+            description: "Value type.".to_string(),
+        }];
+
+        let mut command = test_entry("Command", "interface", "src/types.ts", "Command options.");
+        command.members = vec![
+            ApiDocMember {
+                name: "name".to_string(),
+                kind: "property".to_string(),
+                description: "Command name.".to_string(),
+                signature: None,
+                type_annotation: Some("string".to_string()),
+                params: vec![],
+                returns: None,
+                optional: false,
+                readonly: true,
+                r#static: false,
+                private: false,
+                tags: vec![],
+                line: 2,
+                end_line: 2,
+            },
+            ApiDocMember {
+                name: "run".to_string(),
+                kind: "method".to_string(),
+                description: "Runs the command.".to_string(),
+                signature: Some("run(ctx: Context): Promise<void>".to_string()),
+                type_annotation: None,
+                params: vec![ApiParamDoc {
+                    name: "ctx".to_string(),
+                    type_annotation: "Context".to_string(),
+                    description: "Runtime context.".to_string(),
+                    optional: false,
+                    default_value: None,
+                }],
+                returns: None,
+                optional: false,
+                readonly: false,
+                r#static: false,
+                private: false,
+                tags: vec![],
+                line: 3,
+                end_line: 3,
+            },
+        ];
+
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "mod".to_string(),
+            source_path: String::new(),
+            entries: vec![make, command],
+        }];
+
+        let table_markdown = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                index_format: MarkdownDisplayFormat::Table,
+                parameters_format: MarkdownDisplayFormat::Table,
+                interface_properties_format: MarkdownDisplayFormat::List,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let index = table_markdown.get("index.md").unwrap();
+        assert!(index.contains("<table class=\"ox-api-modules-table\">"));
+        assert!(index.contains("<th>Module</th><th>Symbols</th><th>Description</th>"));
+
+        let page = table_markdown.get("mod.md").unwrap();
+        assert!(page.contains("<table class=\"ox-api-entry__params-table\">"));
+        assert!(page.contains("<table class=\"ox-api-entry__member-params-table\">"));
+        assert!(!page.contains("<ul class=\"ox-api-entry__params\">"));
+        assert!(page.contains("<ul class=\"ox-api-entry__members-list\">"));
+        assert!(page.contains("<li id=\"command-name\" class=\"ox-api-entry__member\">"));
+
+        let list_markdown = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                index_format: MarkdownDisplayFormat::List,
+                parameters_format: MarkdownDisplayFormat::List,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let index = list_markdown.get("index.md").unwrap();
+        assert!(index.contains("<ul class=\"ox-api-modules-list\">"));
+        assert!(!index.contains("<details class=\"ox-api-module\">"));
+
+        let page = list_markdown.get("mod.md").unwrap();
+        assert!(page.contains("<ul class=\"ox-api-entry__type-parameters\">"));
+        assert!(page.contains("<ul class=\"ox-api-entry__member-params\">"));
+        assert!(!page.contains("<table class=\"ox-api-entry__type-parameters-table\">"));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/markdown/markdown_html.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_html.rs
@@ -10,14 +10,16 @@ use std::sync::OnceLock;
 use regex::Regex;
 
 use super::{
-    cached_regex, clean_summary_text, doc_kind_plural, doc_page_href, entry_anchor, fmt_args,
-    format_kind_label, generate_source_href, get_entry_badges, member_anchor, normalize_signature,
-    parse_example_block, process_doc_text, push_fmt, EntryStats, MarkdownDocsOptions,
-    MarkdownLinkContext, MarkdownPathStrategy, RegexCache, DOC_KIND_ORDER,
+    cached_regex, clean_summary_text, doc_kind_plural, doc_page_href, effective_members_format,
+    effective_parameters_format, entry_anchor, file_stem, fmt_args, format_kind_label,
+    generate_source_href, get_entry_badges, member_anchor, normalize_signature,
+    parse_example_block, process_doc_text, push_fmt, EntryStats, MarkdownDisplayFormat,
+    MarkdownDocsOptions, MarkdownLinkContext, MarkdownPathStrategy, RegexCache, DOC_KIND_ORDER,
 };
 use crate::model::{
     ApiDocEntry, ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc, ApiTypeParamDoc,
 };
+use std::collections::HashMap;
 
 fn escape_html(value: &str) -> String {
     // Most inputs (symbol names, type annotations, kind labels) contain none of
@@ -481,29 +483,81 @@ fn render_params_list_html(
     )
 }
 
-fn render_type_parameters_html(
+fn render_params_table_html(
+    params: &[ApiParamDoc],
+    context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    let rows = params
+        .iter()
+        .map(|param| {
+            let mut flags = Vec::new();
+            if param.optional {
+                flags.push("optional".to_string());
+            }
+            if let Some(default_value) = &param.default_value {
+                flags.push(format!("default: {default_value}"));
+            }
+            let flag_text = flags.join(" · ");
+            let description = [param.description.as_str(), flag_text.as_str()]
+                .into_iter()
+                .filter(|value| !value.is_empty())
+                .collect::<Vec<_>>()
+                .join(" — ");
+
+            format!(
+                "<tr>
+  <td><code>{}</code></td>
+  <td><code>{}</code></td>
+  <td>{}</td>
+</tr>",
+                escape_html(&param.name),
+                escape_html(&param.type_annotation),
+                render_doc_inline_html(&description, context)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        "<div class=\"ox-api-entry__section ox-api-entry__section--params\">
+<h4>Parameters</h4>
+<table class=\"ox-api-entry__params-table\">
+<thead><tr><th>Name</th><th>Type</th><th>Description</th></tr></thead>
+<tbody>
+{rows}
+</tbody>
+</table>
+</div>"
+    )
+}
+
+fn render_type_parameter_name_html(type_param: &ApiTypeParamDoc) -> String {
+    let mut name = format!("<code>{}</code>", escape_html(&type_param.name));
+    if let Some(constraint) = &type_param.constraint {
+        push_fmt(
+            &mut name,
+            format_args!(" <em>extends</em> <code>{}</code>", escape_html(constraint)),
+        );
+    }
+    if let Some(default) = &type_param.default {
+        push_fmt(&mut name, format_args!(" = <code>{}</code>", escape_html(default)));
+    }
+    name
+}
+
+fn render_type_parameters_table_html(
     type_parameters: &[ApiTypeParamDoc],
     context: Option<&MarkdownLinkContext<'_>>,
 ) -> String {
     let rows = type_parameters
         .iter()
         .map(|type_param| {
-            let mut name = format!("<code>{}</code>", escape_html(&type_param.name));
-            if let Some(constraint) = &type_param.constraint {
-                push_fmt(
-                    &mut name,
-                    format_args!(" <em>extends</em> <code>{}</code>", escape_html(constraint)),
-                );
-            }
-            if let Some(default) = &type_param.default {
-                push_fmt(&mut name, format_args!(" = <code>{}</code>", escape_html(default)));
-            }
             format!(
                 "<tr>
   <td>{}</td>
   <td>{}</td>
 </tr>",
-                name,
+                render_type_parameter_name_html(type_param),
                 render_doc_inline_html(&type_param.description, context)
             )
         })
@@ -519,6 +573,42 @@ fn render_type_parameters_html(
 {rows}
 </tbody>
 </table>
+</div>"
+    )
+}
+
+fn render_type_parameters_list_html(
+    type_parameters: &[ApiTypeParamDoc],
+    context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    let items = type_parameters
+        .iter()
+        .map(|type_param| {
+            format!(
+                "<li class=\"ox-api-entry__type-parameter\">
+  <div class=\"ox-api-entry__type-parameter-heading\">{}</div>
+  {}
+</li>",
+                render_type_parameter_name_html(type_param),
+                if type_param.description.is_empty() {
+                    String::new()
+                } else {
+                    format!(
+                        "<p class=\"ox-api-entry__type-parameter-description\">{}</p>",
+                        render_doc_inline_html(&type_param.description, context)
+                    )
+                }
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        "<div class=\"ox-api-entry__section ox-api-entry__section--type-parameters\">
+<h4>Type Parameters</h4>
+<ul class=\"ox-api-entry__type-parameters\">
+{items}
+</ul>
 </div>"
     )
 }
@@ -577,6 +667,7 @@ fn render_member_type_html(member: &ApiDocMember) -> String {
 
 fn render_member_description_html(
     member: &ApiDocMember,
+    options: &MarkdownDocsOptions,
     context: Option<&MarkdownLinkContext<'_>>,
 ) -> String {
     let mut blocks = Vec::new();
@@ -589,30 +680,7 @@ fn render_member_description_html(
     }
 
     if !member.params.is_empty() {
-        let mut params = String::new();
-        for param in &member.params {
-            let mut description = param.description.clone();
-            if param.optional {
-                if description.is_empty() {
-                    description.push_str("optional");
-                } else {
-                    description.push_str(" - optional");
-                }
-            }
-            push_fmt(
-                &mut params,
-                format_args!(
-                    "<li><code>{}</code>{}</li>",
-                    escape_html(&param.name),
-                    if description.is_empty() {
-                        String::new()
-                    } else {
-                        format!(" {}", render_doc_inline_html(&description, context))
-                    }
-                ),
-            );
-        }
-        blocks.push(format!("<ul class=\"ox-api-entry__member-params\">{params}</ul>"));
+        blocks.push(render_member_params_html(&member.params, options, context));
     }
 
     if let Some(returns) = &member.returns {
@@ -627,10 +695,75 @@ fn render_member_description_html(
     blocks.join("")
 }
 
+fn render_member_param_description(param: &ApiParamDoc) -> String {
+    let mut description = param.description.clone();
+    let mut flags = Vec::new();
+    if param.optional {
+        flags.push("optional".to_string());
+    }
+    if let Some(default_value) = &param.default_value {
+        flags.push(format!("default: {default_value}"));
+    }
+    if !flags.is_empty() {
+        let flags = flags.join(" · ");
+        if description.is_empty() {
+            description.push_str(&flags);
+        } else {
+            push_fmt(&mut description, format_args!(" — {flags}"));
+        }
+    }
+    description
+}
+
+fn render_member_params_html(
+    params: &[ApiParamDoc],
+    options: &MarkdownDocsOptions,
+    context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    if effective_parameters_format(options) == MarkdownDisplayFormat::Table {
+        let mut rows = String::new();
+        for param in params {
+            let description = render_member_param_description(param);
+            push_fmt(
+                &mut rows,
+                format_args!(
+                    "<tr><td><code>{}</code></td><td><code>{}</code></td><td>{}</td></tr>",
+                    escape_html(&param.name),
+                    escape_html(&param.type_annotation),
+                    render_doc_inline_html(&description, context)
+                ),
+            );
+        }
+
+        return format!(
+            "<table class=\"ox-api-entry__member-params-table\"><thead><tr><th>Name</th><th>Type</th><th>Description</th></tr></thead><tbody>{rows}</tbody></table>"
+        );
+    }
+
+    let mut items = String::new();
+    for param in params {
+        let description = render_member_param_description(param);
+        push_fmt(
+            &mut items,
+            format_args!(
+                "<li><code>{}</code>{}</li>",
+                escape_html(&param.name),
+                if description.is_empty() {
+                    String::new()
+                } else {
+                    format!(" {}", render_doc_inline_html(&description, context))
+                }
+            ),
+        );
+    }
+    format!("<ul class=\"ox-api-entry__member-params\">{items}</ul>")
+}
+
 fn render_member_table_html(
     entry_name: &str,
     title: &str,
     members: &[&ApiDocMember],
+    options: &MarkdownDocsOptions,
     context: Option<&MarkdownLinkContext<'_>>,
 ) -> String {
     if members.is_empty() {
@@ -658,7 +791,7 @@ fn render_member_table_html(
                 render_member_flags(member),
                 escape_html(&member.kind),
                 render_member_type_html(member),
-                render_member_description_html(member, context)
+                render_member_description_html(member, options, context)
             )
         })
         .collect::<Vec<_>>()
@@ -678,8 +811,74 @@ fn render_member_table_html(
     )
 }
 
-fn render_members_table_html(
+fn render_member_list_html(
+    entry_name: &str,
+    title: &str,
+    members: &[&ApiDocMember],
+    options: &MarkdownDocsOptions,
+    context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    if members.is_empty() {
+        return String::new();
+    }
+
+    let items = members
+        .iter()
+        .map(|member| {
+            format!(
+                "<li id=\"{}\" class=\"ox-api-entry__member\">
+  <div class=\"ox-api-entry__member-heading\">
+    <code class=\"ox-api-entry__member-name\">{}</code>{}
+    <span class=\"ox-api-entry__member-kind\">{}</span>
+    {}
+  </div>
+  {}
+</li>",
+                escape_html(&member_anchor(
+                    entry_name,
+                    member,
+                    context.map_or(MarkdownPathStrategy::Flat, |context| context
+                        .options
+                        .path_strategy),
+                )),
+                escape_html(&member.name),
+                render_member_flags(member),
+                escape_html(&member.kind),
+                render_member_type_html(member),
+                render_member_description_html(member, options, context)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        "<div class=\"ox-api-entry__member-group\">
+<h5>{}</h5>
+<ul class=\"ox-api-entry__members-list\">
+{items}
+</ul>
+</div>",
+        escape_html(title)
+    )
+}
+
+fn render_member_group_html(
     entry: &ApiDocEntry,
+    title: &str,
+    members: &[&ApiDocMember],
+    options: &MarkdownDocsOptions,
+    context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    if effective_members_format(options, &entry.kind, title) == MarkdownDisplayFormat::List {
+        render_member_list_html(&entry.name, title, members, options, context)
+    } else {
+        render_member_table_html(&entry.name, title, members, options, context)
+    }
+}
+
+fn render_members_html(
+    entry: &ApiDocEntry,
+    options: &MarkdownDocsOptions,
     context: Option<&MarkdownLinkContext<'_>>,
 ) -> String {
     if entry.members.is_empty() {
@@ -711,62 +910,88 @@ fn render_members_table_html(
         "class" => {
             let constructors =
                 members.iter().filter(|member| member.kind == "constructor").collect::<Vec<_>>();
-            groups.push(render_member_table_html(
-                &entry.name,
+            groups.push(render_member_group_html(
+                entry,
                 "Constructors",
                 &constructors,
+                options,
                 context,
             ));
-            groups.push(render_member_table_html(
-                &entry.name,
+            groups.push(render_member_group_html(
+                entry,
                 "Static Methods",
                 &methods(true),
+                options,
                 context,
             ));
-            groups.push(render_member_table_html(&entry.name, "Methods", &methods(false), context));
-            groups.push(render_member_table_html(
-                &entry.name,
+            groups.push(render_member_group_html(
+                entry,
+                "Methods",
+                &methods(false),
+                options,
+                context,
+            ));
+            groups.push(render_member_group_html(
+                entry,
                 "Static Properties",
                 &properties(true),
+                options,
                 context,
             ));
-            groups.push(render_member_table_html(
-                &entry.name,
+            groups.push(render_member_group_html(
+                entry,
                 "Properties",
                 &properties(false),
+                options,
                 context,
             ));
         }
         "interface" => {
-            groups.push(render_member_table_html(
-                &entry.name,
+            groups.push(render_member_group_html(
+                entry,
                 "Properties",
                 &properties(false),
+                options,
                 context,
             ));
-            groups.push(render_member_table_html(&entry.name, "Methods", &methods(false), context));
+            groups.push(render_member_group_html(
+                entry,
+                "Methods",
+                &methods(false),
+                options,
+                context,
+            ));
         }
         "type" => {
             let enum_members =
                 members.iter().filter(|member| member.kind == "enumMember").collect::<Vec<_>>();
-            groups.push(render_member_table_html(
-                &entry.name,
+            groups.push(render_member_group_html(
+                entry,
                 "Properties",
                 &properties(false),
+                options,
                 context,
             ));
-            groups.push(render_member_table_html(&entry.name, "Methods", &methods(false), context));
-            groups.push(render_member_table_html(
-                &entry.name,
+            groups.push(render_member_group_html(
+                entry,
+                "Methods",
+                &methods(false),
+                options,
+                context,
+            ));
+            groups.push(render_member_group_html(
+                entry,
                 "Enum Members",
                 &enum_members,
+                options,
                 context,
             ));
         }
-        _ => groups.push(render_member_table_html(
-            &entry.name,
+        _ => groups.push(render_member_group_html(
+            entry,
             "Members",
             &members.iter().collect::<Vec<_>>(),
+            options,
             context,
         )),
     }
@@ -825,17 +1050,25 @@ fn render_entry_body_html(
     }
 
     if !entry.type_parameters.is_empty() {
-        body.push_str(&render_type_parameters_html(&entry.type_parameters, link_context));
+        if effective_parameters_format(options) == MarkdownDisplayFormat::List {
+            body.push_str(&render_type_parameters_list_html(&entry.type_parameters, link_context));
+        } else {
+            body.push_str(&render_type_parameters_table_html(&entry.type_parameters, link_context));
+        }
         body.push('\n');
     }
 
     if !entry.members.is_empty() {
-        body.push_str(&render_members_table_html(entry, link_context));
+        body.push_str(&render_members_html(entry, options, link_context));
         body.push('\n');
     }
 
     if !entry.params.is_empty() {
-        body.push_str(&render_params_list_html(&entry.params, link_context));
+        if effective_parameters_format(options) == MarkdownDisplayFormat::Table {
+            body.push_str(&render_params_table_html(&entry.params, link_context));
+        } else {
+            body.push_str(&render_params_list_html(&entry.params, link_context));
+        }
         body.push('\n');
     }
 
@@ -1012,4 +1245,93 @@ pub(super) fn render_module_section_html(
     );
 
     markdown
+}
+
+pub(super) fn render_module_index_html(
+    docs: &[ApiDocModule],
+    options: &MarkdownDocsOptions,
+    doc_to_file: Option<&HashMap<String, String>>,
+    display_format: MarkdownDisplayFormat,
+    link_context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    let items = docs
+        .iter()
+        .map(|doc| {
+            let display_name = file_stem(&doc.file);
+            let mut file_name = display_name.clone();
+
+            if let Some(doc_to_file) = doc_to_file {
+                if let Some(mapped) = doc_to_file.get(&doc.file) {
+                    file_name.clone_from(mapped);
+                }
+            } else if file_name == "index" {
+                file_name = "index-module".to_string();
+            }
+
+            let count_label = fmt_args(format_args!(
+                "{} symbol{}",
+                doc.entries.len(),
+                if doc.entries.len() == 1 { "" } else { "s" }
+            ));
+            let href = doc_page_href(options, &file_name, None);
+            let summary = clean_summary_text(&process_doc_text(&doc.description, link_context), 88);
+            (display_name, href, count_label, summary)
+        })
+        .collect::<Vec<_>>();
+
+    if display_format == MarkdownDisplayFormat::Table {
+        let rows = items
+            .iter()
+            .map(|(display_name, href, count_label, summary)| {
+                format!(
+                    "<tr><td><a href=\"{}\">{}</a></td><td>{}</td><td>{}</td></tr>",
+                    escape_html(href),
+                    escape_html(display_name),
+                    escape_html(count_label),
+                    render_inline_html(summary)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        return format!(
+            "<table class=\"ox-api-modules-table\">
+<thead><tr><th>Module</th><th>Symbols</th><th>Description</th></tr></thead>
+<tbody>
+{rows}
+</tbody>
+</table>
+
+"
+        );
+    }
+
+    let rows = items
+        .iter()
+        .map(|(display_name, href, count_label, summary)| {
+            format!(
+                "<li><a href=\"{}\">{}</a><span class=\"ox-api-module__count\">{}</span>{}</li>",
+                escape_html(href),
+                escape_html(display_name),
+                escape_html(count_label),
+                if summary.is_empty() {
+                    String::new()
+                } else {
+                    format!(
+                        "<span class=\"ox-api-module__summary\">{}</span>",
+                        render_inline_html(summary)
+                    )
+                }
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        "<ul class=\"ox-api-modules-list\">
+{rows}
+</ul>
+
+"
+    )
 }

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -258,7 +258,7 @@ fn render_members_pure(
         }
         push_fmt(&mut out, format_args!("{heading} {title}\n\n"));
         if effective_members_format(options, &entry.kind, title) == MarkdownDisplayFormat::List {
-            for member in members {
+            for member in &members {
                 let mut line =
                     fmt_args(format_args!("- {} `{}`", member_name_span(member), member.kind));
                 let member_type = member_type(member);
@@ -274,7 +274,7 @@ fn render_members_pure(
             }
         } else {
             out.push_str("| Name | Kind | Type | Description |\n| --- | --- | --- | --- |\n");
-            for member in members {
+            for member in &members {
                 push_fmt(
                     &mut out,
                     format_args!(
@@ -288,7 +288,67 @@ fn render_members_pure(
             }
         }
         out.push('\n');
+        out.push_str(&render_member_parameter_sections_pure(
+            &members,
+            options,
+            context,
+            section_level + 1,
+        ));
     }
+    out
+}
+
+fn render_member_parameter_sections_pure(
+    members: &[&ApiDocMember],
+    options: &MarkdownDocsOptions,
+    context: Option<&MarkdownLinkContext<'_>>,
+    section_level: usize,
+) -> String {
+    let mut out = String::new();
+    let heading = "#".repeat(section_level);
+
+    for member in members {
+        if member.params.is_empty() {
+            continue;
+        }
+
+        push_fmt(&mut out, format_args!("{heading} {} Parameters\n\n", member.name));
+        match effective_parameters_format(options) {
+            MarkdownDisplayFormat::Table => {
+                out.push_str("| Name | Type | Description |\n| --- | --- | --- |\n");
+                for param in &member.params {
+                    push_fmt(
+                        &mut out,
+                        format_args!(
+                            "| {} | {} | {} |\n",
+                            code_cell(&param.name),
+                            code_cell(&param.type_annotation),
+                            table_cell(&param_description(param, context)),
+                        ),
+                    );
+                }
+            }
+            _ => {
+                for param in &member.params {
+                    let mut line = fmt_args(format_args!("- {}", code_span(&param.name)));
+                    if !param.type_annotation.is_empty() {
+                        push_fmt(
+                            &mut line,
+                            format_args!(" ({})", code_span(&param.type_annotation)),
+                        );
+                    }
+                    let description = param_description(param, context);
+                    if !description.is_empty() {
+                        push_fmt(&mut line, format_args!(" - {description}"));
+                    }
+                    out.push_str(&line);
+                    out.push('\n');
+                }
+            }
+        }
+        out.push('\n');
+    }
+
     out
 }
 

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -7,10 +7,11 @@
 //! tables and fenced code blocks (no `<details>`, no theme-specific HTML).
 
 use super::{
-    fmt_args, generate_source_href, parse_example_block, process_doc_text, push_fmt, EntryStats,
+    effective_members_format, effective_parameters_format, fmt_args, generate_source_href,
+    parse_example_block, process_doc_text, push_fmt, EntryStats, MarkdownDisplayFormat,
     MarkdownDocsOptions, MarkdownLinkContext,
 };
-use crate::model::{ApiDocEntry, ApiDocMember, ApiTypeParamDoc};
+use crate::model::{ApiDocEntry, ApiDocMember, ApiParamDoc, ApiTypeParamDoc};
 
 /// Renders the per-page stats summary as a single italic Markdown line.
 pub(super) fn render_stats_markdown(stats: &EntryStats, module_count: Option<usize>) -> String {
@@ -92,53 +93,81 @@ pub(super) fn render_entry_body_pure(
 
     if !entry.type_parameters.is_empty() {
         push_fmt(&mut out, format_args!("{heading} Type Parameters\n\n"));
-        out.push_str("| Name | Description |\n| --- | --- |\n");
-        for type_param in &entry.type_parameters {
-            push_fmt(
-                &mut out,
-                format_args!(
-                    "| {} | {} |\n",
-                    type_param_name_cell(type_param),
-                    table_cell(&inline(&type_param.description, context)),
-                ),
-            );
+        match effective_parameters_format(options) {
+            MarkdownDisplayFormat::Table => {
+                out.push_str("| Name | Description |\n| --- | --- |\n");
+                for type_param in &entry.type_parameters {
+                    push_fmt(
+                        &mut out,
+                        format_args!(
+                            "| {} | {} |\n",
+                            type_param_name_cell(type_param),
+                            table_cell(&inline(&type_param.description, context)),
+                        ),
+                    );
+                }
+            }
+            _ => {
+                for type_param in &entry.type_parameters {
+                    let description = inline(&type_param.description, context);
+                    if description.is_empty() {
+                        push_fmt(
+                            &mut out,
+                            format_args!("- {}\n", type_param_name_span(type_param)),
+                        );
+                    } else {
+                        push_fmt(
+                            &mut out,
+                            format_args!(
+                                "- {} - {description}\n",
+                                type_param_name_span(type_param)
+                            ),
+                        );
+                    }
+                }
+            }
         }
         out.push('\n');
     }
 
     if !entry.members.is_empty() {
-        out.push_str(&render_members_pure(entry, context, section_level));
+        out.push_str(&render_members_pure(entry, options, context, section_level));
     }
 
     if !entry.params.is_empty() {
         push_fmt(&mut out, format_args!("{heading} Parameters\n\n"));
-        out.push_str("| Name | Type | Description |\n| --- | --- | --- |\n");
-        for param in &entry.params {
-            let mut description = inline(&param.description, context);
-            let mut flags = Vec::new();
-            if param.optional {
-                flags.push("optional".to_string());
+        match effective_parameters_format(options) {
+            MarkdownDisplayFormat::Table => {
+                out.push_str("| Name | Type | Description |\n| --- | --- | --- |\n");
+                for param in &entry.params {
+                    push_fmt(
+                        &mut out,
+                        format_args!(
+                            "| {} | {} | {} |\n",
+                            code_cell(&param.name),
+                            code_cell(&param.type_annotation),
+                            table_cell(&param_description(param, context)),
+                        ),
+                    );
+                }
             }
-            if let Some(default_value) = &param.default_value {
-                flags.push(fmt_args(format_args!("default: {default_value}")));
+            _ => {
+                for param in &entry.params {
+                    let mut line = fmt_args(format_args!("- {}", code_span(&param.name)));
+                    if !param.type_annotation.is_empty() {
+                        push_fmt(
+                            &mut line,
+                            format_args!(" ({})", code_span(&param.type_annotation)),
+                        );
+                    }
+                    let description = param_description(param, context);
+                    if !description.is_empty() {
+                        push_fmt(&mut line, format_args!(" - {description}"));
+                    }
+                    out.push_str(&line);
+                    out.push('\n');
+                }
             }
-            if !flags.is_empty() {
-                let flags = flags.join(", ");
-                description = if description.is_empty() {
-                    fmt_args(format_args!("_{flags}_"))
-                } else {
-                    fmt_args(format_args!("{description} _({flags})_"))
-                };
-            }
-            push_fmt(
-                &mut out,
-                format_args!(
-                    "| {} | {} | {} |\n",
-                    code_cell(&param.name),
-                    code_cell(&param.type_annotation),
-                    table_cell(&description),
-                ),
-            );
         }
         out.push('\n');
     }
@@ -184,6 +213,7 @@ pub(super) fn render_entry_body_pure(
 /// tables under a separate "Members" heading.
 fn render_members_pure(
     entry: &ApiDocEntry,
+    options: &MarkdownDocsOptions,
     context: Option<&MarkdownLinkContext<'_>>,
     section_level: usize,
 ) -> String {
@@ -216,6 +246,7 @@ fn render_members_pure(
             ("Methods", methods(false)),
             ("Enum Members", members_of(entry, |member| member.kind == "enumMember")),
         ],
+        "enum" => vec![("Enum Members", members_of(entry, |member| member.kind == "enumMember"))],
         _ => vec![("Members", entry.members.iter().collect())],
     };
 
@@ -226,18 +257,35 @@ fn render_members_pure(
             continue;
         }
         push_fmt(&mut out, format_args!("{heading} {title}\n\n"));
-        out.push_str("| Name | Kind | Type | Description |\n| --- | --- | --- | --- |\n");
-        for member in members {
-            push_fmt(
-                &mut out,
-                format_args!(
-                    "| {} | {} | {} | {} |\n",
-                    member_name_cell(member),
-                    table_cell(&member.kind),
-                    code_cell(&member_type(member)),
-                    table_cell(&member_description(member, context)),
-                ),
-            );
+        if effective_members_format(options, &entry.kind, title) == MarkdownDisplayFormat::List {
+            for member in members {
+                let mut line =
+                    fmt_args(format_args!("- {} `{}`", member_name_span(member), member.kind));
+                let member_type = member_type(member);
+                if !member_type.is_empty() {
+                    push_fmt(&mut line, format_args!(" {}", code_span(&member_type)));
+                }
+                let description = member_description(member, context);
+                if !description.is_empty() {
+                    push_fmt(&mut line, format_args!(" - {description}"));
+                }
+                out.push_str(&line);
+                out.push('\n');
+            }
+        } else {
+            out.push_str("| Name | Kind | Type | Description |\n| --- | --- | --- | --- |\n");
+            for member in members {
+                push_fmt(
+                    &mut out,
+                    format_args!(
+                        "| {} | {} | {} | {} |\n",
+                        member_name_cell(member),
+                        table_cell(&member.kind),
+                        code_cell(&member_type(member)),
+                        table_cell(&member_description(member, context)),
+                    ),
+                );
+            }
         }
         out.push('\n');
     }
@@ -252,6 +300,14 @@ fn members_of<'a>(
 }
 
 fn member_name_cell(member: &ApiDocMember) -> String {
+    member_name(member, code_cell)
+}
+
+fn member_name_span(member: &ApiDocMember) -> String {
+    member_name(member, code_span)
+}
+
+fn member_name(member: &ApiDocMember, code: fn(&str) -> String) -> String {
     let mut flags = Vec::new();
     if member.optional {
         flags.push("optional");
@@ -266,7 +322,7 @@ fn member_name_cell(member: &ApiDocMember) -> String {
         flags.push("private");
     }
 
-    let name = code_cell(&member.name);
+    let name = code(&member.name);
     if flags.is_empty() {
         name
     } else {
@@ -298,6 +354,26 @@ fn member_description(member: &ApiDocMember, context: Option<&MarkdownLinkContex
     parts.join(" ")
 }
 
+fn param_description(param: &ApiParamDoc, context: Option<&MarkdownLinkContext<'_>>) -> String {
+    let mut description = inline(&param.description, context);
+    let mut flags = Vec::new();
+    if param.optional {
+        flags.push("optional".to_string());
+    }
+    if let Some(default_value) = &param.default_value {
+        flags.push(fmt_args(format_args!("default: {default_value}")));
+    }
+    if !flags.is_empty() {
+        let flags = flags.join(", ");
+        description = if description.is_empty() {
+            fmt_args(format_args!("_{flags}_"))
+        } else {
+            fmt_args(format_args!("{description} _({flags})_"))
+        };
+    }
+    description
+}
+
 /// Collapses runs of whitespace (including newlines) into single spaces.
 fn collapse_whitespace(text: &str) -> String {
     text.split_whitespace().collect::<Vec<_>>().join(" ")
@@ -313,6 +389,16 @@ fn table_cell(text: &str) -> String {
     text.replace('|', "\\|")
 }
 
+/// Inline code for normal Markdown text; empty string if blank.
+fn code_span(value: &str) -> String {
+    let value = collapse_whitespace(value);
+    if value.is_empty() {
+        String::new()
+    } else {
+        fmt_args(format_args!("`{value}`"))
+    }
+}
+
 /// Inline code for a Markdown table cell (`|` escaped); empty string if blank.
 fn code_cell(value: &str) -> String {
     let value = collapse_whitespace(value);
@@ -326,12 +412,20 @@ fn code_cell(value: &str) -> String {
 /// Builds the Name cell for a type parameter: `` `T` `` plus optional `*extends*`
 /// constraint and `=` default, each rendered as inline code.
 fn type_param_name_cell(type_param: &ApiTypeParamDoc) -> String {
-    let mut cell = code_cell(&type_param.name);
+    type_param_name(type_param, code_cell)
+}
+
+fn type_param_name_span(type_param: &ApiTypeParamDoc) -> String {
+    type_param_name(type_param, code_span)
+}
+
+fn type_param_name(type_param: &ApiTypeParamDoc, code: fn(&str) -> String) -> String {
+    let mut cell = code(&type_param.name);
     if let Some(constraint) = &type_param.constraint {
-        push_fmt(&mut cell, format_args!(" *extends* {}", code_cell(constraint)));
+        push_fmt(&mut cell, format_args!(" *extends* {}", code(constraint)));
     }
     if let Some(default) = &type_param.default {
-        push_fmt(&mut cell, format_args!(" = {}", code_cell(default)));
+        push_fmt(&mut cell, format_args!(" = {}", code(default)));
     }
     cell
 }

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -347,6 +347,14 @@ export interface JsDocsMarkdownOptions {
   basePath?: string
   pathStrategy?: 'flat' | 'typedoc'
   renderStyle?: 'html' | 'markdown'
+  indexFormat?: 'none' | 'list' | 'table'
+  parametersFormat?: 'none' | 'list' | 'table'
+  interfacePropertiesFormat?: 'none' | 'list' | 'table'
+  classPropertiesFormat?: 'none' | 'list' | 'table'
+  typeAliasPropertiesFormat?: 'none' | 'list' | 'table'
+  enumMembersFormat?: 'none' | 'list' | 'table'
+  propertyMembersFormat?: 'none' | 'list' | 'table'
+  typeDeclarationFormat?: 'none' | 'list' | 'table'
 }
 
 /** Ordered JSDoc tag used by generated API Markdown. */

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -34,9 +34,9 @@ use ox_content_docs::{
     DocExtractor, DocItem, DocItemKind, DocTag, DocsDiagnostic, DocsDiagnosticCode, DocsNavItem,
     DocsOutputOptions, EntryPointDocsOptions, EntryPointSpec, ExportGraph, ExportKind,
     ExportSource, ExternalDocsOptions, ExternalPackageSource, ExtractedDocModule, GraphOptions,
-    MarkdownDocsOptions, MarkdownLinkStyle, MarkdownPathStrategy, MarkdownRenderStyle,
-    NormalizedDocEntry, NormalizedMember, NormalizedParamDoc, NormalizedReturnDoc,
-    NormalizedTypeParam, ParamDoc, PublicExport,
+    MarkdownDisplayFormat, MarkdownDocsOptions, MarkdownLinkStyle, MarkdownPathStrategy,
+    MarkdownRenderStyle, NormalizedDocEntry, NormalizedMember, NormalizedParamDoc,
+    NormalizedReturnDoc, NormalizedTypeParam, ParamDoc, PublicExport,
 };
 use ox_content_parser::{Parser, ParserOptions};
 use ox_content_renderer::HtmlRenderer;
@@ -297,7 +297,7 @@ pub struct JsExtractedDocsModule {
 
 /// Options for generated API Markdown.
 #[napi(object)]
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct JsDocsMarkdownOptions {
     pub group_by: Option<String>,
     pub github_url: Option<String>,
@@ -308,6 +308,22 @@ pub struct JsDocsMarkdownOptions {
     pub path_strategy: Option<String>,
     #[napi(ts_type = "'html' | 'markdown'")]
     pub render_style: Option<String>,
+    #[napi(ts_type = "'none' | 'list' | 'table'")]
+    pub index_format: Option<String>,
+    #[napi(ts_type = "'none' | 'list' | 'table'")]
+    pub parameters_format: Option<String>,
+    #[napi(ts_type = "'none' | 'list' | 'table'")]
+    pub interface_properties_format: Option<String>,
+    #[napi(ts_type = "'none' | 'list' | 'table'")]
+    pub class_properties_format: Option<String>,
+    #[napi(ts_type = "'none' | 'list' | 'table'")]
+    pub type_alias_properties_format: Option<String>,
+    #[napi(ts_type = "'none' | 'list' | 'table'")]
+    pub enum_members_format: Option<String>,
+    #[napi(ts_type = "'none' | 'list' | 'table'")]
+    pub property_members_format: Option<String>,
+    #[napi(ts_type = "'none' | 'list' | 'table'")]
+    pub type_declaration_format: Option<String>,
 }
 
 /// Options for writing generated API documentation files.
@@ -1349,6 +1365,26 @@ pub fn generate_docs_markdown(
             base_path: options.base_path,
             path_strategy: parse_markdown_path_strategy(options.path_strategy.as_deref()),
             render_style: parse_markdown_render_style(options.render_style.as_deref()),
+            index_format: parse_markdown_display_format(options.index_format.as_deref()),
+            parameters_format: parse_markdown_display_format(options.parameters_format.as_deref()),
+            interface_properties_format: parse_markdown_display_format(
+                options.interface_properties_format.as_deref(),
+            ),
+            class_properties_format: parse_markdown_display_format(
+                options.class_properties_format.as_deref(),
+            ),
+            type_alias_properties_format: parse_markdown_display_format(
+                options.type_alias_properties_format.as_deref(),
+            ),
+            enum_members_format: parse_markdown_display_format(
+                options.enum_members_format.as_deref(),
+            ),
+            property_members_format: parse_markdown_display_format(
+                options.property_members_format.as_deref(),
+            ),
+            type_declaration_format: parse_markdown_display_format(
+                options.type_declaration_format.as_deref(),
+            ),
         });
     generate_markdown(&docs.into_iter().map(convert_markdown_module).collect::<Vec<_>>(), &options)
         .into_iter()
@@ -1373,6 +1409,14 @@ fn parse_markdown_render_style(render_style: Option<&str>) -> MarkdownRenderStyl
     match render_style {
         Some("markdown") => MarkdownRenderStyle::Markdown,
         _ => MarkdownRenderStyle::Html,
+    }
+}
+
+fn parse_markdown_display_format(format: Option<&str>) -> MarkdownDisplayFormat {
+    match format {
+        Some("list") => MarkdownDisplayFormat::List,
+        Some("table") => MarkdownDisplayFormat::Table,
+        _ => MarkdownDisplayFormat::None,
     }
 }
 
@@ -3470,6 +3514,7 @@ mod tests {
                 base_path: Some("/api-ox".to_string()),
                 path_strategy: None,
                 render_style: None,
+                ..Default::default()
             }),
         );
         let index = markdown.get("index.md").unwrap();
@@ -3510,6 +3555,7 @@ mod tests {
                 base_path: None,
                 path_strategy: None,
                 render_style: Some("markdown".to_string()),
+                ..Default::default()
             }),
         );
         let page = markdown.get("context.md").unwrap();
@@ -3518,6 +3564,51 @@ mod tests {
         assert!(!page.contains("class=\"ox-api"));
         assert!(page.contains("### CommandContext"));
         assert!(page.contains("```ts"));
+    }
+
+    #[test]
+    fn generate_docs_markdown_accepts_display_format_options() {
+        let docs = vec![JsDocsMarkdownModule {
+            description: None,
+            file: "default".to_string(),
+            source_path: None,
+            entries: vec![JsDocsMarkdownEntry {
+                name: "make".to_string(),
+                kind: "function".to_string(),
+                description: "Make a thing.".to_string(),
+                params: Some(vec![JsDocParam {
+                    name: "value".to_string(),
+                    r#type: "string".to_string(),
+                    description: "Input value.".to_string(),
+                    optional: Some(false),
+                    r#default: None,
+                }]),
+                returns: None,
+                examples: None,
+                tags: None,
+                private: false,
+                file: "/repo/src/make.ts".to_string(),
+                line: 1,
+                end_line: 1,
+                signature: Some("export function make(value: string): void".to_string()),
+                members: None,
+                type_parameters: None,
+            }],
+        }];
+
+        let markdown = generate_docs_markdown(
+            docs,
+            Some(JsDocsMarkdownOptions {
+                group_by: Some("file".to_string()),
+                render_style: Some("markdown".to_string()),
+                parameters_format: Some("table".to_string()),
+                ..Default::default()
+            }),
+        );
+        let page = markdown.get("default.md").unwrap();
+
+        assert!(page.contains("| Name | Type | Description |"));
+        assert!(page.contains("| `value` | `string` | Input value. |"));
     }
 
     #[test]
@@ -3662,6 +3753,7 @@ mod tests {
                 base_path: Some("/api".to_string()),
                 path_strategy: Some("typedoc".to_string()),
                 render_style: None,
+                ..Default::default()
             }),
         );
         let cli_page = markdown.get("default/functions/cli.md").unwrap();
@@ -3720,6 +3812,7 @@ mod tests {
                 base_path: None,
                 path_strategy: Some("typedoc".to_string()),
                 render_style: None,
+                ..Default::default()
             }),
         );
 
@@ -3766,6 +3859,7 @@ mod tests {
                 base_path: None,
                 path_strategy: Some("typedoc".to_string()),
                 render_style: Some("markdown".to_string()),
+                ..Default::default()
             }),
         );
         let page = markdown.get("default/functions/make.md").unwrap();
@@ -3809,6 +3903,7 @@ mod tests {
                 base_path: None,
                 path_strategy: Some("typedoc".to_string()),
                 render_style: Some("markdown".to_string()),
+                ..Default::default()
             }),
         );
 
@@ -3937,6 +4032,7 @@ mod tests {
                 base_path: Some("/api".to_string()),
                 path_strategy: Some("typedoc".to_string()),
                 render_style: None,
+                ..Default::default()
             }),
         );
 

--- a/npm/vite-plugin-ox-content/src/docs.test.ts
+++ b/npm/vite-plugin-ox-content/src/docs.test.ts
@@ -239,7 +239,38 @@ describe("generateMarkdown", () => {
     expect(page).not.toContain("<table");
     expect(page).toContain("### capitalize");
     expect(page).toContain("```ts");
+    expect(page).toContain("- `str` (`string`) - Input string");
+    expect(page).not.toContain("| Name | Type | Description |");
+  });
+
+  it("passes Markdown display format options to generated Markdown", () => {
+    const docs: ExtractedDocs[] = [
+      {
+        file: "/repo/src/utils.ts",
+        entries: [
+          {
+            name: "capitalize",
+            kind: "function",
+            description: "Capitalizes the first letter of a string.",
+            file: "/repo/src/utils.ts",
+            line: 4,
+            endLine: 4,
+            signature: "export function capitalize(str: string): string",
+            params: [{ name: "str", type: "string", description: "Input string" }],
+            returns: { type: "string", description: "Capitalized string" },
+          },
+        ],
+      },
+    ];
+
+    const markdown = generateMarkdown(
+      docs,
+      resolveDocsOptions({ renderStyle: "markdown", parametersFormat: "table" })!,
+    );
+
+    const page = markdown["utils.md"];
     expect(page).toContain("| Name | Type | Description |");
+    expect(page).toContain("| `str` | `string` | Input string |");
   });
 
   it("passes clean link options to generated Markdown", () => {

--- a/npm/vite-plugin-ox-content/src/docs.ts
+++ b/npm/vite-plugin-ox-content/src/docs.ts
@@ -220,6 +220,14 @@ export function generateMarkdown(
     basePath: options.basePath,
     pathStrategy: options.pathStrategy,
     renderStyle: options.renderStyle,
+    indexFormat: options.indexFormat,
+    parametersFormat: options.parametersFormat,
+    interfacePropertiesFormat: options.interfacePropertiesFormat,
+    classPropertiesFormat: options.classPropertiesFormat,
+    typeAliasPropertiesFormat: options.typeAliasPropertiesFormat,
+    enumMembersFormat: options.enumMembersFormat,
+    propertyMembersFormat: options.propertyMembersFormat,
+    typeDeclarationFormat: options.typeDeclarationFormat,
   });
 }
 
@@ -313,6 +321,14 @@ export function resolveDocsOptions(
     basePath: opts.basePath,
     pathStrategy: opts.pathStrategy ?? "flat",
     renderStyle: opts.renderStyle ?? "html",
+    indexFormat: opts.indexFormat ?? "none",
+    parametersFormat: opts.parametersFormat ?? "none",
+    interfacePropertiesFormat: opts.interfacePropertiesFormat ?? "none",
+    classPropertiesFormat: opts.classPropertiesFormat ?? "none",
+    typeAliasPropertiesFormat: opts.typeAliasPropertiesFormat ?? "none",
+    enumMembersFormat: opts.enumMembersFormat ?? "none",
+    propertyMembersFormat: opts.propertyMembersFormat ?? "none",
+    typeDeclarationFormat: opts.typeDeclarationFormat ?? "none",
     typeParameters: opts.typeParameters ?? false,
     generateNav: opts.generateNav ?? true,
   };

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -53,6 +53,7 @@ export type {
   ResolvedCodeBlockTypecheckOptions,
   DocsTestOptions,
   ResolvedDocsTestOptions,
+  MarkdownDisplayFormat,
   DocsOptions,
   ResolvedDocsOptions,
   DocEntry,

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -909,6 +909,8 @@ export type DocsEntryPoint =
       name?: string;
     };
 
+export type MarkdownDisplayFormat = "none" | "list" | "table";
+
 /**
  * Resolved public API entry point.
  */
@@ -1023,6 +1025,54 @@ export interface DocsOptions {
   renderStyle?: "html" | "markdown";
 
   /**
+   * Display format for index items.
+   * @default 'none'
+   */
+  indexFormat?: MarkdownDisplayFormat;
+
+  /**
+   * Display format for value and type parameters.
+   * @default 'none'
+   */
+  parametersFormat?: MarkdownDisplayFormat;
+
+  /**
+   * Display format for interface property groups.
+   * @default 'none'
+   */
+  interfacePropertiesFormat?: MarkdownDisplayFormat;
+
+  /**
+   * Display format for class property groups.
+   * @default 'none'
+   */
+  classPropertiesFormat?: MarkdownDisplayFormat;
+
+  /**
+   * Display format for type alias property groups.
+   * @default 'none'
+   */
+  typeAliasPropertiesFormat?: MarkdownDisplayFormat;
+
+  /**
+   * Display format for enum member groups.
+   * @default 'none'
+   */
+  enumMembersFormat?: MarkdownDisplayFormat;
+
+  /**
+   * Reserved display format for property-owned object literal members.
+   * @default 'none'
+   */
+  propertyMembersFormat?: MarkdownDisplayFormat;
+
+  /**
+   * Reserved display format for type declaration members.
+   * @default 'none'
+   */
+  typeDeclarationFormat?: MarkdownDisplayFormat;
+
+  /**
    * Opt in to TSDoc-style type-parameter documentation.
    *
    * When enabled, declaration type parameters (`<T extends C = D>`) are
@@ -1060,6 +1110,14 @@ export interface ResolvedDocsOptions {
   basePath?: string;
   pathStrategy: "flat" | "typedoc";
   renderStyle: "html" | "markdown";
+  indexFormat: MarkdownDisplayFormat;
+  parametersFormat: MarkdownDisplayFormat;
+  interfacePropertiesFormat: MarkdownDisplayFormat;
+  classPropertiesFormat: MarkdownDisplayFormat;
+  typeAliasPropertiesFormat: MarkdownDisplayFormat;
+  enumMembersFormat: MarkdownDisplayFormat;
+  propertyMembersFormat: MarkdownDisplayFormat;
+  typeDeclarationFormat: MarkdownDisplayFormat;
   typeParameters: boolean;
   generateNav: boolean;
 }


### PR DESCRIPTION
## Background
Gunshi currently uses TypeDoc and `typedoc-plugin-markdown` table display options for its API reference. ox-content could emit pure Markdown, but index, parameter, and member sections were fixed-format, so `@ox-content/napi` could not match the TypeDoc-compatible output needed for migration.

## Summary
- Add none/list/table Markdown display format options across Rust, NAPI, and the Vite plugin.
- Support list/table rendering for indexes, parameters/type parameters, and property/enum member groups in pure Markdown.
- Keep existing HTML-renderer defaults unchanged, while plumbing reserved nested-member format options for API compatibility.
- Add Rust, NAPI, and Vite plugin coverage for the new options.
- Default backward compatibility for `renderStyle: 'html'` option

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782900051&installation_id=136613492&pr_number=284&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F284&signature=bb28d4c25a6bdc479ec3ea52e65c1cd7ee5242a5cefc014ece86162b2a73e5c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->