### PR TITLE
perf: optimize html block parsing

### DIFF
--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -49,7 +49,11 @@ impl<'a> Parser<'a> {
             Some(b'`' | b'~') if Self::try_parse_fenced_code_at(line, trimmed) => {
                 return self.parse_fenced_code(start);
             }
-            Some(b'<') if self.try_parse_html_block() => return self.parse_html_block(start),
+            Some(b'<') => {
+                if let Some(html_start) = Self::parse_html_block_start(trimmed) {
+                    return self.parse_html_block(start, html_start);
+                }
+            }
             Some(b'+' | b'0'..=b'9') if Self::try_parse_list_line(trimmed) => {
                 return self.parse_list(start);
             }

--- a/crates/ox_content_parser/src/parser/cursor.rs
+++ b/crates/ox_content_parser/src/parser/cursor.rs
@@ -100,7 +100,7 @@ impl<'a> Parser<'a> {
             Some(b'_') => Self::try_parse_thematic_break_line(line),
             Some(b'>') => true,
             Some(b'`' | b'~') => Self::try_parse_fenced_code_at(line, trimmed),
-            Some(b'<') => self.try_parse_html_block(),
+            Some(b'<') => Self::parse_html_block_start(trimmed).is_some(),
             Some(b'+' | b'0'..=b'9') => Self::try_parse_list_line(trimmed),
             _ => false,
         };

--- a/crates/ox_content_parser/src/parser/html.rs
+++ b/crates/ox_content_parser/src/parser/html.rs
@@ -1,3 +1,4 @@
+use memchr::memchr;
 use ox_content_ast::{Html, Node, Span};
 
 use super::Parser;
@@ -5,65 +6,98 @@ use crate::error::ParseResult;
 #[allow(unused_imports)]
 use crate::profile_span;
 
+/// Classification of an HTML block opener on the current line.
+///
+/// `parse_block` already has the current line and its trimmed view in hand.
+/// Carrying this compact value into `parse_html_block` avoids reparsing that
+/// same line after taking `&mut self`, while still preserving the exact block
+/// kind decisions needed by the Markdown HTML block rules implemented here.
+#[derive(Clone, Copy)]
+pub(super) enum HtmlBlockStart {
+    /// An HTML comment block beginning with `<!--`.
+    Comment,
+    /// A type-1 raw HTML block whose closing tag can appear after blank lines.
+    Type1(Type1HtmlBlockTag),
+    /// A regular supported HTML block that ends before the next blank line.
+    Other,
+}
+
+/// Supported type-1 HTML block tags.
+///
+/// These are stored as an enum instead of a borrowed `&str` so
+/// `parse_html_block` can keep mutating the parser cursor without holding an
+/// immutable borrow into `self.source`.
+#[derive(Clone, Copy)]
+pub(super) enum Type1HtmlBlockTag {
+    Pre,
+    Script,
+    Style,
+    Textarea,
+}
+
+impl Type1HtmlBlockTag {
+    fn closing_name(self) -> &'static [u8] {
+        match self {
+            Self::Pre => b"pre",
+            Self::Script => b"script",
+            Self::Style => b"style",
+            Self::Textarea => b"textarea",
+        }
+    }
+}
+
 impl<'a> Parser<'a> {
-    pub(super) fn try_parse_html_block(&self) -> bool {
-        let line = self.remaining().lines().next().unwrap_or("");
-        Self::parse_html_block_tag_name(line).is_some() || line.trim_start().starts_with("<!--")
+    /// Classifies a trimmed line as a supported HTML block opener.
+    ///
+    /// The caller passes `trimmed` because `parse_block` and
+    /// `line_starts_block` have already paid for `trim_start()`. Returning the
+    /// full block kind lets the parser reuse that dispatch work in the actual
+    /// parse step.
+    pub(super) fn parse_html_block_start(trimmed: &str) -> Option<HtmlBlockStart> {
+        if trimmed.starts_with("<!--") {
+            return Some(HtmlBlockStart::Comment);
+        }
+
+        let tag_name = Self::parse_html_block_tag_name_from_trimmed(trimmed)?;
+        Self::html_block_start_for_tag(tag_name)
     }
 
-    pub(super) fn parse_html_block(&mut self, start: usize) -> ParseResult<Option<Node<'a>>> {
+    /// Parses an HTML block previously classified by `parse_html_block_start`.
+    ///
+    /// `block_start` is trusted to match the current line. This is why the
+    /// function no longer rechecks the opener: the outer dispatcher owns that
+    /// responsibility, and this function only advances `self.position` to the
+    /// end of the block.
+    pub(super) fn parse_html_block(
+        &mut self,
+        start: usize,
+        block_start: HtmlBlockStart,
+    ) -> ParseResult<Option<Node<'a>>> {
         profile_span!("parser::parse_html_block");
-        let line = self.remaining().lines().next().unwrap_or("");
 
-        if line.trim_start().starts_with("<!--") {
-            loop {
+        match block_start {
+            HtmlBlockStart::Comment => loop {
                 let consumed = self.consume_line();
                 if consumed.contains("-->") || self.is_at_end() {
                     break;
                 }
-            }
-
-            let span = Span::new(start as u32, self.position as u32);
-            let value = &self.source[start..self.position];
-            return Ok(Some(Node::Html(Html { value, span })));
-        }
-
-        // `parse_html_block_tag_name` returns a borrowed slice — no allocation.
-        let Some(tag_name) = Self::parse_html_block_tag_name(line) else {
-            return Ok(None);
-        };
-
-        if Self::is_type1_html_block_tag(tag_name) {
-            // Type 1 blocks (`<pre>`, `<script>`, `<style>`, `<textarea>`)
-            // close on the first line containing `</tag`. The previous
-            // implementation built a `String` per parse + lowercased every
-            // line; instead we scan bytes directly with case-insensitive
-            // compare. For a single 25KB document with ~38 blocks this
-            // turns ~hundreds of allocations into zero.
-            let tag_bytes = tag_name.as_bytes();
-            loop {
-                let consumed = self.consume_line();
-                if ascii_contains_closing_tag(consumed, tag_bytes) || self.is_at_end() {
-                    break;
+            },
+            HtmlBlockStart::Type1(tag) => {
+                // Type 1 blocks (`<pre>`, `<script>`, `<style>`, `<textarea>`)
+                // close on the first line containing `</tag`. The block tag
+                // was classified by `parse_block`, so we avoid reparsing the
+                // first line here and only scan the body.
+                let tag_bytes = tag.closing_name();
+                loop {
+                    let consumed = self.consume_line();
+                    if ascii_contains_closing_tag(consumed, tag_bytes) || self.is_at_end() {
+                        break;
+                    }
                 }
             }
-        } else {
-            self.consume_line();
-            // Walk forward line-by-line until a blank line. Previously we
-            // peeked with `remaining().lines().next()` THEN consumed the
-            // line, which walked each line twice. Consume first and inspect
-            // the returned slice so we only scan once.
-            while !self.is_at_end() {
-                let line_start = self.position;
-                let consumed = self.consume_line();
-                if consumed.is_empty()
-                    || consumed.bytes().all(|b| b == b' ' || b == b'\t' || b == b'\r')
-                {
-                    // Roll back so the outer `parse_block` loop sees the
-                    // blank line and skips it via `skip_blank_lines`.
-                    self.position = line_start;
-                    break;
-                }
+            HtmlBlockStart::Other => {
+                self.consume_line();
+                self.advance_html_block_until_blank();
             }
         }
 
@@ -72,13 +106,13 @@ impl<'a> Parser<'a> {
         Ok(Some(Node::Html(Html { value, span })))
     }
 
-    /// Returns the borrowed tag-name slice when `line` begins with one of
-    /// the recognized HTML block tags. The slice points back into `line`'s
-    /// underlying storage, so there's no allocation. Callers that need
-    /// case-insensitive comparison should use `eq_ignore_ascii_case` directly
-    /// — the source casing is preserved.
-    pub(super) fn parse_html_block_tag_name(line: &str) -> Option<&str> {
-        let trimmed = line.trim_start();
+    /// Returns the raw tag name from a line already known to begin with `<`.
+    ///
+    /// This intentionally does not check whether the tag is supported. Keeping
+    /// syntax extraction separate from support classification lets
+    /// `html_block_start_for_tag` return the exact `HtmlBlockStart` variant in
+    /// one pass.
+    fn parse_html_block_tag_name_from_trimmed(trimmed: &str) -> Option<&str> {
         let after_open = trimmed.strip_prefix('<')?;
         let after_slash = after_open.strip_prefix('/').unwrap_or(after_open);
         let mut tag_len = 0;
@@ -104,70 +138,130 @@ impl<'a> Parser<'a> {
             }
         }
 
-        if !Self::is_supported_html_block_tag(tag_name) {
-            return None;
-        }
-
         Some(tag_name)
     }
 
-    pub(super) fn is_supported_html_block_tag(tag_name: &str) -> bool {
-        [
-            "article",
-            "aside",
-            "blockquote",
-            "details",
-            "dialog",
-            "div",
-            "figcaption",
-            "figure",
-            "footer",
-            "header",
-            "main",
-            "nav",
-            "ol",
-            "p",
-            "pre",
-            "script",
-            "section",
-            "style",
-            "summary",
-            "table",
-            "tbody",
-            "td",
-            "tfoot",
-            "th",
-            "thead",
-            "textarea",
-            "tr",
-            "ul",
-        ]
-        .iter()
-        .any(|candidate| tag_name.eq_ignore_ascii_case(candidate))
+    /// Maps a parsed tag name to the supported HTML block kind.
+    ///
+    /// The previous implementation walked a fixed slice of tag strings for
+    /// every `<...>` opener. Length bucketing keeps this allocation-free and
+    /// trims comparisons on generated API docs with many HTML blocks.
+    fn html_block_start_for_tag(tag_name: &str) -> Option<HtmlBlockStart> {
+        let other = HtmlBlockStart::Other;
+        match tag_name.len() {
+            1 if tag_name.eq_ignore_ascii_case("p") => Some(other),
+            2 if tag_name.eq_ignore_ascii_case("ol")
+                || tag_name.eq_ignore_ascii_case("td")
+                || tag_name.eq_ignore_ascii_case("th")
+                || tag_name.eq_ignore_ascii_case("tr")
+                || tag_name.eq_ignore_ascii_case("ul") =>
+            {
+                Some(other)
+            }
+            3 if tag_name.eq_ignore_ascii_case("pre") => {
+                Some(HtmlBlockStart::Type1(Type1HtmlBlockTag::Pre))
+            }
+            3 if tag_name.eq_ignore_ascii_case("div") || tag_name.eq_ignore_ascii_case("nav") => {
+                Some(other)
+            }
+            4 if tag_name.eq_ignore_ascii_case("main") => Some(other),
+            5 if tag_name.eq_ignore_ascii_case("style") => {
+                Some(HtmlBlockStart::Type1(Type1HtmlBlockTag::Style))
+            }
+            5 if tag_name.eq_ignore_ascii_case("aside")
+                || tag_name.eq_ignore_ascii_case("table")
+                || tag_name.eq_ignore_ascii_case("tbody")
+                || tag_name.eq_ignore_ascii_case("tfoot")
+                || tag_name.eq_ignore_ascii_case("thead") =>
+            {
+                Some(other)
+            }
+            6 if tag_name.eq_ignore_ascii_case("script") => {
+                Some(HtmlBlockStart::Type1(Type1HtmlBlockTag::Script))
+            }
+            6 if tag_name.eq_ignore_ascii_case("dialog")
+                || tag_name.eq_ignore_ascii_case("figure")
+                || tag_name.eq_ignore_ascii_case("footer")
+                || tag_name.eq_ignore_ascii_case("header") =>
+            {
+                Some(other)
+            }
+            7 if tag_name.eq_ignore_ascii_case("article")
+                || tag_name.eq_ignore_ascii_case("details")
+                || tag_name.eq_ignore_ascii_case("section")
+                || tag_name.eq_ignore_ascii_case("summary") =>
+            {
+                Some(other)
+            }
+            8 if tag_name.eq_ignore_ascii_case("textarea") => {
+                Some(HtmlBlockStart::Type1(Type1HtmlBlockTag::Textarea))
+            }
+            10 if tag_name.eq_ignore_ascii_case("blockquote")
+                || tag_name.eq_ignore_ascii_case("figcaption") =>
+            {
+                Some(other)
+            }
+            _ => None,
+        }
     }
 
-    pub(super) fn is_type1_html_block_tag(tag_name: &str) -> bool {
-        ["pre", "script", "style", "textarea"]
-            .iter()
-            .any(|candidate| tag_name.eq_ignore_ascii_case(candidate))
+    /// Advances through a regular HTML block until the next blank line.
+    ///
+    /// The cursor must stop *before* that blank line so the outer block parser
+    /// can consume it through `skip_blank_lines`. This mirrors the old
+    /// `consume_line` + rollback behavior but avoids constructing a line slice
+    /// and rescanning it for every nonblank line.
+    fn advance_html_block_until_blank(&mut self) {
+        let bytes = self.source.as_bytes();
+        let mut pos = self.position;
+
+        while pos < bytes.len() {
+            let line_start = pos;
+            let mut scan = pos;
+
+            while scan < bytes.len() {
+                match bytes[scan] {
+                    b'\n' => {
+                        self.position = line_start;
+                        return;
+                    }
+                    b' ' | b'\t' | b'\r' => scan += 1,
+                    _ => break,
+                }
+            }
+
+            if scan >= bytes.len() {
+                self.position = line_start;
+                return;
+            }
+
+            pos = memchr(b'\n', &bytes[scan..]).map_or(bytes.len(), |off| scan + off + 1);
+        }
+
+        self.position = pos;
     }
 }
 
+/// Returns true when `haystack` contains a case-insensitive `</tag` opener.
+///
+/// Type-1 HTML blocks close on the first line containing their closing tag.
+/// Searching for `<` with `memchr` skips the common case of long text/code
+/// lines that contain no tag-looking byte at all.
 pub(super) fn ascii_contains_closing_tag(haystack: &str, tag: &[u8]) -> bool {
     let bytes = haystack.as_bytes();
     if bytes.len() < tag.len() + 2 {
         return false;
     }
-    let limit = bytes.len() - (tag.len() + 1);
-    let mut i = 0;
-    while i <= limit {
-        if bytes[i] == b'<' && bytes[i + 1] == b'/' {
+    let mut search_start = 0;
+    while let Some(off) = memchr(b'<', &bytes[search_start..]) {
+        let i = search_start + off;
+        if i + tag.len() + 2 <= bytes.len() && bytes[i + 1] == b'/' {
             let candidate = &bytes[i + 2..i + 2 + tag.len()];
             if candidate.eq_ignore_ascii_case(tag) {
                 return true;
             }
         }
-        i += 1;
+        search_start = i + 1;
     }
     false
 }

--- a/crates/ox_content_renderer/src/html/renderer.rs
+++ b/crates/ox_content_renderer/src/html/renderer.rs
@@ -19,7 +19,7 @@ use rustc_hash::FxHashMap;
 use super::autolink::FirstByteIndex;
 use super::escape::{write_escaped_into, write_url_escaped_into};
 use super::options::HtmlRendererOptions;
-use super::toc::{collect_inline_toc_entries, document_has_toc_marker, InlineTocEntry};
+use super::toc::{collect_inline_toc_entries, scan_document_for_render, InlineTocEntry};
 use crate::render::{RenderResult, Renderer};
 
 /// Stateful HTML renderer for Markdown AST documents.
@@ -102,14 +102,16 @@ impl HtmlRenderer {
         // TOC collection walks every heading and allocates a slug per entry,
         // which used to fire on every render regardless of whether a
         // `[[toc]]` directive was actually present. Pre-scan the document
-        // cheaply (no allocations) and skip the work when no marker exists —
-        // this is the common case for normal docs.
+        // cheaply (no allocations), skip TOC work when no marker exists, and
+        // reuse the heading count to reserve the unique-id map.
         self.toc_entries.clear();
-        self.document_has_toc_marker = document_has_toc_marker(document);
+        let document_scan = scan_document_for_render(document);
+        self.document_has_toc_marker = document_scan.has_toc_marker;
         if self.document_has_toc_marker {
             collect_inline_toc_entries(document, self.options.toc_max_depth, &mut self.toc_entries);
         }
         self.heading_id_counts.clear();
+        self.heading_id_counts.reserve(document_scan.heading_count);
         // Build the autolink first-byte index once per render (it depends only
         // on the immutable pattern list) so `write_text_with_autolinks` can
         // reuse it instead of rebuilding a 256-byte table per text node.

--- a/crates/ox_content_renderer/src/html/toc.rs
+++ b/crates/ox_content_renderer/src/html/toc.rs
@@ -17,6 +17,17 @@ pub(super) struct InlineTocEntry {
     pub(super) id: String,
 }
 
+/// Cheap document-level facts needed at `HtmlRenderer::render` entry.
+///
+/// Rendering already scans for `[[toc]]` before deciding whether to collect
+/// TOC entries. Counting headings in the same traversal lets the renderer
+/// reserve the heading-id map once, avoiding incremental hash-map growth
+/// while preserving the lazy TOC behavior for documents without a marker.
+pub(super) struct DocumentRenderScan {
+    pub(super) has_toc_marker: bool,
+    pub(super) heading_count: usize,
+}
+
 pub(super) fn collect_inline_toc_entries(
     document: &Document<'_>,
     max_depth: u8,
@@ -29,27 +40,51 @@ pub(super) fn collect_inline_toc_entries(
     }
 }
 
-/// Cheap, allocation-free scan for a standalone `[[toc]]` paragraph. The
-/// directive is recognized only when the paragraph contains a single text
-/// node whose trimmed value is exactly `[[toc]]` — which is also the only
-/// form `visit_paragraph` will render as a TOC.
-pub(super) fn document_has_toc_marker(document: &Document<'_>) -> bool {
-    document.children.iter().any(node_has_toc_marker)
+/// Cheap, allocation-free scan for renderer setup.
+///
+/// The TOC directive is recognized only when a paragraph's text content trims
+/// to exactly `[[toc]]`, which is also the only form `visit_paragraph` will
+/// render as a TOC.
+pub(super) fn scan_document_for_render(document: &Document<'_>) -> DocumentRenderScan {
+    let mut scan = DocumentRenderScan { has_toc_marker: false, heading_count: 0 };
+    for node in &document.children {
+        scan_node_for_render(node, &mut scan);
+    }
+    scan
 }
 
-fn node_has_toc_marker(node: &Node<'_>) -> bool {
+fn scan_node_for_render(node: &Node<'_>, scan: &mut DocumentRenderScan) {
     match node {
-        Node::Paragraph(p) => is_toc_marker_paragraph(p),
-        Node::BlockQuote(bq) => bq.children.iter().any(node_has_toc_marker),
-        Node::List(list) => list.children.iter().any(list_item_has_toc_marker),
-        Node::ListItem(item) => list_item_has_toc_marker(item),
-        Node::FootnoteDefinition(def) => def.children.iter().any(node_has_toc_marker),
-        _ => false,
+        Node::Heading(_) => scan.heading_count += 1,
+        Node::Paragraph(p) => {
+            if !scan.has_toc_marker && is_toc_marker_paragraph(p) {
+                scan.has_toc_marker = true;
+            }
+        }
+        Node::BlockQuote(bq) => {
+            for child in &bq.children {
+                scan_node_for_render(child, scan);
+            }
+        }
+        Node::List(list) => {
+            for item in &list.children {
+                scan_list_item_for_render(item, scan);
+            }
+        }
+        Node::ListItem(item) => scan_list_item_for_render(item, scan),
+        Node::FootnoteDefinition(def) => {
+            for child in &def.children {
+                scan_node_for_render(child, scan);
+            }
+        }
+        _ => {}
     }
 }
 
-fn list_item_has_toc_marker(item: &ListItem<'_>) -> bool {
-    item.children.iter().any(node_has_toc_marker)
+fn scan_list_item_for_render(item: &ListItem<'_>, scan: &mut DocumentRenderScan) {
+    for child in &item.children {
+        scan_node_for_render(child, scan);
+    }
 }
 
 pub(super) fn is_toc_marker_paragraph(paragraph: &Paragraph<'_>) -> bool {


### PR DESCRIPTION
## Summary

- Reuse HTML block opener classification from block dispatch instead of reparsing the same line.
- Speed up regular HTML block advancement and type-1 closing tag scans with byte-level scanning.
- Reuse the renderer setup scan to reserve heading ID storage and reduce small allocations.
- Add documentation comments around the parser and renderer setup paths that are less obvious.

## Validation

- `cargo test -p ox_content_parser -p ox_content_renderer`
- `cargo bench -p ox_content_parser --bench parser -- --warm-up-time 1 --measurement-time 2 --sample-size 10`
- `cargo run --release -p ox_content_profile_cli -- pipeline --gfm --iters 1000 --warmup 50 --json docs/content/api/types.md`
- `cargo run --release -p ox_content_profile_cli -- pipeline --iters 1000 --warmup 50 --json`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782917255&installation_id=136613492&pr_number=286&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F286&signature=f9288984d60e39a0ad98f626929eaa03e0c8b53ac709f98dd5daa50b9282356f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->