### PR TITLE
perf: optimize Rust hot paths and release profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ useless_format = "deny"
 write_with_newline = "deny"
 writeln_empty_string = "deny"
 disallowed_macros = "allow"
+disallowed_types = "allow"
 
 # Allow
 match_same_arms = "allow"
@@ -91,6 +92,8 @@ ox_jsdoc = "0.0.16"
 
 # Memory allocation
 bumpalo = "3.16"
+compact_str = "0.9.1"
+smallvec = "1.15"
 
 # NAPI bindings
 napi = { version = "3", features = ["serde-json"] }
@@ -155,3 +158,16 @@ debug-assertions = false
 overflow-checks = false
 incremental = false
 panic = "abort"
+
+[profile.release.build-override]
+opt-level = 3
+codegen-units = 1
+
+[profile.bench]
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+debug = false
+debug-assertions = false
+overflow-checks = false
+incremental = false

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,9 @@
 disallowed-macros = [
   { path = "std::format", reason = "avoid heap-allocating formatted temporary strings in hot paths; use StringBuilder or direct buffer writes instead" },
 ]
+
+disallowed-types = [
+  { path = "std::boxed::Box", reason = "prefer concrete/static dispatch or arena-owned ox_content_allocator::Box in hot paths" },
+  { path = "std::string::String", reason = "prefer CompactString, Cow<str>, arena strings, or direct buffer writes unless an owned API boundary requires std::String" },
+  { path = "std::vec::Vec", reason = "prefer SmallVec, slices, iterators, or arena-owned ox_content_allocator::Vec unless an owned API boundary requires std::Vec" },
+]

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -2,16 +2,31 @@
 
 use std::collections::BTreeMap;
 
+use phf::phf_set;
 use serde::{Deserialize, Serialize};
 
 use crate::extractor::{DocItem, DocItemKind, DocTag, ParamDoc, TypeParamDoc};
 
 const UNKNOWN_TYPE: &str = "unknown";
-const PARAM_TAG_NAMES: [&str; 3] = ["param", "arg", "argument"];
-const RETURN_TAG_NAMES: [&str; 2] = ["returns", "return"];
+const PARAM_TAG_NAME: &str = "param";
 const EXAMPLE_TAG_NAME: &str = "example";
 const PRIVATE_TAG_NAME: &str = "private";
-const TYPE_PARAM_TAG_NAMES: [&str; 2] = ["typeParam", "template"];
+
+static PARAM_TAG_NAMES: phf::Set<&'static str> = phf_set! {
+    "param",
+    "arg",
+    "argument",
+};
+
+static RETURN_TAG_NAMES: phf::Set<&'static str> = phf_set! {
+    "returns",
+    "return",
+};
+
+static TYPE_PARAM_TAG_NAMES: phf::Set<&'static str> = phf_set! {
+    "typeParam",
+    "template",
+};
 
 /// Documentation item kind supported by the generated API reference.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -331,12 +346,12 @@ fn normalize_doc_metadata(tags: &[DocTag], type_parameters: bool) -> NormalizedD
 
     for tag in tags {
         match tag.tag.as_str() {
-            tag_name if PARAM_TAG_NAMES.contains(&tag_name) => {
+            tag_name if PARAM_TAG_NAMES.contains(tag_name) => {
                 if let Some(param) = normalized_param_from_tag(tag) {
                     merge_param(&mut params, param);
                 }
             }
-            tag_name if RETURN_TAG_NAMES.contains(&tag_name) => {
+            tag_name if RETURN_TAG_NAMES.contains(tag_name) => {
                 let parsed_returns = normalized_return_from_tag(tag);
                 merge_returns(&mut returns, parsed_returns);
             }
@@ -351,7 +366,7 @@ fn normalize_doc_metadata(tags: &[DocTag], type_parameters: bool) -> NormalizedD
             }
             // TSDoc `@typeParam` / `@template`: only handled specially when opted
             // in. Otherwise it falls through to the generic tag map (JSDoc default).
-            tag_name if type_parameters && TYPE_PARAM_TAG_NAMES.contains(&tag_name) => {
+            tag_name if type_parameters && TYPE_PARAM_TAG_NAMES.contains(tag_name) => {
                 if let Some((name, description)) = parse_type_param_tag(tag) {
                     type_param_descriptions.entry(name).or_insert(description);
                 }
@@ -464,7 +479,7 @@ fn merge_extracted_return(returns: &mut Option<NormalizedReturnDoc>, return_type
 
 fn is_placeholder_param(existing_params: &[NormalizedParamDoc], param: &ParamDoc) -> bool {
     !existing_params.is_empty()
-        && param.name == PARAM_TAG_NAMES[0]
+        && param.name == PARAM_TAG_NAME
         && param.type_annotation.is_none()
         && param.description.is_none()
         && param.default_value.is_none()

--- a/crates/ox_content_renderer/Cargo.toml
+++ b/crates/ox_content_renderer/Cargo.toml
@@ -20,6 +20,8 @@ ox_content_ast = { workspace = true }
 thiserror = { workspace = true }
 memchr = { workspace = true }
 rustc-hash = { workspace = true }
+compact_str = { workspace = true }
+smallvec = { workspace = true }
 ox_content_profiler = { workspace = true, optional = true }
 
 [features]

--- a/crates/ox_content_renderer/src/html/code_annotations/attribute.rs
+++ b/crates/ox_content_renderer/src/html/code_annotations/attribute.rs
@@ -7,12 +7,14 @@
 
 use std::collections::BTreeMap;
 
+use smallvec::SmallVec;
+
 use super::state::CodeAnnotationKind;
 
 pub(in crate::html) fn parse_code_annotations(
     meta: &str,
     key: &str,
-) -> BTreeMap<usize, Vec<CodeAnnotationKind>> {
+) -> BTreeMap<usize, SmallVec<[CodeAnnotationKind; 2]>> {
     let Some(value) = extract_meta_attribute(meta, key) else {
         return BTreeMap::new();
     };
@@ -108,8 +110,8 @@ fn extract_meta_attribute<'a>(meta: &'a str, target: &str) -> Option<&'a str> {
     None
 }
 
-pub(in crate::html) fn parse_line_numbers(value: &str) -> Vec<usize> {
-    let mut line_numbers = Vec::new();
+pub(in crate::html) fn parse_line_numbers(value: &str) -> SmallVec<[usize; 4]> {
+    let mut line_numbers = SmallVec::new();
 
     for part in value.split(',').map(str::trim).filter(|part| !part.is_empty()) {
         if let Some((raw_start, raw_end)) = part.split_once('-') {
@@ -146,7 +148,7 @@ pub(in crate::html) fn parse_line_numbers(value: &str) -> Vec<usize> {
 }
 
 fn push_code_annotation(
-    annotations: &mut BTreeMap<usize, Vec<CodeAnnotationKind>>,
+    annotations: &mut BTreeMap<usize, SmallVec<[CodeAnnotationKind; 2]>>,
     line_number: usize,
     kind: CodeAnnotationKind,
 ) {

--- a/crates/ox_content_renderer/src/html/code_annotations/meta.rs
+++ b/crates/ox_content_renderer/src/html/code_annotations/meta.rs
@@ -6,15 +6,18 @@
 
 use std::collections::BTreeMap;
 
+use compact_str::CompactString;
+use smallvec::SmallVec;
+
 use super::state::{
     CodeAnnotationKind, CodeLineRenderState, MetaToken, MetaTokenKind, NormalizedCodeBlockInfo,
     PendingCodeAnnotation,
 };
 
-pub(in crate::html) fn split_code_block_meta(meta: &str) -> Vec<MetaToken<'_>> {
+pub(in crate::html) fn split_code_block_meta(meta: &str) -> SmallVec<[MetaToken<'_>; 4]> {
     let bytes = meta.as_bytes();
     let mut index = 0;
-    let mut tokens = Vec::new();
+    let mut tokens = SmallVec::new();
 
     while index < bytes.len() {
         while index < bytes.len() && bytes[index].is_ascii_whitespace() {
@@ -109,13 +112,13 @@ pub(in crate::html) fn normalize_code_block_info(
     lang: Option<&str>,
     meta: Option<&str>,
 ) -> NormalizedCodeBlockInfo {
-    let mut meta_parts: Vec<&str> = Vec::new();
+    let mut meta_parts: SmallVec<[&str; 2]> = SmallVec::new();
     let mut language = None;
 
     if let Some(raw_lang) = lang.map(str::trim).filter(|value| !value.is_empty()) {
         let (normalized_lang, inline_meta) = split_code_block_language_token(raw_lang);
         if !normalized_lang.is_empty() {
-            language = Some(normalized_lang.to_string());
+            language = Some(CompactString::from(normalized_lang));
         }
         if !inline_meta.trim().is_empty() {
             meta_parts.push(inline_meta.trim());
@@ -126,7 +129,13 @@ pub(in crate::html) fn normalize_code_block_info(
         meta_parts.push(raw_meta);
     }
 
-    NormalizedCodeBlockInfo { language, meta: meta_parts.join(" ") }
+    let meta = if meta_parts.is_empty() {
+        CompactString::default()
+    } else {
+        CompactString::from(meta_parts.join(" "))
+    };
+
+    NormalizedCodeBlockInfo { language, meta }
 }
 
 pub(in crate::html) fn normalize_code_block_language(lang: Option<&str>) -> Option<&str> {
@@ -159,7 +168,7 @@ pub(in crate::html) fn apply_annotation_numbers(
 
 pub(in crate::html) fn apply_btree_annotations(
     lines: &mut [CodeLineRenderState],
-    annotations: &BTreeMap<usize, Vec<CodeAnnotationKind>>,
+    annotations: &BTreeMap<usize, SmallVec<[CodeAnnotationKind; 2]>>,
 ) {
     for (line_number, kinds) in annotations {
         let Some(line) = lines.get_mut(line_number.saturating_sub(1)) else {
@@ -175,9 +184,9 @@ pub(in crate::html) fn apply_btree_annotations(
 
 pub(in crate::html) fn apply_pending_annotations(
     line: &mut CodeLineRenderState,
-    pending_annotations: &mut Vec<PendingCodeAnnotation>,
+    pending_annotations: &mut SmallVec<[PendingCodeAnnotation; 2]>,
 ) {
-    let mut remaining = Vec::new();
+    let mut remaining = SmallVec::new();
 
     for mut pending in pending_annotations.drain(..) {
         if !line.annotations.contains(&pending.kind) {

--- a/crates/ox_content_renderer/src/html/code_annotations/state.rs
+++ b/crates/ox_content_renderer/src/html/code_annotations/state.rs
@@ -4,6 +4,9 @@
 //! writer. Parsers attach semantic annotation kinds to line states; the writer later
 //! turns those semantic kinds into class names and `data-*` attributes.
 
+use compact_str::CompactString;
+use smallvec::SmallVec;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::html) enum CodeAnnotationKind {
     Highlight,
@@ -61,13 +64,13 @@ impl CodeAnnotationKind {
 #[derive(Debug, Clone)]
 pub(in crate::html) struct CodeLineRenderState {
     pub(in crate::html) value: String,
-    pub(in crate::html) annotations: Vec<CodeAnnotationKind>,
+    pub(in crate::html) annotations: SmallVec<[CodeAnnotationKind; 2]>,
 }
 
 #[derive(Debug, Clone)]
 pub(in crate::html) struct CodeBlockRenderState {
-    pub(in crate::html) language: Option<String>,
-    pub(in crate::html) title: Option<String>,
+    pub(in crate::html) language: Option<CompactString>,
+    pub(in crate::html) title: Option<CompactString>,
     pub(in crate::html) line_numbers_start: Option<usize>,
     pub(in crate::html) lines: Vec<CodeLineRenderState>,
 }
@@ -81,8 +84,8 @@ impl CodeBlockRenderState {
         self.lines.iter().any(|line| line.annotations.contains(&CodeAnnotationKind::Focus))
     }
 
-    pub(in crate::html) fn block_classes(&self) -> Vec<&'static str> {
-        let mut classes = Vec::new();
+    pub(in crate::html) fn block_classes(&self) -> SmallVec<[&'static str; 8]> {
+        let mut classes = SmallVec::new();
         if self.has_annotations() || self.line_numbers_start.is_some() || self.title.is_some() {
             classes.push("ox-code-block");
         }
@@ -117,8 +120,8 @@ impl CodeBlockRenderState {
 
 #[derive(Debug, Clone)]
 pub(in crate::html) struct NormalizedCodeBlockInfo {
-    pub(in crate::html) language: Option<String>,
-    pub(in crate::html) meta: String,
+    pub(in crate::html) language: Option<CompactString>,
+    pub(in crate::html) meta: CompactString,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ox_content_renderer/src/html/code_annotations/vitepress.rs
+++ b/crates/ox_content_renderer/src/html/code_annotations/vitepress.rs
@@ -4,6 +4,8 @@
 //! as `// [!code ++]`. This module owns the inline directive grammar and converts it
 //! into the same semantic line states used by ox-content's attribute syntax.
 
+use smallvec::SmallVec;
+
 use super::meta::{apply_pending_annotations, parse_annotation_count};
 use super::state::{
     CodeAnnotationKind, CodeLineRenderState, InlineDirectiveAction, ParsedInlineDirective,
@@ -95,13 +97,15 @@ fn parse_vitepress_inline_directive(line: &str) -> Option<ParsedInlineDirective>
 
 pub(in crate::html) fn parse_vitepress_inline_annotations(value: &str) -> Vec<CodeLineRenderState> {
     let mut lines = Vec::new();
-    let mut pending_annotations: Vec<PendingCodeAnnotation> = Vec::new();
+    let mut pending_annotations: SmallVec<[PendingCodeAnnotation; 2]> = SmallVec::new();
     let mut escape_next_line = false;
 
     for raw_line in value.split('\n') {
         if escape_next_line {
-            lines
-                .push(CodeLineRenderState { value: raw_line.to_string(), annotations: Vec::new() });
+            lines.push(CodeLineRenderState {
+                value: raw_line.to_string(),
+                annotations: SmallVec::new(),
+            });
             escape_next_line = false;
             continue;
         }
@@ -120,7 +124,7 @@ pub(in crate::html) fn parse_vitepress_inline_annotations(value: &str) -> Vec<Co
 
                     let mut line = CodeLineRenderState {
                         value: directive.stripped_line,
-                        annotations: Vec::new(),
+                        annotations: SmallVec::new(),
                     };
                     apply_pending_annotations(&mut line, &mut pending_annotations);
                     if !line.annotations.contains(&kind) {
@@ -136,7 +140,8 @@ pub(in crate::html) fn parse_vitepress_inline_annotations(value: &str) -> Vec<Co
             }
         }
 
-        let mut line = CodeLineRenderState { value: raw_line.to_string(), annotations: Vec::new() };
+        let mut line =
+            CodeLineRenderState { value: raw_line.to_string(), annotations: SmallVec::new() };
         apply_pending_annotations(&mut line, &mut pending_annotations);
         lines.push(line);
     }

--- a/crates/ox_content_renderer/src/html/renderer.rs
+++ b/crates/ox_content_renderer/src/html/renderer.rs
@@ -13,7 +13,7 @@ mod links;
 mod visit;
 mod write;
 
-use ox_content_ast::{Document, Visit};
+use ox_content_ast::{Document, Node};
 use rustc_hash::FxHashMap;
 
 use super::autolink::FirstByteIndex;
@@ -131,8 +131,40 @@ impl HtmlRenderer {
         if self.output.capacity() < estimated_len {
             self.output.reserve(estimated_len - self.output.capacity());
         }
-        self.visit_document(document);
+        self.render_document(document);
         std::mem::take(&mut self.output)
+    }
+
+    pub(in crate::html::renderer) fn render_document(&mut self, document: &Document<'_>) {
+        for child in &document.children {
+            self.render_node(child);
+        }
+    }
+
+    #[inline]
+    pub(in crate::html::renderer) fn render_node(&mut self, node: &Node<'_>) {
+        match node {
+            Node::Paragraph(node) => self.render_paragraph(node),
+            Node::Heading(node) => self.render_heading(node),
+            Node::ThematicBreak(node) => self.render_thematic_break(node),
+            Node::BlockQuote(node) => self.render_block_quote(node),
+            Node::List(node) => self.render_list(node),
+            Node::ListItem(node) => self.render_list_item(node),
+            Node::CodeBlock(node) => self.render_code_block(node),
+            Node::Html(node) => self.render_html(node),
+            Node::Table(node) => self.render_table(node),
+            Node::Text(node) => self.render_text(node),
+            Node::Emphasis(node) => self.render_emphasis(node),
+            Node::Strong(node) => self.render_strong(node),
+            Node::InlineCode(node) => self.render_inline_code(node),
+            Node::Break(node) => self.render_break(node),
+            Node::Link(node) => self.render_link(node),
+            Node::Image(node) => self.render_image(node),
+            Node::Delete(node) => self.render_delete(node),
+            Node::FootnoteReference(node) => self.render_footnote_reference(node),
+            Node::Definition(_) => {}
+            Node::FootnoteDefinition(node) => self.render_footnote_definition(node),
+        }
     }
 
     pub(in crate::html::renderer) fn render_inline_toc(&mut self) {

--- a/crates/ox_content_renderer/src/html/renderer/blocks.rs
+++ b/crates/ox_content_renderer/src/html/renderer/blocks.rs
@@ -6,7 +6,7 @@
 
 use ox_content_ast::{
     BlockQuote, CodeBlock, Heading, Html, List, ListItem, Paragraph, Table, TableCell, TableRow,
-    ThematicBreak, Visit,
+    ThematicBreak,
 };
 
 use super::super::code_annotations::normalize_code_block_language;
@@ -77,7 +77,7 @@ impl HtmlRenderer {
 
         self.write("<blockquote>\n");
         for child in &block_quote.children {
-            self.visit_node(child);
+            self.render_node(child);
         }
         self.write("</blockquote>\n");
     }
@@ -123,7 +123,7 @@ impl HtmlRenderer {
         }
 
         for child in &list_item.children {
-            self.visit_node(child);
+            self.render_node(child);
         }
 
         self.write("</li>\n");

--- a/crates/ox_content_renderer/src/html/renderer/callout.rs
+++ b/crates/ox_content_renderer/src/html/renderer/callout.rs
@@ -4,7 +4,6 @@
 //! marker in the first paragraph, strip it from the body, and emit the themed wrapper
 //! while leaving non-callout block quotes on the regular rendering path.
 
-use ox_content_ast::Visit;
 use ox_content_ast::{BlockQuote, Node, Paragraph};
 
 use super::super::callout::CalloutKind;
@@ -29,7 +28,7 @@ impl HtmlRenderer {
                     renderer.write_escaped(&text.value[skip_chars..]);
                     skip_chars = 0;
                 }
-                _ => renderer.visit_node(child),
+                _ => renderer.render_node(child),
             }
         }
 
@@ -102,7 +101,7 @@ impl HtmlRenderer {
         }
 
         for child in block_quote.children.iter().skip(1) {
-            self.visit_node(child);
+            self.render_node(child);
         }
 
         self.write("</blockquote>\n");

--- a/crates/ox_content_renderer/src/html/renderer/code_block.rs
+++ b/crates/ox_content_renderer/src/html/renderer/code_block.rs
@@ -4,7 +4,9 @@
 //! resulting line states become `<pre><code>` attributes, wrapper spans, line numbers,
 //! and compatibility classes.
 
+use compact_str::CompactString;
 use ox_content_ast::CodeBlock;
+use smallvec::SmallVec;
 
 use super::super::code_annotations::{
     apply_annotation_numbers, apply_btree_annotations, normalize_code_block_info,
@@ -29,7 +31,7 @@ impl HtmlRenderer {
                 .split('\n')
                 .map(|line| CodeLineRenderState {
                     value: line.to_string(),
-                    annotations: Vec::new(),
+                    annotations: SmallVec::new(),
                 })
                 .collect()
         };
@@ -46,13 +48,15 @@ impl HtmlRenderer {
 
         if self.options.code_annotations && !info.meta.is_empty() {
             if syntax.includes_attribute() {
-                let annotations =
-                    parse_code_annotations(&info.meta, &self.options.code_annotation_meta_key);
+                let annotations = parse_code_annotations(
+                    info.meta.as_str(),
+                    &self.options.code_annotation_meta_key,
+                );
                 apply_btree_annotations(&mut lines, &annotations);
             }
 
             if syntax.includes_vitepress() {
-                for token in split_code_block_meta(&info.meta) {
+                for token in split_code_block_meta(info.meta.as_str()) {
                     match token.kind {
                         MetaTokenKind::Braces => {
                             let line_numbers = parse_line_numbers(token.value);
@@ -64,7 +68,7 @@ impl HtmlRenderer {
                         }
                         MetaTokenKind::Brackets => {
                             if title.is_none() && !token.value.trim().is_empty() {
-                                title = Some(token.value.trim().to_string());
+                                title = Some(CompactString::from(token.value.trim()));
                             }
                         }
                         MetaTokenKind::Raw => {
@@ -97,7 +101,9 @@ impl HtmlRenderer {
 
         for (index, line) in state.lines.iter().enumerate() {
             let line_number = index + 1;
-            let mut class_names: Vec<&str> = vec!["line", "ox-code-line"];
+            let mut class_names: SmallVec<[&str; 8]> = SmallVec::new();
+            class_names.push("line");
+            class_names.push("ox-code-line");
 
             for annotation in &line.annotations {
                 let class_name = annotation.class_name();

--- a/crates/ox_content_renderer/src/html/renderer/inlines.rs
+++ b/crates/ox_content_renderer/src/html/renderer/inlines.rs
@@ -6,7 +6,7 @@
 
 use ox_content_ast::{
     Break, Delete, Emphasis, FootnoteDefinition, FootnoteReference, Image, InlineCode, Link,
-    Strong, Text, Visit,
+    Strong, Text,
 };
 
 use super::HtmlRenderer;
@@ -127,7 +127,7 @@ impl HtmlRenderer {
         self.write_escaped(footnote_def.identifier);
         self.write("\" class=\"footnote\">\n");
         for child in &footnote_def.children {
-            self.visit_node(child);
+            self.render_node(child);
         }
         self.write("<a href=\"#fnref-");
         self.write_escaped(footnote_def.identifier);

--- a/crates/ox_content_renderer/src/html/renderer/visit.rs
+++ b/crates/ox_content_renderer/src/html/renderer/visit.rs
@@ -6,17 +6,19 @@
 
 use ox_content_ast::{
     BlockQuote, Break, CodeBlock, Definition, Delete, Document, Emphasis, FootnoteDefinition,
-    FootnoteReference, Heading, Html, Image, InlineCode, Link, List, ListItem, Paragraph, Strong,
-    Table, Text, ThematicBreak, Visit,
+    FootnoteReference, Heading, Html, Image, InlineCode, Link, List, ListItem, Node, Paragraph,
+    Strong, Table, Text, ThematicBreak, Visit,
 };
 
 use super::HtmlRenderer;
 
 impl<'a> Visit<'a> for HtmlRenderer {
     fn visit_document(&mut self, document: &Document<'a>) {
-        for child in &document.children {
-            self.visit_node(child);
-        }
+        self.render_document(document);
+    }
+
+    fn visit_node(&mut self, node: &Node<'a>) {
+        self.render_node(node);
     }
 
     fn visit_paragraph(&mut self, paragraph: &Paragraph<'a>) {

--- a/crates/ox_content_renderer/src/html/renderer/write.rs
+++ b/crates/ox_content_renderer/src/html/renderer/write.rs
@@ -6,7 +6,6 @@
 
 use std::fmt::{Display, Write as _};
 
-use ox_content_ast::Visit;
 use ox_content_ast::{Heading, Node};
 
 use super::super::autolink::find_autolink_match;
@@ -157,7 +156,7 @@ impl HtmlRenderer {
                 }
             }
             Node::Html(html) => self.write_html_value(html.value),
-            _ => self.visit_node(node),
+            _ => self.render_node(node),
         }
     }
 

--- a/crates/ox_content_renderer/src/html/toc.rs
+++ b/crates/ox_content_renderer/src/html/toc.rs
@@ -56,11 +56,10 @@ pub(super) fn scan_document_for_render(document: &Document<'_>) -> DocumentRende
 fn scan_node_for_render(node: &Node<'_>, scan: &mut DocumentRenderScan) {
     match node {
         Node::Heading(_) => scan.heading_count += 1,
-        Node::Paragraph(p) => {
-            if !scan.has_toc_marker && is_toc_marker_paragraph(p) {
-                scan.has_toc_marker = true;
-            }
+        Node::Paragraph(p) if !scan.has_toc_marker && is_toc_marker_paragraph(p) => {
+            scan.has_toc_marker = true;
         }
+        Node::Paragraph(_) => {}
         Node::BlockQuote(bq) => {
             for child in &bq.children {
                 scan_node_for_render(child, scan);

--- a/crates/ox_content_ssg/Cargo.toml
+++ b/crates/ox_content_ssg/Cargo.toml
@@ -19,3 +19,4 @@ askama = "0.16"
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
+memchr = { workspace = true }

--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -3,6 +3,7 @@
 use std::fmt::Write as _;
 
 use askama::Template;
+use memchr::memmem;
 use serde::{Deserialize, Serialize};
 
 // =============================================================================
@@ -781,7 +782,8 @@ fn wrap_css_section(name: &str, css: &str) -> String {
 }
 
 fn page_content_contains_any(content: &str, needles: &[&str]) -> bool {
-    needles.iter().any(|needle| content.contains(needle))
+    let haystack = content.as_bytes();
+    needles.iter().any(|needle| memmem::find(haystack, needle.as_bytes()).is_some())
 }
 
 fn escape_html(value: &str) -> String {


### PR DESCRIPTION
## Summary
- configure Clippy disallowed-type entries for std Box, String, and Vec so audits can target heap-heavy defaults
- reduce renderer code annotation allocations with SmallVec and CompactString, and route rendering through concrete dispatch helpers
- use phf sets for docs tag classification and memmem-backed scanning for SSG plugin CSS detection
- extend max-optimization release settings to build overrides and benchmark builds

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782918456&installation_id=136613492&pr_number=287&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F287&signature=1071d2d32d6ff2262aa861c0ddf1f6688a74e97ccb705284ca16ecaecd62d1b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->