### PR TITLE
perf(parser): fast-path block dispatch

### DIFF
--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -24,17 +24,22 @@ impl<'a> Parser<'a> {
         }
 
         let start = self.position;
-        let line = self.current_line();
-        let trimmed = line.trim_start();
-        let first = trimmed.as_bytes().first().copied();
+        let bytes = self.source.as_bytes();
+        let Some(trimmed_start) = self.first_non_whitespace_in_line(start) else {
+            return Ok(None);
+        };
 
-        // Try to parse different block types. Each dispatch arm hands the
-        // already-scanned `line` / `trimmed` slices to the matching
-        // `*_at` helper so the inner check doesn't re-run `memchr` +
-        // `trim_start` on the same line.
-        match first {
-            Some(b'#') if self.try_parse_heading_at(trimmed) => return self.parse_heading(start),
-            Some(b'-' | b'*') => {
+        // Try to parse different block types. Common prose lines usually
+        // start with a non-marker byte, so classify that byte first and only
+        // materialize `line` / `trimmed` for syntax families that need the
+        // rest of the line.
+        match bytes[trimmed_start] {
+            b'#' if self.try_parse_heading_start(start, trimmed_start) => {
+                return self.parse_heading(start);
+            }
+            b'-' | b'*' => {
+                let line = self.line_at(start);
+                let trimmed = &line[trimmed_start - start..];
                 if Self::try_parse_thematic_break_line(line) {
                     return self.parse_thematic_break(start);
                 }
@@ -42,26 +47,35 @@ impl<'a> Parser<'a> {
                     return self.parse_list(start);
                 }
             }
-            Some(b'_') if Self::try_parse_thematic_break_line(line) => {
+            b'_' if Self::try_parse_thematic_break_line(self.line_at(start)) => {
                 return self.parse_thematic_break(start);
             }
-            Some(b'>') => return self.parse_block_quote(start),
-            Some(b'`' | b'~') if Self::try_parse_fenced_code_at(line, trimmed) => {
-                return self.parse_fenced_code(start);
+            b'>' => return self.parse_block_quote(start),
+            b'`' | b'~' => {
+                let line = self.line_at(start);
+                let trimmed = &line[trimmed_start - start..];
+                if Self::try_parse_fenced_code_at(line, trimmed) {
+                    return self.parse_fenced_code(start);
+                }
             }
-            Some(b'<') => {
+            b'<' => {
+                let line = self.line_at(start);
+                let trimmed = &line[trimmed_start - start..];
                 if let Some(html_start) = Self::parse_html_block_start(trimmed) {
                     return self.parse_html_block(start, html_start);
                 }
             }
-            Some(b'+' | b'0'..=b'9') if Self::try_parse_list_line(trimmed) => {
-                return self.parse_list(start);
+            b'+' | b'0'..=b'9' => {
+                let line = self.line_at(start);
+                let trimmed = &line[trimmed_start - start..];
+                if Self::try_parse_list_line(trimmed) {
+                    return self.parse_list(start);
+                }
             }
             _ => {}
         }
 
-        if self.options.tables && memchr(b'|', line.as_bytes()).is_some() && self.try_parse_table()
-        {
+        if self.options.tables && self.line_contains_byte(start, b'|') && self.try_parse_table() {
             return self.parse_table(start);
         }
 

--- a/crates/ox_content_parser/src/parser/cursor.rs
+++ b/crates/ox_content_parser/src/parser/cursor.rs
@@ -1,4 +1,4 @@
-use memchr::memchr;
+use memchr::{memchr, memchr2};
 
 use super::Parser;
 
@@ -74,40 +74,40 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn line_starts_block(&self) -> bool {
-        let line = self.current_line();
-        let trimmed = line.trim_start();
-        let first = trimmed.as_bytes().first().copied();
+        let line_start = self.position;
+        let bytes = self.source.as_bytes();
+        let Some(trimmed_start) = self.first_non_whitespace_in_line(line_start) else {
+            return false;
+        };
 
-        // NB: dispatch arms must use the same checks as `parse_block`,
-        // which test at `self.position` (the un-trimmed offset). Using
-        // `is_atx_heading_prefix(trimmed.as_bytes())` here would diverge
-        // from `parse_block`'s `Some(b'#') if self.try_parse_heading_at()`
-        // check on indented inputs like `" # heading"`:
-        // `line_starts_block` would say "yes, a heading", `parse_block`
-        // would say "no" (since the byte at position 0 is a space) and
-        // fall through to `parse_paragraph`, which would immediately break
-        // with no content — `parse_block` then returns `Ok(None)` without
-        // advancing position, and the outer `parse()` loop spins forever
-        // on the same offset. We route every arm through the same
-        // line-cached helpers as `parse_block` so the two dispatchers stay
-        // in lock-step and we only `memchr` + `trim_start` the current
-        // line once per call.
-        let starts_block = match first {
-            Some(b'#') => self.try_parse_heading_at(trimmed),
-            Some(b'-' | b'*') => {
+        let starts_block = match bytes[trimmed_start] {
+            b'#' => self.try_parse_heading_start(line_start, trimmed_start),
+            b'-' | b'*' => {
+                let line = self.line_at(line_start);
+                let trimmed = &line[trimmed_start - line_start..];
                 Self::try_parse_thematic_break_line(line) || Self::try_parse_list_line(trimmed)
             }
-            Some(b'_') => Self::try_parse_thematic_break_line(line),
-            Some(b'>') => true,
-            Some(b'`' | b'~') => Self::try_parse_fenced_code_at(line, trimmed),
-            Some(b'<') => Self::parse_html_block_start(trimmed).is_some(),
-            Some(b'+' | b'0'..=b'9') => Self::try_parse_list_line(trimmed),
+            b'_' => Self::try_parse_thematic_break_line(self.line_at(line_start)),
+            b'>' => true,
+            b'`' | b'~' => {
+                let line = self.line_at(line_start);
+                let trimmed = &line[trimmed_start - line_start..];
+                Self::try_parse_fenced_code_at(line, trimmed)
+            }
+            b'<' => {
+                let line = self.line_at(line_start);
+                Self::parse_html_block_start(&line[trimmed_start - line_start..]).is_some()
+            }
+            b'+' | b'0'..=b'9' => {
+                let line = self.line_at(line_start);
+                Self::try_parse_list_line(&line[trimmed_start - line_start..])
+            }
             _ => false,
         };
 
         starts_block
             || (self.options.tables
-                && memchr(b'|', line.as_bytes()).is_some()
+                && self.line_contains_byte(line_start, b'|')
                 && self.try_parse_table())
     }
 
@@ -136,6 +136,29 @@ impl<'a> Parser<'a> {
         } else {
             self.position = self.source.len();
             &self.source[start..]
+        }
+    }
+
+    pub(super) fn first_non_whitespace_in_line(&self, line_start: usize) -> Option<usize> {
+        let bytes = self.source.as_bytes();
+        let mut cursor = line_start;
+
+        while cursor < bytes.len() {
+            match bytes[cursor] {
+                b' ' | b'\t' => cursor += 1,
+                b'\n' => return None,
+                _ => return Some(cursor),
+            }
+        }
+
+        None
+    }
+
+    pub(super) fn line_contains_byte(&self, line_start: usize, needle: u8) -> bool {
+        let bytes = self.source.as_bytes();
+        match memchr2(needle, b'\n', &bytes[line_start..]) {
+            Some(off) => bytes[line_start + off] == needle,
+            None => false,
         }
     }
 }

--- a/crates/ox_content_parser/src/parser/leaf.rs
+++ b/crates/ox_content_parser/src/parser/leaf.rs
@@ -7,13 +7,9 @@ use crate::error::ParseResult;
 use crate::profile_span;
 
 impl<'a> Parser<'a> {
-    pub(super) fn try_parse_heading_at(&self, trimmed: &str) -> bool {
-        let bytes = self.source.as_bytes();
-        let pos = self.position;
-        if pos < bytes.len() && matches!(bytes[pos], b' ' | b'\t') {
-            return false;
-        }
-        is_atx_heading_prefix(trimmed.as_bytes())
+    pub(super) fn try_parse_heading_start(&self, line_start: usize, trimmed_start: usize) -> bool {
+        line_start == trimmed_start
+            && is_atx_heading_prefix(&self.source.as_bytes()[trimmed_start..])
     }
 
     pub(super) fn try_parse_thematic_break_line(line: &str) -> bool {

--- a/crates/ox_content_parser/src/parser/tests.rs
+++ b/crates/ox_content_parser/src/parser/tests.rs
@@ -51,8 +51,8 @@ fn indented_heading_like_text_does_not_loop() {
     // position, so " # heading" caused `parse_paragraph` to break
     // immediately ("looks like a heading") and `parse_block` to return
     // `Ok(None)` without advancing — spinning the outer loop forever.
-    // The fix is for `line_starts_block` to defer to
-    // `self.try_parse_heading_at()` so both checks see the same offset.
+    // The fix is for `line_starts_block` and `parse_block` to share the same
+    // untrimmed-line-start heading check.
     let allocator = Allocator::new();
     let doc = Parser::new(&allocator, " # heading\n").parse().unwrap();
     assert_eq!(doc.children.len(), 1);


### PR DESCRIPTION
## Summary

- Classify block-start candidates from the first non-whitespace byte before materializing current-line slices.
- Share the untrimmed heading check between `parse_block` and paragraph continuation detection.
- Use a `memchr2` bounded scan for table-pipe detection so prose lines avoid a separate full-line slice.

## Rationale

Recent parser work reduced allocation pressure, so this change targets the algorithmic dispatch path instead: most Markdown lines are prose, and they should not pay newline search plus trimming unless their first relevant byte can actually start block syntax.

## Validation

- `cargo clippy -p ox_content_parser -p ox_content_renderer --all-targets -- -D warnings`
- `cargo test -p ox_content_parser -p ox_content_renderer`
- Started `node benchmarks/bundle-size/parse-benchmark.mjs --runs 3 --json /tmp/ox-current-benchmark.json`; stopped during the huge async comparison because it was taking too long locally. The PR Benchmark workflow should provide the comparable base/head runner result.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782927858&installation_id=136613492&pr_number=290&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F290&signature=1297b4258faf4bf4ed155cf69159db4f1d069586feb16cc8c05dd6a8b740ce80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->