### PR TITLE
docs(perf): document optimization hot paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,10 +145,17 @@ insta = "1"
 debug = 2
 
 [profile.dev.package]
+# Snapshot testing spends most of its time in diff/render helpers rather than
+# ox-content itself. Optimizing only these dev dependencies keeps normal debug
+# builds fast while making `cargo test` output comparison cheaper.
 insta.opt-level = 3
 similar.opt-level = 3
 
 [profile.release]
+# Published binaries and CI benchmarks use this profile. It intentionally
+# favors runtime throughput over compile time: fat LTO plus a single codegen
+# unit gives LLVM whole-workspace visibility, while stripping and aborting
+# panics remove unwinding/symbol-table overhead from shipped artifacts.
 opt-level = 3
 lto = "fat"
 codegen-units = 1
@@ -160,10 +167,15 @@ incremental = false
 panic = "abort"
 
 [profile.release.build-override]
+# Build scripts are tiny but run during release packaging and NAPI builds; keep
+# their codegen deterministic with the same single-unit optimization policy.
 opt-level = 3
 codegen-units = 1
 
 [profile.bench]
+# Benchmarks should measure the production hot paths, not a lighter
+# benchmark-only profile. Keep this aligned with `profile.release` except for
+# fields Cargo ignores for benchmark harnesses.
 opt-level = 3
 lto = "fat"
 codegen-units = 1

--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -346,8 +346,16 @@ fn parse_jsdoc_payload(source: &str, comment: &Comment) -> ParsedJsdoc {
     (raw, doc, tags)
 }
 
-/// Pre-parse every JSDoc comment in the program with a single batch call so the
-/// AST visitor can resolve documentation by `attached_to` via a cheap lookup.
+/// Pre-parses every JSDoc comment in the program with a single batch call.
+///
+/// Oxc exposes comments separately from declarations, and the visitor resolves
+/// documentation by `attached_to` while walking the AST. Parsing each comment
+/// on demand repeats decoder setup and makes the visitor pay parse cost at
+/// every declaration. This cache batches decoder input once, stores the parsed
+/// `(raw, description, tags)` payload by `attached_to`, and lets the visitor do
+/// a cheap hash lookup in the hot declaration path. Comments that fail the
+/// batch parser still fall back individually so diagnostics do not poison the
+/// whole file.
 fn build_jsdoc_cache(source: &str, comments: &[Comment]) -> FxHashMap<u32, ParsedJsdoc> {
     let jsdoc_comments: Vec<&Comment> =
         comments.iter().filter(|comment| comment.is_jsdoc()).collect();

--- a/crates/ox_content_docs/src/graph.rs
+++ b/crates/ox_content_docs/src/graph.rs
@@ -483,6 +483,11 @@ fn normalized_entries_for_module<'a>(
     module: &PathBuf,
     type_parameters: bool,
 ) -> Result<&'a [NormalizedDocEntry], GraphError> {
+    // Dependency graph construction can revisit the same module through many
+    // re-export edges. Cache normalized entries per resolved path so each file
+    // is parsed and normalized once, then return borrowed slices for all later
+    // graph edges. The explicit insert-before-get shape keeps the returned
+    // borrow simple while avoiding repeated extractor work.
     if !docs_cache.contains_key(module) {
         let items = extractor
             .extract_file(module)

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -20,6 +20,10 @@ const DOC_KIND_ORDER: [&str; 7] =
 type RegexCache = OnceLock<Option<Regex>>;
 
 fn cached_regex(cache: &'static RegexCache, pattern: &'static str) -> Option<&'static Regex> {
+    // Regex construction is expensive and these helpers run throughout doc
+    // generation. Cache both success and failure in `OnceLock<Option<_>>` so a
+    // bad pattern degrades to the fallback path without recompiling on every
+    // call.
     cache.get_or_init(|| Regex::new(pattern).ok()).as_ref()
 }
 
@@ -657,10 +661,10 @@ fn clean_summary_text(text: &str, max_length: usize) -> String {
         return truncate_summary_text(&fallback(), max_length);
     };
 
-    // `replace_all` returns `Cow::Borrowed` (no allocation) when the pattern
-    // doesn't match — the common case for short summaries. Thread the Cow
-    // through each stage instead of forcing a `String` after every one, and
-    // materialize only at the final `truncate_summary_text` (which takes `&str`).
+    // Summary cleanup is called for every entry in index views. `replace_all`
+    // returns `Cow::Borrowed` when a pattern does not match, which is common
+    // for short summaries, so thread the borrowed/owned value through each
+    // regex stage and materialize only in `truncate_summary_text`.
     let s1 = markdown_link_re.replace_all(text, "$1");
     let s2 = bracket_link_re.replace_all(&s1, "$1");
     let s3 = inline_code_re.replace_all(&s2, "$1");

--- a/crates/ox_content_docs/src/markdown/markdown_html.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_html.rs
@@ -23,10 +23,12 @@ use crate::string_builder::{join3, StringBuilder};
 use std::collections::HashMap;
 
 fn escape_html(value: &str) -> String {
-    // Most inputs (symbol names, type annotations, kind labels) contain none of
-    // these characters, so a single scan with an early-out avoids the five
-    // full-string passes + five intermediate allocations the chained
-    // `replace()` calls performed unconditionally.
+    // Most inputs here are symbol names, type annotations, and kind labels,
+    // which usually contain no escapable HTML bytes. The early scan keeps that
+    // path to one pass plus `to_string()`, while the escaping path still does a
+    // single allocation sized near the input. This replaces chained
+    // `replace()` calls that performed five full-string passes and could
+    // allocate five intermediate strings for every rendered cell.
     if !value.bytes().any(|b| matches!(b, b'&' | b'<' | b'>' | b'"' | b'\'')) {
         return value.to_string();
     }
@@ -65,6 +67,9 @@ fn render_inline_html(text: &str) -> String {
     ) else {
         return replace_line_breaks_html(escape_html(text));
     };
+    // Check for a token before allocating the output buffer or entering the
+    // capture iterator. Plain prose dominates generated descriptions, and for
+    // that case escaping plus newline replacement is enough.
     if !token_re.is_match(text) {
         return replace_line_breaks_html(escape_html(text));
     }
@@ -106,8 +111,10 @@ fn render_inline_html(text: &str) -> String {
 }
 
 // The four block-start regexes are cached once and shared between the
-// value-returning helpers (which capture a group) and `is_markdown_block_start`
-// (which only needs a boolean and so can use the allocation-free `is_match`).
+// value-returning helpers, which need captures, and `is_markdown_block_start`,
+// which only needs a boolean and therefore uses allocation-free `is_match`.
+// This keeps list/paragraph continuation checks from rebuilding regexes or
+// allocating capture groups on every line.
 fn fence_re() -> Option<&'static Regex> {
     static FENCE_RE: RegexCache = OnceLock::new();
     cached_regex(&FENCE_RE, r"^```([\w-]+)?\s*$")
@@ -167,6 +174,11 @@ fn is_markdown_block_start(line: &str) -> bool {
 }
 
 fn render_markdown_blocks_html(text: &str) -> String {
+    // This renderer handles the small Markdown subset embedded in generated
+    // API descriptions. It walks the line slice once and emits blocks as soon
+    // as they are recognized. Continuation checks use cached regexes and the
+    // inline renderer's own token precheck so ordinary paragraphs do not pay
+    // for full Markdown parsing.
     static ORDERED_CONTINUATION_RE: RegexCache = OnceLock::new();
     static UNORDERED_CONTINUATION_RE: RegexCache = OnceLock::new();
 

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -237,11 +237,12 @@ fn render_members_pure(
     context: Option<&MarkdownLinkContext<'_>>,
     section_level: usize,
 ) -> String {
-    // Bucket the members lazily: each `match` arm below only uses a subset of
-    // these groups (the default arm uses none of them), so computing every
-    // bucket up front wasted a full `members` pass + `Vec` per unused group.
-    // Mirrors the same optimization in the HTML renderer's
-    // `render_members_table_html`.
+    // Bucket members lazily. Each entry kind uses a different subset of
+    // groups, and the default arm uses none of the specialized buckets, so the
+    // eager version spent one full member pass plus one `Vec` allocation per
+    // unused group. The closures below defer each filter pass until that group
+    // is actually requested by the selected entry kind, matching the HTML
+    // renderer's optimized member table path.
     let methods = |is_static: bool| {
         members_of(entry, move |member| {
             member.r#static == is_static

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -337,6 +337,9 @@ struct NormalizedDocMetadata {
 }
 
 fn normalize_doc_metadata(tags: &[DocTag], type_parameters: bool) -> NormalizedDocMetadata {
+    // Normalize tags in one pass. The PHF sets keep alias checks (`@arg`,
+    // `@returns`, `@template`, etc.) allocation-free and avoid re-parsing the
+    // same tag list for params, returns, examples, privacy, and generic tags.
     let mut params = Vec::new();
     let mut returns = None;
     let mut examples = Vec::new();

--- a/crates/ox_content_docs/src/output.rs
+++ b/crates/ox_content_docs/src/output.rs
@@ -109,6 +109,9 @@ fn remove_stale_files(out_dir: &Path, generated_files: &[String]) -> DocsOutputR
         Err(error) => return Err(error.into()),
     };
 
+    // `generated_files` is sorted and deduped by the caller, so stale detection
+    // is a binary search per previous file instead of repeatedly scanning the
+    // new file list while cleaning nested TypeDoc output trees.
     for stale_file in previous_files {
         if generated_files.binary_search(&stale_file).is_ok() {
             continue;

--- a/crates/ox_content_docs/src/string_builder.rs
+++ b/crates/ox_content_docs/src/string_builder.rs
@@ -1,3 +1,10 @@
+/// Small append-only string builder used by documentation generation hot paths.
+///
+/// This wraps `String` so call sites can express "append a few known pieces"
+/// without reaching for `format!` or `to_string()` for small numeric fragments.
+/// The helper methods keep the final output allocation explicit via
+/// `with_capacity`, and `push_usize` writes decimal digits through a stack
+/// buffer so count-heavy renderers do not allocate temporary strings.
 pub struct StringBuilder {
     output: String,
 }
@@ -20,6 +27,10 @@ impl StringBuilder {
     }
 
     pub fn push_usize(&mut self, value: usize) {
+        // Maximum decimal length of `usize` on supported targets is 20 bytes
+        // (`u64::MAX`). Fill the stack buffer from the back, then append the
+        // valid suffix in one `push_str`; this replaces `value.to_string()`
+        // in loops that render stats, anchors, headings, and file names.
         let mut buffer = [0_u8; 20];
         let mut cursor = buffer.len();
         let mut rest = value;
@@ -39,6 +50,8 @@ impl StringBuilder {
 
     #[cfg(test)]
     pub fn push_u128(&mut self, value: u128) {
+        // Test-only wide variant for boundary coverage of the digit writer.
+        // `u128::MAX` is 39 decimal digits.
         let mut buffer = [0_u8; 39];
         let mut cursor = buffer.len();
         let mut rest = value;
@@ -66,6 +79,9 @@ impl StringBuilder {
 }
 
 pub fn join2(first: &str, second: &str) -> String {
+    // These tiny join helpers replace `format!("{a}{b}...")` in render loops.
+    // They pre-size exactly for the literal pieces and avoid the formatting
+    // machinery when no formatting is needed.
     let mut out = StringBuilder::with_capacity(first.len() + second.len());
     out.push_str(first);
     out.push_str(second);

--- a/crates/ox_content_lsp/src/backend/diagnostics.rs
+++ b/crates/ox_content_lsp/src/backend/diagnostics.rs
@@ -19,6 +19,9 @@ pub(super) fn markdown_parse_diagnostics(
         |block| (&document.text()[block.block_end_offset..], block.block_end_offset),
     );
 
+    // Diagnostics run on keystrokes and the input length is known. Start the
+    // parser with a source-sized arena so editor feedback does not pay bumpalo
+    // chunk growth on every parse.
     let allocator = Allocator::for_source_len(source.len());
     let parser = Parser::with_options(&allocator, source, ParserOptions::gfm());
     let diagnostics = match parser.parse() {

--- a/crates/ox_content_lsp/src/preview/render.rs
+++ b/crates/ox_content_lsp/src/preview/render.rs
@@ -22,6 +22,9 @@ pub fn render_preview(source: &str) -> Result<PreviewPayload, ParseError> {
     // inside it. `block_end_offset` points just past the closing `---` line.
     let content = block.as_ref().map_or(source, |block| &source[block.block_end_offset..]);
 
+    // Preview rendering is latency-sensitive and reparses the current document
+    // often. Use the same source-length arena heuristic as NAPI so editor
+    // previews do not benchmark a zero-capacity allocator.
     let allocator = Allocator::for_source_len(content.len());
     let parser = Parser::with_options(&allocator, content, ParserOptions::gfm());
     let ast = parser.parse()?;

--- a/crates/ox_content_lsp/src/preview/symbols.rs
+++ b/crates/ox_content_lsp/src/preview/symbols.rs
@@ -21,6 +21,9 @@ pub fn document_symbols(
         (source, 0)
     };
 
+    // Symbol extraction only needs headings, but the parser still constructs
+    // the full AST. Pre-sizing the arena removes allocator churn from repeated
+    // outline refreshes while preserving parser behavior.
     let allocator = Allocator::for_source_len(content.len());
     let parser = Parser::with_options(&allocator, content, ParserOptions::gfm());
     let ast = parser.parse()?;

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -48,6 +48,10 @@ use transfer::TransferPayloadKind;
 use transformer::{parse_frontmatter, MarkdownTransformer};
 
 fn create_allocator_for_source(source: &str) -> Allocator {
+    // NAPI parse/render calls know the full Markdown string length before
+    // parsing. Use the shared source-length heuristic so synchronous native
+    // calls start with one appropriately sized bump chunk instead of growing
+    // from `Bump::new()` while JavaScript is blocked.
     Allocator::for_source_len(source.len())
 }
 
@@ -766,7 +770,10 @@ pub fn parse_transfer_raw(
 
     match payload_kind {
         TransferPayloadKind::Mdast => {
-            let allocator = Allocator::new();
+            // Raw mdast transfer serializes immediately after parsing, so it
+            // has the same arena shape as `parse`/`parseAndRender`; pre-sizing
+            // keeps large transfer requests from paying bumpalo chunk growth.
+            let allocator = create_allocator_for_source(&source);
             let parser_options = options.map(ParserOptions::from).unwrap_or_default();
             let parser = Parser::with_options(&allocator, &source, parser_options);
             let document =

--- a/crates/ox_content_napi/src/tabs.rs
+++ b/crates/ox_content_napi/src/tabs.rs
@@ -83,6 +83,9 @@ pub fn transform_tabs(html: &str, start_group: u32) -> TabsTransform {
 
 /// Collect the direct `<tab>` children of a `<tabs>` block's inner HTML.
 fn parse_tabs(inner: &str) -> Vec<Tab> {
+    // Scan the already-rendered HTML slice and copy panel contents verbatim.
+    // This avoids a DOM allocation while preserving the previous rehype output
+    // for arbitrary Markdown-rendered HTML inside a tab.
     let mut tabs = Vec::new();
     let mut cursor = 0;
     while let Some(open_at) = find_tag(inner, cursor, "<tab") {
@@ -262,6 +265,9 @@ fn find_matching_close(html: &str, from: usize, open: &str, close: &str) -> Opti
 /// Read the value of `name` (case-insensitive) from a start tag's attribute
 /// region. Supports quoted and unquoted values; missing value yields `""`.
 fn attribute_value(attrs: &str, name: &str) -> Option<String> {
+    // The transform only needs one requested attribute from a start-tag slice.
+    // A narrow byte scan is faster and simpler than constructing a generic
+    // attribute map for every tab element.
     let bytes = attrs.as_bytes();
     let mut i = 0;
     while i < bytes.len() {

--- a/crates/ox_content_napi/src/transformer.rs
+++ b/crates/ox_content_napi/src/transformer.rs
@@ -81,6 +81,10 @@ impl MarkdownTransformer {
         let prepared = self.prepare_source(source);
         let preprocessed = features::preprocess_markdown(&prepared.content, &self.feature_options);
         let content = preprocessed.source.as_ref();
+        // Preprocessors may return borrowed or owned content. Size the arena
+        // from the exact slice that will be parsed, not the original source, so
+        // generated feature content and stripped frontmatter both get an arena
+        // that matches their actual AST footprint.
         let allocator = Allocator::for_source_len(content.len());
         let parse_result = self.parse_document(&allocator, content);
         let mut errors = preprocessed.errors;
@@ -172,6 +176,9 @@ impl MarkdownTransformer {
         if self.frontmatter {
             parse_frontmatter_with_origin(source)
         } else {
+            // Frontmatter-disabled mode keeps a simple owned copy because this
+            // value may cross NAPI as a prepared-source payload; the parse hot
+            // path borrows from this string rather than reparsing YAML.
             PreparedMarkdownSource {
                 content: source.to_string(),
                 frontmatter: HashMap::new(),
@@ -210,6 +217,9 @@ fn parse_frontmatter_with_origin(source: &str) -> PreparedMarkdownSource {
     let content = rest[end_pos + 4..].trim_start_matches('\n');
     frontmatter = serde_yaml::from_str(frontmatter_str).unwrap_or_default();
 
+    // Keep both byte and UTF-16 offsets for the stripped body. The byte offset
+    // lets Rust spans be rebased without scanning again, while the UTF-16
+    // offset gives JS/LSP consumers editor-native positions.
     let source_origin = source_origin_for_content(source, content);
 
     PreparedMarkdownSource { content: content.to_string(), frontmatter, source_origin }
@@ -309,8 +319,9 @@ fn slugify(text: &str) -> String {
         .map(|c| if c.is_alphanumeric() || c == ' ' || c == '-' { c } else { ' ' })
         .collect();
     // Join the whitespace-split tokens with '-' directly, skipping the
-    // intermediate `Vec<&str>` and the separate `join` allocation. `mapped.len()`
-    // is a safe upper bound for the slug (separators only shrink it).
+    // intermediate `Vec<&str>` and the separate `join` allocation. This TOC
+    // slugger runs for every heading in NAPI transforms; `mapped.len()` is a
+    // safe upper bound for the slug because separators only shrink it.
     let mut slug = String::with_capacity(mapped.len());
     for token in mapped.split_whitespace() {
         if !slug.is_empty() {

--- a/crates/ox_content_napi/src/youtube.rs
+++ b/crates/ox_content_napi/src/youtube.rs
@@ -80,6 +80,9 @@ fn escape_attribute(value: &str) -> String {
 }
 
 fn build_embed_url(video_id: &str, options: &YouTubeEmbedOptions) -> String {
+    // Build directly from the validated id and option-selected host. Query
+    // string support is intentionally absent because the TS transform being
+    // ported dropped `start` before URL construction.
     let domain =
         if options.privacy_enhanced { "www.youtube-nocookie.com" } else { "www.youtube.com" };
     format!("https://{domain}/embed/{video_id}")
@@ -205,6 +208,9 @@ fn find_youtube_element(html: &str, from: usize) -> Option<YouTubeElement> {
 /// Parse `name="value"` / `name='value'` / `name=value` / bare `name`
 /// attributes from the inside of a start tag. Names are lower-cased.
 fn parse_attributes(inner: &str) -> Vec<(String, String)> {
+    // Returning a small vector keeps first-wins semantics obvious at the call
+    // site. The scan respects quoted values so it can run on raw HTML without
+    // the rehype parse/stringify round-trip this Rust port replaced.
     let bytes = inner.as_bytes();
     let mut attrs = Vec::new();
     let mut i = 0;

--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -29,10 +29,19 @@ impl<'a> Parser<'a> {
             return Ok(None);
         };
 
-        // Try to parse different block types. Common prose lines usually
-        // start with a non-marker byte, so classify that byte first and only
-        // materialize `line` / `trimmed` for syntax families that need the
-        // rest of the line.
+        // Fast block dispatch.
+        //
+        // Most documentation lines are plain paragraph text. The old shape
+        // built `line` and `trimmed` up front, then tried each block parser in
+        // sequence; that meant every paragraph paid for newline search,
+        // trimming, and several failed recognizers. Here the first
+        // non-whitespace byte is used as a cheap discriminator. Only marker
+        // families that can actually begin with that byte materialize the
+        // full line slice and run their more expensive syntax checks.
+        //
+        // Keep this table in sync with `line_starts_block`: paragraph parsing
+        // uses that helper to decide when a following line terminates the
+        // paragraph, so the two dispatchers must agree on block starts.
         match bytes[trimmed_start] {
             b'#' if self.try_parse_heading_start(start, trimmed_start) => {
                 return self.parse_heading(start);
@@ -75,6 +84,11 @@ impl<'a> Parser<'a> {
             _ => {}
         }
 
+        // Table recognition is the one feature that cannot be decided from
+        // the first byte because table headers usually look like ordinary
+        // paragraph text. Guard the expensive two-line delimiter check with a
+        // same-line `|` probe so non-table prose does one memchr2 scan and
+        // then falls through to paragraph parsing.
         if self.options.tables && self.line_contains_byte(start, b'|') && self.try_parse_table() {
             return self.parse_table(start);
         }

--- a/crates/ox_content_parser/src/parser/block_quote.rs
+++ b/crates/ox_content_parser/src/parser/block_quote.rs
@@ -7,6 +7,12 @@ use crate::error::ParseResult;
 use crate::profile_span;
 
 impl<'a> Parser<'a> {
+    /// Parses a block quote by stripping quote markers into arena storage.
+    ///
+    /// The nested parser needs a contiguous source string without the leading
+    /// `>` markers. Building that string directly in the bump arena avoids the
+    /// old two-step path of filling a system `String` and then copying it into
+    /// arena storage before recursive parsing.
     pub(super) fn parse_block_quote(&mut self, start: usize) -> ParseResult<Option<Node<'a>>> {
         profile_span!("parser::parse_block_quote");
         self.nesting_depth += 1;

--- a/crates/ox_content_parser/src/parser/cursor.rs
+++ b/crates/ox_content_parser/src/parser/cursor.rs
@@ -73,6 +73,14 @@ impl<'a> Parser<'a> {
         &self.source[self.position..end]
     }
 
+    /// Returns true when the current line begins a block-level construct.
+    ///
+    /// This is the paragraph-continuation counterpart of `parse_block`'s
+    /// first-byte dispatcher. Paragraph parsing calls it for each following
+    /// line, so it deliberately avoids `current_line().trim_start()` unless
+    /// the leading marker byte makes a block parse plausible. Keeping this
+    /// byte-dispatch table aligned with `parse_block` preserves Markdown
+    /// behavior while avoiding repeated full-line scans on ordinary prose.
     pub(super) fn line_starts_block(&self) -> bool {
         let line_start = self.position;
         let bytes = self.source.as_bytes();
@@ -139,6 +147,12 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// Finds the first non-space, non-tab byte before the next newline.
+    ///
+    /// The parser only treats ASCII space and tab as indentation in these
+    /// block-level dispatchers. Returning the byte offset, rather than a
+    /// trimmed `&str`, lets callers inspect the discriminator byte first and
+    /// defer `line_at()` until they know a full line slice is needed.
     pub(super) fn first_non_whitespace_in_line(&self, line_start: usize) -> Option<usize> {
         let bytes = self.source.as_bytes();
         let mut cursor = line_start;
@@ -154,6 +168,12 @@ impl<'a> Parser<'a> {
         None
     }
 
+    /// Checks whether `needle` appears before the end of the current line.
+    ///
+    /// `memchr2` searches for either `needle` or `\n` in one pass. This is
+    /// used as a guard for rare syntax families such as tables: the common
+    /// no-marker case stops at the newline and avoids constructing the line
+    /// slice or running the full parser for that feature.
     pub(super) fn line_contains_byte(&self, line_start: usize, needle: u8) -> bool {
         let bytes = self.source.as_bytes();
         match memchr2(needle, b'\n', &bytes[line_start..]) {

--- a/crates/ox_content_parser/src/parser/fenced_code.rs
+++ b/crates/ox_content_parser/src/parser/fenced_code.rs
@@ -7,6 +7,13 @@ use crate::error::{ParseError, ParseResult};
 use crate::profile_span;
 
 impl<'a> Parser<'a> {
+    /// Finds the body end and cursor position after a closing fence.
+    ///
+    /// This helper is used only by the zero-copy fenced-code path where the
+    /// opening fence has no indentation. In that case body lines do not need
+    /// stripping, so the parser can search line starts in the original source
+    /// and return a borrowed body slice. The tuple separates the end of code
+    /// content from the end of the closing fence line.
     pub(super) fn find_fenced_close(
         &self,
         fence_char: char,
@@ -113,9 +120,9 @@ impl<'a> Parser<'a> {
             &self.source[body_start..body_end]
         } else {
             // Indented opening fence: lines may need leading-space stripping,
-            // so we have to materialize a new string. Write directly into a
-            // bump-allocated string so we don't pay for `String` (system
-            // allocator) → `alloc_str` (arena copy).
+            // so a borrowed source slice would be wrong. Materialize only this
+            // uncommon case, and write directly into a bump-allocated string
+            // so the final AST can borrow it without a second arena copy.
             let remaining_estimate = self.source.len().saturating_sub(self.position);
             let mut value = ox_content_allocator::String::with_capacity_in(
                 remaining_estimate.min(8 * 1024),

--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -20,6 +20,11 @@ impl<'a> Parser<'a> {
 
         while pos < content.len() {
             let start = pos;
+            // Plain text is the common inline case. Jump over bytes that
+            // cannot start any inline construct, then push that entire run as
+            // one Text node. This keeps the parser on bulk byte scans for
+            // prose and only enters the slower match when a real marker byte
+            // has been reached.
             pos = next_inline_special(bytes, pos);
 
             if pos > start {
@@ -201,8 +206,13 @@ impl<'a> Parser<'a> {
     }
 }
 
-/// Lookup table: `INLINE_SPECIAL[b] == 1` iff the byte is one of the
-/// inline-special markers.
+/// Lookup table: `INLINE_SPECIAL[b] == 1` iff the byte can begin an inline
+/// construct handled by `parse_inline_special`.
+///
+/// The table deliberately stores flags instead of enum variants. The scan in
+/// `next_inline_special` ORs eight table entries at a time, which gives LLVM a
+/// simple branch-free loop for long runs of normal text. The actual parser
+/// decision still happens only after a candidate byte is found.
 static INLINE_SPECIAL: [u8; 256] = {
     let mut t = [0u8; 256];
     t[b'*' as usize] = 1;
@@ -218,6 +228,10 @@ static INLINE_SPECIAL: [u8; 256] = {
 
 #[inline]
 fn next_inline_special(bytes: &[u8], from: usize) -> usize {
+    // Skip eight bytes at a time while the OR of their marker flags is zero.
+    // This is not a semantic parser: it only proves that none of those bytes
+    // can start inline syntax, so returning the first flagged byte preserves
+    // the exact same marker positions as the previous per-byte loop.
     let mut i = from;
     let end = bytes.len();
 

--- a/crates/ox_content_parser/src/parser/inline_helpers.rs
+++ b/crates/ox_content_parser/src/parser/inline_helpers.rs
@@ -122,6 +122,11 @@ impl<'a> Parser<'a> {
         count
     }
 
+    /// Finds the next emphasis/strong delimiter run of at least `min_count`.
+    ///
+    /// Only occurrences of `marker` can change the result. Using `memchr` to
+    /// jump between marker runs preserves the delimiter positions visited by
+    /// the old byte-by-byte loop while making long non-marker spans cheap.
     pub(super) fn find_marker_run(
         bytes: &[u8],
         mut cursor: usize,
@@ -143,6 +148,12 @@ impl<'a> Parser<'a> {
         None
     }
 
+    /// Scans a balanced delimiter region and returns the matching close byte.
+    ///
+    /// Link labels and destinations only care about nested `open`/`close`
+    /// delimiters; every other byte is inert. `memchr2` moves directly to the
+    /// next byte that can affect depth, which keeps deeply textual labels from
+    /// paying a branch for each character.
     fn scan_balanced(bytes: &[u8], mut cursor: usize, open: u8, close: u8) -> usize {
         let mut depth = 1;
         while cursor < bytes.len() {

--- a/crates/ox_content_parser/src/parser/leaf.rs
+++ b/crates/ox_content_parser/src/parser/leaf.rs
@@ -7,6 +7,12 @@ use crate::error::ParseResult;
 use crate::profile_span;
 
 impl<'a> Parser<'a> {
+    /// Cheap recognizer for ATX heading starts used by block dispatch.
+    ///
+    /// The caller has already found the first non-whitespace byte. Requiring
+    /// `line_start == trimmed_start` preserves the current rule that headings
+    /// are not indented, while `is_atx_heading_prefix` validates the marker
+    /// with byte checks and without allocating a trimmed line.
     pub(super) fn try_parse_heading_start(&self, line_start: usize, trimmed_start: usize) -> bool {
         line_start == trimmed_start
             && is_atx_heading_prefix(&self.source.as_bytes()[trimmed_start..])
@@ -32,6 +38,12 @@ impl<'a> Parser<'a> {
         count >= 3
     }
 
+    /// Checks whether a line begins a fenced code block.
+    ///
+    /// `line` is used only for indentation, and `trimmed` is the caller's
+    /// already-sliced view starting at the first non-whitespace byte. This
+    /// avoids recomputing `trim_start` in both `parse_block` and
+    /// `line_starts_block`.
     pub(super) fn try_parse_fenced_code_at(line: &str, trimmed: &str) -> bool {
         if Self::indentation_columns(line) > 3 {
             return false;
@@ -110,6 +122,9 @@ impl<'a> Parser<'a> {
 }
 
 fn is_atx_heading_prefix(bytes: &[u8]) -> bool {
+    // Count at most six leading hashes with direct byte checks. The following
+    // byte must be whitespace, newline, or EOF, which lets the dispatcher
+    // reject `#not-heading` without materializing a line string.
     let mut hashes = 0;
     while hashes < bytes.len() && bytes[hashes] == b'#' {
         hashes += 1;

--- a/crates/ox_content_parser/src/parser/list.rs
+++ b/crates/ox_content_parser/src/parser/list.rs
@@ -219,6 +219,14 @@ impl<'a> Parser<'a> {
         })))
     }
 
+    /// Builds the synthetic source used when a list item needs block parsing.
+    ///
+    /// Simple single-line list items take `parse_inline_list_item_children`
+    /// instead and never allocate this buffer. When continuation lines, nested
+    /// blocks, or block-looking inline text require the historical sub-parser
+    /// path, the buffer is allocated directly in the bump arena so ownership
+    /// matches the resulting AST and we avoid a system `String` followed by an
+    /// arena copy.
     fn init_list_item_source(
         &self,
         content: &'a str,
@@ -239,6 +247,15 @@ impl<'a> Parser<'a> {
         source
     }
 
+    /// Returns true when a single-line list item can bypass the sub-parser.
+    ///
+    /// A list item like `- hello **world**` has exactly one paragraph child in
+    /// the old implementation: the sub-parser parsed the item source as a
+    /// document, then offset the paragraph spans back into the parent source.
+    /// Reconstructing that paragraph directly removes a parser allocation and
+    /// a second block-dispatch pass. Items whose first non-space byte can open
+    /// a block stay on the old path so cases such as `- # heading`, nested
+    /// lists, fenced code, thematic breaks, and HTML blocks keep their AST.
     fn can_inline_parse_list_item(content: &str) -> bool {
         let Some(&first) = content.trim_start().as_bytes().first() else {
             return true;
@@ -251,6 +268,13 @@ impl<'a> Parser<'a> {
         !matches!(first, b'#' | b'-' | b'*' | b'_' | b'>' | b'`' | b'~' | b'<' | b'+' | b'0'..=b'9')
     }
 
+    /// Creates the direct AST for the single-paragraph list-item fast path.
+    ///
+    /// `content_offset` is the byte position of `content` in the original
+    /// document, so inline spans are produced with their final coordinates on
+    /// the first parse. `item_end` remains the list-item line end to preserve
+    /// the paragraph span that callers observed when this went through the
+    /// sub-parser.
     fn parse_inline_list_item_children(
         &self,
         content: &'a str,

--- a/crates/ox_content_parser/src/parser/table.rs
+++ b/crates/ox_content_parser/src/parser/table.rs
@@ -8,9 +8,13 @@ use crate::error::ParseResult;
 use crate::profile_span;
 
 impl<'a> Parser<'a> {
+    /// Returns true when the next two lines look like a GFM table header.
+    ///
+    /// Table detection sits behind a cheap `|` guard in block dispatch, but it
+    /// still runs on many prose lines containing pipes. Peek the first two
+    /// lines directly with `memchr` and inspect slices in place instead of
+    /// collecting `lines().take(2)` into a temporary `Vec`.
     pub(super) fn try_parse_table(&self) -> bool {
-        // Avoid the `Vec` allocation: peek the first two lines directly via
-        // `memchr` and inspect them in place.
         let bytes = self.source.as_bytes();
         let p0 = self.position;
         let nl0 = match memchr(b'\n', &bytes[p0..]) {
@@ -71,8 +75,10 @@ impl<'a> Parser<'a> {
             align.push(alignment);
         }
 
-        // Build the table AST directly instead of first collecting row
-        // slices into short-lived heap Vecs.
+        // Build the table AST directly instead of first collecting row slices
+        // into short-lived heap Vecs. Each consumed source line is parsed into
+        // arena-backed cells immediately, which keeps the table path linear in
+        // the input and avoids throwaway row containers.
         let mut children: Vec<'a, TableRow<'a>> = self.allocator.new_vec();
         children.push(self.parse_table_row(header_line)?);
 
@@ -110,6 +116,10 @@ impl<'a> Parser<'a> {
 
     /// Parses a table row into arena-backed AST cells without temporary heap
     /// collection.
+    ///
+    /// The row iterator yields borrowed cell slices from the original line.
+    /// Inline parsing then writes cell children into the parser arena, so no
+    /// intermediate `Vec<&str>` or owned cell text is needed.
     pub(super) fn parse_table_row(&self, line: &'a str) -> ParseResult<TableRow<'a>> {
         let mut cells: Vec<'a, TableCell<'a>> = self.allocator.new_vec();
         for cell_content in Self::table_row_cells(line) {
@@ -120,6 +130,9 @@ impl<'a> Parser<'a> {
     }
 
     /// Iterates table row cells from a line.
+    ///
+    /// Leading/trailing pipes are syntax delimiters, not empty cells in this
+    /// parser's table model, so they are stripped once before splitting.
     pub(super) fn table_row_cells(line: &'a str) -> impl Iterator<Item = &'a str> {
         let trimmed = line.trim();
         let trimmed = trimmed.strip_prefix('|').unwrap_or(trimmed);

--- a/crates/ox_content_renderer/src/html/autolink.rs
+++ b/crates/ox_content_renderer/src/html/autolink.rs
@@ -21,6 +21,13 @@ pub(super) struct FirstByteIndex {
 }
 
 impl FirstByteIndex {
+    /// Builds a compact candidate-start index for the configured patterns.
+    ///
+    /// Each pattern contributes both lowercase and uppercase variants of its
+    /// first byte so later prefix checks can stay case-insensitive without
+    /// lowercasing the whole text node. One to three distinct bytes are stored
+    /// in `needles` for `memchr`, `memchr2`, or `memchr3`; larger custom
+    /// pattern sets keep correctness by falling back to the table scan.
     pub(super) fn from_patterns(patterns: &[String]) -> Self {
         let mut table = [false; 256];
         let mut needles = [0u8; 3];
@@ -52,6 +59,9 @@ impl FirstByteIndex {
     #[inline]
     fn next(&self, hay: &[u8]) -> Option<usize> {
         if self.overflow {
+            // Rare custom-pattern case. The table is still a single indexed
+            // load per byte, but the common one/two/three-needle cases use
+            // memchr's specialized search loops instead.
             return hay.iter().position(|&b| self.table[b as usize]);
         }
         match self.needle_len {

--- a/crates/ox_content_renderer/src/html/code_annotations/attribute.rs
+++ b/crates/ox_content_renderer/src/html/code_annotations/attribute.rs
@@ -39,6 +39,9 @@ pub(in crate::html) fn parse_code_annotations(
 }
 
 fn extract_meta_attribute<'a>(meta: &'a str, target: &str) -> Option<&'a str> {
+    // Fence meta is short but this parser runs for every annotated code block.
+    // Scan the byte slice once and return a borrowed value slice for the target
+    // attribute instead of tokenizing every key/value pair into owned strings.
     let bytes = meta.as_bytes();
     let mut index = 0;
 
@@ -111,6 +114,9 @@ fn extract_meta_attribute<'a>(meta: &'a str, target: &str) -> Option<&'a str> {
 }
 
 pub(in crate::html) fn parse_line_numbers(value: &str) -> SmallVec<[usize; 4]> {
+    // Line lists are usually tiny (`1`, `1,3`, `2-4`), so SmallVec keeps the
+    // common case stack-backed. Sorting once at the end gives deterministic
+    // application order without a heap allocation for typical metadata.
     let mut line_numbers = SmallVec::new();
 
     for part in value.split(',').map(str::trim).filter(|part| !part.is_empty()) {

--- a/crates/ox_content_renderer/src/html/code_annotations/meta.rs
+++ b/crates/ox_content_renderer/src/html/code_annotations/meta.rs
@@ -15,6 +15,9 @@ use super::state::{
 };
 
 pub(in crate::html) fn split_code_block_meta(meta: &str) -> SmallVec<[MetaToken<'_>; 4]> {
+    // Split the metadata once into borrowed tokens. VitePress braces/brackets
+    // and raw `:line-numbers` tokens are then consumed by later stages without
+    // repeatedly rescanning the original string or allocating token strings.
     let bytes = meta.as_bytes();
     let mut index = 0;
     let mut tokens = SmallVec::new();
@@ -93,6 +96,9 @@ pub(in crate::html) fn split_code_block_meta(meta: &str) -> SmallVec<[MetaToken<
 }
 
 fn split_code_block_language_token(raw: &str) -> (&str, &str) {
+    // Some authors put VitePress metadata directly in the language token
+    // (`js{1}` or `ts:line-numbers`). Return borrowed slices so normalization
+    // can merge this inline metadata with the separate fence meta field.
     for (index, ch) in raw.char_indices() {
         match ch {
             '{' | '[' => return (&raw[..index], &raw[index..]),
@@ -186,6 +192,10 @@ pub(in crate::html) fn apply_pending_annotations(
     line: &mut CodeLineRenderState,
     pending_annotations: &mut SmallVec<[PendingCodeAnnotation; 2]>,
 ) {
+    // Standalone VitePress directives annotate following lines. Drain the
+    // current pending list into the line and rebuild only the entries whose
+    // remaining count extends past this line, keeping the list tiny and
+    // stack-backed in normal use.
     let mut remaining = SmallVec::new();
 
     for mut pending in pending_annotations.drain(..) {

--- a/crates/ox_content_renderer/src/html/code_annotations/state.rs
+++ b/crates/ox_content_renderer/src/html/code_annotations/state.rs
@@ -85,6 +85,10 @@ impl CodeBlockRenderState {
     }
 
     pub(in crate::html) fn block_classes(&self) -> SmallVec<[&'static str; 8]> {
+        // Most code blocks need only the base class, line-number class, and at
+        // most one semantic aggregate (`has-diff`, `has-focused`, etc.).
+        // SmallVec avoids a heap allocation for that common case while still
+        // allowing class de-duplication across many annotated lines.
         let mut classes = SmallVec::new();
         if self.has_annotations() || self.line_numbers_start.is_some() || self.title.is_some() {
             classes.push("ox-code-block");

--- a/crates/ox_content_renderer/src/html/code_annotations/vitepress.rs
+++ b/crates/ox_content_renderer/src/html/code_annotations/vitepress.rs
@@ -56,6 +56,9 @@ fn parse_vitepress_directive_action(value: &str) -> Option<InlineDirectiveAction
 }
 
 fn parse_vitepress_inline_directive(line: &str) -> Option<ParsedInlineDirective> {
+    // Inline directives must be inside a recognized comment form. Validating
+    // the prefix/suffix while parsing lets rendering remove directive comments
+    // without a secondary cleanup pass over the code line.
     let marker_start = line.find("[!code ")?;
     let directive_start = marker_start + "[!code ".len();
     let marker_end = line[directive_start..].find(']')? + directive_start;
@@ -96,6 +99,10 @@ fn parse_vitepress_inline_directive(line: &str) -> Option<ParsedInlineDirective>
 }
 
 pub(in crate::html) fn parse_vitepress_inline_annotations(value: &str) -> Vec<CodeLineRenderState> {
+    // Walk the code block once. Each line becomes its final render state as it
+    // is seen, while standalone directives update a small pending list for the
+    // following lines. This avoids first collecting directive positions and
+    // then doing a second pass to apply them.
     let mut lines = Vec::new();
     let mut pending_annotations: SmallVec<[PendingCodeAnnotation; 2]> = SmallVec::new();
     let mut escape_next_line = false;

--- a/crates/ox_content_renderer/src/html/escape.rs
+++ b/crates/ox_content_renderer/src/html/escape.rs
@@ -51,13 +51,21 @@ static URL_ESCAPE_FLAG: [u8; 256] = {
 
 #[inline]
 pub(super) fn write_escaped_into(out: &mut String, s: &str) {
+    // The invariant for this routine is: bytes in `s[start..i]` have not yet
+    // been copied, and every byte before `start` has already been emitted in
+    // escaped form. Safe runs are copied with one `push_str`; only bytes that
+    // require replacement are handled individually. `reserve(s.len())` covers
+    // the no-escape case exactly and reduces growth even when replacements make
+    // the final output longer.
     let bytes = s.as_bytes();
     let mut start = 0usize;
     let mut i = 0usize;
     out.reserve(s.len());
 
-    // 8-byte chunk fast-skip — the OR over 8 lookups vectorizes well and
-    // dominates the inner loop on long no-escape runs (most plain text).
+    // 8-byte chunk fast-skip: the OR over 8 lookups vectorizes well and
+    // dominates the inner loop on long no-escape runs (most plain text). A
+    // nonzero mask only says "at least one byte in this chunk needs the slow
+    // path"; the scalar loop below still finds the exact byte to replace.
     while i + 8 <= bytes.len() {
         let chunk = &bytes[i..i + 8];
         let mask = ESCAPE_FLAG[chunk[0] as usize]
@@ -111,6 +119,10 @@ pub(super) fn write_escaped_into(out: &mut String, s: &str) {
 }
 
 pub(super) fn write_url_escaped_into(out: &mut String, s: &str) {
+    // Same chunked scanner as `write_escaped_into`, but with URL attribute
+    // semantics. Ampersand remains HTML-escaped because the result is written
+    // inside an HTML attribute, while spaces and tag delimiters are percent
+    // encoded to keep the URL value itself stable.
     let bytes = s.as_bytes();
     let mut start = 0usize;
     let mut i = 0usize;

--- a/crates/ox_content_renderer/src/html/heading.rs
+++ b/crates/ox_content_renderer/src/html/heading.rs
@@ -52,14 +52,19 @@ pub(super) fn slugify_heading(text: &str) -> String {
     out
 }
 
-/// Slugify `text` into `out`. `out` is **not** cleared by this function —
-/// callers should clear it themselves so they can reuse a long-lived
-/// scratch buffer across many headings without giving up the allocation.
+/// Slugify `text` into `out`.
+///
+/// `out` is **not** cleared by this function. Renderers keep a long-lived
+/// scratch buffer for heading IDs, clear it at the call site, and pass it back
+/// here on every heading. That avoids allocating one temporary slug string per
+/// heading while still leaving ownership decisions, such as cloning the final
+/// unique id into a hash map, with the caller.
 pub(super) fn slugify_heading_into(text: &str, out: &mut String) {
-    // Single-pass slugify. Hot path is the all-ASCII byte loop (no
-    // UTF-8 decode, no `char::to_lowercase` iterator allocation per
-    // character); we fall back to the char iterator only when a
-    // non-ASCII byte appears.
+    // Single-pass slugify. The hot path is the all-ASCII byte loop: no UTF-8
+    // decode and no `char::to_lowercase` iterator allocation per character.
+    // We switch to the Unicode-aware char iterator only for contiguous
+    // non-ASCII runs, preserving Japanese and other non-Latin heading text
+    // without slowing down the common ASCII API-doc heading.
     let bytes = text.as_bytes();
     out.reserve(text.len());
     let start_len = out.len();

--- a/crates/ox_content_renderer/src/html/renderer.rs
+++ b/crates/ox_content_renderer/src/html/renderer.rs
@@ -99,11 +99,13 @@ impl HtmlRenderer {
     pub fn render(&mut self, document: &Document<'_>) -> String {
         crate::profile_span!("renderer::render");
         self.output.clear();
-        // TOC collection walks every heading and allocates a slug per entry,
-        // which used to fire on every render regardless of whether a
-        // `[[toc]]` directive was actually present. Pre-scan the document
-        // cheaply (no allocations), skip TOC work when no marker exists, and
-        // reuse the heading count to reserve the unique-id map.
+        // Renderer setup is intentionally split into a cheap structural scan
+        // and the expensive optional work. TOC collection walks every heading
+        // and allocates a slug per entry, which used to fire on every render
+        // regardless of whether a `[[toc]]` directive existed. The scan below
+        // records only booleans/counts, so documents without TOC markers skip
+        // all TOC allocation while the heading count still lets us reserve the
+        // unique-id map once.
         self.toc_entries.clear();
         let document_scan = scan_document_for_render(document);
         self.document_has_toc_marker = document_scan.has_toc_marker;
@@ -112,9 +114,10 @@ impl HtmlRenderer {
         }
         self.heading_id_counts.clear();
         self.heading_id_counts.reserve(document_scan.heading_count);
-        // Build the autolink first-byte index once per render (it depends only
-        // on the immutable pattern list) so `write_text_with_autolinks` can
-        // reuse it instead of rebuilding a 256-byte table per text node.
+        // Build the autolink first-byte index once per render. It depends only
+        // on the immutable pattern list, not on the text node being rendered,
+        // so reusing it avoids rebuilding a 256-byte table on every inline
+        // text visit.
         self.autolink_index =
             if self.options.autolink_urls && !self.options.autolink_patterns.is_empty() {
                 Some(FirstByteIndex::from_patterns(&self.options.autolink_patterns))

--- a/crates/ox_content_renderer/src/html/renderer/code_block.rs
+++ b/crates/ox_content_renderer/src/html/renderer/code_block.rs
@@ -17,6 +17,13 @@ use super::super::code_annotations::{
 use super::HtmlRenderer;
 
 impl HtmlRenderer {
+    /// Builds the normalized render state for one fenced code block.
+    ///
+    /// The renderer only pays the expensive annotation parsers when annotation
+    /// output is enabled and the configured syntax can produce them. Plain code
+    /// blocks become a simple line list, while VitePress inline annotations and
+    /// meta annotations share the same `CodeLineRenderState` vector so later
+    /// rendering walks each line once.
     pub(in crate::html::renderer) fn build_code_block_state(
         &self,
         code_block: &CodeBlock<'_>,
@@ -96,6 +103,12 @@ impl HtmlRenderer {
         CodeBlockRenderState { language: info.language, title, line_numbers_start, lines }
     }
 
+    /// Emits annotated code lines from precomputed render state.
+    ///
+    /// Class names use `SmallVec` because typical lines have only one or two
+    /// classes, but focus/highlight/diff combinations can add a few more. This
+    /// keeps the common case stack-backed while still preserving de-duplication
+    /// when multiple annotations imply the same class.
     pub(in crate::html::renderer) fn write_code_lines(&mut self, state: &CodeBlockRenderState) {
         let has_focus = state.has_focus();
 

--- a/crates/ox_content_renderer/src/html/renderer/write.rs
+++ b/crates/ox_content_renderer/src/html/renderer/write.rs
@@ -27,10 +27,14 @@ impl HtmlRenderer {
         write_escaped_into(&mut self.output, s);
     }
 
-    /// Walks `s` and emits an `<a>` tag for each registered URL pattern
-    /// match, escaping the non-URL spans the normal way. Caller is expected
-    /// to have already gated this on the autolink flag — the function does
-    /// no flag checks of its own.
+    /// Walks `s` and emits an `<a>` tag for each registered URL pattern match.
+    ///
+    /// The caller has already gated on the autolink option and link nesting
+    /// state, so this routine can focus on the hot loop: use the per-render
+    /// first-byte index to jump to possible URL starts, escape the intervening
+    /// non-URL text in chunks, then write the matched URL once for `href` and
+    /// once for visible text. If the index is absent, we fail open by emitting
+    /// escaped text rather than rebuilding the index here.
     pub(in crate::html::renderer) fn write_text_with_autolinks(&mut self, s: &str) {
         crate::profile_span!("renderer::write_text_with_autolinks");
         let bytes = s.as_bytes();
@@ -161,10 +165,12 @@ impl HtmlRenderer {
     }
 
     /// Writes the heading's slugified id directly into `self.output`.
-    /// Avoids allocating a return `String`: the unique-heading hot path
-    /// now pays for exactly one `String` allocation (the slug clone that
-    /// becomes the map key) and the duplicate-heading path pays for
-    /// zero, since the `-N` suffix is written directly via `write!`.
+    ///
+    /// This avoids allocating a return `String`. The unique-heading path pays
+    /// for exactly one owned string, the slug clone that becomes the map key.
+    /// The duplicate-heading path pays for zero additional strings because the
+    /// existing scratch slug is written directly and the numeric suffix is
+    /// formatted into `self.output`.
     pub(in crate::html::renderer) fn write_heading_id(&mut self, heading: &Heading<'_>) {
         use std::fmt::Write as _;
 
@@ -180,10 +186,8 @@ impl HtmlRenderer {
             let n = *count;
             *count += 1;
             self.output.push_str(&self.heading_slug_scratch);
-            // `write!` into `String` is infallible; the formatter pushes
-            // bytes directly into the existing buffer with no formatted
-            // temporary string allocation.
-            // intermediate allocation.
+            // `write!` into `String` is infallible; the formatter pushes bytes
+            // directly into the existing buffer with no temporary allocation.
             let _ = write!(self.output, "-{n}");
             return;
         }

--- a/crates/ox_content_renderer/src/html/toc.rs
+++ b/crates/ox_content_renderer/src/html/toc.rs
@@ -54,6 +54,11 @@ pub(super) fn scan_document_for_render(document: &Document<'_>) -> DocumentRende
 }
 
 fn scan_node_for_render(node: &Node<'_>, scan: &mut DocumentRenderScan) {
+    // This traversal intentionally collects only facts that are free to derive:
+    // "does any paragraph equal the TOC marker?" and "how many headings exist?".
+    // It does not slugify headings or collect text. That keeps the no-TOC
+    // render path allocation-free while still giving `HtmlRenderer::render`
+    // enough information to reserve the heading-id map up front.
     match node {
         Node::Heading(_) => scan.heading_count += 1,
         Node::Paragraph(p) if !scan.has_toc_marker && is_toc_marker_paragraph(p) => {

--- a/crates/ox_content_search/src/query.rs
+++ b/crates/ox_content_search/src/query.rs
@@ -83,6 +83,9 @@ impl SearchIndex {
             let is_last = i == tokens.len() - 1;
 
             if is_last && options.prefix && token.len() >= MIN_PREFIX_MATCH_LEN {
+                // Prefix expansion is limited to the final token so a query
+                // like "render mar" can reuse exact postings for "render" and
+                // only scan vocabulary terms for the active completion token.
                 for term in self.index.keys().filter(|term| term.starts_with(token)) {
                     self.score_matching_term(term, &mut doc_scores);
                 }
@@ -91,8 +94,10 @@ impl SearchIndex {
             }
         }
 
-        // Sort and limit candidates before constructing result payloads. Snippet generation
-        // scans document bodies, so doing it only for returned results avoids wasted work.
+        // Sort and limit candidates before constructing result payloads.
+        // Snippet generation scans and lowercases document bodies, so doing it
+        // only for returned results avoids wasted work on documents that lose
+        // the ranking step.
         let mut ranked_docs: Vec<_> = doc_scores
             .into_iter()
             .filter(|(_, (score, _))| *score >= options.threshold)
@@ -151,6 +156,10 @@ impl SearchIndex {
                 * ((tf * (K1 + 1.0)) / K1.mul_add(1.0 - B + B * doc_len / self.avg_dl, tf))
                 * posting.field.boost();
 
+            // Accumulate in one per-document entry so repeated matches across
+            // query tokens do not allocate intermediate result rows. The small
+            // `matches` Vec is de-duplicated in place because it is surfaced in
+            // the final result payload.
             let entry = doc_scores.entry(posting.doc_idx).or_insert((0.0, Vec::new()));
             entry.0 += score;
             if !entry.1.iter().any(|matched| matched == term) {

--- a/crates/ox_content_search/src/search-runtime.js
+++ b/crates/ox_content_search/src/search-runtime.js
@@ -51,6 +51,9 @@ function matchesScopes(doc, scopes) {
     return true;
   }
 
+  // Scope checks run once per posting during scoring. Keep the transformation
+  // from doc id/url to cumulative scope strings isolated here so generated
+  // runtimes can cache it without touching BM25 scoring.
   const docScopes = new Set(getScopesForDoc(doc));
   return scopes.some((scope) => docScopes.has(scope));
 }
@@ -180,6 +183,9 @@ export async function search(query, options = {}) {
     const isLast = i === tokens.length - 1;
 
     if (prefix && isLast && token.length >= MIN_PREFIX_MATCH_LENGTH) {
+      // Only the active final token expands across the vocabulary. Completed
+      // tokens score exact postings, keeping multi-word queries from
+      // multiplying prefix scan cost by token count.
       for (const term in index.index) {
         if (term.startsWith(token)) {
           scoreTerm(term);
@@ -201,6 +207,9 @@ export async function search(query, options = {}) {
     })
     .slice(0, limit)
     .map(([docIdx, data]) => {
+      // Snippets require lowercasing and scanning the document body, so they
+      // are built only after ranking and limiting rather than for every scored
+      // candidate.
       const doc = index.documents[docIdx];
       const matches = Array.from(data.matches);
       const scopes = getScopesForDoc(doc);

--- a/crates/ox_content_ssg/src/assets.rs
+++ b/crates/ox_content_ssg/src/assets.rs
@@ -89,6 +89,11 @@ struct AssetCache {
 }
 
 impl AssetCache {
+    /// Returns an existing content-addressed chunk or creates it once.
+    ///
+    /// Multiple pages often share identical base CSS, plugin CSS, and client
+    /// runtime JS. Keying by full content means each unique payload is hashed
+    /// and written once, while every page receives the same public URL.
     fn get_or_create(
         &mut self,
         kind: AssetKind,
@@ -113,6 +118,11 @@ impl AssetCache {
 }
 
 /// Extracts shared CSS/JS chunks from generated HTML pages.
+///
+/// The Rust HTML generator emits marked style/script regions. This pass walks
+/// each generated page once, replaces those inline regions with links/scripts
+/// to content-addressed shared files, and preserves page-local inline CSS when
+/// externalizing would break relative `url(...)` references.
 #[must_use]
 pub fn externalize_shared_page_assets(
     pages: Vec<GeneratedHtmlPage>,
@@ -179,6 +189,10 @@ fn build_style_replacement(
     out_dir: &str,
     base: &str,
 ) -> String {
+    // CSS is split by `ox-content:css:*` section markers so globally shared
+    // base/footer/plugin styles can become cacheable files while page-specific
+    // theme overrides may stay inline. Without this split every page's full
+    // `<style>` block would differ as soon as theme CSS differed.
     let sections = extract_css_sections(css_content);
     let effective_sections = if sections.is_empty() {
         vec![CssSection { name: "css".to_string(), content: css_content.trim().to_string() }]
@@ -234,6 +248,10 @@ fn build_script_replacement(
     out_dir: &str,
     base: &str,
 ) -> String {
+    // The search UI runtime is large and only needed after the user opens
+    // search. Split it into its own deferred chunk and replace the placeholder
+    // in the core runtime with that chunk URL. If the marker is absent, fall
+    // back to one shared JS asset for the whole script block.
     if let Some(search_chunk) = find_search_chunk(js_content) {
         if js_content.contains(SEARCH_CHUNK_PLACEHOLDER) {
             let search_content = search_chunk.content.trim();
@@ -294,6 +312,9 @@ fn create_shared_asset_chunk(
 }
 
 fn create_content_hash(content: &str) -> String {
+    // Five SHA-256 bytes are enough for stable cache-busting filenames here:
+    // chunks are generated per site build, not used as a security boundary, and
+    // the content map above still de-duplicates exact matches before hashing.
     let hash = Sha256::digest(content.as_bytes());
     let mut output = String::with_capacity(10);
     for byte in hash.iter().take(5) {
@@ -332,6 +353,9 @@ fn to_public_asset_path(base: &str, file_name: &str) -> String {
 }
 
 fn extract_css_sections(css_content: &str) -> Vec<CssSection> {
+    // Section markers are emitted as CSS comments, so they survive template
+    // rendering and minification-free builds. Parse with string searches rather
+    // than regex to keep this pass cheap over the full page stylesheet.
     let mut sections = Vec::new();
     let mut cursor = 0;
 
@@ -365,6 +389,9 @@ fn extract_css_sections(css_content: &str) -> Vec<CssSection> {
 }
 
 fn has_relative_css_urls(css: &str) -> bool {
+    // Relative URLs are resolved relative to the HTML page when CSS is inline,
+    // but relative to `/assets/...` after extraction. Detect those sections and
+    // leave them inline rather than rewriting every CSS URL.
     let mut cursor = 0;
     let bytes = css.as_bytes();
 

--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -778,15 +778,25 @@ fn wrap_css_section(name: &str, css: &str) -> String {
         return String::new();
     }
 
+    // These markers let `externalize_shared_page_assets` split one generated
+    // `<style>` block into stable shared chunks. They are CSS comments, so the
+    // page remains valid even before the extraction pass runs.
     format!("/* ox-content:css:{name}:start */\n{css}\n/* ox-content:css:{name}:end */\n")
 }
 
 fn page_content_contains_any(content: &str, needles: &[&str]) -> bool {
+    // Page asset detection checks for a small set of HTML markers in the final
+    // content. `memmem` keeps each probe on optimized byte search instead of
+    // Rust's substring machinery, and the caller short-circuits as soon as one
+    // marker is present.
     let haystack = content.as_bytes();
     needles.iter().any(|needle| memmem::find(haystack, needle.as_bytes()).is_some())
 }
 
 fn escape_html(value: &str) -> String {
+    // SSG escaping favors predictable allocation over chained `replace()`:
+    // allocate once at the input length, stream characters into the output,
+    // and let `String` grow only if replacements make the result longer.
     let mut output = String::with_capacity(value.len());
     for ch in value.chars() {
         match ch {
@@ -892,6 +902,9 @@ pub fn generate_html(page_data: &PageData, nav_groups: &[NavGroup], config: &Ssg
 
     // Check if this is an entry page
     let is_entry_page = page_data.entry_page.is_some();
+    // Build CSS as named sections instead of one anonymous blob. Shared,
+    // content-addressed extraction can then pull out only the sections that are
+    // globally cacheable and keep page-specific or relative-url CSS inline.
     let mut css_sections = vec![wrap_css_section("base", SSG_CSS)];
 
     if is_entry_page {

--- a/crates/ox_content_ssg/src/ssg.js
+++ b/crates/ox_content_ssg/src/ssg.js
@@ -206,9 +206,11 @@ const getOxContentScopesForDoc = (doc) => {
 
 const matchesOxContentScopes = (doc, scopes) => {
   if (!scopes.length) return true;
-  // A doc's scopes derive only from its (immutable) id/url, but this runs once
-  // per posting per term — the same doc is revisited many times in a query.
-  // Cache the Set on the doc so it's built once for the index's lifetime.
+  // A doc's scopes derive only from its immutable id/url, but this predicate
+  // runs once per posting per term. The same doc is therefore revisited many
+  // times during a single query and across subsequent keystrokes. Cache the
+  // Set on the document object so scope membership becomes one property read
+  // plus `Set.has` for the rest of the index lifetime.
   const docScopes = doc.__oxScopes || (doc.__oxScopes = new Set(getOxContentScopesForDoc(doc)));
   return scopes.some((scope) => docScopes.has(scope));
 };
@@ -279,9 +281,10 @@ const scoreOxContentSearchTerms = (searchIndex, parsedQuery, tokens) => {
       isLast = i === tokens.length - 1;
     const terms =
       isLast && token.length >= 2
-        ? // Prefix expansion scans the whole vocabulary. Materialize the term
-          // list once and reuse it across keystrokes instead of rebuilding the
-          // `Object.keys` array on every query.
+        ? // Prefix expansion scans the whole vocabulary. Materialize the
+          // vocabulary key list once and reuse it across keystrokes instead of
+          // rebuilding `Object.keys(searchIndex.index)` on every query. The
+          // final `filter` still runs per query because the prefix changes.
           (
             searchIndex.__oxIndexKeys ||
             (searchIndex.__oxIndexKeys = Object.keys(searchIndex.index))
@@ -313,8 +316,9 @@ const addOxContentTermScores = (searchIndex, scores, scopes, terms, k1, b) => {
             (posting.tf + k1 * (1 - b + (b * doc.body.length) / searchIndex.avg_dl))) *
           boost;
 
-      // One Map lookup in the steady state (entry present) instead of the
-      // has/get pair; this runs once per posting per term on every keystroke.
+      // One Map lookup in the steady state instead of `has` followed by `get`.
+      // This runs once per posting per term on every keystroke, so removing
+      // the duplicate lookup matters more than the few cold inserts.
       let entry = scores.get(posting.doc_idx);
       if (entry === undefined) {
         entry = { score: 0, matches: new Set() };

--- a/crates/ox_content_wasm/src/lib.rs
+++ b/crates/ox_content_wasm/src/lib.rs
@@ -174,7 +174,9 @@ pub fn transform(source: &str, options: Option<WasmParserOptions>) -> JsValue {
     let opts = options.unwrap_or_default();
     let toc_max_depth = opts.toc_max_depth;
 
-    // Parse frontmatter
+    // Parse frontmatter into a borrowed content slice. In the common "no
+    // frontmatter" case this avoids allocating a second Markdown string before
+    // handing the source to the parser.
     let (content, frontmatter) = parse_frontmatter(source);
 
     // Parse markdown
@@ -225,6 +227,9 @@ pub fn version() -> String {
 
 /// Parses YAML frontmatter from Markdown content.
 fn parse_frontmatter(source: &str) -> (Cow<'_, str>, HashMap<String, serde_json::Value>) {
+    // wasm-bindgen exposes the JS string as `&str` for this call. Return
+    // `Cow::Borrowed` for the Markdown body so stripping frontmatter adjusts
+    // slice boundaries instead of copying the body into a new `String`.
     let mut frontmatter = HashMap::new();
 
     if !source.starts_with("---") {

--- a/npm/vite-plugin-ox-content/src/lint.ts
+++ b/npm/vite-plugin-ox-content/src/lint.ts
@@ -595,6 +595,9 @@ function createStandardSpellcheckSettings(
 }
 
 async function loadCspellLib(): Promise<typeof import("cspell-lib")> {
+  // CSpell is optional and relatively heavy; lazy-load it only when standard
+  // dictionaries are enabled, then reuse the same module promise for all files
+  // in the lint run.
   cspellLibPromise ??= import("cspell-lib");
   return cspellLibPromise;
 }

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -337,6 +337,9 @@ async function externalizeSharedPageAssets(
   outDir: string,
   base: string,
 ): Promise<{ pages: GeneratedHtmlPage[]; assets: string[] }> {
+  // Asset extraction is batched after all pages are rendered so the Rust side
+  // can de-duplicate identical CSS/JS chunks across the whole build. Doing it
+  // page-by-page would miss shared chunks and write duplicate assets.
   const mod = await importNapiModule();
   const optimized = mod.externalizeSsgAssets(pages, outDir, base) as {
     pages: GeneratedHtmlPage[];
@@ -659,6 +662,10 @@ async function transformSsgPage(
 }
 
 async function transformSsgHtml(html: string, options: ResolvedOptions): Promise<string> {
+  // Mermaid SVGs are protected before plugin transforms because some transforms
+  // still use HTML parser/stringifier steps that can corrupt SVG foreignObject
+  // markup. The protect/restore pair keeps the rest of the pipeline free to
+  // operate on normal HTML strings.
   const { html: protectedHtml, svgs: mermaidSvgs } = protectMermaidSvgs(html);
   const pluginOptions: TransformAllOptions = {
     tabs: true,
@@ -858,6 +865,9 @@ async function writeGeneratedPages(
   context: BuildSsgContext,
   generatedFiles: string[],
 ): Promise<void> {
+  // Shared asset extraction needs the complete page set to maximize
+  // de-duplication. Only after replacement do we write pages and record both
+  // the generated assets and the rewritten HTML files.
   const optimizedOutput = await externalizeSharedPageAssets(
     generatedPages,
     context.outDir,


### PR DESCRIPTION
## Summary

- Add detailed comments for parser, renderer, docs, SSG, search, NAPI, WASM, and LSP optimization hot paths traced from the repository's `perf*` commit history.
- Document why byte dispatch, memchr/memmem scans, arena pre-sizing, scratch buffers, cache maps, and shared asset extraction are structured the way they are.
- Align raw mdast transfer with the existing source-length arena sizing helper so it follows the documented allocator optimization.

## Validation

- `cargo test --workspace`
- `pnpm --filter @ox-content/vite-plugin typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782929383&installation_id=136613492&pr_number=291&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F291&signature=40d85f4768e3678f193175d052c4bfd37eed98f08a5ff5fd3b092f5220ddab98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->