### PR TITLE
fix(docs): render `@experimental` and `@deprecated` as GitHub alerts in markdown output

### DIFF
--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -1043,6 +1043,12 @@ fn generate_typedoc_module_index(
     builder.push_str("\n\n");
     let mut markdown = builder.into_string();
 
+    // Module-level `@experimental` / `@deprecated` render as GitHub alerts just
+    // below the title (markdown render style only; HTML keeps its own structure).
+    if options.render_style == MarkdownRenderStyle::Markdown {
+        markdown.push_str(&markdown_pure::render_lifecycle_alerts(&doc.tags, Some(&link_context)));
+    }
+
     let description = process_doc_text(&doc.description, Some(&link_context));
     let description = description.trim();
     if !description.is_empty() {
@@ -3046,6 +3052,138 @@ mod tests {
         assert!(default_page.contains("<a href=\"/api/default/interfaces/Command\">Command</a>"));
         assert!(plugin_page.contains("<a href=\"/api/plugin/interfaces/Command\">Command</a>"));
         assert!(!default_page.contains(".md"));
+    }
+
+    fn lifecycle_module(entry: ApiDocEntry) -> Vec<ApiDocModule> {
+        vec![ApiDocModule {
+            description: String::new(),
+            file: "combinators".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![entry],
+        }]
+    }
+
+    fn markdown_typedoc_options() -> MarkdownDocsOptions {
+        MarkdownDocsOptions {
+            path_strategy: MarkdownPathStrategy::TypeDoc,
+            render_style: MarkdownRenderStyle::Markdown,
+            ..MarkdownDocsOptions::default()
+        }
+    }
+
+    #[test]
+    fn typedoc_renders_experimental_tag_as_warning_alert() {
+        let mut entry =
+            test_entry("string", "function", "/repo/src/combinators.ts", "Create a string schema.");
+        entry.tags = vec![ApiDocTag { tag: "experimental".to_string(), value: String::new() }];
+        let out = generate_markdown(&lifecycle_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/functions/string.md").unwrap();
+
+        assert!(page.contains(
+            "> [!WARNING]\n> This API is experimental and may change in future versions."
+        ));
+        // Lifecycle tags move to the alert, not the generic Tags section.
+        assert!(!page.contains("## Tags"));
+        assert!(!page.contains("@experimental"));
+        assert!(!page.contains("**Deprecated.**"));
+    }
+
+    #[test]
+    fn typedoc_renders_deprecated_tag_as_caution_alert_with_body() {
+        let mut entry =
+            test_entry("oldDefine", "function", "/repo/src/definition.ts", "Old helper.");
+        entry.tags = vec![ApiDocTag {
+            tag: "deprecated".to_string(),
+            value: "Use `define` instead.".to_string(),
+        }];
+        let out = generate_markdown(&lifecycle_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/functions/oldDefine.md").unwrap();
+
+        assert!(page.contains("> [!CAUTION]\n> Use `define` instead."));
+        assert!(!page.contains("## Tags"));
+    }
+
+    #[test]
+    fn typedoc_keeps_non_lifecycle_tags_in_tags_section() {
+        let mut entry = test_entry("run", "function", "/repo/src/run.ts", "Run it.");
+        entry.tags = vec![
+            ApiDocTag { tag: "since".to_string(), value: "1.0.0".to_string() },
+            ApiDocTag { tag: "experimental".to_string(), value: String::new() },
+        ];
+        let out = generate_markdown(&lifecycle_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/functions/run.md").unwrap();
+
+        assert!(page.contains("> [!WARNING]"));
+        assert!(page.contains("## Tags"));
+        assert!(page.contains("`@since`"));
+        assert!(!page.contains("`@experimental`"));
+    }
+
+    #[test]
+    fn typedoc_marks_experimental_members_in_table() {
+        let mut entry =
+            test_entry("StringOptions", "interface", "/repo/src/combinators.ts", "String options.");
+        entry.members = vec![ApiDocMember {
+            name: "minLength".to_string(),
+            kind: "property".to_string(),
+            description: "Minimum string length.".to_string(),
+            signature: None,
+            type_annotation: Some("number".to_string()),
+            params: vec![],
+            returns: None,
+            optional: true,
+            readonly: false,
+            r#static: false,
+            private: false,
+            tags: vec![ApiDocTag { tag: "experimental".to_string(), value: String::new() }],
+            line: 1,
+            end_line: 1,
+        }];
+        let out = generate_markdown(&lifecycle_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/interfaces/StringOptions.md").unwrap();
+
+        assert!(page.contains("**Experimental.** Minimum string length."));
+    }
+
+    #[test]
+    fn typedoc_renders_module_level_experimental_alert() {
+        let docs = vec![ApiDocModule {
+            description: "Parser combinator entry point.".to_string(),
+            file: "combinators".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![ApiDocTag {
+                tag: "experimental".to_string(),
+                value: "This module is experimental and may change in future versions.".to_string(),
+            }],
+            entries: vec![test_entry("string", "function", "/repo/src/combinators.ts", "S.")],
+        }];
+        let out = generate_markdown(&docs, &markdown_typedoc_options());
+        let index = out.get("combinators/index.md").unwrap();
+
+        // Alert sits between the title and the description.
+        assert!(index.contains(
+            "# combinators\n\n> [!WARNING]\n> This module is experimental and may change in future versions.\n\nParser combinator entry point."
+        ));
+    }
+
+    #[test]
+    fn typedoc_resolves_links_in_lifecycle_alert_body() {
+        let mut entry = test_entry("string", "function", "/repo/src/combinators.ts", "S.");
+        entry.tags = vec![ApiDocTag {
+            tag: "deprecated".to_string(),
+            value: "Use {@link integer} instead.".to_string(),
+        }];
+        let mut docs = lifecycle_module(entry);
+        docs[0].entries.push(test_entry("integer", "function", "/repo/src/combinators.ts", "I."));
+        let out = generate_markdown(&docs, &markdown_typedoc_options());
+        let page = out.get("combinators/functions/string.md").unwrap();
+
+        assert!(page.contains("> [!CAUTION]"));
+        assert!(page.contains("Use [integer](./integer.md) instead."));
+        assert!(!page.contains("{@link"));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -11,8 +11,46 @@ use super::{
     parse_example_block, process_doc_text, EntryStats, MarkdownDisplayFormat, MarkdownDocsOptions,
     MarkdownLinkContext,
 };
-use crate::model::{ApiDocEntry, ApiDocMember, ApiParamDoc, ApiTypeParamDoc};
+use crate::model::{ApiDocEntry, ApiDocMember, ApiDocTag, ApiParamDoc, ApiTypeParamDoc};
 use crate::string_builder::StringBuilder;
+
+/// JSDoc lifecycle tags rendered as GitHub alerts rather than generic `## Tags`
+/// entries: `@experimental` → `> [!WARNING]`, `@deprecated` → `> [!CAUTION]`.
+const LIFECYCLE_TAGS: [&str; 2] = ["deprecated", "experimental"];
+
+/// Renders GitHub alert blocks for the lifecycle tags (`@experimental`,
+/// `@deprecated`) present in `tags`, in source order. Uses the tag's own text as
+/// the alert body (with `{@link}` resolved), falling back to a default message.
+/// Returns an empty string when no lifecycle tag is present.
+pub(super) fn render_lifecycle_alerts(
+    tags: &[ApiDocTag],
+    context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    let mut out = String::new();
+    for tag in tags {
+        let (kind, default) = match tag.tag.as_str() {
+            "deprecated" => {
+                ("CAUTION", "This API is deprecated and may be removed in a future version.")
+            }
+            "experimental" => {
+                ("WARNING", "This API is experimental and may change in future versions.")
+            }
+            _ => continue,
+        };
+        let body = inline(&tag.value, context);
+        let body = if body.is_empty() { default } else { body.as_str() };
+        out.push_str("> [!");
+        out.push_str(kind);
+        out.push_str("]\n");
+        for line in body.lines() {
+            out.push_str("> ");
+            out.push_str(line);
+            out.push('\n');
+        }
+        out.push('\n');
+    }
+    out
+}
 
 /// Renders the per-page stats summary as a single italic Markdown line.
 pub(super) fn render_stats_markdown(stats: &EntryStats, module_count: Option<usize>) -> String {
@@ -73,9 +111,9 @@ pub(super) fn render_entry_body_pure(
     let mut out = String::new();
     let heading = "#".repeat(section_level);
 
-    if entry.tags.iter().any(|tag| tag.tag == "deprecated") {
-        out.push_str("**Deprecated.**\n\n");
-    }
+    // Lifecycle tags (`@experimental` / `@deprecated`) render as GitHub alerts
+    // near the summary instead of a generic `## Tags` entry.
+    out.push_str(&render_lifecycle_alerts(&entry.tags, context));
 
     let description = process_doc_text(&entry.description, context);
     let description = description.trim();
@@ -204,10 +242,16 @@ pub(super) fn render_entry_body_pure(
         }
     }
 
-    if !entry.tags.is_empty() {
+    // Lifecycle tags are rendered as alerts above, so exclude them here.
+    let other_tags = entry
+        .tags
+        .iter()
+        .filter(|tag| !LIFECYCLE_TAGS.contains(&tag.tag.as_str()))
+        .collect::<Vec<_>>();
+    if !other_tags.is_empty() {
         out.push_str(&heading);
         out.push_str(" Tags\n\n");
-        for tag in &entry.tags {
+        for tag in other_tags {
             let value = inline(&tag.value, context);
             out.push_str("- `@");
             out.push_str(&tag.tag);
@@ -439,15 +483,27 @@ fn member_type(member: &ApiDocMember) -> &str {
 
 fn member_description(member: &ApiDocMember, context: Option<&MarkdownLinkContext<'_>>) -> String {
     let mut description = String::new();
+    // Lifecycle tags cannot hold a GitHub alert inside a table cell, so surface
+    // them as a short bold marker prefix instead.
+    let push_part = |description: &mut String, part: &str| {
+        if !description.is_empty() {
+            description.push(' ');
+        }
+        description.push_str(part);
+    };
+    if member.tags.iter().any(|tag| tag.tag == "deprecated") {
+        push_part(&mut description, "**Deprecated.**");
+    }
+    if member.tags.iter().any(|tag| tag.tag == "experimental") {
+        push_part(&mut description, "**Experimental.**");
+    }
     if !member.description.is_empty() {
-        description.push_str(&inline(&member.description, context));
+        push_part(&mut description, &inline(&member.description, context));
     }
     if let Some(returns) = &member.returns {
         if !returns.description.is_empty() {
-            if !description.is_empty() {
-                description.push(' ');
-            }
-            description.push_str("Returns: ");
+            push_part(&mut description, "Returns:");
+            description.push(' ');
             description.push_str(&inline(&returns.description, context));
         }
     }


### PR DESCRIPTION
## Background

`@experimental` and `@deprecated` are API lifecycle signals, but under `generateDocsMarkdown(..., { renderStyle: 'markdown' })` ox-content did not surface them prominently:

- Module-level `@experimental` was carried in the model (since #292) but never rendered on `{module}/index.md`.
- Symbol-level `@experimental` was only listed as a generic `## Tags` entry (`- @experimental`) at the bottom of the page; `@deprecated` rendered as a weak `**Deprecated.**` bold line.
- Member/property tables showed no lifecycle marker.

gunshi prefers GitHub Alert syntax over TypeDoc's inline bold modifier, since alerts are far more visible in GitHub/VitePress:

- `@experimental` → `> [!WARNING]`
- `@deprecated` → `> [!CAUTION]`

The data was already wired end-to-end by #292 (`ApiDocModule.tags`, `ApiDocEntry.tags`, `ApiDocMember.tags`), so this is purely a rendering change in the markdown render style.

## Summary

All changes are in the pure-markdown renderer (`markdown_pure.rs`) and the module index (`markdown.rs`); the extractor, model, NAPI types, `docs.json`, and the HTML render style are unchanged.

- Lifecycle alerts: A shared `render_lifecycle_alerts` helper emits `> [!WARNING]` for `@experimental` and `> [!CAUTION]` for `@deprecated`. The tag's own text (with `{@link}` resolved) becomes the alert body, falling back to a sensible default when the tag has no text.
- Symbol pages: The alert renders near the declaration summary (replacing the old `**Deprecated.**` line). `@experimental`/`@deprecated` are removed from the generic `## Tags` section to avoid duplication; other tags (e.g. `@since`) stay.
- Module index: Module-level `@experimental`/`@deprecated` render as an alert just below the `# Title`, before the description (markdown render style only).
- Member tables: Since alert blocks cannot live inside a table cell, member descriptions are prefixed with a short `**Experimental.**` / `**Deprecated.**` marker.

```md
# combinators

> [!WARNING]
> This module is experimental and may change in future versions.

Parser combinator entry point.
```

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782968806&installation_id=136613492&pr_number=293&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F293&signature=9d28d33fd416dffe06a4e530c851c5f66cb5932ffa50ba9e14d3a8ce16de4280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->