### PR TITLE
perf(docs): reduce markdown renderer allocations

### DIFF
--- a/crates/ox_content_docs/src/data.rs
+++ b/crates/ox_content_docs/src/data.rs
@@ -15,7 +15,7 @@ struct EntryStats {
     returns: u32,
     examples: u32,
     deprecated: u32,
-    by_kind: Map<String, Value>,
+    by_kind: [u32; DOC_KIND_ORDER.len()],
 }
 
 /// Generates the machine-readable docs data JSON payload.
@@ -41,8 +41,9 @@ fn build_docs_summary(docs: &[ApiDocModule]) -> Value {
         stats.examples += module.examples.len() as u32;
         for entry in &module.entries {
             stats.entries += 1;
-            let count = stats.by_kind.get(&entry.kind).and_then(Value::as_u64).unwrap_or(0) + 1;
-            stats.by_kind.insert(entry.kind.clone(), json!(count));
+            if let Some(index) = doc_kind_index(&entry.kind) {
+                stats.by_kind[index] += 1;
+            }
             stats.members += entry.members.len() as u32;
             stats.params += entry.params.len() as u32;
             stats.returns += u32::from(entry.returns.is_some());
@@ -52,9 +53,10 @@ fn build_docs_summary(docs: &[ApiDocModule]) -> Value {
     }
 
     let mut by_kind = Map::new();
-    for kind in DOC_KIND_ORDER {
-        if let Some(count) = stats.by_kind.get(kind) {
-            by_kind.insert(kind.to_string(), count.clone());
+    for (index, kind) in DOC_KIND_ORDER.iter().enumerate() {
+        let count = stats.by_kind[index];
+        if count > 0 {
+            by_kind.insert((*kind).to_string(), json!(count));
         }
     }
 
@@ -68,6 +70,19 @@ fn build_docs_summary(docs: &[ApiDocModule]) -> Value {
         "examples": stats.examples,
         "deprecated": stats.deprecated,
     })
+}
+
+fn doc_kind_index(kind: &str) -> Option<usize> {
+    match kind {
+        "function" => Some(0),
+        "class" => Some(1),
+        "interface" => Some(2),
+        "type" => Some(3),
+        "enum" => Some(4),
+        "variable" => Some(5),
+        "module" => Some(6),
+        _ => None,
+    }
 }
 
 fn module_to_json(module: &ApiDocModule) -> Value {

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -154,7 +154,7 @@ fn default_group_by() -> String {
 #[derive(Debug, Clone, Default)]
 struct EntryStats {
     entries: usize,
-    by_kind: BTreeMap<String, usize>,
+    by_kind: [usize; DOC_KIND_ORDER.len()],
     members: usize,
     params: usize,
     returns: usize,
@@ -452,27 +452,38 @@ fn typedoc_kind_singular(kind: &str) -> &'static str {
     TYPEDOC_KIND_SINGULAR.get(kind).copied().unwrap_or("Symbol")
 }
 
-/// TypeDoc-style H1 title for a per-symbol page, e.g. `Function: args()`,
-/// `Interface: Command<G>`, `Variable: CLI_OPTIONS_DEFAULT`. Functions append
-/// `()` (no type parameters); other kinds append `<…>` when generic.
-fn typedoc_entry_page_title(entry: &ApiDocEntry) -> String {
-    let mut title = String::new();
-    title.push_str(typedoc_kind_singular(&entry.kind));
-    title.push_str(": ");
-    title.push_str(&entry.name);
+fn typedoc_entry_page_title_len(entry: &ApiDocEntry) -> usize {
+    let mut len = typedoc_kind_singular(&entry.kind).len() + ": ".len() + entry.name.len();
     if entry.kind == "function" {
-        title.push_str("()");
+        len += "()".len();
     } else if !entry.type_parameters.is_empty() {
-        title.push('<');
+        len += "<>".len();
+        len += entry.type_parameters.iter().map(|type_param| type_param.name.len()).sum::<usize>();
+        len += ", ".len() * entry.type_parameters.len().saturating_sub(1);
+    }
+    len
+}
+
+/// Appends a TypeDoc-style H1 title for a per-symbol page, e.g.
+/// `Function: args()`, `Interface: Command<G>`, `Variable: CLI_OPTIONS_DEFAULT`.
+/// Functions append `()` (no type parameters); other kinds append `<...>` when
+/// generic.
+fn push_typedoc_entry_page_title(out: &mut String, entry: &ApiDocEntry) {
+    out.push_str(typedoc_kind_singular(&entry.kind));
+    out.push_str(": ");
+    out.push_str(&entry.name);
+    if entry.kind == "function" {
+        out.push_str("()");
+    } else if !entry.type_parameters.is_empty() {
+        out.push('<');
         for (index, type_param) in entry.type_parameters.iter().enumerate() {
             if index > 0 {
-                title.push_str(", ");
+                out.push_str(", ");
             }
-            title.push_str(&type_param.name);
+            out.push_str(&type_param.name);
         }
-        title.push('>');
+        out.push('>');
     }
-    title
 }
 
 fn typedoc_entry_file_name(module_name: &str, entry: &ApiDocEntry) -> String {
@@ -714,7 +725,9 @@ fn summarize_entries<'a>(entries: impl IntoIterator<Item = &'a ApiDocEntry>) -> 
 
     for entry in entries {
         stats.entries += 1;
-        *stats.by_kind.entry(entry.kind.clone()).or_default() += 1;
+        if let Some(index) = doc_kind_index(&entry.kind) {
+            stats.by_kind[index] += 1;
+        }
         stats.members += entry.members.len();
         stats.params += entry.params.len();
         stats.returns += usize::from(entry.returns.is_some());
@@ -735,6 +748,19 @@ fn summarize_docs(docs: &[ApiDocModule]) -> EntryStats {
     let mut stats = summarize_entries(docs.iter().flat_map(|doc| doc.entries.iter()));
     stats.examples += docs.iter().map(|doc| doc.examples.len()).sum::<usize>();
     stats
+}
+
+fn doc_kind_index(kind: &str) -> Option<usize> {
+    match kind {
+        "function" => Some(0),
+        "class" => Some(1),
+        "interface" => Some(2),
+        "type" => Some(3),
+        "enum" => Some(4),
+        "variable" => Some(5),
+        "module" => Some(6),
+        _ => None,
+    }
 }
 
 fn doc_kind_plural(kind: &str) -> &'static str {
@@ -1069,7 +1095,7 @@ fn generate_typedoc_module_index(
     // Module-level `@experimental` / `@deprecated` render as GitHub alerts just
     // below the title (markdown render style only; HTML keeps its own structure).
     if options.render_style == MarkdownRenderStyle::Markdown {
-        markdown.push_str(&markdown_pure::render_lifecycle_alerts(&doc.tags, Some(&link_context)));
+        markdown_pure::push_lifecycle_alerts(&mut markdown, &doc.tags, Some(&link_context));
     }
 
     let description = process_doc_text(&doc.description, Some(&link_context));
@@ -1225,28 +1251,23 @@ fn generate_typedoc_entry_page(
     };
     // TypeDoc-style H1 includes the declaration kind (and generics / `()`),
     // e.g. `# Function: cli()`, `# Interface: Command<G>`.
-    let title = typedoc_entry_page_title(entry);
-    if options.render_style == MarkdownRenderStyle::Markdown {
+    let title_len = typedoc_entry_page_title_len(entry);
+    let body = if options.render_style == MarkdownRenderStyle::Markdown {
         // Per-symbol page: title is `# {title}` (H1), so sections render at H2.
-        let body = markdown_pure::render_entry_body_pure(entry, options, Some(&link_context), 2);
-        let mut builder = StringBuilder::with_capacity(title.len() + 4);
-        builder.push_str("# ");
-        builder.push_str(&title);
-        builder.push_str("\n\n");
-        let mut markdown = builder.into_string();
-        if !body.is_empty() {
-            markdown.push_str(&body);
+        markdown_pure::render_entry_body_pure(entry, options, Some(&link_context), 2)
+    } else {
+        markdown_html::render_entry_page_html(entry, options, Some(&link_context))
+    };
+    let mut markdown = String::with_capacity(title_len + 4 + body.len() + 1);
+    markdown.push_str("# ");
+    push_typedoc_entry_page_title(&mut markdown, entry);
+    markdown.push_str("\n\n");
+    if !body.is_empty() {
+        markdown.push_str(&body);
+        if options.render_style == MarkdownRenderStyle::Markdown {
             markdown.push('\n');
         }
-        return markdown;
     }
-
-    let mut builder = StringBuilder::with_capacity(title.len() + 4);
-    builder.push_str("# ");
-    builder.push_str(&title);
-    builder.push_str("\n\n");
-    let mut markdown = builder.into_string();
-    markdown.push_str(&markdown_html::render_entry_page_html(entry, options, Some(&link_context)));
     markdown
 }
 
@@ -1388,20 +1409,20 @@ fn get_entry_badges(entry: &ApiDocEntry) -> Vec<EntryBadge> {
     badges
 }
 
-fn parse_example_block(example: &str) -> (String, String) {
+fn parse_example_block(example: &str) -> (&str, &str) {
     static FENCE_RE: RegexCache = OnceLock::new();
 
     let trimmed = example.trim();
     let Some(fence_re) = cached_regex(&FENCE_RE, r"(?s)^```([\w-]+)?[^\n]*\n(.*?)\n?```$") else {
-        return (trimmed.to_string(), "ts".to_string());
+        return (trimmed, "ts");
     };
 
     if let Some(captures) = fence_re.captures(trimmed) {
-        let language = captures.get(1).map_or("ts", |value| value.as_str()).to_string();
-        let code = captures.get(2).map_or("", |value| value.as_str()).to_string();
+        let language = captures.get(1).map_or("ts", |value| value.as_str());
+        let code = captures.get(2).map_or("", |value| value.as_str());
         (code, language)
     } else {
-        (trimmed.to_string(), "ts".to_string())
+        (trimmed, "ts")
     }
 }
 
@@ -1413,9 +1434,9 @@ fn render_module_examples_markdown(examples: &[String]) -> String {
     for example in examples {
         let (code, language) = parse_example_block(example);
         out.push_str("```");
-        out.push_str(&language);
+        out.push_str(language);
         out.push('\n');
-        out.push_str(&code);
+        out.push_str(code);
         out.push_str("\n```\n\n");
     }
     out

--- a/crates/ox_content_docs/src/markdown/markdown_html.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_html.rs
@@ -379,8 +379,9 @@ pub(super) fn render_stats_html(stats: &EntryStats, module_count: Option<usize>)
 
     push_stat_html(&mut rendered_items, "symbols", stats.entries, None);
 
-    for kind in DOC_KIND_ORDER {
-        if let Some(count) = stats.by_kind.get(kind).copied().filter(|count| *count > 0) {
+    for (index, kind) in DOC_KIND_ORDER.iter().enumerate() {
+        let count = stats.by_kind[index];
+        if count > 0 {
             push_stat_html(&mut rendered_items, doc_kind_plural(kind), count, None);
         }
     }
@@ -429,7 +430,7 @@ pub(super) fn render_module_examples_html(examples: &[String]) -> String {
             "</div>
 ",
         );
-        examples_html.push_str(&render_code_block_html(&code, &language));
+        examples_html.push_str(&render_code_block_html(code, language));
         examples_html.push_str(
             "
 </div>",
@@ -1248,7 +1249,7 @@ fn render_entry_body_html(
                 "</div>
 ",
             );
-            examples_html.push_str(&render_code_block_html(&code, &language));
+            examples_html.push_str(&render_code_block_html(code, language));
             examples_html.push_str(
                 "
 </div>",

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -16,17 +16,14 @@ use crate::string_builder::StringBuilder;
 
 /// JSDoc lifecycle tags rendered as GitHub alerts rather than generic `## Tags`
 /// entries: `@experimental` → `> [!WARNING]`, `@deprecated` → `> [!CAUTION]`.
-const LIFECYCLE_TAGS: [&str; 2] = ["deprecated", "experimental"];
-
-/// Renders GitHub alert blocks for the lifecycle tags (`@experimental`,
+/// Appends GitHub alert blocks for lifecycle tags (`@experimental`,
 /// `@deprecated`) present in `tags`, in source order. Uses the tag's own text as
 /// the alert body (with `{@link}` resolved), falling back to a default message.
-/// Returns an empty string when no lifecycle tag is present.
-pub(super) fn render_lifecycle_alerts(
+pub(super) fn push_lifecycle_alerts(
+    out: &mut String,
     tags: &[ApiDocTag],
     context: Option<&MarkdownLinkContext<'_>>,
-) -> String {
-    let mut out = String::new();
+) {
     for tag in tags {
         let (kind, default) = match tag.tag.as_str() {
             "deprecated" => {
@@ -37,8 +34,17 @@ pub(super) fn render_lifecycle_alerts(
             }
             _ => continue,
         };
-        let body = inline(&tag.value, context);
-        let body = if body.is_empty() { default } else { body.as_str() };
+        let body_storage;
+        let body = if tag.value.trim().is_empty() {
+            default
+        } else {
+            body_storage = inline(&tag.value, context);
+            if body_storage.is_empty() {
+                default
+            } else {
+                body_storage.as_str()
+            }
+        };
         out.push_str("> [!");
         out.push_str(kind);
         out.push_str("]\n");
@@ -49,7 +55,10 @@ pub(super) fn render_lifecycle_alerts(
         }
         out.push('\n');
     }
-    out
+}
+
+fn is_lifecycle_tag(tag: &str) -> bool {
+    matches!(tag, "deprecated" | "experimental")
 }
 
 /// Renders the per-page stats summary as a single italic Markdown line.
@@ -61,8 +70,9 @@ pub(super) fn render_stats_markdown(stats: &EntryStats, module_count: Option<usi
         push_stat_part(&mut out, &mut has_parts, module_count, "modules");
     }
     push_stat_part(&mut out, &mut has_parts, stats.entries, "symbols");
-    for kind in super::DOC_KIND_ORDER {
-        if let Some(count) = stats.by_kind.get(kind).copied().filter(|count| *count > 0) {
+    for (index, kind) in super::DOC_KIND_ORDER.iter().enumerate() {
+        let count = stats.by_kind[index];
+        if count > 0 {
             push_stat_part(&mut out, &mut has_parts, count, super::doc_kind_plural(kind));
         }
     }
@@ -113,7 +123,7 @@ pub(super) fn render_entry_body_pure(
 
     // Lifecycle tags (`@experimental` / `@deprecated`) render as GitHub alerts
     // near the summary instead of a generic `## Tags` entry.
-    out.push_str(&render_lifecycle_alerts(&entry.tags, context));
+    push_lifecycle_alerts(&mut out, &entry.tags, context);
 
     let description = process_doc_text(&entry.description, context);
     let description = description.trim();
@@ -235,34 +245,36 @@ pub(super) fn render_entry_body_pure(
         for example in &entry.examples {
             let (code, language) = parse_example_block(example);
             out.push_str("```");
-            out.push_str(&language);
+            out.push_str(language);
             out.push('\n');
-            out.push_str(&code);
+            out.push_str(code);
             out.push_str("\n```\n\n");
         }
     }
 
     // Lifecycle tags are rendered as alerts above, so exclude them here.
-    let other_tags = entry
-        .tags
-        .iter()
-        .filter(|tag| !LIFECYCLE_TAGS.contains(&tag.tag.as_str()))
-        .collect::<Vec<_>>();
-    if !other_tags.is_empty() {
-        out.push_str(&heading);
-        out.push_str(" Tags\n\n");
-        for tag in other_tags {
-            let value = inline(&tag.value, context);
-            out.push_str("- `@");
-            out.push_str(&tag.tag);
-            if value.is_empty() {
-                out.push_str("`\n");
-            } else {
-                out.push_str("` — ");
-                out.push_str(&value);
-                out.push('\n');
-            }
+    let mut rendered_tags_heading = false;
+    for tag in &entry.tags {
+        if is_lifecycle_tag(&tag.tag) {
+            continue;
         }
+        if !rendered_tags_heading {
+            out.push_str(&heading);
+            out.push_str(" Tags\n\n");
+            rendered_tags_heading = true;
+        }
+        let value = inline(&tag.value, context);
+        out.push_str("- `@");
+        out.push_str(&tag.tag);
+        if value.is_empty() {
+            out.push_str("`\n");
+        } else {
+            out.push_str("` — ");
+            out.push_str(&value);
+            out.push('\n');
+        }
+    }
+    if rendered_tags_heading {
         out.push('\n');
     }
 
@@ -281,94 +293,125 @@ fn render_members_pure(
     context: Option<&MarkdownLinkContext<'_>>,
     section_level: usize,
 ) -> String {
-    // Bucket members lazily. Each entry kind uses a different subset of
-    // groups, and the default arm uses none of the specialized buckets, so the
-    // eager version spent one full member pass plus one `Vec` allocation per
-    // unused group. The closures below defer each filter pass until that group
-    // is actually requested by the selected entry kind, matching the HTML
-    // renderer's optimized member table path.
-    let methods = |is_static: bool| {
-        members_of(entry, move |member| {
-            member.r#static == is_static
-                && matches!(member.kind.as_str(), "method" | "getter" | "setter")
-        })
-    };
-    let properties = |is_static: bool| {
-        members_of(entry, move |member| member.r#static == is_static && member.kind == "property")
-    };
-
-    let groups: Vec<(&str, Vec<&ApiDocMember>)> = match entry.kind.as_str() {
-        "class" => vec![
-            ("Constructors", members_of(entry, |member| member.kind == "constructor")),
-            ("Static Methods", methods(true)),
-            ("Methods", methods(false)),
-            ("Static Properties", properties(true)),
-            ("Properties", properties(false)),
-        ],
-        "interface" => vec![("Properties", properties(false)), ("Methods", methods(false))],
-        "type" => vec![
-            ("Properties", properties(false)),
-            ("Methods", methods(false)),
-            ("Enum Members", members_of(entry, |member| member.kind == "enumMember")),
-        ],
-        "enum" => vec![("Enum Members", members_of(entry, |member| member.kind == "enumMember"))],
-        _ => vec![("Members", entry.members.iter().collect())],
-    };
-
     let mut out = String::new();
     let heading = "#".repeat(section_level);
-    for (title, members) in groups {
-        if members.is_empty() {
-            continue;
-        }
-        out.push_str(&heading);
-        out.push(' ');
-        out.push_str(title);
-        out.push_str("\n\n");
-        if effective_members_format(options, &entry.kind, title) == MarkdownDisplayFormat::List {
-            for member in &members {
-                let mut line = String::new();
-                line.push_str("- ");
-                line.push_str(&member_name_span(member));
-                line.push_str(" `");
-                line.push_str(&member.kind);
-                line.push('`');
-                let member_type = member_type(member);
-                if !member_type.is_empty() {
-                    line.push(' ');
-                    line.push_str(&code_span(member_type));
+    let group_context = MemberGroupRenderContext {
+        entry_kind: &entry.kind,
+        options,
+        link_context: context,
+        parameter_section_level: section_level + 1,
+    };
+
+    match entry.kind.as_str() {
+        "class" => {
+            let mut constructors = Vec::new();
+            let mut static_methods = Vec::new();
+            let mut methods = Vec::new();
+            let mut static_properties = Vec::new();
+            let mut properties = Vec::new();
+
+            for member in &entry.members {
+                match member.kind.as_str() {
+                    "constructor" => constructors.push(member),
+                    "method" | "getter" | "setter" if member.r#static => {
+                        static_methods.push(member);
+                    }
+                    "method" | "getter" | "setter" => methods.push(member),
+                    "property" if member.r#static => static_properties.push(member),
+                    "property" => properties.push(member),
+                    _ => {}
                 }
-                let description = member_description(member, context);
-                if !description.is_empty() {
-                    line.push_str(" - ");
-                    line.push_str(&description);
-                }
-                out.push_str(&line);
-                out.push('\n');
             }
-        } else {
-            out.push_str("| Name | Kind | Type | Description |\n| --- | --- | --- | --- |\n");
-            for member in &members {
-                out.push_str("| ");
-                out.push_str(&member_name_cell(member));
-                out.push_str(" | ");
-                out.push_str(&table_cell(&member.kind));
-                out.push_str(" | ");
-                out.push_str(&code_cell(member_type(member)));
-                out.push_str(" | ");
-                out.push_str(&table_cell(&member_description(member, context)));
-                out.push_str(" |\n");
-            }
+            render_member_group_pure(
+                &mut out,
+                &heading,
+                "Constructors",
+                &constructors,
+                &group_context,
+            );
+            render_member_group_pure(
+                &mut out,
+                &heading,
+                "Static Methods",
+                &static_methods,
+                &group_context,
+            );
+            render_member_group_pure(&mut out, &heading, "Methods", &methods, &group_context);
+            render_member_group_pure(
+                &mut out,
+                &heading,
+                "Static Properties",
+                &static_properties,
+                &group_context,
+            );
+            render_member_group_pure(&mut out, &heading, "Properties", &properties, &group_context);
         }
-        out.push('\n');
-        out.push_str(&render_member_parameter_sections_pure(
-            &members,
-            options,
-            context,
-            section_level + 1,
-        ));
+        "interface" => {
+            let mut properties = Vec::new();
+            let mut methods = Vec::new();
+
+            for member in &entry.members {
+                match member.kind.as_str() {
+                    "method" | "getter" | "setter" if !member.r#static => methods.push(member),
+                    "property" if !member.r#static => properties.push(member),
+                    _ => {}
+                }
+            }
+            render_member_group_pure(&mut out, &heading, "Properties", &properties, &group_context);
+            render_member_group_pure(&mut out, &heading, "Methods", &methods, &group_context);
+        }
+        "type" => {
+            let mut properties = Vec::new();
+            let mut methods = Vec::new();
+            let mut enum_members = Vec::new();
+
+            for member in &entry.members {
+                match member.kind.as_str() {
+                    "method" | "getter" | "setter" if !member.r#static => methods.push(member),
+                    "property" if !member.r#static => properties.push(member),
+                    "enumMember" => enum_members.push(member),
+                    _ => {}
+                }
+            }
+            render_member_group_pure(&mut out, &heading, "Properties", &properties, &group_context);
+            render_member_group_pure(&mut out, &heading, "Methods", &methods, &group_context);
+            render_member_group_pure(
+                &mut out,
+                &heading,
+                "Enum Members",
+                &enum_members,
+                &group_context,
+            );
+        }
+        "enum" => {
+            let mut enum_members = Vec::new();
+
+            for member in &entry.members {
+                if member.kind == "enumMember" {
+                    enum_members.push(member);
+                }
+            }
+            render_member_group_pure(
+                &mut out,
+                &heading,
+                "Enum Members",
+                &enum_members,
+                &group_context,
+            );
+        }
+        _ => {
+            let members = entry.members.iter().collect::<Vec<_>>();
+            render_member_group_pure(&mut out, &heading, "Members", &members, &group_context);
+        }
     }
     out
+}
+
+struct MemberGroupRenderContext<'a, 'ctx> {
+    entry_kind: &'a str,
+    options: &'a MarkdownDocsOptions,
+    link_context: Option<&'a MarkdownLinkContext<'ctx>>,
+    parameter_section_level: usize,
 }
 
 fn render_member_parameter_sections_pure(
@@ -428,11 +471,65 @@ fn render_member_parameter_sections_pure(
     out
 }
 
-fn members_of<'a>(
-    entry: &'a ApiDocEntry,
-    predicate: impl Fn(&&'a ApiDocMember) -> bool,
-) -> Vec<&'a ApiDocMember> {
-    entry.members.iter().filter(predicate).collect()
+fn render_member_group_pure(
+    out: &mut String,
+    heading: &str,
+    title: &str,
+    members: &[&ApiDocMember],
+    context: &MemberGroupRenderContext<'_, '_>,
+) {
+    if members.is_empty() {
+        return;
+    }
+
+    out.push_str(heading);
+    out.push(' ');
+    out.push_str(title);
+    out.push_str("\n\n");
+    if effective_members_format(context.options, context.entry_kind, title)
+        == MarkdownDisplayFormat::List
+    {
+        for member in members {
+            let mut line = String::new();
+            line.push_str("- ");
+            line.push_str(&member_name_span(member));
+            line.push_str(" `");
+            line.push_str(&member.kind);
+            line.push('`');
+            let member_type = member_type(member);
+            if !member_type.is_empty() {
+                line.push(' ');
+                line.push_str(&code_span(member_type));
+            }
+            let description = member_description(member, context.link_context);
+            if !description.is_empty() {
+                line.push_str(" - ");
+                line.push_str(&description);
+            }
+            out.push_str(&line);
+            out.push('\n');
+        }
+    } else {
+        out.push_str("| Name | Kind | Type | Description |\n| --- | --- | --- | --- |\n");
+        for member in members {
+            out.push_str("| ");
+            out.push_str(&member_name_cell(member));
+            out.push_str(" | ");
+            out.push_str(&table_cell(&member.kind));
+            out.push_str(" | ");
+            out.push_str(&code_cell(member_type(member)));
+            out.push_str(" | ");
+            out.push_str(&table_cell(&member_description(member, context.link_context)));
+            out.push_str(" |\n");
+        }
+    }
+    out.push('\n');
+    out.push_str(&render_member_parameter_sections_pure(
+        members,
+        context.options,
+        context.link_context,
+        context.parameter_section_level,
+    ));
 }
 
 fn member_name_cell(member: &ApiDocMember) -> String {
@@ -491,10 +588,22 @@ fn member_description(member: &ApiDocMember, context: Option<&MarkdownLinkContex
         }
         description.push_str(part);
     };
-    if member.tags.iter().any(|tag| tag.tag == "deprecated") {
+    let mut deprecated = false;
+    let mut experimental = false;
+    for tag in &member.tags {
+        match tag.tag.as_str() {
+            "deprecated" => deprecated = true,
+            "experimental" => experimental = true,
+            _ => {}
+        }
+        if deprecated && experimental {
+            break;
+        }
+    }
+    if deprecated {
         push_part(&mut description, "**Deprecated.**");
     }
-    if member.tags.iter().any(|tag| tag.tag == "experimental") {
+    if experimental {
         push_part(&mut description, "**Experimental.**");
     }
     if !member.description.is_empty() {


### PR DESCRIPTION
## Summary

Follow-up performance pass for the docs renderer changes from #292, #293, and #294.

- Avoid temporary `String` allocation when rendering lifecycle alerts by appending directly into the active Markdown buffer.
- Keep non-lifecycle tag rendering single-pass instead of collecting a filtered `Vec`.
- Return borrowed `&str` slices from example fence parsing to avoid cloning module and entry examples.
- Replace docs summary `byKind` maps with fixed counters for the known doc kinds.
- Render TypeDoc symbol H1 titles directly into the page buffer.
- Bucket pure-Markdown members in a single pass before rendering groups.

## Performance

Criterion comparison against `origin/main` baseline (`cargo bench -p ox_content_docs --bench markdown -- --warm-up-time 1 --measurement-time 2 --baseline main-pr292-294`):

- `markdown_category`: ~16.5% faster in the stable rerun (`7.33 ms` current, significant improvement).
- `markdown_typedoc`: improvement estimate around ~2.1%, within Criterion noise threshold in final rerun.
- `markdown_flat` / `html_flat`: no regression detected in final rerun.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p ox_content_docs`
- `cargo clippy -p ox_content_docs --all-targets -- -D warnings`
- `corepack pnpm exec vp exec --filter @ox-content/vite-plugin -- vp test src/docs.test.ts src/docs.snapshot.test.ts`
- `cargo bench -p ox_content_docs --bench markdown -- --warm-up-time 1 --measurement-time 2 --baseline main-pr292-294`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782973958&installation_id=136613492&pr_number=295&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F295&signature=d1f174a24e647e5d69520a301d9af23ce0ff2dfd17411390eeb36b2c8013e36c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->