### PR TITLE
fix(docs): render `@since` and `@version` as a Since section in markdown output

### DIFF
--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -2221,7 +2221,9 @@ mod tests {
         assert!(page.contains("## Parameters"));
         assert!(page.contains("## Returns"));
         assert!(page.contains("## Examples"));
-        assert!(page.contains("## Tags"));
+        // `@since` renders as a dedicated `## Since` section, not generic `## Tags`.
+        assert!(page.contains("## Since"));
+        assert!(!page.contains("## Tags"));
         assert!(!page.contains("**Signature**"));
         assert!(!page.contains("**Returns**"));
         assert!(!page.contains("#### "));
@@ -3221,9 +3223,12 @@ mod tests {
     }
 
     #[test]
-    fn typedoc_keeps_non_lifecycle_tags_in_tags_section() {
+    fn typedoc_keeps_non_structured_tags_in_tags_section() {
+        // `@see` is neither a lifecycle tag nor a `@since`/`@version` tag, so it
+        // stays in the generic `## Tags` list while structured tags move out.
         let mut entry = test_entry("run", "function", "/repo/src/run.ts", "Run it.");
         entry.tags = vec![
+            ApiDocTag { tag: "see".to_string(), value: "related".to_string() },
             ApiDocTag { tag: "since".to_string(), value: "1.0.0".to_string() },
             ApiDocTag { tag: "experimental".to_string(), value: String::new() },
         ];
@@ -3231,8 +3236,10 @@ mod tests {
         let page = out.get("combinators/functions/run.md").unwrap();
 
         assert!(page.contains("> [!WARNING]"));
+        assert!(page.contains("## Since"));
         assert!(page.contains("## Tags"));
-        assert!(page.contains("`@since`"));
+        assert!(page.contains("`@see`"));
+        assert!(!page.contains("`@since`"));
         assert!(!page.contains("`@experimental`"));
     }
 
@@ -3260,6 +3267,70 @@ mod tests {
         let page = out.get("combinators/interfaces/StringOptions.md").unwrap();
 
         assert!(page.contains("**Experimental.** Minimum string length."));
+    }
+
+    #[test]
+    fn typedoc_renders_since_as_dedicated_section() {
+        let mut entry = test_entry("Example", "interface", "/repo/src/example.ts", "Example API.");
+        entry.tags = vec![ApiDocTag { tag: "since".to_string(), value: "v0.27.0".to_string() }];
+        let out = generate_markdown(&lifecycle_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/interfaces/Example.md").unwrap();
+
+        assert!(page.contains("## Since\n\nv0.27.0"));
+        assert!(!page.contains("## Tags"));
+        assert!(!page.contains("@since"));
+    }
+
+    #[test]
+    fn typedoc_normalizes_version_into_since_section() {
+        let mut entry = test_entry("Example", "interface", "/repo/src/example.ts", "Example API.");
+        entry.tags = vec![ApiDocTag { tag: "version".to_string(), value: "1.2.3".to_string() }];
+        let out = generate_markdown(&lifecycle_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/interfaces/Example.md").unwrap();
+
+        assert!(page.contains("## Since\n\n1.2.3"));
+        assert!(!page.contains("## Version"));
+        assert!(!page.contains("## Tags"));
+    }
+
+    #[test]
+    fn typedoc_combines_since_and_version_into_one_section() {
+        let mut entry = test_entry("Example", "interface", "/repo/src/example.ts", "Example API.");
+        entry.tags = vec![
+            ApiDocTag { tag: "since".to_string(), value: "v0.27.0".to_string() },
+            ApiDocTag { tag: "version".to_string(), value: "1.2.3".to_string() },
+        ];
+        let out = generate_markdown(&lifecycle_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/interfaces/Example.md").unwrap();
+
+        assert!(page.contains("## Since\n\nv0.27.0\n\n1.2.3"));
+        assert_eq!(page.matches("## Since").count(), 1);
+    }
+
+    #[test]
+    fn typedoc_renders_member_since_inline() {
+        let mut entry =
+            test_entry("PluginOptions", "interface", "/repo/src/plugin.ts", "Plugin options.");
+        entry.members = vec![ApiDocMember {
+            name: "entry".to_string(),
+            kind: "property".to_string(),
+            description: "Whether this is an entry command.".to_string(),
+            signature: None,
+            type_annotation: Some("boolean".to_string()),
+            params: vec![],
+            returns: None,
+            optional: true,
+            readonly: false,
+            r#static: false,
+            private: false,
+            tags: vec![ApiDocTag { tag: "since".to_string(), value: "v0.27.0".to_string() }],
+            line: 1,
+            end_line: 1,
+        }];
+        let out = generate_markdown(&lifecycle_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/interfaces/PluginOptions.md").unwrap();
+
+        assert!(page.contains("Whether this is an entry command. **Since** v0.27.0"));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -14,6 +14,16 @@ use super::{
 use crate::model::{ApiDocEntry, ApiDocMember, ApiDocTag, ApiParamDoc, ApiTypeParamDoc};
 use crate::string_builder::StringBuilder;
 
+/// JSDoc tags folded into a dedicated `## Since` section (TypeDoc parity) instead
+/// of generic `## Tags`. `@version` is normalized into the same section.
+const SINCE_TAGS: [&str; 2] = ["since", "version"];
+
+/// True when a tag is rendered as a structured section/alert and therefore must
+/// not also appear in the generic `## Tags` list.
+fn is_structured_tag(name: &str) -> bool {
+    is_lifecycle_tag(name) || SINCE_TAGS.contains(&name)
+}
+
 /// JSDoc lifecycle tags rendered as GitHub alerts rather than generic `## Tags`
 /// entries: `@experimental` → `> [!WARNING]`, `@deprecated` → `> [!CAUTION]`.
 /// Appends GitHub alert blocks for lifecycle tags (`@experimental`,
@@ -59,6 +69,31 @@ pub(super) fn push_lifecycle_alerts(
 
 fn is_lifecycle_tag(tag: &str) -> bool {
     matches!(tag, "deprecated" | "experimental")
+}
+
+/// Renders a `## Since` section from `@since` / `@version` tags (both folded into
+/// one section, matching TypeDoc), or "" when none carry a value. `heading` is
+/// the section prefix (`##` on typedoc per-symbol pages).
+fn render_since_section(
+    tags: &[ApiDocTag],
+    context: Option<&MarkdownLinkContext<'_>>,
+    heading: &str,
+) -> String {
+    let values = tags
+        .iter()
+        .filter(|tag| SINCE_TAGS.contains(&tag.tag.as_str()))
+        .map(|tag| inline(&tag.value, context))
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>();
+    if values.is_empty() {
+        return String::new();
+    }
+    let mut out = String::new();
+    out.push_str(heading);
+    out.push_str(" Since\n\n");
+    out.push_str(&values.join("\n\n"));
+    out.push_str("\n\n");
+    out
 }
 
 /// Renders the per-page stats summary as a single italic Markdown line.
@@ -131,6 +166,10 @@ pub(super) fn render_entry_body_pure(
         out.push_str(description);
         out.push_str("\n\n");
     }
+
+    // `@since` / `@version` render as a dedicated `## Since` section near the
+    // summary instead of a generic `## Tags` entry.
+    out.push_str(&render_since_section(&entry.tags, context, &heading));
 
     if let Some(signature) = &entry.signature {
         out.push_str(&heading);
@@ -252,10 +291,11 @@ pub(super) fn render_entry_body_pure(
         }
     }
 
-    // Lifecycle tags are rendered as alerts above, so exclude them here.
+    // Structured tags (lifecycle alerts, `## Since`) are rendered above, so
+    // exclude them from the generic list here.
     let mut rendered_tags_heading = false;
     for tag in &entry.tags {
-        if is_lifecycle_tag(&tag.tag) {
+        if is_structured_tag(&tag.tag) {
             continue;
         }
         if !rendered_tags_heading {
@@ -615,6 +655,20 @@ fn member_description(member: &ApiDocMember, context: Option<&MarkdownLinkContex
             description.push(' ');
             description.push_str(&inline(&returns.description, context));
         }
+    }
+    // `@since` / `@version` render inline (TypeDoc shows them in the cell); a
+    // GitHub alert or section cannot live inside a table cell.
+    let since = member
+        .tags
+        .iter()
+        .filter(|tag| SINCE_TAGS.contains(&tag.tag.as_str()))
+        .map(|tag| inline(&tag.value, context))
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>();
+    if !since.is_empty() {
+        push_part(&mut description, "**Since**");
+        description.push(' ');
+        description.push_str(&since.join(", "));
     }
     description
 }


### PR DESCRIPTION
## Summary

All changes are in the pure-markdown renderer (`markdown_pure.rs`); the extractor, model, NAPI types, `docs.json`, and the HTML render style are unchanged.

- A new `render_since_section` helper emits a `## Since` section from `@since` / `@version` tags, folding both into one section (multiple values separated by blank lines), with `{@link}` resolved.
- On symbol pages the section renders right after the summary (before `## Signature`).
- `@since` / `@version` are excluded from the generic `## Tags` list (a shared `is_structured_tag` helper now covers lifecycle tags and since/version), so they are not duplicated. Other tags (e.g. `@see`) still render in `## Tags`.
- In member/property tables, where an alert/section cannot live inside a cell, the description is suffixed with an inline `**Since** <value>` marker (matching TypeDoc, which shows `@since` inline in the cell).

```md
# Interface: PluginOptions

Plugin definition options.

## Since

v0.27.0
```

## Background

Under `generateDocsMarkdown(..., { renderStyle: 'markdown' })`, ox-content rendered `@since` as a generic `## Tags` entry:

```md
## Tags

- `@since` — v0.27.0
```

TypeDoc renders the same lifecycle metadata as a dedicated section:

```md
## Since

v0.27.0
```

This is the follow-up to #293 (`@experimental`/`@deprecated` → GitHub alerts): `@since` and `@version` are API lifecycle metadata that should be surfaced structurally rather than as generic tags.

Per the gunshi migration, `@version` is treated as equivalent to `@since` and normalized into the same `## Since` section (no separate `## Version`).

The tag data is already wired end-to-end (`entry.tags` / `member.tags`), so this is purely a rendering change in the markdown render style.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782977698&installation_id=136613492&pr_number=296&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F296&signature=d0a1d602ecf6b6529cd2be09b5c6c738c99b5e500e5aa7cfb71fcc6d13cf9179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->