### PR TITLE
feat(docs): add groupOrder option to control typedoc section and nav group order

### DIFF
--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -80,6 +80,11 @@ pub struct MarkdownDocsOptions {
     /// without stats.
     #[serde(default = "default_render_stats")]
     pub render_stats: bool,
+    /// TypeDoc-style group order for module index sections and nav groups. `None`
+    /// keeps the historical fixed order; `Some` reorders groups by title, placing
+    /// unlisted groups alphabetically at `*` (or at the end when `*` is absent).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group_order: Option<Vec<String>>,
 }
 
 /// Internal documentation link style.
@@ -149,6 +154,7 @@ impl Default for MarkdownDocsOptions {
             property_members_format: MarkdownDisplayFormat::None,
             type_declaration_format: MarkdownDisplayFormat::None,
             render_stats: true,
+            group_order: None,
         }
     }
 }
@@ -1264,6 +1270,11 @@ fn generate_typedoc_module_index(
     push_stats(&mut markdown, options, &summarize_module(doc), None);
 
     let index_format = effective_index_format(options);
+
+    // Collect the kind sections (in the historical order) plus the References
+    // section, then order them by `group_order` before rendering. TypeDoc treats
+    // References as just another group, so it participates in the ordering too.
+    let mut sections: Vec<(String, IndexSection)> = Vec::new();
     for kind in ordered_entry_kinds(&doc.entries) {
         // Only entries whose canonical page lives in this module are listed in
         // the kind sections; re-exports are collected into "References" below.
@@ -1275,70 +1286,8 @@ fn generate_typedoc_module_index(
         if entries.is_empty() {
             continue;
         }
-
-        markdown.push_str("## ");
-        markdown.push_str(typedoc_kind_title(&kind));
-        markdown.push_str("\n\n");
-        let mut seen = std::collections::HashSet::new();
-        if index_format == MarkdownDisplayFormat::List {
-            for entry in entries {
-                // Overloads share a name (and page); collapse them to one row.
-                if !seen.insert(entry.name.as_str()) {
-                    continue;
-                }
-                let href = doc_page_href_from(
-                    options,
-                    &current_file_name,
-                    &typedoc_entry_file_name(module_name, entry),
-                    None,
-                );
-                let summary = clean_summary_text(
-                    &process_doc_text(&entry.description, Some(&link_context)),
-                    88,
-                );
-                markdown.push_str("- [");
-                markdown.push_str(&entry.name);
-                markdown.push_str("](");
-                markdown.push_str(&href);
-                if summary.is_empty() {
-                    markdown.push_str(")\n");
-                } else {
-                    markdown.push_str(") - ");
-                    markdown.push_str(&summary);
-                    markdown.push('\n');
-                }
-            }
-            markdown.push('\n');
-            continue;
-        }
-
-        // Render a compact `Name | Description` table (matching TypeDoc) rather
-        // than a bullet list with the full signature inlined; the signature
-        // stays on the per-symbol page.
-        markdown.push_str("| ");
-        markdown.push_str(typedoc_kind_singular(&kind));
-        markdown.push_str(" | Description |\n| ------ | ------ |\n");
-        for entry in entries {
-            // Overloads share a name (and page); collapse them to one row.
-            if !seen.insert(entry.name.as_str()) {
-                continue;
-            }
-            let href = doc_page_href_from(
-                options,
-                &current_file_name,
-                &typedoc_entry_file_name(module_name, entry),
-                None,
-            );
-            let summary = typedoc_index_summary(&entry.description, &link_context);
-            markdown.push_str("| [");
-            markdown.push_str(&entry.name);
-            markdown.push_str("](");
-            markdown.push_str(&href);
-            markdown.push_str(") | ");
-            markdown.push_str(&summary);
-            markdown.push_str(" |\n");
-        }
-        markdown.push('\n');
+        let title = typedoc_kind_title(&kind).to_string();
+        sections.push((title, IndexSection::Kind { kind, entries }));
     }
 
     // Symbols this module re-exports but does not own: link to the canonical page
@@ -1349,33 +1298,140 @@ fn generate_typedoc_module_index(
         .entries
         .iter()
         .filter(|entry| !owners.is_canonical(doc, entry))
-        .filter_map(|entry| owners.canonical_module(entry).map(|owner| (entry, owner)))
+        .filter_map(|entry| owners.canonical_module(entry).map(|owner| (entry, owner.to_string())))
         .filter(|(entry, _)| seen_references.insert(entry.name.as_str()))
         .collect::<Vec<_>>();
     if !references.is_empty() {
-        markdown.push_str("## References\n\n");
-        for (index, (entry, owner)) in references.iter().enumerate() {
-            // TypeDoc separates consecutive reference entries with a thematic break.
-            if index > 0 {
-                markdown.push_str("***\n\n");
+        sections.push(("References".to_string(), IndexSection::References(references)));
+    }
+
+    for (_title, section) in order_by_group_title(sections, options.group_order.as_deref()) {
+        match section {
+            IndexSection::Kind { kind, entries } => render_typedoc_kind_section(
+                &mut markdown,
+                &kind,
+                &entries,
+                &link_context,
+                index_format,
+            ),
+            IndexSection::References(references) => {
+                render_typedoc_references_section(&mut markdown, &references, &link_context);
             }
-            let href = doc_page_href_from(
-                options,
-                &current_file_name,
-                &typedoc_entry_file_name(owner, entry),
-                None,
-            );
-            markdown.push_str("### ");
-            markdown.push_str(&entry.name);
-            markdown.push_str("\n\nRe-exports [");
-            markdown.push_str(&entry.name);
-            markdown.push_str("](");
-            markdown.push_str(&href);
-            markdown.push_str(")\n\n");
         }
     }
 
     markdown
+}
+
+/// A renderable section of a TypeDoc module index, kept title-tagged so
+/// `group_order` can reorder kinds and References together.
+enum IndexSection<'a> {
+    Kind { kind: String, entries: Vec<&'a ApiDocEntry> },
+    References(Vec<(&'a ApiDocEntry, String)>),
+}
+
+/// Renders one `## {kind title}` section (table or list) for a module index.
+fn render_typedoc_kind_section(
+    markdown: &mut String,
+    kind: &str,
+    entries: &[&ApiDocEntry],
+    link_context: &MarkdownLinkContext<'_>,
+    index_format: MarkdownDisplayFormat,
+) {
+    let options = link_context.options;
+    let module_name = link_context.current_module_name;
+    let current_file_name = link_context.current_file_name;
+    markdown.push_str("## ");
+    markdown.push_str(typedoc_kind_title(kind));
+    markdown.push_str("\n\n");
+    let mut seen = std::collections::HashSet::new();
+    if index_format == MarkdownDisplayFormat::List {
+        for entry in entries {
+            // Overloads share a name (and page); collapse them to one row.
+            if !seen.insert(entry.name.as_str()) {
+                continue;
+            }
+            let href = doc_page_href_from(
+                options,
+                current_file_name,
+                &typedoc_entry_file_name(module_name, entry),
+                None,
+            );
+            let summary =
+                clean_summary_text(&process_doc_text(&entry.description, Some(link_context)), 88);
+            markdown.push_str("- [");
+            markdown.push_str(&entry.name);
+            markdown.push_str("](");
+            markdown.push_str(&href);
+            if summary.is_empty() {
+                markdown.push_str(")\n");
+            } else {
+                markdown.push_str(") - ");
+                markdown.push_str(&summary);
+                markdown.push('\n');
+            }
+        }
+        markdown.push('\n');
+        return;
+    }
+
+    // Render a compact `Name | Description` table (matching TypeDoc) rather than a
+    // bullet list with the full signature inlined; the signature stays on the
+    // per-symbol page.
+    markdown.push_str("| ");
+    markdown.push_str(typedoc_kind_singular(kind));
+    markdown.push_str(" | Description |\n| ------ | ------ |\n");
+    for entry in entries {
+        // Overloads share a name (and page); collapse them to one row.
+        if !seen.insert(entry.name.as_str()) {
+            continue;
+        }
+        let href = doc_page_href_from(
+            options,
+            current_file_name,
+            &typedoc_entry_file_name(module_name, entry),
+            None,
+        );
+        let summary = typedoc_index_summary(&entry.description, link_context);
+        markdown.push_str("| [");
+        markdown.push_str(&entry.name);
+        markdown.push_str("](");
+        markdown.push_str(&href);
+        markdown.push_str(") | ");
+        markdown.push_str(&summary);
+        markdown.push_str(" |\n");
+    }
+    markdown.push('\n');
+}
+
+/// Renders the `## References` section for a module index.
+fn render_typedoc_references_section(
+    markdown: &mut String,
+    references: &[(&ApiDocEntry, String)],
+    link_context: &MarkdownLinkContext<'_>,
+) {
+    let options = link_context.options;
+    let current_file_name = link_context.current_file_name;
+    markdown.push_str("## References\n\n");
+    for (index, (entry, owner)) in references.iter().enumerate() {
+        // TypeDoc separates consecutive reference entries with a thematic break.
+        if index > 0 {
+            markdown.push_str("***\n\n");
+        }
+        let href = doc_page_href_from(
+            options,
+            current_file_name,
+            &typedoc_entry_file_name(owner, entry),
+            None,
+        );
+        markdown.push_str("### ");
+        markdown.push_str(&entry.name);
+        markdown.push_str("\n\nRe-exports [");
+        markdown.push_str(&entry.name);
+        markdown.push_str("](");
+        markdown.push_str(&href);
+        markdown.push_str(")\n\n");
+    }
 }
 
 fn generate_typedoc_entry_page(
@@ -1429,6 +1485,62 @@ fn ordered_entry_kinds(entries: &[ApiDocEntry]) -> Vec<String> {
     extra.dedup();
     kinds.extend(extra);
     kinds
+}
+
+/// Reorders `(group_title, payload)` sections by a TypeDoc-style `group_order`.
+///
+/// `None` returns the input unchanged (preserving the caller's default order).
+/// Otherwise titles listed before `*` lead in the given order, titles after `*`
+/// trail in the given order, and titles not listed are placed at the `*` position
+/// (or the end when there is no `*`) sorted alphabetically. Listed titles that are
+/// not present are ignored.
+pub fn order_by_group_title<T>(
+    sections: Vec<(String, T)>,
+    group_order: Option<&[String]>,
+) -> Vec<(String, T)> {
+    let Some(group_order) = group_order else {
+        return sections;
+    };
+    let star = group_order.iter().position(|group| group == "*");
+    let (head, tail): (&[String], &[String]) = match star {
+        Some(index) => (&group_order[..index], &group_order[index + 1..]),
+        None => (group_order, &group_order[group_order.len()..]),
+    };
+
+    let mut remaining: Vec<Option<(String, T)>> = sections.into_iter().map(Some).collect();
+    let mut result = Vec::with_capacity(remaining.len());
+
+    for title in head {
+        if let Some(section) = take_section(&mut remaining, title) {
+            result.push(section);
+        }
+    }
+
+    let mut unspecified = Vec::new();
+    for slot in &mut remaining {
+        let is_tail = slot.as_ref().is_some_and(|(title, _)| tail.iter().any(|t| t == title));
+        if !is_tail {
+            if let Some(section) = slot.take() {
+                unspecified.push(section);
+            }
+        }
+    }
+    unspecified.sort_by(|a, b| a.0.cmp(&b.0));
+    result.extend(unspecified);
+
+    for title in tail {
+        if let Some(section) = take_section(&mut remaining, title) {
+            result.push(section);
+        }
+    }
+    result
+}
+
+fn take_section<T>(remaining: &mut [Option<(String, T)>], title: &str) -> Option<(String, T)> {
+    remaining
+        .iter_mut()
+        .find(|slot| slot.as_ref().is_some_and(|(t, _)| t == title))
+        .and_then(Option::take)
 }
 
 fn normalize_signature(signature: Option<&str>) -> Option<String> {
@@ -3336,6 +3448,125 @@ mod tests {
             render_style: MarkdownRenderStyle::Markdown,
             ..MarkdownDocsOptions::default()
         }
+    }
+
+    fn group_order_docs() -> Vec<ApiDocModule> {
+        vec![ApiDocModule {
+            description: "Module description.".to_string(),
+            file: "default".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![
+                test_entry("alpha", "function", "/repo/src/a.ts", "A function."),
+                test_entry("Config", "interface", "/repo/src/c.ts", "An interface."),
+                test_entry("Engine", "class", "/repo/src/e.ts", "A class."),
+                test_entry("VERSION", "variable", "/repo/src/v.ts", "A variable."),
+            ],
+        }]
+    }
+
+    #[test]
+    fn order_by_group_title_none_preserves_order() {
+        let sections = vec![("Functions".to_string(), 1), ("Variables".to_string(), 2)];
+        assert_eq!(order_by_group_title(sections.clone(), None), sections);
+    }
+
+    #[test]
+    fn order_by_group_title_orders_listed_then_alphabetical() {
+        let sections = vec![
+            ("Functions".to_string(), 1),
+            ("Classes".to_string(), 2),
+            ("Interfaces".to_string(), 3),
+            ("References".to_string(), 4),
+            ("Type Aliases".to_string(), 5),
+            ("Variables".to_string(), 6),
+        ];
+        let group_order = ["Variables".to_string(), "Functions".to_string(), "Class".to_string()];
+        let titles = order_by_group_title(sections, Some(&group_order))
+            .into_iter()
+            .map(|(title, _)| title)
+            .collect::<Vec<_>>();
+
+        // `Class` does not match the `Classes` group and is ignored; unlisted
+        // groups (including References) follow alphabetically.
+        assert_eq!(
+            titles,
+            vec!["Variables", "Functions", "Classes", "Interfaces", "References", "Type Aliases"]
+        );
+    }
+
+    #[test]
+    fn order_by_group_title_places_unspecified_at_star() {
+        let sections = vec![
+            ("Functions".to_string(), 1),
+            ("Classes".to_string(), 2),
+            ("Variables".to_string(), 3),
+        ];
+        let group_order = ["Variables".to_string(), "*".to_string(), "Functions".to_string()];
+        let titles = order_by_group_title(sections, Some(&group_order))
+            .into_iter()
+            .map(|(title, _)| title)
+            .collect::<Vec<_>>();
+
+        assert_eq!(titles, vec!["Variables", "Classes", "Functions"]);
+    }
+
+    #[test]
+    fn typedoc_group_order_defaults_to_fixed_kind_order() {
+        let out = generate_markdown(&group_order_docs(), &markdown_typedoc_options());
+        let index = out.get("default/index.md").unwrap();
+        let functions = index.find("## Functions").unwrap();
+        let classes = index.find("## Classes").unwrap();
+        let interfaces = index.find("## Interfaces").unwrap();
+        let variables = index.find("## Variables").unwrap();
+
+        // Unchanged historical order (DOC_KIND_ORDER).
+        assert!(functions < classes);
+        assert!(classes < interfaces);
+        assert!(interfaces < variables);
+    }
+
+    #[test]
+    fn typedoc_group_order_reorders_module_index_sections() {
+        let options = MarkdownDocsOptions {
+            group_order: Some(vec!["Variables".to_string(), "Functions".to_string()]),
+            ..markdown_typedoc_options()
+        };
+        let out = generate_markdown(&group_order_docs(), &options);
+        let index = out.get("default/index.md").unwrap();
+        let variables = index.find("## Variables").unwrap();
+        let functions = index.find("## Functions").unwrap();
+        let classes = index.find("## Classes").unwrap();
+        let interfaces = index.find("## Interfaces").unwrap();
+
+        // Listed groups lead in order; the rest follow alphabetically.
+        assert!(variables < functions);
+        assert!(functions < classes);
+        assert!(classes < interfaces);
+    }
+
+    #[test]
+    fn typedoc_group_order_supports_star_wildcard() {
+        let options = MarkdownDocsOptions {
+            group_order: Some(vec![
+                "Variables".to_string(),
+                "*".to_string(),
+                "Functions".to_string(),
+            ]),
+            ..markdown_typedoc_options()
+        };
+        let out = generate_markdown(&group_order_docs(), &options);
+        let index = out.get("default/index.md").unwrap();
+        let variables = index.find("## Variables").unwrap();
+        let classes = index.find("## Classes").unwrap();
+        let interfaces = index.find("## Interfaces").unwrap();
+        let functions = index.find("## Functions").unwrap();
+
+        // Variables first, unspecified groups (alphabetical) in the middle, Functions last.
+        assert!(variables < classes);
+        assert!(classes < interfaces);
+        assert!(interfaces < functions);
     }
 
     fn stats_docs() -> Vec<ApiDocModule> {

--- a/crates/ox_content_docs/src/nav.rs
+++ b/crates/ox_content_docs/src/nav.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use phf::phf_map;
 use serde::{Deserialize, Serialize};
 
-use crate::markdown::{CanonicalOwners, MarkdownPathStrategy};
+use crate::markdown::{order_by_group_title, CanonicalOwners, MarkdownPathStrategy};
 use crate::model::{ApiDocEntry, ApiDocModule};
 use crate::string_builder::{join2, join3, join5, StringBuilder};
 
@@ -49,23 +49,30 @@ pub fn generate_nav_metadata(files: &[String], base_path: Option<&str>) -> Vec<D
 }
 
 /// Generates sidebar navigation metadata from extracted docs and the output path strategy.
+///
+/// `group_order` reorders the TypeDoc nav kind groups (matching the module index
+/// section order); `None` keeps the historical fixed order.
 pub fn generate_nav_metadata_from_docs(
     docs: &[ApiDocModule],
     base_path: Option<&str>,
     path_strategy: MarkdownPathStrategy,
+    group_order: Option<&[String]>,
 ) -> Vec<DocsNavItem> {
     match path_strategy {
         MarkdownPathStrategy::Flat => {
             let files = docs.iter().map(|doc| doc.file.clone()).collect::<Vec<_>>();
             generate_nav_metadata(&files, base_path)
         }
-        MarkdownPathStrategy::TypeDoc => generate_typedoc_nav_metadata(docs, base_path),
+        MarkdownPathStrategy::TypeDoc => {
+            generate_typedoc_nav_metadata(docs, base_path, group_order)
+        }
     }
 }
 
 fn generate_typedoc_nav_metadata(
     docs: &[ApiDocModule],
     base_path: Option<&str>,
+    group_order: Option<&[String]>,
 ) -> Vec<DocsNavItem> {
     let base_path = normalize_base_path(base_path.unwrap_or(DEFAULT_BASE_PATH));
     let mut docs = docs.to_vec();
@@ -79,7 +86,19 @@ fn generate_typedoc_nav_metadata(
             let module_name = typedoc_module_route_name(&doc);
             let module_title = typedoc_module_display_name(&doc);
             let mut children = Vec::new();
-            for kind in ordered_entry_kinds(&doc.entries) {
+            // Collect the present kind groups (title-tagged) in the historical
+            // order, then reorder them by `group_order` so the sidebar matches the
+            // module index section order.
+            let kind_groups = ordered_entry_kinds(&doc.entries)
+                .into_iter()
+                .filter(|kind| {
+                    doc.entries
+                        .iter()
+                        .any(|entry| entry.kind == *kind && owners.is_canonical(&doc, entry))
+                })
+                .map(|kind| (typedoc_kind_title(&kind).to_string(), kind))
+                .collect::<Vec<_>>();
+            for (_title, kind) in order_by_group_title(kind_groups, group_order) {
                 let entries = doc
                     .entries
                     .iter()
@@ -319,6 +338,54 @@ fn format_doc_title(name: &str) -> String {
 mod tests {
     use super::*;
 
+    fn nav_entry(name: &str, kind: &str) -> ApiDocEntry {
+        ApiDocEntry {
+            name: name.to_string(),
+            kind: kind.to_string(),
+            description: String::new(),
+            params: vec![],
+            returns: None,
+            examples: vec![],
+            tags: vec![],
+            private: false,
+            file: join3("/repo/src/", name, ".ts"),
+            line: 1,
+            end_line: 1,
+            signature: None,
+            has_body: false,
+            members: vec![],
+            type_parameters: vec![],
+        }
+    }
+
+    #[test]
+    fn typedoc_nav_respects_group_order() {
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "default".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![
+                nav_entry("alpha", "function"),
+                nav_entry("Engine", "class"),
+                nav_entry("VERSION", "variable"),
+            ],
+        }];
+        let group_order = ["Variables".to_string(), "Functions".to_string()];
+        let nav = generate_nav_metadata_from_docs(
+            &docs,
+            Some("/api"),
+            MarkdownPathStrategy::TypeDoc,
+            Some(&group_order),
+        );
+        let children = nav[0].children.as_ref().unwrap();
+        let titles = children.iter().map(|child| child.title.as_str()).collect::<Vec<_>>();
+
+        // Listed groups lead in order; the rest follow alphabetically.
+        assert_eq!(titles, vec!["Variables", "Functions", "Classes"]);
+    }
+
     #[test]
     fn generates_nav_metadata_from_file_paths() {
         let nav = generate_nav_metadata(
@@ -405,8 +472,12 @@ mod tests {
             ],
         }];
 
-        let nav =
-            generate_nav_metadata_from_docs(&docs, Some("/api"), MarkdownPathStrategy::TypeDoc);
+        let nav = generate_nav_metadata_from_docs(
+            &docs,
+            Some("/api"),
+            MarkdownPathStrategy::TypeDoc,
+            None,
+        );
 
         assert_eq!(nav[0].title, "default");
         assert_eq!(nav[0].path, "/api/default");
@@ -448,8 +519,12 @@ mod tests {
             }],
         }];
 
-        let nav =
-            generate_nav_metadata_from_docs(&docs, Some("/api"), MarkdownPathStrategy::TypeDoc);
+        let nav = generate_nav_metadata_from_docs(
+            &docs,
+            Some("/api"),
+            MarkdownPathStrategy::TypeDoc,
+            None,
+        );
         let children = nav[0].children.as_ref().unwrap();
 
         assert_eq!(children[0].title, "Enumerations");
@@ -490,8 +565,12 @@ mod tests {
         let docs =
             vec![make("context", "/repo/src/context.ts"), make("default", "/repo/src/index.ts")];
 
-        let nav =
-            generate_nav_metadata_from_docs(&docs, Some("/api"), MarkdownPathStrategy::TypeDoc);
+        let nav = generate_nav_metadata_from_docs(
+            &docs,
+            Some("/api"),
+            MarkdownPathStrategy::TypeDoc,
+            None,
+        );
 
         let context = nav.iter().find(|item| item.path == "/api/context").unwrap();
         assert!(context.children.is_some(), "owner module keeps the symbol in the sidebar");

--- a/crates/ox_content_docs/src/output.rs
+++ b/crates/ox_content_docs/src/output.rs
@@ -83,6 +83,7 @@ pub fn write_docs_output(
                 extracted_docs,
                 Some(base_path),
                 options.path_strategy,
+                None,
             );
             fs::write(
                 out_dir.join(DOCS_NAV_FILE),

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -372,6 +372,11 @@ export interface JsDocsMarkdownOptions {
   typeDeclarationFormat?: 'none' | 'list' | 'table'
   /** Emit the stats summary line on index pages (default: true). */
   renderStats?: boolean
+  /**
+   * TypeDoc-style group order for module index sections and nav groups. Unlisted
+   * groups are sorted alphabetically at `*` (or at the end when `*` is absent).
+   */
+  groupOrder?: Array<string>
 }
 
 /** Ordered JSDoc tag used by generated API Markdown. */
@@ -391,6 +396,11 @@ export interface JsDocsNavItem {
 export interface JsDocsNavOptions {
   basePath?: string
   pathStrategy?: 'flat' | 'typedoc'
+  /**
+   * TypeDoc-style group order for nav groups (matches `generateDocsMarkdown`'s
+   * `groupOrder` so the sidebar and page order stay in sync).
+   */
+  groupOrder?: Array<string>
 }
 
 /** Options for writing generated API documentation files. */

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -250,6 +250,9 @@ pub struct JsDocsNavOptions {
     pub base_path: Option<String>,
     #[napi(ts_type = "'flat' | 'typedoc'")]
     pub path_strategy: Option<String>,
+    /// TypeDoc-style group order for nav groups (matches `generateDocsMarkdown`'s
+    /// `groupOrder` so the sidebar and page order stay in sync).
+    pub group_order: Option<Vec<String>>,
 }
 
 /// Ordered JSDoc tag used by generated API Markdown.
@@ -341,6 +344,9 @@ pub struct JsDocsMarkdownOptions {
     pub type_declaration_format: Option<String>,
     /// Emit the stats summary line on index pages (default: true).
     pub render_stats: Option<bool>,
+    /// TypeDoc-style group order for module index sections and nav groups. Unlisted
+    /// groups are sorted alphabetically at `*` (or at the end when `*` is absent).
+    pub group_order: Option<Vec<String>>,
 }
 
 /// Options for writing generated API documentation files.
@@ -1297,10 +1303,15 @@ pub fn generate_docs_nav_metadata_from_docs_napi(
     let options = options.unwrap_or_default();
     let strategy = parse_markdown_path_strategy(options.path_strategy.as_deref());
     let modules = docs.into_iter().map(convert_markdown_module).collect::<Vec<_>>();
-    generate_nav_metadata_from_docs(&modules, options.base_path.as_deref(), strategy)
-        .into_iter()
-        .map(map_docs_nav_item)
-        .collect()
+    generate_nav_metadata_from_docs(
+        &modules,
+        options.base_path.as_deref(),
+        strategy,
+        options.group_order.as_deref(),
+    )
+    .into_iter()
+    .map(map_docs_nav_item)
+    .collect()
 }
 
 /// Generates TypeScript source code for documentation navigation metadata.
@@ -1420,6 +1431,7 @@ pub fn generate_docs_markdown(
                 options.type_declaration_format.as_deref(),
             ),
             render_stats: options.render_stats.unwrap_or(true),
+            group_order: options.group_order,
         });
     generate_markdown(&docs.into_iter().map(convert_markdown_module).collect::<Vec<_>>(), &options)
         .into_iter()
@@ -3893,6 +3905,50 @@ mod tests {
     }
 
     #[test]
+    fn generate_docs_markdown_group_order_reorders_module_index() {
+        fn entry(name: &str, kind: &str) -> JsDocsMarkdownEntry {
+            JsDocsMarkdownEntry {
+                name: name.to_string(),
+                kind: kind.to_string(),
+                description: String::new(),
+                params: None,
+                returns: None,
+                examples: None,
+                tags: None,
+                private: false,
+                file: format!("/repo/src/{name}.ts"),
+                line: 1,
+                end_line: 1,
+                signature: Some(format!("export declare const {name}: unknown")),
+                has_body: None,
+                members: None,
+                type_parameters: None,
+            }
+        }
+        let docs = vec![JsDocsMarkdownModule {
+            description: None,
+            file: "default".to_string(),
+            source_path: None,
+            examples: None,
+            tags: None,
+            entries: vec![entry("alpha", "function"), entry("VERSION", "variable")],
+        }];
+
+        let markdown = generate_docs_markdown(
+            docs,
+            Some(JsDocsMarkdownOptions {
+                path_strategy: Some("typedoc".to_string()),
+                render_style: Some("markdown".to_string()),
+                group_order: Some(vec!["Variables".to_string(), "Functions".to_string()]),
+                ..Default::default()
+            }),
+        );
+        let index = markdown.get("default/index.md").unwrap();
+
+        assert!(index.find("## Variables").unwrap() < index.find("## Functions").unwrap());
+    }
+
+    #[test]
     fn generate_docs_markdown_render_stats_option_toggles_stats_summary() {
         fn module() -> Vec<JsDocsMarkdownModule> {
             vec![JsDocsMarkdownModule {
@@ -4147,6 +4203,7 @@ mod tests {
             Some(JsDocsNavOptions {
                 base_path: Some("/api".to_string()),
                 path_strategy: Some("typedoc".to_string()),
+                group_order: None,
             }),
         );
 


### PR DESCRIPTION
## Summray

Adds a TypeDoc-compatible `groupOrder` option to `generateDocsMarkdown` and `generateDocsNavMetadataFromDocs`, defaulting to the historical fixed order so existing output is unchanged.

```ts
generateDocsMarkdown(modules, { pathStrategy: 'typedoc', groupOrder: ['Variables', 'Functions', 'Class'] })
generateDocsNavMetadataFromDocs(modules, { pathStrategy: 'typedoc', groupOrder: ['Variables', 'Functions', 'Class'] })
```

- Adds `groupOrder?: string[]` (Rust `MarkdownDocsOptions::group_order` / `JsDocsNavOptions`), threaded through both the Markdown and nav generators.
- Introduces a shared `order_by_group_title` helper implementing TypeDoc semantics: titles before `*` lead in the given order, titles after `*` trail, and unlisted groups are placed at `*` (or the end when absent) sorted alphabetically; listed-but-absent titles are ignored. `None` preserves the existing order.
- Restructures the TypeDoc module index into title-tagged sections so References participates in the ordering as its own group (matching TypeDoc, which interleaves it alphabetically), instead of being pinned last.
- Applies consistently to both `renderStyle: 'markdown'` and `'html'` (the module index generator is shared) and to nav, so sidebar and page order stay in sync.

With `groupOrder: ['Variables', 'Functions', 'Class']`, the module index and sidebar render `Variables, Functions, Classes, Interfaces, References, Type Aliases`, matching TypeDoc. (`Class` does not match the `Classes` group title and is ignored, exactly as TypeDoc does.)

Scope: this PR implements `groupOrder` only — the organization option gunshi actually uses and the only current divergence. `sort`, `sortEntryPoints`, and `kindSortOrder` are out of scope (gunshi sets none of them; entry/module order already matches) and can be added later additively.

## Background

TypeDoc lets consumers control declaration group ordering via `groupOrder`.

gunshi's TypeDoc config sets `groupOrder: ['Variables', 'Functions', 'Class']`, so its module index lists Variables before Functions.

ox-content instead emits groups in a fixed internal order (`function, class, interface, type, enum, variable, module`) and always appends References last, so generated module indexes and the TypeDoc sidebar diverge from TypeDoc output:

```txt
TypeDoc:    Variables, Functions, Classes, Interfaces, References, Type Aliases
ox-content: Functions, Classes, Interfaces, Type Aliases, Variables, References
```

There was no way to control this short of post-processing the generated Markdown and nav.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783050756&installation_id=136613492&pr_number=299&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F299&signature=a822827d6f7585b05e7e019528a5ca843bd6dd6e64377e488b0487d116d29011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->