### PR TITLE
fix(docs): sort and dedupe typedoc nav leaf entries to match markdown order

### DIFF
--- a/crates/ox_content_docs/src/nav.rs
+++ b/crates/ox_content_docs/src/nav.rs
@@ -99,7 +99,7 @@ fn generate_typedoc_nav_metadata(
                 .map(|kind| (typedoc_kind_title(&kind).to_string(), kind))
                 .collect::<Vec<_>>();
             for (_title, kind) in order_by_group_title(kind_groups, group_order) {
-                let entries = doc
+                let mut entries = doc
                     .entries
                     .iter()
                     .filter(|entry| entry.kind == kind && owners.is_canonical(&doc, entry))
@@ -107,12 +107,19 @@ fn generate_typedoc_nav_metadata(
                 if entries.is_empty() {
                     continue;
                 }
+                // Sort leaf entries alphabetically (case-insensitive) to match
+                // TypeDoc's sidebar and ox-content's generated Markdown module index.
+                entries.sort_by_cached_key(|entry| (entry.name.to_lowercase(), entry.name.clone()));
 
                 let kind_segment = typedoc_kind_segment(&kind);
                 let kind_file_name = join3(&module_name, "/", kind_segment);
                 let kind_path = nav_route_path(&base_path, &kind_file_name);
+                // Overloads share a name and resolve to one typedoc page, so collapse
+                // them to a single sidebar leaf (matching the module index).
+                let mut seen = std::collections::HashSet::new();
                 let entry_children = entries
                     .into_iter()
+                    .filter(|entry| seen.insert(entry.name.as_str()))
                     .map(|entry| {
                         let entry_file_name = join5(
                             &module_name,
@@ -384,6 +391,67 @@ mod tests {
 
         // Listed groups lead in order; the rest follow alphabetically.
         assert_eq!(titles, vec!["Variables", "Functions", "Classes"]);
+    }
+
+    #[test]
+    fn typedoc_nav_sorts_leaf_entries_alphabetically() {
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "default".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            // Supplied out of order.
+            entries: vec![
+                nav_entry("plugin", "function"),
+                nav_entry("cli", "function"),
+                nav_entry("resolveArgs", "function"),
+                nav_entry("parseArgs", "function"),
+            ],
+        }];
+
+        let nav = generate_nav_metadata_from_docs(
+            &docs,
+            Some("/api"),
+            MarkdownPathStrategy::TypeDoc,
+            None,
+        );
+        let functions = nav[0].children.as_ref().unwrap()[0].children.as_ref().unwrap();
+        let leaves = functions.iter().map(|child| child.title.as_str()).collect::<Vec<_>>();
+
+        // Leaf entries are sorted case-insensitively, matching TypeDoc and the
+        // generated Markdown module index.
+        assert_eq!(leaves, vec!["cli", "parseArgs", "plugin", "resolveArgs"]);
+    }
+
+    #[test]
+    fn typedoc_nav_collapses_overloads_to_one_leaf() {
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "default".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            // `cli` is overloaded (multiple same-name entries resolving to one page).
+            entries: vec![
+                nav_entry("cli", "function"),
+                nav_entry("cli", "function"),
+                nav_entry("cli", "function"),
+                nav_entry("define", "function"),
+            ],
+        }];
+
+        let nav = generate_nav_metadata_from_docs(
+            &docs,
+            Some("/api"),
+            MarkdownPathStrategy::TypeDoc,
+            None,
+        );
+        let functions = nav[0].children.as_ref().unwrap()[0].children.as_ref().unwrap();
+        let leaves = functions.iter().map(|child| child.title.as_str()).collect::<Vec<_>>();
+
+        // The overloaded `cli` appears once, like TypeDoc's sidebar.
+        assert_eq!(leaves, vec!["cli", "define"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Sorts and de-duplicates the symbol leaf entries within each TypeDoc nav kind group so the sidebar matches TypeDoc and ox-content's generated Markdown module index, change scoped to `crates/ox_content_docs/src/nav.rs` (`generate_typedoc_nav_metadata`):

- sorts each group's leaf entries by `(name.to_lowercase(), name)`, the same key the Markdown side already uses;
- collapses overloads (multiple same-name entries that resolve to one typedoc page) to a single sidebar leaf, matching the module index.

No NAPI surface change (`index.d.ts` unchanged), no new options; only the nav leaf order and overload de-duplication change.

Markdown generation, `docs.json`, and the flat path are untouched.

## Background

`generateDocsNavMetadataFromDocs(..., { pathStrategy: 'typedoc' })` sorts modules and (since the `groupOrder` work) orders the kind groups, but it never sorts the symbol leaf entries *inside* each kind group.

They stay in extraction/canonical-ownership order, and it does not de-duplicate overloads. As a result the generated VitePress sidebar diverges from both TypeDoc's sidebar and ox-content's own generated Markdown:

- the Markdown module index already renders sorted, de-duplicated entries, because `generate_markdown` runs `sort_extracted_docs` (which sorts `doc.entries` by name) and the kind sections collapse overloads by name;
- but the nav generator receives `docs` directly, bypassing that sort, and has no de-duplication — so an overloaded function such as `cli` appears multiple times in the sidebar and groups like `Functions`/`Interfaces`/`Type Aliases` are unordered.

Consumers (gunshi) currently work around this by sorting and de-duplicating the nav metadata in their own script.


## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783060932&installation_id=136613492&pr_number=302&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F302&signature=b0954fff6a9c385ea0231a48b993fe3cc58855f423ed3a0acd053351bedfb50b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->