### PR TITLE
fix(docs): sort class/interface/type members alphabetically to match typedoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ benchmarks/corpus/
 
 # Local VS Code extension test harness downloads
 .vscode-test/
+
+# Playwright VRT output (screenshots/diffs/last-run are transient; baselines live
+# under `*-snapshots/` and are committed)
+test-results/

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -811,6 +811,9 @@ fn sort_extracted_docs(docs: &[ApiDocModule]) -> Vec<ApiDocModule> {
 
     for doc in &mut sorted {
         doc.entries.sort_by_cached_key(|entry| (entry.name.to_lowercase(), entry.name.clone()));
+        for entry in &mut doc.entries {
+            sort_api_doc_members(entry);
+        }
     }
 
     sorted.sort_by_cached_key(|module| {
@@ -818,6 +821,18 @@ fn sort_extracted_docs(docs: &[ApiDocModule]) -> Vec<ApiDocModule> {
         (name.to_lowercase(), name)
     });
     sorted
+}
+
+/// Sorts an entry's members alphabetically (case-insensitive) for the member kinds
+/// TypeDoc sorts. Enum members keep declaration order, which can be semantically
+/// meaningful. Renderers bucket members by group while preserving relative order,
+/// so a single global sort yields alphabetical order within each group.
+fn sort_api_doc_members(entry: &mut ApiDocEntry) {
+    if matches!(entry.kind.as_str(), "class" | "interface" | "type") {
+        entry
+            .members
+            .sort_by_cached_key(|member| (member.name.to_lowercase(), member.name.clone()));
+    }
 }
 
 /// Renders the per-page stats summary in the configured render style.
@@ -3683,6 +3698,94 @@ mod tests {
             render_style: MarkdownRenderStyle::Html,
             ..MarkdownDocsOptions::default()
         }
+    }
+
+    fn member(name: &str, kind: &str, is_static: bool) -> ApiDocMember {
+        ApiDocMember {
+            name: name.to_string(),
+            kind: kind.to_string(),
+            description: String::new(),
+            signature: None,
+            type_annotation: Some("unknown".to_string()),
+            params: vec![],
+            returns: None,
+            optional: false,
+            readonly: false,
+            r#static: is_static,
+            private: false,
+            tags: vec![],
+            line: 1,
+            end_line: 1,
+        }
+    }
+
+    #[test]
+    fn typedoc_sorts_interface_members_alphabetically() {
+        let mut entry = test_entry("Command", "interface", "/repo/src/types.ts", "A command.");
+        // Declared out of alphabetical order.
+        entry.members = vec![
+            member("zebra", "property", false),
+            member("apple", "property", false),
+            member("mango", "property", false),
+        ];
+        let out = generate_markdown(&lifecycle_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/interfaces/Command.md").unwrap();
+
+        let pos = |name: &str| page.find(&join3("`", name, "`")).unwrap();
+        assert!(pos("apple") < pos("mango"));
+        assert!(pos("mango") < pos("zebra"));
+    }
+
+    #[test]
+    fn typedoc_sorts_class_members_within_each_group() {
+        let mut entry = test_entry("Engine", "class", "/repo/src/engine.ts", "Engine.");
+        entry.members = vec![
+            member("zeta", "property", false),
+            member("alpha", "property", false),
+            member("run", "method", false),
+            member("build", "method", false),
+        ];
+        let out = generate_markdown(&lifecycle_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/classes/Engine.md").unwrap();
+
+        let pos = |name: &str| page.find(&join3("`", name, "`")).unwrap();
+        // Properties group alphabetical.
+        assert!(pos("alpha") < pos("zeta"));
+        // Methods group alphabetical.
+        assert!(pos("build") < pos("run"));
+    }
+
+    #[test]
+    fn typedoc_keeps_enum_members_in_declaration_order() {
+        let mut entry = test_entry("Level", "enum", "/repo/src/level.ts", "Level.");
+        // Non-alphabetical declaration order, which must be preserved for enums.
+        entry.members = vec![
+            member("Medium", "enumMember", false),
+            member("High", "enumMember", false),
+            member("Low", "enumMember", false),
+        ];
+        let out = generate_markdown(&lifecycle_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/enumerations/Level.md").unwrap();
+
+        let pos = |name: &str| page.find(&join3("`", name, "`")).unwrap();
+        assert!(pos("Medium") < pos("High"));
+        assert!(pos("High") < pos("Low"));
+    }
+
+    #[test]
+    fn typedoc_html_sorts_interface_members_alphabetically() {
+        let mut entry = test_entry("Command", "interface", "/repo/src/types.ts", "A command.");
+        entry.members = vec![
+            member("zebra", "property", false),
+            member("apple", "property", false),
+            member("mango", "property", false),
+        ];
+        let out = generate_markdown(&lifecycle_module(entry), &html_typedoc_options());
+        let page = out.get("combinators/interfaces/Command.md").unwrap();
+
+        let pos = |name: &str| page.find(&join3("<code>", name, "</code>")).unwrap();
+        assert!(pos("apple") < pos("mango"));
+        assert!(pos("mango") < pos("zebra"));
     }
 
     #[test]

--- a/npm/vite-plugin-ox-content/test-results/.last-run.json
+++ b/npm/vite-plugin-ox-content/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/npm/vite-plugin-ox-content/test-results/.last-run.json
+++ b/npm/vite-plugin-ox-content/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
## Summary

Sorts `entry.members` alphabetically (case-insensitive) for `class`, `interface`, and `type` entries in `sort_extracted_docs` (`crates/ox_content_docs/src/markdown.rs`).

The same point that already sorts modules and entries:

- adds a `sort_api_doc_members` helper and applies it to each entry after the existing entry sort;
- the renderers bucket members by group while preserving relative order, so a single global sort yields alphabetical order within every rendered group, in both `renderStyle: 'markdown'` and `renderStyle: 'html'`;
- **enum members keep declaration order** (their order can be semantically meaningful, matching TypeDoc and the existing `enum_emits_enum_members_in_declaration_order` behavior).

No NAPI surface change (`index.d.ts` unchanged), no new options; only member display order changes.

`docs.json` is unaffected (it serializes raw extraction order, independent of `sort_extracted_docs`), and module index / nav are unaffected (members only appear on per-symbol pages).

## Background

ox-content sorts modules and top-level entries before rendering (via `sort_extracted_docs`), but it never sorts `entry.members`.

So class/interface/type member tables are rendered in source declaration order, whereas TypeDoc's generated reference sorts members alphabetically within each member group (`Properties`, `Methods`, `Static Properties`, `Static Methods`, …).

For gunshi this is visible on pages like `default/interfaces/Command.md`, where ox-content emits `name, description, args, …` while TypeDoc emits `args, description, entry, …`.

Both render styles are affected, because the renderers only bucket `entry.members` into groups and preserve their incoming order.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783062914&installation_id=136613492&pr_number=303&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F303&signature=eb63d07394bde0f5ea2c31cb2d54e4ff3c95ba51c2aaa3003d103f0b179492f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->