### PR TITLE
fix(docs): drop redundant Kind column from named member tables

### DIFF
--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -835,6 +835,15 @@ fn sort_api_doc_members(entry: &mut ApiDocEntry) {
     }
 }
 
+/// Whether a member table should keep the `Kind` column. Named member groups
+/// (`Properties`, `Methods`, `Constructors`, `Enum Members`, `Static …`) state the
+/// kind in their heading, so the column is redundant and dropped to match TypeDoc.
+/// Only the generic `Members` fallback (mixed kinds) keeps it. Shared by both
+/// renderers via `super::member_table_includes_kind`.
+fn member_table_includes_kind(group_title: &str) -> bool {
+    group_title == "Members"
+}
+
 /// Renders the per-page stats summary in the configured render style.
 fn render_stats_summary(
     options: &MarkdownDocsOptions,
@@ -2376,11 +2385,12 @@ mod tests {
         assert!(!page.contains("**Signature**"));
         assert!(page.contains("```ts"));
         assert!(page.contains("- `argv` (`string[]`) - Arguments."));
-        assert!(!page.contains("| Name | Type | Description |"));
+        // Named member groups drop the redundant Kind column (the heading states it).
+        assert!(page.contains("| Name | Type | Description |"));
+        assert!(!page.contains("| Name | Kind | Type | Description |"));
         // The interface member group is a real heading (no `**Members**` wrapper).
         assert!(page.lines().any(|line| line == "#### Methods"));
         assert!(!page.contains("**Members**"));
-        assert!(page.contains("| Name | Kind | Type | Description |"));
         assert!(page.contains("[View source](https://github.com/x/y/blob/main/"));
 
         let index = out.get("index.md").unwrap();
@@ -3119,10 +3129,10 @@ mod tests {
             },
         );
         let table_page = table_markdown.get("mod/interfaces/Command.md").unwrap();
-        assert!(table_page.contains("| Name | Kind | Type | Description |"));
-        assert!(
-            table_page.contains("| `name` _(readonly)_ | property | `string` | Command name. |")
-        );
+        // The `Properties` heading states the kind, so the table omits the Kind column.
+        assert!(table_page.contains("| Name | Type | Description |"));
+        assert!(!table_page.contains("| Name | Kind | Type | Description |"));
+        assert!(table_page.contains("| `name` _(readonly)_ | `string` | Command name. |"));
     }
 
     #[test]
@@ -3786,6 +3796,79 @@ mod tests {
         let pos = |name: &str| page.find(&join3("<code>", name, "</code>")).unwrap();
         assert!(pos("apple") < pos("mango"));
         assert!(pos("mango") < pos("zebra"));
+    }
+
+    #[test]
+    fn typedoc_member_table_drops_kind_for_named_groups() {
+        // The `Properties` heading already states the kind, so the table omits it.
+        let mut entry = test_entry("Command", "interface", "/repo/src/types.ts", "A command.");
+        entry.members = vec![member("name", "property", false)];
+        let options = MarkdownDocsOptions {
+            interface_properties_format: MarkdownDisplayFormat::Table,
+            ..markdown_typedoc_options()
+        };
+        let out = generate_markdown(&lifecycle_module(entry), &options);
+        let page = out.get("combinators/interfaces/Command.md").unwrap();
+
+        assert!(page.contains("| Name | Type | Description |"));
+        assert!(!page.contains("| Name | Kind | Type | Description |"));
+        // The redundant per-row kind cell is gone too.
+        assert!(!page.contains("| property |"));
+    }
+
+    #[test]
+    fn typedoc_enum_member_table_drops_kind() {
+        let mut entry = test_entry("Level", "enum", "/repo/src/level.ts", "Level.");
+        entry.members = vec![member("Low", "enumMember", false)];
+        let options = MarkdownDocsOptions {
+            enum_members_format: MarkdownDisplayFormat::Table,
+            ..markdown_typedoc_options()
+        };
+        let out = generate_markdown(&lifecycle_module(entry), &options);
+        let page = out.get("combinators/enumerations/Level.md").unwrap();
+
+        assert!(page.contains("| Name | Type | Description |"));
+        assert!(!page.contains("| Name | Kind | Type | Description |"));
+    }
+
+    #[test]
+    fn typedoc_html_member_table_drops_kind_for_named_groups() {
+        let mut entry = test_entry("Command", "interface", "/repo/src/types.ts", "A command.");
+        entry.members = vec![member("name", "property", false)];
+        let out = generate_markdown(&lifecycle_module(entry), &html_typedoc_options());
+        let page = out.get("combinators/interfaces/Command.md").unwrap();
+
+        assert!(page.contains("<th>Name</th><th>Type</th><th>Description</th>"));
+        assert!(!page.contains("<th>Kind</th>"));
+        assert!(!page.contains("ox-api-entry__member-kind"));
+    }
+
+    #[test]
+    fn typedoc_html_enum_member_table_drops_kind() {
+        // The html renderer groups enum members under `Enum Members` (parity with
+        // the markdown renderer), so the redundant Kind column is dropped.
+        let mut entry = test_entry("Level", "enum", "/repo/src/level.ts", "Level.");
+        entry.members =
+            vec![member("Low", "enumMember", false), member("High", "enumMember", false)];
+        let out = generate_markdown(&lifecycle_module(entry), &html_typedoc_options());
+        let page = out.get("combinators/enumerations/Level.md").unwrap();
+
+        assert!(page.contains("<h5>Enum Members</h5>"));
+        assert!(page.contains("<th>Name</th><th>Type</th><th>Description</th>"));
+        assert!(!page.contains("<th>Kind</th>"));
+    }
+
+    #[test]
+    fn typedoc_html_members_fallback_keeps_kind_column() {
+        // A non class/interface/type/enum entry falls back to a mixed-kind `Members`
+        // group, where the Kind column stays meaningful.
+        let mut entry = test_entry("config", "variable", "/repo/src/config.ts", "Config.");
+        entry.members = vec![member("name", "property", false), member("load", "method", false)];
+        let out = generate_markdown(&lifecycle_module(entry), &html_typedoc_options());
+        let page = out.get("combinators/variables/config.md").unwrap();
+
+        assert!(page.contains("<th>Name</th><th>Kind</th><th>Type</th><th>Description</th>"));
+        assert!(page.contains("ox-api-entry__member-kind"));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/markdown/markdown_html.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_html.rs
@@ -946,6 +946,8 @@ fn render_member_table_html(
         return String::new();
     }
 
+    let include_kind = super::member_table_includes_kind(title);
+
     let mut rows = StringBuilder::new();
     for member in members {
         if !rows.is_empty() {
@@ -961,9 +963,13 @@ fn render_member_table_html(
         rows.push_str(&escape_html(&member.name));
         rows.push_str("</code>");
         rows.push_str(&render_member_flags(member));
-        rows.push_str("</td>\n  <td><span class=\"ox-api-entry__member-kind\">");
-        rows.push_str(&escape_html(&member.kind));
-        rows.push_str("</span></td>\n  <td>");
+        rows.push_str("</td>\n  ");
+        if include_kind {
+            rows.push_str("<td><span class=\"ox-api-entry__member-kind\">");
+            rows.push_str(&escape_html(&member.kind));
+            rows.push_str("</span></td>\n  ");
+        }
+        rows.push_str("<td>");
         rows.push_str(&render_member_type_html(member));
         rows.push_str("</td>\n  <td>");
         rows.push_str(&render_member_description_html(member, options, context));
@@ -981,8 +987,17 @@ fn render_member_table_html(
     out.push_str(
         "</h5>
 <table class=\"ox-api-entry__members-table\">
-<thead><tr><th>Name</th><th>Kind</th><th>Type</th><th>Description</th></tr></thead>
-<tbody>
+",
+    );
+    if include_kind {
+        out.push_str(
+            "<thead><tr><th>Name</th><th>Kind</th><th>Type</th><th>Description</th></tr></thead>\n",
+        );
+    } else {
+        out.push_str("<thead><tr><th>Name</th><th>Type</th><th>Description</th></tr></thead>\n");
+    }
+    out.push_str(
+        "<tbody>
 ",
     );
     out.push_str(&rows);
@@ -1169,6 +1184,17 @@ fn render_members_html(
                 options,
                 context,
             ));
+            groups.push(render_member_group_html(
+                entry,
+                "Enum Members",
+                &enum_members,
+                options,
+                context,
+            ));
+        }
+        "enum" => {
+            let enum_members =
+                members.iter().filter(|member| member.kind == "enumMember").collect::<Vec<_>>();
             groups.push(render_member_group_html(
                 entry,
                 "Enum Members",

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -662,13 +662,20 @@ fn render_member_group_pure(
             out.push('\n');
         }
     } else {
-        out.push_str("| Name | Kind | Type | Description |\n| --- | --- | --- | --- |\n");
+        let include_kind = super::member_table_includes_kind(title);
+        if include_kind {
+            out.push_str("| Name | Kind | Type | Description |\n| --- | --- | --- | --- |\n");
+        } else {
+            out.push_str("| Name | Type | Description |\n| --- | --- | --- |\n");
+        }
         for member in members {
             out.push_str("| ");
             out.push_str(&member_name_cell(member));
             out.push_str(" | ");
-            out.push_str(&table_cell(&member.kind));
-            out.push_str(" | ");
+            if include_kind {
+                out.push_str(&table_cell(&member.kind));
+                out.push_str(" | ");
+            }
             out.push_str(&code_cell(member_type(member)));
             out.push_str(" | ");
             out.push_str(&table_cell(&member_description(member, context.link_context)));


### PR DESCRIPTION
## Summary

- Add a shared `member_table_includes_kind(group_title)` helper: keep the `Kind` column only for the generic `Members` fallback (mixed kinds); drop it for all named groups.
- Apply it in both render styles (`markdown_pure.rs` table branch and `markdown_html.rs` table header + rows). The list format is unchanged.
- Add an `enum` arm to the HTML renderer so enum members render under `Enum Members` (parity with markdown), which also drops their redundant `Kind` column.

No NAPI surface change (`index.d.ts` unchanged) and no `docs.json` change, `kind` is still preserved in machine-readable data.

## Background

For class/interface/type/enum symbols, member tables always rendered four columns: `| Name | Kind | Type | Description |`.

But members are bucketed into kind-specific groups whose heading already states the kind (`Properties` → every row `property`, `Methods` → every row `method`, `Enum Members` → every row `enumMember`, etc.), so the `Kind` column repeats the same value on every row and is redundant.

TypeDoc omits it for these groups. The kind is only meaningful in the generic `Members` fallback group used for non class/interface/type/enum symbols, where kinds can be mixed.

While fixing this, an existing html/markdown parity gap surfaced: the HTML renderer had no `enum` arm and dropped enum members into the generic `Members` fallback, so HTML enum pages showed a `Members` heading and kept the redundant `Kind` column, diverging from the markdown renderer, which groups them under `Enum Members`.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783067098&installation_id=136613492&pr_number=304&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F304&signature=960e80ceb70adc734f8ff0282ea164894cf70cee8b9008c1a5bb1b5237a2ec01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->