### PR TITLE
fix(docs): use entry source path for typedoc module index source link

### DIFF
--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -1440,8 +1440,15 @@ fn generate_typedoc_module_index(
     }
 
     if let Some(github_url) = &options.github_url {
-        markdown.push_str(&generate_source_link(&doc.file, github_url, None, None));
-        markdown.push_str("\n\n");
+        // Link to the entry point's real source file. `doc.file` is the module
+        // route name (e.g. `default`) under the TypeDoc strategy, which would
+        // produce a dead link; `doc.source_path` holds the actual entry-point
+        // path. Omit the link when no source path is available (matching the
+        // per-symbol pages and TypeDoc, which has no module source line).
+        if !doc.source_path.is_empty() {
+            markdown.push_str(&generate_source_link(&doc.source_path, github_url, None, None));
+            markdown.push_str("\n\n");
+        }
     }
 
     push_stats(&mut markdown, options, &summarize_module(doc), None);
@@ -3772,6 +3779,48 @@ mod tests {
             render_style: MarkdownRenderStyle::Markdown,
             ..MarkdownDocsOptions::default()
         }
+    }
+
+    fn module_with_source_path(source_path: &str) -> Vec<ApiDocModule> {
+        vec![ApiDocModule {
+            description: String::new(),
+            // `file` is the module route name, not a real path.
+            file: "default".to_string(),
+            source_path: source_path.to_string(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![test_entry("cli", "function", "/repo/packages/x/src/cli.ts", "Run.")],
+        }]
+    }
+
+    #[test]
+    fn typedoc_module_index_source_link_uses_source_path() {
+        let options = MarkdownDocsOptions {
+            github_url: Some("https://github.com/x/y".to_string()),
+            ..markdown_typedoc_options()
+        };
+        let out =
+            generate_markdown(&module_with_source_path("/repo/packages/x/src/index.ts"), &options);
+        let index = out.get("default/index.md").unwrap();
+
+        // Links to the real entry-point file, never the dead `blob/main/default`.
+        assert!(index
+            .contains("**[Source](https://github.com/x/y/blob/main/packages/x/src/index.ts)**"));
+        assert!(!index.contains("blob/main/default"));
+    }
+
+    #[test]
+    fn typedoc_module_index_omits_source_link_without_source_path() {
+        let options = MarkdownDocsOptions {
+            github_url: Some("https://github.com/x/y".to_string()),
+            ..markdown_typedoc_options()
+        };
+        let out = generate_markdown(&module_with_source_path(""), &options);
+        let index = out.get("default/index.md").unwrap();
+
+        // No source path → no module source line (and no dead link).
+        assert!(!index.contains("**[Source]"));
+        assert!(!index.contains("blob/main/default"));
     }
 
     fn group_order_docs() -> Vec<ApiDocModule> {


### PR DESCRIPTION
## Summary

Fixes the dead module `**[Source]**` link on typedoc `{module}/index.md`.

The link now targets the entry point's real source file (`source_path`) and is omitted when none is available, instead of pointing at the module route name.

Applies to both markdown and html; no NAPI or docs.json change.

## Background

Under `pathStrategy: "typedoc"`, the module index built the source link from `doc.file`, the module route name (e.g. `default`), producing `${githubUrl}/blob/main/default`,  a 404 for every module. `source_path` holds the real entry-point path (per-symbol links use it), so it is correct.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783097117&installation_id=136613492&pr_number=308&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F308&signature=816b20e2258a18f8c8f3b720cf8907dd7f3d32aedae20a371ce5f16871265983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->