### PR TITLE
feat(profiler): add JS/TS docs-generator profiling mode

### DIFF
--- a/crates/ox_content_docs/Cargo.toml
+++ b/crates/ox_content_docs/Cargo.toml
@@ -35,6 +35,18 @@ oxc_ast_visit = { workspace = true }
 oxc_span = { workspace = true }
 oxc_resolver = { workspace = true }
 
+ox_content_profiler = { workspace = true, optional = true }
+
+[features]
+default = []
+# Compiles in lightweight RAII span guards at the docs generator's hot-path
+# boundaries (OXC parse, JSDoc parse, AST visit, export-graph resolution,
+# normalize, Markdown render, nav/JSON emit). Off by default: when disabled,
+# `profile_span!` expands to nothing and call sites pay zero overhead. Enable
+# via `cargo check -p ox_content_docs --features profile` or through the
+# `ox_content_profile_cli` binary's `docs-*` subcommands.
+profile = ["dep:ox_content_profiler"]
+
 [dev-dependencies]
 criterion = { workspace = true }
 

--- a/crates/ox_content_docs/src/data.rs
+++ b/crates/ox_content_docs/src/data.rs
@@ -3,6 +3,8 @@ use serde_json::{json, Map, Value};
 use crate::model::{
     ApiDocEntry, ApiDocMember, ApiDocModule, ApiParamDoc, ApiReturnDoc, ApiTypeParamDoc,
 };
+#[allow(unused_imports)]
+use crate::profile_span;
 
 const DOC_KIND_ORDER: [&str; 7] =
     ["function", "class", "interface", "type", "enum", "variable", "module"];
@@ -26,6 +28,7 @@ pub fn generate_docs_data_json(
     docs: &[ApiDocModule],
     generated_at: &str,
 ) -> serde_json::Result<String> {
+    profile_span!("docs::generate_json");
     serde_json::to_string_pretty(&json!({
         "version": 1,
         "generatedAt": generated_at,

--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -19,6 +19,8 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use thiserror::Error;
 
+#[allow(unused_imports)]
+use crate::profile_span;
 use crate::string_builder::{join2, join3, join5, StringBuilder};
 
 /// Result type for extraction operations.
@@ -255,8 +257,12 @@ impl DocExtractor {
         file_path: &str,
         source_type: SourceType,
     ) -> ExtractResult<Vec<DocItem>> {
+        profile_span!("docs::extract_source");
         let allocator = Allocator::default();
-        let ret = Parser::new(&allocator, source, source_type).parse();
+        let ret = {
+            profile_span!("docs::oxc_parse");
+            Parser::new(&allocator, source, source_type).parse()
+        };
 
         if !ret.errors.is_empty() {
             let error_msg = ret
@@ -280,10 +286,13 @@ impl DocExtractor {
             jsdoc_cache,
         );
         let first_stmt_start = ret.program.body.first().map(|statement| statement.span().start);
-        if let Some(module_item) = visitor.extract_module_entry(&comments, first_stmt_start) {
-            visitor.items.push(module_item);
+        {
+            profile_span!("docs::visit_ast");
+            if let Some(module_item) = visitor.extract_module_entry(&comments, first_stmt_start) {
+                visitor.items.push(module_item);
+            }
+            visitor.visit_program(&ret.program);
         }
-        visitor.visit_program(&ret.program);
 
         Ok(visitor.items)
     }
@@ -363,6 +372,7 @@ fn parse_jsdoc_payload(source: &str, comment: &Comment) -> ParsedJsdoc {
 /// batch parser still fall back individually so diagnostics do not poison the
 /// whole file.
 fn build_jsdoc_cache(source: &str, comments: &[Comment]) -> FxHashMap<u32, ParsedJsdoc> {
+    profile_span!("docs::parse_jsdoc");
     let jsdoc_comments: Vec<&Comment> =
         comments.iter().filter(|comment| comment.is_jsdoc()).collect();
     if jsdoc_comments.is_empty() {

--- a/crates/ox_content_docs/src/graph.rs
+++ b/crates/ox_content_docs/src/graph.rs
@@ -14,6 +14,8 @@ use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+#[allow(unused_imports)]
+use crate::profile_span;
 use crate::string_builder::{join2, join4, StringBuilder};
 use crate::{
     normalize_doc_items, ApiDocTag, DocExtractor, ExtractError, NormalizedDocEntry,
@@ -268,6 +270,7 @@ pub fn build_export_graph(
     entrypoints: &[EntryPointSpec],
     options: &GraphOptions,
 ) -> Result<ExportGraph, GraphError> {
+    profile_span!("docs::build_export_graph");
     let root = graph_root(options);
     let resolver = ModuleResolver::new(&root, options);
     let mut builder = GraphBuilder {
@@ -293,6 +296,7 @@ pub fn extract_docs_from_entry_points(
     entrypoints: &[EntryPointSpec],
     options: &EntryPointDocsOptions,
 ) -> Result<Vec<EntrypointDocsModule>, GraphError> {
+    profile_span!("docs::extract_entry_points");
     let graph = build_export_graph(entrypoints, &options.graph)?;
     let extractor =
         DocExtractor::for_entrypoint_exports(options.include_private, options.include_internal);
@@ -669,6 +673,7 @@ impl ModuleResolver {
         importer: &Path,
         specifier: &str,
     ) -> Result<Option<ResolvedModuleRef>, GraphError> {
+        profile_span!("docs::resolve_specifier");
         if !is_local_specifier(specifier) && !self.external_docs_enabled {
             return Ok(None);
         }
@@ -731,6 +736,7 @@ impl GraphBuilder {
     }
 
     fn collect_module_exports(&mut self, path: &Path) -> Result<Vec<PublicExport>, GraphError> {
+        profile_span!("docs::collect_exports");
         let path = normalize_existing_path(path);
         if let Some(module) = self.modules.get(&path) {
             return Ok(module.exports.clone());
@@ -756,7 +762,10 @@ impl GraphBuilder {
     ) -> Result<Vec<PublicExport>, GraphError> {
         let allocator = Allocator::default();
         let source_type = SourceType::from_path(path).unwrap_or_default();
-        let ret = Parser::new(&allocator, source, source_type).parse();
+        let ret = {
+            profile_span!("docs::graph_oxc_parse");
+            Parser::new(&allocator, source, source_type).parse()
+        };
         if !ret.errors.is_empty() {
             let message = ret
                 .errors

--- a/crates/ox_content_docs/src/lib.rs
+++ b/crates/ox_content_docs/src/lib.rs
@@ -7,6 +7,27 @@
 #![deny(clippy::disallowed_macros)]
 #![cfg_attr(test, allow(clippy::disallowed_macros))]
 
+/// Lightweight RAII span guard used internally by the docs generator modules.
+///
+/// Compiles to nothing when the `profile` feature is disabled (the default)
+/// so non-profiling builds pay zero overhead. Under `--features profile`,
+/// expands to `ox_content_profiler::ScopeGuard::enter(name)` which records the
+/// scope timing + allocation delta into the thread-local span tree. See
+/// `ox_content_parser::profile_span` for the same pattern in the parser.
+#[cfg(feature = "profile")]
+macro_rules! profile_span {
+    ($name:literal) => {
+        let __ox_profile_guard = ::ox_content_profiler::ScopeGuard::enter($name);
+    };
+}
+
+#[cfg(not(feature = "profile"))]
+macro_rules! profile_span {
+    ($name:literal) => {};
+}
+
+pub(crate) use profile_span;
+
 mod config;
 mod data;
 mod extractor;

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -10,6 +10,8 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::model::{ApiDocEntry, ApiDocMember, ApiDocModule};
+#[allow(unused_imports)]
+use crate::profile_span;
 use crate::string_builder::{join2, join3, join4, join5, StringBuilder};
 
 mod markdown_html;
@@ -243,6 +245,7 @@ pub fn generate_markdown(
     docs: &[ApiDocModule],
     options: &MarkdownDocsOptions,
 ) -> BTreeMap<String, String> {
+    profile_span!("docs::generate_markdown");
     let mut result = BTreeMap::new();
     let sorted_docs = sort_extracted_docs(docs, options);
     let symbol_map = build_symbol_map(&sorted_docs, options);
@@ -1075,6 +1078,7 @@ fn generate_file_markdown(
     current_file_name: &str,
     symbol_map: &HashMap<String, Vec<SymbolLocation>>,
 ) -> String {
+    profile_span!("docs::render_file");
     let display_name = file_name(&doc.file);
     let mut markdown = String::new();
     markdown.push_str("# ");
@@ -1185,6 +1189,7 @@ fn generate_typedoc_markdown(
     options: &MarkdownDocsOptions,
     symbol_map: &HashMap<String, Vec<SymbolLocation>>,
 ) -> BTreeMap<String, String> {
+    profile_span!("docs::render_typedoc");
     let mut result = BTreeMap::new();
     let owners = CanonicalOwners::compute(docs);
 
@@ -1261,6 +1266,7 @@ fn generate_typedoc_entry_page_grouped(
     file_name: &str,
     symbol_map: &HashMap<String, Vec<SymbolLocation>>,
 ) -> String {
+    profile_span!("docs::render_entry_page");
     if entries.len() == 1 {
         return generate_typedoc_entry_page(
             entries[0],
@@ -1402,6 +1408,7 @@ fn generate_typedoc_module_index(
     symbol_map: &HashMap<String, Vec<SymbolLocation>>,
     owners: &CanonicalOwners,
 ) -> String {
+    profile_span!("docs::render_module_index");
     let current_file_name = typedoc_module_index_file_name(module_name);
     let link_context = MarkdownLinkContext {
         options,
@@ -2374,6 +2381,7 @@ fn build_symbol_map(
     docs: &[ApiDocModule],
     options: &MarkdownDocsOptions,
 ) -> HashMap<String, Vec<SymbolLocation>> {
+    profile_span!("docs::build_symbol_map");
     let mut map = HashMap::new();
     // In the TypeDoc strategy a re-exported symbol has a single canonical page;
     // resolve every reference to that owner module so cross-links never point at

--- a/crates/ox_content_docs/src/nav.rs
+++ b/crates/ox_content_docs/src/nav.rs
@@ -10,6 +10,8 @@ use crate::markdown::{
     parse_sort_strategies, CanonicalOwners, MarkdownPathStrategy,
 };
 use crate::model::ApiDocModule;
+#[allow(unused_imports)]
+use crate::profile_span;
 use crate::string_builder::{join2, join3, join5, StringBuilder};
 
 const DEFAULT_BASE_PATH: &str = "/api";
@@ -67,6 +69,7 @@ pub fn generate_nav_metadata_from_docs(
     sort_entry_points: bool,
     kind_sort_order: Option<&[String]>,
 ) -> Vec<DocsNavItem> {
+    profile_span!("docs::generate_nav");
     match path_strategy {
         MarkdownPathStrategy::Flat => {
             let files = docs.iter().map(|doc| doc.file.clone()).collect::<Vec<_>>();

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -6,6 +6,8 @@ use phf::phf_set;
 use serde::{Deserialize, Serialize};
 
 use crate::extractor::{DocItem, DocItemKind, DocTag, ParamDoc, TypeParamDoc};
+#[allow(unused_imports)]
+use crate::profile_span;
 
 const UNKNOWN_TYPE: &str = "unknown";
 const PARAM_TAG_NAME: &str = "param";
@@ -258,6 +260,7 @@ pub struct NormalizedDocEntry {
 /// Normalizes extracted documentation items into API reference entries.
 #[must_use]
 pub fn normalize_doc_items(items: Vec<DocItem>, type_parameters: bool) -> Vec<NormalizedDocEntry> {
+    profile_span!("docs::normalize_items");
     items.into_iter().filter_map(|item| normalize_doc_item(item, type_parameters)).collect()
 }
 

--- a/crates/ox_content_docs/src/output.rs
+++ b/crates/ox_content_docs/src/output.rs
@@ -10,6 +10,8 @@ use crate::data::generate_docs_data_json;
 use crate::markdown::MarkdownPathStrategy;
 use crate::model::ApiDocModule;
 use crate::nav::{generate_nav_code, generate_nav_metadata_from_docs};
+#[allow(unused_imports)]
+use crate::profile_span;
 
 const DOCS_MANIFEST_FILE: &str = ".ox-content-docs-manifest.json";
 const DOCS_DATA_FILE: &str = "docs.json";
@@ -54,6 +56,7 @@ pub fn write_docs_output(
     extracted_docs: Option<&[ApiDocModule]>,
     options: &DocsOutputOptions,
 ) -> DocsOutputResult<()> {
+    profile_span!("docs::write_output");
     fs::create_dir_all(out_dir)?;
 
     let mut generated_files = docs.keys().cloned().collect::<Vec<_>>();

--- a/crates/ox_content_profile_cli/Cargo.toml
+++ b/crates/ox_content_profile_cli/Cargo.toml
@@ -24,5 +24,6 @@ ox_content_allocator = { workspace = true }
 ox_content_ast = { workspace = true }
 ox_content_parser = { workspace = true, features = ["profile"] }
 ox_content_renderer = { workspace = true, features = ["profile"] }
+ox_content_docs = { workspace = true, features = ["profile"] }
 ox_content_profiler = { workspace = true }
 clap = { workspace = true }

--- a/crates/ox_content_profile_cli/src/main.rs
+++ b/crates/ox_content_profile_cli/src/main.rs
@@ -21,13 +21,35 @@
 //!
 //! Without a `<FILE>` the embedded corpus is used so the binary stays
 //! useful in CI / first-time setup.
+//!
+//! The `docs-*` subcommands profile the JS/TS documentation generator
+//! (`ox_content_docs`) over a source directory instead of a Markdown file:
+//!
+//! ```text
+//! cargo run --release -p ox_content_profile_cli -- docs-extract <DIR>
+//! cargo run --release -p ox_content_profile_cli -- docs-render <DIR>
+//! cargo run --release -p ox_content_profile_cli -- docs-pipeline <DIR>
+//! ```
+//!
+//! These exercise the OXC parse + JSDoc parse + AST visit + normalize path
+//! (`docs-extract`), the TypeDoc/pure-Markdown render path (`docs-render`,
+//! extraction hoisted out of the measurement loop), or both end to end
+//! (`docs-pipeline`).
 
 use std::fmt::Write as _;
-use std::path::PathBuf;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use clap::{Parser as ClapParser, Subcommand};
 use ox_content_allocator::Allocator;
+use ox_content_docs::{
+    collect_source_files, extract_docs_from_directories, generate_markdown, ApiDocEntry,
+    ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc, ApiReturnDoc, ApiTypeParamDoc,
+    ExtractedDocModule, MarkdownDocsOptions, MarkdownPathStrategy, MarkdownRenderStyle,
+    NormalizedDocEntry, NormalizedMember, NormalizedParamDoc, NormalizedReturnDoc,
+    NormalizedTypeParam,
+};
 use ox_content_parser::{Parser, ParserOptions};
 use ox_content_profiler::{report::ReportConfig, scope, CountingAllocator, Recorder};
 use ox_content_renderer::{HtmlRenderer, HtmlRendererOptions};
@@ -74,6 +96,22 @@ enum Cmd {
     Render { file: Option<PathBuf> },
     /// Profile the full pipeline: allocator + parse + render.
     Pipeline { file: Option<PathBuf> },
+    /// Profile JS/TS docs extraction over a directory tree: OXC parse + JSDoc
+    /// parse + AST visit + normalize, for every matched source file.
+    DocsExtract { dir: PathBuf },
+    /// Profile the docs Markdown render path. Extraction runs once outside the
+    /// measurement loop so the timing reflects rendering in isolation.
+    DocsRender { dir: PathBuf },
+    /// Profile the full docs pipeline: extraction + normalize + Markdown render.
+    DocsPipeline { dir: PathBuf },
+}
+
+/// Which slice of the docs pipeline a `docs-*` run measures.
+#[derive(Clone, Copy)]
+enum DocsPhase {
+    Extract,
+    Render,
+    Pipeline,
 }
 
 fn load_input(file: Option<&PathBuf>) -> std::io::Result<(String, String)> {
@@ -100,32 +138,54 @@ fn parse_error(err: impl std::fmt::Display) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::InvalidData, message)
 }
 
+/// Which slice of the Markdown engine a `parse`/`render`/`pipeline` run measures.
+#[derive(Clone, Copy)]
+enum MarkdownPhase {
+    Parse,
+    Render,
+    Pipeline,
+}
+
 fn run(cli: &Cli) -> std::io::Result<()> {
     CountingAllocator::enable();
     scope::enable();
 
-    let (label_input, source) = match &cli.cmd {
-        Cmd::Parse { file } | Cmd::Render { file } | Cmd::Pipeline { file } => {
-            load_input(file.as_ref())?
-        }
+    match &cli.cmd {
+        Cmd::DocsExtract { dir } => run_docs(cli, dir, DocsPhase::Extract),
+        Cmd::DocsRender { dir } => run_docs(cli, dir, DocsPhase::Render),
+        Cmd::DocsPipeline { dir } => run_docs(cli, dir, DocsPhase::Pipeline),
+        Cmd::Parse { .. } | Cmd::Render { .. } | Cmd::Pipeline { .. } => run_markdown(cli),
+    }
+}
+
+/// Profile the Markdown parse/render/pipeline path against a single input file
+/// (or the embedded corpus when none is given).
+fn run_markdown(cli: &Cli) -> std::io::Result<()> {
+    let (phase, file) = match &cli.cmd {
+        Cmd::Parse { file } => (MarkdownPhase::Parse, file.as_ref()),
+        Cmd::Render { file } => (MarkdownPhase::Render, file.as_ref()),
+        Cmd::Pipeline { file } => (MarkdownPhase::Pipeline, file.as_ref()),
+        // docs-* commands are dispatched to run_docs in run().
+        _ => unreachable!("non-Markdown command routed to run_markdown"),
     };
+    let (label_input, source) = load_input(file)?;
     let bytes = source.len() as u64;
 
     let total_iters = cli.warmup + cli.iters;
     let config = ReportConfig { input_bytes: Some(bytes), warmup: cli.warmup, max_span_rows: 24 };
 
-    let label_prefix = match &cli.cmd {
-        Cmd::Parse { .. } => "parse",
-        Cmd::Render { .. } => "render",
-        Cmd::Pipeline { .. } => "pipeline",
+    let label_prefix = match phase {
+        MarkdownPhase::Parse => "parse",
+        MarkdownPhase::Render => "render",
+        MarkdownPhase::Pipeline => "pipeline",
     };
     let mut label = String::new();
     push_fmt(&mut label, format_args!("{label_prefix} ({label_input}, {bytes} bytes)"));
 
     let mut recorder = Recorder::new(label).with_config(config);
 
-    match &cli.cmd {
-        Cmd::Parse { .. } => {
+    match phase {
+        MarkdownPhase::Parse => {
             for _ in 0..total_iters {
                 recorder.record(|| -> std::io::Result<()> {
                     let alloc = Allocator::for_source_len(source.len());
@@ -135,7 +195,7 @@ fn run(cli: &Cli) -> std::io::Result<()> {
                 })?;
             }
         }
-        Cmd::Render { .. } => {
+        MarkdownPhase::Render => {
             // Renderer needs a pre-parsed document. Allocate one for each
             // iteration to keep the AST distinct (rendering itself mutates
             // shared HtmlRenderer state across iterations otherwise).
@@ -149,7 +209,7 @@ fn run(cli: &Cli) -> std::io::Result<()> {
                 });
             }
         }
-        Cmd::Pipeline { .. } => {
+        MarkdownPhase::Pipeline => {
             for _ in 0..total_iters {
                 recorder.record(|| -> std::io::Result<()> {
                     let alloc = Allocator::for_source_len(source.len());
@@ -163,20 +223,230 @@ fn run(cli: &Cli) -> std::io::Result<()> {
         }
     }
 
-    let report = recorder.finish();
+    emit_report(recorder, cli);
+    Ok(())
+}
 
-    // We disable instrumentation before stringifying so the report's own
-    // allocations don't pollute the final picture if a user re-uses
-    // `AllocSnapshot::capture` after this.
+/// Markdown render options used by the `docs-render` / `docs-pipeline` drivers.
+///
+/// Mirrors the modern VitePress-style production path that recent work targets:
+/// the TypeDoc page layout with pure-Markdown output (rather than the legacy
+/// flat/HTML defaults).
+fn docs_markdown_options() -> MarkdownDocsOptions {
+    MarkdownDocsOptions {
+        path_strategy: MarkdownPathStrategy::TypeDoc,
+        render_style: MarkdownRenderStyle::Markdown,
+        ..MarkdownDocsOptions::default()
+    }
+}
+
+/// Glob filters matching the source files a typical docs build ingests.
+fn docs_filters() -> (Vec<String>, Vec<String>) {
+    let include = ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"]
+        .iter()
+        .map(|pattern| (*pattern).to_string())
+        .collect();
+    let exclude = ["**/*.d.ts", "**/*.test.*", "**/*.spec.*", "node_modules"]
+        .iter()
+        .map(|pattern| (*pattern).to_string())
+        .collect();
+    (include, exclude)
+}
+
+/// Profile the JS/TS docs generator over `dir`.
+fn run_docs(cli: &Cli, dir: &Path, phase: DocsPhase) -> std::io::Result<()> {
+    if !dir.is_dir() {
+        let mut message = String::from("docs profiling target is not a directory: ");
+        push_fmt(&mut message, format_args!("{}", dir.display()));
+        return Err(std::io::Error::new(std::io::ErrorKind::NotFound, message));
+    }
+
+    let dir_str = dir.display().to_string();
+    let (include, exclude) = docs_filters();
+    let src_dirs = [dir_str.clone()];
+
+    // Total source bytes processed, so the report's MB/s reflects throughput
+    // over the real input rather than a single synthetic buffer.
+    let files = collect_source_files(&dir_str, &include, &exclude);
+    let file_count = files.len();
+    let bytes: u64 =
+        files.iter().filter_map(|file| std::fs::metadata(file).ok()).map(|meta| meta.len()).sum();
+
+    let total_iters = cli.warmup + cli.iters;
+    let config = ReportConfig { input_bytes: Some(bytes), warmup: cli.warmup, max_span_rows: 32 };
+
+    let label_prefix = match phase {
+        DocsPhase::Extract => "docs-extract",
+        DocsPhase::Render => "docs-render",
+        DocsPhase::Pipeline => "docs-pipeline",
+    };
+    let mut label = String::new();
+    push_fmt(
+        &mut label,
+        format_args!("{label_prefix} ({dir_str}, {file_count} files, {bytes} bytes)"),
+    );
+    let mut recorder = Recorder::new(label).with_config(config);
+
+    match phase {
+        DocsPhase::Extract => {
+            for _ in 0..total_iters {
+                recorder.record(|| -> std::io::Result<()> {
+                    let modules = extract_docs(&src_dirs, &include, &exclude)?;
+                    black_box(modules);
+                    Ok(())
+                })?;
+            }
+        }
+        DocsPhase::Render => {
+            // Extraction is hoisted out of the loop so the timing reflects the
+            // Markdown render path in isolation.
+            let api_modules = extract_api_modules(&src_dirs, &include, &exclude)?;
+            let options = docs_markdown_options();
+            for _ in 0..total_iters {
+                recorder.record(|| {
+                    let pages = generate_markdown(&api_modules, &options);
+                    black_box(pages);
+                });
+            }
+        }
+        DocsPhase::Pipeline => {
+            let options = docs_markdown_options();
+            for _ in 0..total_iters {
+                recorder.record(|| -> std::io::Result<()> {
+                    let api_modules = extract_api_modules(&src_dirs, &include, &exclude)?;
+                    let pages = generate_markdown(&api_modules, &options);
+                    black_box(pages);
+                    Ok(())
+                })?;
+            }
+        }
+    }
+
+    emit_report(recorder, cli);
+    Ok(())
+}
+
+/// Run extraction + normalization over `src_dirs`, mapping the error into the
+/// CLI's `io::Error` channel.
+fn extract_docs(
+    src_dirs: &[String],
+    include: &[String],
+    exclude: &[String],
+) -> std::io::Result<Vec<ExtractedDocModule>> {
+    extract_docs_from_directories(src_dirs, include, exclude, false, false, true)
+        .map_err(docs_error)
+}
+
+/// Extract and convert into the render IR consumed by `generate_markdown`.
+fn extract_api_modules(
+    src_dirs: &[String],
+    include: &[String],
+    exclude: &[String],
+) -> std::io::Result<Vec<ApiDocModule>> {
+    Ok(extract_docs(src_dirs, include, exclude)?.into_iter().map(to_api_module).collect())
+}
+
+/// Finish a recording window and print the report.
+///
+/// Instrumentation is disabled before stringifying so the report's own
+/// allocations don't pollute the final picture.
+fn emit_report(recorder: Recorder, cli: &Cli) {
+    let report = recorder.finish();
     CountingAllocator::disable();
     scope::disable();
-
     if cli.json {
         println!("{}", report.render_json());
     } else {
         println!("{}", report.render_table());
     }
-    Ok(())
+}
+
+fn docs_error(err: impl std::fmt::Display) -> std::io::Error {
+    let mut message = String::from("failed to extract docs for profiling: ");
+    push_fmt(&mut message, format_args!("{err}"));
+    std::io::Error::new(std::io::ErrorKind::InvalidData, message)
+}
+
+// Bridge the normalized extraction output into the `ApiDocModule` render IR.
+// `generate_markdown` consumes the IR that the NAPI layer reconstructs in JS
+// between the `extractDocsFrom*` and `generateDocsMarkdown` calls; this mirrors
+// that conversion so the full pipeline can be profiled in-process. The mapping
+// tracks `ox_content_napi`'s `convert_markdown_*` helpers.
+
+fn to_api_module(module: ExtractedDocModule) -> ApiDocModule {
+    ApiDocModule {
+        file: module.file,
+        description: String::new(),
+        source_path: String::new(),
+        examples: Vec::new(),
+        tags: Vec::new(),
+        entries: module.entries.into_iter().map(to_api_entry).collect(),
+    }
+}
+
+fn to_api_entry(entry: NormalizedDocEntry) -> ApiDocEntry {
+    ApiDocEntry {
+        name: entry.name,
+        kind: entry.kind.as_str().to_string(),
+        description: entry.description,
+        params: entry.params.into_iter().map(to_api_param).collect(),
+        returns: entry.returns.map(to_api_return),
+        examples: entry.examples,
+        tags: entry.tags.into_iter().map(|(tag, value)| ApiDocTag { tag, value }).collect(),
+        private: entry.private,
+        file: entry.file,
+        line: entry.line,
+        end_line: entry.end_line,
+        signature: entry.signature,
+        has_body: entry.has_body,
+        members: entry.members.into_iter().map(to_api_member).collect(),
+        type_parameters: entry.type_parameters.into_iter().map(to_api_type_param).collect(),
+    }
+}
+
+fn to_api_member(member: NormalizedMember) -> ApiDocMember {
+    ApiDocMember {
+        name: member.name,
+        kind: member.kind.as_str().to_string(),
+        description: member.description,
+        signature: member.signature,
+        type_annotation: member.type_annotation,
+        params: member.params.into_iter().map(to_api_param).collect(),
+        returns: member.returns.map(to_api_return),
+        optional: member.optional,
+        readonly: member.readonly,
+        r#static: member.r#static,
+        private: member.private,
+        tags: member.tags.into_iter().map(|(tag, value)| ApiDocTag { tag, value }).collect(),
+        line: member.line,
+        end_line: member.end_line,
+    }
+}
+
+fn to_api_param(param: NormalizedParamDoc) -> ApiParamDoc {
+    ApiParamDoc {
+        name: param.name,
+        type_annotation: param.type_annotation,
+        description: param.description,
+        optional: param.optional,
+        default_value: param.default_value,
+    }
+}
+
+fn to_api_return(return_doc: NormalizedReturnDoc) -> ApiReturnDoc {
+    ApiReturnDoc {
+        type_annotation: return_doc.type_annotation,
+        description: return_doc.description,
+    }
+}
+
+fn to_api_type_param(type_param: NormalizedTypeParam) -> ApiTypeParamDoc {
+    ApiTypeParamDoc {
+        name: type_param.name,
+        constraint: type_param.constraint,
+        default: type_param.default,
+        description: type_param.description,
+    }
 }
 
 fn push_fmt(output: &mut String, args: std::fmt::Arguments<'_>) {

--- a/docs/content/profiling.md
+++ b/docs/content/profiling.md
@@ -24,12 +24,14 @@ There are three independent layers, all exposed through one CLI:
 
 2. **Hierarchical timing spans** (`ox_content_profiler::scope`) maintain a
    thread-local span stack with self / inclusive time aggregation, plus
-   per-span allocation deltas. The parser and renderer crates each have a
-   `profile` Cargo feature that swaps in real `profile_span!` guards at
-   their hot block-level entry points (`parse_block`, `parse_html_block`,
-   `visit_heading`, `write_escaped`, etc.). With the feature disabled
-   (the default), `profile_span!` expands to a zero-sized binding the
-   optimizer drops.
+   per-span allocation deltas. The parser, renderer, and docs-generator
+   crates each have a `profile` Cargo feature that swaps in real
+   `profile_span!` guards at their hot entry points — `parse_block`,
+   `parse_html_block`, `visit_heading`, `write_escaped` in the Markdown
+   engine, and `docs::oxc_parse`, `docs::parse_jsdoc`, `docs::visit_ast`,
+   `docs::render_entry_page`, etc. in the JS/TS docs generator. With the
+   feature disabled (the default), `profile_span!` expands to a zero-sized
+   binding the optimizer drops.
 
 3. **Report formatting** (`ox_content_profiler::Report`) folds per-iteration
    records into percentile timings, allocation summaries, span breakdown,
@@ -62,6 +64,30 @@ cargo run --release -p ox_content_profile_cli -- pipeline --json path/to/file.md
 
 Always build `--release`: the macro-expanded `profile_span!` guards are
 cheap, but in a debug build they dominate the actual work.
+
+### Profiling the JS/TS docs generator
+
+The `docs-*` subcommands profile `ox_content_docs` (the "cargo doc for
+JavaScript" generator) over a source **directory** rather than a single
+Markdown file. They reproduce the production pipeline — OXC parse → JSDoc
+parse → AST visit → normalize → TypeDoc/pure-Markdown render:
+
+```bash
+# Extraction only: OXC parse + JSDoc parse + AST visit + normalize,
+# for every .ts/.tsx/.mts/.cts file under the directory.
+cargo run --release -p ox_content_profile_cli -- docs-extract path/to/src
+
+# Render only: extraction is hoisted out of the measurement loop so the
+# timing reflects the Markdown render path in isolation.
+cargo run --release -p ox_content_profile_cli -- docs-render path/to/src
+
+# Full pipeline: extraction + normalize + Markdown render.
+cargo run --release -p ox_content_profile_cli -- docs-pipeline path/to/src --json
+```
+
+The report's throughput is computed over the total bytes of source ingested,
+and span rows are prefixed with `docs::` so they're easy to tell apart from
+the Markdown-engine spans.
 
 ## Reading the report
 


### PR DESCRIPTION
## Summary

Phase 1 of a multi-phase performance effort. The profiler previously only covered the Markdown engine (`ox_content_parser` + `ox_content_renderer`), even though almost all recent work has landed in **`ox_content_docs`** (the "cargo doc for JavaScript" generator). That entire pipeline had **zero profiling coverage**.

This PR closes that gap:

- **`profile` Cargo feature + `profile_span!` shim** in `ox_content_docs`, mirroring the parser/renderer pattern. Disabled by default → every span expands to nothing → non-profiling builds pay zero overhead.
- **16 instrumentation points** at the hot-path boundaries:
  - Extraction: `docs::extract_source`, `docs::oxc_parse`, `docs::parse_jsdoc`, `docs::visit_ast`
  - Graph: `docs::build_export_graph`, `docs::extract_entry_points`, `docs::collect_exports`, `docs::graph_oxc_parse`, `docs::resolve_specifier`
  - Normalize: `docs::normalize_items`
  - Render: `docs::generate_markdown`, `docs::build_symbol_map`, `docs::render_typedoc`, `docs::render_file`, `docs::render_entry_page`, `docs::render_module_index`
  - Emit: `docs::generate_nav`, `docs::generate_json`, `docs::write_output`
- **Three `docs-*` subcommands** in `ox-content-profile` that drive the real generator over a source **directory**:
  - `docs-extract` — OXC parse + JSDoc parse + AST visit + normalize
  - `docs-render` — TypeDoc/pure-Markdown render (extraction hoisted out of the loop)
  - `docs-pipeline` — extraction + normalize + render, end to end
  - The render driver reconstructs the `ApiDocModule` render IR in-process, mirroring the conversion the NAPI layer does in JS between `extractDocsFrom*` and `generateDocsMarkdown`, so the full pipeline is measurable without a Node round-trip.
- **`docs/content/profiling.md`** updated with the new commands.

### Example output (`docs-pipeline` over `npm/`, 108 files / 789 KB)

```
 docs::render_entry_page   16860   80.08 ms   80.08 ms  22.6%   1306180   84.32 MB
 docs::oxc_parse            2160   66.58 ms   66.58 ms  18.8%     26360  161.99 MB
 docs::render_module_index  1440   43.03 ms   43.03 ms  12.1%    535260   23.92 MB
 docs::parse_jsdoc          2160   33.35 ms   33.35 ms   9.4%    259700  157.61 MB
 ...
 Allocations (per iteration): count 216213.0, bytes 34.25 MB
```

This immediately surfaces the candidates for the follow-up phases (per-symbol render, OXC re-parsing across the graph + extract passes, JSDoc allocation churn).

## Risk

- Risk level: **low**
- User or production impact: **none.** Additive only — a new opt-in Cargo feature (off by default) and new subcommands on an internal (`publish = false`) profiling binary. No public API or runtime-behavior change to the docs generator; with the feature off, `profile_span!` expands to nothing.
- Rollback plan: revert the commit; nothing depends on it.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_docs` (133 pass), `cargo check --workspace`, `cargo clippy -p ox_content_docs -p ox_content_profile_cli` (clean for both default and `--features profile`), `cargo fmt --check`.
- [x] Manual verification completed: ran all three `docs-*` subcommands against `npm/` (table + `--json`); spans, allocation counts, and throughput render correctly.
- [x] Edge cases or failure modes considered: non-directory target errors cleanly; default (no-feature) build emits no `unused_import` warnings (`#[allow(unused_imports)]` on the macro import, matching the parser).

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed. (`profiling.md`)
- [x] Configuration, migration, or environment changes documented, or not needed. (none)
- [x] Observability, logging, and alerting impact considered, or not needed. (none)
- [x] Security, privacy, and dependency impact considered, or not needed. (no new external deps; `ox_content_profiler` is already in-tree)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783146010&installation_id=136613492&pr_number=309&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F309&signature=92d9227134fba85178f4ab16f4d66c0c3d7e17ef3aa22db747f4d29512286315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->