### PR TITLE
perf(docs): reuse the OXC arena allocator across files

### DIFF
--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -242,10 +242,29 @@ impl DocExtractor {
 
     /// Extracts documentation from a source file.
     pub fn extract_file(&self, path: &Path) -> ExtractResult<Vec<DocItem>> {
+        let mut allocator = Allocator::default();
+        self.extract_file_with(&mut allocator, path)
+    }
+
+    /// Like [`extract_file`](Self::extract_file), but reuses a caller-owned
+    /// arena allocator.
+    ///
+    /// Batch callers (directory walks, multi-file extraction) create one
+    /// [`Allocator`] and pass it to every file. The arena is rewound at the
+    /// start of each parse, so a single allocation is reused instead of
+    /// allocating and freeing a fresh multi-MB arena per file. The public
+    /// [`extract_file`](Self::extract_file) wrapper just hands in a fresh one.
+    pub(crate) fn extract_file_with(
+        &self,
+        allocator: &mut Allocator,
+        path: &Path,
+    ) -> ExtractResult<Vec<DocItem>> {
         let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
         match extension {
-            "ts" | "tsx" | "js" | "jsx" | "mts" | "mjs" | "cts" | "cjs" => self.extract_js_ts(path),
+            "ts" | "tsx" | "js" | "jsx" | "mts" | "mjs" | "cts" | "cjs" => {
+                self.extract_js_ts(allocator, path)
+            }
             _ => Err(ExtractError::UnsupportedFile(extension.to_string())),
         }
     }
@@ -257,11 +276,27 @@ impl DocExtractor {
         file_path: &str,
         source_type: SourceType,
     ) -> ExtractResult<Vec<DocItem>> {
+        let mut allocator = Allocator::default();
+        self.extract_source_with(&mut allocator, source, file_path, source_type)
+    }
+
+    /// Like [`extract_source`](Self::extract_source), but reuses a caller-owned
+    /// arena allocator. See [`extract_file_with`](Self::extract_file_with).
+    pub(crate) fn extract_source_with(
+        &self,
+        allocator: &mut Allocator,
+        source: &str,
+        file_path: &str,
+        source_type: SourceType,
+    ) -> ExtractResult<Vec<DocItem>> {
         profile_span!("docs::extract_source");
-        let allocator = Allocator::default();
+        // Rewind the arena so a reused allocator starts clean for this file.
+        // Extraction returns owned `DocItem`s, so by the time the next file
+        // resets, nothing borrows the previous file's arena.
+        allocator.reset();
         let ret = {
             profile_span!("docs::oxc_parse");
-            Parser::new(&allocator, source, source_type).parse()
+            Parser::new(&*allocator, source, source_type).parse()
         };
 
         if !ret.errors.is_empty() {
@@ -297,13 +332,14 @@ impl DocExtractor {
         Ok(visitor.items)
     }
 
-    /// Extracts documentation from a JavaScript/TypeScript file.
-    fn extract_js_ts(&self, path: &Path) -> ExtractResult<Vec<DocItem>> {
+    /// Extracts documentation from a JavaScript/TypeScript file, reusing the
+    /// caller-owned arena allocator.
+    fn extract_js_ts(&self, allocator: &mut Allocator, path: &Path) -> ExtractResult<Vec<DocItem>> {
         let content = std::fs::read_to_string(path)?;
         let file_path = path.to_string_lossy().to_string();
         let source_type = SourceType::from_path(path).unwrap_or_default();
 
-        self.extract_source(&content, &file_path, source_type)
+        self.extract_source_with(allocator, &content, &file_path, source_type)
     }
 }
 

--- a/crates/ox_content_docs/src/generator.rs
+++ b/crates/ox_content_docs/src/generator.rs
@@ -2,6 +2,8 @@
 
 use std::path::Path;
 
+use oxc_allocator::Allocator;
+
 use crate::config::DocsConfig;
 use crate::extractor::{DocExtractor, DocItem, ExtractResult};
 use crate::normalize::{normalize_doc_items, NormalizedDocEntry};
@@ -66,17 +68,19 @@ impl DocsGenerator {
     /// Extracts documentation from all source files.
     pub fn extract_all(&self) -> ExtractResult<Vec<DocItem>> {
         let mut all_items = Vec::new();
+        // One arena reused across every file in the tree (rewound per file).
+        let mut allocator = Allocator::default();
 
         for src_dir in &self.config.src_dirs {
-            let items = self.extract_dir(Path::new(src_dir))?;
+            let items = self.extract_dir(&mut allocator, Path::new(src_dir))?;
             all_items.extend(items);
         }
 
         Ok(all_items)
     }
 
-    /// Extracts documentation from a directory.
-    fn extract_dir(&self, dir: &Path) -> ExtractResult<Vec<DocItem>> {
+    /// Extracts documentation from a directory, reusing one arena allocator.
+    fn extract_dir(&self, allocator: &mut Allocator, dir: &Path) -> ExtractResult<Vec<DocItem>> {
         let mut items = Vec::new();
 
         if !dir.is_dir() {
@@ -88,9 +92,9 @@ impl DocsGenerator {
             let path = entry.path();
 
             if path.is_dir() {
-                items.extend(self.extract_dir(&path)?);
+                items.extend(self.extract_dir(allocator, &path)?);
             } else if self.should_include(&path) {
-                if let Ok(file_items) = self.extractor.extract_file(&path) {
+                if let Ok(file_items) = self.extractor.extract_file_with(allocator, &path) {
                     items.extend(file_items);
                 }
             }
@@ -158,11 +162,16 @@ pub fn extract_docs_from_directories(
 ) -> ExtractResult<Vec<ExtractedDocModule>> {
     let extractor = DocExtractor::with_visibility(include_private, include_internal);
     let mut modules = Vec::new();
+    // One arena reused across every file (rewound per file) instead of
+    // allocating and freeing a fresh multi-MB arena for each parse.
+    let mut allocator = Allocator::default();
 
     for src_dir in src_dirs {
         for file in collect_source_files(src_dir, include, exclude) {
-            let entries =
-                normalize_doc_items(extractor.extract_file(Path::new(&file))?, type_parameters);
+            let entries = normalize_doc_items(
+                extractor.extract_file_with(&mut allocator, Path::new(&file))?,
+                type_parameters,
+            );
             if !entries.is_empty() {
                 modules.push(ExtractedDocModule { file, entries });
             }


### PR DESCRIPTION
Closes #310. Phase 3 of the perf effort.

> **Stacked on #309** (the profiling-mode PR), because the before/after numbers below are produced by the `docs-extract` driver added there. Base will retarget to `main` once #309 merges.

## Summary

Extraction created a fresh `oxc_allocator::Allocator` for every file and dropped it after each parse — the exact per-iteration anti-pattern the allocator's docs warn against. This reuses one arena across the whole directory walk, rewinding it (`reset()`) per file.

- New internal `extract_source_with` / `extract_file_with` take a caller-owned `&mut Allocator`; the public `extract_file` / `extract_source` keep their signatures (NAPI + one-shot callers unaffected) and just delegate with a fresh allocator.
- `extract_docs_from_directories` and `DocsGenerator::extract_dir` create one allocator and reuse it across every file.

Safe because extraction returns owned `DocItem`s — nothing borrows the arena across files, so the per-file `reset()` has no live references into the previous file's arena.

## Validation

Measured on `npm/` (108 files, 789 KB) with `cargo run --release -p ox_content_profile_cli -- docs-extract npm`:

| metric | before | after | Δ |
|---|---|---|---|
| `docs::oxc_parse` bytes/iter | ~8.1 MB | ~1.06 MB | **−87%** |
| total bytes/iter | 24.45 MB | 17.41 MB | **−29%** |
| wall-clock (p50) | ~21.8 ms | ~22.3 ms | neutral |

Wall-clock is intentionally neutral — OXC parse CPU is unchanged; the win is eliminating per-file arena malloc/free churn. (Timing measured across several back-to-back runs to filter machine noise.)

- [x] Automated tests: `cargo test -p ox_content_docs` (133 pass), `cargo check --workspace` (incl. NAPI), `cargo clippy -p ox_content_docs --features profile` clean.
- [x] Manual verification: `docs-extract npm` before/after as above.
- [x] Edge cases: public API unchanged; reset-at-start handles a fresh allocator (no-op) and a reused one identically.

## Risk

- Risk level: **low**
- Impact: internal refactor; extracted output is byte-identical (tests green). Public API unchanged.
- Rollback: revert the commit.

## Release and docs checklist

- [x] Docs/comments updated, or not needed. (doc comments on the new `*_with` methods)
- [x] Config/migration changes, or not needed. (none)
- [x] Observability impact, or not needed. (none)
- [x] Security/dependency impact, or not needed. (no new deps)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783146984&installation_id=136613492&pr_number=314&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F314&signature=8867074dd779899d51e548788c124b8de0385aae7c3c26b6d34a127b6e85efa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->