### PR TITLE
perf(docs): borrow instead of allocate in doc-text/link processing

### DIFF
--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -1,5 +1,6 @@
 //! Markdown rendering for generated API reference documentation.
 
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
@@ -671,7 +672,10 @@ fn render_jsdoc_inline_link(
     }
 }
 
-fn convert_jsdoc_inline_links(text: &str, context: Option<&MarkdownLinkContext<'_>>) -> String {
+fn convert_jsdoc_inline_links<'a>(
+    text: &'a str,
+    context: Option<&MarkdownLinkContext<'_>>,
+) -> Cow<'a, str> {
     let mut result = String::new();
     let mut cursor = 0;
 
@@ -689,17 +693,26 @@ fn convert_jsdoc_inline_links(text: &str, context: Option<&MarkdownLinkContext<'
     }
 
     if cursor == 0 {
-        return text.to_string();
+        return Cow::Borrowed(text);
     }
 
     result.push_str(&text[cursor..]);
-    result
+    Cow::Owned(result)
 }
 
-fn process_doc_text(text: &str, context: Option<&MarkdownLinkContext<'_>>) -> String {
-    let text =
-        context.map_or_else(|| text.to_string(), |context| convert_symbol_links(text, context));
-    convert_jsdoc_inline_links(&text, context)
+fn process_doc_text<'a>(text: &'a str, context: Option<&MarkdownLinkContext<'_>>) -> Cow<'a, str> {
+    // Resolve `[Symbol]` references first, then `{@link}` inline tags. Both
+    // passes borrow the input untouched when there is nothing to rewrite, so a
+    // description with no links allocates nothing.
+    match context {
+        Some(context) => match convert_symbol_links(text, context) {
+            Cow::Borrowed(borrowed) => convert_jsdoc_inline_links(borrowed, Some(context)),
+            Cow::Owned(owned) => {
+                Cow::Owned(convert_jsdoc_inline_links(&owned, Some(context)).into_owned())
+            }
+        },
+        None => convert_jsdoc_inline_links(text, None),
+    }
 }
 
 /// One-line summary for a module index table cell.
@@ -716,7 +729,15 @@ fn typedoc_index_summary(description: &str, context: &MarkdownLinkContext<'_>) -
 fn markdown_index_summary(description: &str, context: Option<&MarkdownLinkContext<'_>>) -> String {
     let resolved = process_doc_text(description, context);
     let first_paragraph = resolved.split("\n\n").next().unwrap_or_default();
-    let one_line = first_paragraph.split_whitespace().collect::<Vec<_>>().join(" ");
+    // Collapse the first paragraph onto one line (words joined by single
+    // spaces) without an intermediate `Vec`, then escape table-cell pipes.
+    let mut one_line = String::with_capacity(first_paragraph.len());
+    for word in first_paragraph.split_whitespace() {
+        if !one_line.is_empty() {
+            one_line.push(' ');
+        }
+        one_line.push_str(word);
+    }
     one_line.replace('|', "\\|")
 }
 
@@ -2222,11 +2243,11 @@ fn generate_category_index(
     markdown
 }
 
-fn convert_symbol_links(text: &str, context: &MarkdownLinkContext<'_>) -> String {
+fn convert_symbol_links<'a>(text: &'a str, context: &MarkdownLinkContext<'_>) -> Cow<'a, str> {
     static SYMBOL_RE: RegexCache = OnceLock::new();
 
     let Some(symbol_re) = cached_regex(&SYMBOL_RE, r"\[([A-Z_]\w*)\]") else {
-        return text.to_string();
+        return Cow::Borrowed(text);
     };
     let mut result = String::new();
     let mut last_index = 0;
@@ -2255,11 +2276,11 @@ fn convert_symbol_links(text: &str, context: &MarkdownLinkContext<'_>) -> String
     }
 
     if last_index == 0 {
-        return text.to_string();
+        return Cow::Borrowed(text);
     }
 
     result.push_str(&text[last_index..]);
-    result
+    Cow::Owned(result)
 }
 
 /// A fragment of a tokenized TypeScript type annotation.

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -6,6 +6,7 @@
 //! same per-entry information as the HTML renderer — but as Markdown headings,
 //! tables and fenced code blocks (no `<details>`, no theme-specific HTML).
 
+use std::borrow::Cow;
 use std::collections::HashSet;
 
 use super::{
@@ -828,13 +829,28 @@ fn param_description(param: &ApiParamDoc, context: Option<&MarkdownLinkContext<'
 }
 
 /// Collapses runs of whitespace (including newlines) into single spaces.
-fn collapse_whitespace(text: &str) -> String {
+///
+/// Borrows the input (after trimming) when it is already collapsed — i.e. every
+/// whitespace char is a single ASCII space with no runs — so the common case of
+/// already-clean doc text allocates nothing.
+fn collapse_whitespace(text: &str) -> Cow<'_, str> {
     let text = text.trim();
     if text.is_empty() {
-        return String::new();
+        return Cow::Borrowed("");
     }
-    if !text.chars().any(char::is_whitespace) {
-        return text.to_string();
+    // Fast path: nothing to collapse iff every whitespace char is a lone ASCII
+    // space. Any other whitespace char, or two adjacent whitespace chars, would
+    // be rewritten below, so it must be owned.
+    let needs_collapse = {
+        let mut prev_ws = false;
+        text.chars().any(|ch| {
+            let collapse = ch.is_whitespace() && (ch != ' ' || prev_ws);
+            prev_ws = ch.is_whitespace();
+            collapse
+        })
+    };
+    if !needs_collapse {
+        return Cow::Borrowed(text);
     }
 
     let mut out = String::with_capacity(text.len());
@@ -850,12 +866,12 @@ fn collapse_whitespace(text: &str) -> String {
             out.push(ch);
         }
     }
-    out
+    Cow::Owned(out)
 }
 
 /// Inline Markdown for a doc-text fragment (resolves `{@link}`), single-line.
 fn inline(text: &str, context: Option<&MarkdownLinkContext<'_>>) -> String {
-    collapse_whitespace(&process_doc_text(text, context))
+    collapse_whitespace(&process_doc_text(text, context)).into_owned()
 }
 
 /// Escapes a value for use inside a Markdown table cell.


### PR DESCRIPTION
First increment of #312. Phase 3 of the perf effort.

> **Stacked on #309** (profiling mode), which provides the `docs-render` driver used for the numbers below. Base retargets to `main` after #309 merges. Independent of #314 (touches different files).

## Summary

Rendering ran every entry/member/param description and type annotation through `process_doc_text` + `collapse_whitespace`, both of which **always** returned an owned `String` — even when the text had no `[Symbol]` / `{@link}` references and needed no whitespace collapsing (the overwhelmingly common case).

This makes `convert_symbol_links`, `convert_jsdoc_inline_links`, `process_doc_text`, and `collapse_whitespace` return `Cow<str>`, borrowing the input untouched on the no-op fast path. `inline` keeps its `String` signature (a single `into_owned` at the end), so its 10 callers are unchanged. Also drops the intermediate `Vec` in `markdown_index_summary`.

## Byte-identical

Each fast path returns exactly the bytes the previous owned path produced — the old code already did `return text.to_string()` on no match, so `Cow::Borrowed(text)` is the same string. The 133 `ox_content_docs` tests (incl. TypeDoc snapshot/string-equality cases) pass unchanged.

## Validation

`docs-render npm` (108 files), baseline vs after built back-to-back and run interleaved to filter machine noise:

| metric | before | after | Δ |
|---|---|---|---|
| allocations/iter | 154,580 | 142,411 | **−7.9%** |
| `render_entry_page` allocs/iter | ~65K | ~54.8K | **−16%** |
| wall-clock (p50) | ~6.2 ms | ~5.8 ms | neutral / slightly faster |

- [x] `cargo test -p ox_content_docs` (133 pass), `cargo clippy` clean (default + `--features profile`), `cargo fmt --check`.
- [x] Before/after measured interleaved (above).

## Scope

This is the **lowest-risk first increment** of #312. The larger remaining wins — appending per-member/param fragments straight into the page buffer instead of building intermediate `String`s, and sharing `SymbolLocation` strings in `build_symbol_map` — are higher-risk refactors and stay tracked on #312 as follow-ups.

## Risk

- Risk level: **low** — byte-identical output, mechanical `Cow` change, compiler-checked call sites.
- Rollback: revert the commit.

## Release and docs checklist

- [x] Docs/comments updated, or not needed. (doc comments on the `Cow` helpers)
- [x] Config/migration, or not needed. (none)
- [x] Observability, or not needed. (none)
- [x] Security/dependency, or not needed. (no new deps)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783149488&installation_id=136613492&pr_number=315&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F315&signature=859ff1aa6401d815438130ada55716738de4e504642d4abeddd74f197e844d31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->