### PR TITLE
perf(docs): skip raw JSDoc text and param formatting on normalize paths

### DIFF
--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -209,6 +209,12 @@ pub struct DocExtractor {
     include_internal: bool,
     /// Include declarations without JSDoc. Used for public entry point exports.
     include_undocumented_declarations: bool,
+    /// Capture the verbatim JSDoc comment text into [`DocItem::jsdoc`].
+    ///
+    /// Only the raw `extract_file_docs` NAPI path reads it; the normalize-bound
+    /// paths (directory + entry-point extraction) discard it, so they opt out
+    /// to skip a per-comment allocation and a per-declaration clone.
+    capture_jsdoc_raw: bool,
 }
 
 impl DocExtractor {
@@ -219,25 +225,53 @@ impl DocExtractor {
             include_private: false,
             include_internal: false,
             include_undocumented_declarations: false,
+            capture_jsdoc_raw: true,
         }
     }
 
     /// Creates a new extractor that includes private items.
     #[must_use]
     pub fn with_private(include_private: bool) -> Self {
-        Self { include_private, include_internal: false, include_undocumented_declarations: false }
+        Self {
+            include_private,
+            include_internal: false,
+            include_undocumented_declarations: false,
+            capture_jsdoc_raw: true,
+        }
     }
 
     /// Creates a new extractor with explicit visibility options.
     #[must_use]
     pub fn with_visibility(include_private: bool, include_internal: bool) -> Self {
-        Self { include_private, include_internal, include_undocumented_declarations: false }
+        Self {
+            include_private,
+            include_internal,
+            include_undocumented_declarations: false,
+            capture_jsdoc_raw: true,
+        }
+    }
+
+    /// Drops the verbatim JSDoc text from extracted items.
+    ///
+    /// For callers that immediately normalize (which discards `DocItem::jsdoc`),
+    /// this avoids allocating and cloning the raw comment text per declaration.
+    #[must_use]
+    pub fn without_raw_jsdoc(mut self) -> Self {
+        self.capture_jsdoc_raw = false;
+        self
     }
 
     /// Creates a new extractor for public entry point exports.
+    ///
+    /// This path always normalizes, so it never captures the raw JSDoc text.
     #[must_use]
     pub(crate) fn for_entrypoint_exports(include_private: bool, include_internal: bool) -> Self {
-        Self { include_private, include_internal, include_undocumented_declarations: true }
+        Self {
+            include_private,
+            include_internal,
+            include_undocumented_declarations: true,
+            capture_jsdoc_raw: false,
+        }
     }
 
     /// Extracts documentation from a source file.
@@ -275,7 +309,7 @@ impl DocExtractor {
         }
 
         let comments: Vec<Comment> = ret.program.comments.iter().copied().collect();
-        let jsdoc_cache = build_jsdoc_cache(source, &comments);
+        let jsdoc_cache = build_jsdoc_cache(source, &comments, self.capture_jsdoc_raw);
 
         let mut visitor = DocVisitor::new(
             source,
@@ -351,7 +385,10 @@ fn parse_jsdoc_payload(source: &str, comment: &Comment) -> ParsedJsdoc {
                 let doc = root
                     .description_text(false)
                     .map_or_else(String::new, |description| description.trim().to_string());
-                let tags = root.tags().map(DocVisitor::convert_jsdoc_tag).collect();
+                // Module-entry parse happens once per file, so always format the
+                // tag value (cheap, and the raw path may surface it).
+                let tags =
+                    root.tags().map(|tag| DocVisitor::convert_jsdoc_tag(tag, true)).collect();
                 return (raw, doc, tags);
             }
         }
@@ -371,7 +408,11 @@ fn parse_jsdoc_payload(source: &str, comment: &Comment) -> ParsedJsdoc {
 /// a cheap hash lookup in the hot declaration path. Comments that fail the
 /// batch parser still fall back individually so diagnostics do not poison the
 /// whole file.
-fn build_jsdoc_cache(source: &str, comments: &[Comment]) -> FxHashMap<u32, ParsedJsdoc> {
+fn build_jsdoc_cache(
+    source: &str,
+    comments: &[Comment],
+    capture_raw: bool,
+) -> FxHashMap<u32, ParsedJsdoc> {
     profile_span!("docs::parse_jsdoc");
     let jsdoc_comments: Vec<&Comment> =
         comments.iter().filter(|comment| comment.is_jsdoc()).collect();
@@ -400,16 +441,27 @@ fn build_jsdoc_cache(source: &str, comments: &[Comment]) -> FxHashMap<u32, Parse
         ox_jsdoc::decoder::source_file::LazySourceFile::new(&result.binary_bytes)
     {
         for (index, (comment, root)) in jsdoc_comments.iter().zip(source_file.asts()).enumerate() {
-            let raw = extract_raw_jsdoc(comment, source);
-            let (doc, tags) = match root {
+            let (raw, doc, tags) = match root {
                 Some(root) if !failed.contains(&(index as u32)) => {
                     let doc = root
                         .description_text(false)
                         .map_or_else(String::new, |description| description.trim().to_string());
-                    let tags = root.tags().map(DocVisitor::convert_jsdoc_tag).collect();
-                    (doc, tags)
+                    let tags = root
+                        .tags()
+                        .map(|tag| DocVisitor::convert_jsdoc_tag(tag, capture_raw))
+                        .collect();
+                    // The decoder gave us the description/tags directly, so the
+                    // raw text is only needed when the caller will surface it.
+                    let raw = capture_raw.then(|| extract_raw_jsdoc(comment, source));
+                    (raw.unwrap_or_default(), doc, tags)
                 }
-                _ => DocVisitor::parse_jsdoc_fallback(&raw),
+                _ => {
+                    // The fallback parser works off the raw text, so we always
+                    // build it here; keep it only when the caller captures raw.
+                    let raw = extract_raw_jsdoc(comment, source);
+                    let (doc, tags) = DocVisitor::parse_jsdoc_fallback(&raw);
+                    (if capture_raw { raw } else { String::new() }, doc, tags)
+                }
             };
             cache.insert(comment.attached_to, (raw, doc, tags));
         }
@@ -417,7 +469,10 @@ fn build_jsdoc_cache(source: &str, comments: &[Comment]) -> FxHashMap<u32, Parse
         for comment in &jsdoc_comments {
             let raw = extract_raw_jsdoc(comment, source);
             let (doc, tags) = DocVisitor::parse_jsdoc_fallback(&raw);
-            cache.insert(comment.attached_to, (raw, doc, tags));
+            cache.insert(
+                comment.attached_to,
+                (if capture_raw { raw } else { String::new() }, doc, tags),
+            );
         }
     }
 
@@ -500,11 +555,18 @@ impl<'a> DocVisitor<'a> {
         &self,
         attached_to: u32,
     ) -> Option<(Option<String>, Option<String>, Vec<DocTag>)> {
-        if let Some((jsdoc, doc, tags)) = self.extract_jsdoc(attached_to) {
-            if self.should_skip_by_visibility(&tags) {
+        if let Some((jsdoc, doc, tags)) = self.jsdoc_cache.get(&attached_to) {
+            // Borrow from the cache and apply the visibility filter first, so a
+            // private/internal declaration is dropped without cloning the whole
+            // (raw, description, tags) payload only to throw it away.
+            if self.should_skip_by_visibility(tags) {
                 return None;
             }
-            return Some((Some(jsdoc), (!doc.is_empty()).then_some(doc), tags));
+            return Some((
+                Some(jsdoc.clone()),
+                (!doc.is_empty()).then(|| doc.clone()),
+                tags.clone(),
+            ));
         }
 
         self.include_undocumented_declarations.then(|| (None, None, Vec::new()))
@@ -628,9 +690,17 @@ impl<'a> DocVisitor<'a> {
             .to_string()
     }
 
-    fn convert_jsdoc_tag(tag: LazyJsdocTag<'_>) -> DocTag {
+    fn convert_jsdoc_tag(tag: LazyJsdocTag<'_>, capture_value: bool) -> DocTag {
         let tag_name = tag.tag().value().to_string();
-        let value = Self::format_jsdoc_tag_value(&tag_name, &tag);
+        // `value` is the formatted tag body that the raw `extract_file_docs`
+        // path surfaces. Normalize ignores it for param-family tags (it reads
+        // the structured name/type/description instead), so skip the costly
+        // `format_jsdoc_tag_value` join when the caller will not read it.
+        let value = if capture_value || !matches!(tag_name.as_str(), "param" | "arg" | "argument") {
+            Self::format_jsdoc_tag_value(&tag_name, &tag)
+        } else {
+            String::new()
+        };
         let type_annotation = tag
             .raw_type()
             .map(|raw_type| raw_type.raw().trim().to_string())

--- a/crates/ox_content_docs/src/generator.rs
+++ b/crates/ox_content_docs/src/generator.rs
@@ -156,7 +156,10 @@ pub fn extract_docs_from_directories(
     include_internal: bool,
     type_parameters: bool,
 ) -> ExtractResult<Vec<ExtractedDocModule>> {
-    let extractor = DocExtractor::with_visibility(include_private, include_internal);
+    // This path normalizes immediately, so the verbatim JSDoc text is never
+    // surfaced — skip capturing it to avoid a per-comment allocation.
+    let extractor =
+        DocExtractor::with_visibility(include_private, include_internal).without_raw_jsdoc();
     let mut modules = Vec::new();
 
     for src_dir in src_dirs {


### PR DESCRIPTION
Phase 4 — driven by the gunshi API-docs comparison. Refs #313.

## gunshi as a real workload

Profiled the docs generator against `kazupon/gunshi` (branch `topic/ox-content-api-docs-comparison` — a heavily JSDoc-documented CLI library whose docs site builds with `@ox-content/napi` via `extractDocsFromEntryPoints`). `docs-extract` over `packages/gunshi/src`: `oxc_parse` 40.4%, **`parse_jsdoc` 26.2%**, `visit_ast` 16.1% — far more JSDoc-bound than the `npm/` fixture (9%).

## Change

Two artifacts are read **only** by the raw `extractFileDocs` NAPI path; the normalize-bound paths (directory extraction + `extractDocsFromEntryPoints`, gunshi's actual build) discard them:
1. **Verbatim JSDoc text** (`DocItem::jsdoc`) — allocated per comment, cloned per declaration, dropped by normalize.
2. **Formatted `value` for param-family tags** (`@param`/`@arg`/`@argument`) — `format_jsdoc_tag_value` builds a `Vec<String>`+join (`{type} [name] - desc`, ~5 allocs/tag); normalize reads the structured `name`/`type`/`description` fields and never touches `value`.

A `capture_jsdoc_raw` flag on `DocExtractor` (`without_raw_jsdoc()` for the directory path; always off for `for_entrypoint_exports`) gates both. The raw `extractFileDocs` path keeps it `true`, so its output is unchanged. `extract_declaration_docs` also borrows the cache entry to apply the visibility filter **before** cloning, dropping private/internal declarations without copying the payload.

## Byte-identical

`value` for param tags and the raw text are dead in the normalize paths; the raw NAPI path still captures both. The 143 `ox_content_docs` tests (exact descriptions/tags/params/returns) pass.

## Validation — `docs-extract` over gunshi's `packages/gunshi/src`, interleaved before/after

| metric | before | after | Δ |
|---|---|---|---|
| allocations/iter | 9278 | 8290 | **−10.6%** |
| `docs::parse_jsdoc` allocs/iter | ~3335 | ~2718 | **−18%** |
| wall-clock | — | — | neutral / slightly faster |

(Allocation **count** is the metric; total bytes move little — the remaining `parse_jsdoc` allocations are the OXC arena and the JSDoc decoder's binary buffers.)

- [x] `cargo test -p ox_content_docs` (143 pass), clippy clean (default + `--features profile`), `cargo fmt --check`.
- [x] Interleaved before/after on gunshi (above).

## Follow-up

The bigger **structural** win for gunshi's entry-point build — eliminating the per-module double-parse (#311) — is not attempted here.

## Risk

- Risk level: **low** — gated, byte-identical, compiler-checked; raw NAPI path untouched.
- Rollback: revert the commit.