### PR TITLE
perf(docs): reduce TypeDoc render allocations (symbol map + list rows)

### DIFF
--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
+use std::rc::Rc;
 use std::sync::OnceLock;
 
 use phf::{phf_map, phf_set};
@@ -213,8 +214,11 @@ struct EntryBadge {
 
 #[derive(Debug, Clone)]
 struct SymbolLocation {
-    module_name: String,
-    file_name: String,
+    // `Rc<str>` because `build_symbol_map` shares one module name across every
+    // entry in a module and one file name across an entry and all its members;
+    // cloning the location into the map is then a refcount bump, not a heap copy.
+    module_name: Rc<str>,
+    file_name: Rc<str>,
     anchor: Option<String>,
 }
 
@@ -561,7 +565,7 @@ fn sanitize_doc_path_segment(value: &str) -> String {
 }
 
 fn format_symbol_href(context: &MarkdownLinkContext<'_>, location: &SymbolLocation) -> String {
-    if location.file_name == context.current_file_name {
+    if location.file_name.as_ref() == context.current_file_name {
         if let Some(anchor) = location.anchor.as_deref().filter(|anchor| !anchor.is_empty()) {
             join2("#", anchor)
         } else {
@@ -589,9 +593,11 @@ fn resolve_symbol_location<'a>(
     let locations = context.symbol_map.get(symbol_name)?;
     locations
         .iter()
-        .find(|location| location.module_name == context.current_module_name)
+        .find(|location| location.module_name.as_ref() == context.current_module_name)
         .or_else(|| {
-            locations.iter().find(|location| location.file_name == context.current_file_name)
+            locations
+                .iter()
+                .find(|location| location.file_name.as_ref() == context.current_file_name)
         })
         .or_else(|| locations.first())
 }
@@ -2412,27 +2418,30 @@ fn build_symbol_map(
         .then(|| CanonicalOwners::compute(docs));
 
     for doc in docs {
-        let module_name = module_file_name(&doc.file);
+        // Interned once per module and shared by every entry + member below.
+        let module_name: Rc<str> = Rc::from(module_file_name(&doc.file));
         for entry in &doc.entries {
-            let (file_name, anchor) = match (options.group_by.as_str(), options.path_strategy) {
-                ("file", MarkdownPathStrategy::TypeDoc) => {
-                    let owner_module = canonical
-                        .as_ref()
-                        .and_then(|owners| owners.canonical_module(entry))
-                        .unwrap_or(module_name.as_str());
-                    (typedoc_entry_file_name(owner_module, entry), None)
-                }
-                ("category", _) => {
-                    (plural_kind_file_name(&entry.kind), Some(entry_anchor(&entry.name)))
-                }
-                _ => (module_name.clone(), Some(entry_anchor(&entry.name))),
-            };
+            let (file_name, anchor): (Rc<str>, Option<String>) =
+                match (options.group_by.as_str(), options.path_strategy) {
+                    ("file", MarkdownPathStrategy::TypeDoc) => {
+                        let owner_module = canonical
+                            .as_ref()
+                            .and_then(|owners| owners.canonical_module(entry))
+                            .unwrap_or(&module_name);
+                        (Rc::from(typedoc_entry_file_name(owner_module, entry)), None)
+                    }
+                    ("category", _) => (
+                        Rc::from(plural_kind_file_name(&entry.kind)),
+                        Some(entry_anchor(&entry.name)),
+                    ),
+                    _ => (Rc::clone(&module_name), Some(entry_anchor(&entry.name))),
+                };
             insert_symbol_location(
                 &mut map,
                 entry.name.clone(),
                 SymbolLocation {
-                    module_name: module_name.clone(),
-                    file_name: file_name.clone(),
+                    module_name: Rc::clone(&module_name),
+                    file_name: Rc::clone(&file_name),
                     anchor,
                 },
             );
@@ -2441,8 +2450,8 @@ fn build_symbol_map(
                     &mut map,
                     member_symbol_name(&entry.name, &member.name),
                     SymbolLocation {
-                        module_name: module_name.clone(),
-                        file_name: file_name.clone(),
+                        module_name: Rc::clone(&module_name),
+                        file_name: Rc::clone(&file_name),
                         anchor: Some(member_anchor(&entry.name, member, options.path_strategy)),
                     },
                 );

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -348,20 +348,18 @@ fn push_parameters(
         }
         _ => {
             for param in params {
-                let mut line = String::new();
-                line.push_str("- ");
-                line.push_str(&code_span(&param.name));
+                out.push_str("- ");
+                out.push_str(&code_span(&param.name));
                 if !param.type_annotation.is_empty() {
-                    line.push_str(" (");
-                    line.push_str(&linked_type_span(&param.type_annotation, context));
-                    line.push(')');
+                    out.push_str(" (");
+                    out.push_str(&linked_type_span(&param.type_annotation, context));
+                    out.push(')');
                 }
                 let description = param_description(param, context);
                 if !description.is_empty() {
-                    line.push_str(" - ");
-                    line.push_str(&description);
+                    out.push_str(" - ");
+                    out.push_str(&description);
                 }
-                out.push_str(&line);
                 out.push('\n');
             }
         }
@@ -603,20 +601,18 @@ fn render_member_parameter_sections_pure(
             }
             _ => {
                 for param in &member.params {
-                    let mut line = String::new();
-                    line.push_str("- ");
-                    line.push_str(&code_span(&param.name));
+                    out.push_str("- ");
+                    out.push_str(&code_span(&param.name));
                     if !param.type_annotation.is_empty() {
-                        line.push_str(" (");
-                        line.push_str(&linked_type_span(&param.type_annotation, context));
-                        line.push(')');
+                        out.push_str(" (");
+                        out.push_str(&linked_type_span(&param.type_annotation, context));
+                        out.push(')');
                     }
                     let description = param_description(param, context);
                     if !description.is_empty() {
-                        line.push_str(" - ");
-                        line.push_str(&description);
+                        out.push_str(" - ");
+                        out.push_str(&description);
                     }
-                    out.push_str(&line);
                     out.push('\n');
                 }
             }
@@ -646,23 +642,23 @@ fn render_member_group_pure(
         == MarkdownDisplayFormat::List
     {
         for member in members {
-            let mut line = String::new();
-            line.push_str("- ");
-            line.push_str(&member_name_span(member));
-            line.push_str(" `");
-            line.push_str(&member.kind);
-            line.push('`');
+            // Append straight into `out`; the row is always emitted, so an
+            // intermediate per-member `String` would just be an extra alloc.
+            out.push_str("- ");
+            out.push_str(&member_name_span(member));
+            out.push_str(" `");
+            out.push_str(&member.kind);
+            out.push('`');
             let member_type = member_type(member);
             if !member_type.is_empty() {
-                line.push(' ');
-                line.push_str(&linked_type_span(member_type, context.link_context));
+                out.push(' ');
+                out.push_str(&linked_type_span(member_type, context.link_context));
             }
             let description = member_description(member, context.link_context);
             if !description.is_empty() {
-                line.push_str(" - ");
-                line.push_str(&description);
+                out.push_str(" - ");
+                out.push_str(&description);
             }
-            out.push_str(&line);
             out.push('\n');
         }
     } else {


### PR DESCRIPTION
Continues #312 (render allocation reduction). Builds on the merged #315. Two byte-identical changes to the TypeDoc/pure-Markdown render path:

## 1. Intern shared module/file names in the symbol map

`build_symbol_map` builds `HashMap<String, Vec<SymbolLocation>>` where every `SymbolLocation` owns its `module_name` and `file_name`. The same module name is shared by every entry in a module, and the same file name by an entry and all its members — yet each was **deep-cloned** per entry and per member. Store the two fields as `Rc<str>`: intern once, clone the `Rc` (refcount bump) into each location. The two readers compare via `as_ref()`.

## 2. Append list rows directly instead of per-item String temporaries

The pure-Markdown list renderers for parameters and members built a fresh `String` per row, then appended it whole. The row is always emitted, so append straight into the output buffer — dropping one allocation per param/member across three sites (entry param list, member-group list, member parameter-section list).

## Byte-identical

Only an internal field's storage type and an append target change; strings and output are unchanged. The 143 `ox_content_docs` tests pass.

## Validation — `docs-render npm`, interleaved before/after

| metric | before | after | Δ |
|---|---|---|---|
| total render allocs/iter | 142,484 | 126,552 | **−11.2%** |
| └ symbol-map interning | | | −3.8% |
| └ list-row append | | | −7.7% |
| `docs::build_symbol_map` allocs/iter | 24,513 | 19,152 | −22% |
| wall-clock | — | — | neutral |

- [x] `cargo test -p ox_content_docs` (143 pass), clippy clean (default + `--features profile`), `cargo fmt --check`.
- [x] Interleaved before/after (above).

## Risk

- Risk level: **low** — internal/mechanical, byte-identical, compiler-checked.

Remaining #312 follow-up (capacity hints / table-format row building) tracked on the issue.