### PR TITLE
perf(docs): extract docs during the export-graph walk to avoid a second parse

### DIFF
--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -343,7 +343,23 @@ impl DocExtractor {
             return Err(ExtractError::Parse(error_msg));
         }
 
-        let comments: Vec<Comment> = ret.program.comments.iter().copied().collect();
+        Ok(self.extract_items_from_program(source, file_path, &ret.program))
+    }
+
+    /// Extract doc items from an already-parsed program (build the JSDoc cache,
+    /// then walk the AST).
+    ///
+    /// Shared by [`extract_source_with`](Self::extract_source_with) and the
+    /// export-graph walk: the graph parses every reachable module to collect its
+    /// exports, so it extracts docs from that same AST instead of parsing the
+    /// file a second time.
+    pub(crate) fn extract_items_from_program(
+        &self,
+        source: &str,
+        file_path: &str,
+        program: &oxc_ast::ast::Program<'_>,
+    ) -> Vec<DocItem> {
+        let comments: Vec<Comment> = program.comments.iter().copied().collect();
         let jsdoc_cache = build_jsdoc_cache(source, &comments, self.capture_jsdoc_raw);
 
         let mut visitor = DocVisitor::new(
@@ -354,16 +370,16 @@ impl DocExtractor {
             self.include_undocumented_declarations,
             jsdoc_cache,
         );
-        let first_stmt_start = ret.program.body.first().map(|statement| statement.span().start);
+        let first_stmt_start = program.body.first().map(|statement| statement.span().start);
         {
             profile_span!("docs::visit_ast");
             if let Some(module_item) = visitor.extract_module_entry(&comments, first_stmt_start) {
                 visitor.items.push(module_item);
             }
-            visitor.visit_program(&ret.program);
+            visitor.visit_program(program);
         }
 
-        Ok(visitor.items)
+        visitor.items
     }
 
     /// Extracts documentation from a JavaScript/TypeScript file, reusing the

--- a/crates/ox_content_docs/src/graph.rs
+++ b/crates/ox_content_docs/src/graph.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 use crate::profile_span;
 use crate::string_builder::{join2, join4, StringBuilder};
 use crate::{
-    normalize_doc_items, ApiDocTag, DocExtractor, ExtractError, NormalizedDocEntry,
+    normalize_doc_items, ApiDocTag, DocExtractor, DocItem, ExtractError, NormalizedDocEntry,
     NormalizedDocKind,
 };
 
@@ -270,6 +270,21 @@ pub fn build_export_graph(
     entrypoints: &[EntryPointSpec],
     options: &GraphOptions,
 ) -> Result<ExportGraph, GraphError> {
+    Ok(build_export_graph_inner(entrypoints, options, None)?.0)
+}
+
+/// Shared implementation behind [`build_export_graph`] and
+/// [`extract_docs_from_entry_points`].
+///
+/// When `doc_extractor` is `Some`, doc items are extracted from each module's
+/// already-parsed AST during the walk and returned in the second tuple element,
+/// keyed by normalized path, so the extraction phase can reuse them instead of
+/// re-parsing every module.
+fn build_export_graph_inner(
+    entrypoints: &[EntryPointSpec],
+    options: &GraphOptions,
+    doc_extractor: Option<DocExtractor>,
+) -> Result<(ExportGraph, FxHashMap<PathBuf, Vec<DocItem>>), GraphError> {
     profile_span!("docs::build_export_graph");
     let root = graph_root(options);
     let resolver = ModuleResolver::new(&root, options);
@@ -278,6 +293,8 @@ pub fn build_export_graph(
         resolver,
         modules: FxHashMap::with_hasher(FxBuildHasher),
         active: FxHashSet::default(),
+        doc_extractor,
+        docs: FxHashMap::with_hasher(FxBuildHasher),
     };
 
     let mut graph_entrypoints = Vec::with_capacity(entrypoints.len());
@@ -288,7 +305,7 @@ pub fn build_export_graph(
         graph_entrypoints.push(EntrypointModule { name, source_path, exports });
     }
 
-    Ok(ExportGraph { entrypoints: graph_entrypoints, modules: builder.modules })
+    Ok((ExportGraph { entrypoints: graph_entrypoints, modules: builder.modules }, builder.docs))
 }
 
 /// Extracts normalized docs grouped by public entry points.
@@ -297,7 +314,16 @@ pub fn extract_docs_from_entry_points(
     options: &EntryPointDocsOptions,
 ) -> Result<Vec<EntrypointDocsModule>, GraphError> {
     profile_span!("docs::extract_entry_points");
-    let graph = build_export_graph(entrypoints, &options.graph)?;
+    // Build the export graph and extract docs from the same parse in one walk,
+    // so each reachable module is parsed once here instead of again below.
+    let (graph, mut walk_docs) = build_export_graph_inner(
+        entrypoints,
+        &options.graph,
+        Some(DocExtractor::for_entrypoint_exports(
+            options.include_private,
+            options.include_internal,
+        )),
+    )?;
     let extractor =
         DocExtractor::for_entrypoint_exports(options.include_private, options.include_internal);
     let all_visibility_extractor = DocExtractor::for_entrypoint_exports(true, true);
@@ -349,6 +375,7 @@ pub fn extract_docs_from_entry_points(
             let matched = {
                 let module_entries = normalized_entries_for_module(
                     &mut docs_cache,
+                    Some(&mut walk_docs),
                     &extractor,
                     module,
                     options.type_parameters,
@@ -388,6 +415,7 @@ pub fn extract_docs_from_entry_points(
 
             let all_module_entries = normalized_entries_for_module(
                 &mut all_docs_cache,
+                None,
                 &all_visibility_extractor,
                 module,
                 options.type_parameters,
@@ -431,6 +459,7 @@ pub fn extract_docs_from_entry_points(
             &entrypoint.name,
             normalized_entries_for_module(
                 &mut docs_cache,
+                Some(&mut walk_docs),
                 &extractor,
                 &entrypoint.source_path,
                 options.type_parameters,
@@ -506,6 +535,7 @@ fn is_dependency_source(module: &Path) -> bool {
 
 fn normalized_entries_for_module<'a>(
     docs_cache: &'a mut FxHashMap<PathBuf, Vec<NormalizedDocEntry>>,
+    walk_docs: Option<&mut FxHashMap<PathBuf, Vec<DocItem>>>,
     extractor: &DocExtractor,
     module: &PathBuf,
     type_parameters: bool,
@@ -516,9 +546,17 @@ fn normalized_entries_for_module<'a>(
     // graph edges. The explicit insert-before-get shape keeps the returned
     // borrow simple while avoiding repeated extractor work.
     if !docs_cache.contains_key(module) {
-        let items = extractor
-            .extract_file(module)
-            .map_err(|source| GraphError::Extract { path: module.clone(), source })?;
+        // Take the doc items the export-graph walk already extracted from this
+        // module's AST when available — `remove` so they move into the cache
+        // rather than being cloned (each module is normalized once). Only parse
+        // the file again on a miss (the all-visibility fallback, or a module the
+        // walk didn't visit).
+        let items = match walk_docs.and_then(|docs| docs.remove(&normalize_existing_path(module))) {
+            Some(items) => items,
+            None => extractor
+                .extract_file(module)
+                .map_err(|source| GraphError::Extract { path: module.clone(), source })?,
+        };
         docs_cache.insert(module.clone(), normalize_doc_items(items, type_parameters));
     }
 
@@ -727,6 +765,12 @@ struct GraphBuilder {
     resolver: ModuleResolver,
     modules: FxHashMap<PathBuf, ResolvedModule>,
     active: FxHashSet<PathBuf>,
+    /// When set, doc items are extracted from each module's already-parsed AST
+    /// during the walk and stashed in `docs`, so the doc-extraction phase reuses
+    /// them instead of parsing every module a second time. `None` for the
+    /// standalone `build_export_graph` (exports only).
+    doc_extractor: Option<DocExtractor>,
+    docs: FxHashMap<PathBuf, Vec<DocItem>>,
 }
 
 impl GraphBuilder {
@@ -774,6 +818,15 @@ impl GraphBuilder {
                 .collect::<Vec<_>>()
                 .join(", ");
             return Err(GraphError::Parse { path: path.to_path_buf(), message });
+        }
+
+        // Extract docs from this same AST when requested, so the doc-extraction
+        // phase reads them from the cache rather than parsing the file again.
+        // Disjoint field borrows: `&self.doc_extractor` then `&mut self.docs`.
+        if let Some(items) = self.doc_extractor.as_ref().map(|extractor| {
+            extractor.extract_items_from_program(source, &path.to_string_lossy(), &ret.program)
+        }) {
+            self.docs.insert(path.to_path_buf(), items);
         }
 
         let mut exports = Vec::new();

--- a/crates/ox_content_profile_cli/src/main.rs
+++ b/crates/ox_content_profile_cli/src/main.rs
@@ -47,8 +47,9 @@ use ox_content_docs::{
     collect_source_files, extract_docs_from_directories, extract_docs_from_entry_points,
     generate_markdown, ApiDocEntry, ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc,
     ApiReturnDoc, ApiTypeParamDoc, EntryPointDocsOptions, EntryPointSpec, ExtractedDocModule,
-    GraphOptions, MarkdownDocsOptions, MarkdownPathStrategy, MarkdownRenderStyle, NormalizedDocEntry,
-    NormalizedMember, NormalizedParamDoc, NormalizedReturnDoc, NormalizedTypeParam,
+    GraphOptions, MarkdownDocsOptions, MarkdownPathStrategy, MarkdownRenderStyle,
+    NormalizedDocEntry, NormalizedMember, NormalizedParamDoc, NormalizedReturnDoc,
+    NormalizedTypeParam,
 };
 use ox_content_parser::{Parser, ParserOptions};
 use ox_content_profiler::{report::ReportConfig, scope, CountingAllocator, Recorder};

--- a/crates/ox_content_profile_cli/src/main.rs
+++ b/crates/ox_content_profile_cli/src/main.rs
@@ -44,11 +44,11 @@ use std::process::ExitCode;
 use clap::{Parser as ClapParser, Subcommand};
 use ox_content_allocator::Allocator;
 use ox_content_docs::{
-    collect_source_files, extract_docs_from_directories, generate_markdown, ApiDocEntry,
-    ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc, ApiReturnDoc, ApiTypeParamDoc,
-    ExtractedDocModule, MarkdownDocsOptions, MarkdownPathStrategy, MarkdownRenderStyle,
-    NormalizedDocEntry, NormalizedMember, NormalizedParamDoc, NormalizedReturnDoc,
-    NormalizedTypeParam,
+    collect_source_files, extract_docs_from_directories, extract_docs_from_entry_points,
+    generate_markdown, ApiDocEntry, ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc,
+    ApiReturnDoc, ApiTypeParamDoc, EntryPointDocsOptions, EntryPointSpec, ExtractedDocModule,
+    GraphOptions, MarkdownDocsOptions, MarkdownPathStrategy, MarkdownRenderStyle, NormalizedDocEntry,
+    NormalizedMember, NormalizedParamDoc, NormalizedReturnDoc, NormalizedTypeParam,
 };
 use ox_content_parser::{Parser, ParserOptions};
 use ox_content_profiler::{report::ReportConfig, scope, CountingAllocator, Recorder};
@@ -104,6 +104,11 @@ enum Cmd {
     DocsRender { dir: PathBuf },
     /// Profile the full docs pipeline: extraction + normalize + Markdown render.
     DocsPipeline { dir: PathBuf },
+    /// Profile the entry-point docs path (`extractDocsFromEntryPoints`): builds
+    /// the export graph and extracts normalized docs for the given entry files.
+    /// This is the path published packages (e.g. gunshi) use, where the export
+    /// graph and doc extraction each parse every reachable module.
+    DocsEntrypoints { entries: Vec<PathBuf> },
 }
 
 /// Which slice of the docs pipeline a `docs-*` run measures.
@@ -154,6 +159,7 @@ fn run(cli: &Cli) -> std::io::Result<()> {
         Cmd::DocsExtract { dir } => run_docs(cli, dir, DocsPhase::Extract),
         Cmd::DocsRender { dir } => run_docs(cli, dir, DocsPhase::Render),
         Cmd::DocsPipeline { dir } => run_docs(cli, dir, DocsPhase::Pipeline),
+        Cmd::DocsEntrypoints { entries } => run_docs_entrypoints(cli, entries),
         Cmd::Parse { .. } | Cmd::Render { .. } | Cmd::Pipeline { .. } => run_markdown(cli),
     }
 }
@@ -320,6 +326,54 @@ fn run_docs(cli: &Cli, dir: &Path, phase: DocsPhase) -> std::io::Result<()> {
                 })?;
             }
         }
+    }
+
+    emit_report(recorder, cli);
+    Ok(())
+}
+
+/// Profile `extract_docs_from_entry_points` over the given entry files — the
+/// published-package path. Today it parses every reachable module twice (once
+/// to build the export graph, once to extract docs), visible as the
+/// `docs::graph_oxc_parse` and `docs::oxc_parse` spans.
+fn run_docs_entrypoints(cli: &Cli, entries: &[PathBuf]) -> std::io::Result<()> {
+    if entries.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "docs-entrypoints needs at least one entry file",
+        ));
+    }
+
+    // Canonicalize entry paths so resolution doesn't depend on the graph root.
+    let mut specs = Vec::with_capacity(entries.len());
+    let mut label = String::from("docs-entrypoints (");
+    for (index, entry) in entries.iter().enumerate() {
+        let path = std::fs::canonicalize(entry)?;
+        if index > 0 {
+            label.push_str(", ");
+        }
+        push_fmt(&mut label, format_args!("{}", entry.display()));
+        specs.push(EntryPointSpec { path, name: None });
+    }
+    label.push(')');
+
+    let options = EntryPointDocsOptions {
+        graph: GraphOptions::default(),
+        include_private: false,
+        include_internal: false,
+        type_parameters: true,
+    };
+
+    let total_iters = cli.warmup + cli.iters;
+    let config = ReportConfig { input_bytes: None, warmup: cli.warmup, max_span_rows: 32 };
+    let mut recorder = Recorder::new(label).with_config(config);
+
+    for _ in 0..total_iters {
+        recorder.record(|| -> std::io::Result<()> {
+            let modules = extract_docs_from_entry_points(&specs, &options).map_err(docs_error)?;
+            black_box(modules);
+            Ok(())
+        })?;
     }
 
     emit_report(recorder, cli);


### PR DESCRIPTION
Closes #311. The big structural item from the gunshi API-docs comparison.

## Problem

`extract_docs_from_entry_points` (the path published packages use via `extractDocsFromEntryPoints`) parsed **every reachable module twice**: once in `build_export_graph` to collect its exports, then again in `extract_file` to extract docs. Profiling gunshi's entry-point build with a new `docs-entrypoints` driver confirmed it — `docs::graph_oxc_parse` and `docs::oxc_parse` each fired once per module per iteration.

(JSDoc parsing, AST visiting, and module resolution are **not** duplicated — only the OXC parse is — so the win is the redundant parse, not the whole pipeline.)

## Change

Extract doc items from the export graph's already-parsed AST. `DocExtractor` gains `extract_items_from_program` (the post-parse half of `extract_source`); the graph walk runs it at the configured visibility when doc extraction is requested, stashing items per normalized path. The extraction phase **moves** them out of that cache (no clone — each module is normalized once) instead of parsing the file again.

- `build_export_graph` stays exports-only, so the standalone `buildExportGraph` NAPI path is unchanged.
- The all-visibility fallback (used only to diagnose visibility-filtered exports) and any module the walk didn't visit fall back to `extract_file` — **a cache miss is always correct, just not faster**, so there's no path-normalization footgun.
- Adds a `docs-entrypoints` profiler driver to make this path measurable.

## Byte-identical

Same extraction logic on the same AST at the same visibility → identical doc items. **143 `ox_content_docs` tests + 87 `ox_content_napi` tests** (the latter drive entry-point extraction across re-export/visibility scenarios) pass.

## Validation — `docs-entrypoints` over gunshi's 7 local entry points, before vs after built back-to-back

| metric | before (double-parse) | after (single parse) | Δ |
|---|---|---|---|
| `docs::oxc_parse` (extraction re-parse) hits | 560 | 80 (fallback only) | **−86%** |
| bytes/iter | 6.19 MB | 5.44 MB | **−12%** |
| mean wall-clock | ~3.06 ms | ~2.61 ms | **~−15%** |
| allocations/iter | 19,500 | 19,519 | neutral |

Allocation **count** is flat (the eliminated parse is few-allocations-but-large-bytes — the arena); the win shows in **bytes and time**. The `remove`-from-cache (vs clone) keeps count from regressing.

- [x] `cargo test -p ox_content_docs` (143) + `cargo test -p ox_content_napi` (87), clippy clean (default + `--features profile`), `cargo fmt --check`.
- [x] Before/after measured on gunshi (above).

## Risk

- Risk level: **medium** — touches the entry-point extraction flow, but output is byte-identical (tests green) and any cache miss safely falls back to the original re-parse path.
- Rollback: revert the two commits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783154467&installation_id=136613492&pr_number=318&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F318&signature=a2648758fc22ca40428fbc6a7cf8343905a14f32a1fe9a8a0a061ab43a2ad535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->