### PR TITLE
perf(docs): append Markdown table cells directly + make the docs driver table-faithful

### DIFF
--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -300,7 +300,7 @@ fn push_type_parameters(
                 out.push_str("| ");
                 out.push_str(&type_param_name_cell(type_param, context, &skip));
                 out.push_str(" | ");
-                out.push_str(&table_cell(&inline(&type_param.description, context)));
+                push_table_cell(out, &inline(&type_param.description, context));
                 out.push_str(" |\n");
             }
         }
@@ -342,7 +342,7 @@ fn push_parameters(
                 out.push_str(" | ");
                 out.push_str(&linked_type_cell(&param.type_annotation, context));
                 out.push_str(" | ");
-                out.push_str(&table_cell(&param_description(param, context)));
+                push_table_cell(out, &param_description(param, context));
                 out.push_str(" |\n");
             }
         }
@@ -595,7 +595,7 @@ fn render_member_parameter_sections_pure(
                     out.push_str(" | ");
                     out.push_str(&linked_type_cell(&param.type_annotation, context));
                     out.push_str(" | ");
-                    out.push_str(&table_cell(&param_description(param, context)));
+                    push_table_cell(&mut out, &param_description(param, context));
                     out.push_str(" |\n");
                 }
             }
@@ -673,12 +673,12 @@ fn render_member_group_pure(
             out.push_str(&member_name_cell(member));
             out.push_str(" | ");
             if include_kind {
-                out.push_str(&table_cell(&member.kind));
+                push_table_cell(out, &member.kind);
                 out.push_str(" | ");
             }
             out.push_str(&linked_type_cell(member_type(member), context.link_context));
             out.push_str(" | ");
-            out.push_str(&table_cell(&member_description(member, context.link_context)));
+            push_table_cell(out, &member_description(member, context.link_context));
             out.push_str(" |\n");
         }
     }
@@ -876,6 +876,22 @@ fn table_cell(text: &str) -> String {
         text.replace('|', "\\|")
     } else {
         text.to_string()
+    }
+}
+
+/// Append a table-cell value directly to `out` (pipes escaped), avoiding the
+/// intermediate `String` that [`table_cell`] allocates for every cell.
+fn push_table_cell(out: &mut String, text: &str) {
+    if text.contains('|') {
+        let mut rest = text;
+        while let Some(index) = rest.find('|') {
+            out.push_str(&rest[..index]);
+            out.push_str("\\|");
+            rest = &rest[index + 1..];
+        }
+        out.push_str(rest);
+    } else {
+        out.push_str(text);
     }
 }
 

--- a/crates/ox_content_profile_cli/src/main.rs
+++ b/crates/ox_content_profile_cli/src/main.rs
@@ -47,9 +47,9 @@ use ox_content_docs::{
     collect_source_files, extract_docs_from_directories, extract_docs_from_entry_points,
     generate_markdown, ApiDocEntry, ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc,
     ApiReturnDoc, ApiTypeParamDoc, EntryPointDocsOptions, EntryPointSpec, ExtractedDocModule,
-    GraphOptions, MarkdownDocsOptions, MarkdownPathStrategy, MarkdownRenderStyle,
-    NormalizedDocEntry, NormalizedMember, NormalizedParamDoc, NormalizedReturnDoc,
-    NormalizedTypeParam,
+    GraphOptions, MarkdownDisplayFormat, MarkdownDocsOptions, MarkdownPathStrategy,
+    MarkdownRenderStyle, NormalizedDocEntry, NormalizedMember, NormalizedParamDoc,
+    NormalizedReturnDoc, NormalizedTypeParam,
 };
 use ox_content_parser::{Parser, ParserOptions};
 use ox_content_profiler::{report::ReportConfig, scope, CountingAllocator, Recorder};
@@ -240,9 +240,19 @@ fn run_markdown(cli: &Cli) -> std::io::Result<()> {
 /// the TypeDoc page layout with pure-Markdown output (rather than the legacy
 /// flat/HTML defaults).
 fn docs_markdown_options() -> MarkdownDocsOptions {
+    // Mirror a real consumer (gunshi): TypeDoc page layout, pure-Markdown output,
+    // and `table` display formats for indexes / params / members, so the driver
+    // exercises the table render path published packages actually use.
     MarkdownDocsOptions {
         path_strategy: MarkdownPathStrategy::TypeDoc,
         render_style: MarkdownRenderStyle::Markdown,
+        index_format: MarkdownDisplayFormat::Table,
+        parameters_format: MarkdownDisplayFormat::Table,
+        interface_properties_format: MarkdownDisplayFormat::Table,
+        class_properties_format: MarkdownDisplayFormat::Table,
+        type_alias_properties_format: MarkdownDisplayFormat::Table,
+        enum_members_format: MarkdownDisplayFormat::Table,
+        property_members_format: MarkdownDisplayFormat::Table,
         ..MarkdownDocsOptions::default()
     }
 }


### PR DESCRIPTION
Continues #312. Two small, byte-identical changes to the pure-Markdown **table** render path — the one published packages like gunshi actually use (`parametersFormat: 'table'`, etc.).

## Changes

1. **Append table cells directly.** The parameter / member / type-parameter table renderers escaped each cell via `table_cell`, allocating a `String` per cell. New `push_table_cell` writes the pipe-escaped value straight into the output buffer; used at the five table-row sites. (`table_cell` stays for `code_cell`'s internal use.)
2. **Gunshi-faithful profiler driver.** `docs-render`/`docs-pipeline` now use `table` display formats (matching gunshi), so the docs commands exercise the table render path instead of the list fallback. Without this the table path wasn't profiled at all.

## Byte-identical

Same pipe-escaping, same content. 143 `ox_content_docs` tests pass.

## Validation — `docs-render` over gunshi's `packages/gunshi/src` (table format), before/after interleaved

| metric | before | after | Δ |
|---|---|---|---|
| render allocations/iter | 21,579 | 21,325 | **−1.2%** |
| `render_entry_page` allocs/iter | 12,722 | 12,468 | −2% |
| bytes/iter | 1.53 MB | 1.51 MB | −1.3% |
| wall-clock | ~782 µs | ~776 µs | neutral |

**Honest note:** the perf win is small — gunshi's rendered tables are modest, so per-cell allocations aren't a big share. The lasting value is the gunshi-faithful driver (so the table path is measurable at all) plus completing the table path's allocation cleanup after #315/#317. With this, the TypeDoc render path (Cow text, interned symbol map, list rows, table cells) is comprehensively de-allocated.

- [x] tests (143), clippy + `cargo fmt --all --check` clean.

Risk: **low** (byte-identical, internal).