### PR TITLE
fix(docs): do not double-wrap mixed markdown `@example` bodies in a code fence

### DIFF
--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -1912,20 +1912,47 @@ fn get_entry_badges(entry: &ApiDocEntry) -> Vec<EntryBadge> {
     badges
 }
 
-fn parse_example_block(example: &str) -> (&str, &str) {
+/// A parsed `@example` body.
+enum ExampleBlock<'a> {
+    /// Pure code: a single fenced block (unwrapped, with its language) or a bare
+    /// code body (defaulting to `ts`). Rendered inside a code fence / `<pre>`.
+    Code { code: &'a str, language: &'a str },
+    /// Mixed Markdown (prose and/or fenced code). Rendered as Markdown as-is so it
+    /// is not wrapped in an extra code fence.
+    Markdown(&'a str),
+}
+
+/// True when any line is a code-fence line (opens with ```` ``` ````). Counts fence
+/// *lines* only, so a stray ```` ``` ```` inside a single-line string literal is
+/// ignored.
+fn example_has_fence_line(text: &str) -> bool {
+    text.lines().any(|line| line.trim_start().starts_with("```"))
+}
+
+/// Classifies an `@example` body. A whole-body single fence is unwrapped to
+/// [`ExampleBlock::Code`]; a body that still contains a fence line (prose + code,
+/// multiple blocks, …) is kept verbatim as [`ExampleBlock::Markdown`] so it is not
+/// double-wrapped; a fence-free body is treated as bare code (`ts`).
+fn parse_example_block(example: &str) -> ExampleBlock<'_> {
     static FENCE_RE: RegexCache = OnceLock::new();
 
     let trimmed = example.trim();
-    let Some(fence_re) = cached_regex(&FENCE_RE, r"(?s)^```([\w-]+)?[^\n]*\n(.*?)\n?```$") else {
-        return (trimmed, "ts");
-    };
+    if let Some(fence_re) = cached_regex(&FENCE_RE, r"(?s)^```([\w-]+)?[^\n]*\n(.*?)\n?```$") {
+        if let Some(captures) = fence_re.captures(trimmed) {
+            let language = captures.get(1).map_or("ts", |value| value.as_str());
+            let code = captures.get(2).map_or("", |value| value.as_str());
+            // Only a single whole-body fence when the inner code has no further
+            // fence line; otherwise the body is multiple blocks → Markdown.
+            if !example_has_fence_line(code) {
+                return ExampleBlock::Code { code, language };
+            }
+        }
+    }
 
-    if let Some(captures) = fence_re.captures(trimmed) {
-        let language = captures.get(1).map_or("ts", |value| value.as_str());
-        let code = captures.get(2).map_or("", |value| value.as_str());
-        (code, language)
+    if example_has_fence_line(trimmed) {
+        ExampleBlock::Markdown(trimmed)
     } else {
-        (trimmed, "ts")
+        ExampleBlock::Code { code: trimmed, language: "ts" }
     }
 }
 
@@ -1935,12 +1962,19 @@ fn render_module_examples_markdown(examples: &[String]) -> String {
     out.push_str(if examples.len() == 1 { "Example" } else { "Examples" });
     out.push_str("\n\n");
     for example in examples {
-        let (code, language) = parse_example_block(example);
-        out.push_str("```");
-        out.push_str(language);
-        out.push('\n');
-        out.push_str(code);
-        out.push_str("\n```\n\n");
+        match parse_example_block(example) {
+            ExampleBlock::Code { code, language } => {
+                out.push_str("```");
+                out.push_str(language);
+                out.push('\n');
+                out.push_str(code);
+                out.push_str("\n```\n\n");
+            }
+            ExampleBlock::Markdown(markdown) => {
+                out.push_str(markdown);
+                out.push_str("\n\n");
+            }
+        }
     }
     out
 }
@@ -3279,6 +3313,66 @@ mod tests {
         assert!(module_index.contains("<h2>Example</h2>"));
         assert!(module_index.contains("<pre><code class=\"language-ts\">string()</code></pre>"));
         assert!(module_index.contains(">1</strong>\n  <span>examples</span>"));
+    }
+
+    #[test]
+    fn markdown_example_with_prose_and_fence_is_not_double_wrapped() {
+        let mut entry = test_entry("ArgSchema", "interface", "/repo/src/a.ts", "Schema.");
+        entry.examples = vec![
+            "Basic string argument:\n```ts\nconst schema = { type: 'string' }\n```".to_string(),
+        ];
+        let out = generate_markdown(&lifecycle_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/interfaces/ArgSchema.md").unwrap();
+
+        // Prose stays a real line immediately followed by the single code fence; the
+        // whole example is not wrapped in another ```ts (which would put the fence
+        // before the prose).
+        assert!(
+            page.contains("Basic string argument:\n```ts\nconst schema = { type: 'string' }\n```")
+        );
+        assert!(!page.contains("```ts\nBasic string argument:"));
+    }
+
+    #[test]
+    fn markdown_example_single_fence_is_unchanged() {
+        let mut entry = test_entry("ArgSchema", "interface", "/repo/src/a.ts", "Schema.");
+        entry.examples = vec!["```ts\nconst x = 1\n```".to_string()];
+        let out = generate_markdown(&lifecycle_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/interfaces/ArgSchema.md").unwrap();
+        assert!(page.contains("```ts\nconst x = 1\n```"));
+    }
+
+    #[test]
+    fn markdown_example_bare_code_is_wrapped_in_ts_fence() {
+        let mut entry = test_entry("ArgSchema", "interface", "/repo/src/a.ts", "Schema.");
+        entry.examples = vec!["const x = 1".to_string()];
+        let out = generate_markdown(&lifecycle_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/interfaces/ArgSchema.md").unwrap();
+        assert!(page.contains("```ts\nconst x = 1\n```"));
+    }
+
+    #[test]
+    fn markdown_example_with_multiple_fences_passes_through() {
+        let mut entry = test_entry("ArgSchema", "interface", "/repo/src/a.ts", "Schema.");
+        entry.examples = vec!["```ts\na\n```\n\n```js\nb\n```".to_string()];
+        let out = generate_markdown(&lifecycle_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/interfaces/ArgSchema.md").unwrap();
+
+        // Both fenced blocks are preserved verbatim (not collapsed or double-wrapped).
+        assert!(page.contains("```ts\na\n```\n\n```js\nb\n```"));
+    }
+
+    #[test]
+    fn html_example_with_prose_and_fence_renders_blocks() {
+        let mut entry = test_entry("ArgSchema", "interface", "/repo/src/a.ts", "Schema.");
+        entry.examples = vec!["Basic string argument:\n```ts\nconst schema = 1\n```".to_string()];
+        let out = generate_markdown(&lifecycle_module(entry), &html_typedoc_options());
+        let page = out.get("combinators/interfaces/ArgSchema.md").unwrap();
+
+        // Prose becomes a paragraph and the code a code block, rather than the whole
+        // mixed example being escaped inside a single <pre><code>.
+        assert!(page.contains("<p>Basic string argument:</p>"));
+        assert!(page.contains("<pre><code class=\"language-ts\">const schema = 1</code></pre>"));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/markdown/markdown_html.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_html.rs
@@ -14,7 +14,7 @@ use super::{
     cached_regex, clean_summary_text, doc_kind_plural, doc_page_href, effective_members_format,
     effective_parameters_format, entry_anchor, file_stem, format_count_label, format_kind_label,
     generate_source_href, get_entry_badges, member_anchor, normalize_signature,
-    parse_example_block, process_doc_text, resolve_type_fragments, EntryStats,
+    parse_example_block, process_doc_text, resolve_type_fragments, EntryStats, ExampleBlock,
     MarkdownDisplayFormat, MarkdownDocsOptions, MarkdownLinkContext, MarkdownPathStrategy,
     RegexCache, TypeFragment, DOC_KIND_ORDER,
 };
@@ -458,7 +458,13 @@ pub(super) fn render_module_examples_html(examples: &[String]) -> String {
         if !examples_html.is_empty() {
             examples_html.push_char('\n');
         }
-        let (code, language) = parse_example_block(example);
+        // Mixed Markdown examples (prose + fenced code) render as HTML blocks; a
+        // pure-code example renders as a single highlighted code block. This avoids
+        // double-wrapping a Markdown example in another `<pre><code>`.
+        let rendered = match parse_example_block(example) {
+            ExampleBlock::Code { code, language } => render_code_block_html(code, language),
+            ExampleBlock::Markdown(markdown) => render_markdown_blocks_html(markdown),
+        };
         examples_html.push_str(
             "<div class=\"ox-api-entry__example\">
 <div class=\"ox-api-entry__example-heading\">Example ",
@@ -468,7 +474,7 @@ pub(super) fn render_module_examples_html(examples: &[String]) -> String {
             "</div>
 ",
         );
-        examples_html.push_str(&render_code_block_html(code, language));
+        examples_html.push_str(&rendered);
         examples_html.push_str(
             "
 </div>",
@@ -1424,7 +1430,13 @@ fn push_examples_html(body: &mut String, examples: &[String]) {
         if !examples_html.is_empty() {
             examples_html.push_char('\n');
         }
-        let (code, language) = parse_example_block(example);
+        // Mixed Markdown examples (prose + fenced code) render as HTML blocks; a
+        // pure-code example renders as a single highlighted code block. This avoids
+        // double-wrapping a Markdown example in another `<pre><code>`.
+        let rendered = match parse_example_block(example) {
+            ExampleBlock::Code { code, language } => render_code_block_html(code, language),
+            ExampleBlock::Markdown(markdown) => render_markdown_blocks_html(markdown),
+        };
         examples_html.push_str(
             "<div class=\"ox-api-entry__example\">
 <div class=\"ox-api-entry__example-heading\">Example ",
@@ -1434,7 +1446,7 @@ fn push_examples_html(body: &mut String, examples: &[String]) {
             "</div>
 ",
         );
-        examples_html.push_str(&render_code_block_html(code, language));
+        examples_html.push_str(&rendered);
         examples_html.push_str(
             "
 </div>",

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -11,7 +11,7 @@ use std::collections::HashSet;
 
 use super::{
     effective_members_format, effective_parameters_format, generate_source_href,
-    parse_example_block, process_doc_text, resolve_type_fragments, EntryStats,
+    parse_example_block, process_doc_text, resolve_type_fragments, EntryStats, ExampleBlock,
     MarkdownDisplayFormat, MarkdownDocsOptions, MarkdownLinkContext, TypeFragment,
 };
 use crate::model::{
@@ -392,12 +392,19 @@ fn push_examples(out: &mut String, examples: &[String], heading: &str) {
     out.push_str(heading);
     out.push_str(" Examples\n\n");
     for example in examples {
-        let (code, language) = parse_example_block(example);
-        out.push_str("```");
-        out.push_str(language);
-        out.push('\n');
-        out.push_str(code);
-        out.push_str("\n```\n\n");
+        match parse_example_block(example) {
+            ExampleBlock::Code { code, language } => {
+                out.push_str("```");
+                out.push_str(language);
+                out.push('\n');
+                out.push_str(code);
+                out.push_str("\n```\n\n");
+            }
+            ExampleBlock::Markdown(markdown) => {
+                out.push_str(markdown);
+                out.push_str("\n\n");
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes mixed `@example` bodies (prose + a fenced code block) being wrapped in an extra `ts` fence, producing nested fences.

Each example is now classified: a single fence or bare code stays a code block; a mixed/multi-fence body is emitted as Markdown as-is.

Both render styles, no API change.

## Background

`parse_example_block` only unwrapped a body that was exactly one fence; anything else fell through and every caller wrapped it in ```ts.

So a TSDoc example of prose + a ```ts block became a nested fence — invalid.

The html renderer already had a Markdown block renderer reused for the mixed case.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783160428&installation_id=136613492&pr_number=320&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F320&signature=245067b6c9fa8f4e3fb54d64ad238d30f1c928dcc3053122d19cbe2558fba2ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->