### PR TITLE
fix(docs): collapse multiline type params

### DIFF
--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -721,6 +721,79 @@ fn process_doc_text<'a>(text: &'a str, context: Option<&MarkdownLinkContext<'_>>
     }
 }
 
+/// Collapses runs of whitespace (including newlines) into single spaces.
+///
+/// Borrows the input (after trimming) when it is already collapsed — i.e. every
+/// whitespace char is a single ASCII space with no runs — so the common case of
+/// already-clean doc text allocates nothing.
+fn collapse_inline_whitespace(text: &str) -> Cow<'_, str> {
+    let text = text.trim();
+    if text.is_empty() {
+        return Cow::Borrowed("");
+    }
+    // Fast path: nothing to collapse iff every whitespace char is a lone ASCII
+    // space. Any other whitespace char, or two adjacent whitespace chars, would
+    // be rewritten below, so it must be owned.
+    let needs_collapse = {
+        let mut prev_ws = false;
+        text.chars().any(|ch| {
+            let collapse = ch.is_whitespace() && (ch != ' ' || prev_ws);
+            prev_ws = ch.is_whitespace();
+            collapse
+        })
+    };
+    if !needs_collapse {
+        return Cow::Borrowed(text);
+    }
+
+    let mut out = String::with_capacity(text.len());
+    let mut pending_space = false;
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            pending_space = !out.is_empty();
+        } else {
+            if pending_space {
+                out.push(' ');
+                pending_space = false;
+            }
+            out.push(ch);
+        }
+    }
+    Cow::Owned(out)
+}
+
+/// Collapses type annotations for inline rendering while avoiding spaces created
+/// by multiline generic formatting, e.g. `Foo<\n  Bar\n>` -> `Foo<Bar>`.
+fn collapse_type_annotation_whitespace(text: &str) -> Cow<'_, str> {
+    let text = text.trim();
+    if text.is_empty() {
+        return Cow::Borrowed("");
+    }
+
+    let mut out = String::with_capacity(text.len());
+    let mut pending_space = false;
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            pending_space = !out.is_empty();
+            continue;
+        }
+
+        if pending_space {
+            if !matches!(out.chars().next_back(), Some('<')) && ch != '>' {
+                out.push(' ');
+            }
+            pending_space = false;
+        }
+        out.push(ch);
+    }
+
+    if out == text {
+        Cow::Borrowed(text)
+    } else {
+        Cow::Owned(out)
+    }
+}
+
 /// One-line summary for a module index table cell.
 ///
 /// Resolves `{@link}`/`{@linkcode}` exactly like the per-symbol pages (keeping
@@ -4350,6 +4423,7 @@ mod tests {
                 type_stub("CommandRunner"),
                 type_stub("GunshiParamsConstraint"),
                 type_stub("DefaultGunshiParams"),
+                type_stub("PluginExtension"),
                 type_stub("U"),
                 // Symbols that collide with TypeScript intrinsic primitive types,
                 // mirroring gunshi's `string()` / `boolean()` / `number()`
@@ -4359,6 +4433,31 @@ mod tests {
                 function_stub("number"),
             ],
         }]
+    }
+
+    fn multiline_plugin_ext_type_parameters() -> Vec<ApiTypeParamDoc> {
+        vec![
+            ApiTypeParamDoc {
+                name: "Extension".to_string(),
+                constraint: None,
+                default: None,
+                description: String::new(),
+            },
+            ApiTypeParamDoc {
+                name: "ResolvedDepExtensions".to_string(),
+                constraint: None,
+                default: None,
+                description: String::new(),
+            },
+            ApiTypeParamDoc {
+                name: "PluginExt".to_string(),
+                constraint: Some("PluginExtension<Extension, DefaultGunshiParams>".to_string()),
+                default: Some(
+                    "PluginExtension<\n    Extension,\n    ResolvedDepExtensions\n  >".to_string(),
+                ),
+                description: String::new(),
+            },
+        ]
     }
 
     #[test]
@@ -4415,6 +4514,34 @@ mod tests {
         assert!(page.contains("= [`DefaultGunshiParams`]("));
         // The type parameter's own name is never linked.
         assert!(page.contains("| `G` *extends*"));
+    }
+
+    #[test]
+    fn typedoc_markdown_table_collapses_multiline_linked_type_parameter_defaults() {
+        let mut entry = test_entry("make", "function", "/repo/src/make.ts", "Make.");
+        entry.type_parameters = multiline_plugin_ext_type_parameters();
+        let options = MarkdownDocsOptions {
+            parameters_format: MarkdownDisplayFormat::Table,
+            ..markdown_typedoc_options()
+        };
+        let out = generate_markdown(&type_link_module(entry), &options);
+        let page = out.get("combinators/functions/make.md").unwrap();
+
+        assert!(page.contains("| `PluginExt` *extends* [`PluginExtension`](../type-aliases/PluginExtension.md)\\<`Extension`, [`DefaultGunshiParams`](../type-aliases/DefaultGunshiParams.md)\\> = [`PluginExtension`](../type-aliases/PluginExtension.md)\\<`Extension`, `ResolvedDepExtensions`\\> |  |"));
+        assert!(!page.contains("\\<\n"));
+        assert!(!page.contains("ResolvedDepExtensions`\n"));
+    }
+
+    #[test]
+    fn typedoc_markdown_list_collapses_multiline_linked_type_parameter_defaults() {
+        let mut entry = test_entry("make", "function", "/repo/src/make.ts", "Make.");
+        entry.type_parameters = multiline_plugin_ext_type_parameters();
+        let out = generate_markdown(&type_link_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/functions/make.md").unwrap();
+
+        assert!(page.contains("- `PluginExt` *extends* [`PluginExtension`](../type-aliases/PluginExtension.md)\\<`Extension`, [`DefaultGunshiParams`](../type-aliases/DefaultGunshiParams.md)\\> = [`PluginExtension`](../type-aliases/PluginExtension.md)\\<`Extension`, `ResolvedDepExtensions`\\>"));
+        assert!(!page.contains("\\<\n"));
+        assert!(!page.contains("`Extension`,\n"));
     }
 
     #[test]
@@ -4543,6 +4670,18 @@ mod tests {
         // No anchor in the type cell; escaped union pipe preserved.
         assert!(page.contains("string | number"));
         assert!(!page.contains("<a href=\"./type-aliases"));
+    }
+
+    #[test]
+    fn typedoc_html_collapses_multiline_linked_type_parameter_defaults() {
+        let mut entry = test_entry("make", "function", "/repo/src/make.ts", "Make.");
+        entry.type_parameters = multiline_plugin_ext_type_parameters();
+        let out = generate_markdown(&type_link_module(entry), &html_typedoc_options());
+        let page = out.get("combinators/functions/make.md").unwrap();
+
+        assert!(page.contains("= <code><a href=\"../type-aliases/PluginExtension.md\">PluginExtension</a>&lt;Extension, ResolvedDepExtensions&gt;</code>"));
+        assert!(!page.contains("&lt;\n"));
+        assert!(!page.contains("ResolvedDepExtensions\n"));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/markdown/markdown_html.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_html.rs
@@ -11,12 +11,12 @@ use std::sync::OnceLock;
 use regex::Regex;
 
 use super::{
-    cached_regex, clean_summary_text, doc_kind_plural, doc_page_href, effective_members_format,
-    effective_parameters_format, entry_anchor, file_stem, format_count_label, format_kind_label,
-    generate_source_href, get_entry_badges, member_anchor, normalize_signature,
-    parse_example_block, process_doc_text, resolve_type_fragments, EntryStats, ExampleBlock,
-    MarkdownDisplayFormat, MarkdownDocsOptions, MarkdownLinkContext, MarkdownPathStrategy,
-    RegexCache, TypeFragment, DOC_KIND_ORDER,
+    cached_regex, clean_summary_text, collapse_type_annotation_whitespace, doc_kind_plural,
+    doc_page_href, effective_members_format, effective_parameters_format, entry_anchor, file_stem,
+    format_count_label, format_kind_label, generate_source_href, get_entry_badges, member_anchor,
+    normalize_signature, parse_example_block, process_doc_text, resolve_type_fragments, EntryStats,
+    ExampleBlock, MarkdownDisplayFormat, MarkdownDocsOptions, MarkdownLinkContext,
+    MarkdownPathStrategy, RegexCache, TypeFragment, DOC_KIND_ORDER,
 };
 use crate::model::{
     ApiDocEntry, ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc, ApiReturnDoc, ApiTypeParamDoc,
@@ -365,18 +365,17 @@ fn render_highlighted_inline_code_html(code: &str, class_name: &str, language: &
     out.into_string()
 }
 
-/// Inner HTML for a TypeScript type annotation: escaped text with `<a>` anchors for
-/// known symbols. When nothing resolves to a symbol page this equals
-/// `escape_html(value)` exactly (HTML escaping is per-character), so callers keep
-/// their existing `<code …>` wrappers byte-for-byte and only gain anchors when a
-/// type actually links.
+/// Inner HTML for a TypeScript type annotation: escaped text with `<a>` anchors
+/// for known symbols. Type annotations are always rendered as inline code, so
+/// multiline generic formatting is collapsed before link resolution.
 fn render_type_inner_html(
     value: &str,
     context: Option<&MarkdownLinkContext<'_>>,
     skip: &HashSet<&str>,
 ) -> String {
-    match resolve_type_fragments(value, context, skip) {
-        None => escape_html(value),
+    let value = collapse_type_annotation_whitespace(value);
+    match resolve_type_fragments(&value, context, skip) {
+        None => escape_html(&value),
         Some(fragments) => {
             let mut out = String::new();
             for fragment in fragments {

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -6,13 +6,13 @@
 //! same per-entry information as the HTML renderer — but as Markdown headings,
 //! tables and fenced code blocks (no `<details>`, no theme-specific HTML).
 
-use std::borrow::Cow;
 use std::collections::HashSet;
 
 use super::{
-    effective_members_format, effective_parameters_format, generate_source_href,
-    parse_example_block, process_doc_text, resolve_type_fragments, EntryStats, ExampleBlock,
-    MarkdownDisplayFormat, MarkdownDocsOptions, MarkdownLinkContext, TypeFragment,
+    collapse_inline_whitespace, collapse_type_annotation_whitespace, effective_members_format,
+    effective_parameters_format, generate_source_href, parse_example_block, process_doc_text,
+    resolve_type_fragments, EntryStats, ExampleBlock, MarkdownDisplayFormat, MarkdownDocsOptions,
+    MarkdownLinkContext, TypeFragment,
 };
 use crate::model::{
     ApiDocEntry, ApiDocMember, ApiDocTag, ApiParamDoc, ApiReturnDoc, ApiTypeParamDoc,
@@ -831,50 +831,9 @@ fn param_description(param: &ApiParamDoc, context: Option<&MarkdownLinkContext<'
     description
 }
 
-/// Collapses runs of whitespace (including newlines) into single spaces.
-///
-/// Borrows the input (after trimming) when it is already collapsed — i.e. every
-/// whitespace char is a single ASCII space with no runs — so the common case of
-/// already-clean doc text allocates nothing.
-fn collapse_whitespace(text: &str) -> Cow<'_, str> {
-    let text = text.trim();
-    if text.is_empty() {
-        return Cow::Borrowed("");
-    }
-    // Fast path: nothing to collapse iff every whitespace char is a lone ASCII
-    // space. Any other whitespace char, or two adjacent whitespace chars, would
-    // be rewritten below, so it must be owned.
-    let needs_collapse = {
-        let mut prev_ws = false;
-        text.chars().any(|ch| {
-            let collapse = ch.is_whitespace() && (ch != ' ' || prev_ws);
-            prev_ws = ch.is_whitespace();
-            collapse
-        })
-    };
-    if !needs_collapse {
-        return Cow::Borrowed(text);
-    }
-
-    let mut out = String::with_capacity(text.len());
-    let mut pending_space = false;
-    for ch in text.chars() {
-        if ch.is_whitespace() {
-            pending_space = !out.is_empty();
-        } else {
-            if pending_space {
-                out.push(' ');
-                pending_space = false;
-            }
-            out.push(ch);
-        }
-    }
-    Cow::Owned(out)
-}
-
 /// Inline Markdown for a doc-text fragment (resolves `{@link}`), single-line.
 fn inline(text: &str, context: Option<&MarkdownLinkContext<'_>>) -> String {
-    collapse_whitespace(&process_doc_text(text, context)).into_owned()
+    collapse_inline_whitespace(&process_doc_text(text, context)).into_owned()
 }
 
 /// Escapes a value for use inside a Markdown table cell.
@@ -904,7 +863,7 @@ fn push_table_cell(out: &mut String, text: &str) {
 
 /// Inline code for normal Markdown text; empty string if blank.
 fn code_span(value: &str) -> String {
-    let value = collapse_whitespace(value);
+    let value = collapse_inline_whitespace(value);
     if value.is_empty() {
         String::new()
     } else {
@@ -918,7 +877,7 @@ fn code_span(value: &str) -> String {
 
 /// Inline code for a Markdown table cell (`|` escaped); empty string if blank.
 fn code_cell(value: &str) -> String {
-    let value = collapse_whitespace(value);
+    let value = collapse_inline_whitespace(value);
     if value.is_empty() {
         String::new()
     } else {
@@ -962,8 +921,9 @@ fn linked_type(
     code: fn(&str) -> String,
     in_cell: bool,
 ) -> String {
-    match resolve_type_fragments(value, context, skip) {
-        None => code(value),
+    let value = collapse_type_annotation_whitespace(value);
+    match resolve_type_fragments(&value, context, skip) {
+        None => code(&value),
         Some(fragments) => {
             let mut out = String::new();
             for fragment in fragments {

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -4135,6 +4135,83 @@ mod tests {
     }
 
     #[test]
+    fn generate_docs_markdown_collapses_multiline_linked_type_parameter_defaults() {
+        fn entry(name: &str, kind: &str, signature: &str) -> JsDocsMarkdownEntry {
+            JsDocsMarkdownEntry {
+                name: name.to_string(),
+                kind: kind.to_string(),
+                description: String::new(),
+                params: None,
+                returns: None,
+                examples: None,
+                tags: None,
+                private: false,
+                file: format!("/repo/src/{name}.ts"),
+                line: 1,
+                end_line: 1,
+                signature: Some(signature.to_string()),
+                has_body: None,
+                members: None,
+                type_parameters: None,
+            }
+        }
+
+        let mut plugin = entry("plugin", "function", "export function plugin(): void");
+        plugin.type_parameters = Some(vec![
+            JsTypeParam {
+                name: "Extension".to_string(),
+                constraint: None,
+                r#default: None,
+                description: String::new(),
+            },
+            JsTypeParam {
+                name: "ResolvedDepExtensions".to_string(),
+                constraint: None,
+                r#default: None,
+                description: String::new(),
+            },
+            JsTypeParam {
+                name: "PluginExt".to_string(),
+                constraint: Some("PluginExtension<Extension, DefaultGunshiParams>".to_string()),
+                r#default: Some(
+                    "PluginExtension<\n    Extension,\n    ResolvedDepExtensions\n  >".to_string(),
+                ),
+                description: String::new(),
+            },
+        ]);
+
+        let docs = vec![JsDocsMarkdownModule {
+            description: None,
+            file: "default".to_string(),
+            source_path: None,
+            examples: None,
+            tags: None,
+            entries: vec![
+                plugin,
+                entry("PluginExtension", "type", "export type PluginExtension = unknown"),
+                entry("DefaultGunshiParams", "type", "export type DefaultGunshiParams = unknown"),
+            ],
+        }];
+
+        let markdown = generate_docs_markdown(
+            docs,
+            Some(JsDocsMarkdownOptions {
+                group_by: Some("file".to_string()),
+                link_style: Some("markdown".to_string()),
+                path_strategy: Some("typedoc".to_string()),
+                render_style: Some("markdown".to_string()),
+                parameters_format: Some("table".to_string()),
+                ..Default::default()
+            }),
+        );
+        let page = markdown.get("default/functions/plugin.md").unwrap();
+
+        assert!(page.contains("| `PluginExt` *extends* [`PluginExtension`](../type-aliases/PluginExtension.md)\\<`Extension`, [`DefaultGunshiParams`](../type-aliases/DefaultGunshiParams.md)\\> = [`PluginExtension`](../type-aliases/PluginExtension.md)\\<`Extension`, `ResolvedDepExtensions`\\> |  |"));
+        assert!(!page.contains("\\<\n"));
+        assert!(!page.contains("ResolvedDepExtensions`\n"));
+    }
+
+    #[test]
     fn generate_docs_markdown_renders_module_description_in_typedoc_index() {
         let docs = vec![JsDocsMarkdownModule {
             description: Some("The entry for gunshi context.".to_string()),


### PR DESCRIPTION
## Summary

Normalize multiline type annotations before Markdown/HTML type rendering so linked generic defaults stay single-line.

Added docs and NAPI regression tests.

## Background

gunshi exposed raw newlines in Type Parameters table cells for PluginExt defaults.

Linked type fragments bypassed the whitespace collapse used by unlinked code spans, breaking VitePress tables.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783171197&installation_id=136613492&pr_number=321&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F321&signature=61157779c6c7a511d1c49455f6e5a551b32d50bf6974818f05ad75468cfbd571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->