### PR TITLE
fix(docs): render return type literal members

### DIFF
--- a/crates/ox_content_docs/benches/markdown.rs
+++ b/crates/ox_content_docs/benches/markdown.rs
@@ -135,6 +135,7 @@ fn member(module: usize, entry: usize, index: usize) -> ApiDocMember {
         returns: (kind != "property").then(|| ApiReturnDoc {
             type_annotation: "boolean".to_string(),
             description: "Whether the member accepted the value.".to_string(),
+            members: Vec::new(),
         }),
         optional: index % 2 == 0,
         readonly: index % 3 == 0,
@@ -191,6 +192,7 @@ fn entry(module: usize, index: usize) -> ApiDocEntry {
                 type_annotation
             },
             description: "A processed result object.".to_string(),
+            members: Vec::new(),
         }),
         examples: Vec::from([{
             let mut example = String::with_capacity(name.len() + 80);

--- a/crates/ox_content_docs/src/data.rs
+++ b/crates/ox_content_docs/src/data.rs
@@ -229,10 +229,16 @@ fn param_to_json(param: &ApiParamDoc) -> Value {
 }
 
 fn return_to_json(return_doc: &ApiReturnDoc) -> Value {
-    json!({
-        "type": return_doc.type_annotation,
-        "description": return_doc.description,
-    })
+    let mut value = Map::new();
+    value.insert("type".to_string(), json!(return_doc.type_annotation));
+    value.insert("description".to_string(), json!(return_doc.description));
+    if !return_doc.members.is_empty() {
+        value.insert(
+            "members".to_string(),
+            Value::Array(return_doc.members.iter().map(member_to_json).collect()),
+        );
+    }
+    Value::Object(value)
 }
 
 fn type_param_to_json(type_param: &ApiTypeParamDoc) -> Value {
@@ -266,7 +272,7 @@ fn normalize_doc_file_path(file_path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{ApiDocTag, ApiParamDoc};
+    use crate::model::{ApiDocMember, ApiDocTag, ApiParamDoc, ApiReturnDoc};
 
     #[test]
     fn generated_docs_data_counts_and_normalizes_paths() {
@@ -430,5 +436,60 @@ mod tests {
         assert!(type_params[0].get("description").is_none());
         assert_eq!(type_params[1]["name"], "T");
         assert_eq!(type_params[1]["description"], "Value.");
+    }
+
+    #[test]
+    fn return_members_serialize_to_json() {
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "/repo/src/resolver.ts".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![ApiDocEntry {
+                name: "resolveArgs".to_string(),
+                kind: "function".to_string(),
+                description: "Resolve.".to_string(),
+                params: vec![],
+                returns: Some(ApiReturnDoc {
+                    type_annotation: "object".to_string(),
+                    description: "Resolved args.".to_string(),
+                    members: vec![ApiDocMember {
+                        name: "values".to_string(),
+                        kind: "property".to_string(),
+                        description: String::new(),
+                        signature: None,
+                        type_annotation: Some("ArgValues<A>".to_string()),
+                        params: vec![],
+                        returns: None,
+                        optional: false,
+                        readonly: false,
+                        r#static: false,
+                        private: false,
+                        tags: vec![],
+                        line: 3,
+                        end_line: 3,
+                    }],
+                }),
+                examples: vec![],
+                tags: vec![],
+                private: false,
+                file: "/repo/src/resolver.ts".to_string(),
+                line: 1,
+                end_line: 6,
+                signature: None,
+                has_body: false,
+                members: vec![],
+                type_parameters: vec![],
+            }],
+        }];
+
+        let json = generate_docs_data_json(&docs, "2026-05-31T00:00:00.000Z").unwrap();
+        let value: Value = serde_json::from_str(&json).unwrap();
+        let returns = &value["modules"][0]["entries"][0]["returns"];
+
+        assert_eq!(returns["type"], "object");
+        assert_eq!(returns["members"][0]["name"], "values");
+        assert_eq!(returns["members"][0]["type"], "ArgValues<A>");
     }
 }

--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -84,6 +84,9 @@ pub struct DocItem {
     pub params: Vec<ParamDoc>,
     /// Return type (for functions/methods).
     pub return_type: Option<String>,
+    /// Members of an inline object literal return type.
+    #[serde(default)]
+    pub return_members: Vec<DocItem>,
     /// Child items (for classes, modules, etc.).
     pub children: Vec<DocItem>,
     /// JSDoc tags.
@@ -677,6 +680,7 @@ impl<'a> DocVisitor<'a> {
             r#static: false,
             params: Vec::new(),
             return_type: None,
+            return_members: Vec::new(),
             children: Vec::new(),
             tags,
             type_parameters: Vec::new(),
@@ -1500,9 +1504,29 @@ impl<'a> DocVisitor<'a> {
         })
     }
 
-    /// Extract return type from tags.
-    fn extract_return_type(&self, func: &Function, tags: &[DocTag]) -> Option<String> {
-        self.extract_return_type_from_annotation(func.return_type.as_ref(), tags)
+    fn extract_return_from_annotation(
+        &self,
+        return_type: Option<&oxc_allocator::Box<'a, oxc_ast::ast::TSTypeAnnotation<'a>>>,
+        tags: &[DocTag],
+    ) -> (Option<String>, Vec<DocItem>) {
+        if let Some(return_type) = return_type {
+            if let TSType::TSTypeLiteral(type_literal) = &return_type.type_annotation {
+                let members = self.extract_ts_signature_members(&type_literal.members);
+                let type_annotation = if members.is_empty() {
+                    self.format_ts_type(&return_type.type_annotation)
+                } else {
+                    "object".to_string()
+                };
+                return (Some(type_annotation), members);
+            }
+            return (Some(self.format_ts_type(&return_type.type_annotation)), Vec::new());
+        }
+
+        (self.extract_return_type_from_annotation(None, tags), Vec::new())
+    }
+
+    fn extract_return(&self, func: &Function, tags: &[DocTag]) -> (Option<String>, Vec<DocItem>) {
+        self.extract_return_from_annotation(func.return_type.as_ref(), tags)
     }
 
     /// Create a DocItem from a function.
@@ -1515,6 +1539,7 @@ impl<'a> DocVisitor<'a> {
         let name = func.id.as_ref()?.name.to_string();
         let (jsdoc, doc, tags) = self.extract_declaration_docs(attached_to)?;
         let (line, end_line) = self.span_lines(attached_to, func.span.end);
+        let (return_type, return_members) = self.extract_return(func, &tags);
 
         Some(DocItem {
             name,
@@ -1536,7 +1561,8 @@ impl<'a> DocVisitor<'a> {
             readonly: false,
             r#static: false,
             params: self.extract_params(func, &tags),
-            return_type: self.extract_return_type(func, &tags),
+            return_type,
+            return_members,
             children: Vec::new(),
             tags,
             type_parameters: self.extract_type_parameters(func.type_parameters.as_ref()),
@@ -1582,6 +1608,8 @@ impl<'a> DocVisitor<'a> {
                     }
                     let (method_line, method_end_line) =
                         self.span_lines(method.span.start, method.span.end);
+                    let (return_type, return_members) =
+                        self.extract_return(&method.value, &method_tags);
 
                     children.push(DocItem {
                         name: method_name.clone(),
@@ -1609,7 +1637,8 @@ impl<'a> DocVisitor<'a> {
                         readonly: false,
                         r#static: method.r#static,
                         params: self.extract_params(&method.value, &method_tags),
-                        return_type: self.extract_return_type(&method.value, &method_tags),
+                        return_type,
+                        return_members,
                         children: Vec::new(),
                         tags: method_tags,
                         type_parameters: Vec::new(),
@@ -1654,6 +1683,7 @@ impl<'a> DocVisitor<'a> {
                         r#static: prop.r#static,
                         params: Vec::new(),
                         return_type: None,
+                        return_members: Vec::new(),
                         children: Vec::new(),
                         tags: prop_tags,
                         type_parameters: Vec::new(),
@@ -1680,6 +1710,7 @@ impl<'a> DocVisitor<'a> {
             r#static: false,
             params: Vec::new(),
             return_type: None,
+            return_members: Vec::new(),
             children,
             tags,
             type_parameters: self.extract_type_parameters(class.type_parameters.as_ref()),
@@ -1730,6 +1761,7 @@ impl<'a> DocVisitor<'a> {
                         r#static: false,
                         params: Vec::new(),
                         return_type: None,
+                        return_members: Vec::new(),
                         children: Vec::new(),
                         tags: prop_tags,
                         type_parameters: Vec::new(),
@@ -1751,6 +1783,8 @@ impl<'a> DocVisitor<'a> {
                     }
                     let (method_line, method_end_line) =
                         self.span_lines(method.span.start, method.span.end);
+                    let (return_type, return_members) = self
+                        .extract_return_from_annotation(method.return_type.as_ref(), &method_tags);
 
                     let kind = match method.kind {
                         oxc_ast::ast::TSMethodSignatureKind::Method => DocItemKind::Method,
@@ -1780,10 +1814,8 @@ impl<'a> DocVisitor<'a> {
                         readonly: false,
                         r#static: false,
                         params: self.extract_params_from_formals(&method.params, &method_tags),
-                        return_type: self.extract_return_type_from_annotation(
-                            method.return_type.as_ref(),
-                            &method_tags,
-                        ),
+                        return_type,
+                        return_members,
                         children: Vec::new(),
                         tags: method_tags,
                         type_parameters: Vec::new(),
@@ -1903,62 +1935,71 @@ impl<'a> DocVisitor<'a> {
 
             let name = id.name.to_string();
             let item = match initializer {
-                Expression::ArrowFunctionExpression(arrow) => DocItem {
-                    name: name.clone(),
-                    kind: DocItemKind::Function,
-                    doc: doc.clone(),
-                    source_path: self.file_path.to_string(),
-                    line,
-                    end_line,
-                    column: self.column_number(attached_to),
-                    jsdoc: jsdoc.clone(),
-                    exported,
-                    signature: Some(self.format_assigned_function_signature(
-                        &name,
-                        arrow.r#async,
-                        arrow.type_parameters.as_ref(),
-                        &arrow.params,
-                        arrow.return_type.as_ref(),
-                    )),
-                    has_body: false,
-                    optional: false,
-                    readonly: false,
-                    r#static: false,
-                    params: self.extract_params_from_formals(&arrow.params, &tags),
-                    return_type: self
-                        .extract_return_type_from_annotation(arrow.return_type.as_ref(), &tags),
-                    children: Vec::new(),
-                    tags: tags.clone(),
-                    type_parameters: self.extract_type_parameters(arrow.type_parameters.as_ref()),
-                },
-                Expression::FunctionExpression(func_expr) => DocItem {
-                    name: name.clone(),
-                    kind: DocItemKind::Function,
-                    doc: doc.clone(),
-                    source_path: self.file_path.to_string(),
-                    line,
-                    end_line,
-                    column: self.column_number(attached_to),
-                    jsdoc: jsdoc.clone(),
-                    exported,
-                    signature: Some(self.format_assigned_function_signature(
-                        &name,
-                        func_expr.r#async,
-                        func_expr.type_parameters.as_ref(),
-                        &func_expr.params,
-                        func_expr.return_type.as_ref(),
-                    )),
-                    has_body: false,
-                    optional: false,
-                    readonly: false,
-                    r#static: false,
-                    params: self.extract_params(func_expr, &tags),
-                    return_type: self.extract_return_type(func_expr, &tags),
-                    children: Vec::new(),
-                    tags: tags.clone(),
-                    type_parameters: self
-                        .extract_type_parameters(func_expr.type_parameters.as_ref()),
-                },
+                Expression::ArrowFunctionExpression(arrow) => {
+                    let (return_type, return_members) =
+                        self.extract_return_from_annotation(arrow.return_type.as_ref(), &tags);
+                    DocItem {
+                        name: name.clone(),
+                        kind: DocItemKind::Function,
+                        doc: doc.clone(),
+                        source_path: self.file_path.to_string(),
+                        line,
+                        end_line,
+                        column: self.column_number(attached_to),
+                        jsdoc: jsdoc.clone(),
+                        exported,
+                        signature: Some(self.format_assigned_function_signature(
+                            &name,
+                            arrow.r#async,
+                            arrow.type_parameters.as_ref(),
+                            &arrow.params,
+                            arrow.return_type.as_ref(),
+                        )),
+                        has_body: false,
+                        optional: false,
+                        readonly: false,
+                        r#static: false,
+                        params: self.extract_params_from_formals(&arrow.params, &tags),
+                        return_type,
+                        return_members,
+                        children: Vec::new(),
+                        tags: tags.clone(),
+                        type_parameters: self
+                            .extract_type_parameters(arrow.type_parameters.as_ref()),
+                    }
+                }
+                Expression::FunctionExpression(func_expr) => {
+                    let (return_type, return_members) = self.extract_return(func_expr, &tags);
+                    DocItem {
+                        name: name.clone(),
+                        kind: DocItemKind::Function,
+                        doc: doc.clone(),
+                        source_path: self.file_path.to_string(),
+                        line,
+                        end_line,
+                        column: self.column_number(attached_to),
+                        jsdoc: jsdoc.clone(),
+                        exported,
+                        signature: Some(self.format_assigned_function_signature(
+                            &name,
+                            func_expr.r#async,
+                            func_expr.type_parameters.as_ref(),
+                            &func_expr.params,
+                            func_expr.return_type.as_ref(),
+                        )),
+                        has_body: false,
+                        optional: false,
+                        readonly: false,
+                        r#static: false,
+                        params: self.extract_params(func_expr, &tags),
+                        return_type,
+                        return_members,
+                        children: Vec::new(),
+                        tags: tags.clone(),
+                        type_parameters: self
+                            .extract_type_parameters(func_expr.type_parameters.as_ref()),
+                    }
+                }
                 other => DocItem {
                     name: name.clone(),
                     kind: DocItemKind::Variable,
@@ -1982,6 +2023,7 @@ impl<'a> DocVisitor<'a> {
                     r#static: false,
                     params: Vec::new(),
                     return_type: None,
+                    return_members: Vec::new(),
                     children: Vec::new(),
                     tags: tags.clone(),
                     type_parameters: Vec::new(),
@@ -2025,6 +2067,7 @@ impl<'a> DocVisitor<'a> {
             r#static: false,
             params: Vec::new(),
             return_type: None,
+            return_members: Vec::new(),
             children,
             tags,
             type_parameters: self.extract_type_parameters(type_alias.type_parameters.as_ref()),
@@ -2060,6 +2103,7 @@ impl<'a> DocVisitor<'a> {
             r#static: false,
             params: Vec::new(),
             return_type: None,
+            return_members: Vec::new(),
             children,
             tags,
             type_parameters: self.extract_type_parameters(interface.type_parameters.as_ref()),
@@ -2100,6 +2144,7 @@ impl<'a> DocVisitor<'a> {
             r#static: false,
             params: Vec::new(),
             return_type: None,
+            return_members: Vec::new(),
             children,
             tags,
             type_parameters: Vec::new(),
@@ -2145,6 +2190,7 @@ impl<'a> DocVisitor<'a> {
             r#static: false,
             params: Vec::new(),
             return_type: None,
+            return_members: Vec::new(),
             children: Vec::new(),
             tags: member_tags,
             type_parameters: Vec::new(),
@@ -2209,6 +2255,39 @@ export function add(a: number, b: number): number {
         assert!(items[0].exported);
         assert!(items[0].doc.as_ref().unwrap().contains("Adds two numbers"));
         assert_eq!(items[0].params.len(), 2);
+    }
+
+    #[test]
+    fn function_return_type_literal_emits_return_members() {
+        let source = r"
+/**
+ * Resolve arguments.
+ * @returns Resolved args.
+ */
+export function resolveArgs<A extends Args>(): {
+    values: ArgValues<A>;
+    positionals: string[];
+    error: AggregateError | undefined;
+} {
+    return {} as any;
+}
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "resolver.ts", SourceType::ts()).unwrap();
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].return_type.as_deref(), Some("object"));
+        assert_eq!(
+            items[0].return_members.iter().map(|member| member.name.as_str()).collect::<Vec<_>>(),
+            ["values", "positionals", "error"]
+        );
+        assert_eq!(items[0].return_members[0].signature.as_deref(), Some("ArgValues<A>"));
+        assert_eq!(items[0].return_members[1].signature.as_deref(), Some("string[]"));
+        assert_eq!(
+            items[0].return_members[2].signature.as_deref(),
+            Some("AggregateError | undefined")
+        );
     }
 
     #[test]

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -11,7 +11,7 @@ use phf::{phf_map, phf_set};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-use crate::model::{ApiDocEntry, ApiDocMember, ApiDocModule};
+use crate::model::{ApiDocEntry, ApiDocMember, ApiDocModule, ApiReturnDoc};
 #[allow(unused_imports)]
 use crate::profile_span;
 use crate::string_builder::{join2, join3, join4, join5, StringBuilder};
@@ -1067,11 +1067,13 @@ fn sort_extracted_docs(docs: &[ApiDocModule], options: &MarkdownDocsOptions) -> 
             doc.entries.sort_by(|a, b| compare_entries(a, b, strategies, &kind_order));
             for entry in &mut doc.entries {
                 entry.members.sort_by(|a, b| compare_members(a, b, strategies, &kind_order));
+                sort_api_doc_return_members(entry, Some(strategies), &kind_order);
             }
         } else {
             doc.entries.sort_by_cached_key(|entry| (entry.name.to_lowercase(), entry.name.clone()));
             for entry in &mut doc.entries {
                 sort_api_doc_members(entry);
+                sort_api_doc_return_members(entry, None, &kind_order);
             }
         }
     }
@@ -1096,6 +1098,37 @@ fn sort_api_doc_members(entry: &mut ApiDocEntry) {
         entry
             .members
             .sort_by_cached_key(|member| (member.name.to_lowercase(), member.name.clone()));
+    }
+}
+
+fn sort_api_doc_return_members(
+    entry: &mut ApiDocEntry,
+    strategies: Option<&[SortStrategy]>,
+    kind_order: &[&str],
+) {
+    sort_return_members(entry.returns.as_mut(), strategies, kind_order);
+    for member in &mut entry.members {
+        sort_return_members(member.returns.as_mut(), strategies, kind_order);
+    }
+}
+
+fn sort_return_members(
+    returns: Option<&mut ApiReturnDoc>,
+    strategies: Option<&[SortStrategy]>,
+    kind_order: &[&str],
+) {
+    let Some(returns) = returns else {
+        return;
+    };
+    if let Some(strategies) = strategies {
+        returns.members.sort_by(|a, b| compare_members(a, b, strategies, kind_order));
+    } else {
+        returns
+            .members
+            .sort_by_cached_key(|member| (member.name.to_lowercase(), member.name.clone()));
+    }
+    for member in &mut returns.members {
+        sort_return_members(member.returns.as_mut(), strategies, kind_order);
     }
 }
 
@@ -2643,7 +2676,7 @@ fn capitalize_ascii(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{ApiDocTag, ApiParamDoc, ApiReturnDoc, ApiTypeParamDoc};
+    use crate::model::{ApiDocMember, ApiDocTag, ApiParamDoc, ApiReturnDoc, ApiTypeParamDoc};
 
     fn test_entry(name: &str, kind: &str, file: &str, description: &str) -> ApiDocEntry {
         ApiDocEntry {
@@ -2718,6 +2751,7 @@ mod tests {
                     returns: Some(ApiReturnDoc {
                         type_annotation: "void".to_string(),
                         description: "Nothing.".to_string(),
+                        members: Vec::new(),
                     }),
                     examples: vec!["```ts\ncli([])\n```".to_string()],
                     tags: vec![ApiDocTag { tag: "since".to_string(), value: "1.0.0".to_string() }],
@@ -3155,6 +3189,7 @@ mod tests {
                     returns: Some(ApiReturnDoc {
                         type_annotation: "AgentProfile".to_string(),
                         description: "An {@link AgentProfile} result.".to_string(),
+                        members: Vec::new(),
                     }),
                     examples: vec![],
                     tags: vec![
@@ -4424,6 +4459,8 @@ mod tests {
                 type_stub("GunshiParamsConstraint"),
                 type_stub("DefaultGunshiParams"),
                 type_stub("PluginExtension"),
+                type_stub("ArgValues"),
+                type_stub("ArgExplicitlyProvided"),
                 type_stub("U"),
                 // Symbols that collide with TypeScript intrinsic primitive types,
                 // mirroring gunshi's `string()` / `boolean()` / `number()`
@@ -4460,6 +4497,25 @@ mod tests {
         ]
     }
 
+    fn return_property(name: &str, type_annotation: &str) -> ApiDocMember {
+        ApiDocMember {
+            name: name.to_string(),
+            kind: "property".to_string(),
+            description: String::new(),
+            signature: None,
+            type_annotation: Some(type_annotation.to_string()),
+            params: vec![],
+            returns: None,
+            optional: false,
+            readonly: false,
+            r#static: false,
+            private: false,
+            tags: vec![],
+            line: 1,
+            end_line: 1,
+        }
+    }
+
     #[test]
     fn typedoc_links_known_symbols_in_param_types() {
         let mut entry = test_entry("make", "function", "/repo/src/make.ts", "Make.");
@@ -4487,11 +4543,51 @@ mod tests {
         entry.returns = Some(ApiReturnDoc {
             type_annotation: "CommandRunner<G>".to_string(),
             description: String::new(),
+            members: Vec::new(),
         });
         let out = generate_markdown(&type_link_module(entry), &markdown_typedoc_options());
         let page = out.get("combinators/functions/make.md").unwrap();
 
         assert!(page.contains("[`CommandRunner`]("));
+    }
+
+    #[test]
+    fn typedoc_markdown_renders_return_type_literal_members() {
+        let mut entry = test_entry("resolveArgs", "function", "/repo/src/resolver.ts", "Resolve.");
+        entry.returns = Some(ApiReturnDoc {
+            type_annotation: "object".to_string(),
+            description: "Resolved args.".to_string(),
+            members: vec![
+                return_property("values", "ArgValues<A>"),
+                return_property("positionals", "string[]"),
+                return_property("error", "AggregateError | undefined"),
+                return_property("explicit", "ArgExplicitlyProvided<A>"),
+            ],
+        });
+        let out = generate_markdown(&type_link_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/functions/resolveArgs.md").unwrap();
+
+        assert!(page.contains("## Returns\n\n`object` — Resolved args.\n\n"));
+        assert!(page.contains("### error\n\n```ts\nerror: AggregateError | undefined;\n```"));
+        assert!(page.contains("### explicit\n\n```ts\nexplicit: ArgExplicitlyProvided<A>;\n```"));
+        assert!(page.contains("### values\n\n```ts\nvalues: ArgValues<A>;\n```"));
+    }
+
+    #[test]
+    fn typedoc_html_renders_return_type_literal_members() {
+        let mut entry = test_entry("resolveArgs", "function", "/repo/src/resolver.ts", "Resolve.");
+        entry.returns = Some(ApiReturnDoc {
+            type_annotation: "object".to_string(),
+            description: "Resolved args.".to_string(),
+            members: vec![return_property("values", "ArgValues<A>")],
+        });
+        let out = generate_markdown(&type_link_module(entry), &html_typedoc_options());
+        let page = out.get("combinators/functions/resolveArgs.md").unwrap();
+
+        assert!(page.contains("ox-api-entry__return-members"));
+        assert!(page.contains("<h5>values</h5>"));
+        assert!(page
+            .contains("values: <a href=\"../type-aliases/ArgValues.md\">ArgValues</a>&lt;A&gt;;"));
     }
 
     #[test]
@@ -5681,6 +5777,7 @@ mod tests {
                         returns: Some(ApiReturnDoc {
                             type_annotation: "Promise".to_string(),
                             description: "Run result.".to_string(),
+                            members: Vec::new(),
                         }),
                         optional: false,
                         readonly: false,

--- a/crates/ox_content_docs/src/markdown/markdown_html.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_html.rs
@@ -1412,11 +1412,71 @@ fn push_returns_html(
         body.push_str(&render_doc_inline_html(&returns.description, link_context));
         body.push_str("</p>");
     }
+    body.push_str(&render_return_members_html(&returns.members, link_context));
     body.push_str(
         "
 </div>
 </div>\n",
     );
+}
+
+fn render_return_members_html(
+    members: &[ApiDocMember],
+    link_context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    if members.is_empty() {
+        return String::new();
+    }
+
+    let mut rendered = StringBuilder::new();
+    rendered.push_str("<div class=\"ox-api-entry__return-members\">");
+    for member in members {
+        rendered.push_str("\n<div class=\"ox-api-entry__return-member\">\n<h5>");
+        rendered.push_str(&escape_html(&member.name));
+        rendered.push_str(
+            "</h5>\n<code class=\"ox-api-entry__return-member-type language-typescript\">",
+        );
+        push_return_member_signature_html(&mut rendered, member, link_context);
+        rendered.push_str("</code>");
+        let description =
+            render_member_description_html(member, &MarkdownDocsOptions::default(), link_context);
+        if !description.is_empty() {
+            rendered.push_str(&description);
+        }
+        rendered.push_str("\n</div>");
+    }
+    rendered.push_str("\n</div>");
+    rendered.into_string()
+}
+
+fn push_return_member_signature_html(
+    out: &mut StringBuilder,
+    member: &ApiDocMember,
+    link_context: Option<&MarkdownLinkContext<'_>>,
+) {
+    if let Some(signature) = member.signature.as_deref().filter(|signature| !signature.is_empty()) {
+        out.push_str(&escape_html(signature.trim()));
+        if !signature.trim_end().ends_with(';') {
+            out.push_char(';');
+        }
+        return;
+    }
+
+    if member.readonly {
+        out.push_str("readonly ");
+    }
+    out.push_str(&escape_html(&member.name));
+    if member.optional {
+        out.push_char('?');
+    }
+    out.push_str(": ");
+    let member_type = member
+        .type_annotation
+        .as_deref()
+        .or_else(|| member.returns.as_ref().map(|returns| returns.type_annotation.as_str()))
+        .unwrap_or("unknown");
+    out.push_str(&render_type_inner_html(member_type, link_context, &HashSet::new()));
+    out.push_char(';');
 }
 
 /// Appends the examples section, or nothing when empty.

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -382,6 +382,62 @@ fn push_returns(
         out.push_str(&inline(&returns.description, context));
     }
     out.push_str("\n\n");
+    push_return_members(out, &returns.members, context, heading);
+}
+
+fn push_return_members(
+    out: &mut String,
+    members: &[ApiDocMember],
+    context: Option<&MarkdownLinkContext<'_>>,
+    heading: &str,
+) {
+    if members.is_empty() {
+        return;
+    }
+
+    for member in members {
+        out.push_str(heading);
+        out.push('#');
+        out.push(' ');
+        out.push_str(&member.name);
+        out.push_str("\n\n```ts\n");
+        out.push_str(&return_member_signature(member));
+        out.push_str("\n```\n\n");
+        let description = member_description(member, context);
+        if !description.is_empty() {
+            out.push_str(&description);
+            out.push_str("\n\n");
+        }
+    }
+}
+
+fn return_member_signature(member: &ApiDocMember) -> String {
+    if let Some(signature) = member.signature.as_deref().filter(|signature| !signature.is_empty()) {
+        let signature = signature.trim();
+        return if signature.ends_with(';') {
+            signature.to_string()
+        } else {
+            let mut out = StringBuilder::with_capacity(signature.len() + 1);
+            out.push_str(signature);
+            out.push_char(';');
+            out.into_string()
+        };
+    }
+
+    let member_type = member_type(member);
+    let member_type = if member_type.is_empty() { "unknown" } else { member_type };
+    let mut out = StringBuilder::with_capacity(member.name.len() + member_type.len() + 16);
+    if member.readonly {
+        out.push_str("readonly ");
+    }
+    out.push_str(&member.name);
+    if member.optional {
+        out.push_char('?');
+    }
+    out.push_str(": ");
+    out.push_str(member_type);
+    out.push_char(';');
+    out.into_string()
 }
 
 /// Appends a `{heading} Examples` section, or nothing when empty.

--- a/crates/ox_content_docs/src/model.rs
+++ b/crates/ox_content_docs/src/model.rs
@@ -138,6 +138,9 @@ pub struct ApiReturnDoc {
     pub type_annotation: String,
     /// Return description.
     pub description: String,
+    /// Members of an inline object literal return type.
+    #[serde(default)]
+    pub members: Vec<ApiDocMember>,
 }
 
 /// Type parameter documentation (`<T extends C = D>`).

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -162,6 +162,9 @@ pub struct NormalizedReturnDoc {
     pub type_annotation: String,
     /// Return value description.
     pub description: String,
+    /// Members of an inline object literal return type.
+    #[serde(default)]
+    pub members: Vec<NormalizedMember>,
 }
 
 /// Normalized type parameter documentation (`<T extends C = D>`).
@@ -276,7 +279,7 @@ pub fn normalize_doc_item(item: DocItem, type_parameters: bool) -> Option<Normal
 
     let mut metadata = normalize_doc_metadata(&item.tags, type_parameters);
     merge_extracted_params(&mut metadata.params, item.params);
-    merge_extracted_return(&mut metadata.returns, item.return_type);
+    merge_extracted_return(&mut metadata.returns, item.return_type, item.return_members);
     let members = item.children.into_iter().filter_map(normalize_member).collect();
     let type_parameters = if type_parameters {
         build_type_parameters(item.type_parameters, &metadata.type_param_descriptions)
@@ -308,7 +311,7 @@ fn normalize_member(item: DocItem) -> Option<NormalizedMember> {
     // Member-level type parameters are out of scope; keep generic-tag behavior.
     let mut metadata = normalize_doc_metadata(&item.tags, false);
     merge_extracted_params(&mut metadata.params, item.params);
-    merge_extracted_return(&mut metadata.returns, item.return_type);
+    merge_extracted_return(&mut metadata.returns, item.return_type, item.return_members);
 
     let (signature, type_annotation) = match kind {
         NormalizedMemberKind::Property | NormalizedMemberKind::EnumMember => (None, item.signature),
@@ -475,16 +478,31 @@ fn merge_extracted_params(params: &mut Vec<NormalizedParamDoc>, extracted_params
     }
 }
 
-fn merge_extracted_return(returns: &mut Option<NormalizedReturnDoc>, return_type: Option<String>) {
-    if let Some(return_type) = return_type {
-        match returns {
-            Some(current) => current.type_annotation = return_type,
-            None => {
-                *returns = Some(NormalizedReturnDoc {
-                    type_annotation: return_type,
-                    description: String::new(),
-                });
+fn merge_extracted_return(
+    returns: &mut Option<NormalizedReturnDoc>,
+    return_type: Option<String>,
+    return_members: Vec<DocItem>,
+) {
+    let members = return_members.into_iter().filter_map(normalize_member).collect::<Vec<_>>();
+    if return_type.is_none() && members.is_empty() {
+        return;
+    }
+
+    match returns {
+        Some(current) => {
+            if let Some(return_type) = return_type {
+                current.type_annotation = return_type;
             }
+            if !members.is_empty() {
+                current.members = members;
+            }
+        }
+        None => {
+            *returns = Some(NormalizedReturnDoc {
+                type_annotation: return_type.unwrap_or_else(|| UNKNOWN_TYPE.to_string()),
+                description: String::new(),
+                members,
+            });
         }
     }
 }
@@ -529,6 +547,9 @@ fn merge_returns(returns: &mut Option<NormalizedReturnDoc>, next: NormalizedRetu
     if existing.description.is_empty() {
         existing.description = next.description;
     }
+    if existing.members.is_empty() {
+        existing.members = next.members;
+    }
 }
 
 fn normalized_param_from_tag(tag: &DocTag) -> Option<NormalizedParamDoc> {
@@ -546,6 +567,7 @@ fn normalized_return_from_tag(tag: &DocTag) -> NormalizedReturnDoc {
     NormalizedReturnDoc {
         type_annotation: tag.type_annotation.clone().unwrap_or_else(|| UNKNOWN_TYPE.to_string()),
         description: tag.description.clone().unwrap_or_default(),
+        members: Vec::new(),
     }
 }
 
@@ -595,7 +617,8 @@ export function label(value, maxLength = 20) {
             entry.returns,
             Some(NormalizedReturnDoc {
                 type_annotation: "string".to_string(),
-                description: "Formatted label".to_string()
+                description: "Formatted label".to_string(),
+                members: Vec::new()
             })
         );
         assert_eq!(entry.examples, vec!["label(\"hello\", 3)"]);
@@ -703,8 +726,43 @@ export interface Command {
             member.returns,
             Some(NormalizedReturnDoc {
                 type_annotation: "Promise<void>".to_string(),
-                description: "Run result".to_string()
+                description: "Run result".to_string(),
+                members: Vec::new()
             })
+        );
+    }
+
+    #[test]
+    fn function_return_type_literal_members_are_normalized() {
+        let source = r"
+/**
+ * Resolve arguments.
+ * @returns Resolved args.
+ */
+export function resolveArgs<A extends Args>(): {
+    values: ArgValues<A>;
+    positionals: string[];
+    error: AggregateError | undefined;
+} {
+    return {} as any;
+}
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "resolver.ts", SourceType::ts()).unwrap();
+        let entries = normalize_doc_items(items, false);
+        let returns = entries[0].returns.as_ref().unwrap();
+
+        assert_eq!(returns.type_annotation, "object");
+        assert_eq!(returns.description, "Resolved args.");
+        assert_eq!(
+            returns.members.iter().map(|member| member.name.as_str()).collect::<Vec<_>>(),
+            ["values", "positionals", "error"]
+        );
+        assert_eq!(returns.members[0].type_annotation.as_deref(), Some("ArgValues<A>"));
+        assert_eq!(
+            returns.members[2].type_annotation.as_deref(),
+            Some("AggregateError | undefined")
         );
     }
 

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -300,6 +300,7 @@ export interface JsDocParam {
 export interface JsDocReturn {
   type: string
   description: string
+  members?: Array<JsDocMember>
 }
 
 /** Diagnostic for an entry point export during docs extraction. */
@@ -915,6 +916,7 @@ export interface JsSourceDocItem {
   signature?: string
   params: Array<JsSourceDocParam>
   returnType?: string
+  returnMembers?: Array<JsSourceDocItem>
   members?: Array<JsSourceDocItem>
   tags: Array<JsSourceDocTag>
 }

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -158,6 +158,7 @@ pub struct JsSourceDocItem {
     pub signature: Option<String>,
     pub params: Vec<JsSourceDocParam>,
     pub return_type: Option<String>,
+    pub return_members: Option<Vec<JsSourceDocItem>>,
     pub members: Option<Vec<JsSourceDocItem>>,
     pub tags: Vec<JsSourceDocTag>,
 }
@@ -179,6 +180,7 @@ pub struct JsDocParam {
 pub struct JsDocReturn {
     pub r#type: String,
     pub description: String,
+    pub members: Option<Vec<JsDocMember>>,
 }
 
 /// Type parameter documentation (`<T extends C = D>`) used by generated API docs.
@@ -909,6 +911,8 @@ fn map_param_doc(param: ParamDoc) -> JsSourceDocParam {
 }
 
 fn map_doc_item(item: DocItem) -> JsSourceDocItem {
+    let return_members = (!item.return_members.is_empty())
+        .then(|| item.return_members.into_iter().map(map_doc_item).collect());
     let members =
         (!item.children.is_empty()).then(|| item.children.into_iter().map(map_doc_item).collect());
 
@@ -924,6 +928,7 @@ fn map_doc_item(item: DocItem) -> JsSourceDocItem {
         signature: item.signature,
         params: item.params.into_iter().map(map_param_doc).collect(),
         return_type: item.return_type,
+        return_members,
         members,
         tags: item.tags.into_iter().map(map_doc_tag).collect(),
     }
@@ -940,7 +945,12 @@ fn map_normalized_param_doc(param: NormalizedParamDoc) -> JsDocParam {
 }
 
 fn map_normalized_return_doc(return_doc: NormalizedReturnDoc) -> JsDocReturn {
-    JsDocReturn { r#type: return_doc.type_annotation, description: return_doc.description }
+    JsDocReturn {
+        r#type: return_doc.type_annotation,
+        description: return_doc.description,
+        members: (!return_doc.members.is_empty())
+            .then(|| return_doc.members.into_iter().map(map_normalized_member).collect()),
+    }
 }
 
 fn map_normalized_member(member: NormalizedMember) -> JsDocMember {
@@ -1163,7 +1173,16 @@ fn convert_markdown_param(param: JsDocParam) -> ApiParamDoc {
 }
 
 fn convert_markdown_return(return_doc: JsDocReturn) -> ApiReturnDoc {
-    ApiReturnDoc { type_annotation: return_doc.r#type, description: return_doc.description }
+    ApiReturnDoc {
+        type_annotation: return_doc.r#type,
+        description: return_doc.description,
+        members: return_doc
+            .members
+            .unwrap_or_default()
+            .into_iter()
+            .map(convert_markdown_member)
+            .collect(),
+    }
 }
 
 fn convert_markdown_tag(tag: JsDocsMarkdownTag) -> ApiDocTag {
@@ -3467,6 +3486,7 @@ pub fn extract_translation_keys(
 mod tests {
     use ox_content_docs::{
         NormalizedDocEntry, NormalizedDocKind, NormalizedMember, NormalizedMemberKind,
+        NormalizedReturnDoc,
     };
     use serde_json::json;
     use std::collections::BTreeMap;
@@ -3558,6 +3578,54 @@ mod tests {
         assert_eq!(member.r#type.as_deref(), Some("string"));
         assert_eq!(member.optional, Some(true));
         assert_eq!(member.readonly, Some(true));
+    }
+
+    #[test]
+    fn normalized_doc_entry_maps_return_members_to_js_shape() {
+        let entry = NormalizedDocEntry {
+            name: "resolveArgs".to_string(),
+            kind: NormalizedDocKind::Function,
+            description: "Resolve.".to_string(),
+            params: vec![],
+            returns: Some(NormalizedReturnDoc {
+                type_annotation: "object".to_string(),
+                description: "Resolved args.".to_string(),
+                members: vec![NormalizedMember {
+                    name: "values".to_string(),
+                    kind: NormalizedMemberKind::Property,
+                    description: String::new(),
+                    signature: None,
+                    type_annotation: Some("ArgValues<A>".to_string()),
+                    params: vec![],
+                    returns: None,
+                    optional: false,
+                    readonly: false,
+                    r#static: false,
+                    private: false,
+                    tags: BTreeMap::new(),
+                    line: 3,
+                    end_line: 3,
+                }],
+            }),
+            examples: vec![],
+            tags: BTreeMap::new(),
+            private: false,
+            file: "resolver.ts".to_string(),
+            line: 1,
+            end_line: 8,
+            signature: Some("export function resolveArgs(): object".to_string()),
+            has_body: false,
+            members: vec![],
+            type_parameters: vec![],
+        };
+
+        let js_entry = map_normalized_doc_entry(entry);
+        let returns = js_entry.returns.as_ref().unwrap();
+        let member = &returns.members.as_ref().unwrap()[0];
+
+        assert_eq!(returns.r#type, "object");
+        assert_eq!(member.name, "values");
+        assert_eq!(member.r#type.as_deref(), Some("ArgValues<A>"));
     }
 
     #[test]
@@ -3829,6 +3897,7 @@ mod tests {
                     returns: Some(JsDocReturn {
                         r#type: "Command".to_string(),
                         description: "A {@link Command} result.".to_string(),
+                        members: None,
                     }),
                     examples: None,
                     tags: Some(vec![JsDocsMarkdownTag {
@@ -4209,6 +4278,85 @@ mod tests {
         assert!(page.contains("| `PluginExt` *extends* [`PluginExtension`](../type-aliases/PluginExtension.md)\\<`Extension`, [`DefaultGunshiParams`](../type-aliases/DefaultGunshiParams.md)\\> = [`PluginExtension`](../type-aliases/PluginExtension.md)\\<`Extension`, `ResolvedDepExtensions`\\> |  |"));
         assert!(!page.contains("\\<\n"));
         assert!(!page.contains("ResolvedDepExtensions`\n"));
+    }
+
+    #[test]
+    fn generate_docs_markdown_renders_return_members() {
+        let docs = vec![JsDocsMarkdownModule {
+            description: None,
+            file: "default".to_string(),
+            source_path: None,
+            examples: None,
+            tags: None,
+            entries: vec![
+                JsDocsMarkdownEntry {
+                    name: "resolveArgs".to_string(),
+                    kind: "function".to_string(),
+                    description: "Resolve.".to_string(),
+                    params: None,
+                    returns: Some(JsDocReturn {
+                        r#type: "object".to_string(),
+                        description: "Resolved args.".to_string(),
+                        members: Some(vec![JsDocMember {
+                            name: "values".to_string(),
+                            kind: "property".to_string(),
+                            description: String::new(),
+                            signature: None,
+                            r#type: Some("ArgValues<A>".to_string()),
+                            params: None,
+                            returns: None,
+                            optional: Some(false),
+                            readonly: Some(false),
+                            r#static: Some(false),
+                            private: Some(false),
+                            tags: None,
+                            line: 1,
+                            end_line: 1,
+                        }]),
+                    }),
+                    examples: None,
+                    tags: None,
+                    private: false,
+                    file: "/repo/src/resolver.ts".to_string(),
+                    line: 1,
+                    end_line: 1,
+                    signature: Some("export function resolveArgs(): object".to_string()),
+                    has_body: None,
+                    members: None,
+                    type_parameters: None,
+                },
+                JsDocsMarkdownEntry {
+                    name: "ArgValues".to_string(),
+                    kind: "type".to_string(),
+                    description: String::new(),
+                    params: None,
+                    returns: None,
+                    examples: None,
+                    tags: None,
+                    private: false,
+                    file: "/repo/src/types.ts".to_string(),
+                    line: 1,
+                    end_line: 1,
+                    signature: Some("export type ArgValues = unknown".to_string()),
+                    has_body: None,
+                    members: None,
+                    type_parameters: None,
+                },
+            ],
+        }];
+
+        let markdown = generate_docs_markdown(
+            docs,
+            Some(JsDocsMarkdownOptions {
+                path_strategy: Some("typedoc".to_string()),
+                render_style: Some("markdown".to_string()),
+                ..Default::default()
+            }),
+        );
+        let page = markdown.get("default/functions/resolveArgs.md").unwrap();
+
+        assert!(page.contains("## Returns\n\n`object` — Resolved args."));
+        assert!(page.contains("### values\n\n```ts\nvalues: ArgValues<A>;\n```"));
     }
 
     #[test]

--- a/crates/ox_content_profile_cli/src/main.rs
+++ b/crates/ox_content_profile_cli/src/main.rs
@@ -502,6 +502,7 @@ fn to_api_return(return_doc: NormalizedReturnDoc) -> ApiReturnDoc {
     ApiReturnDoc {
         type_annotation: return_doc.type_annotation,
         description: return_doc.description,
+        members: return_doc.members.into_iter().map(to_api_member).collect(),
     }
 }
 


### PR DESCRIPTION
## Summary

Preserve inline object return members through extraction, normalization, data, NAPI, and markdown/HTML rendering so API docs show returned object properties.

## Background

gunshi docs using `@ox-content/napi` lost properties from literal object return types, leaving only a vague object return.

This made outputs like resolveArgs omit important fields.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783178490&installation_id=136613492&pr_number=322&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F322&signature=4caa3244e5a7957d4abaa1249788963edc6758c9a1e513a787f92e83d503f58d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->