### PR TITLE
fix(docs): render TypeScript index signatures

### DIFF
--- a/crates/ox_content_docs/src/data.rs
+++ b/crates/ox_content_docs/src/data.rs
@@ -512,6 +512,70 @@ mod tests {
     }
 
     #[test]
+    fn index_signature_members_serialize_to_json() {
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "/repo/src/args.ts".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![ApiDocEntry {
+                name: "Args".to_string(),
+                kind: "interface".to_string(),
+                description: "Arguments.".to_string(),
+                params: vec![],
+                returns: None,
+                examples: vec![],
+                tags: vec![],
+                private: false,
+                file: "/repo/src/args.ts".to_string(),
+                line: 1,
+                end_line: 5,
+                signature: Some("export interface Args".to_string()),
+                extends: vec![],
+                implements: vec![],
+                has_body: false,
+                members: vec![ApiDocMember {
+                    name: "[option: string]".to_string(),
+                    kind: "indexSignature".to_string(),
+                    description: "Argument schema by option name.".to_string(),
+                    signature: Some("readonly [option: string]: ArgSchema".to_string()),
+                    type_annotation: Some("ArgSchema".to_string()),
+                    params: vec![ApiParamDoc {
+                        name: "option".to_string(),
+                        type_annotation: "string".to_string(),
+                        description: String::new(),
+                        optional: false,
+                        default_value: None,
+                    }],
+                    returns: None,
+                    optional: false,
+                    readonly: true,
+                    r#static: false,
+                    private: false,
+                    tags: vec![],
+                    implementation_of: vec![],
+                    line: 4,
+                    end_line: 4,
+                }],
+                type_parameters: vec![],
+            }],
+        }];
+
+        let json = generate_docs_data_json(&docs, "2026-05-31T00:00:00.000Z").unwrap();
+        let value: Value = serde_json::from_str(&json).unwrap();
+        let member = &value["modules"][0]["entries"][0]["members"][0];
+
+        assert_eq!(member["name"], "[option: string]");
+        assert_eq!(member["kind"], "indexSignature");
+        assert_eq!(member["signature"], "readonly [option: string]: ArgSchema");
+        assert_eq!(member["type"], "ArgSchema");
+        assert_eq!(member["params"][0]["name"], "option");
+        assert_eq!(member["params"][0]["type"], "string");
+        assert_eq!(member["readonly"], true);
+    }
+
+    #[test]
     fn heritage_and_implementation_metadata_serialize_to_json() {
         let docs = vec![ApiDocModule {
             description: String::new(),

--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -8,8 +8,9 @@ use ox_jsdoc::parser::{
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
     BindingPattern, Class, Comment, Declaration, ExportDefaultDeclarationKind, Expression,
-    Function, Statement, TSEnumDeclaration, TSEnumMember, TSInterfaceDeclaration, TSSignature,
-    TSType, TSTypeAliasDeclaration, TSTypeAnnotation, TSTypeName, VariableDeclaration,
+    Function, Statement, TSEnumDeclaration, TSEnumMember, TSIndexSignature, TSIndexSignatureName,
+    TSInterfaceDeclaration, TSSignature, TSType, TSTypeAliasDeclaration, TSTypeAnnotation,
+    TSTypeName, VariableDeclaration,
 };
 use oxc_ast_visit::{walk, Visit};
 use oxc_parser::Parser;
@@ -208,6 +209,9 @@ pub enum DocItemKind {
     /// Enum member.
     #[serde(rename = "enumMember")]
     EnumMember,
+    /// TypeScript index signature.
+    #[serde(rename = "indexSignature")]
+    IndexSignature,
 }
 
 /// Documentation extractor.
@@ -1733,6 +1737,11 @@ impl<'a> DocVisitor<'a> {
                         type_parameters: Vec::new(),
                     });
                 }
+                oxc_ast::ast::ClassElement::TSIndexSignature(index_signature) => {
+                    if let Some(item) = self.create_index_signature_item(index_signature) {
+                        children.push(item);
+                    }
+                }
                 _ => {}
             }
         }
@@ -1875,11 +1884,94 @@ impl<'a> DocVisitor<'a> {
                         type_parameters: Vec::new(),
                     });
                 }
+                TSSignature::TSIndexSignature(index_signature) => {
+                    if let Some(item) = self.create_index_signature_item(index_signature) {
+                        children.push(item);
+                    }
+                }
                 _ => {}
             }
         }
 
         children
+    }
+
+    fn create_index_signature_item(
+        &self,
+        index_signature: &TSIndexSignature<'a>,
+    ) -> Option<DocItem> {
+        let parameter = index_signature.parameters.first()?;
+        let (name, param_name, param_type) = self.format_index_signature_name(parameter);
+        let value_type = self.format_ts_type(&index_signature.type_annotation.type_annotation);
+        let signature = Self::format_index_signature(index_signature, &name, &value_type);
+
+        let (jsdoc, doc, tags) = self
+            .extract_jsdoc(index_signature.span.start)
+            .map_or((None, None, Vec::new()), |(jsdoc, doc, tags)| {
+                (Some(jsdoc), (!doc.is_empty()).then_some(doc), tags)
+            });
+        if self.should_skip_by_visibility(&tags) {
+            return None;
+        }
+        let (line, end_line) =
+            self.span_lines(index_signature.span.start, index_signature.span.end);
+        let params = Vec::from([ParamDoc {
+            name: param_name,
+            type_annotation: Some(param_type),
+            optional: false,
+            default_value: None,
+            description: None,
+        }]);
+
+        Some(DocItem {
+            name,
+            kind: DocItemKind::IndexSignature,
+            doc,
+            source_path: self.file_path.to_string(),
+            line,
+            end_line,
+            column: self.column_number(index_signature.span.start),
+            jsdoc,
+            exported: false,
+            signature: Some(signature),
+            extends: Vec::new(),
+            implements: Vec::new(),
+            has_body: false,
+            optional: false,
+            readonly: index_signature.readonly,
+            r#static: index_signature.r#static,
+            params,
+            return_type: Some(value_type),
+            return_members: Vec::new(),
+            children: Vec::new(),
+            tags,
+            type_parameters: Vec::new(),
+        })
+    }
+
+    fn format_index_signature_name(
+        &self,
+        parameter: &TSIndexSignatureName<'a>,
+    ) -> (String, String, String) {
+        let param_name = parameter.name.to_string();
+        let param_type = self.format_ts_type(&parameter.type_annotation.type_annotation);
+        let name = join5("[", &param_name, ": ", &param_type, "]");
+        (name, param_name, param_type)
+    }
+
+    fn format_index_signature(
+        index_signature: &TSIndexSignature<'a>,
+        name: &str,
+        value_type: &str,
+    ) -> String {
+        let mut signature = StringBuilder::new();
+        if index_signature.readonly {
+            signature.push_str("readonly ");
+        }
+        signature.push_str(name);
+        signature.push_str(": ");
+        signature.push_str(value_type);
+        signature.into_string()
     }
 }
 
@@ -2358,6 +2450,76 @@ export function resolveArgs<A extends Args>(): {
             items[0].return_members[2].signature.as_deref(),
             Some("AggregateError | undefined")
         );
+    }
+
+    #[test]
+    fn index_signatures_are_extracted_from_members_and_return_literals() {
+        let source = r"
+/**
+ * Value type.
+ */
+export interface ArgSchema {}
+
+/**
+ * Arguments.
+ */
+export interface Args {
+    /** Argument schema by option name. */
+    readonly [option: string]: ArgSchema;
+}
+
+/**
+ * Numeric arguments.
+ */
+export type NumericArgs = {
+    [index: number]: ArgSchema;
+};
+
+/**
+ * Argument store.
+ */
+export class Store {
+    [key: string]: ArgSchema;
+}
+
+/**
+ * Makes arguments.
+ */
+export function makeArgs(): {
+    [key: string]: ArgSchema;
+} {
+    return {} as any;
+}
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "args.ts", SourceType::ts()).unwrap();
+        let args = items.iter().find(|item| item.name == "Args").unwrap();
+        let numeric_args = items.iter().find(|item| item.name == "NumericArgs").unwrap();
+        let store = items.iter().find(|item| item.name == "Store").unwrap();
+        let make_args = items.iter().find(|item| item.name == "makeArgs").unwrap();
+
+        let args_member = &args.children[0];
+        assert_eq!(args_member.kind, DocItemKind::IndexSignature);
+        assert_eq!(args_member.name, "[option: string]");
+        assert_eq!(args_member.signature.as_deref(), Some("readonly [option: string]: ArgSchema"));
+        assert_eq!(args_member.return_type.as_deref(), Some("ArgSchema"));
+        assert_eq!(args_member.params[0].name, "option");
+        assert_eq!(args_member.params[0].type_annotation.as_deref(), Some("string"));
+        assert!(args_member.readonly);
+
+        let numeric_member = &numeric_args.children[0];
+        assert_eq!(numeric_member.kind, DocItemKind::IndexSignature);
+        assert_eq!(numeric_member.name, "[index: number]");
+        assert_eq!(numeric_member.signature.as_deref(), Some("[index: number]: ArgSchema"));
+
+        let store_member = &store.children[0];
+        assert_eq!(store_member.kind, DocItemKind::IndexSignature);
+        assert_eq!(store_member.signature.as_deref(), Some("[key: string]: ArgSchema"));
+
+        let return_member = &make_args.return_members[0];
+        assert_eq!(return_member.kind, DocItemKind::IndexSignature);
+        assert_eq!(return_member.signature.as_deref(), Some("[key: string]: ArgSchema"));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -4807,6 +4807,25 @@ mod tests {
         }]
     }
 
+    fn index_signature_docs() -> Vec<ApiDocModule> {
+        let mut schema = test_entry("ArgSchema", "interface", "/repo/src/args.ts", "Value type.");
+        schema.signature = Some("export interface ArgSchema".to_string());
+
+        let mut args = test_entry("Args", "interface", "/repo/src/args.ts", "Arguments.");
+        args.signature = Some("export interface Args".to_string());
+        args.members =
+            vec![index_signature_member("[option: string]", "option", "string", "ArgSchema", true)];
+
+        vec![ApiDocModule {
+            description: String::new(),
+            file: "default".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![schema, args],
+        }]
+    }
+
     fn multiline_plugin_ext_type_parameters() -> Vec<ApiTypeParamDoc> {
         vec![
             ApiTypeParamDoc {
@@ -4843,6 +4862,36 @@ mod tests {
             returns: None,
             optional: false,
             readonly: false,
+            r#static: false,
+            private: false,
+            tags: vec![],
+            implementation_of: vec![],
+            line: 1,
+            end_line: 1,
+        }
+    }
+
+    fn index_signature_member(
+        name: &str,
+        param_name: &str,
+        param_type: &str,
+        value_type: &str,
+        readonly: bool,
+    ) -> ApiDocMember {
+        ApiDocMember {
+            name: name.to_string(),
+            kind: "indexSignature".to_string(),
+            description: "Argument schema by option name.".to_string(),
+            signature: Some(if readonly {
+                format!("readonly {name}: {value_type}")
+            } else {
+                format!("{name}: {value_type}")
+            }),
+            type_annotation: Some(value_type.to_string()),
+            params: vec![param(param_name, param_type)],
+            returns: None,
+            optional: false,
+            readonly,
             r#static: false,
             private: false,
             tags: vec![],
@@ -4924,6 +4973,72 @@ mod tests {
         assert!(page.contains("<h5>values</h5>"));
         assert!(page
             .contains("values: <a href=\"../type-aliases/ArgValues.md\">ArgValues</a>&lt;A&gt;;"));
+    }
+
+    #[test]
+    fn typedoc_markdown_renders_index_signature_members() {
+        let out = generate_markdown(&index_signature_docs(), &markdown_typedoc_options());
+        let page = out.get("default/interfaces/Args.md").unwrap();
+
+        assert!(page.contains("## Indexable\n\n"));
+        assert!(page.contains("```ts\nreadonly [option: string]: ArgSchema\n```"));
+        assert!(page.contains("Argument schema by option name."));
+    }
+
+    #[test]
+    fn typedoc_html_renders_index_signature_members() {
+        let out = generate_markdown(&index_signature_docs(), &html_typedoc_options());
+        let page = out.get("default/interfaces/Args.md").unwrap();
+
+        assert!(page.contains("ox-api-entry__member-group--indexable"));
+        assert!(page.contains("<h5>Indexable</h5>"));
+        assert!(
+            page.contains("readonly [option: string]: <a href=\"./ArgSchema.md\">ArgSchema</a>")
+        );
+        assert!(page.contains("Argument schema by option name."));
+    }
+
+    #[test]
+    fn typedoc_markdown_renders_return_index_signature_members() {
+        let mut entry = test_entry("makeArgs", "function", "/repo/src/resolver.ts", "Make.");
+        entry.returns = Some(ApiReturnDoc {
+            type_annotation: "object".to_string(),
+            description: "Resolved args.".to_string(),
+            members: vec![index_signature_member(
+                "[option: string]",
+                "option",
+                "string",
+                "ArgSchema",
+                false,
+            )],
+        });
+        let out = generate_markdown(&type_link_module(entry), &markdown_typedoc_options());
+        let page = out.get("combinators/functions/makeArgs.md").unwrap();
+
+        assert!(page.contains("## Returns\n\n`object` — Resolved args.\n\n"));
+        assert!(page.contains("### Indexable\n\n```ts\n[option: string]: ArgSchema\n```"));
+    }
+
+    #[test]
+    fn typedoc_html_renders_return_index_signature_members() {
+        let mut entry = test_entry("makeArgs", "function", "/repo/src/resolver.ts", "Make.");
+        entry.returns = Some(ApiReturnDoc {
+            type_annotation: "object".to_string(),
+            description: "Resolved args.".to_string(),
+            members: vec![index_signature_member(
+                "[option: string]",
+                "option",
+                "string",
+                "ArgSchema",
+                false,
+            )],
+        });
+        let out = generate_markdown(&type_link_module(entry), &html_typedoc_options());
+        let page = out.get("combinators/functions/makeArgs.md").unwrap();
+
+        assert!(page.contains("ox-api-entry__return-member--indexable"));
+        assert!(page.contains("<h5>Indexable</h5>"));
+        assert!(page.contains("[option: string]: ArgSchema"));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/markdown/markdown_html.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_html.rs
@@ -1351,6 +1351,8 @@ fn render_members_html(
             .filter(|member| member.r#static == is_static && member.kind == "property")
             .collect::<Vec<_>>()
     };
+    let index_signatures =
+        || members.iter().filter(|member| member.kind == "indexSignature").collect::<Vec<_>>();
 
     let mut groups = Vec::new();
     match entry.kind.as_str() {
@@ -1378,6 +1380,7 @@ fn render_members_html(
                 options,
                 context,
             ));
+            groups.push(render_index_signature_group_html(&index_signatures(), context));
             groups.push(render_member_group_html(
                 entry,
                 "Static Properties",
@@ -1394,6 +1397,7 @@ fn render_members_html(
             ));
         }
         "interface" => {
+            groups.push(render_index_signature_group_html(&index_signatures(), context));
             groups.push(render_member_group_html(
                 entry,
                 "Properties",
@@ -1412,6 +1416,7 @@ fn render_members_html(
         "type" => {
             let enum_members =
                 members.iter().filter(|member| member.kind == "enumMember").collect::<Vec<_>>();
+            groups.push(render_index_signature_group_html(&index_signatures(), context));
             groups.push(render_member_group_html(
                 entry,
                 "Properties",
@@ -1467,6 +1472,72 @@ fn render_members_html(
         "
 </div>",
     )
+}
+
+fn render_index_signature_group_html(
+    members: &[&ApiDocMember],
+    context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    if members.is_empty() {
+        return String::new();
+    }
+
+    let mut details = StringBuilder::new();
+    for member in members {
+        details.push_str("<section class=\"ox-api-entry__member-detail ox-api-entry__member-detail--indexable\">\n");
+        details.push_str(&render_index_signature_code_block_html(member, context));
+        details.push_str(&render_member_detail_description_html(member, context));
+        details.push_str("</section>");
+    }
+
+    let mut out = StringBuilder::new();
+    out.push_str(
+        "<div class=\"ox-api-entry__member-group ox-api-entry__member-group--indexable\">\n<h5>Indexable</h5>\n<div class=\"ox-api-entry__member-details\">\n",
+    );
+    out.push_str(&details.into_string());
+    out.push_str("\n</div>\n</div>");
+    out.into_string()
+}
+
+fn render_index_signature_code_block_html(
+    member: &ApiDocMember,
+    context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    let mut out = StringBuilder::new();
+    out.push_str("<pre><code class=\"language-ts\">");
+    push_index_signature_code_html(&mut out, member, context);
+    out.push_str("</code></pre>");
+    out.into_string()
+}
+
+fn push_index_signature_code_html(
+    out: &mut StringBuilder,
+    member: &ApiDocMember,
+    context: Option<&MarkdownLinkContext<'_>>,
+) {
+    let Some(param) = member.params.first() else {
+        if let Some(signature) =
+            member.signature.as_deref().filter(|signature| !signature.is_empty())
+        {
+            out.push_str(&escape_html(signature.trim().trim_end_matches(';').trim_end()));
+        }
+        return;
+    };
+
+    if member.readonly {
+        out.push_str("readonly ");
+    }
+    out.push_char('[');
+    out.push_str(&escape_html(&param.name));
+    out.push_str(": ");
+    out.push_str(&render_type_inner_html(&param.type_annotation, context, &HashSet::new()));
+    out.push_str("]: ");
+    let member_type = member
+        .type_annotation
+        .as_deref()
+        .or_else(|| member.returns.as_ref().map(|returns| returns.type_annotation.as_str()))
+        .unwrap_or("unknown");
+    out.push_str(&render_type_inner_html(member_type, context, &HashSet::new()));
 }
 
 fn render_entry_body_html(
@@ -1636,6 +1707,12 @@ fn render_return_members_html(
     let mut rendered = StringBuilder::new();
     rendered.push_str("<div class=\"ox-api-entry__return-members\">");
     for member in members {
+        if member.kind == "indexSignature" {
+            rendered.push_str("\n<div class=\"ox-api-entry__return-member ox-api-entry__return-member--indexable\">\n<h5>Indexable</h5>\n");
+            rendered.push_str(&render_index_signature_code_block_html(member, link_context));
+            rendered.push_str("\n</div>");
+            continue;
+        }
         rendered.push_str("\n<div class=\"ox-api-entry__return-member\">\n<h5>");
         rendered.push_str(&escape_html(&member.name));
         rendered.push_str(

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -17,7 +17,7 @@ use super::{
 use crate::model::{
     ApiDocEntry, ApiDocMember, ApiDocTag, ApiParamDoc, ApiReturnDoc, ApiTypeParamDoc,
 };
-use crate::string_builder::StringBuilder;
+use crate::string_builder::{join2, StringBuilder};
 
 /// JSDoc lifecycle tags rendered as GitHub alerts rather than generic `## Tags`
 /// entries: `@experimental` → `> [!WARNING]`, `@deprecated` → `> [!CAUTION]`.
@@ -428,7 +428,18 @@ fn push_return_members(
         return;
     }
 
+    let mut rendered_indexable_heading = false;
     for member in members {
+        if member.kind == "indexSignature" {
+            if !rendered_indexable_heading {
+                out.push_str(heading);
+                out.push_str("# Indexable\n\n");
+                rendered_indexable_heading = true;
+            }
+            let detail_heading = join2(heading, "##");
+            push_index_signature_detail_pure(out, member, context, &detail_heading);
+            continue;
+        }
         out.push_str(heading);
         out.push('#');
         out.push(' ');
@@ -558,6 +569,7 @@ fn render_members_pure(
             let mut constructors = Vec::new();
             let mut static_methods = Vec::new();
             let mut methods = Vec::new();
+            let mut index_signatures = Vec::new();
             let mut static_properties = Vec::new();
             let mut properties = Vec::new();
 
@@ -568,6 +580,7 @@ fn render_members_pure(
                         static_methods.push(member);
                     }
                     "method" | "getter" | "setter" => methods.push(member),
+                    "indexSignature" => index_signatures.push(member),
                     "property" if member.r#static => static_properties.push(member),
                     "property" => properties.push(member),
                     _ => {}
@@ -588,6 +601,12 @@ fn render_members_pure(
                 &group_context,
             );
             render_member_group_pure(&mut out, &heading, "Methods", &methods, &group_context);
+            render_index_signature_group_pure(
+                &mut out,
+                &heading,
+                &index_signatures,
+                &group_context,
+            );
             render_member_group_pure(
                 &mut out,
                 &heading,
@@ -600,30 +619,46 @@ fn render_members_pure(
         "interface" => {
             let mut properties = Vec::new();
             let mut methods = Vec::new();
+            let mut index_signatures = Vec::new();
 
             for member in &entry.members {
                 match member.kind.as_str() {
+                    "indexSignature" => index_signatures.push(member),
                     "method" | "getter" | "setter" if !member.r#static => methods.push(member),
                     "property" if !member.r#static => properties.push(member),
                     _ => {}
                 }
             }
+            render_index_signature_group_pure(
+                &mut out,
+                &heading,
+                &index_signatures,
+                &group_context,
+            );
             render_member_group_pure(&mut out, &heading, "Properties", &properties, &group_context);
             render_member_group_pure(&mut out, &heading, "Methods", &methods, &group_context);
         }
         "type" => {
             let mut properties = Vec::new();
             let mut methods = Vec::new();
+            let mut index_signatures = Vec::new();
             let mut enum_members = Vec::new();
 
             for member in &entry.members {
                 match member.kind.as_str() {
+                    "indexSignature" => index_signatures.push(member),
                     "method" | "getter" | "setter" if !member.r#static => methods.push(member),
                     "property" if !member.r#static => properties.push(member),
                     "enumMember" => enum_members.push(member),
                     _ => {}
                 }
             }
+            render_index_signature_group_pure(
+                &mut out,
+                &heading,
+                &index_signatures,
+                &group_context,
+            );
             render_member_group_pure(&mut out, &heading, "Properties", &properties, &group_context);
             render_member_group_pure(&mut out, &heading, "Methods", &methods, &group_context);
             render_member_group_pure(
@@ -656,6 +691,62 @@ fn render_members_pure(
         }
     }
     out
+}
+
+fn push_index_signature_detail_pure(
+    out: &mut String,
+    member: &ApiDocMember,
+    context: Option<&MarkdownLinkContext<'_>>,
+    detail_heading: &str,
+) {
+    out.push_str("```ts\n");
+    push_index_signature_code_pure(out, member);
+    out.push_str("\n```\n\n");
+
+    push_lifecycle_alerts(out, &member.tags, context);
+    let description = process_doc_text(&member.description, context);
+    let description = description.trim();
+    if !description.is_empty() {
+        out.push_str(description);
+        out.push_str("\n\n");
+    }
+    out.push_str(&render_since_section(&member.tags, context, detail_heading));
+    push_generic_tags(out, &member.tags, context, detail_heading);
+}
+
+fn render_index_signature_group_pure(
+    out: &mut String,
+    heading: &str,
+    members: &[&ApiDocMember],
+    context: &MemberGroupRenderContext<'_, '_>,
+) {
+    if members.is_empty() {
+        return;
+    }
+    let detail_heading = "#".repeat(context.parameter_section_level);
+    out.push_str(heading);
+    out.push_str(" Indexable\n\n");
+    for member in members {
+        push_index_signature_detail_pure(out, member, context.link_context, &detail_heading);
+    }
+}
+
+fn push_index_signature_code_pure(out: &mut String, member: &ApiDocMember) {
+    if let Some(signature) = member.signature.as_deref().filter(|signature| !signature.is_empty()) {
+        out.push_str(signature.trim().trim_end_matches(';').trim_end());
+        return;
+    }
+    if member.readonly {
+        out.push_str("readonly ");
+    }
+    out.push_str(&member.name);
+    out.push_str(": ");
+    let member_type = member
+        .type_annotation
+        .as_deref()
+        .or_else(|| member.returns.as_ref().map(|returns| returns.type_annotation.as_str()))
+        .unwrap_or("unknown");
+    out.push_str(member_type);
 }
 
 struct MemberGroupRenderContext<'a, 'ctx> {

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -67,7 +67,8 @@ impl NormalizedDocKind {
             | DocItemKind::Constructor
             | DocItemKind::Getter
             | DocItemKind::Setter
-            | DocItemKind::EnumMember => None,
+            | DocItemKind::EnumMember
+            | DocItemKind::IndexSignature => None,
         }
     }
 
@@ -103,6 +104,9 @@ pub enum NormalizedMemberKind {
     /// Enum member.
     #[serde(rename = "enumMember")]
     EnumMember,
+    /// TypeScript index signature.
+    #[serde(rename = "indexSignature")]
+    IndexSignature,
 }
 
 impl NormalizedMemberKind {
@@ -116,6 +120,7 @@ impl NormalizedMemberKind {
             DocItemKind::Getter => Some(Self::Getter),
             DocItemKind::Setter => Some(Self::Setter),
             DocItemKind::EnumMember => Some(Self::EnumMember),
+            DocItemKind::IndexSignature => Some(Self::IndexSignature),
             DocItemKind::Module
             | DocItemKind::Function
             | DocItemKind::Class
@@ -136,6 +141,7 @@ impl NormalizedMemberKind {
             Self::Getter => "getter",
             Self::Setter => "setter",
             Self::EnumMember => "enumMember",
+            Self::IndexSignature => "indexSignature",
         }
     }
 }
@@ -319,10 +325,14 @@ fn normalize_member(item: DocItem) -> Option<NormalizedMember> {
     // Member-level type parameters are out of scope; keep generic-tag behavior.
     let mut metadata = normalize_doc_metadata(&item.tags, false);
     merge_extracted_params(&mut metadata.params, item.params);
-    merge_extracted_return(&mut metadata.returns, item.return_type, item.return_members);
+    let mut return_type = item.return_type;
+    if kind != NormalizedMemberKind::IndexSignature {
+        merge_extracted_return(&mut metadata.returns, return_type.take(), item.return_members);
+    }
 
     let (signature, type_annotation) = match kind {
         NormalizedMemberKind::Property | NormalizedMemberKind::EnumMember => (None, item.signature),
+        NormalizedMemberKind::IndexSignature => (item.signature, return_type),
         NormalizedMemberKind::Method
         | NormalizedMemberKind::Constructor
         | NormalizedMemberKind::Getter
@@ -802,6 +812,39 @@ export function resolveArgs<A extends Args>(): {
             returns.members[2].type_annotation.as_deref(),
             Some("AggregateError | undefined")
         );
+    }
+
+    #[test]
+    fn index_signature_members_are_normalized_with_parameter_and_value_types() {
+        let source = r"
+/**
+ * Value type.
+ */
+export interface ArgSchema {}
+
+/**
+ * Arguments.
+ */
+export interface Args {
+    /** Argument schema by option name. */
+    readonly [option: string]: ArgSchema;
+}
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "args.ts", SourceType::ts()).unwrap();
+        let entries = normalize_doc_items(items, false);
+        let args = entries.iter().find(|entry| entry.name == "Args").unwrap();
+        let member = &args.members[0];
+
+        assert_eq!(member.name, "[option: string]");
+        assert_eq!(member.kind, NormalizedMemberKind::IndexSignature);
+        assert_eq!(member.signature.as_deref(), Some("readonly [option: string]: ArgSchema"));
+        assert_eq!(member.type_annotation.as_deref(), Some("ArgSchema"));
+        assert_eq!(member.params[0].name, "option");
+        assert_eq!(member.params[0].type_annotation, "string");
+        assert!(member.readonly);
+        assert!(member.returns.is_none());
     }
 
     #[test]

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -899,6 +899,7 @@ fn doc_item_kind_to_string(kind: DocItemKind) -> String {
         DocItemKind::Getter => "getter",
         DocItemKind::Setter => "setter",
         DocItemKind::EnumMember => "enumMember",
+        DocItemKind::IndexSignature => "indexSignature",
     }
     .to_string()
 }
@@ -3598,6 +3599,61 @@ mod tests {
     }
 
     #[test]
+    fn normalized_doc_entry_maps_index_signature_members_to_js_shape() {
+        let entry = NormalizedDocEntry {
+            name: "Args".to_string(),
+            kind: NormalizedDocKind::Interface,
+            description: "Arguments.".to_string(),
+            params: vec![],
+            returns: None,
+            examples: vec![],
+            tags: BTreeMap::new(),
+            private: false,
+            file: "args.ts".to_string(),
+            line: 1,
+            end_line: 5,
+            signature: Some("export interface Args".to_string()),
+            extends: vec![],
+            implements: vec![],
+            has_body: false,
+            members: vec![NormalizedMember {
+                name: "[option: string]".to_string(),
+                kind: NormalizedMemberKind::IndexSignature,
+                description: "Argument schema by option name.".to_string(),
+                signature: Some("readonly [option: string]: ArgSchema".to_string()),
+                type_annotation: Some("ArgSchema".to_string()),
+                params: vec![ox_content_docs::NormalizedParamDoc {
+                    name: "option".to_string(),
+                    type_annotation: "string".to_string(),
+                    description: String::new(),
+                    optional: false,
+                    default_value: None,
+                }],
+                returns: None,
+                optional: false,
+                readonly: true,
+                r#static: false,
+                private: false,
+                tags: BTreeMap::new(),
+                line: 4,
+                end_line: 4,
+            }],
+            type_parameters: vec![],
+        };
+
+        let js_entry = map_normalized_doc_entry(entry);
+        let member = &js_entry.members.as_ref().unwrap()[0];
+
+        assert_eq!(member.name, "[option: string]");
+        assert_eq!(member.kind, "indexSignature");
+        assert_eq!(member.signature.as_deref(), Some("readonly [option: string]: ArgSchema"));
+        assert_eq!(member.r#type.as_deref(), Some("ArgSchema"));
+        assert_eq!(member.params.as_ref().unwrap()[0].name, "option");
+        assert_eq!(member.params.as_ref().unwrap()[0].r#type, "string");
+        assert_eq!(member.readonly, Some(true));
+    }
+
+    #[test]
     fn normalized_doc_entry_maps_heritage_to_js_shape() {
         let entry = NormalizedDocEntry {
             name: "DefaultTranslation".to_string(),
@@ -4487,6 +4543,93 @@ mod tests {
 
         assert!(page.contains("## Returns\n\n`object` — Resolved args."));
         assert!(page.contains("### values\n\n```ts\nvalues: ArgValues<A>;\n```"));
+    }
+
+    #[test]
+    fn generate_docs_markdown_renders_index_signature_members() {
+        let docs = vec![JsDocsMarkdownModule {
+            description: None,
+            file: "default".to_string(),
+            source_path: None,
+            examples: None,
+            tags: None,
+            entries: vec![
+                JsDocsMarkdownEntry {
+                    name: "ArgSchema".to_string(),
+                    kind: "interface".to_string(),
+                    description: "Value type.".to_string(),
+                    params: None,
+                    returns: None,
+                    examples: None,
+                    tags: None,
+                    private: false,
+                    file: "/repo/src/args.ts".to_string(),
+                    line: 1,
+                    end_line: 1,
+                    signature: Some("export interface ArgSchema".to_string()),
+                    extends: None,
+                    implements: None,
+                    has_body: None,
+                    members: None,
+                    type_parameters: None,
+                },
+                JsDocsMarkdownEntry {
+                    name: "Args".to_string(),
+                    kind: "interface".to_string(),
+                    description: "Arguments.".to_string(),
+                    params: None,
+                    returns: None,
+                    examples: None,
+                    tags: None,
+                    private: false,
+                    file: "/repo/src/args.ts".to_string(),
+                    line: 1,
+                    end_line: 5,
+                    signature: Some("export interface Args".to_string()),
+                    extends: None,
+                    implements: None,
+                    has_body: None,
+                    members: Some(vec![JsDocMember {
+                        name: "[option: string]".to_string(),
+                        kind: "indexSignature".to_string(),
+                        description: "Argument schema by option name.".to_string(),
+                        signature: Some("readonly [option: string]: ArgSchema".to_string()),
+                        r#type: Some("ArgSchema".to_string()),
+                        params: Some(vec![JsDocParam {
+                            name: "option".to_string(),
+                            r#type: "string".to_string(),
+                            description: String::new(),
+                            optional: None,
+                            r#default: None,
+                        }]),
+                        returns: None,
+                        optional: Some(false),
+                        readonly: Some(true),
+                        r#static: Some(false),
+                        private: Some(false),
+                        tags: None,
+                        implementation_of: None,
+                        line: 4,
+                        end_line: 4,
+                    }]),
+                    type_parameters: None,
+                },
+            ],
+        }];
+
+        let markdown = generate_docs_markdown(
+            docs,
+            Some(JsDocsMarkdownOptions {
+                path_strategy: Some("typedoc".to_string()),
+                render_style: Some("markdown".to_string()),
+                ..Default::default()
+            }),
+        );
+        let page = markdown.get("default/interfaces/Args.md").unwrap();
+
+        assert!(page.contains("## Indexable\n\n"));
+        assert!(page.contains("```ts\nreadonly [option: string]: ArgSchema\n```"));
+        assert!(page.contains("Argument schema by option name."));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds support for TypeScript index signatures in API docs.

Extracts them from interfaces, type literals, classes, and return type literals, then renders Indexable sections in Markdown/HTML while preserving JSON/NAPI output.

## Background

gunshi `Args` is defined mainly by `[option: string]: ArgSchema`, but ox-content dropped `TSIndexSignature` nodes, leaving the generated `Args` page without its core shape.

This matches TypeDoc's Indexable output.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783215320&installation_id=136613492&pr_number=324&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F324&signature=a10ac40a16c181fa871c04594902d7d01af682337eb4bd884b3642d8a8b9fde2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->