### PR TITLE
fix(docs): preserve function-valued property types

### DIFF
--- a/crates/ox_content_docs/src/data.rs
+++ b/crates/ox_content_docs/src/data.rs
@@ -576,6 +576,75 @@ mod tests {
     }
 
     #[test]
+    fn function_valued_property_metadata_serializes_to_json() {
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "/repo/src/schema.ts".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![ApiDocEntry {
+                name: "ArgSchema".to_string(),
+                kind: "interface".to_string(),
+                description: "Argument schema.".to_string(),
+                params: vec![],
+                returns: None,
+                examples: vec![],
+                tags: vec![],
+                private: false,
+                file: "/repo/src/schema.ts".to_string(),
+                line: 1,
+                end_line: 10,
+                signature: Some("export interface ArgSchema".to_string()),
+                extends: vec![],
+                implements: vec![],
+                has_body: false,
+                members: vec![ApiDocMember {
+                    name: "parse".to_string(),
+                    kind: "property".to_string(),
+                    description: "Parses a raw value.".to_string(),
+                    signature: None,
+                    type_annotation: Some("(value: string) => any".to_string()),
+                    params: vec![ApiParamDoc {
+                        name: "value".to_string(),
+                        type_annotation: "string".to_string(),
+                        description: "Raw string value from command line.".to_string(),
+                        optional: false,
+                        default_value: None,
+                    }],
+                    returns: Some(ApiReturnDoc {
+                        type_annotation: "any".to_string(),
+                        description: "Parsed value.".to_string(),
+                        members: Vec::new(),
+                    }),
+                    optional: true,
+                    readonly: false,
+                    r#static: false,
+                    private: false,
+                    tags: vec![],
+                    implementation_of: vec![],
+                    line: 5,
+                    end_line: 10,
+                }],
+                type_parameters: vec![],
+            }],
+        }];
+
+        let json = generate_docs_data_json(&docs, "2026-05-31T00:00:00.000Z").unwrap();
+        let value: Value = serde_json::from_str(&json).unwrap();
+        let member = &value["modules"][0]["entries"][0]["members"][0];
+
+        assert_eq!(member["name"], "parse");
+        assert_eq!(member["kind"], "property");
+        assert_eq!(member["type"], "(value: string) => any");
+        assert_eq!(member["params"][0]["name"], "value");
+        assert_eq!(member["params"][0]["type"], "string");
+        assert_eq!(member["returns"]["type"], "any");
+        assert_eq!(member["returns"]["description"], "Parsed value.");
+        assert_eq!(member["optional"], true);
+    }
+
+    #[test]
     fn heritage_and_implementation_metadata_serialize_to_json() {
         let docs = vec![ApiDocModule {
             description: String::new(),

--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -1352,33 +1352,6 @@ impl<'a> DocVisitor<'a> {
         }
     }
 
-    /// Format a binding pattern.
-    fn format_binding_pattern(
-        &self,
-        pattern: &BindingPattern<'a>,
-        optional: bool,
-        type_annotation: Option<&TSTypeAnnotation<'a>>,
-    ) -> String {
-        match pattern {
-            BindingPattern::BindingIdentifier(id) => {
-                let mut s = id.name.to_string();
-                if optional {
-                    s.push('?');
-                }
-                if let Some(type_ann) = type_annotation {
-                    s.push_str(": ");
-                    s.push_str(&self.format_ts_type(&type_ann.type_annotation));
-                }
-                s
-            }
-            BindingPattern::ObjectPattern(_) => "{...}".to_string(),
-            BindingPattern::ArrayPattern(_) => "[...]".to_string(),
-            BindingPattern::AssignmentPattern(assign) => {
-                self.format_binding_pattern(&assign.left, optional, type_annotation)
-            }
-        }
-    }
-
     /// Format a TypeScript type.
     fn format_ts_type(&self, ts_type: &TSType) -> String {
         match ts_type {
@@ -1393,10 +1366,19 @@ impl<'a> DocVisitor<'a> {
             TSType::TSBigIntKeyword(_) => "bigint".to_string(),
             TSType::TSSymbolKeyword(_) => "symbol".to_string(),
             TSType::TSObjectKeyword(_) => "object".to_string(),
+            TSType::TSUnknownKeyword(_) => "unknown".to_string(),
             TSType::TSTypeReference(ref_type) => {
                 self.slice(ref_type.span().start, ref_type.span().end)
             }
             TSType::TSArrayType(arr) => join2(&self.format_ts_type(&arr.element_type), "[]"),
+            TSType::TSTypeOperatorType(op) => {
+                let inner = self.format_ts_type(&op.type_annotation);
+                match op.operator {
+                    oxc_ast::ast::TSTypeOperatorOperator::Keyof => join2("keyof ", &inner),
+                    oxc_ast::ast::TSTypeOperatorOperator::Unique => join2("unique ", &inner),
+                    oxc_ast::ast::TSTypeOperatorOperator::Readonly => join2("readonly ", &inner),
+                }
+            }
             TSType::TSUnionType(union) => {
                 let types: Vec<String> =
                     union.types.iter().map(|t| self.format_ts_type(t)).collect();
@@ -1408,20 +1390,8 @@ impl<'a> DocVisitor<'a> {
                 types.join(" & ")
             }
             TSType::TSFunctionType(func) => {
-                let params: Vec<String> = func
-                    .params
-                    .items
-                    .iter()
-                    .map(|p| {
-                        self.format_binding_pattern(
-                            &p.pattern,
-                            p.optional,
-                            p.type_annotation.as_deref(),
-                        )
-                    })
-                    .collect();
+                let params = self.format_formal_parameters(&func.params);
                 let ret = self.format_ts_type(&func.return_type.type_annotation);
-                let params = params.join(", ");
                 let mut out = StringBuilder::with_capacity(params.len() + ret.len() + 6);
                 out.push_char('(');
                 out.push_str(&params);
@@ -1430,6 +1400,9 @@ impl<'a> DocVisitor<'a> {
                 out.into_string()
             }
             TSType::TSTypeLiteral(_) => "{ ... }".to_string(),
+            TSType::TSParenthesizedType(paren) => {
+                join3("(", &self.format_ts_type(&paren.type_annotation), ")")
+            }
             TSType::TSTupleType(tuple) => {
                 let types: Vec<String> = tuple
                     .element_types
@@ -1447,8 +1420,17 @@ impl<'a> DocVisitor<'a> {
                 oxc_ast::ast::TSLiteral::BooleanLiteral(b) => b.value.to_string(),
                 _ => "literal".to_string(),
             },
-            _ => "unknown".to_string(),
+            _ => self.format_type_from_span(ts_type),
         }
+    }
+
+    fn format_type_from_span(&self, ts_type: &TSType) -> String {
+        self.slice(ts_type.span().start, ts_type.span().end)
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .trim()
+            .to_string()
     }
 
     /// Format a TypeScript type name.
@@ -1535,7 +1517,7 @@ impl<'a> DocVisitor<'a> {
 
     fn extract_return_type_from_annotation(
         &self,
-        return_type: Option<&oxc_allocator::Box<'a, oxc_ast::ast::TSTypeAnnotation<'a>>>,
+        return_type: Option<&oxc_ast::ast::TSTypeAnnotation<'a>>,
         tags: &[DocTag],
     ) -> Option<String> {
         return_type.map(|r| self.format_ts_type(&r.type_annotation)).or_else(|| {
@@ -1548,7 +1530,7 @@ impl<'a> DocVisitor<'a> {
 
     fn extract_return_from_annotation(
         &self,
-        return_type: Option<&oxc_allocator::Box<'a, oxc_ast::ast::TSTypeAnnotation<'a>>>,
+        return_type: Option<&oxc_ast::ast::TSTypeAnnotation<'a>>,
         tags: &[DocTag],
     ) -> (Option<String>, Vec<DocItem>) {
         if let Some(return_type) = return_type {
@@ -1568,7 +1550,29 @@ impl<'a> DocVisitor<'a> {
     }
 
     fn extract_return(&self, func: &Function, tags: &[DocTag]) -> (Option<String>, Vec<DocItem>) {
-        self.extract_return_from_annotation(func.return_type.as_ref(), tags)
+        self.extract_return_from_annotation(func.return_type.as_ref().map(AsRef::as_ref), tags)
+    }
+
+    fn extract_function_type_metadata(
+        &self,
+        ts_type: &TSType,
+        tags: &[DocTag],
+    ) -> Option<(Vec<ParamDoc>, Option<String>, Vec<DocItem>)> {
+        match ts_type {
+            TSType::TSFunctionType(func) => {
+                let (return_type, return_members) =
+                    self.extract_return_from_annotation(Some(&func.return_type), tags);
+                Some((
+                    self.extract_params_from_formals(&func.params, tags),
+                    return_type,
+                    return_members,
+                ))
+            }
+            TSType::TSParenthesizedType(paren) => {
+                self.extract_function_type_metadata(&paren.type_annotation, tags)
+            }
+            _ => None,
+        }
     }
 
     /// Create a DocItem from a function.
@@ -1707,10 +1711,24 @@ impl<'a> DocVisitor<'a> {
                     let (prop_line, prop_end_line) =
                         self.span_lines(prop.span.start, prop.span.end);
 
-                    let type_annotation = prop
-                        .type_annotation
-                        .as_ref()
-                        .map(|t| self.format_ts_type(&t.type_annotation));
+                    let mut params = Vec::new();
+                    let mut return_type = None;
+                    let mut return_members = Vec::new();
+                    let type_annotation = prop.type_annotation.as_ref().map(|t| {
+                        let ts_type = &t.type_annotation;
+                        if let Some((
+                            extracted_params,
+                            extracted_return_type,
+                            extracted_return_members,
+                        )) = self.extract_function_type_metadata(ts_type, &prop_tags)
+                        {
+                            params = extracted_params;
+                            return_type = extracted_return_type;
+                            return_members = extracted_return_members;
+                        }
+
+                        self.format_ts_type(ts_type)
+                    });
 
                     children.push(DocItem {
                         name: prop_name,
@@ -1729,9 +1747,9 @@ impl<'a> DocVisitor<'a> {
                         optional: prop.optional,
                         readonly: prop.readonly,
                         r#static: prop.r#static,
-                        params: Vec::new(),
-                        return_type: None,
-                        return_members: Vec::new(),
+                        params,
+                        return_type,
+                        return_members,
                         children: Vec::new(),
                         tags: prop_tags,
                         type_parameters: Vec::new(),
@@ -1798,10 +1816,24 @@ impl<'a> DocVisitor<'a> {
                     let (prop_line, prop_end_line) =
                         self.span_lines(prop.span.start, prop.span.end);
 
-                    let type_annotation = prop
-                        .type_annotation
-                        .as_ref()
-                        .map(|t| self.format_ts_type(&t.type_annotation));
+                    let mut params = Vec::new();
+                    let mut return_type = None;
+                    let mut return_members = Vec::new();
+                    let type_annotation = prop.type_annotation.as_ref().map(|t| {
+                        let ts_type = &t.type_annotation;
+                        if let Some((
+                            extracted_params,
+                            extracted_return_type,
+                            extracted_return_members,
+                        )) = self.extract_function_type_metadata(ts_type, &prop_tags)
+                        {
+                            params = extracted_params;
+                            return_type = extracted_return_type;
+                            return_members = extracted_return_members;
+                        }
+
+                        self.format_ts_type(ts_type)
+                    });
 
                     children.push(DocItem {
                         name: prop_name,
@@ -1820,9 +1852,9 @@ impl<'a> DocVisitor<'a> {
                         optional: prop.optional,
                         readonly: prop.readonly,
                         r#static: false,
-                        params: Vec::new(),
-                        return_type: None,
-                        return_members: Vec::new(),
+                        params,
+                        return_type,
+                        return_members,
                         children: Vec::new(),
                         tags: prop_tags,
                         type_parameters: Vec::new(),
@@ -1844,8 +1876,10 @@ impl<'a> DocVisitor<'a> {
                     }
                     let (method_line, method_end_line) =
                         self.span_lines(method.span.start, method.span.end);
-                    let (return_type, return_members) = self
-                        .extract_return_from_annotation(method.return_type.as_ref(), &method_tags);
+                    let (return_type, return_members) = self.extract_return_from_annotation(
+                        method.return_type.as_deref(),
+                        &method_tags,
+                    );
 
                     let kind = match method.kind {
                         oxc_ast::ast::TSMethodSignatureKind::Method => DocItemKind::Method,
@@ -2083,7 +2117,7 @@ impl<'a> DocVisitor<'a> {
             let item = match initializer {
                 Expression::ArrowFunctionExpression(arrow) => {
                     let (return_type, return_members) =
-                        self.extract_return_from_annotation(arrow.return_type.as_ref(), &tags);
+                        self.extract_return_from_annotation(arrow.return_type.as_deref(), &tags);
                     DocItem {
                         name: name.clone(),
                         kind: DocItemKind::Function,
@@ -2195,12 +2229,25 @@ impl<'a> DocVisitor<'a> {
             return;
         };
         let (line, end_line) = self.span_lines(attached_to, type_alias.span.end);
-        let children = match &type_alias.type_annotation {
+        let mut children = Vec::new();
+        let mut params = Vec::new();
+        let mut return_type = None;
+        let mut return_members = Vec::new();
+
+        match &type_alias.type_annotation {
             TSType::TSTypeLiteral(type_literal) => {
-                self.extract_ts_signature_members(&type_literal.members)
+                children = self.extract_ts_signature_members(&type_literal.members);
             }
-            _ => Vec::new(),
-        };
+            ts_type => {
+                if let Some((extracted_params, extracted_return_type, extracted_return_members)) =
+                    self.extract_function_type_metadata(ts_type, &tags)
+                {
+                    params = extracted_params;
+                    return_type = extracted_return_type;
+                    return_members = extracted_return_members;
+                }
+            }
+        }
 
         self.items.push(DocItem {
             name: type_alias.id.name.to_string(),
@@ -2219,9 +2266,9 @@ impl<'a> DocVisitor<'a> {
             optional: false,
             readonly: false,
             r#static: false,
-            params: Vec::new(),
-            return_type: None,
-            return_members: Vec::new(),
+            params,
+            return_type,
+            return_members,
             children,
             tags,
             type_parameters: self.extract_type_parameters(type_alias.type_parameters.as_ref()),
@@ -2667,6 +2714,111 @@ export type CommandOptions = BaseOptions & {
         assert_eq!(items[0].name, "CommandOptions");
         assert!(items[0].children.is_empty());
         assert!(items[0].signature.as_deref().unwrap().contains("BaseOptions &"));
+    }
+
+    #[test]
+    fn function_valued_interface_property_extracts_params_and_returns() {
+        let source = r"
+/**
+ * Options for parsing.
+ */
+export interface ArgSchema {
+    /**
+     * Parse a value.
+     */
+    parse?: (value: string) => any;
+}
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "options.ts", SourceType::ts()).unwrap();
+        let schema = items.iter().find(|item| item.name == "ArgSchema").unwrap();
+        let parse = schema.children.iter().find(|member| member.name == "parse").unwrap();
+
+        assert_eq!(parse.kind, DocItemKind::Property);
+        assert_eq!(parse.signature.as_deref(), Some("(value: string) => any"));
+        assert_eq!(parse.params.len(), 1);
+        assert_eq!(parse.params[0].name, "value");
+        assert_eq!(parse.params[0].type_annotation.as_deref(), Some("string"));
+        assert_eq!(parse.return_type.as_deref(), Some("any"));
+    }
+
+    #[test]
+    fn function_valued_class_property_extracts_params_and_returns() {
+        let source = r"
+/**
+ * Argument parser.
+ */
+export class ArgParser {
+    /**
+     * Parse a value.
+     */
+    parse: (value: string) => any;
+}
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "parser.ts", SourceType::ts()).unwrap();
+        let parser = items.iter().find(|item| item.name == "ArgParser").unwrap();
+        let parse = parser.children.iter().find(|member| member.name == "parse").unwrap();
+
+        assert_eq!(parse.kind, DocItemKind::Property);
+        assert_eq!(parse.signature.as_deref(), Some("(value: string) => any"));
+        assert_eq!(parse.params[0].name, "value");
+        assert_eq!(parse.params[0].type_annotation.as_deref(), Some("string"));
+        assert_eq!(parse.return_type.as_deref(), Some("any"));
+    }
+
+    #[test]
+    fn readonly_type_and_parenthesized_union_preserve_types() {
+        let source = r"
+/**
+ * Command arguments.
+ */
+export interface ArgSchema {
+    /**
+     * Parse a value.
+     */
+    choices?: string[] | readonly string[];
+}
+
+/**
+ * Example rendering hooks.
+ */
+export interface SubCommandable {
+    examples?: string | ((...args: any[]) => any);
+}
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "schemas.ts", SourceType::ts()).unwrap();
+        let arg_schema = items.iter().find(|item| item.name == "ArgSchema").unwrap();
+        let sub = items.iter().find(|item| item.name == "SubCommandable").unwrap();
+
+        let choices = arg_schema.children.iter().find(|member| member.name == "choices").unwrap();
+        assert_eq!(choices.signature.as_deref(), Some("string[] | readonly string[]"));
+
+        let examples = sub.children.iter().find(|member| member.name == "examples").unwrap();
+        assert_eq!(examples.signature.as_deref(), Some("string | ((...args: any[]) => any)"));
+    }
+
+    #[test]
+    fn type_alias_function_extracts_params_and_returns() {
+        let source = r"
+/**
+ * Run a command.
+ */
+export type CommandRunner<G> = (ctx: Readonly<CommandContext<G>>) => Awaitable<string | void>;
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "runner.ts", SourceType::ts()).unwrap();
+        let alias = items.iter().find(|item| item.name == "CommandRunner").unwrap();
+
+        assert_eq!(alias.params.len(), 1);
+        assert_eq!(alias.params[0].name, "ctx");
+        assert_eq!(alias.params[0].type_annotation.as_deref(), Some("Readonly<CommandContext<G>>"));
+        assert_eq!(alias.return_type.as_deref(), Some("Awaitable<string | void>"));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -3960,6 +3960,64 @@ mod tests {
     }
 
     #[test]
+    fn typedoc_markdown_renders_function_valued_property_details() {
+        let mut schema =
+            test_entry("ArgSchema", "interface", "/repo/src/schema.ts", "Argument schema.");
+        schema.members = vec![ApiDocMember {
+            name: "parse".to_string(),
+            kind: "property".to_string(),
+            description: "Parses a raw value.".to_string(),
+            signature: None,
+            type_annotation: Some("(value: string) => any".to_string()),
+            params: vec![ApiParamDoc {
+                name: "value".to_string(),
+                type_annotation: "string".to_string(),
+                description: "Raw string value from command line.".to_string(),
+                optional: false,
+                default_value: None,
+            }],
+            returns: Some(ApiReturnDoc {
+                type_annotation: "any".to_string(),
+                description: "Parsed value.".to_string(),
+                members: Vec::new(),
+            }),
+            optional: true,
+            readonly: false,
+            r#static: false,
+            private: false,
+            tags: vec![],
+            implementation_of: vec![],
+            line: 5,
+            end_line: 10,
+        }];
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "default".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![schema],
+        }];
+
+        let markdown = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                interface_properties_format: MarkdownDisplayFormat::Table,
+                parameters_format: MarkdownDisplayFormat::Table,
+                ..markdown_typedoc_options()
+            },
+        );
+        let page = markdown.get("default/interfaces/ArgSchema.md").unwrap();
+
+        assert!(page.contains("| `parse` _(optional)_ | `(value: string) => any` | Parses a raw value. Returns: Parsed value. |"));
+        assert!(page.contains("### parse Parameters"));
+        assert!(page.contains("| `value` | `string` | Raw string value from command line. |"));
+        assert!(page.contains("### parse Returns"));
+        assert!(page.contains("`any` — Parsed value."));
+        assert!(!page.contains("`unknown`"));
+    }
+
+    #[test]
     fn html_display_format_options_switch_explicit_sections() {
         let mut make = test_entry("make", "function", "src/make.ts", "Make a thing.");
         make.params = vec![ApiParamDoc {

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -767,46 +767,62 @@ fn render_member_parameter_sections_pure(
     let heading = "#".repeat(section_level);
 
     for member in members {
-        if member.params.is_empty() {
+        if member.params.is_empty() && member.returns.is_none() {
             continue;
         }
 
-        out.push_str(&heading);
-        out.push(' ');
-        out.push_str(&member.name);
-        out.push_str(" Parameters\n\n");
-        match effective_parameters_format(options) {
-            MarkdownDisplayFormat::Table => {
-                out.push_str("| Name | Type | Description |\n| --- | --- | --- |\n");
-                for param in &member.params {
-                    out.push_str("| ");
-                    out.push_str(&code_cell(&param.name));
-                    out.push_str(" | ");
-                    out.push_str(&linked_type_cell(&param.type_annotation, context));
-                    out.push_str(" | ");
-                    push_table_cell(&mut out, &param_description(param, context));
-                    out.push_str(" |\n");
+        if !member.params.is_empty() {
+            out.push_str(&heading);
+            out.push(' ');
+            out.push_str(&member.name);
+            out.push_str(" Parameters\n\n");
+            match effective_parameters_format(options) {
+                MarkdownDisplayFormat::Table => {
+                    out.push_str("| Name | Type | Description |\n| --- | --- | --- |\n");
+                    for param in &member.params {
+                        out.push_str("| ");
+                        out.push_str(&code_cell(&param.name));
+                        out.push_str(" | ");
+                        out.push_str(&linked_type_cell(&param.type_annotation, context));
+                        out.push_str(" | ");
+                        push_table_cell(&mut out, &param_description(param, context));
+                        out.push_str(" |\n");
+                    }
+                }
+                _ => {
+                    for param in &member.params {
+                        out.push_str("- ");
+                        out.push_str(&code_span(&param.name));
+                        if !param.type_annotation.is_empty() {
+                            out.push_str(" (");
+                            out.push_str(&linked_type_span(&param.type_annotation, context));
+                            out.push(')');
+                        }
+                        let description = param_description(param, context);
+                        if !description.is_empty() {
+                            out.push_str(" - ");
+                            out.push_str(&description);
+                        }
+                        out.push('\n');
+                    }
                 }
             }
-            _ => {
-                for param in &member.params {
-                    out.push_str("- ");
-                    out.push_str(&code_span(&param.name));
-                    if !param.type_annotation.is_empty() {
-                        out.push_str(" (");
-                        out.push_str(&linked_type_span(&param.type_annotation, context));
-                        out.push(')');
-                    }
-                    let description = param_description(param, context);
-                    if !description.is_empty() {
-                        out.push_str(" - ");
-                        out.push_str(&description);
-                    }
-                    out.push('\n');
-                }
-            }
+            out.push('\n');
         }
-        out.push('\n');
+
+        if let Some(returns) = &member.returns {
+            out.push_str(&heading);
+            out.push(' ');
+            out.push_str(&member.name);
+            out.push_str(" Returns\n\n");
+            out.push_str(&linked_type_cell(&returns.type_annotation, context));
+            if !returns.description.is_empty() {
+                out.push_str(" — ");
+                out.push_str(&inline(&returns.description, context));
+            }
+            out.push_str("\n\n");
+            push_return_members(&mut out, &returns.members, context, &heading);
+        }
     }
 
     out

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -751,6 +751,44 @@ export interface Command {
     }
 
     #[test]
+    fn function_valued_property_merges_extracted_types_with_description_only_tags() {
+        let source = r"
+/**
+ * Argument schema.
+ */
+export interface ArgSchema {
+    /**
+     * Parses a raw value.
+     * @param value - Raw string value from command line.
+     * @returns Parsed value.
+     */
+    parse?: (value: string) => any;
+}
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "schema.ts", SourceType::ts()).unwrap();
+        let entries = normalize_doc_items(items, false);
+        let member = &entries[0].members[0];
+
+        assert_eq!(member.name, "parse");
+        assert_eq!(member.kind, NormalizedMemberKind::Property);
+        assert_eq!(member.type_annotation.as_deref(), Some("(value: string) => any"));
+        assert_eq!(member.params.len(), 1);
+        assert_eq!(member.params[0].name, "value");
+        assert_eq!(member.params[0].type_annotation, "string");
+        assert_eq!(member.params[0].description, "Raw string value from command line.");
+        assert_eq!(
+            member.returns,
+            Some(NormalizedReturnDoc {
+                type_annotation: "any".to_string(),
+                description: "Parsed value.".to_string(),
+                members: Vec::new()
+            })
+        );
+    }
+
+    #[test]
     fn preserves_heritage_fields_in_normalized_entries() {
         let source = r"
 /**


### PR DESCRIPTION
## Summary

Fix API docs extraction for function-valued properties and type aliases, preserving concrete parameter and return types plus TypeScript operators like readonly instead of falling back to unknown.

## Background

Gunshi docs generated with `@ox-content/napi` showed unknown for valid types such as readonly arrays and parse callbacks because some OXC type nodes were not formatted or structured into docs metadata.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783219539&installation_id=136613492&pr_number=325&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F325&signature=3d818085774e723b1d181b1878dafb4c0465c883a0ada0def3d1d4d1e7221318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->