### PR TITLE
test(docs): preserve function type alias metadata

### DIFF
--- a/crates/ox_content_docs/src/data.rs
+++ b/crates/ox_content_docs/src/data.rs
@@ -645,6 +645,58 @@ mod tests {
     }
 
     #[test]
+    fn function_type_alias_metadata_serializes_to_json() {
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "/repo/src/plugin.ts".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![ApiDocEntry {
+                name: "CommandRunner".to_string(),
+                kind: "type".to_string(),
+                description: "Command runner type.".to_string(),
+                params: vec![ApiParamDoc {
+                    name: "ctx".to_string(),
+                    type_annotation: "Readonly<CommandContext<G>>".to_string(),
+                    description: String::new(),
+                    optional: false,
+                    default_value: None,
+                }],
+                returns: Some(ApiReturnDoc {
+                    type_annotation: "Awaitable<string | void>".to_string(),
+                    description: String::new(),
+                    members: Vec::new(),
+                }),
+                examples: vec![],
+                tags: vec![],
+                private: false,
+                file: "/repo/src/plugin.ts".to_string(),
+                line: 1,
+                end_line: 1,
+                signature: Some(
+                    "export type CommandRunner<G> = (ctx: Readonly<CommandContext<G>>) => Awaitable<string | void>".to_string(),
+                ),
+                extends: vec![],
+                implements: vec![],
+                has_body: false,
+                members: vec![],
+                type_parameters: vec![],
+            }],
+        }];
+
+        let json = generate_docs_data_json(&docs, "2026-06-05T00:00:00.000Z").unwrap();
+        let value: Value = serde_json::from_str(&json).unwrap();
+        let entry = &value["modules"][0]["entries"][0];
+
+        assert_eq!(entry["kind"], "type");
+        assert_eq!(entry["name"], "CommandRunner");
+        assert_eq!(entry["params"][0]["name"], "ctx");
+        assert_eq!(entry["params"][0]["type"], "Readonly<CommandContext<G>>");
+        assert_eq!(entry["returns"]["type"], "Awaitable<string | void>");
+    }
+
+    #[test]
     fn heritage_and_implementation_metadata_serialize_to_json() {
         let docs = vec![ApiDocModule {
             description: String::new(),

--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -2822,6 +2822,73 @@ export type CommandRunner<G> = (ctx: Readonly<CommandContext<G>>) => Awaitable<s
     }
 
     #[test]
+    fn type_alias_function_with_multiple_parameters_extracts_all_params_and_return() {
+        let source = r"
+/**
+ * Extend a command.
+ */
+export type PluginExtension<T, G> = (ctx: CommandContextCore<G>, cmd: Command<G>) => Awaitable<T>;
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "plugin.ts", SourceType::ts()).unwrap();
+        let alias = items.iter().find(|item| item.name == "PluginExtension").unwrap();
+
+        assert_eq!(alias.params.len(), 2);
+        assert_eq!(alias.params[0].name, "ctx");
+        assert_eq!(alias.params[0].type_annotation.as_deref(), Some("CommandContextCore<G>"));
+        assert_eq!(alias.params[1].name, "cmd");
+        assert_eq!(alias.params[1].type_annotation.as_deref(), Some("Command<G>"));
+        assert_eq!(alias.return_type.as_deref(), Some("Awaitable<T>"));
+    }
+
+    #[test]
+    fn type_alias_function_with_function_param_and_return_extracts_nested_function_types() {
+        let source = r"
+/**
+ * Decorate a runner.
+ */
+export type CommandDecorator<G> = (
+    baseRunner: (ctx: Readonly<CommandContext<G>>) => Awaitable<string | void>
+) => (ctx: Readonly<CommandContext<G>>) => Awaitable<string | void>;
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "decorator.ts", SourceType::ts()).unwrap();
+        let alias = items.iter().find(|item| item.name == "CommandDecorator").unwrap();
+
+        assert_eq!(alias.params.len(), 1);
+        assert_eq!(alias.params[0].name, "baseRunner");
+        assert_eq!(
+            alias.params[0].type_annotation.as_deref(),
+            Some("(ctx: Readonly<CommandContext<G>>) => Awaitable<string | void>"),
+        );
+        assert_eq!(
+            alias.return_type.as_deref(),
+            Some("(ctx: Readonly<CommandContext<G>>) => Awaitable<string | void>"),
+        );
+    }
+
+    #[test]
+    fn type_alias_function_without_jsdoc_tags_still_extracts_metadata() {
+        let source = r"
+/**
+ * Plugin function.
+ */
+export type PluginFunction<G> = (ctx: Readonly<PluginContext<G>>) => Awaitable<void>;
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "plugin.ts", SourceType::ts()).unwrap();
+        let alias = items.iter().find(|item| item.name == "PluginFunction").unwrap();
+
+        assert_eq!(alias.params.len(), 1);
+        assert_eq!(alias.params[0].name, "ctx");
+        assert_eq!(alias.params[0].type_annotation.as_deref(), Some("Readonly<PluginContext<G>>"));
+        assert_eq!(alias.return_type.as_deref(), Some("Awaitable<void>"));
+    }
+
+    #[test]
     fn test_extract_jsdoc_types_from_javascript() {
         let source = r"
 /**

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -3432,6 +3432,58 @@ mod tests {
     }
 
     #[test]
+    fn typedoc_type_alias_renders_concrete_function_metadata() {
+        let mut entry = test_entry("CommandRunner", "type", "/repo/src/types.ts", "Run a command.");
+        entry.signature = Some(
+            "export type CommandRunner<G> = (ctx: Readonly<CommandContext<G>>) => Awaitable<string | void>"
+                .to_string(),
+        );
+        entry.params = vec![param("ctx", "Readonly<CommandContext<G>>")];
+        entry.returns = Some(ApiReturnDoc {
+            type_annotation: "Awaitable<string | void>".to_string(),
+            description: "CLI output.".to_string(),
+            members: Vec::new(),
+        });
+
+        let mut docs = type_link_module(entry);
+        if let Some(module) = docs.get_mut(0) {
+            module.entries.push(ApiDocEntry {
+                name: "CommandContext".to_string(),
+                kind: "interface".to_string(),
+                description: "Command context.".to_string(),
+                params: Vec::new(),
+                returns: None,
+                examples: Vec::new(),
+                tags: Vec::new(),
+                private: false,
+                file: "/repo/src/context.ts".to_string(),
+                line: 1,
+                end_line: 1,
+                signature: Some(
+                    "export interface CommandContext<G = DefaultGunshiParams> {}".to_string(),
+                ),
+                extends: Vec::new(),
+                implements: Vec::new(),
+                has_body: false,
+                members: Vec::new(),
+                type_parameters: Vec::new(),
+            });
+            module.entries.push(type_stub("CommandContextCore"));
+        }
+        let out = generate_markdown(&docs, &markdown_typedoc_options());
+        let page = out.get("combinators/type-aliases/CommandRunner.md").unwrap();
+
+        assert!(page.contains("## Parameters"));
+        assert!(page.contains("[`CommandContext`](../interfaces/CommandContext.md)\\<`G`\\>"));
+        assert!(page.contains("## Returns"));
+        assert!(!page.contains("| `ctx` | `unknown` |"));
+        assert!(page.contains("`Awaitable<string \\| void>`"));
+        assert!(page.contains("CLI output."));
+        assert!(!page.contains("`unknown`"));
+        assert!(page.contains("[`CommandContext`](../interfaces/CommandContext.md)"));
+    }
+
+    #[test]
     fn typedoc_index_uses_module_description_not_symbol_description() {
         let docs = vec![
             ApiDocModule {

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -853,6 +853,56 @@ export function resolveArgs<A extends Args>(): {
     }
 
     #[test]
+    fn function_type_alias_metadata_keeps_extracted_types_and_jsdoc_descriptions() {
+        let source = r"
+/**
+ * Run a command.
+ * @param ctx - Command execution context.
+ * @returns CLI output result.
+ */
+export type CommandRunner<G> = (ctx: Readonly<CommandContext<G>>) => Awaitable<string | void>;
+";
+
+        let extractor = DocExtractor::new();
+        let entries = normalize_doc_items(
+            extractor.extract_source(source, "runner.ts", SourceType::ts()).unwrap(),
+            false,
+        );
+        let alias = entries.iter().find(|entry| entry.name == "CommandRunner").unwrap();
+
+        assert_eq!(alias.params.len(), 1);
+        assert_eq!(alias.params[0].name, "ctx");
+        assert_eq!(alias.params[0].type_annotation, "Readonly<CommandContext<G>>");
+        assert_eq!(alias.params[0].description, "Command execution context.");
+        let returns = alias.returns.as_ref().unwrap();
+        assert_eq!(returns.type_annotation, "Awaitable<string | void>");
+        assert_eq!(returns.description, "CLI output result.");
+    }
+
+    #[test]
+    fn function_type_alias_without_jsdoc_tags_still_has_type_information() {
+        let source = r"
+/**
+ * Plugin function.
+ */
+export type PluginFunction<G> = (ctx: Readonly<PluginContext<G>>) => Awaitable<void>;
+";
+
+        let extractor = DocExtractor::new();
+        let entries = normalize_doc_items(
+            extractor.extract_source(source, "plugin.ts", SourceType::ts()).unwrap(),
+            false,
+        );
+        let alias = entries.iter().find(|entry| entry.name == "PluginFunction").unwrap();
+
+        assert_eq!(alias.params.len(), 1);
+        assert_eq!(alias.params[0].name, "ctx");
+        assert_eq!(alias.params[0].type_annotation, "Readonly<PluginContext<G>>");
+        assert_eq!(alias.params[0].description, "");
+        assert_eq!(alias.returns.as_ref().unwrap().type_annotation, "Awaitable<void>");
+    }
+
+    #[test]
     fn index_signature_members_are_normalized_with_parameter_and_value_types() {
         let source = r"
 /**

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -4546,6 +4546,91 @@ mod tests {
     }
 
     #[test]
+    fn generate_docs_markdown_renders_type_alias_function_metadata() {
+        let docs = vec![JsDocsMarkdownModule {
+            description: None,
+            file: "default".to_string(),
+            source_path: None,
+            examples: None,
+            tags: None,
+            entries: vec![
+                JsDocsMarkdownEntry {
+                    name: "CommandRunner".to_string(),
+                    kind: "type".to_string(),
+                    description: "Run a command.".to_string(),
+                    params: Some(vec![JsDocParam {
+                        name: "ctx".to_string(),
+                        r#type: "Readonly<CommandContext<G>>".to_string(),
+                        description: String::new(),
+                        optional: Some(false),
+                        r#default: None,
+                    }]),
+                    returns: Some(JsDocReturn {
+                        r#type: "Awaitable<string | void>".to_string(),
+                        description: "CLI output.".to_string(),
+                        members: None,
+                    }),
+                    examples: None,
+                    tags: None,
+                    private: false,
+                    file: "/repo/src/types.ts".to_string(),
+                    line: 1,
+                    end_line: 1,
+                    signature: Some(
+                        "export type CommandRunner<G> = (ctx: Readonly<CommandContext<G>>) => Awaitable<string | void>"
+                            .to_string(),
+                    ),
+                    extends: None,
+                    implements: None,
+                    has_body: None,
+                    members: None,
+                    type_parameters: None,
+                },
+                JsDocsMarkdownEntry {
+                    name: "CommandContext".to_string(),
+                    kind: "type".to_string(),
+                    description: String::new(),
+                    params: Some(vec![]),
+                    returns: None,
+                    examples: None,
+                    tags: None,
+                    private: false,
+                    file: "/repo/src/context.ts".to_string(),
+                    line: 1,
+                    end_line: 1,
+                    signature: Some("export type CommandContext = unknown".to_string()),
+                    extends: None,
+                    implements: None,
+                    has_body: None,
+                    members: None,
+                    type_parameters: None,
+                },
+            ],
+        }];
+
+        let markdown = generate_docs_markdown(
+            docs,
+            Some(JsDocsMarkdownOptions {
+                group_by: Some("file".to_string()),
+                path_strategy: Some("typedoc".to_string()),
+                render_style: Some("markdown".to_string()),
+                parameters_format: Some("table".to_string()),
+                ..Default::default()
+            }),
+        );
+        let page = markdown.get("default/type-aliases/CommandRunner.md").unwrap();
+
+        assert!(page.contains("## Parameters"));
+        assert!(page.contains("Readonly"));
+        assert!(page.contains("CommandContext"));
+        assert!(page.contains("## Returns"));
+        assert!(!page.contains("| `ctx` | `unknown` |"));
+        assert!(page.contains("`Awaitable<string \\| void>`"));
+        assert!(page.contains("CLI output."));
+        assert!(!page.contains("`unknown`"));
+    }
+
+    #[test]
     fn generate_docs_markdown_renders_index_signature_members() {
         let docs = vec![JsDocsMarkdownModule {
             description: None,


### PR DESCRIPTION
## Summary

Add **regression coverage** for function type alias metadata so params and returns stay concrete across extractor, normalization, JSON, Markdown, and NAPI output.

## Background
The underlying fix already exists on main via #325.

This PR locks the note gunshi cases where `@ox-content/napi` previously rendered function type alias params/returns as unknown or omitted returns.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783228770&installation_id=136613492&pr_number=326&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F326&signature=4d63f5ca081cb24037e44b485d8f7e5c88e6dbc66524fc7d38091d6c7f315a3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->