### PR TITLE
test(docs): cover function type alias returns

### DIFF
--- a/crates/ox_content_docs/src/data.rs
+++ b/crates/ox_content_docs/src/data.rs
@@ -697,6 +697,68 @@ mod tests {
     }
 
     #[test]
+    fn function_type_alias_return_without_description_serializes_to_json() {
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "/repo/src/plugin.ts".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![ApiDocEntry {
+                name: "OnPluginExtension".to_string(),
+                kind: "type".to_string(),
+                description: "Plugin extension hook.".to_string(),
+                params: vec![
+                    ApiParamDoc {
+                        name: "ctx".to_string(),
+                        type_annotation: "Readonly<CommandContext<G>>".to_string(),
+                        description: "The command context.".to_string(),
+                        optional: false,
+                        default_value: None,
+                    },
+                    ApiParamDoc {
+                        name: "cmd".to_string(),
+                        type_annotation: "Readonly<Command<G>>".to_string(),
+                        description: "The command.".to_string(),
+                        optional: false,
+                        default_value: None,
+                    },
+                ],
+                returns: Some(ApiReturnDoc {
+                    type_annotation: "Awaitable<void>".to_string(),
+                    description: String::new(),
+                    members: Vec::new(),
+                }),
+                examples: vec![],
+                tags: vec![],
+                private: false,
+                file: "/repo/src/plugin.ts".to_string(),
+                line: 1,
+                end_line: 5,
+                signature: Some(
+                    "export type OnPluginExtension<G> = (ctx: Readonly<CommandContext<G>>, cmd: Readonly<Command<G>>) => Awaitable<void>"
+                        .to_string(),
+                ),
+                extends: vec![],
+                implements: vec![],
+                has_body: false,
+                members: vec![],
+                type_parameters: vec![],
+            }],
+        }];
+
+        let json = generate_docs_data_json(&docs, "2026-06-05T00:00:00.000Z").unwrap();
+        let value: Value = serde_json::from_str(&json).unwrap();
+        let entry = &value["modules"][0]["entries"][0];
+
+        assert_eq!(entry["name"], "OnPluginExtension");
+        assert_eq!(entry["params"][0]["type"], "Readonly<CommandContext<G>>");
+        assert_eq!(entry["params"][1]["type"], "Readonly<Command<G>>");
+        assert_eq!(entry["returns"]["type"], "Awaitable<void>");
+        assert_eq!(entry["returns"]["description"], "");
+    }
+
+    #[test]
     fn heritage_and_implementation_metadata_serialize_to_json() {
         let docs = vec![ApiDocModule {
             description: String::new(),

--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -2843,6 +2843,35 @@ export type PluginExtension<T, G> = (ctx: CommandContextCore<G>, cmd: Command<G>
     }
 
     #[test]
+    fn type_alias_function_with_jsdoc_params_but_no_returns_tag_extracts_return() {
+        let source = r"
+/**
+ * Plugin extension hook.
+ *
+ * @param ctx - The command context.
+ * @param cmd - The command.
+ */
+export type OnPluginExtension<G> = (
+    ctx: Readonly<CommandContext<G>>,
+    cmd: Readonly<Command<G>>
+) => Awaitable<void>;
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "plugin.ts", SourceType::ts()).unwrap();
+        let alias = items.iter().find(|item| item.name == "OnPluginExtension").unwrap();
+
+        assert_eq!(alias.params.len(), 2);
+        assert_eq!(alias.params[0].name, "ctx");
+        assert_eq!(alias.params[0].type_annotation.as_deref(), Some("Readonly<CommandContext<G>>"));
+        assert_eq!(alias.params[0].description.as_deref(), Some("The command context."));
+        assert_eq!(alias.params[1].name, "cmd");
+        assert_eq!(alias.params[1].type_annotation.as_deref(), Some("Readonly<Command<G>>"));
+        assert_eq!(alias.params[1].description.as_deref(), Some("The command."));
+        assert_eq!(alias.return_type.as_deref(), Some("Awaitable<void>"));
+    }
+
+    #[test]
     fn type_alias_function_with_function_param_and_return_extracts_nested_function_types() {
         let source = r"
 /**

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -3484,6 +3484,89 @@ mod tests {
     }
 
     #[test]
+    fn typedoc_type_alias_without_returns_tag_renders_return_section() {
+        let mut entry = test_entry(
+            "OnPluginExtension",
+            "type",
+            "/repo/src/plugin.ts",
+            "Plugin extension hook.",
+        );
+        entry.signature = Some(
+            "export type OnPluginExtension<G> = (ctx: Readonly<CommandContext<G>>, cmd: Readonly<Command<G>>) => Awaitable<void>"
+                .to_string(),
+        );
+        entry.params = vec![
+            ApiParamDoc {
+                name: "ctx".to_string(),
+                type_annotation: "Readonly<CommandContext<G>>".to_string(),
+                description: "The command context.".to_string(),
+                optional: false,
+                default_value: None,
+            },
+            ApiParamDoc {
+                name: "cmd".to_string(),
+                type_annotation: "Readonly<Command<G>>".to_string(),
+                description: "The command.".to_string(),
+                optional: false,
+                default_value: None,
+            },
+        ];
+        entry.returns = Some(ApiReturnDoc {
+            type_annotation: "Awaitable<void>".to_string(),
+            description: String::new(),
+            members: Vec::new(),
+        });
+
+        let mut docs = type_link_module(entry);
+        if let Some(module) = docs.get_mut(0) {
+            let mut command_context =
+                test_entry("CommandContext", "interface", "/repo/src/context.ts", "");
+            command_context.signature = Some("export interface CommandContext<G> {}".to_string());
+            let mut command = test_entry("Command", "interface", "/repo/src/command.ts", "");
+            command.signature = Some("export interface Command<G> {}".to_string());
+            module.entries.push(command_context);
+            module.entries.push(command);
+        }
+        let out = generate_markdown(&docs, &markdown_typedoc_options());
+        let page = out.get("combinators/type-aliases/OnPluginExtension.md").unwrap();
+
+        assert!(page.contains("## Parameters"));
+        assert!(page.contains("The command context."));
+        assert!(page.contains("The command."));
+        assert!(page.contains("[`CommandContext`](../interfaces/CommandContext.md)"));
+        assert!(page.contains("[`Command`](../interfaces/Command.md)"));
+        assert!(page.contains("## Returns\n\n`Awaitable<void>`"));
+        assert!(!page.contains("`unknown`"));
+    }
+
+    #[test]
+    fn typedoc_html_type_alias_without_returns_tag_renders_return_section() {
+        let mut entry = test_entry(
+            "OnPluginExtension",
+            "type",
+            "/repo/src/plugin.ts",
+            "Plugin extension hook.",
+        );
+        entry.signature = Some(
+            "export type OnPluginExtension<G> = (ctx: Readonly<CommandContext<G>>, cmd: Readonly<Command<G>>) => Awaitable<void>"
+                .to_string(),
+        );
+        entry.params = vec![param("ctx", "Readonly<CommandContext<G>>")];
+        entry.returns = Some(ApiReturnDoc {
+            type_annotation: "Awaitable<void>".to_string(),
+            description: String::new(),
+            members: Vec::new(),
+        });
+
+        let out = generate_markdown(&type_link_module(entry), &html_typedoc_options());
+        let page = out.get("combinators/type-aliases/OnPluginExtension.md").unwrap();
+
+        assert!(page.contains("<h4>Returns</h4>"));
+        assert!(page.contains("Awaitable&lt;void&gt;"));
+        assert!(!page.contains("unknown"));
+    }
+
+    #[test]
     fn typedoc_index_uses_module_description_not_symbol_description() {
         let docs = vec![
             ApiDocModule {

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -903,6 +903,40 @@ export type PluginFunction<G> = (ctx: Readonly<PluginContext<G>>) => Awaitable<v
     }
 
     #[test]
+    fn function_type_alias_without_returns_tag_still_normalizes_return_section() {
+        let source = r"
+/**
+ * Plugin extension hook.
+ *
+ * @param ctx - The command context.
+ * @param cmd - The command.
+ */
+export type OnPluginExtension<G> = (
+    ctx: Readonly<CommandContext<G>>,
+    cmd: Readonly<Command<G>>
+) => Awaitable<void>;
+";
+
+        let extractor = DocExtractor::new();
+        let entries = normalize_doc_items(
+            extractor.extract_source(source, "plugin.ts", SourceType::ts()).unwrap(),
+            false,
+        );
+        let alias = entries.iter().find(|entry| entry.name == "OnPluginExtension").unwrap();
+
+        assert_eq!(alias.params.len(), 2);
+        assert_eq!(alias.params[0].name, "ctx");
+        assert_eq!(alias.params[0].type_annotation, "Readonly<CommandContext<G>>");
+        assert_eq!(alias.params[0].description, "The command context.");
+        assert_eq!(alias.params[1].name, "cmd");
+        assert_eq!(alias.params[1].type_annotation, "Readonly<Command<G>>");
+        assert_eq!(alias.params[1].description, "The command.");
+        let returns = alias.returns.as_ref().unwrap();
+        assert_eq!(returns.type_annotation, "Awaitable<void>");
+        assert_eq!(returns.description, "");
+    }
+
+    #[test]
     fn index_signature_members_are_normalized_with_parameter_and_value_types() {
         let source = r"
 /**

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -3511,11 +3511,11 @@ mod tests {
 
     use super::transformer::parse_frontmatter;
     use super::{
-        convert_markdown_entry, extract_docs_from_entry_points_napi, generate_docs_markdown,
-        generate_docs_nav_metadata_from_docs_napi, get_git_last_updated, map_normalized_doc_entry,
-        JsDocMember, JsDocParam, JsDocReturn, JsDocsMarkdownEntry, JsDocsMarkdownModule,
-        JsDocsMarkdownOptions, JsDocsMarkdownTag, JsDocsNavOptions, JsEntryPointDocsOptions,
-        JsEntryPointSpec, JsTypeParam,
+        convert_markdown_entry, extract_docs_from_entry_points_napi, extract_file_doc_entries,
+        generate_docs_markdown, generate_docs_nav_metadata_from_docs_napi, get_git_last_updated,
+        map_normalized_doc_entry, JsDocMember, JsDocParam, JsDocReturn, JsDocsMarkdownEntry,
+        JsDocsMarkdownModule, JsDocsMarkdownOptions, JsDocsMarkdownTag, JsDocsNavOptions,
+        JsEntryPointDocsOptions, JsEntryPointSpec, JsTypeParam,
     };
 
     #[test]
@@ -3729,6 +3729,50 @@ mod tests {
         assert_eq!(returns.r#type, "object");
         assert_eq!(member.name, "values");
         assert_eq!(member.r#type.as_deref(), Some("ArgValues<A>"));
+    }
+
+    #[test]
+    fn extract_file_doc_entries_preserves_type_alias_return_without_returns_tag() {
+        let unique =
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos();
+        let root = std::env::temp_dir()
+            .join(format!("ox-content-napi-type-alias-return-{}-{unique}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let file = root.join("plugin.ts");
+        fs::write(
+            &file,
+            r"
+/**
+ * Plugin extension hook.
+ *
+ * @param ctx - The command context.
+ * @param cmd - The command.
+ */
+export type OnPluginExtension<G> = (
+    ctx: Readonly<CommandContext<G>>,
+    cmd: Readonly<Command<G>>
+) => Awaitable<void>;
+",
+        )
+        .unwrap();
+
+        let entries =
+            extract_file_doc_entries(file.to_string_lossy().into_owned(), None, None, None)
+                .unwrap();
+        let entry = entries.iter().find(|entry| entry.name == "OnPluginExtension").unwrap();
+        let params = entry.params.as_ref().unwrap();
+        let returns = entry.returns.as_ref().unwrap();
+
+        assert_eq!(params.len(), 2);
+        assert_eq!(params[0].r#type, "Readonly<CommandContext<G>>");
+        assert_eq!(params[0].description, "The command context.");
+        assert_eq!(params[1].r#type, "Readonly<Command<G>>");
+        assert_eq!(params[1].description, "The command.");
+        assert_eq!(returns.r#type, "Awaitable<void>");
+        assert_eq!(returns.description, "");
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]
@@ -4627,6 +4671,76 @@ mod tests {
         assert!(!page.contains("| `ctx` | `unknown` |"));
         assert!(page.contains("`Awaitable<string \\| void>`"));
         assert!(page.contains("CLI output."));
+        assert!(!page.contains("`unknown`"));
+    }
+
+    #[test]
+    fn generate_docs_markdown_renders_type_alias_return_without_description() {
+        let docs = vec![JsDocsMarkdownModule {
+            description: None,
+            file: "default".to_string(),
+            source_path: None,
+            examples: None,
+            tags: None,
+            entries: vec![JsDocsMarkdownEntry {
+                name: "OnPluginExtension".to_string(),
+                kind: "type".to_string(),
+                description: "Plugin extension hook.".to_string(),
+                params: Some(vec![
+                    JsDocParam {
+                        name: "ctx".to_string(),
+                        r#type: "Readonly<CommandContext<G>>".to_string(),
+                        description: "The command context.".to_string(),
+                        optional: Some(false),
+                        r#default: None,
+                    },
+                    JsDocParam {
+                        name: "cmd".to_string(),
+                        r#type: "Readonly<Command<G>>".to_string(),
+                        description: "The command.".to_string(),
+                        optional: Some(false),
+                        r#default: None,
+                    },
+                ]),
+                returns: Some(JsDocReturn {
+                    r#type: "Awaitable<void>".to_string(),
+                    description: String::new(),
+                    members: None,
+                }),
+                examples: None,
+                tags: None,
+                private: false,
+                file: "/repo/src/plugin.ts".to_string(),
+                line: 1,
+                end_line: 5,
+                signature: Some(
+                    "export type OnPluginExtension<G> = (ctx: Readonly<CommandContext<G>>, cmd: Readonly<Command<G>>) => Awaitable<void>"
+                        .to_string(),
+                ),
+                extends: None,
+                implements: None,
+                has_body: None,
+                members: None,
+                type_parameters: None,
+            }],
+        }];
+
+        let markdown = generate_docs_markdown(
+            docs,
+            Some(JsDocsMarkdownOptions {
+                group_by: Some("file".to_string()),
+                path_strategy: Some("typedoc".to_string()),
+                render_style: Some("markdown".to_string()),
+                parameters_format: Some("table".to_string()),
+                ..Default::default()
+            }),
+        );
+        let page = markdown.get("default/type-aliases/OnPluginExtension.md").unwrap();
+
+        assert!(page.contains("## Parameters"));
+        assert!(page.contains("The command context."));
+        assert!(page.contains("The command."));
+        assert!(page.contains("## Returns\n\n`Awaitable<void>`"));
         assert!(!page.contains("`unknown`"));
     }
 


### PR DESCRIPTION
## Summary

Add **regression coverage** for function type aliases so extracted params and return annotations survive JSON, Markdown, HTML, and NAPI paths, including aliases without a JSDoc `@returns` tag.

## Background

Gunshi note 058 showed `@ox-content/napi` omitted the Returns section for `OnPluginExtension/PluginFunction` because no `@returns` tag existed.

Main already has the extractor fix, so this PR locks that path.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783234603&installation_id=136613492&pr_number=327&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F327&signature=bb23d254b150d8b98f9aad0e509dd8a25997bd8f6a061826b5adbf11362df96f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->