### PR TITLE
fix(docs): avoid escaping return union pipes

### DIFF
--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -3101,6 +3101,44 @@ mod tests {
     }
 
     #[test]
+    fn typedoc_markdown_return_union_pipe_is_not_escaped_inside_inline_code() {
+        let mut entry = test_entry("cli", "function", "/repo/src/cli.ts", "Run the command.");
+        entry.signature = Some(
+            "export function cli(entry: Command<G> | CommandRunner<G>): Promise<string | undefined>"
+                .to_string(),
+        );
+        entry.params = vec![param("entry", "Command<G> | CommandRunner<G>")];
+        entry.returns = Some(ApiReturnDoc {
+            type_annotation: "Promise<string | undefined>".to_string(),
+            description: "A rendered usage or undefined.".to_string(),
+            members: Vec::new(),
+        });
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "default".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![entry],
+        }];
+
+        let out = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                parameters_format: MarkdownDisplayFormat::Table,
+                ..markdown_typedoc_options()
+            },
+        );
+        let page = out.get("default/functions/cli.md").unwrap();
+
+        assert!(page.contains("| `entry` | `Command<G> \\| CommandRunner<G>` |"));
+        assert!(page.contains(
+            "## Returns\n\n`Promise<string | undefined>` — A rendered usage or undefined."
+        ));
+        assert!(!page.contains("`Promise<string \\| undefined>`"));
+    }
+
+    #[test]
     fn render_style_markdown_flat_sections_render_at_h4() {
         let options = MarkdownDocsOptions {
             render_style: MarkdownRenderStyle::Markdown,
@@ -3477,7 +3515,7 @@ mod tests {
         assert!(page.contains("[`CommandContext`](../interfaces/CommandContext.md)\\<`G`\\>"));
         assert!(page.contains("## Returns"));
         assert!(!page.contains("| `ctx` | `unknown` |"));
-        assert!(page.contains("`Awaitable<string \\| void>`"));
+        assert!(page.contains("`Awaitable<string | void>`"));
         assert!(page.contains("CLI output."));
         assert!(!page.contains("`unknown`"));
         assert!(page.contains("[`CommandContext`](../interfaces/CommandContext.md)"));
@@ -4090,6 +4128,9 @@ mod tests {
         assert!(page.contains("getResource(locale: string): Record<string, string> | undefined;"));
         assert!(page.contains("#### Parameters"));
         assert!(page.contains("| `locale` | `string` | Locale name. |"));
+        assert!(page.contains("#### Returns"));
+        assert!(page.contains("`Record<string, string> | undefined` — The locale resource."));
+        assert!(!page.contains("`Record<string, string> \\| undefined`"));
         assert!(page.contains("#### Implementation of"));
         assert!(page.contains("TranslationAdapter.getResource"));
     }
@@ -4103,7 +4144,7 @@ mod tests {
             kind: "property".to_string(),
             description: "Parses a raw value.".to_string(),
             signature: None,
-            type_annotation: Some("(value: string) => any".to_string()),
+            type_annotation: Some("(value: string) => string | undefined".to_string()),
             params: vec![ApiParamDoc {
                 name: "value".to_string(),
                 type_annotation: "string".to_string(),
@@ -4112,7 +4153,7 @@ mod tests {
                 default_value: None,
             }],
             returns: Some(ApiReturnDoc {
-                type_annotation: "any".to_string(),
+                type_annotation: "string | undefined".to_string(),
                 description: "Parsed value.".to_string(),
                 members: Vec::new(),
             }),
@@ -4144,11 +4185,12 @@ mod tests {
         );
         let page = markdown.get("default/interfaces/ArgSchema.md").unwrap();
 
-        assert!(page.contains("| `parse` _(optional)_ | `(value: string) => any` | Parses a raw value. Returns: Parsed value. |"));
+        assert!(page.contains("| `parse` _(optional)_ | `(value: string) => string \\| undefined` | Parses a raw value. Returns: Parsed value. |"));
         assert!(page.contains("### parse Parameters"));
         assert!(page.contains("| `value` | `string` | Raw string value from command line. |"));
         assert!(page.contains("### parse Returns"));
-        assert!(page.contains("`any` — Parsed value."));
+        assert!(page.contains("`string | undefined` — Parsed value."));
+        assert!(!page.contains("`string \\| undefined` — Parsed value."));
         assert!(!page.contains("`unknown`"));
     }
 
@@ -5680,14 +5722,20 @@ mod tests {
 
     #[test]
     fn typedoc_overloads_render_all_call_signatures() {
+        let mut with_extension = overload_entry(
+            "plugin",
+            "/repo/src/plugin.ts",
+            "Define a plugin with extension.",
+            "export function plugin<E>(options: WithExt): Promise<string | undefined>",
+            false,
+        );
+        with_extension.returns = Some(ApiReturnDoc {
+            type_annotation: "Promise<string | undefined>".to_string(),
+            description: "A rendered usage or undefined.".to_string(),
+            members: Vec::new(),
+        });
         let docs = overload_module(vec![
-            overload_entry(
-                "plugin",
-                "/repo/src/plugin.ts",
-                "Define a plugin with extension.",
-                "export function plugin<E>(options: WithExt): PluginWithExtension<E>",
-                false,
-            ),
+            with_extension,
             overload_entry(
                 "plugin",
                 "/repo/src/plugin.ts",
@@ -5709,8 +5757,12 @@ mod tests {
         assert!(page.contains("# Function: plugin()"));
         // Both public overloads survive on one page (not overwritten by the last).
         assert_eq!(page.matches("## Call Signature").count(), 2);
-        assert!(page.contains("PluginWithExtension<E>"));
+        assert!(page.contains("Promise<string | undefined>"));
         assert!(page.contains("PluginWithoutExtension"));
+        assert!(page.contains(
+            "### Returns\n\n`Promise<string | undefined>` — A rendered usage or undefined."
+        ));
+        assert!(!page.contains("`Promise<string \\| undefined>`"));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -409,7 +409,7 @@ fn push_returns(
 ) {
     out.push_str(heading);
     out.push_str(" Returns\n\n");
-    out.push_str(&linked_type_cell(&returns.type_annotation, context));
+    out.push_str(&linked_type_span(&returns.type_annotation, context));
     if !returns.description.is_empty() {
         out.push_str(" — ");
         out.push_str(&inline(&returns.description, context));
@@ -815,7 +815,7 @@ fn render_member_parameter_sections_pure(
             out.push(' ');
             out.push_str(&member.name);
             out.push_str(" Returns\n\n");
-            out.push_str(&linked_type_cell(&returns.type_annotation, context));
+            out.push_str(&linked_type_span(&returns.type_annotation, context));
             if !returns.description.is_empty() {
                 out.push_str(" — ");
                 out.push_str(&inline(&returns.description, context));

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -4669,9 +4669,70 @@ export type OnPluginExtension<G> = (
         assert!(page.contains("CommandContext"));
         assert!(page.contains("## Returns"));
         assert!(!page.contains("| `ctx` | `unknown` |"));
-        assert!(page.contains("`Awaitable<string \\| void>`"));
+        assert!(page.contains("`Awaitable<string | void>`"));
         assert!(page.contains("CLI output."));
         assert!(!page.contains("`unknown`"));
+    }
+
+    #[test]
+    fn generate_docs_markdown_does_not_escape_return_union_pipe_inside_inline_code() {
+        let docs = vec![JsDocsMarkdownModule {
+            description: None,
+            file: "default".to_string(),
+            source_path: None,
+            examples: None,
+            tags: None,
+            entries: vec![JsDocsMarkdownEntry {
+                name: "cli".to_string(),
+                kind: "function".to_string(),
+                description: "Run the command.".to_string(),
+                params: Some(vec![JsDocParam {
+                    name: "entry".to_string(),
+                    r#type: "Command<G> | CommandRunner<G>".to_string(),
+                    description: "Command entry.".to_string(),
+                    optional: Some(false),
+                    r#default: None,
+                }]),
+                returns: Some(JsDocReturn {
+                    r#type: "Promise<string | undefined>".to_string(),
+                    description: "A rendered usage or undefined.".to_string(),
+                    members: None,
+                }),
+                examples: None,
+                tags: None,
+                private: false,
+                file: "/repo/src/cli.ts".to_string(),
+                line: 1,
+                end_line: 5,
+                signature: Some(
+                    "export function cli(entry: Command<G> | CommandRunner<G>): Promise<string | undefined>"
+                        .to_string(),
+                ),
+                extends: None,
+                implements: None,
+                has_body: None,
+                members: None,
+                type_parameters: None,
+            }],
+        }];
+
+        let markdown = generate_docs_markdown(
+            docs,
+            Some(JsDocsMarkdownOptions {
+                group_by: Some("file".to_string()),
+                path_strategy: Some("typedoc".to_string()),
+                render_style: Some("markdown".to_string()),
+                parameters_format: Some("table".to_string()),
+                ..Default::default()
+            }),
+        );
+        let page = markdown.get("default/functions/cli.md").unwrap();
+
+        assert!(page.contains("| `entry` | `Command<G> \\| CommandRunner<G>` | Command entry. |"));
+        assert!(page.contains(
+            "## Returns\n\n`Promise<string | undefined>` — A rendered usage or undefined."
+        ));
+        assert!(!page.contains("`Promise<string \\| undefined>`"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix Markdown Returns rendering so union pipes stay unescaped in inline code, while table cells still escape pipes.

Adds regression coverage across docs and NAPI paths for top-level, overload, member, and function type alias returns.

## Background

`@ox-content/napi` outputting `Promise<string \| undefined>` in non-table Returns sections.

The docs data was already clean, so the bug was scoped to using table-cell rendering in section bodies.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783243514&installation_id=136613492&pr_number=328&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F328&signature=95005bccb4b521aa1105ff8b7b2c9b91cfdc5b15350d712b63eb47722a66100b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->