### PR TITLE
fix(docs): expand object literal params

### DIFF
--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -10,7 +10,7 @@ use oxc_ast::ast::{
     BindingPattern, Class, Comment, Declaration, ExportDefaultDeclarationKind, Expression,
     Function, Statement, TSEnumDeclaration, TSEnumMember, TSIndexSignature, TSIndexSignatureName,
     TSInterfaceDeclaration, TSSignature, TSType, TSTypeAliasDeclaration, TSTypeAnnotation,
-    TSTypeName, VariableDeclaration,
+    TSTypeLiteral, TSTypeName, VariableDeclaration,
 };
 use oxc_ast_visit::{walk, Visit};
 use oxc_parser::Parser;
@@ -966,6 +966,40 @@ impl<'a> DocVisitor<'a> {
         items.join(", ")
     }
 
+    fn format_type_formal_parameters(&self, params: &oxc_ast::ast::FormalParameters<'a>) -> String {
+        let mut items = Vec::with_capacity(params.items.len() + usize::from(params.rest.is_some()));
+
+        for param in &params.items {
+            let name = Self::binding_pattern_name(&param.pattern);
+            let mut item = StringBuilder::with_capacity(name.len() + 16);
+            item.push_str(&name);
+            if param.optional {
+                item.push_char('?');
+            }
+            if let Some(type_annotation) = param.type_annotation.as_ref() {
+                let formatted = self.format_ts_type(&type_annotation.type_annotation);
+                item.push_str(": ");
+                item.push_str(&formatted);
+            }
+            items.push(item.into_string());
+        }
+
+        if let Some(rest) = params.rest.as_ref() {
+            let name = Self::binding_pattern_name(&rest.rest.argument);
+            let mut item = StringBuilder::with_capacity(name.len() + 19);
+            item.push_str("...");
+            item.push_str(&name);
+            if let Some(type_annotation) = rest.type_annotation.as_ref() {
+                let formatted = self.format_ts_type(&type_annotation.type_annotation);
+                item.push_str(": ");
+                item.push_str(&formatted);
+            }
+            items.push(item.into_string());
+        }
+
+        items.join(", ")
+    }
+
     fn format_function_signature(&self, func: &Function<'a>, name: &str, exported: bool) -> String {
         let mut sig = String::new();
 
@@ -1325,6 +1359,13 @@ impl<'a> DocVisitor<'a> {
         })
     }
 
+    fn find_exact_parsed_param_tag<'t>(
+        parsed: &'t [ParsedParamTag],
+        name: &str,
+    ) -> Option<&'t ParsedParamTag> {
+        parsed.iter().find(|tag| tag.name.trim_start_matches("...").trim_end_matches('?') == name)
+    }
+
     fn parse_return_tag(tag: &DocTag) -> (Option<String>, Option<String>) {
         if tag.type_annotation.is_some() || tag.description.is_some() {
             return (tag.type_annotation.clone(), tag.description.clone());
@@ -1368,7 +1409,7 @@ impl<'a> DocVisitor<'a> {
             TSType::TSObjectKeyword(_) => "object".to_string(),
             TSType::TSUnknownKeyword(_) => "unknown".to_string(),
             TSType::TSTypeReference(ref_type) => {
-                self.slice(ref_type.span().start, ref_type.span().end)
+                self.format_type_span(ref_type.span().start, ref_type.span().end)
             }
             TSType::TSArrayType(arr) => join2(&self.format_ts_type(&arr.element_type), "[]"),
             TSType::TSTypeOperatorType(op) => {
@@ -1390,7 +1431,7 @@ impl<'a> DocVisitor<'a> {
                 types.join(" & ")
             }
             TSType::TSFunctionType(func) => {
-                let params = self.format_formal_parameters(&func.params);
+                let params = self.format_type_formal_parameters(&func.params);
                 let ret = self.format_ts_type(&func.return_type.type_annotation);
                 let mut out = StringBuilder::with_capacity(params.len() + ret.len() + 6);
                 out.push_char('(');
@@ -1399,7 +1440,7 @@ impl<'a> DocVisitor<'a> {
                 out.push_str(&ret);
                 out.into_string()
             }
-            TSType::TSTypeLiteral(_) => "{ ... }".to_string(),
+            TSType::TSTypeLiteral(type_literal) => self.format_type_literal(type_literal),
             TSType::TSParenthesizedType(paren) => {
                 join3("(", &self.format_ts_type(&paren.type_annotation), ")")
             }
@@ -1425,12 +1466,122 @@ impl<'a> DocVisitor<'a> {
     }
 
     fn format_type_from_span(&self, ts_type: &TSType) -> String {
-        self.slice(ts_type.span().start, ts_type.span().end)
-            .split_whitespace()
-            .collect::<Vec<_>>()
-            .join(" ")
-            .trim()
-            .to_string()
+        self.format_type_span(ts_type.span().start, ts_type.span().end)
+    }
+
+    fn format_span(&self, start: u32, end: u32) -> String {
+        self.slice(start, end).split_whitespace().collect::<Vec<_>>().join(" ").trim().to_string()
+    }
+
+    fn format_type_span(&self, start: u32, end: u32) -> String {
+        Self::collapse_type_annotation_text(&self.slice(start, end))
+    }
+
+    fn collapse_type_annotation_text(text: &str) -> String {
+        let text = text.trim();
+        if text.is_empty() {
+            return String::new();
+        }
+
+        let mut out = String::with_capacity(text.len());
+        let mut pending_space = false;
+        for ch in text.chars() {
+            if ch.is_whitespace() {
+                pending_space = !out.is_empty();
+                continue;
+            }
+
+            if pending_space {
+                if !matches!(out.chars().next_back(), Some('<')) && ch != '>' {
+                    out.push(' ');
+                }
+                pending_space = false;
+            }
+            out.push(ch);
+        }
+        out
+    }
+
+    fn property_key_name(key: &oxc_ast::ast::PropertyKey<'a>) -> Option<String> {
+        match key {
+            oxc_ast::ast::PropertyKey::StaticIdentifier(id) => Some(id.name.to_string()),
+            _ => None,
+        }
+    }
+
+    fn format_type_literal(&self, type_literal: &TSTypeLiteral<'a>) -> String {
+        let members = type_literal
+            .members
+            .iter()
+            .map(|member| self.format_type_literal_member(member))
+            .filter(|member| !member.is_empty())
+            .collect::<Vec<_>>();
+
+        if members.is_empty() {
+            "{}".to_string()
+        } else {
+            join3("{ ", &members.join("; "), " }")
+        }
+    }
+
+    fn format_type_literal_member(&self, member: &TSSignature<'a>) -> String {
+        match member {
+            TSSignature::TSPropertySignature(prop) => {
+                let Some(name) = Self::property_key_name(&prop.key) else {
+                    return self.format_span(prop.span.start, prop.span.end);
+                };
+                let type_annotation = prop.type_annotation.as_ref().map_or_else(
+                    || "unknown".to_string(),
+                    |t| self.format_ts_type(&t.type_annotation),
+                );
+                let mut out = StringBuilder::with_capacity(name.len() + type_annotation.len() + 16);
+                if prop.readonly {
+                    out.push_str("readonly ");
+                }
+                out.push_str(&name);
+                if prop.optional {
+                    out.push_char('?');
+                }
+                out.push_str(": ");
+                out.push_str(&type_annotation);
+                out.into_string()
+            }
+            TSSignature::TSMethodSignature(method) => {
+                let Some(name) = Self::property_key_name(&method.key) else {
+                    return self.format_span(method.span.start, method.span.end);
+                };
+                let params = self.format_type_formal_parameters(&method.params);
+                let return_type = method.return_type.as_ref().map_or_else(
+                    || "unknown".to_string(),
+                    |t| self.format_ts_type(&t.type_annotation),
+                );
+                let type_parameters =
+                    self.format_type_parameter_declaration(method.type_parameters.as_ref());
+                let mut out = StringBuilder::with_capacity(
+                    name.len() + type_parameters.len() + params.len() + return_type.len() + 8,
+                );
+                out.push_str(&name);
+                if method.optional {
+                    out.push_char('?');
+                }
+                out.push_str(&type_parameters);
+                out.push_char('(');
+                out.push_str(&params);
+                out.push_str("): ");
+                out.push_str(&return_type);
+                out.into_string()
+            }
+            TSSignature::TSIndexSignature(index_signature) => {
+                let Some(parameter) = index_signature.parameters.first() else {
+                    return self.format_span(index_signature.span.start, index_signature.span.end);
+                };
+                let (name, _, _) = self.format_index_signature_name(parameter);
+                let value_type =
+                    self.format_ts_type(&index_signature.type_annotation.type_annotation);
+                Self::format_index_signature(index_signature, &name, &value_type)
+            }
+            _ => self.format_span(member.span().start, member.span().end),
+        }
     }
 
     /// Format a TypeScript type name.
@@ -1458,36 +1609,51 @@ impl<'a> DocVisitor<'a> {
             .filter_map(Self::parse_param_tag)
             .collect();
 
-        let mut docs = params
-            .items
-            .iter()
-            .map(|param| {
-                let name = Self::binding_pattern_name(&param.pattern);
-                let tag = Self::find_parsed_param_tag(&parsed_param_tags, &name);
-                let default_value = self
-                    .binding_pattern_default_value(&param.pattern)
-                    .or_else(|| {
-                        param
-                            .initializer
-                            .as_ref()
-                            .map(|init| self.slice(init.span().start, init.span().end))
-                    })
-                    .or_else(|| tag.and_then(|tag| tag.default_value.clone()));
+        let mut docs = Vec::with_capacity(params.items.len() + usize::from(params.rest.is_some()));
 
-                let type_annotation = param
-                    .type_annotation
-                    .as_ref()
-                    .map(|t| self.format_ts_type(&t.type_annotation))
-                    .or_else(|| tag.and_then(|tag| tag.type_annotation.clone()));
+        for param in &params.items {
+            let name = Self::binding_pattern_name(&param.pattern);
+            let tag = Self::find_parsed_param_tag(&parsed_param_tags, &name);
+            let default_value = self
+                .binding_pattern_default_value(&param.pattern)
+                .or_else(|| {
+                    param
+                        .initializer
+                        .as_ref()
+                        .map(|init| self.slice(init.span().start, init.span().end))
+                })
+                .or_else(|| tag.and_then(|tag| tag.default_value.clone()));
 
-                let optional = param.optional
-                    || default_value.is_some()
-                    || tag.is_some_and(|tag| tag.optional);
-                let description = tag.and_then(|tag| tag.description.clone());
+            let type_annotation = param
+                .type_annotation
+                .as_ref()
+                .map(|t| self.format_ts_type(&t.type_annotation))
+                .or_else(|| tag.and_then(|tag| tag.type_annotation.clone()));
 
-                ParamDoc { name, type_annotation, optional, default_value, description }
-            })
-            .collect::<Vec<_>>();
+            let optional =
+                param.optional || default_value.is_some() || tag.is_some_and(|tag| tag.optional);
+            let description = tag.and_then(|tag| tag.description.clone());
+
+            docs.push(ParamDoc {
+                name: name.clone(),
+                type_annotation,
+                optional,
+                default_value,
+                description,
+            });
+
+            if let Some(type_literal) = param
+                .type_annotation
+                .as_ref()
+                .and_then(|t| Self::type_literal_from_ts_type(&t.type_annotation))
+            {
+                docs.extend(self.extract_type_literal_param_members(
+                    &name,
+                    type_literal,
+                    &parsed_param_tags,
+                ));
+            }
+        }
 
         if let Some(rest) = params.rest.as_ref() {
             let name = Self::binding_pattern_name(&rest.rest.argument);
@@ -1499,15 +1665,104 @@ impl<'a> DocVisitor<'a> {
                 .or_else(|| tag.and_then(|tag| tag.type_annotation.clone()));
 
             docs.push(ParamDoc {
-                name,
+                name: name.clone(),
                 type_annotation,
                 optional: tag.is_some_and(|tag| tag.optional),
                 default_value: tag.and_then(|tag| tag.default_value.clone()),
                 description: tag.and_then(|tag| tag.description.clone()),
             });
+
+            if let Some(type_literal) = rest
+                .type_annotation
+                .as_ref()
+                .and_then(|t| Self::type_literal_from_ts_type(&t.type_annotation))
+            {
+                docs.extend(self.extract_type_literal_param_members(
+                    &name,
+                    type_literal,
+                    &parsed_param_tags,
+                ));
+            }
         }
 
         docs
+    }
+
+    fn type_literal_from_ts_type<'t>(ts_type: &'t TSType<'a>) -> Option<&'t TSTypeLiteral<'a>> {
+        match ts_type {
+            TSType::TSTypeLiteral(type_literal) => Some(type_literal),
+            TSType::TSParenthesizedType(paren) => {
+                Self::type_literal_from_ts_type(&paren.type_annotation)
+            }
+            _ => None,
+        }
+    }
+
+    fn extract_type_literal_param_members(
+        &self,
+        parent_name: &str,
+        type_literal: &TSTypeLiteral<'a>,
+        parsed_param_tags: &[ParsedParamTag],
+    ) -> Vec<ParamDoc> {
+        let mut params = Vec::new();
+        for member in &type_literal.members {
+            match member {
+                TSSignature::TSPropertySignature(prop) => {
+                    let Some(property_name) = Self::property_key_name(&prop.key) else {
+                        continue;
+                    };
+                    let lookup_name = join3(parent_name, ".", &property_name);
+                    let tag = Self::find_exact_parsed_param_tag(parsed_param_tags, &lookup_name);
+                    let optional = prop.optional || tag.is_some_and(|tag| tag.optional);
+                    let name =
+                        if optional { join2(&lookup_name, "?") } else { lookup_name.clone() };
+                    let type_annotation = prop
+                        .type_annotation
+                        .as_ref()
+                        .map(|t| self.format_ts_type(&t.type_annotation))
+                        .or_else(|| tag.and_then(|tag| tag.type_annotation.clone()));
+
+                    params.push(ParamDoc {
+                        name,
+                        type_annotation,
+                        optional,
+                        default_value: tag.and_then(|tag| tag.default_value.clone()),
+                        description: tag.and_then(|tag| tag.description.clone()),
+                    });
+                }
+                TSSignature::TSMethodSignature(method) => {
+                    let Some(method_name) = Self::property_key_name(&method.key) else {
+                        continue;
+                    };
+                    let lookup_name = join3(parent_name, ".", &method_name);
+                    let tag = Self::find_exact_parsed_param_tag(parsed_param_tags, &lookup_name);
+                    let optional = method.optional || tag.is_some_and(|tag| tag.optional);
+                    let name =
+                        if optional { join2(&lookup_name, "?") } else { lookup_name.clone() };
+                    let params_text = self.format_type_formal_parameters(&method.params);
+                    let return_type = method.return_type.as_ref().map_or_else(
+                        || "unknown".to_string(),
+                        |t| self.format_ts_type(&t.type_annotation),
+                    );
+                    let mut type_annotation =
+                        StringBuilder::with_capacity(params_text.len() + return_type.len() + 6);
+                    type_annotation.push_char('(');
+                    type_annotation.push_str(&params_text);
+                    type_annotation.push_str(") => ");
+                    type_annotation.push_str(&return_type);
+
+                    params.push(ParamDoc {
+                        name,
+                        type_annotation: Some(type_annotation.into_string()),
+                        optional,
+                        default_value: tag.and_then(|tag| tag.default_value.clone()),
+                        description: tag.and_then(|tag| tag.description.clone()),
+                    });
+                }
+                _ => {}
+            }
+        }
+        params
     }
 
     /// Extract parameters from a function.
@@ -2464,6 +2719,73 @@ export function add(a: number, b: number): number {
         assert!(items[0].exported);
         assert!(items[0].doc.as_ref().unwrap().contains("Adds two numbers"));
         assert_eq!(items[0].params.len(), 2);
+    }
+
+    #[test]
+    fn function_object_literal_parameter_preserves_type_and_members() {
+        let source = r"
+/**
+ * Define a plugin.
+ *
+ * @param options - Plugin options.
+ * @param options.id - Plugin id.
+ * @param options.name - Plugin display name.
+ * @param options.setup - Setup hook.
+ */
+export function plugin<Id, Deps, PluginExt, MergedExtensions>(options: {
+    id: Id;
+    name?: string;
+    dependencies?: Deps;
+    setup?: (
+        ctx: Readonly<
+            PluginContext<MergedExtensions>
+        >
+    ) => Awaitable<void>;
+    extension: PluginExt;
+    onExtension?: OnPluginExtension<MergedExtensions>;
+}): PluginWithExtension<PluginExt>;
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "plugin.ts", SourceType::ts()).unwrap();
+        let plugin = items.iter().find(|item| item.name == "plugin").unwrap();
+
+        assert_eq!(plugin.params.len(), 7);
+        assert_eq!(plugin.params[0].name, "options");
+        let parent_type = plugin.params[0].type_annotation.as_deref().unwrap();
+        assert_ne!(parent_type, "{ ... }");
+        assert!(parent_type.contains("id: Id"));
+        assert!(parent_type.contains("name?: string"));
+        assert!(parent_type.contains(
+            "setup?: (ctx: Readonly<PluginContext<MergedExtensions>>) => Awaitable<void>"
+        ));
+        assert_eq!(plugin.params[0].description.as_deref(), Some("Plugin options."));
+
+        let names = plugin.params.iter().map(|param| param.name.as_str()).collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            [
+                "options",
+                "options.id",
+                "options.name?",
+                "options.dependencies?",
+                "options.setup?",
+                "options.extension",
+                "options.onExtension?",
+            ]
+        );
+        assert_eq!(plugin.params[1].type_annotation.as_deref(), Some("Id"));
+        assert_eq!(plugin.params[1].description.as_deref(), Some("Plugin id."));
+        assert_eq!(plugin.params[2].description.as_deref(), Some("Plugin display name."));
+        assert_eq!(
+            plugin.params[4].type_annotation.as_deref(),
+            Some("(ctx: Readonly<PluginContext<MergedExtensions>>) => Awaitable<void>")
+        );
+        assert_eq!(plugin.params[4].description.as_deref(), Some("Setup hook."));
+        assert!(plugin.params[2].optional);
+        assert!(plugin.params[3].optional);
+        assert!(plugin.params[4].optional);
+        assert!(plugin.params[6].optional);
     }
 
     #[test]

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -4494,6 +4494,43 @@ mod tests {
         }
     }
 
+    fn object_literal_parameter_entry() -> ApiDocEntry {
+        let mut entry = test_entry("plugin", "function", "/repo/src/plugin.ts", "Define a plugin.");
+        entry.params = vec![
+            ApiParamDoc {
+                name: "options".to_string(),
+                type_annotation:
+                    "{ id: Id; name?: string; setup?: (ctx: PluginContext) => Awaitable<void> }"
+                        .to_string(),
+                description: "Plugin options.".to_string(),
+                optional: false,
+                default_value: None,
+            },
+            ApiParamDoc {
+                name: "options.id".to_string(),
+                type_annotation: "Id".to_string(),
+                description: "Plugin id.".to_string(),
+                optional: false,
+                default_value: None,
+            },
+            ApiParamDoc {
+                name: "options.name?".to_string(),
+                type_annotation: "string".to_string(),
+                description: String::new(),
+                optional: true,
+                default_value: None,
+            },
+            ApiParamDoc {
+                name: "options.setup?".to_string(),
+                type_annotation: "(ctx: PluginContext) => Awaitable<void>".to_string(),
+                description: "Setup hook.".to_string(),
+                optional: true,
+                default_value: None,
+            },
+        ];
+        entry
+    }
+
     fn module_with_source_path(source_path: &str) -> Vec<ApiDocModule> {
         vec![ApiDocModule {
             description: String::new(),
@@ -4504,6 +4541,43 @@ mod tests {
             tags: vec![],
             entries: vec![test_entry("cli", "function", "/repo/packages/x/src/cli.ts", "Run.")],
         }]
+    }
+
+    #[test]
+    fn typedoc_markdown_renders_object_literal_parameter_members() {
+        let options = MarkdownDocsOptions {
+            parameters_format: MarkdownDisplayFormat::Table,
+            ..markdown_typedoc_options()
+        };
+        let out = generate_markdown(&type_link_module(object_literal_parameter_entry()), &options);
+        let page = out.get("combinators/functions/plugin.md").unwrap();
+
+        assert!(!page.contains("{ ... }"));
+        assert!(page.contains("| `options` | `{ id: Id; name?: string; setup?: (ctx: PluginContext) => Awaitable<void> }` | Plugin options. |"));
+        assert!(page.contains("| `options.id` | `Id` | Plugin id. |"));
+        assert!(page.contains("| `options.name?` | `string` | _optional_ |"));
+        assert!(page.contains(
+            "| `options.setup?` | `(ctx: PluginContext) => Awaitable<void>` | Setup hook. _(optional)_ |"
+        ));
+    }
+
+    #[test]
+    fn typedoc_html_renders_object_literal_parameter_members() {
+        let options = MarkdownDocsOptions {
+            parameters_format: MarkdownDisplayFormat::Table,
+            ..html_typedoc_options()
+        };
+        let out = generate_markdown(&type_link_module(object_literal_parameter_entry()), &options);
+        let page = out.get("combinators/functions/plugin.md").unwrap();
+
+        assert!(!page.contains("{ ... }"));
+        assert!(page.contains(
+            "{ id: Id; name?: string; setup?: (ctx: PluginContext) =&gt; Awaitable&lt;void&gt; }"
+        ));
+        assert!(page.contains("options.id"));
+        assert!(page.contains("Plugin id."));
+        assert!(page.contains("options.setup?"));
+        assert!(page.contains("Setup hook."));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -534,11 +534,15 @@ fn is_placeholder_param(existing_params: &[NormalizedParamDoc], param: &ParamDoc
 }
 
 fn merge_param(params: &mut Vec<NormalizedParamDoc>, next: NormalizedParamDoc) {
-    let Some(existing) = params.iter_mut().find(|param| param.name == next.name) else {
+    let Some(existing) = params.iter_mut().find(|param| param_names_match(&param.name, &next.name))
+    else {
         params.push(next);
         return;
     };
 
+    if existing.name != next.name && next.name.ends_with('?') {
+        existing.name.clone_from(&next.name);
+    }
     if existing.type_annotation == UNKNOWN_TYPE || next.type_annotation != UNKNOWN_TYPE {
         existing.type_annotation = next.type_annotation;
     }
@@ -551,6 +555,10 @@ fn merge_param(params: &mut Vec<NormalizedParamDoc>, next: NormalizedParamDoc) {
     if next.default_value.is_some() {
         existing.default_value = next.default_value;
     }
+}
+
+fn param_names_match(left: &str, right: &str) -> bool {
+    left == right || left.trim_end_matches('?') == right.trim_end_matches('?')
 }
 
 fn merge_returns(returns: &mut Option<NormalizedReturnDoc>, next: NormalizedReturnDoc) {

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -3776,6 +3776,68 @@ export type OnPluginExtension<G> = (
     }
 
     #[test]
+    fn extract_file_doc_entries_preserves_object_literal_parameter_members() {
+        let unique =
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos();
+        let root = std::env::temp_dir()
+            .join(format!("ox-content-napi-object-literal-param-{}-{unique}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let file = root.join("plugin.ts");
+        fs::write(
+            &file,
+            r"
+/**
+ * Define a plugin.
+ *
+ * @param options - Plugin options.
+ * @param options.id - Plugin id.
+ * @param options.name - Plugin display name.
+ */
+export function plugin<Id, PluginExt>(options: {
+    id: Id;
+    name?: string;
+    setup?: (
+        ctx: Readonly<
+            PluginContext
+        >
+    ) => Awaitable<void>;
+    extension: PluginExt;
+}): PluginWithExtension<PluginExt>;
+",
+        )
+        .unwrap();
+
+        let entries =
+            extract_file_doc_entries(file.to_string_lossy().into_owned(), None, None, None)
+                .unwrap();
+        let entry = entries.iter().find(|entry| entry.name == "plugin").unwrap();
+        let params = entry.params.as_ref().unwrap();
+
+        assert_eq!(params.len(), 5);
+        assert_eq!(params[0].name, "options");
+        assert_ne!(params[0].r#type, "{ ... }");
+        assert!(params[0].r#type.contains("id: Id"));
+        assert!(params[0].r#type.contains("name?: string"));
+        assert!(params[0]
+            .r#type
+            .contains("setup?: (ctx: Readonly<PluginContext>) => Awaitable<void>"));
+        assert_eq!(params[0].description, "Plugin options.");
+        assert_eq!(params[1].name, "options.id");
+        assert_eq!(params[1].r#type, "Id");
+        assert_eq!(params[1].description, "Plugin id.");
+        assert_eq!(params[2].name, "options.name?");
+        assert_eq!(params[2].description, "Plugin display name.");
+        assert_eq!(params[2].optional, Some(true));
+        assert_eq!(params[3].name, "options.setup?");
+        assert_eq!(params[3].r#type, "(ctx: Readonly<PluginContext>) => Awaitable<void>");
+        assert_eq!(params[4].name, "options.extension");
+        assert_eq!(params[4].r#type, "PluginExt");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn has_body_round_trips_from_extract_output_to_markdown_model() {
         let normalized = NormalizedDocEntry {
             name: "plugin".to_string(),


### PR DESCRIPTION
## Summary

Preserve inline object literal parameter types and emit TypeDoc-style child rows such as `options.id` in generated docs.

Adds extractor, normalization, Markdown, HTML, and NAPI regression coverage.

## Background

gunshi note 060 showed `@ox-content/napi` collapsing `plugin(options: { ... })` parameters to `{ ... }`.

The type shape was lost during extraction, before Markdown rendering, so the fix expands `TSTypeLiteral` metadata in the extractor.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783245981&installation_id=136613492&pr_number=329&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F329&signature=8b5b60afd8e21c93066daf5b45883c86698a4214dc2423867fa3dde3563ab6bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->