### PR TITLE
fix(docs): render member type parameters

### DIFF
--- a/crates/ox_content_docs/benches/markdown.rs
+++ b/crates/ox_content_docs/benches/markdown.rs
@@ -132,6 +132,7 @@ fn member(module: usize, entry: usize, index: usize) -> ApiDocMember {
         } else {
             Vec::new()
         },
+        type_parameters: Vec::new(),
         returns: (kind != "property").then(|| ApiReturnDoc {
             type_annotation: "boolean".to_string(),
             description: "Whether the member accepted the value.".to_string(),

--- a/crates/ox_content_docs/src/data.rs
+++ b/crates/ox_content_docs/src/data.rs
@@ -191,6 +191,12 @@ fn member_to_json(member: &ApiDocMember) -> Value {
             Value::Array(member.params.iter().map(param_to_json).collect()),
         );
     }
+    if !member.type_parameters.is_empty() {
+        value.insert(
+            "typeParameters".to_string(),
+            Value::Array(member.type_parameters.iter().map(type_param_to_json).collect()),
+        );
+    }
     if let Some(returns) = &member.returns {
         value.insert("returns".to_string(), return_to_json(returns));
     }
@@ -476,6 +482,7 @@ mod tests {
                         signature: None,
                         type_annotation: Some("ArgValues<A>".to_string()),
                         params: vec![],
+                        type_parameters: vec![],
                         returns: None,
                         optional: false,
                         readonly: false,
@@ -548,6 +555,7 @@ mod tests {
                         optional: false,
                         default_value: None,
                     }],
+                    type_parameters: vec![],
                     returns: None,
                     optional: false,
                     readonly: true,
@@ -612,6 +620,12 @@ mod tests {
                         optional: false,
                         default_value: None,
                     }],
+                    type_parameters: vec![ApiTypeParamDoc {
+                        name: "T".to_string(),
+                        constraint: Some("Base".to_string()),
+                        default: Some("Default".to_string()),
+                        description: "Parsed value type.".to_string(),
+                    }],
                     returns: Some(ApiReturnDoc {
                         type_annotation: "any".to_string(),
                         description: "Parsed value.".to_string(),
@@ -639,6 +653,10 @@ mod tests {
         assert_eq!(member["type"], "(value: string) => any");
         assert_eq!(member["params"][0]["name"], "value");
         assert_eq!(member["params"][0]["type"], "string");
+        assert_eq!(member["typeParameters"][0]["name"], "T");
+        assert_eq!(member["typeParameters"][0]["constraint"], "Base");
+        assert_eq!(member["typeParameters"][0]["default"], "Default");
+        assert_eq!(member["typeParameters"][0]["description"], "Parsed value type.");
         assert_eq!(member["returns"]["type"], "any");
         assert_eq!(member["returns"]["description"], "Parsed value.");
         assert_eq!(member["optional"], true);
@@ -794,6 +812,7 @@ mod tests {
                     ),
                     type_annotation: None,
                     params: vec![],
+                    type_parameters: vec![],
                     returns: None,
                     optional: false,
                     readonly: false,

--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -131,6 +131,13 @@ pub struct TypeParamDoc {
     pub description: String,
 }
 
+struct FunctionTypeMetadata {
+    params: Vec<ParamDoc>,
+    return_type: Option<String>,
+    return_members: Vec<DocItem>,
+    type_parameters: Vec<TypeParamDoc>,
+}
+
 /// JSDoc tag.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DocTag {
@@ -1812,16 +1819,17 @@ impl<'a> DocVisitor<'a> {
         &self,
         ts_type: &TSType,
         tags: &[DocTag],
-    ) -> Option<(Vec<ParamDoc>, Option<String>, Vec<DocItem>)> {
+    ) -> Option<FunctionTypeMetadata> {
         match ts_type {
             TSType::TSFunctionType(func) => {
                 let (return_type, return_members) =
                     self.extract_return_from_annotation(Some(&func.return_type), tags);
-                Some((
-                    self.extract_params_from_formals(&func.params, tags),
+                Some(FunctionTypeMetadata {
+                    params: self.extract_params_from_formals(&func.params, tags),
                     return_type,
                     return_members,
-                ))
+                    type_parameters: self.extract_type_parameters(func.type_parameters.as_ref()),
+                })
             }
             TSType::TSParenthesizedType(paren) => {
                 self.extract_function_type_metadata(&paren.type_annotation, tags)
@@ -1946,7 +1954,8 @@ impl<'a> DocVisitor<'a> {
                         return_members,
                         children: Vec::new(),
                         tags: method_tags,
-                        type_parameters: Vec::new(),
+                        type_parameters: self
+                            .extract_type_parameters(method.value.type_parameters.as_ref()),
                     });
                 }
                 oxc_ast::ast::ClassElement::PropertyDefinition(prop) => {
@@ -1969,17 +1978,16 @@ impl<'a> DocVisitor<'a> {
                     let mut params = Vec::new();
                     let mut return_type = None;
                     let mut return_members = Vec::new();
+                    let mut type_parameters = Vec::new();
                     let type_annotation = prop.type_annotation.as_ref().map(|t| {
                         let ts_type = &t.type_annotation;
-                        if let Some((
-                            extracted_params,
-                            extracted_return_type,
-                            extracted_return_members,
-                        )) = self.extract_function_type_metadata(ts_type, &prop_tags)
+                        if let Some(metadata) =
+                            self.extract_function_type_metadata(ts_type, &prop_tags)
                         {
-                            params = extracted_params;
-                            return_type = extracted_return_type;
-                            return_members = extracted_return_members;
+                            params = metadata.params;
+                            return_type = metadata.return_type;
+                            return_members = metadata.return_members;
+                            type_parameters = metadata.type_parameters;
                         }
 
                         self.format_ts_type(ts_type)
@@ -2007,7 +2015,7 @@ impl<'a> DocVisitor<'a> {
                         return_members,
                         children: Vec::new(),
                         tags: prop_tags,
-                        type_parameters: Vec::new(),
+                        type_parameters,
                     });
                 }
                 oxc_ast::ast::ClassElement::TSIndexSignature(index_signature) => {
@@ -2074,17 +2082,16 @@ impl<'a> DocVisitor<'a> {
                     let mut params = Vec::new();
                     let mut return_type = None;
                     let mut return_members = Vec::new();
+                    let mut type_parameters = Vec::new();
                     let type_annotation = prop.type_annotation.as_ref().map(|t| {
                         let ts_type = &t.type_annotation;
-                        if let Some((
-                            extracted_params,
-                            extracted_return_type,
-                            extracted_return_members,
-                        )) = self.extract_function_type_metadata(ts_type, &prop_tags)
+                        if let Some(metadata) =
+                            self.extract_function_type_metadata(ts_type, &prop_tags)
                         {
-                            params = extracted_params;
-                            return_type = extracted_return_type;
-                            return_members = extracted_return_members;
+                            params = metadata.params;
+                            return_type = metadata.return_type;
+                            return_members = metadata.return_members;
+                            type_parameters = metadata.type_parameters;
                         }
 
                         self.format_ts_type(ts_type)
@@ -2112,7 +2119,7 @@ impl<'a> DocVisitor<'a> {
                         return_members,
                         children: Vec::new(),
                         tags: prop_tags,
-                        type_parameters: Vec::new(),
+                        type_parameters,
                     });
                 }
                 TSSignature::TSMethodSignature(method) => {
@@ -2170,7 +2177,8 @@ impl<'a> DocVisitor<'a> {
                         return_members,
                         children: Vec::new(),
                         tags: method_tags,
-                        type_parameters: Vec::new(),
+                        type_parameters: self
+                            .extract_type_parameters(method.type_parameters.as_ref()),
                     });
                 }
                 TSSignature::TSIndexSignature(index_signature) => {
@@ -2488,18 +2496,18 @@ impl<'a> DocVisitor<'a> {
         let mut params = Vec::new();
         let mut return_type = None;
         let mut return_members = Vec::new();
+        let mut function_type_parameters = Vec::new();
 
         match &type_alias.type_annotation {
             TSType::TSTypeLiteral(type_literal) => {
                 children = self.extract_ts_signature_members(&type_literal.members);
             }
             ts_type => {
-                if let Some((extracted_params, extracted_return_type, extracted_return_members)) =
-                    self.extract_function_type_metadata(ts_type, &tags)
-                {
-                    params = extracted_params;
-                    return_type = extracted_return_type;
-                    return_members = extracted_return_members;
+                if let Some(metadata) = self.extract_function_type_metadata(ts_type, &tags) {
+                    params = metadata.params;
+                    return_type = metadata.return_type;
+                    return_members = metadata.return_members;
+                    function_type_parameters = metadata.type_parameters;
                 }
             }
         }
@@ -2526,7 +2534,12 @@ impl<'a> DocVisitor<'a> {
             return_members,
             children,
             tags,
-            type_parameters: self.extract_type_parameters(type_alias.type_parameters.as_ref()),
+            type_parameters: {
+                let mut type_parameters =
+                    self.extract_type_parameters(type_alias.type_parameters.as_ref());
+                type_parameters.extend(function_type_parameters);
+                type_parameters
+            },
         });
     }
 
@@ -3378,6 +3391,46 @@ export function make<G extends Base = Default, V>(value: V): G {
         assert_eq!(func.type_parameters[1].name, "V");
         assert_eq!(func.type_parameters[1].constraint, None);
         assert_eq!(func.type_parameters[1].default, None);
+    }
+
+    #[test]
+    fn test_extract_member_type_parameters() {
+        let source = r"
+/** Plugin context. */
+export interface PluginContext<G> {
+  /**
+   * Decorate the command.
+   * @typeParam L - Extension context.
+   */
+  decorateCommand<L extends Record<string, unknown> = DefaultExtensions>(
+    decorator: (value: L) => void
+  ): void;
+
+  /**
+   * Setup hook.
+   * @typeParam T - Hook value.
+   */
+  setup?: <T extends BaseHook = DefaultHook>(value: T) => Result;
+}
+";
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "src/context.ts", SourceType::ts()).unwrap();
+        let interface = items.iter().find(|item| item.name == "PluginContext").unwrap();
+
+        let method = interface.children.iter().find(|item| item.name == "decorateCommand").unwrap();
+        assert_eq!(method.type_parameters.len(), 1);
+        assert_eq!(method.type_parameters[0].name, "L");
+        assert_eq!(
+            method.type_parameters[0].constraint.as_deref(),
+            Some("Record<string, unknown>")
+        );
+        assert_eq!(method.type_parameters[0].default.as_deref(), Some("DefaultExtensions"));
+
+        let property = interface.children.iter().find(|item| item.name == "setup").unwrap();
+        assert_eq!(property.type_parameters.len(), 1);
+        assert_eq!(property.type_parameters[0].name, "T");
+        assert_eq!(property.type_parameters[0].constraint.as_deref(), Some("BaseHook"));
+        assert_eq!(property.type_parameters[0].default.as_deref(), Some("DefaultHook"));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -2873,6 +2873,7 @@ mod tests {
                         signature: Some("run(): void".to_string()),
                         type_annotation: None,
                         params: vec![],
+                        type_parameters: vec![],
                         returns: None,
                         optional: false,
                         readonly: false,
@@ -3284,6 +3285,7 @@ mod tests {
                         signature: None,
                         type_annotation: Some("Record<string, unknown>".to_string()),
                         params: vec![],
+                        type_parameters: vec![],
                         returns: None,
                         optional: false,
                         readonly: false,
@@ -3419,6 +3421,7 @@ mod tests {
                         signature: None,
                         type_annotation: Some("boolean".to_string()),
                         params: vec![],
+                        type_parameters: vec![],
                         returns: None,
                         optional: true,
                         readonly: false,
@@ -3886,6 +3889,7 @@ mod tests {
             signature: None,
             type_annotation: Some("string".to_string()),
             params: vec![],
+            type_parameters: vec![],
             returns: None,
             optional: false,
             readonly: true,
@@ -3949,6 +3953,7 @@ mod tests {
                 optional: false,
                 default_value: None,
             }],
+            type_parameters: vec![],
             returns: None,
             optional: false,
             readonly: false,
@@ -3998,6 +4003,81 @@ mod tests {
     }
 
     #[test]
+    fn markdown_member_type_parameters_render_before_parameters() {
+        let mut entry =
+            test_entry("PluginContext", "interface", "src/context.ts", "Plugin context.");
+        entry.members = vec![ApiDocMember {
+            name: "decorateCommand".to_string(),
+            kind: "method".to_string(),
+            description: "Decorate the command.".to_string(),
+            signature: Some(
+                "decorateCommand<L extends Record<string, unknown> = DefaultExtensions>(decorator: (value: L) => void): void"
+                    .to_string(),
+            ),
+            type_annotation: None,
+            params: vec![ApiParamDoc {
+                name: "decorator".to_string(),
+                type_annotation: "(value: L) => void".to_string(),
+                description: "Decorator function.".to_string(),
+                optional: false,
+                default_value: None,
+            }],
+            type_parameters: vec![ApiTypeParamDoc {
+                name: "L".to_string(),
+                constraint: Some("Record<string, unknown>".to_string()),
+                default: Some("DefaultExtensions".to_string()),
+                description: "Extension context.".to_string(),
+            }],
+            returns: None,
+            optional: false,
+            readonly: false,
+            r#static: false,
+            private: false,
+            tags: vec![],
+            implementation_of: vec![],
+            line: 2,
+            end_line: 5,
+        }];
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "mod".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![entry],
+        }];
+
+        let pure = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                render_style: MarkdownRenderStyle::Markdown,
+                parameters_format: MarkdownDisplayFormat::Table,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let page = pure.get("mod/interfaces/PluginContext.md").unwrap();
+        let type_parameters = page.find("#### Type Parameters").unwrap();
+        let parameters = page.find("#### Parameters").unwrap();
+        assert!(type_parameters < parameters);
+        assert!(page.contains("`L` *extends*"));
+        assert!(page.contains("Extension context."));
+
+        let html = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                render_style: MarkdownRenderStyle::Html,
+                parameters_format: MarkdownDisplayFormat::Table,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let page = html.get("mod/interfaces/PluginContext.md").unwrap();
+        assert!(page.contains("<h6>Type Parameters</h6>"));
+        assert!(page.contains("Extension context."));
+    }
+
+    #[test]
     fn typedoc_markdown_renders_class_callable_member_details() {
         let mut adapter =
             test_entry("TranslationAdapter", "interface", "/repo/src/i18n.ts", "Runtime adapter.");
@@ -4016,6 +4096,7 @@ mod tests {
                 optional: false,
                 default_value: None,
             }],
+            type_parameters: vec![],
             returns: Some(ApiReturnDoc {
                 type_annotation: "Record<string, string> | undefined".to_string(),
                 description: "The locale resource.".to_string(),
@@ -4056,6 +4137,7 @@ mod tests {
                     optional: false,
                     default_value: None,
                 }],
+                type_parameters: vec![],
                 returns: None,
                 optional: false,
                 readonly: false,
@@ -4081,6 +4163,7 @@ mod tests {
                     optional: false,
                     default_value: None,
                 }],
+                type_parameters: vec![],
                 returns: Some(ApiReturnDoc {
                     type_annotation: "Record<string, string> | undefined".to_string(),
                     description: "The locale resource.".to_string(),
@@ -4152,6 +4235,7 @@ mod tests {
                 optional: false,
                 default_value: None,
             }],
+            type_parameters: vec![],
             returns: Some(ApiReturnDoc {
                 type_annotation: "string | undefined".to_string(),
                 description: "Parsed value.".to_string(),
@@ -4220,6 +4304,7 @@ mod tests {
                 signature: None,
                 type_annotation: Some("string".to_string()),
                 params: vec![],
+                type_parameters: vec![],
                 returns: None,
                 optional: false,
                 readonly: true,
@@ -4243,6 +4328,7 @@ mod tests {
                     optional: false,
                     default_value: None,
                 }],
+                type_parameters: vec![],
                 returns: None,
                 optional: false,
                 readonly: false,
@@ -4963,6 +5049,7 @@ mod tests {
                 optional: false,
                 default_value: None,
             }],
+            type_parameters: vec![],
             returns: Some(ApiReturnDoc {
                 type_annotation: "Record<string, string> | undefined".to_string(),
                 description: "The locale resource.".to_string(),
@@ -5002,6 +5089,7 @@ mod tests {
                 optional: false,
                 default_value: None,
             }],
+            type_parameters: vec![],
             returns: Some(ApiReturnDoc {
                 type_annotation: "Record<string, string> | undefined".to_string(),
                 description: "The locale resource.".to_string(),
@@ -5046,6 +5134,7 @@ mod tests {
             signature: None,
             type_annotation: Some("unknown".to_string()),
             params: vec![],
+            type_parameters: vec![],
             returns: None,
             optional: false,
             readonly: false,
@@ -5168,6 +5257,7 @@ mod tests {
             signature: None,
             type_annotation: Some(type_annotation.to_string()),
             params: vec![],
+            type_parameters: vec![],
             returns: None,
             optional: false,
             readonly: false,
@@ -5198,6 +5288,7 @@ mod tests {
             }),
             type_annotation: Some(value_type.to_string()),
             params: vec![param(param_name, param_type)],
+            type_parameters: vec![],
             returns: None,
             optional: false,
             readonly,
@@ -5763,6 +5854,7 @@ mod tests {
             signature: None,
             type_annotation: Some("string".to_string()),
             params: vec![],
+            type_parameters: vec![],
             returns: None,
             optional: false,
             readonly: false,
@@ -6032,6 +6124,7 @@ mod tests {
             signature: None,
             type_annotation: Some("number".to_string()),
             params: vec![],
+            type_parameters: vec![],
             returns: None,
             optional: true,
             readonly: false,
@@ -6097,6 +6190,7 @@ mod tests {
             signature: None,
             type_annotation: Some("boolean".to_string()),
             params: vec![],
+            type_parameters: vec![],
             returns: None,
             optional: true,
             readonly: false,
@@ -6446,6 +6540,7 @@ mod tests {
                         signature: None,
                         type_annotation: Some("\"strict\"".to_string()),
                         params: vec![],
+                        type_parameters: vec![],
                         returns: None,
                         optional: false,
                         readonly: false,
@@ -6533,6 +6628,7 @@ mod tests {
                         signature: None,
                         type_annotation: Some("string".to_string()),
                         params: vec![],
+                        type_parameters: vec![],
                         returns: None,
                         optional: false,
                         readonly: true,
@@ -6556,6 +6652,7 @@ mod tests {
                             optional: false,
                             default_value: None,
                         }],
+                        type_parameters: vec![],
                         returns: Some(ApiReturnDoc {
                             type_annotation: "Promise".to_string(),
                             description: "Run result.".to_string(),

--- a/crates/ox_content_docs/src/markdown/markdown_html.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_html.rs
@@ -901,6 +901,10 @@ fn render_member_description_html(
         ));
     }
 
+    if !member.type_parameters.is_empty() {
+        blocks.push(render_member_type_parameters_html(&member.type_parameters, options, context));
+    }
+
     if !member.params.is_empty() {
         blocks.push(render_member_params_html(&member.params, options, context));
     }
@@ -1000,6 +1004,43 @@ fn render_member_params_html(
         items.push_str("</li>");
     }
     join3("<ul class=\"ox-api-entry__member-params\">", &items.into_string(), "</ul>")
+}
+
+fn render_member_type_parameters_html(
+    type_parameters: &[ApiTypeParamDoc],
+    options: &MarkdownDocsOptions,
+    context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    let skip = type_parameter_skip_set(type_parameters);
+    if effective_parameters_format(options) == MarkdownDisplayFormat::Table {
+        let mut rows = StringBuilder::new();
+        for type_param in type_parameters {
+            rows.push_str("<tr><td>");
+            rows.push_str(&render_type_parameter_name_html(type_param, context, &skip));
+            rows.push_str("</td><td>");
+            rows.push_str(&render_doc_inline_html(&type_param.description, context));
+            rows.push_str("</td></tr>");
+        }
+        return join3(
+            "<table class=\"ox-api-entry__type-parameters-table\"><thead><tr><th>Name</th><th>Description</th></tr></thead><tbody>",
+            &rows.into_string(),
+            "</tbody></table>",
+        );
+    }
+
+    let mut items = StringBuilder::new();
+    for type_param in type_parameters {
+        items.push_str("<li class=\"ox-api-entry__type-parameter\"><div class=\"ox-api-entry__type-parameter-heading\">");
+        items.push_str(&render_type_parameter_name_html(type_param, context, &skip));
+        items.push_str("</div>");
+        if !type_param.description.is_empty() {
+            items.push_str("<p class=\"ox-api-entry__type-parameter-description\">");
+            items.push_str(&render_doc_inline_html(&type_param.description, context));
+            items.push_str("</p>");
+        }
+        items.push_str("</li>");
+    }
+    join3("<ul class=\"ox-api-entry__type-parameters\">", &items.into_string(), "</ul>")
 }
 
 fn render_member_table_html(
@@ -1177,6 +1218,7 @@ fn render_callable_member_group_html(
             details.push_char('\n');
         }
         details.push_str(&render_member_detail_description_html(member, context));
+        details.push_str(&render_member_detail_type_parameters_html(member, options, context));
         details.push_str(&render_member_detail_params_html(member, options, context));
         if let Some(returns) = &member.returns {
             details.push_str(&render_member_detail_returns_html(returns, context));
@@ -1286,6 +1328,21 @@ fn render_member_detail_params_html(
     let mut out = StringBuilder::new();
     out.push_str("<div class=\"ox-api-entry__member-detail-section ox-api-entry__member-detail-section--params\">\n<h6>Parameters</h6>\n");
     out.push_str(&render_member_params_html(&member.params, options, context));
+    out.push_str("\n</div>");
+    out.into_string()
+}
+
+fn render_member_detail_type_parameters_html(
+    member: &ApiDocMember,
+    options: &MarkdownDocsOptions,
+    context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    if member.type_parameters.is_empty() {
+        return String::new();
+    }
+    let mut out = StringBuilder::new();
+    out.push_str("<div class=\"ox-api-entry__member-detail-section ox-api-entry__member-detail-section--type-parameters\">\n<h6>Type Parameters</h6>\n");
+    out.push_str(&render_member_type_parameters_html(&member.type_parameters, options, context));
     out.push_str("\n</div>");
     out.into_string()
 }

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -767,8 +767,43 @@ fn render_member_parameter_sections_pure(
     let heading = "#".repeat(section_level);
 
     for member in members {
-        if member.params.is_empty() && member.returns.is_none() {
+        if member.type_parameters.is_empty() && member.params.is_empty() && member.returns.is_none()
+        {
             continue;
+        }
+
+        if !member.type_parameters.is_empty() {
+            out.push_str(&heading);
+            out.push(' ');
+            out.push_str(&member.name);
+            out.push_str(" Type Parameters\n\n");
+            let skip: HashSet<&str> =
+                member.type_parameters.iter().map(|param| param.name.as_str()).collect();
+            match effective_parameters_format(options) {
+                MarkdownDisplayFormat::Table => {
+                    out.push_str("| Name | Description |\n| --- | --- |\n");
+                    for type_param in &member.type_parameters {
+                        out.push_str("| ");
+                        out.push_str(&type_param_name_cell(type_param, context, &skip));
+                        out.push_str(" | ");
+                        push_table_cell(&mut out, &inline(&type_param.description, context));
+                        out.push_str(" |\n");
+                    }
+                }
+                _ => {
+                    for type_param in &member.type_parameters {
+                        let description = inline(&type_param.description, context);
+                        out.push_str("- ");
+                        out.push_str(&type_param_name_span(type_param, context, &skip));
+                        if !description.is_empty() {
+                            out.push_str(" - ");
+                            out.push_str(&description);
+                        }
+                        out.push('\n');
+                    }
+                }
+            }
+            out.push('\n');
         }
 
         if !member.params.is_empty() {
@@ -935,6 +970,13 @@ fn render_callable_member_details_pure(
         }
 
         out.push_str(&render_since_section(&member.tags, context.link_context, &detail_heading));
+        push_type_parameters(
+            out,
+            &member.type_parameters,
+            context.options,
+            context.link_context,
+            &detail_heading,
+        );
         push_parameters(
             out,
             &member.params,

--- a/crates/ox_content_docs/src/model.rs
+++ b/crates/ox_content_docs/src/model.rs
@@ -99,6 +99,9 @@ pub struct ApiDocMember {
     /// Parameters.
     #[serde(default)]
     pub params: Vec<ApiParamDoc>,
+    /// Member type parameters (opt-in; empty unless enabled).
+    #[serde(default)]
+    pub type_parameters: Vec<ApiTypeParamDoc>,
     /// Return documentation.
     pub returns: Option<ApiReturnDoc>,
     /// Whether the member is optional.

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -202,6 +202,10 @@ pub struct NormalizedMember {
     /// Parameters, if any.
     #[serde(default)]
     pub params: Vec<NormalizedParamDoc>,
+    /// Member type parameters. Populated only when type-parameter docs are
+    /// enabled (opt-in); empty otherwise.
+    #[serde(default)]
+    pub type_parameters: Vec<NormalizedTypeParam>,
     /// Return documentation, if any.
     pub returns: Option<NormalizedReturnDoc>,
     /// Whether the member is optional.
@@ -291,8 +295,17 @@ pub fn normalize_doc_item(item: DocItem, type_parameters: bool) -> Option<Normal
 
     let mut metadata = normalize_doc_metadata(&item.tags, type_parameters);
     merge_extracted_params(&mut metadata.params, item.params);
-    merge_extracted_return(&mut metadata.returns, item.return_type, item.return_members);
-    let members = item.children.into_iter().filter_map(normalize_member).collect();
+    merge_extracted_return(
+        &mut metadata.returns,
+        item.return_type,
+        item.return_members,
+        type_parameters,
+    );
+    let members = item
+        .children
+        .into_iter()
+        .filter_map(|item| normalize_member(item, type_parameters))
+        .collect();
     let type_parameters = if type_parameters {
         build_type_parameters(item.type_parameters, &metadata.type_param_descriptions)
     } else {
@@ -320,15 +333,24 @@ pub fn normalize_doc_item(item: DocItem, type_parameters: bool) -> Option<Normal
     })
 }
 
-fn normalize_member(item: DocItem) -> Option<NormalizedMember> {
+fn normalize_member(item: DocItem, type_parameters: bool) -> Option<NormalizedMember> {
     let kind = NormalizedMemberKind::from_doc_item_kind(item.kind)?;
-    // Member-level type parameters are out of scope; keep generic-tag behavior.
-    let mut metadata = normalize_doc_metadata(&item.tags, false);
+    let mut metadata = normalize_doc_metadata(&item.tags, type_parameters);
     merge_extracted_params(&mut metadata.params, item.params);
     let mut return_type = item.return_type;
     if kind != NormalizedMemberKind::IndexSignature {
-        merge_extracted_return(&mut metadata.returns, return_type.take(), item.return_members);
+        merge_extracted_return(
+            &mut metadata.returns,
+            return_type.take(),
+            item.return_members,
+            type_parameters,
+        );
     }
+    let type_parameters = if type_parameters {
+        build_type_parameters(item.type_parameters, &metadata.type_param_descriptions)
+    } else {
+        Vec::new()
+    };
 
     let (signature, type_annotation) = match kind {
         NormalizedMemberKind::Property | NormalizedMemberKind::EnumMember => (None, item.signature),
@@ -346,6 +368,7 @@ fn normalize_member(item: DocItem) -> Option<NormalizedMember> {
         signature,
         type_annotation,
         params: metadata.params,
+        type_parameters,
         returns: metadata.returns,
         optional: item.optional,
         readonly: item.readonly,
@@ -500,8 +523,12 @@ fn merge_extracted_return(
     returns: &mut Option<NormalizedReturnDoc>,
     return_type: Option<String>,
     return_members: Vec<DocItem>,
+    type_parameters: bool,
 ) {
-    let members = return_members.into_iter().filter_map(normalize_member).collect::<Vec<_>>();
+    let members = return_members
+        .into_iter()
+        .filter_map(|item| normalize_member(item, type_parameters))
+        .collect::<Vec<_>>();
     if return_type.is_none() && members.is_empty() {
         return;
     }
@@ -1106,5 +1133,47 @@ export type Combinator<T> = { parse: (value: string) => T };
         assert_eq!(on.type_parameters[0].description, "The parsed value type.");
         assert!(!on.tags.contains_key("typeParam"));
         assert!(on.tags.contains_key("experimental"));
+    }
+
+    #[test]
+    fn member_type_parameters_opt_in_merges_typeparam_and_excludes_tag() {
+        let source = r"
+/** Plugin context. */
+export interface PluginContext<G> {
+  /**
+   * Decorate the command.
+   * @typeParam L - Extension context.
+   * @experimental
+   */
+  decorateCommand<L extends Record<string, unknown> = DefaultExtensions>(
+    decorator: (value: L) => void
+  ): void;
+}
+";
+        let items =
+            DocExtractor::new().extract_source(source, "src/context.ts", SourceType::ts()).unwrap();
+
+        let off = normalize_doc_items(items.clone(), false);
+        let off_member =
+            off[0].members.iter().find(|member| member.name == "decorateCommand").unwrap();
+        assert!(off_member.type_parameters.is_empty());
+        assert_eq!(
+            off_member.tags.get("typeParam").map(String::as_str),
+            Some("L - Extension context.")
+        );
+
+        let on = normalize_doc_items(items, true);
+        let on_member =
+            on[0].members.iter().find(|member| member.name == "decorateCommand").unwrap();
+        assert_eq!(on_member.type_parameters.len(), 1);
+        assert_eq!(on_member.type_parameters[0].name, "L");
+        assert_eq!(
+            on_member.type_parameters[0].constraint.as_deref(),
+            Some("Record<string, unknown>")
+        );
+        assert_eq!(on_member.type_parameters[0].default.as_deref(), Some("DefaultExtensions"));
+        assert_eq!(on_member.type_parameters[0].description, "Extension context.");
+        assert!(!on_member.tags.contains_key("typeParam"));
+        assert!(on_member.tags.contains_key("experimental"));
     }
 }

--- a/crates/ox_content_docs/src/output.rs
+++ b/crates/ox_content_docs/src/output.rs
@@ -288,6 +288,7 @@ mod tests {
                         signature: None,
                         type_annotation: Some("\"strict\"".to_string()),
                         params: vec![],
+                        type_parameters: vec![],
                         returns: None,
                         optional: false,
                         readonly: false,

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -279,6 +279,7 @@ export interface JsDocMember {
   signature?: string
   type?: string
   params?: Array<JsDocParam>
+  typeParameters?: Array<JsTypeParam>
   returns?: JsDocReturn
   optional?: boolean
   readonly?: boolean

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -205,6 +205,7 @@ pub struct JsDocMember {
     pub signature: Option<String>,
     pub r#type: Option<String>,
     pub params: Option<Vec<JsDocParam>>,
+    pub type_parameters: Option<Vec<JsTypeParam>>,
     pub returns: Option<JsDocReturn>,
     pub optional: Option<bool>,
     pub readonly: Option<bool>,
@@ -972,6 +973,8 @@ fn map_normalized_member(member: NormalizedMember) -> JsDocMember {
         r#type: member.type_annotation,
         params: (!member.params.is_empty())
             .then(|| member.params.into_iter().map(map_normalized_param_doc).collect()),
+        type_parameters: (!member.type_parameters.is_empty())
+            .then(|| member.type_parameters.into_iter().map(map_normalized_type_param).collect()),
         returns: member.returns.map(map_normalized_return_doc),
         optional: member.optional.then_some(true),
         readonly: member.readonly.then_some(true),
@@ -1214,6 +1217,12 @@ fn convert_markdown_member(member: JsDocMember) -> ApiDocMember {
         signature: member.signature,
         type_annotation: member.r#type,
         params: member.params.unwrap_or_default().into_iter().map(convert_markdown_param).collect(),
+        type_parameters: member
+            .type_parameters
+            .unwrap_or_default()
+            .into_iter()
+            .map(convert_markdown_type_param)
+            .collect(),
         returns: member.returns.map(convert_markdown_return),
         optional: member.optional.unwrap_or(false),
         readonly: member.readonly.unwrap_or(false),
@@ -3502,7 +3511,7 @@ pub fn extract_translation_keys(
 mod tests {
     use ox_content_docs::{
         NormalizedDocEntry, NormalizedDocKind, NormalizedMember, NormalizedMemberKind,
-        NormalizedReturnDoc,
+        NormalizedReturnDoc, NormalizedTypeParam,
     };
     use serde_json::json;
     use std::collections::BTreeMap;
@@ -3576,6 +3585,12 @@ mod tests {
                 signature: None,
                 type_annotation: Some("string".to_string()),
                 params: vec![],
+                type_parameters: vec![NormalizedTypeParam {
+                    name: "T".to_string(),
+                    constraint: Some("Base".to_string()),
+                    default: Some("Default".to_string()),
+                    description: "Value type.".to_string(),
+                }],
                 returns: None,
                 optional: true,
                 readonly: true,
@@ -3594,6 +3609,11 @@ mod tests {
         assert_eq!(member.name, "name");
         assert_eq!(member.kind, "property");
         assert_eq!(member.r#type.as_deref(), Some("string"));
+        let type_param = &member.type_parameters.as_ref().unwrap()[0];
+        assert_eq!(type_param.name, "T");
+        assert_eq!(type_param.constraint.as_deref(), Some("Base"));
+        assert_eq!(type_param.r#default.as_deref(), Some("Default"));
+        assert_eq!(type_param.description, "Value type.");
         assert_eq!(member.optional, Some(true));
         assert_eq!(member.readonly, Some(true));
     }
@@ -3629,6 +3649,7 @@ mod tests {
                     optional: false,
                     default_value: None,
                 }],
+                type_parameters: vec![],
                 returns: None,
                 optional: false,
                 readonly: true,
@@ -3698,6 +3719,7 @@ mod tests {
                     signature: None,
                     type_annotation: Some("ArgValues<A>".to_string()),
                     params: vec![],
+                    type_parameters: vec![],
                     returns: None,
                     optional: false,
                     readonly: false,
@@ -3939,6 +3961,12 @@ export function plugin<Id, PluginExt>(options: {
                 ),
                 r#type: None,
                 params: None,
+                type_parameters: Some(vec![JsTypeParam {
+                    name: "L".to_string(),
+                    constraint: Some("Base".to_string()),
+                    r#default: Some("Default".to_string()),
+                    description: "Locale type.".to_string(),
+                }]),
                 returns: None,
                 optional: None,
                 readonly: None,
@@ -3957,6 +3985,8 @@ export function plugin<Id, PluginExt>(options: {
         assert_eq!(converted.extends, vec!["BaseTranslation"]);
         assert_eq!(converted.implements, vec!["TranslationAdapter"]);
         assert_eq!(converted.members[0].implementation_of, vec!["TranslationAdapter.getResource"]);
+        assert_eq!(converted.members[0].type_parameters[0].name, "L");
+        assert_eq!(converted.members[0].type_parameters[0].constraint.as_deref(), Some("Base"));
     }
 
     #[test]
@@ -4135,6 +4165,7 @@ export function plugin<Id, PluginExt>(options: {
                         signature: None,
                         r#type: Some("Record<string, unknown>".to_string()),
                         params: None,
+                        type_parameters: None,
                         returns: None,
                         optional: Some(false),
                         readonly: Some(false),
@@ -4591,6 +4622,7 @@ export function plugin<Id, PluginExt>(options: {
                             signature: None,
                             r#type: Some("ArgValues<A>".to_string()),
                             params: None,
+                            type_parameters: None,
                             returns: None,
                             optional: Some(false),
                             readonly: Some(false),
@@ -4924,6 +4956,7 @@ export function plugin<Id, PluginExt>(options: {
                             optional: None,
                             r#default: None,
                         }]),
+                        type_parameters: None,
                         returns: None,
                         optional: Some(false),
                         readonly: Some(true),

--- a/crates/ox_content_profile_cli/src/main.rs
+++ b/crates/ox_content_profile_cli/src/main.rs
@@ -479,6 +479,7 @@ fn to_api_member(member: NormalizedMember) -> ApiDocMember {
         signature: member.signature,
         type_annotation: member.type_annotation,
         params: member.params.into_iter().map(to_api_param).collect(),
+        type_parameters: member.type_parameters.into_iter().map(to_api_type_param).collect(),
         returns: member.returns.map(to_api_return),
         optional: member.optional,
         readonly: member.readonly,


### PR DESCRIPTION
## Summary

Adds member-level type parameter support across extraction, normalization, NAPI data, JSON, and Markdown/HTML rendering so generic methods and properties show structured Type Parameters sections.

## Background

gunshi's `PluginContext.decorate` methods exposed `<L>` in signatures but left `@typeParam` as raw Tags because member models dropped typeParameters and normalization skipped them.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783261665&installation_id=136613492&pr_number=330&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F330&signature=92ab10a8f08943f656e7e13ac9307f1eab1aa55b1f5af6fdcdcd6074da68feb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->