### PR TITLE
fix(docs): suppress property returns sections

### DIFF
--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -336,15 +336,28 @@ pub fn normalize_doc_item(item: DocItem, type_parameters: bool) -> Option<Normal
 fn normalize_member(item: DocItem, type_parameters: bool) -> Option<NormalizedMember> {
     let kind = NormalizedMemberKind::from_doc_item_kind(item.kind)?;
     let mut metadata = normalize_doc_metadata(&item.tags, type_parameters);
+    let has_extracted_params = !item.params.is_empty();
+    let has_extracted_return = item.return_type.is_some() || !item.return_members.is_empty();
+    let has_callable_shape = matches!(
+        kind,
+        NormalizedMemberKind::Method
+            | NormalizedMemberKind::Constructor
+            | NormalizedMemberKind::Getter
+            | NormalizedMemberKind::Setter
+    ) || has_extracted_params
+        || has_extracted_return;
     merge_extracted_params(&mut metadata.params, item.params);
     let mut return_type = item.return_type;
-    if kind != NormalizedMemberKind::IndexSignature {
+
+    if has_callable_shape && kind != NormalizedMemberKind::IndexSignature {
         merge_extracted_return(
             &mut metadata.returns,
             return_type.take(),
             item.return_members,
             type_parameters,
         );
+    } else {
+        metadata.returns = None;
     }
     let type_parameters = if type_parameters {
         build_type_parameters(item.type_parameters, &metadata.type_param_descriptions)
@@ -745,6 +758,35 @@ export interface Command {
         assert_eq!(members[1].name, "args");
         assert_eq!(members[1].type_annotation.as_deref(), Some("string[]"));
         assert!(members[1].optional);
+    }
+
+    #[test]
+    fn normal_property_suppresses_description_only_returns_tag() {
+        let source = r"
+/**
+ * Plugin context.
+ */
+export interface PluginContext {
+    /**
+     * Get the global options.
+     *
+     * @returns A map of global options.
+     */
+    readonly globalOptions: Map<string, ArgSchema>;
+}
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "context.ts", SourceType::ts()).unwrap();
+        let entries = normalize_doc_items(items, false);
+        let member = &entries[0].members[0];
+
+        assert_eq!(member.name, "globalOptions");
+        assert_eq!(member.kind, NormalizedMemberKind::Property);
+        assert_eq!(member.description, "Get the global options.");
+        assert_eq!(member.type_annotation.as_deref(), Some("Map<string, ArgSchema>"));
+        assert!(member.readonly);
+        assert!(member.returns.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Suppress Returns sections for non-callable properties while keeping callable member returns intact.

Add regression coverage for description-only `@returns` on normal properties.

## Background

Gunshi's PluginContext properties used `@returns` as prose, causing ox-content to normalize them as unknown return types and render duplicate Returns sections unlike TypeDoc.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783271961&installation_id=136613492&pr_number=331&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F331&signature=550a1fad0b2a7321d340509ee5f62ed220881f1b244bd782fecbcd011bb4a832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->