### PR TITLE
fix(docs): merge destructured param docs

### DIFF
--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -1356,11 +1356,8 @@ impl<'a> DocVisitor<'a> {
     /// predicate as before (strip a leading `...`, then exact-name or
     /// dotted-prefix match). Operating on already-parsed tags avoids
     /// re-parsing every `@param` for each formal parameter.
-    fn find_parsed_param_tag<'t>(
-        parsed: &'t [ParsedParamTag],
-        name: &str,
-    ) -> Option<&'t ParsedParamTag> {
-        parsed.iter().find(|tag| {
+    fn find_parsed_param_tag_index(parsed: &[ParsedParamTag], name: &str) -> Option<usize> {
+        parsed.iter().position(|tag| {
             let tag_name = tag.name.trim_start_matches("...");
             tag_name == name || tag_name.split('.').next() == Some(name)
         })
@@ -1389,6 +1386,52 @@ impl<'a> DocVisitor<'a> {
             BindingPattern::ObjectPattern(_) => "param".to_string(),
             BindingPattern::ArrayPattern(_) => "param".to_string(),
         }
+    }
+
+    fn binding_pattern_identifier_name(pattern: &BindingPattern<'a>) -> Option<String> {
+        match pattern {
+            BindingPattern::BindingIdentifier(id) => Some(id.name.to_string()),
+            BindingPattern::AssignmentPattern(assign) => {
+                Self::binding_pattern_identifier_name(&assign.left)
+            }
+            BindingPattern::ObjectPattern(_) | BindingPattern::ArrayPattern(_) => None,
+        }
+    }
+
+    fn binding_pattern_is_destructured(pattern: &BindingPattern<'a>) -> bool {
+        match pattern {
+            BindingPattern::AssignmentPattern(assign) => {
+                Self::binding_pattern_is_destructured(&assign.left)
+            }
+            BindingPattern::ObjectPattern(_) | BindingPattern::ArrayPattern(_) => true,
+            BindingPattern::BindingIdentifier(_) => false,
+        }
+    }
+
+    fn top_level_param_tag_name(tag: &ParsedParamTag) -> Option<&str> {
+        let raw_name = tag.name.trim();
+        if raw_name.starts_with("...") {
+            return None;
+        }
+        let name = raw_name.trim_end_matches('?');
+        (!name.is_empty() && !name.contains('.')).then_some(name)
+    }
+
+    fn find_destructured_param_tag_index(
+        parsed: &[ParsedParamTag],
+        used_indices: &[usize],
+        reserved_names: &[String],
+    ) -> Option<usize> {
+        parsed.iter().enumerate().find_map(|(index, tag)| {
+            if used_indices.contains(&index) {
+                return None;
+            }
+            let name = Self::top_level_param_tag_name(tag)?;
+            if reserved_names.iter().any(|reserved| reserved == name) {
+                return None;
+            }
+            Some(index)
+        })
     }
 
     fn binding_pattern_default_value(&self, pattern: &BindingPattern<'a>) -> Option<String> {
@@ -1615,12 +1658,37 @@ impl<'a> DocVisitor<'a> {
             .filter(|tag| matches!(tag.tag.as_str(), "param" | "arg" | "argument"))
             .filter_map(Self::parse_param_tag)
             .collect();
+        let mut reserved_param_names = params
+            .items
+            .iter()
+            .filter_map(|param| Self::binding_pattern_identifier_name(&param.pattern))
+            .collect::<Vec<_>>();
+        if let Some(rest) = params.rest.as_ref() {
+            if let Some(name) = Self::binding_pattern_identifier_name(&rest.rest.argument) {
+                reserved_param_names.push(name);
+            }
+        }
+        let mut used_param_tag_indices = Vec::new();
 
         let mut docs = Vec::with_capacity(params.items.len() + usize::from(params.rest.is_some()));
 
         for param in &params.items {
-            let name = Self::binding_pattern_name(&param.pattern);
-            let tag = Self::find_parsed_param_tag(&parsed_param_tags, &name);
+            let fallback_name = Self::binding_pattern_name(&param.pattern);
+            let tag_index = if Self::binding_pattern_is_destructured(&param.pattern) {
+                Self::find_destructured_param_tag_index(
+                    &parsed_param_tags,
+                    &used_param_tag_indices,
+                    &reserved_param_names,
+                )
+            } else {
+                Self::find_parsed_param_tag_index(&parsed_param_tags, &fallback_name)
+            };
+            let tag = tag_index.map(|index| &parsed_param_tags[index]);
+            if let Some(index) = tag_index {
+                used_param_tag_indices.push(index);
+            }
+            let name =
+                tag.and_then(Self::top_level_param_tag_name).unwrap_or(&fallback_name).to_string();
             let default_value = self
                 .binding_pattern_default_value(&param.pattern)
                 .or_else(|| {
@@ -1664,7 +1732,8 @@ impl<'a> DocVisitor<'a> {
 
         if let Some(rest) = params.rest.as_ref() {
             let name = Self::binding_pattern_name(&rest.rest.argument);
-            let tag = Self::find_parsed_param_tag(&parsed_param_tags, &name);
+            let tag_index = Self::find_parsed_param_tag_index(&parsed_param_tags, &name);
+            let tag = tag_index.map(|index| &parsed_param_tags[index]);
             let type_annotation = rest
                 .type_annotation
                 .as_ref()
@@ -2799,6 +2868,81 @@ export function plugin<Id, Deps, PluginExt, MergedExtensions>(options: {
         assert!(plugin.params[3].optional);
         assert!(plugin.params[4].optional);
         assert!(plugin.params[6].optional);
+    }
+
+    #[test]
+    fn destructured_parameter_uses_jsdoc_name_and_extracted_type() {
+        let source = r"
+/**
+ * Resolve command line arguments.
+ *
+ * @param args - Argument schema.
+ * @param tokens - Parsed tokens.
+ * @param resolveArgs - Resolve options.
+ */
+export declare function resolveArgs<A extends Args>(
+    args: A,
+    tokens: ArgToken[],
+    { shortGrouping, skipPositional, toKebab }?: ResolveArgs
+): void;
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "resolver.ts", SourceType::ts()).unwrap();
+        let resolve = items.iter().find(|item| item.name == "resolveArgs").unwrap();
+
+        assert_eq!(
+            resolve.params.iter().map(|param| param.name.as_str()).collect::<Vec<_>>(),
+            ["args", "tokens", "resolveArgs"]
+        );
+        assert_eq!(resolve.params[2].type_annotation.as_deref(), Some("ResolveArgs"));
+        assert!(resolve.params[2].optional);
+        assert_eq!(resolve.params[2].description.as_deref(), Some("Resolve options."));
+    }
+
+    #[test]
+    fn destructured_parameter_without_jsdoc_name_keeps_param_fallback() {
+        let source = r"
+/**
+ * Run a command.
+ */
+export declare function run({ cwd }: RunOptions): void;
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "runner.ts", SourceType::ts()).unwrap();
+        let run = items.iter().find(|item| item.name == "run").unwrap();
+
+        assert_eq!(run.params.len(), 1);
+        assert_eq!(run.params[0].name, "param");
+        assert_eq!(run.params[0].type_annotation.as_deref(), Some("RunOptions"));
+        assert_eq!(run.params[0].description, None);
+    }
+
+    #[test]
+    fn destructured_parameter_keeps_nested_param_tags_on_members() {
+        let source = r"
+/**
+ * Run a command.
+ *
+ * @param options - Runtime options.
+ * @param options.cwd - Working directory.
+ */
+export declare function run({ cwd }: { cwd: string }): void;
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "runner.ts", SourceType::ts()).unwrap();
+        let run = items.iter().find(|item| item.name == "run").unwrap();
+
+        assert_eq!(
+            run.params.iter().map(|param| param.name.as_str()).collect::<Vec<_>>(),
+            ["options", "options.cwd"]
+        );
+        assert_eq!(run.params[0].type_annotation.as_deref(), Some("{ cwd: string }"));
+        assert_eq!(run.params[0].description.as_deref(), Some("Runtime options."));
+        assert_eq!(run.params[1].type_annotation.as_deref(), Some("string"));
+        assert_eq!(run.params[1].description.as_deref(), Some("Working directory."));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -828,6 +828,37 @@ export interface Command {
     }
 
     #[test]
+    fn destructured_parameter_merges_jsdoc_name_without_unknown_duplicate() {
+        let source = r"
+/**
+ * Resolve command line arguments.
+ *
+ * @param args - Argument schema.
+ * @param tokens - Parsed tokens.
+ * @param resolveArgs - Resolve options.
+ */
+export declare function resolveArgs<A extends Args>(
+    args: A,
+    tokens: ArgToken[],
+    { shortGrouping, skipPositional, toKebab }?: ResolveArgs
+): void;
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "resolver.ts", SourceType::ts()).unwrap();
+        let entries = normalize_doc_items(items, false);
+        let entry = entries.iter().find(|entry| entry.name == "resolveArgs").unwrap();
+
+        assert_eq!(
+            entry.params.iter().map(|param| param.name.as_str()).collect::<Vec<_>>(),
+            ["args", "tokens", "resolveArgs"]
+        );
+        assert_eq!(entry.params[2].type_annotation, "ResolveArgs");
+        assert_eq!(entry.params[2].description, "Resolve options.");
+        assert!(entry.params[2].optional);
+    }
+
+    #[test]
     fn function_valued_property_merges_extracted_types_with_description_only_tags() {
         let source = r"
 /**


### PR DESCRIPTION
## Summary

Merge JSDoc names with extracted types for destructured parameters. This removes duplicate `resolveArgs: unknown` / `param: ResolveArgs` rows while preserving nested parameter docs.

## Background

Gunshi re-exports `resolveArgs`, whose third argument is destructured but documented as `resolveArgs`. ox-content named it `param`, so JSDoc and type data failed to merge.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783272994&installation_id=136613492&pr_number=332&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F332&signature=843eb4a0b9ffce82b1761b4d81ec7cba99db7f8e76d01dfbf4ef2fa859a8cdea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->