### PR TITLE
fix(docs): resolve intersection callable aliases

### DIFF
--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -131,11 +131,33 @@ pub struct TypeParamDoc {
     pub description: String,
 }
 
+#[derive(Debug, Clone)]
 struct FunctionTypeMetadata {
     params: Vec<ParamDoc>,
     return_type: Option<String>,
     return_members: Vec<DocItem>,
     type_parameters: Vec<TypeParamDoc>,
+}
+
+impl FunctionTypeMetadata {
+    fn as_reference_metadata(&self) -> Self {
+        Self {
+            params: self
+                .params
+                .iter()
+                .map(|param| ParamDoc {
+                    name: param.name.clone(),
+                    type_annotation: param.type_annotation.clone(),
+                    optional: param.optional,
+                    default_value: param.default_value.clone(),
+                    description: None,
+                })
+                .collect(),
+            return_type: self.return_type.clone(),
+            return_members: self.return_members.clone(),
+            type_parameters: Vec::new(),
+        }
+    }
 }
 
 /// JSDoc tag.
@@ -561,6 +583,7 @@ struct DocVisitor<'a> {
     jsdoc_cache: FxHashMap<u32, ParsedJsdoc>,
     line_starts: Vec<usize>,
     items: Vec<DocItem>,
+    type_alias_function_metadata: FxHashMap<String, FunctionTypeMetadata>,
     /// Track default export
     has_default_export: bool,
 }
@@ -592,6 +615,7 @@ impl<'a> DocVisitor<'a> {
             jsdoc_cache,
             line_starts,
             items: Vec::new(),
+            type_alias_function_metadata: FxHashMap::default(),
             has_default_export: false,
         }
     }
@@ -1886,7 +1910,7 @@ impl<'a> DocVisitor<'a> {
 
     fn extract_function_type_metadata(
         &self,
-        ts_type: &TSType,
+        ts_type: &TSType<'a>,
         tags: &[DocTag],
     ) -> Option<FunctionTypeMetadata> {
         match ts_type {
@@ -1903,7 +1927,26 @@ impl<'a> DocVisitor<'a> {
             TSType::TSParenthesizedType(paren) => {
                 self.extract_function_type_metadata(&paren.type_annotation, tags)
             }
+            TSType::TSTypeReference(ref_type) => {
+                let name = Self::type_reference_identifier_name(ref_type)?;
+                self.type_alias_function_metadata
+                    .get(&name)
+                    .map(FunctionTypeMetadata::as_reference_metadata)
+            }
+            TSType::TSIntersectionType(inter) => inter
+                .types
+                .iter()
+                .find_map(|ts_type| self.extract_function_type_metadata(ts_type, tags)),
             _ => None,
+        }
+    }
+
+    fn type_reference_identifier_name(
+        ref_type: &oxc_ast::ast::TSTypeReference<'a>,
+    ) -> Option<String> {
+        match &ref_type.type_name {
+            TSTypeName::IdentifierReference(id) => Some(id.name.to_string()),
+            TSTypeName::QualifiedName(_) | TSTypeName::ThisExpression(_) => None,
         }
     }
 
@@ -2262,6 +2305,23 @@ impl<'a> DocVisitor<'a> {
         children
     }
 
+    fn extract_type_alias_members_from_type(&self, ts_type: &TSType<'a>) -> Vec<DocItem> {
+        match ts_type {
+            TSType::TSTypeLiteral(type_literal) => {
+                self.extract_ts_signature_members(&type_literal.members)
+            }
+            TSType::TSParenthesizedType(paren) => {
+                self.extract_type_alias_members_from_type(&paren.type_annotation)
+            }
+            TSType::TSIntersectionType(intersection) => intersection
+                .types
+                .iter()
+                .flat_map(|ts_type| self.extract_type_alias_members_from_type(ts_type))
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
+
     fn create_index_signature_item(
         &self,
         index_signature: &TSIndexSignature<'a>,
@@ -2557,32 +2617,35 @@ impl<'a> DocVisitor<'a> {
         exported: bool,
         attached_to: u32,
     ) {
+        let name = type_alias.id.name.to_string();
+        if let Some(metadata) =
+            self.extract_function_type_metadata(&type_alias.type_annotation, &[])
+        {
+            self.type_alias_function_metadata
+                .insert(name.clone(), metadata.as_reference_metadata());
+        }
+
         let Some((jsdoc, doc, tags)) = self.extract_declaration_docs(attached_to) else {
             return;
         };
         let (line, end_line) = self.span_lines(attached_to, type_alias.span.end);
-        let mut children = Vec::new();
+        let children = self.extract_type_alias_members_from_type(&type_alias.type_annotation);
         let mut params = Vec::new();
         let mut return_type = None;
         let mut return_members = Vec::new();
         let mut function_type_parameters = Vec::new();
 
-        match &type_alias.type_annotation {
-            TSType::TSTypeLiteral(type_literal) => {
-                children = self.extract_ts_signature_members(&type_literal.members);
-            }
-            ts_type => {
-                if let Some(metadata) = self.extract_function_type_metadata(ts_type, &tags) {
-                    params = metadata.params;
-                    return_type = metadata.return_type;
-                    return_members = metadata.return_members;
-                    function_type_parameters = metadata.type_parameters;
-                }
-            }
+        if let Some(metadata) =
+            self.extract_function_type_metadata(&type_alias.type_annotation, &tags)
+        {
+            params = metadata.params;
+            return_type = metadata.return_type;
+            return_members = metadata.return_members;
+            function_type_parameters = metadata.type_parameters;
         }
 
         self.items.push(DocItem {
-            name: type_alias.id.name.to_string(),
+            name,
             kind: DocItemKind::Type,
             doc,
             source_path: self.file_path.to_string(),
@@ -3175,7 +3238,7 @@ export type CommandOptions = {
     }
 
     #[test]
-    fn type_alias_intersection_falls_back_to_signature_only() {
+    fn type_alias_intersection_extracts_object_literal_members() {
         let source = r"
 /**
  * Command options.
@@ -3191,8 +3254,47 @@ export type CommandOptions = BaseOptions & {
 
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].name, "CommandOptions");
-        assert!(items[0].children.is_empty());
+        assert_eq!(items[0].children.len(), 1);
+        assert_eq!(items[0].children[0].name, "name");
+        assert_eq!(items[0].children[0].signature.as_deref(), Some("string"));
         assert!(items[0].signature.as_deref().unwrap().contains("BaseOptions &"));
+    }
+
+    #[test]
+    fn type_alias_intersection_resolves_callable_alias_and_members() {
+        let source = r"
+/**
+ * Plugin function.
+ */
+export type PluginFunction<G> = (ctx: Readonly<PluginContext<G>>) => Awaitable<void>;
+
+/**
+ * Plugin.
+ * @param ctx - Plugin context.
+ * @returns Plugin setup result.
+ */
+export type Plugin<E> = PluginFunction & {
+    id: string;
+    name?: string;
+};
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "plugin.ts", SourceType::ts()).unwrap();
+        let plugin = items.iter().find(|item| item.name == "Plugin").unwrap();
+
+        assert_eq!(plugin.params.len(), 1);
+        assert_eq!(plugin.params[0].name, "ctx");
+        assert_eq!(plugin.params[0].type_annotation.as_deref(), Some("Readonly<PluginContext<G>>"));
+        assert_eq!(plugin.params[0].description, None);
+        assert_eq!(plugin.return_type.as_deref(), Some("Awaitable<void>"));
+        assert_eq!(
+            plugin.children.iter().map(|child| child.name.as_str()).collect::<Vec<_>>(),
+            ["id", "name"]
+        );
+        assert_eq!(plugin.children[0].signature.as_deref(), Some("string"));
+        assert_eq!(plugin.children[1].signature.as_deref(), Some("string"));
+        assert!(plugin.children[1].optional);
     }
 
     #[test]

--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -2630,19 +2630,19 @@ impl<'a> DocVisitor<'a> {
         };
         let (line, end_line) = self.span_lines(attached_to, type_alias.span.end);
         let children = self.extract_type_alias_members_from_type(&type_alias.type_annotation);
-        let mut params = Vec::new();
-        let mut return_type = None;
-        let mut return_members = Vec::new();
-        let mut function_type_parameters = Vec::new();
-
-        if let Some(metadata) =
-            self.extract_function_type_metadata(&type_alias.type_annotation, &tags)
-        {
-            params = metadata.params;
-            return_type = metadata.return_type;
-            return_members = metadata.return_members;
-            function_type_parameters = metadata.type_parameters;
-        }
+        let (params, return_type, return_members, function_type_parameters) =
+            if let Some(metadata) =
+                self.extract_function_type_metadata(&type_alias.type_annotation, &tags)
+            {
+                (
+                    metadata.params,
+                    metadata.return_type,
+                    metadata.return_members,
+                    metadata.type_parameters,
+                )
+            } else {
+                (Vec::new(), None, Vec::new(), Vec::new())
+            };
 
         self.items.push(DocItem {
             name,

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -1011,6 +1011,47 @@ export type PluginFunction<G> = (ctx: Readonly<PluginContext<G>>) => Awaitable<v
     }
 
     #[test]
+    fn intersection_type_alias_merges_callable_reference_metadata() {
+        let source = r"
+/**
+ * Plugin function.
+ */
+export type PluginFunction<G> = (ctx: Readonly<PluginContext<G>>) => Awaitable<void>;
+
+/**
+ * Plugin.
+ * @param ctx - Plugin context.
+ * @returns Plugin setup result.
+ */
+export type Plugin<E> = PluginFunction & {
+    id: string;
+    name?: string;
+};
+";
+
+        let extractor = DocExtractor::new();
+        let entries = normalize_doc_items(
+            extractor.extract_source(source, "plugin.ts", SourceType::ts()).unwrap(),
+            false,
+        );
+        let alias = entries.iter().find(|entry| entry.name == "Plugin").unwrap();
+
+        assert_eq!(alias.params.len(), 1);
+        assert_eq!(alias.params[0].name, "ctx");
+        assert_eq!(alias.params[0].type_annotation, "Readonly<PluginContext<G>>");
+        assert_eq!(alias.params[0].description, "Plugin context.");
+        let returns = alias.returns.as_ref().unwrap();
+        assert_eq!(returns.type_annotation, "Awaitable<void>");
+        assert_eq!(returns.description, "Plugin setup result.");
+        assert_eq!(
+            alias.members.iter().map(|member| member.name.as_str()).collect::<Vec<_>>(),
+            ["id", "name"]
+        );
+        assert_eq!(alias.members[0].type_annotation.as_deref(), Some("string"));
+        assert!(alias.members[1].optional);
+    }
+
+    #[test]
     fn function_type_alias_without_returns_tag_still_normalizes_return_section() {
         let source = r"
 /**


### PR DESCRIPTION
## Summary

Resolve same-file callable aliases inside intersection type aliases and extract object-literal members.

This removes `unknown` params/returns from `PluginFunction & { ... }` docs.

## Background

Gunshi's `Plugin` type intersects `PluginFunction` with options fields.

ox-content missed both the callable alias metadata and the object members, producing fake `unknown` sections.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783274165&installation_id=136613492&pr_number=333&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F333&signature=29d59529892242055842bc4bf244f6be1779002db7bb700acbf295e37b9f1b10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->