### PR TITLE
fix(docs): omit empty type parameter descriptions

### DIFF
--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -3880,6 +3880,149 @@ mod tests {
     }
 
     #[test]
+    fn markdown_type_parameter_table_omits_description_column_when_all_empty() {
+        let mut entry = test_entry("make", "function", "src/make.ts", "Make a thing.");
+        entry.type_parameters = vec![
+            ApiTypeParamDoc {
+                name: "G".to_string(),
+                constraint: Some("Base".to_string()),
+                default: Some("Default".to_string()),
+                description: String::new(),
+            },
+            ApiTypeParamDoc {
+                name: "V".to_string(),
+                constraint: None,
+                default: None,
+                description: "   ".to_string(),
+            },
+        ];
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "mod".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![entry],
+        }];
+
+        let markdown = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                render_style: MarkdownRenderStyle::Markdown,
+                parameters_format: MarkdownDisplayFormat::Table,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let page = markdown.get("mod/functions/make.md").unwrap();
+
+        assert!(page.contains("## Type Parameters"));
+        assert!(page.contains("| Name |\n| --- |"));
+        assert!(!page.contains("| Name | Description |"));
+        assert!(page.contains("| `G` *extends* `Base` = `Default` |"));
+        assert!(page.contains("| `V` |"));
+        assert!(!page.contains("|  |"));
+    }
+
+    #[test]
+    fn markdown_type_parameter_table_renders_dash_for_missing_descriptions() {
+        let mut entry = test_entry("make", "function", "src/make.ts", "Make a thing.");
+        entry.type_parameters = vec![
+            ApiTypeParamDoc {
+                name: "T".to_string(),
+                constraint: None,
+                default: None,
+                description: "Value type.".to_string(),
+            },
+            ApiTypeParamDoc {
+                name: "G".to_string(),
+                constraint: Some("Base".to_string()),
+                default: Some("Default".to_string()),
+                description: String::new(),
+            },
+        ];
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "mod".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![entry],
+        }];
+
+        let markdown = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                render_style: MarkdownRenderStyle::Markdown,
+                parameters_format: MarkdownDisplayFormat::Table,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let page = markdown.get("mod/functions/make.md").unwrap();
+
+        assert!(page.contains("| Name | Description |\n| --- | --- |"));
+        assert!(page.contains("| `T` | Value type. |"));
+        assert!(page.contains("| `G` *extends* `Base` = `Default` | - |"));
+        assert!(!page.contains("| `G` *extends* `Base` = `Default` |  |"));
+    }
+
+    #[test]
+    fn html_type_parameter_tables_follow_empty_description_policy() {
+        let mut all_empty = test_entry("make", "function", "src/make.ts", "Make a thing.");
+        all_empty.type_parameters = vec![ApiTypeParamDoc {
+            name: "G".to_string(),
+            constraint: Some("Base".to_string()),
+            default: Some("Default".to_string()),
+            description: String::new(),
+        }];
+
+        let mut mixed = test_entry("build", "function", "src/build.ts", "Build a thing.");
+        mixed.type_parameters = vec![
+            ApiTypeParamDoc {
+                name: "T".to_string(),
+                constraint: None,
+                default: None,
+                description: "Value type.".to_string(),
+            },
+            ApiTypeParamDoc {
+                name: "G".to_string(),
+                constraint: Some("Base".to_string()),
+                default: Some("Default".to_string()),
+                description: String::new(),
+            },
+        ];
+
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "mod".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![all_empty, mixed],
+        }];
+        let html = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                render_style: MarkdownRenderStyle::Html,
+                parameters_format: MarkdownDisplayFormat::Table,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let all_empty_page = html.get("mod/functions/make.md").unwrap();
+        let mixed_page = html.get("mod/functions/build.md").unwrap();
+
+        assert!(all_empty_page.contains("<thead><tr><th>Name</th></tr></thead>"));
+        assert!(!all_empty_page.contains("<th>Description</th>"));
+        assert!(!all_empty_page.contains("<td></td>"));
+
+        assert!(mixed_page.contains("<thead><tr><th>Name</th><th>Description</th></tr></thead>"));
+        assert!(mixed_page.contains("<td>Value type.</td>"));
+        assert!(mixed_page.contains("<td>-</td>"));
+    }
+
+    #[test]
     fn markdown_property_display_format_controls_property_groups() {
         let mut entry = test_entry("Command", "interface", "src/types.ts", "Command options.");
         entry.members = vec![ApiDocMember {
@@ -4022,12 +4165,20 @@ mod tests {
                 optional: false,
                 default_value: None,
             }],
-            type_parameters: vec![ApiTypeParamDoc {
-                name: "L".to_string(),
-                constraint: Some("Record<string, unknown>".to_string()),
-                default: Some("DefaultExtensions".to_string()),
-                description: "Extension context.".to_string(),
-            }],
+            type_parameters: vec![
+                ApiTypeParamDoc {
+                    name: "L".to_string(),
+                    constraint: Some("Record<string, unknown>".to_string()),
+                    default: Some("DefaultExtensions".to_string()),
+                    description: "Extension context.".to_string(),
+                },
+                ApiTypeParamDoc {
+                    name: "Fallback".to_string(),
+                    constraint: None,
+                    default: None,
+                    description: String::new(),
+                },
+            ],
             returns: None,
             optional: false,
             readonly: false,
@@ -4062,6 +4213,8 @@ mod tests {
         assert!(type_parameters < parameters);
         assert!(page.contains("`L` *extends*"));
         assert!(page.contains("Extension context."));
+        assert!(page.contains("| `Fallback` | - |"));
+        assert!(!page.contains("| `Fallback` |  |"));
 
         let html = generate_markdown(
             &docs,
@@ -4075,6 +4228,7 @@ mod tests {
         let page = html.get("mod/interfaces/PluginContext.md").unwrap();
         assert!(page.contains("<h6>Type Parameters</h6>"));
         assert!(page.contains("Extension context."));
+        assert!(page.contains("<td><code>Fallback</code></td><td>-</td>"));
     }
 
     #[test]
@@ -5474,7 +5628,9 @@ mod tests {
         let out = generate_markdown(&type_link_module(entry), &options);
         let page = out.get("combinators/functions/make.md").unwrap();
 
-        assert!(page.contains("| `PluginExt` *extends* [`PluginExtension`](../type-aliases/PluginExtension.md)\\<`Extension`, [`DefaultGunshiParams`](../type-aliases/DefaultGunshiParams.md)\\> = [`PluginExtension`](../type-aliases/PluginExtension.md)\\<`Extension`, `ResolvedDepExtensions`\\> |  |"));
+        assert!(page.contains("| Name |\n| --- |"));
+        assert!(!page.contains("| Name | Description |"));
+        assert!(page.contains("| `PluginExt` *extends* [`PluginExtension`](../type-aliases/PluginExtension.md)\\<`Extension`, [`DefaultGunshiParams`](../type-aliases/DefaultGunshiParams.md)\\> = [`PluginExtension`](../type-aliases/PluginExtension.md)\\<`Extension`, `ResolvedDepExtensions`\\> |"));
         assert!(!page.contains("\\<\n"));
         assert!(!page.contains("ResolvedDepExtensions`\n"));
     }
@@ -5626,6 +5782,8 @@ mod tests {
         let out = generate_markdown(&type_link_module(entry), &html_typedoc_options());
         let page = out.get("combinators/functions/make.md").unwrap();
 
+        assert!(page.contains("<thead><tr><th>Name</th></tr></thead>"));
+        assert!(!page.contains("<th>Description</th>"));
         assert!(page.contains("= <code><a href=\"../type-aliases/PluginExtension.md\">PluginExtension</a>&lt;Extension, ResolvedDepExtensions&gt;</code>"));
         assert!(!page.contains("&lt;\n"));
         assert!(!page.contains("ResolvedDepExtensions\n"));

--- a/crates/ox_content_docs/src/markdown/markdown_html.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_html.rs
@@ -721,11 +721,16 @@ fn type_parameter_skip_set(type_parameters: &[ApiTypeParamDoc]) -> HashSet<&str>
     type_parameters.iter().map(|param| param.name.as_str()).collect()
 }
 
+fn type_parameters_have_descriptions(type_parameters: &[ApiTypeParamDoc]) -> bool {
+    type_parameters.iter().any(|type_param| !type_param.description.trim().is_empty())
+}
+
 fn render_type_parameters_table_html(
     type_parameters: &[ApiTypeParamDoc],
     context: Option<&MarkdownLinkContext<'_>>,
 ) -> String {
     let skip = type_parameter_skip_set(type_parameters);
+    let has_description = type_parameters_have_descriptions(type_parameters);
     let mut rows = StringBuilder::new();
     for type_param in type_parameters {
         if !rows.is_empty() {
@@ -733,8 +738,19 @@ fn render_type_parameters_table_html(
         }
         rows.push_str("<tr>\n  <td>");
         rows.push_str(&render_type_parameter_name_html(type_param, context, &skip));
-        rows.push_str("</td>\n  <td>");
-        rows.push_str(&render_doc_inline_html(&type_param.description, context));
+        if has_description {
+            rows.push_str("</td>\n  <td>");
+            if type_param.description.trim().is_empty() {
+                rows.push_char('-');
+            } else {
+                let description = render_doc_inline_html(&type_param.description, context);
+                if description.is_empty() {
+                    rows.push_char('-');
+                } else {
+                    rows.push_str(&description);
+                }
+            }
+        }
         rows.push_str("</td>\n</tr>");
     }
     let rows = rows.into_string();
@@ -744,7 +760,13 @@ fn render_type_parameters_table_html(
         "<div class=\"ox-api-entry__section ox-api-entry__section--type-parameters\">
 <h4>Type Parameters</h4>
 <table class=\"ox-api-entry__type-parameters-table\">
-<thead><tr><th>Name</th><th>Description</th></tr></thead>
+<thead><tr><th>Name</th>",
+    );
+    if has_description {
+        out.push_str("<th>Description</th>");
+    }
+    out.push_str(
+        "</tr></thead>
 <tbody>
 ",
     );
@@ -1013,19 +1035,37 @@ fn render_member_type_parameters_html(
 ) -> String {
     let skip = type_parameter_skip_set(type_parameters);
     if effective_parameters_format(options) == MarkdownDisplayFormat::Table {
+        let has_description = type_parameters_have_descriptions(type_parameters);
         let mut rows = StringBuilder::new();
         for type_param in type_parameters {
             rows.push_str("<tr><td>");
             rows.push_str(&render_type_parameter_name_html(type_param, context, &skip));
-            rows.push_str("</td><td>");
-            rows.push_str(&render_doc_inline_html(&type_param.description, context));
+            if has_description {
+                rows.push_str("</td><td>");
+                if type_param.description.trim().is_empty() {
+                    rows.push_char('-');
+                } else {
+                    let description = render_doc_inline_html(&type_param.description, context);
+                    if description.is_empty() {
+                        rows.push_char('-');
+                    } else {
+                        rows.push_str(&description);
+                    }
+                }
+            }
             rows.push_str("</td></tr>");
         }
-        return join3(
-            "<table class=\"ox-api-entry__type-parameters-table\"><thead><tr><th>Name</th><th>Description</th></tr></thead><tbody>",
-            &rows.into_string(),
-            "</tbody></table>",
+        let mut table = StringBuilder::new();
+        table.push_str(
+            "<table class=\"ox-api-entry__type-parameters-table\"><thead><tr><th>Name</th>",
         );
+        if has_description {
+            table.push_str("<th>Description</th>");
+        }
+        table.push_str("</tr></thead><tbody>");
+        table.push_str(&rows.into_string());
+        table.push_str("</tbody></table>");
+        return table.into_string();
     }
 
     let mut items = StringBuilder::new();

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -87,6 +87,10 @@ fn render_since_section(
     out
 }
 
+fn type_parameters_have_descriptions(type_parameters: &[ApiTypeParamDoc]) -> bool {
+    type_parameters.iter().any(|type_param| !type_param.description.trim().is_empty())
+}
+
 /// Renders the per-page stats summary as a single italic Markdown line.
 pub(super) fn render_stats_markdown(stats: &EntryStats, module_count: Option<usize>) -> String {
     let mut out = StringBuilder::new();
@@ -328,12 +332,28 @@ fn push_type_parameters(
     let skip: HashSet<&str> = type_parameters.iter().map(|param| param.name.as_str()).collect();
     match effective_parameters_format(options) {
         MarkdownDisplayFormat::Table => {
-            out.push_str("| Name | Description |\n| --- | --- |\n");
+            let has_description = type_parameters_have_descriptions(type_parameters);
+            if has_description {
+                out.push_str("| Name | Description |\n| --- | --- |\n");
+            } else {
+                out.push_str("| Name |\n| --- |\n");
+            }
             for type_param in type_parameters {
                 out.push_str("| ");
                 out.push_str(&type_param_name_cell(type_param, context, &skip));
-                out.push_str(" | ");
-                push_table_cell(out, &inline(&type_param.description, context));
+                if has_description {
+                    out.push_str(" | ");
+                    if type_param.description.trim().is_empty() {
+                        out.push('-');
+                    } else {
+                        let description = inline(&type_param.description, context);
+                        if description.is_empty() {
+                            out.push('-');
+                        } else {
+                            push_table_cell(out, &description);
+                        }
+                    }
+                }
                 out.push_str(" |\n");
             }
         }
@@ -781,12 +801,29 @@ fn render_member_parameter_sections_pure(
                 member.type_parameters.iter().map(|param| param.name.as_str()).collect();
             match effective_parameters_format(options) {
                 MarkdownDisplayFormat::Table => {
-                    out.push_str("| Name | Description |\n| --- | --- |\n");
+                    let has_description =
+                        type_parameters_have_descriptions(&member.type_parameters);
+                    if has_description {
+                        out.push_str("| Name | Description |\n| --- | --- |\n");
+                    } else {
+                        out.push_str("| Name |\n| --- |\n");
+                    }
                     for type_param in &member.type_parameters {
                         out.push_str("| ");
                         out.push_str(&type_param_name_cell(type_param, context, &skip));
-                        out.push_str(" | ");
-                        push_table_cell(&mut out, &inline(&type_param.description, context));
+                        if has_description {
+                            out.push_str(" | ");
+                            if type_param.description.trim().is_empty() {
+                                out.push('-');
+                            } else {
+                                let description = inline(&type_param.description, context);
+                                if description.is_empty() {
+                                    out.push('-');
+                                } else {
+                                    push_table_cell(&mut out, &description);
+                                }
+                            }
+                        }
                         out.push_str(" |\n");
                     }
                 }

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -4593,7 +4593,9 @@ export function plugin<Id, PluginExt>(options: {
         );
         let page = markdown.get("default/functions/plugin.md").unwrap();
 
-        assert!(page.contains("| `PluginExt` *extends* [`PluginExtension`](../type-aliases/PluginExtension.md)\\<`Extension`, [`DefaultGunshiParams`](../type-aliases/DefaultGunshiParams.md)\\> = [`PluginExtension`](../type-aliases/PluginExtension.md)\\<`Extension`, `ResolvedDepExtensions`\\> |  |"));
+        assert!(page.contains("| Name |\n| --- |"));
+        assert!(!page.contains("| Name | Description |"));
+        assert!(page.contains("| `PluginExt` *extends* [`PluginExtension`](../type-aliases/PluginExtension.md)\\<`Extension`, [`DefaultGunshiParams`](../type-aliases/DefaultGunshiParams.md)\\> = [`PluginExtension`](../type-aliases/PluginExtension.md)\\<`Extension`, `ResolvedDepExtensions`\\> |"));
         assert!(!page.contains("\\<\n"));
         assert!(!page.contains("ResolvedDepExtensions`\n"));
     }


### PR DESCRIPTION
## Summary

Fix Type Parameters tables so all-empty descriptions omit the Description column, while mixed tables render missing descriptions as `-` in Markdown and HTML.

## Background

Gunshi docs generated by `@ox-content/napi` showed blank Description cells for undocumented type parameters, which looked broken and differed from TypeDoc behavior.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783317551&installation_id=136613492&pr_number=334&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F334&signature=15464e70b603690db9e43cf9eb03c74fe9f56d596b11650ef85da51b3d2329e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->