### PR TITLE
fix(docs): strip JSDoc from type alias signatures

### DIFF
--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -1223,12 +1223,7 @@ impl<'a> DocVisitor<'a> {
         sig.push_str(type_alias.id.name.as_str());
         sig.push_str(&self.format_type_parameter_declaration(type_alias.type_parameters.as_ref()));
         sig.push_str(" = ");
-        sig.push_str(
-            &self.slice(
-                type_alias.type_annotation.span().start,
-                type_alias.type_annotation.span().end,
-            ),
-        );
+        sig.push_str(&self.format_ts_type(&type_alias.type_annotation));
         sig
     }
 
@@ -3212,6 +3207,46 @@ export type CommandOptions = {
     }
 
     #[test]
+    fn type_alias_signature_omits_nested_property_jsdoc_comments() {
+        let source = r"
+/**
+ * A combinator produced by combinator factory functions.
+ */
+export type Combinator<T> = {
+    /**
+     * The parse function that converts a string to the desired type.
+     *
+     * @param value - The input string value.
+     * @returns The parsed value of type T.
+     */
+    parse: (value: string) => T;
+};
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "combinators.ts", SourceType::ts()).unwrap();
+        let combinator = items.iter().find(|item| item.name == "Combinator").unwrap();
+        let signature = combinator.signature.as_deref().unwrap();
+
+        assert!(!signature.contains("/**"));
+        assert!(!signature.contains("@param"));
+        assert!(!signature.contains("@returns"));
+        assert_eq!(signature, "export type Combinator<T> = { parse: (value: string) => T }");
+
+        let parse = &combinator.children[0];
+        assert_eq!(
+            parse.doc.as_deref(),
+            Some("The parse function that converts a string to the desired type.")
+        );
+        assert_eq!(parse.signature.as_deref(), Some("(value: string) => T"));
+        assert_eq!(parse.params[0].name, "value");
+        assert_eq!(parse.params[0].description.as_deref(), Some("The input string value."));
+        assert_eq!(parse.return_type.as_deref(), Some("T"));
+        let returns_tag = parse.tags.iter().find(|tag| tag.tag == "returns").unwrap();
+        assert_eq!(returns_tag.description.as_deref(), Some("The parsed value of type T."));
+    }
+
+    #[test]
     fn type_alias_object_literal_with_method_signature() {
         let source = r"
 /**
@@ -3228,8 +3263,12 @@ export type CommandOptions = {
 
         let extractor = DocExtractor::new();
         let items = extractor.extract_source(source, "options.ts", SourceType::ts()).unwrap();
+        let signature = items[0].signature.as_deref().unwrap();
         let member = &items[0].children[0];
 
+        assert!(!signature.contains("/**"));
+        assert!(!signature.contains("@param"));
+        assert_eq!(signature, "export type CommandOptions = { run(ctx: Context): void }");
         assert_eq!(member.name, "run");
         assert_eq!(member.kind, DocItemKind::Method);
         assert_eq!(member.signature.as_deref(), Some("run(ctx: Context): void"));
@@ -3255,6 +3294,9 @@ export type CommandOptions = BaseOptions & {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].name, "CommandOptions");
         assert_eq!(items[0].children.len(), 1);
+        let signature = items[0].signature.as_deref().unwrap();
+        assert!(!signature.contains("/**"));
+        assert!(signature.contains("BaseOptions & { name: string }"));
         assert_eq!(items[0].children[0].name, "name");
         assert_eq!(items[0].children[0].signature.as_deref(), Some("string"));
         assert!(items[0].signature.as_deref().unwrap().contains("BaseOptions &"));


### PR DESCRIPTION
## Summary

Clean type alias signatures by formatting the type annotation through the extractor instead of slicing raw source, so nested member JSDoc comments no longer appear in generated Markdown.

## Background

gunshi hit this with `@ox-content/napi`: Combinator rendered member JSDoc inside its Signature block even though the same member docs were already emitted in structured property sections.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783320306&installation_id=136613492&pr_number=336&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F336&signature=4dc8d9b94111adbab70da817e25aae80f92503978abc16ca6548be9fc7a2c4de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->