### PR TITLE
fix(docs): avoid duplicate property returns

### DIFF
--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -4395,34 +4395,7 @@ mod tests {
     fn typedoc_markdown_renders_function_valued_property_details() {
         let mut schema =
             test_entry("ArgSchema", "interface", "/repo/src/schema.ts", "Argument schema.");
-        schema.members = vec![ApiDocMember {
-            name: "parse".to_string(),
-            kind: "property".to_string(),
-            description: "Parses a raw value.".to_string(),
-            signature: None,
-            type_annotation: Some("(value: string) => string | undefined".to_string()),
-            params: vec![ApiParamDoc {
-                name: "value".to_string(),
-                type_annotation: "string".to_string(),
-                description: "Raw string value from command line.".to_string(),
-                optional: false,
-                default_value: None,
-            }],
-            type_parameters: vec![],
-            returns: Some(ApiReturnDoc {
-                type_annotation: "string | undefined".to_string(),
-                description: "Parsed value.".to_string(),
-                members: Vec::new(),
-            }),
-            optional: true,
-            readonly: false,
-            r#static: false,
-            private: false,
-            tags: vec![],
-            implementation_of: vec![],
-            line: 5,
-            end_line: 10,
-        }];
+        schema.members = vec![function_valued_parse_member()];
         let docs = vec![ApiDocModule {
             description: String::new(),
             file: "default".to_string(),
@@ -4442,7 +4415,8 @@ mod tests {
         );
         let page = markdown.get("default/interfaces/ArgSchema.md").unwrap();
 
-        assert!(page.contains("| `parse` _(optional)_ | `(value: string) => string \\| undefined` | Parses a raw value. Returns: Parsed value. |"));
+        assert!(page.contains("| `parse` _(optional)_ | `(value: string) => string \\| undefined` | Parses a raw value. |"));
+        assert!(!page.contains("Parses a raw value. Returns: Parsed value."));
         assert!(page.contains("### parse Parameters"));
         assert!(page.contains("| `value` | `string` | Raw string value from command line. |"));
         assert!(page.contains("### parse Returns"));
@@ -5389,6 +5363,37 @@ mod tests {
         }
     }
 
+    fn function_valued_parse_member() -> ApiDocMember {
+        ApiDocMember {
+            name: "parse".to_string(),
+            kind: "property".to_string(),
+            description: "Parses a raw value.".to_string(),
+            signature: None,
+            type_annotation: Some("(value: string) => string | undefined".to_string()),
+            params: vec![ApiParamDoc {
+                name: "value".to_string(),
+                type_annotation: "string".to_string(),
+                description: "Raw string value from command line.".to_string(),
+                optional: false,
+                default_value: None,
+            }],
+            type_parameters: vec![],
+            returns: Some(ApiReturnDoc {
+                type_annotation: "string | undefined".to_string(),
+                description: "Parsed value.".to_string(),
+                members: Vec::new(),
+            }),
+            optional: true,
+            readonly: false,
+            r#static: false,
+            private: false,
+            tags: vec![],
+            implementation_of: vec![],
+            line: 5,
+            end_line: 10,
+        }
+    }
+
     fn type_param(name: &str) -> ApiParamDoc {
         ApiParamDoc {
             name: name.to_string(),
@@ -6119,6 +6124,30 @@ mod tests {
 
         assert!(page.contains(">deprecated</span>"));
         assert!(page.contains("since 1.0.0"));
+    }
+
+    #[test]
+    fn typedoc_html_renders_function_valued_property_return_once() {
+        let mut entry =
+            test_entry("ArgSchema", "interface", "/repo/src/schema.ts", "Argument schema.");
+        entry.members = vec![function_valued_parse_member()];
+        let out = generate_markdown(
+            &lifecycle_module(entry),
+            &MarkdownDocsOptions {
+                interface_properties_format: MarkdownDisplayFormat::Table,
+                parameters_format: MarkdownDisplayFormat::Table,
+                ..html_typedoc_options()
+            },
+        );
+        let page = out.get("combinators/interfaces/ArgSchema.md").unwrap();
+
+        assert!(page.contains("Parses a raw value."));
+        assert!(page.contains("<table class=\"ox-api-entry__member-params-table\">"));
+        assert!(page.contains(
+            "<div class=\"ox-api-entry__member-return\"><span>Returns</span> Parsed value.</div>"
+        ));
+        assert_eq!(page.matches("Parsed value.").count(), 1);
+        assert!(!page.contains("ox-api-entry__member-detail-section--returns"));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -467,7 +467,7 @@ fn push_return_members(
         out.push_str("\n\n```ts\n");
         out.push_str(&return_member_signature(member));
         out.push_str("\n```\n\n");
-        let description = member_description(member, context);
+        let description = member_description(member, context, true);
         if !description.is_empty() {
             out.push_str(&description);
             out.push_str("\n\n");
@@ -936,7 +936,7 @@ fn render_member_group_pure(
                 out.push(' ');
                 out.push_str(&linked_type_span(member_type, context.link_context));
             }
-            let description = member_description(member, context.link_context);
+            let description = member_description(member, context.link_context, false);
             if !description.is_empty() {
                 out.push_str(" - ");
                 out.push_str(&description);
@@ -960,7 +960,7 @@ fn render_member_group_pure(
             }
             out.push_str(&linked_type_cell(member_type(member), context.link_context));
             out.push_str(" | ");
-            push_table_cell(out, &member_description(member, context.link_context));
+            push_table_cell(out, &member_description(member, context.link_context, false));
             out.push_str(" |\n");
         }
     }
@@ -1135,7 +1135,11 @@ fn member_type(member: &ApiDocMember) -> &str {
         .unwrap_or_default()
 }
 
-fn member_description(member: &ApiDocMember, context: Option<&MarkdownLinkContext<'_>>) -> String {
+fn member_description(
+    member: &ApiDocMember,
+    context: Option<&MarkdownLinkContext<'_>>,
+    include_returns: bool,
+) -> String {
     let mut description = String::new();
     // Lifecycle tags cannot hold a GitHub alert inside a table cell, so surface
     // them as a short bold marker prefix instead.
@@ -1166,11 +1170,13 @@ fn member_description(member: &ApiDocMember, context: Option<&MarkdownLinkContex
     if !member.description.is_empty() {
         push_part(&mut description, &inline(&member.description, context));
     }
-    if let Some(returns) = &member.returns {
-        if !returns.description.is_empty() {
-            push_part(&mut description, "Returns:");
-            description.push(' ');
-            description.push_str(&inline(&returns.description, context));
+    if include_returns {
+        if let Some(returns) = &member.returns {
+            if !returns.description.is_empty() {
+                push_part(&mut description, "Returns:");
+                description.push(' ');
+                description.push_str(&inline(&returns.description, context));
+            }
         }
     }
     // `@since` / `@version` render inline (TypeDoc shows them in the cell); a


### PR DESCRIPTION
## Summary

Fix Markdown rendering for function-valued properties so return descriptions are no longer duplicated in table/list summaries and structured Returns sections.

Add regression coverage for Markdown and HTML behavior.

## Background

Gunshi API docs generated with `@ox-content/napi` showed Returns text in property table descriptions and again in parse Returns.

The IR already separated description and returns, so the issue was isolated to Markdown renderer summary formatting.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783322011&installation_id=136613492&pr_number=337&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F337&signature=d85f056fe3c0a104b8435290f45deaa189ab20790514c8e98e3f8c313770f78a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->