### PR TITLE
fix(docs): render nested HTML member formats

### DIFF
--- a/crates/ox_content_docs/benches/markdown.rs
+++ b/crates/ox_content_docs/benches/markdown.rs
@@ -138,6 +138,7 @@ fn member(module: usize, entry: usize, index: usize) -> ApiDocMember {
             description: "Whether the member accepted the value.".to_string(),
             members: Vec::new(),
         }),
+        members: Vec::new(),
         optional: index % 2 == 0,
         readonly: index % 3 == 0,
         r#static: index % 11 == 0,

--- a/crates/ox_content_docs/src/data.rs
+++ b/crates/ox_content_docs/src/data.rs
@@ -200,6 +200,12 @@ fn member_to_json(member: &ApiDocMember) -> Value {
     if let Some(returns) = &member.returns {
         value.insert("returns".to_string(), return_to_json(returns));
     }
+    if !member.members.is_empty() {
+        value.insert(
+            "members".to_string(),
+            Value::Array(member.members.iter().map(member_to_json).collect()),
+        );
+    }
     if member.optional {
         value.insert("optional".to_string(), json!(true));
     }
@@ -484,6 +490,7 @@ mod tests {
                         params: vec![],
                         type_parameters: vec![],
                         returns: None,
+                        members: vec![],
                         optional: false,
                         readonly: false,
                         r#static: false,
@@ -516,6 +523,82 @@ mod tests {
         assert_eq!(returns["type"], "object");
         assert_eq!(returns["members"][0]["name"], "values");
         assert_eq!(returns["members"][0]["type"], "ArgValues<A>");
+    }
+
+    #[test]
+    fn property_members_serialize_to_json() {
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "/repo/src/options.ts".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![ApiDocEntry {
+                name: "Options".to_string(),
+                kind: "interface".to_string(),
+                description: "Request options.".to_string(),
+                params: vec![],
+                returns: None,
+                examples: vec![],
+                tags: vec![],
+                private: false,
+                file: "/repo/src/options.ts".to_string(),
+                line: 1,
+                end_line: 8,
+                signature: Some("export interface Options".to_string()),
+                extends: vec![],
+                implements: vec![],
+                has_body: false,
+                members: vec![ApiDocMember {
+                    name: "http".to_string(),
+                    kind: "property".to_string(),
+                    description: "HTTP options.".to_string(),
+                    signature: None,
+                    type_annotation: Some("{ timeout?: number }".to_string()),
+                    params: vec![],
+                    type_parameters: vec![],
+                    returns: None,
+                    members: vec![ApiDocMember {
+                        name: "timeout".to_string(),
+                        kind: "property".to_string(),
+                        description: "Request timeout.".to_string(),
+                        signature: None,
+                        type_annotation: Some("number".to_string()),
+                        params: vec![],
+                        type_parameters: vec![],
+                        returns: None,
+                        members: vec![],
+                        optional: true,
+                        readonly: false,
+                        r#static: false,
+                        private: false,
+                        tags: vec![],
+                        implementation_of: vec![],
+                        line: 4,
+                        end_line: 4,
+                    }],
+                    optional: false,
+                    readonly: false,
+                    r#static: false,
+                    private: false,
+                    tags: vec![],
+                    implementation_of: vec![],
+                    line: 3,
+                    end_line: 6,
+                }],
+                type_parameters: vec![],
+            }],
+        }];
+
+        let json = generate_docs_data_json(&docs, "2026-05-31T00:00:00.000Z").unwrap();
+        let value: Value = serde_json::from_str(&json).unwrap();
+        let nested_member = &value["modules"][0]["entries"][0]["members"][0]["members"][0];
+
+        assert_eq!(nested_member["name"], "timeout");
+        assert_eq!(nested_member["kind"], "property");
+        assert_eq!(nested_member["description"], "Request timeout.");
+        assert_eq!(nested_member["type"], "number");
+        assert_eq!(nested_member["optional"], true);
     }
 
     #[test]
@@ -557,6 +640,7 @@ mod tests {
                     }],
                     type_parameters: vec![],
                     returns: None,
+                    members: vec![],
                     optional: false,
                     readonly: true,
                     r#static: false,
@@ -631,6 +715,7 @@ mod tests {
                         description: "Parsed value.".to_string(),
                         members: Vec::new(),
                     }),
+                    members: vec![],
                     optional: true,
                     readonly: false,
                     r#static: false,
@@ -814,6 +899,7 @@ mod tests {
                     params: vec![],
                     type_parameters: vec![],
                     returns: None,
+                    members: vec![],
                     optional: false,
                     readonly: false,
                     r#static: false,

--- a/crates/ox_content_docs/src/extractor.rs
+++ b/crates/ox_content_docs/src/extractor.rs
@@ -2086,6 +2086,7 @@ impl<'a> DocVisitor<'a> {
                     let mut return_type = None;
                     let mut return_members = Vec::new();
                     let mut type_parameters = Vec::new();
+                    let mut property_members = Vec::new();
                     let type_annotation = prop.type_annotation.as_ref().map(|t| {
                         let ts_type = &t.type_annotation;
                         if let Some(metadata) =
@@ -2096,6 +2097,7 @@ impl<'a> DocVisitor<'a> {
                             return_members = metadata.return_members;
                             type_parameters = metadata.type_parameters;
                         }
+                        property_members = self.extract_type_alias_members_from_type(ts_type);
 
                         self.format_ts_type(ts_type)
                     });
@@ -2120,7 +2122,7 @@ impl<'a> DocVisitor<'a> {
                         params,
                         return_type,
                         return_members,
-                        children: Vec::new(),
+                        children: property_members,
                         tags: prop_tags,
                         type_parameters,
                     });
@@ -2190,6 +2192,7 @@ impl<'a> DocVisitor<'a> {
                     let mut return_type = None;
                     let mut return_members = Vec::new();
                     let mut type_parameters = Vec::new();
+                    let mut property_members = Vec::new();
                     let type_annotation = prop.type_annotation.as_ref().map(|t| {
                         let ts_type = &t.type_annotation;
                         if let Some(metadata) =
@@ -2200,6 +2203,7 @@ impl<'a> DocVisitor<'a> {
                             return_members = metadata.return_members;
                             type_parameters = metadata.type_parameters;
                         }
+                        property_members = self.extract_type_alias_members_from_type(ts_type);
 
                         self.format_ts_type(ts_type)
                     });
@@ -2224,7 +2228,7 @@ impl<'a> DocVisitor<'a> {
                         params,
                         return_type,
                         return_members,
-                        children: Vec::new(),
+                        children: property_members,
                         tags: prop_tags,
                         type_parameters,
                     });
@@ -3204,6 +3208,38 @@ export type CommandOptions = {
         assert_eq!(items[0].children[1].name, "aliases");
         assert_eq!(items[0].children[1].signature.as_deref(), Some("string[]"));
         assert!(items[0].children[1].optional);
+    }
+
+    #[test]
+    fn interface_property_type_literal_emits_property_members() {
+        let source = r"
+/**
+ * Request options.
+ */
+export interface RequestOptions {
+    /** HTTP options. */
+    http: {
+        /** Request timeout. */
+        timeout?: number;
+        /** Request headers. */
+        headers: Record<string, string>;
+    };
+}
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "request.ts", SourceType::ts()).unwrap();
+        let http = &items[0].children[0];
+
+        assert_eq!(http.name, "http");
+        assert_eq!(http.kind, DocItemKind::Property);
+        assert_eq!(http.children.len(), 2);
+        assert_eq!(http.children[0].name, "timeout");
+        assert_eq!(http.children[0].doc.as_deref(), Some("Request timeout."));
+        assert_eq!(http.children[0].signature.as_deref(), Some("number"));
+        assert!(http.children[0].optional);
+        assert_eq!(http.children[1].name, "headers");
+        assert_eq!(http.children[1].signature.as_deref(), Some("Record<string, string>"));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -2894,6 +2894,7 @@ mod tests {
                         params: vec![],
                         type_parameters: vec![],
                         returns: None,
+                        members: vec![],
                         optional: false,
                         readonly: false,
                         r#static: false,
@@ -3306,6 +3307,7 @@ mod tests {
                         params: vec![],
                         type_parameters: vec![],
                         returns: None,
+                        members: vec![],
                         optional: false,
                         readonly: false,
                         r#static: false,
@@ -3442,6 +3444,7 @@ mod tests {
                         params: vec![],
                         type_parameters: vec![],
                         returns: None,
+                        members: vec![],
                         optional: true,
                         readonly: false,
                         r#static: false,
@@ -4053,6 +4056,7 @@ mod tests {
             params: vec![],
             type_parameters: vec![],
             returns: None,
+            members: vec![],
             optional: false,
             readonly: true,
             r#static: false,
@@ -4117,6 +4121,7 @@ mod tests {
             }],
             type_parameters: vec![],
             returns: None,
+            members: vec![],
             optional: false,
             readonly: false,
             r#static: false,
@@ -4199,6 +4204,7 @@ mod tests {
                 },
             ],
             returns: None,
+            members: vec![],
             optional: false,
             readonly: false,
             r#static: false,
@@ -4275,6 +4281,7 @@ mod tests {
                 description: "The locale resource.".to_string(),
                 members: Vec::new(),
             }),
+            members: vec![],
             optional: false,
             readonly: false,
             r#static: false,
@@ -4312,6 +4319,7 @@ mod tests {
                 }],
                 type_parameters: vec![],
                 returns: None,
+                members: vec![],
                 optional: false,
                 readonly: false,
                 r#static: false,
@@ -4342,6 +4350,7 @@ mod tests {
                     description: "The locale resource.".to_string(),
                     members: Vec::new(),
                 }),
+                members: vec![],
                 optional: false,
                 readonly: false,
                 r#static: false,
@@ -4453,6 +4462,7 @@ mod tests {
                 params: vec![],
                 type_parameters: vec![],
                 returns: None,
+                members: vec![],
                 optional: false,
                 readonly: true,
                 r#static: false,
@@ -4477,6 +4487,7 @@ mod tests {
                 }],
                 type_parameters: vec![],
                 returns: None,
+                members: vec![],
                 optional: false,
                 readonly: false,
                 r#static: false,
@@ -5271,6 +5282,7 @@ mod tests {
                 description: "The locale resource.".to_string(),
                 members: Vec::new(),
             }),
+            members: vec![],
             optional: false,
             readonly: false,
             r#static: false,
@@ -5311,6 +5323,7 @@ mod tests {
                 description: "The locale resource.".to_string(),
                 members: Vec::new(),
             }),
+            members: vec![],
             optional: false,
             readonly: false,
             r#static: false,
@@ -5352,6 +5365,7 @@ mod tests {
             params: vec![],
             type_parameters: vec![],
             returns: None,
+            members: vec![],
             optional: false,
             readonly: false,
             r#static: is_static,
@@ -5383,6 +5397,7 @@ mod tests {
                 description: "Parsed value.".to_string(),
                 members: Vec::new(),
             }),
+            members: vec![],
             optional: true,
             readonly: false,
             r#static: false,
@@ -5506,6 +5521,7 @@ mod tests {
             params: vec![],
             type_parameters: vec![],
             returns: None,
+            members: vec![],
             optional: false,
             readonly: false,
             r#static: false,
@@ -5537,6 +5553,7 @@ mod tests {
             params: vec![param(param_name, param_type)],
             type_parameters: vec![],
             returns: None,
+            members: vec![],
             optional: false,
             readonly,
             r#static: false,
@@ -5620,6 +5637,53 @@ mod tests {
         assert!(page.contains("<h5>values</h5>"));
         assert!(page
             .contains("values: <a href=\"../type-aliases/ArgValues.md\">ArgValues</a>&lt;A&gt;;"));
+    }
+
+    #[test]
+    fn typedoc_html_type_declaration_format_table_renders_return_members_table() {
+        let mut values = return_property("values", "ArgValues<A>");
+        values.description = "Resolved values.".to_string();
+        let mut entry = test_entry("resolveArgs", "function", "/repo/src/resolver.ts", "Resolve.");
+        entry.returns = Some(ApiReturnDoc {
+            type_annotation: "object".to_string(),
+            description: "Resolved args.".to_string(),
+            members: vec![values],
+        });
+        let options = MarkdownDocsOptions {
+            type_declaration_format: MarkdownDisplayFormat::Table,
+            ..html_typedoc_options()
+        };
+        let out = generate_markdown(&type_link_module(entry), &options);
+        let page = out.get("combinators/functions/resolveArgs.md").unwrap();
+
+        assert!(page.contains("ox-api-entry__type-declaration-table"));
+        assert!(page.contains("<td><code>values</code></td>"));
+        assert!(page.contains("<a href=\"../type-aliases/ArgValues.md\">ArgValues</a>&lt;A&gt;"));
+        assert!(page.contains("Resolved values."));
+        assert!(!page.contains("ox-api-entry__return-members"));
+    }
+
+    #[test]
+    fn typedoc_html_type_declaration_format_list_renders_return_members_list() {
+        let mut values = return_property("values", "ArgValues<A>");
+        values.description = "Resolved values.".to_string();
+        let mut entry = test_entry("resolveArgs", "function", "/repo/src/resolver.ts", "Resolve.");
+        entry.returns = Some(ApiReturnDoc {
+            type_annotation: "object".to_string(),
+            description: "Resolved args.".to_string(),
+            members: vec![values],
+        });
+        let options = MarkdownDocsOptions {
+            type_declaration_format: MarkdownDisplayFormat::List,
+            ..html_typedoc_options()
+        };
+        let out = generate_markdown(&type_link_module(entry), &options);
+        let page = out.get("combinators/functions/resolveArgs.md").unwrap();
+
+        assert!(page.contains("ox-api-entry__type-declaration-list"));
+        assert!(page.contains("ox-api-entry__type-declaration-member"));
+        assert!(page.contains("Resolved values."));
+        assert!(!page.contains("ox-api-entry__return-members"));
     }
 
     #[test]
@@ -6107,6 +6171,7 @@ mod tests {
             params: vec![],
             type_parameters: vec![],
             returns: None,
+            members: vec![],
             optional: false,
             readonly: false,
             r#static: false,
@@ -6124,6 +6189,88 @@ mod tests {
 
         assert!(page.contains(">deprecated</span>"));
         assert!(page.contains("since 1.0.0"));
+    }
+
+    #[test]
+    fn typedoc_html_property_members_format_table_renders_owned_members() {
+        let mut http = member("http", "property", false);
+        http.description = "HTTP options.".to_string();
+        http.type_annotation =
+            Some("{ timeout?: number; headers: Record<string, string> }".to_string());
+        let mut timeout = member("timeout", "property", false);
+        timeout.description = "Request timeout.".to_string();
+        timeout.type_annotation = Some("number".to_string());
+        timeout.optional = true;
+        http.members = vec![timeout];
+
+        let mut entry = test_entry("Options", "interface", "/repo/src/o.ts", "Options.");
+        entry.members = vec![http];
+        let out = generate_markdown(
+            &lifecycle_module(entry),
+            &MarkdownDocsOptions {
+                interface_properties_format: MarkdownDisplayFormat::Table,
+                property_members_format: MarkdownDisplayFormat::Table,
+                ..html_typedoc_options()
+            },
+        );
+        let page = out.get("combinators/interfaces/Options.md").unwrap();
+
+        assert!(page.contains("ox-api-entry__property-members-row"));
+        assert!(page.contains("ox-api-entry__property-members-table"));
+        assert!(page
+            .contains("<td><code>timeout</code><span class=\"ox-api-badge\">optional</span></td>"));
+        assert!(page.contains("Request timeout."));
+    }
+
+    #[test]
+    fn typedoc_html_property_members_format_list_renders_owned_members() {
+        let mut http = member("http", "property", false);
+        http.description = "HTTP options.".to_string();
+        http.type_annotation = Some("{ timeout?: number }".to_string());
+        let mut timeout = member("timeout", "property", false);
+        timeout.description = "Request timeout.".to_string();
+        timeout.type_annotation = Some("number".to_string());
+        timeout.optional = true;
+        http.members = vec![timeout];
+
+        let mut entry = test_entry("Options", "interface", "/repo/src/o.ts", "Options.");
+        entry.members = vec![http];
+        let out = generate_markdown(
+            &lifecycle_module(entry),
+            &MarkdownDocsOptions {
+                interface_properties_format: MarkdownDisplayFormat::List,
+                property_members_format: MarkdownDisplayFormat::List,
+                ..html_typedoc_options()
+            },
+        );
+        let page = out.get("combinators/interfaces/Options.md").unwrap();
+
+        assert!(page.contains("ox-api-entry__property-members-list"));
+        assert!(page.contains("ox-api-entry__property-member"));
+        assert!(page.contains("Request timeout."));
+    }
+
+    #[test]
+    fn typedoc_html_property_members_format_none_omits_owned_members() {
+        let mut http = member("http", "property", false);
+        http.description = "HTTP options.".to_string();
+        http.type_annotation = Some("{ timeout?: number }".to_string());
+        http.members = vec![member("timeout", "property", false)];
+
+        let mut entry = test_entry("Options", "interface", "/repo/src/o.ts", "Options.");
+        entry.members = vec![http];
+        let out = generate_markdown(
+            &lifecycle_module(entry),
+            &MarkdownDocsOptions {
+                interface_properties_format: MarkdownDisplayFormat::Table,
+                property_members_format: MarkdownDisplayFormat::None,
+                ..html_typedoc_options()
+            },
+        );
+        let page = out.get("combinators/interfaces/Options.md").unwrap();
+
+        assert!(!page.contains("ox-api-entry__property-members-table"));
+        assert!(!page.contains("ox-api-entry__property-members-list"));
     }
 
     #[test]
@@ -6401,6 +6548,7 @@ mod tests {
             params: vec![],
             type_parameters: vec![],
             returns: None,
+            members: vec![],
             optional: true,
             readonly: false,
             r#static: false,
@@ -6467,6 +6615,7 @@ mod tests {
             params: vec![],
             type_parameters: vec![],
             returns: None,
+            members: vec![],
             optional: true,
             readonly: false,
             r#static: false,
@@ -6817,6 +6966,7 @@ mod tests {
                         params: vec![],
                         type_parameters: vec![],
                         returns: None,
+                        members: vec![],
                         optional: false,
                         readonly: false,
                         r#static: false,
@@ -6905,6 +7055,7 @@ mod tests {
                         params: vec![],
                         type_parameters: vec![],
                         returns: None,
+                        members: vec![],
                         optional: false,
                         readonly: true,
                         r#static: false,
@@ -6933,6 +7084,7 @@ mod tests {
                             description: "Run result.".to_string(),
                             members: Vec::new(),
                         }),
+                        members: vec![],
                         optional: false,
                         readonly: false,
                         r#static: false,

--- a/crates/ox_content_docs/src/markdown/markdown_html.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_html.rs
@@ -1122,6 +1122,15 @@ fn render_member_table_html(
         rows.push_str("</td>\n  <td>");
         rows.push_str(&render_member_description_html(member, options, context));
         rows.push_str("</td>\n</tr>");
+        let property_members = render_property_members_html(&member.members, options, context);
+        if !property_members.is_empty() {
+            let colspan = if include_kind { 4 } else { 3 };
+            rows.push_str("\n<tr class=\"ox-api-entry__property-members-row\"><td colspan=\"");
+            rows.push_usize(colspan);
+            rows.push_str("\">");
+            rows.push_str(&property_members);
+            rows.push_str("</td></tr>");
+        }
     }
     let rows = rows.into_string();
 
@@ -1190,6 +1199,11 @@ fn render_member_list_html(
         items.push_str(&render_member_type_html(member, context, &HashSet::new()));
         items.push_str("\n  </div>\n  ");
         items.push_str(&render_member_description_html(member, options, context));
+        let property_members = render_property_members_html(&member.members, options, context);
+        if !property_members.is_empty() {
+            items.push_char('\n');
+            items.push_str(&property_members);
+        }
         items.push_str("\n</li>");
     }
     let items = items.into_string();
@@ -1261,14 +1275,14 @@ fn render_callable_member_group_html(
         details.push_str(&render_member_detail_type_parameters_html(member, options, context));
         details.push_str(&render_member_detail_params_html(member, options, context));
         if let Some(returns) = &member.returns {
-            details.push_str(&render_member_detail_returns_html(returns, context));
+            details.push_str(&render_member_detail_returns_html(returns, options, context));
         } else if member.kind == "constructor" {
             let returns = ApiReturnDoc {
                 type_annotation: entry.name.clone(),
                 description: String::new(),
                 members: Vec::new(),
             };
-            details.push_str(&render_member_detail_returns_html(&returns, context));
+            details.push_str(&render_member_detail_returns_html(&returns, options, context));
         }
         details.push_str(&render_implementation_of_html(&member.implementation_of));
         details.push_str("</section>");
@@ -1389,6 +1403,7 @@ fn render_member_detail_type_parameters_html(
 
 fn render_member_detail_returns_html(
     returns: &ApiReturnDoc,
+    options: &MarkdownDocsOptions,
     context: Option<&MarkdownLinkContext<'_>>,
 ) -> String {
     let mut out = StringBuilder::new();
@@ -1400,7 +1415,7 @@ fn render_member_detail_returns_html(
         out.push_str(&render_doc_inline_html(&returns.description, context));
         out.push_str("</p>");
     }
-    out.push_str(&render_return_members_html(&returns.members, context));
+    out.push_str(&render_return_members_html(&returns.members, options, context));
     out.push_str("\n</div>");
     out.into_string()
 }
@@ -1688,7 +1703,7 @@ fn render_entry_body_html(
     push_params_html(&mut body, &entry.params, options, link_context);
 
     if let Some(returns) = &entry.returns {
-        push_returns_html(&mut body, returns, link_context);
+        push_returns_html(&mut body, returns, options, link_context);
     }
 
     push_examples_html(&mut body, &entry.examples);
@@ -1767,6 +1782,7 @@ fn push_params_html(
 fn push_returns_html(
     body: &mut String,
     returns: &ApiReturnDoc,
+    options: &MarkdownDocsOptions,
     link_context: Option<&MarkdownLinkContext<'_>>,
 ) {
     body.push_str(
@@ -1785,7 +1801,7 @@ fn push_returns_html(
         body.push_str(&render_doc_inline_html(&returns.description, link_context));
         body.push_str("</p>");
     }
-    body.push_str(&render_return_members_html(&returns.members, link_context));
+    body.push_str(&render_return_members_html(&returns.members, options, link_context));
     body.push_str(
         "
 </div>
@@ -1795,10 +1811,21 @@ fn push_returns_html(
 
 fn render_return_members_html(
     members: &[ApiDocMember],
+    options: &MarkdownDocsOptions,
     link_context: Option<&MarkdownLinkContext<'_>>,
 ) -> String {
     if members.is_empty() {
         return String::new();
+    }
+
+    match options.type_declaration_format {
+        MarkdownDisplayFormat::Table => {
+            return render_type_declaration_members_table_html(members, link_context);
+        }
+        MarkdownDisplayFormat::List => {
+            return render_type_declaration_members_list_html(members, link_context);
+        }
+        MarkdownDisplayFormat::None => {}
     }
 
     let mut rendered = StringBuilder::new();
@@ -1826,6 +1853,167 @@ fn render_return_members_html(
     }
     rendered.push_str("\n</div>");
     rendered.into_string()
+}
+
+fn render_type_declaration_members_table_html(
+    members: &[ApiDocMember],
+    link_context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    render_nested_members_table_html(members, "ox-api-entry__type-declaration-table", link_context)
+}
+
+fn render_type_declaration_members_list_html(
+    members: &[ApiDocMember],
+    link_context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    render_nested_members_list_html(
+        members,
+        "ox-api-entry__type-declaration-list",
+        "ox-api-entry__type-declaration-member",
+        "ox-api-entry__type-declaration-member-heading",
+        "ox-api-entry__type-declaration-member-description",
+        link_context,
+    )
+}
+
+fn render_property_members_html(
+    members: &[ApiDocMember],
+    options: &MarkdownDocsOptions,
+    link_context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    if members.is_empty() {
+        return String::new();
+    }
+
+    match options.property_members_format {
+        MarkdownDisplayFormat::Table => render_nested_members_table_html(
+            members,
+            "ox-api-entry__property-members-table",
+            link_context,
+        ),
+        MarkdownDisplayFormat::List => render_nested_members_list_html(
+            members,
+            "ox-api-entry__property-members-list",
+            "ox-api-entry__property-member",
+            "ox-api-entry__property-member-heading",
+            "ox-api-entry__property-member-description",
+            link_context,
+        ),
+        MarkdownDisplayFormat::None => String::new(),
+    }
+}
+
+fn render_nested_members_table_html(
+    members: &[ApiDocMember],
+    class_name: &str,
+    link_context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    let mut rows = StringBuilder::new();
+    for member in members {
+        if !rows.is_empty() {
+            rows.push_char('\n');
+        }
+        rows.push_str("<tr>\n  <td>");
+        rows.push_str(&render_nested_member_name_html(member));
+        rows.push_str("</td>\n  <td>");
+        rows.push_str(&render_nested_member_type_html(member, link_context));
+        rows.push_str("</td>\n  <td>");
+        rows.push_str(&render_nested_member_description_html(member, link_context));
+        rows.push_str("</td>\n</tr>");
+    }
+
+    let mut out = StringBuilder::new();
+    out.push_str("<table class=\"");
+    out.push_str(class_name);
+    out.push_str(
+        "\"><thead><tr><th>Name</th><th>Type</th><th>Description</th></tr></thead><tbody>\n",
+    );
+    out.push_str(&rows.into_string());
+    out.push_str("\n</tbody></table>");
+    out.into_string()
+}
+
+fn render_nested_members_list_html(
+    members: &[ApiDocMember],
+    list_class_name: &str,
+    item_class_name: &str,
+    heading_class_name: &str,
+    description_class_name: &str,
+    link_context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    let mut items = StringBuilder::new();
+    for member in members {
+        if !items.is_empty() {
+            items.push_char('\n');
+        }
+        items.push_str("<li class=\"");
+        items.push_str(item_class_name);
+        items.push_str("\">");
+        items.push_str("<div class=\"");
+        items.push_str(heading_class_name);
+        items.push_str("\">");
+        items.push_str(&render_nested_member_name_html(member));
+        let member_type = render_nested_member_type_html(member, link_context);
+        if !member_type.is_empty() {
+            items.push_char(' ');
+            items.push_str(&member_type);
+        }
+        items.push_str("</div>");
+        let description = render_nested_member_description_html(member, link_context);
+        if !description.is_empty() {
+            items.push_str("<div class=\"");
+            items.push_str(description_class_name);
+            items.push_str("\">");
+            items.push_str(&description);
+            items.push_str("</div>");
+        }
+        items.push_str("</li>");
+    }
+
+    let mut out = StringBuilder::new();
+    out.push_str("<ul class=\"");
+    out.push_str(list_class_name);
+    out.push_str("\">\n");
+    out.push_str(&items.into_string());
+    out.push_str("\n</ul>");
+    out.into_string()
+}
+
+fn render_nested_member_name_html(member: &ApiDocMember) -> String {
+    let mut out = StringBuilder::new();
+    out.push_str("<code>");
+    out.push_str(&escape_html(&member.name));
+    out.push_str("</code>");
+    out.push_str(&render_member_flags(member));
+    out.into_string()
+}
+
+fn render_nested_member_type_html(
+    member: &ApiDocMember,
+    link_context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    let Some(member_type) = member
+        .type_annotation
+        .as_deref()
+        .or_else(|| member.returns.as_ref().map(|returns| returns.type_annotation.as_str()))
+        .or(member.signature.as_deref())
+        .filter(|value| !value.is_empty())
+    else {
+        return String::new();
+    };
+
+    let mut out = StringBuilder::new();
+    out.push_str("<code class=\"ox-api-entry__member-type language-typescript\">");
+    out.push_str(&render_type_inner_html(member_type, link_context, &HashSet::new()));
+    out.push_str("</code>");
+    out.into_string()
+}
+
+fn render_nested_member_description_html(
+    member: &ApiDocMember,
+    link_context: Option<&MarkdownLinkContext<'_>>,
+) -> String {
+    render_member_description_html(member, &MarkdownDocsOptions::default(), link_context)
 }
 
 fn push_return_member_signature_html(
@@ -2070,7 +2258,7 @@ pub(super) fn render_overload_body_html(
         push_type_parameters_html(&mut out, &signature.type_parameters, options, link_context);
         push_params_html(&mut out, &signature.params, options, link_context);
         if let Some(returns) = &signature.returns {
-            push_returns_html(&mut out, returns, link_context);
+            push_returns_html(&mut out, returns, options, link_context);
         }
         push_examples_html(&mut out, &signature.examples);
         push_tag_list_html(&mut out, &signature.tags, link_context);

--- a/crates/ox_content_docs/src/model.rs
+++ b/crates/ox_content_docs/src/model.rs
@@ -104,6 +104,9 @@ pub struct ApiDocMember {
     pub type_parameters: Vec<ApiTypeParamDoc>,
     /// Return documentation.
     pub returns: Option<ApiReturnDoc>,
+    /// Nested members owned by this member (for property-owned object literals).
+    #[serde(default)]
+    pub members: Vec<ApiDocMember>,
     /// Whether the member is optional.
     #[serde(default)]
     pub optional: bool,

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -208,6 +208,9 @@ pub struct NormalizedMember {
     pub type_parameters: Vec<NormalizedTypeParam>,
     /// Return documentation, if any.
     pub returns: Option<NormalizedReturnDoc>,
+    /// Nested members owned by this member (for property-owned object literals).
+    #[serde(default)]
+    pub members: Vec<NormalizedMember>,
     /// Whether the member is optional.
     #[serde(default)]
     pub optional: bool,
@@ -334,6 +337,7 @@ pub fn normalize_doc_item(item: DocItem, type_parameters: bool) -> Option<Normal
 }
 
 fn normalize_member(item: DocItem, type_parameters: bool) -> Option<NormalizedMember> {
+    let include_type_parameters = type_parameters;
     let kind = NormalizedMemberKind::from_doc_item_kind(item.kind)?;
     let mut metadata = normalize_doc_metadata(&item.tags, type_parameters);
     let has_extracted_params = !item.params.is_empty();
@@ -359,11 +363,16 @@ fn normalize_member(item: DocItem, type_parameters: bool) -> Option<NormalizedMe
     } else {
         metadata.returns = None;
     }
-    let type_parameters = if type_parameters {
+    let type_parameters = if include_type_parameters {
         build_type_parameters(item.type_parameters, &metadata.type_param_descriptions)
     } else {
         Vec::new()
     };
+    let members = item
+        .children
+        .into_iter()
+        .filter_map(|item| normalize_member(item, include_type_parameters))
+        .collect();
 
     let (signature, type_annotation) = match kind {
         NormalizedMemberKind::Property | NormalizedMemberKind::EnumMember => (None, item.signature),
@@ -383,6 +392,7 @@ fn normalize_member(item: DocItem, type_parameters: bool) -> Option<NormalizedMe
         params: metadata.params,
         type_parameters,
         returns: metadata.returns,
+        members,
         optional: item.optional,
         readonly: item.readonly,
         r#static: item.r#static,
@@ -758,6 +768,40 @@ export interface Command {
         assert_eq!(members[1].name, "args");
         assert_eq!(members[1].type_annotation.as_deref(), Some("string[]"));
         assert!(members[1].optional);
+    }
+
+    #[test]
+    fn interface_property_type_literal_members_are_normalized() {
+        let source = r"
+/**
+ * Request options.
+ */
+export interface RequestOptions {
+    /** HTTP options. */
+    http: {
+        /** Request timeout. */
+        timeout?: number;
+        /** Request headers. */
+        headers: Record<string, string>;
+    };
+}
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "request.ts", SourceType::ts()).unwrap();
+        let entries = normalize_doc_items(items, false);
+        let http = &entries[0].members[0];
+
+        assert_eq!(http.name, "http");
+        assert_eq!(http.kind, NormalizedMemberKind::Property);
+        assert_eq!(http.description, "HTTP options.");
+        assert_eq!(http.members.len(), 2);
+        assert_eq!(http.members[0].name, "timeout");
+        assert_eq!(http.members[0].description, "Request timeout.");
+        assert_eq!(http.members[0].type_annotation.as_deref(), Some("number"));
+        assert!(http.members[0].optional);
+        assert_eq!(http.members[1].name, "headers");
+        assert_eq!(http.members[1].type_annotation.as_deref(), Some("Record<string, string>"));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/output.rs
+++ b/crates/ox_content_docs/src/output.rs
@@ -290,6 +290,7 @@ mod tests {
                         params: vec![],
                         type_parameters: vec![],
                         returns: None,
+                        members: vec![],
                         optional: false,
                         readonly: false,
                         r#static: false,

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -281,6 +281,7 @@ export interface JsDocMember {
   params?: Array<JsDocParam>
   typeParameters?: Array<JsTypeParam>
   returns?: JsDocReturn
+  members?: Array<JsDocMember>
   optional?: boolean
   readonly?: boolean
   static?: boolean

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -207,6 +207,7 @@ pub struct JsDocMember {
     pub params: Option<Vec<JsDocParam>>,
     pub type_parameters: Option<Vec<JsTypeParam>>,
     pub returns: Option<JsDocReturn>,
+    pub members: Option<Vec<JsDocMember>>,
     pub optional: Option<bool>,
     pub readonly: Option<bool>,
     pub r#static: Option<bool>,
@@ -978,6 +979,8 @@ fn map_normalized_member(member: NormalizedMember) -> JsDocMember {
         type_parameters: (!member.type_parameters.is_empty())
             .then(|| member.type_parameters.into_iter().map(map_normalized_type_param).collect()),
         returns: member.returns.map(map_normalized_return_doc),
+        members: (!member.members.is_empty())
+            .then(|| member.members.into_iter().map(map_normalized_member).collect()),
         optional: member.optional.then_some(true),
         readonly: member.readonly.then_some(true),
         r#static: member.r#static.then_some(true),
@@ -1226,6 +1229,12 @@ fn convert_markdown_member(member: JsDocMember) -> ApiDocMember {
             .map(convert_markdown_type_param)
             .collect(),
         returns: member.returns.map(convert_markdown_return),
+        members: member
+            .members
+            .unwrap_or_default()
+            .into_iter()
+            .map(convert_markdown_member)
+            .collect(),
         optional: member.optional.unwrap_or(false),
         readonly: member.readonly.unwrap_or(false),
         r#static: member.r#static.unwrap_or(false),
@@ -3595,6 +3604,24 @@ mod tests {
                     description: "Value type.".to_string(),
                 }],
                 returns: None,
+                members: vec![NormalizedMember {
+                    name: "timeout".to_string(),
+                    kind: NormalizedMemberKind::Property,
+                    description: "Request timeout.".to_string(),
+                    signature: None,
+                    type_annotation: Some("number".to_string()),
+                    params: vec![],
+                    type_parameters: vec![],
+                    returns: None,
+                    members: vec![],
+                    optional: true,
+                    readonly: false,
+                    r#static: false,
+                    private: false,
+                    tags: BTreeMap::new(),
+                    line: 5,
+                    end_line: 5,
+                }],
                 optional: true,
                 readonly: true,
                 r#static: false,
@@ -3619,6 +3646,12 @@ mod tests {
         assert_eq!(type_param.description, "Value type.");
         assert_eq!(member.optional, Some(true));
         assert_eq!(member.readonly, Some(true));
+        let nested_member = &member.members.as_ref().unwrap()[0];
+        assert_eq!(nested_member.name, "timeout");
+        assert_eq!(nested_member.kind, "property");
+        assert_eq!(nested_member.r#type.as_deref(), Some("number"));
+        assert_eq!(nested_member.description, "Request timeout.");
+        assert_eq!(nested_member.optional, Some(true));
     }
 
     #[test]
@@ -3654,6 +3687,7 @@ mod tests {
                 }],
                 type_parameters: vec![],
                 returns: None,
+                members: vec![],
                 optional: false,
                 readonly: true,
                 r#static: false,
@@ -3724,6 +3758,7 @@ mod tests {
                     params: vec![],
                     type_parameters: vec![],
                     returns: None,
+                    members: vec![],
                     optional: false,
                     readonly: false,
                     r#static: false,
@@ -3971,6 +4006,7 @@ export function plugin<Id, PluginExt>(options: {
                     description: "Locale type.".to_string(),
                 }]),
                 returns: None,
+                members: None,
                 optional: None,
                 readonly: None,
                 r#static: None,
@@ -4137,6 +4173,180 @@ export function plugin<Id, PluginExt>(options: {
     }
 
     #[test]
+    fn generate_docs_markdown_type_declaration_format_table_renders_html() {
+        let docs = vec![JsDocsMarkdownModule {
+            description: None,
+            file: "default".to_string(),
+            source_path: None,
+            examples: None,
+            tags: None,
+            entries: vec![
+                JsDocsMarkdownEntry {
+                    name: "resolveArgs".to_string(),
+                    kind: "function".to_string(),
+                    description: "Resolve.".to_string(),
+                    params: None,
+                    returns: Some(JsDocReturn {
+                        r#type: "object".to_string(),
+                        description: "Resolved args.".to_string(),
+                        members: Some(vec![JsDocMember {
+                            name: "values".to_string(),
+                            kind: "property".to_string(),
+                            description: "Resolved values.".to_string(),
+                            signature: None,
+                            r#type: Some("ArgValues<A>".to_string()),
+                            params: None,
+                            type_parameters: None,
+                            returns: None,
+                            members: None,
+                            optional: Some(false),
+                            readonly: Some(false),
+                            r#static: Some(false),
+                            private: Some(false),
+                            tags: None,
+                            implementation_of: None,
+                            line: 1,
+                            end_line: 1,
+                        }]),
+                    }),
+                    examples: None,
+                    tags: None,
+                    private: false,
+                    file: "/repo/src/resolver.ts".to_string(),
+                    line: 1,
+                    end_line: 1,
+                    signature: Some("export function resolveArgs(): object".to_string()),
+                    extends: None,
+                    implements: None,
+                    has_body: None,
+                    members: None,
+                    type_parameters: None,
+                },
+                JsDocsMarkdownEntry {
+                    name: "ArgValues".to_string(),
+                    kind: "type".to_string(),
+                    description: String::new(),
+                    params: None,
+                    returns: None,
+                    examples: None,
+                    tags: None,
+                    private: false,
+                    file: "/repo/src/types.ts".to_string(),
+                    line: 1,
+                    end_line: 1,
+                    signature: Some("export type ArgValues = unknown".to_string()),
+                    extends: None,
+                    implements: None,
+                    has_body: None,
+                    members: None,
+                    type_parameters: None,
+                },
+            ],
+        }];
+
+        let markdown = generate_docs_markdown(
+            docs,
+            Some(JsDocsMarkdownOptions {
+                group_by: Some("file".to_string()),
+                path_strategy: Some("typedoc".to_string()),
+                render_style: Some("html".to_string()),
+                type_declaration_format: Some("table".to_string()),
+                ..Default::default()
+            }),
+        );
+        let page = markdown.get("default/functions/resolveArgs.md").unwrap();
+
+        assert!(page.contains("ox-api-entry__type-declaration-table"));
+        assert!(page.contains("<td><code>values</code></td>"));
+        assert!(page.contains("Resolved values."));
+        assert!(!page.contains("ox-api-entry__return-members"));
+    }
+
+    #[test]
+    fn generate_docs_markdown_property_members_format_table_renders_html() {
+        let docs = vec![JsDocsMarkdownModule {
+            description: None,
+            file: "default".to_string(),
+            source_path: None,
+            examples: None,
+            tags: None,
+            entries: vec![JsDocsMarkdownEntry {
+                name: "Options".to_string(),
+                kind: "interface".to_string(),
+                description: "Request options.".to_string(),
+                params: None,
+                returns: None,
+                examples: None,
+                tags: None,
+                private: false,
+                file: "/repo/src/options.ts".to_string(),
+                line: 1,
+                end_line: 8,
+                signature: Some("export interface Options".to_string()),
+                extends: None,
+                implements: None,
+                has_body: None,
+                members: Some(vec![JsDocMember {
+                    name: "http".to_string(),
+                    kind: "property".to_string(),
+                    description: "HTTP options.".to_string(),
+                    signature: None,
+                    r#type: Some("{ timeout?: number }".to_string()),
+                    params: None,
+                    type_parameters: None,
+                    returns: None,
+                    members: Some(vec![JsDocMember {
+                        name: "timeout".to_string(),
+                        kind: "property".to_string(),
+                        description: "Request timeout.".to_string(),
+                        signature: None,
+                        r#type: Some("number".to_string()),
+                        params: None,
+                        type_parameters: None,
+                        returns: None,
+                        members: None,
+                        optional: Some(true),
+                        readonly: Some(false),
+                        r#static: Some(false),
+                        private: Some(false),
+                        tags: None,
+                        implementation_of: None,
+                        line: 4,
+                        end_line: 4,
+                    }]),
+                    optional: Some(false),
+                    readonly: Some(false),
+                    r#static: Some(false),
+                    private: Some(false),
+                    tags: None,
+                    implementation_of: None,
+                    line: 3,
+                    end_line: 6,
+                }]),
+                type_parameters: None,
+            }],
+        }];
+
+        let markdown = generate_docs_markdown(
+            docs,
+            Some(JsDocsMarkdownOptions {
+                group_by: Some("file".to_string()),
+                path_strategy: Some("typedoc".to_string()),
+                render_style: Some("html".to_string()),
+                interface_properties_format: Some("table".to_string()),
+                property_members_format: Some("table".to_string()),
+                ..Default::default()
+            }),
+        );
+        let page = markdown.get("default/interfaces/Options.md").unwrap();
+
+        assert!(page.contains("ox-api-entry__property-members-table"));
+        assert!(page
+            .contains("<td><code>timeout</code><span class=\"ox-api-badge\">optional</span></td>"));
+        assert!(page.contains("Request timeout."));
+    }
+
+    #[test]
     fn generate_docs_markdown_resolves_jsdoc_inline_links() {
         let docs = vec![
             JsDocsMarkdownModule {
@@ -4170,6 +4380,7 @@ export function plugin<Id, PluginExt>(options: {
                         params: None,
                         type_parameters: None,
                         returns: None,
+                        members: None,
                         optional: Some(false),
                         readonly: Some(false),
                         r#static: Some(false),
@@ -4656,6 +4867,7 @@ export function plugin<Id, PluginExt>(options: {
                             params: None,
                             type_parameters: None,
                             returns: None,
+                            members: None,
                             optional: Some(false),
                             readonly: Some(false),
                             r#static: Some(false),
@@ -4990,6 +5202,7 @@ export function plugin<Id, PluginExt>(options: {
                         }]),
                         type_parameters: None,
                         returns: None,
+                        members: None,
                         optional: Some(false),
                         readonly: Some(true),
                         r#static: Some(false),

--- a/crates/ox_content_profile_cli/src/main.rs
+++ b/crates/ox_content_profile_cli/src/main.rs
@@ -481,6 +481,7 @@ fn to_api_member(member: NormalizedMember) -> ApiDocMember {
         params: member.params.into_iter().map(to_api_param).collect(),
         type_parameters: member.type_parameters.into_iter().map(to_api_type_param).collect(),
         returns: member.returns.map(to_api_return),
+        members: member.members.into_iter().map(to_api_member).collect(),
         optional: member.optional,
         readonly: member.readonly,
         r#static: member.r#static,

--- a/docs/content/jsdoc.md
+++ b/docs/content/jsdoc.md
@@ -63,6 +63,9 @@ To turn it off entirely, set `docs: { enabled: false }`.
 | `linkStyle`    | `'markdown'`                                     | Internal link style: `'markdown'` (`.md` links) or `'clean'` (extensionless). |
 | `basePath`     | `'/api'`                                         | Route prefix for generated links and nav metadata.                            |
 | `pathStrategy` | `'flat'`                                         | Output layout: `'flat'` or `'typedoc'` (see below).                           |
+| `renderStyle`  | `'html'`                                         | Output renderer: themed HTML-in-Markdown or plain Markdown.                   |
+| `propertyMembersFormat` | `'none'`                                | Display nested object-literal members owned by properties as `'list'` or `'table'`. |
+| `typeDeclarationFormat` | `'none'`                              | Display return type declaration members as `'list'` or `'table'`.             |
 | `generateNav`  | `true`                                           | Emit the `nav.ts` navigation file.                                            |
 
 ## What gets extracted
@@ -115,6 +118,18 @@ exported as.
 Alongside the Markdown, `writeDocs` emits `docs.json` (the structured payload)
 and, when `generateNav` is on, `nav.ts`. A manifest tracks generated files so
 stale pages are cleaned up on the next run.
+
+## Display formats
+
+`renderStyle` controls the generated page body:
+
+- **`html`** (default) — emits ox-content themed HTML inside Markdown files.
+- **`markdown`** — emits plain Markdown without raw HTML scaffolding.
+
+Display-format options accept `'none'`, `'list'`, or `'table'`. With
+`renderStyle: 'html'`, `propertyMembersFormat` and `typeDeclarationFormat`
+render the requested HTML list/table for nested property object literals and
+return type declaration members.
 
 ## Wire the nav into your sidebar
 

--- a/docs/content/jsdoc.md
+++ b/docs/content/jsdoc.md
@@ -46,27 +46,27 @@ To turn it off entirely, set `docs: { enabled: false }`.
 
 ## Options
 
-| Option         | Default                                          | Description                                                                   |
-| -------------- | ------------------------------------------------ | ----------------------------------------------------------------------------- |
-| `enabled`      | `true`                                           | Enable/disable docs generation.                                               |
-| `src`          | `['./src']`                                      | Source directories to scan.                                                   |
-| `out`          | `'docs/api'`                                     | Output directory for generated docs.                                          |
-| `include`      | `['**/*.ts', '**/*.tsx', …]`                     | Glob patterns of files to include.                                            |
-| `exclude`      | `['**/*.test.*', '**/*.spec.*', 'node_modules']` | Glob patterns to exclude.                                                     |
-| `entryPoints`  | —                                                | Public API entry points used to group re-exported docs (see below).           |
-| `format`       | `'markdown'`                                     | `'markdown'`, `'json'`, or `'html'`.                                          |
-| `private`      | `false`                                          | Include `@private` members.                                                   |
-| `internal`     | `false`                                          | Include `@internal` members.                                                  |
-| `toc`          | `true`                                           | Emit a table of contents per file.                                            |
-| `groupBy`      | `'file'`                                         | Group output by `'file'` or `'category'`.                                     |
-| `githubUrl`    | —                                                | Repository URL; when set, signatures link to their source lines.              |
-| `linkStyle`    | `'markdown'`                                     | Internal link style: `'markdown'` (`.md` links) or `'clean'` (extensionless). |
-| `basePath`     | `'/api'`                                         | Route prefix for generated links and nav metadata.                            |
-| `pathStrategy` | `'flat'`                                         | Output layout: `'flat'` or `'typedoc'` (see below).                           |
-| `renderStyle`  | `'html'`                                         | Output renderer: themed HTML-in-Markdown or plain Markdown.                   |
-| `propertyMembersFormat` | `'none'`                                | Display nested object-literal members owned by properties as `'list'` or `'table'`. |
-| `typeDeclarationFormat` | `'none'`                              | Display return type declaration members as `'list'` or `'table'`.             |
-| `generateNav`  | `true`                                           | Emit the `nav.ts` navigation file.                                            |
+| Option                  | Default                                          | Description                                                                         |
+| ----------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| `enabled`               | `true`                                           | Enable/disable docs generation.                                                     |
+| `src`                   | `['./src']`                                      | Source directories to scan.                                                         |
+| `out`                   | `'docs/api'`                                     | Output directory for generated docs.                                                |
+| `include`               | `['**/*.ts', '**/*.tsx', …]`                     | Glob patterns of files to include.                                                  |
+| `exclude`               | `['**/*.test.*', '**/*.spec.*', 'node_modules']` | Glob patterns to exclude.                                                           |
+| `entryPoints`           | —                                                | Public API entry points used to group re-exported docs (see below).                 |
+| `format`                | `'markdown'`                                     | `'markdown'`, `'json'`, or `'html'`.                                                |
+| `private`               | `false`                                          | Include `@private` members.                                                         |
+| `internal`              | `false`                                          | Include `@internal` members.                                                        |
+| `toc`                   | `true`                                           | Emit a table of contents per file.                                                  |
+| `groupBy`               | `'file'`                                         | Group output by `'file'` or `'category'`.                                           |
+| `githubUrl`             | —                                                | Repository URL; when set, signatures link to their source lines.                    |
+| `linkStyle`             | `'markdown'`                                     | Internal link style: `'markdown'` (`.md` links) or `'clean'` (extensionless).       |
+| `basePath`              | `'/api'`                                         | Route prefix for generated links and nav metadata.                                  |
+| `pathStrategy`          | `'flat'`                                         | Output layout: `'flat'` or `'typedoc'` (see below).                                 |
+| `renderStyle`           | `'html'`                                         | Output renderer: themed HTML-in-Markdown or plain Markdown.                         |
+| `propertyMembersFormat` | `'none'`                                         | Display nested object-literal members owned by properties as `'list'` or `'table'`. |
+| `typeDeclarationFormat` | `'none'`                                         | Display return type declaration members as `'list'` or `'table'`.                   |
+| `generateNav`           | `true`                                           | Emit the `nav.ts` navigation file.                                                  |
 
 ## What gets extracted
 

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -1061,13 +1061,13 @@ export interface DocsOptions {
   enumMembersFormat?: MarkdownDisplayFormat;
 
   /**
-   * Reserved display format for property-owned object literal members.
+   * Display format for property-owned object literal members.
    * @default 'none'
    */
   propertyMembersFormat?: MarkdownDisplayFormat;
 
   /**
-   * Reserved display format for type declaration members.
+   * Display format for return type declaration members.
    * @default 'none'
    */
   typeDeclarationFormat?: MarkdownDisplayFormat;


### PR DESCRIPTION
## Summary

- Enable `propertyMembersFormat` and `typeDeclarationFormat` for HTML-rendered API docs.
- Add nested member flow through extraction, normalization, JSON, and NAPI types.

## Background

These options were exposed by `@ox-content/napi` but not applied by the HTML renderer.

Property-owned object literal members also lacked a nested member field, so their format option had no renderable data.

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783340826&installation_id=136613492&pr_number=338&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F338&signature=118e9cb7851cac6ebf716bfd2ebb880b28dab48d2ca6f85f3ff99cbbdf1e8d98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->