### PR TITLE
fix: allow media embeds through sanitizer

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -826,7 +826,7 @@ export interface JsSanitizeOptions {
   allowedTags?: Array<string>
   /** Allowed attribute names. Omit for safe defaults. */
   allowedAttributes?: Array<string>
-  /** Allowed URL schemes for href/src/action attributes. Omit for safe defaults. */
+  /** Allowed URL schemes for URL-bearing attributes. Omit for safe defaults. */
   allowedUrlSchemes?: Array<string>
 }
 

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -571,7 +571,7 @@ pub struct JsSanitizeOptions {
     pub allowed_tags: Option<Vec<String>>,
     /// Allowed attribute names. Omit for safe defaults.
     pub allowed_attributes: Option<Vec<String>>,
-    /// Allowed URL schemes for href/src/action attributes. Omit for safe defaults.
+    /// Allowed URL schemes for URL-bearing attributes. Omit for safe defaults.
     pub allowed_url_schemes: Option<Vec<String>>,
 }
 

--- a/crates/ox_content_napi/src/sanitize.rs
+++ b/crates/ox_content_napi/src/sanitize.rs
@@ -23,6 +23,7 @@ impl Default for SanitizeConfig {
         Self {
             tags: [
                 "a",
+                "audio",
                 "blockquote",
                 "br",
                 "code",
@@ -44,7 +45,9 @@ impl Default for SanitizeConfig {
                 "nav",
                 "ol",
                 "p",
+                "picture",
                 "pre",
+                "source",
                 "span",
                 "strong",
                 "summary",
@@ -54,8 +57,10 @@ impl Default for SanitizeConfig {
                 "td",
                 "th",
                 "thead",
+                "track",
                 "tr",
                 "ul",
+                "video",
             ]
             .into_iter()
             .map(ToString::to_string)
@@ -65,8 +70,12 @@ impl Default for SanitizeConfig {
                 "allowfullscreen",
                 "alt",
                 "aria-label",
+                "autoplay",
                 "checked",
                 "class",
+                "controls",
+                "controlslist",
+                "crossorigin",
                 "data-code-title",
                 "data-group",
                 "data-line",
@@ -74,16 +83,30 @@ impl Default for SanitizeConfig {
                 "data-line-number-start",
                 "data-line-numbers",
                 "data-ox-tab-group",
+                "default",
                 "disabled",
+                "disablepictureinpicture",
+                "disableremoteplayback",
                 "height",
                 "href",
                 "id",
+                "kind",
+                "label",
                 "loading",
+                "loop",
+                "media",
+                "muted",
                 "name",
+                "playsinline",
+                "poster",
+                "preload",
                 "referrerpolicy",
                 "rel",
                 "sandbox",
+                "sizes",
                 "src",
+                "srcset",
+                "srclang",
                 "style",
                 "target",
                 "title",
@@ -152,6 +175,19 @@ impl SanitizeConfig {
             .flat_map(char::to_lowercase)
             .collect::<String>();
         self.url_schemes.contains(&scheme)
+    }
+
+    fn allows_srcset(&self, value: &str) -> bool {
+        value.split(',').all(|candidate| {
+            let candidate = candidate.trim();
+            if candidate.is_empty() {
+                return false;
+            }
+            let url_end =
+                candidate.find(|ch: char| ch.is_ascii_whitespace()).unwrap_or(candidate.len());
+            let url = &candidate[..url_end];
+            !url.is_empty() && self.allows_url(url)
+        })
     }
 }
 
@@ -337,10 +373,12 @@ fn write_sanitized_attr(out: &mut String, attr: &ParsedAttr<'_>, config: &Saniti
     if attr.name.starts_with("on") || !is_attr_name(&attr.name) || !config.allows_attr(&attr.name) {
         return;
     }
-    if matches!(attr.name.as_str(), "href" | "src" | "action")
-        && attr.value.is_some_and(|value| !config.allows_url(value))
-    {
-        return;
+    if let Some(value) = attr.value {
+        match attr.name.as_str() {
+            "href" | "src" | "action" | "poster" if !config.allows_url(value) => return,
+            "srcset" if !config.allows_srcset(value) => return,
+            _ => {}
+        }
     }
     out.push(' ');
     out.push_str(&attr.name);
@@ -443,5 +481,36 @@ mod tests {
 
         assert!(sanitized.contains("<iframe"));
         assert!(sanitized.contains("src=\"https://open.spotify.com/embed/track/a\""));
+    }
+
+    #[test]
+    fn keeps_safe_media_tags_and_attributes() {
+        let html = r#"<video controls muted loop playsinline poster="/poster.jpg" width="640" height="360" preload="metadata"><source src="/demo.webm" type="video/webm"><track src="/captions.vtt" kind="captions" srclang="en" label="English" default>Fallback</video><audio controls src="./clip.mp3"></audio><picture><source media="(min-width: 800px)" srcset="/hero-large.jpg 2x, /hero.jpg 1x" sizes="100vw"><img src="/hero.jpg" alt="Hero"></picture>"#;
+        let sanitized = sanitize_html(html, Some(&JsSanitizeOptions::default()));
+
+        assert!(sanitized.contains(
+            r#"<video controls muted loop playsinline poster="/poster.jpg" width="640" height="360" preload="metadata">"#
+        ));
+        assert!(sanitized.contains(r#"<source src="/demo.webm" type="video/webm">"#));
+        assert!(sanitized.contains(
+            r#"<track src="/captions.vtt" kind="captions" srclang="en" label="English" default>"#
+        ));
+        assert!(sanitized.contains("Fallback</video>"));
+        assert!(sanitized.contains(r#"<audio controls src="./clip.mp3"></audio>"#));
+        assert!(sanitized.contains(
+            r#"<source media="(min-width: 800px)" srcset="/hero-large.jpg 2x, /hero.jpg 1x" sizes="100vw">"#
+        ));
+    }
+
+    #[test]
+    fn removes_unsafe_media_urls() {
+        let html = r#"<video poster="javascript:alert(1)"><source src="javascript:alert(2)" srcset="javascript:alert(3) 1x, /safe.jpg 2x"></video><img src="/safe.jpg" srcset="/safe.jpg 1x, javascript:alert(4) 2x">"#;
+        let sanitized = sanitize_html(html, Some(&JsSanitizeOptions::default()));
+
+        assert!(!sanitized.contains("javascript"));
+        assert!(!sanitized.contains("poster="));
+        assert!(!sanitized.contains("srcset="));
+        assert!(sanitized.contains("<source>"));
+        assert!(sanitized.contains(r#"<img src="/safe.jpg">"#));
     }
 }

--- a/crates/ox_content_parser/tests/snapshot_parse.rs
+++ b/crates/ox_content_parser/tests/snapshot_parse.rs
@@ -177,6 +177,15 @@ fn snapshot_unordered_list_dash_marker() {
 }
 
 #[test]
+fn snapshot_wrapped_list_item_continuation() {
+    check(
+        "wrapped_list_item_continuation",
+        "- [Blacksmith](https://www.blacksmith.sh/) for sponsoring CI and\n  Testbox infrastructure across projects.\n- [Mates Inc.](https://eng.mates.education/) for supporting OSS and\n  adopting Vize in production.\n",
+        ParserOptions::default(),
+    );
+}
+
+#[test]
 fn snapshot_ordered_list_with_start() {
     check("ordered_list_with_start", "3. third\n4. fourth\n", ParserOptions::default());
 }

--- a/crates/ox_content_parser/tests/snapshots/parser/wrapped_list_item_continuation.snap
+++ b/crates/ox_content_parser/tests/snapshots/parser/wrapped_list_item_continuation.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ox_content_parser/tests/snapshot_parse.rs
+description: "- [Blacksmith](https://www.blacksmith.sh/) for sponsoring CI and\n  Testbox infrastructure across projects.\n- [Mates Inc.](https://eng.mates.education/) for supporting OSS and\n  adopting Vize in production.\n"
+---
+Document [0..206]
+  List ordered=false start=- spread=false [0..206]
+    ListItem spread=false checked=- [0..107]
+      Paragraph [2..105]
+        Link url="https://www.blacksmith.sh/" title=None [2..42]
+          Text "Blacksmith" [3..13]
+        Text " for sponsoring CI and\nTestbox infrastructure across projects." [42..104]
+    ListItem spread=false checked=- [107..206]
+      Paragraph [109..204]
+        Link url="https://eng.mates.education/" title=None [109..151]
+          Text "Mates Inc." [110..120]
+        Text " for supporting OSS and\nadopting Vize in production." [151..203]

--- a/crates/ox_content_renderer/tests/snapshot_render.rs
+++ b/crates/ox_content_renderer/tests/snapshot_render.rs
@@ -109,6 +109,16 @@ fn html_unordered_list_basic() {
 }
 
 #[test]
+fn html_wrapped_list_item_continuation() {
+    check(
+        "wrapped_list_item_continuation",
+        "- [Blacksmith](https://www.blacksmith.sh/) for sponsoring CI and\n  Testbox infrastructure across projects.\n- [Mates Inc.](https://eng.mates.education/) for supporting OSS and\n  adopting Vize in production.\n",
+        ParserOptions::default(),
+        HtmlRendererOptions::default(),
+    );
+}
+
+#[test]
 fn html_ordered_list_with_start() {
     check(
         "ordered_list_with_start",

--- a/crates/ox_content_renderer/tests/snapshots/renderer/wrapped_list_item_continuation.snap
+++ b/crates/ox_content_renderer/tests/snapshots/renderer/wrapped_list_item_continuation.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ox_content_renderer/tests/snapshot_render.rs
+description: "- [Blacksmith](https://www.blacksmith.sh/) for sponsoring CI and\n  Testbox infrastructure across projects.\n- [Mates Inc.](https://eng.mates.education/) for supporting OSS and\n  adopting Vize in production.\n"
+---
+<ul>
+<li><p><a href="https://www.blacksmith.sh/" target="_blank" rel="noopener noreferrer">Blacksmith</a> for sponsoring CI and
+Testbox infrastructure across projects.</p>
+</li>
+<li><p><a href="https://eng.mates.education/" target="_blank" rel="noopener noreferrer">Mates Inc.</a> for supporting OSS and
+adopting Vize in production.</p>
+</li>
+</ul>

--- a/docs/content/examples/html-sanitizer.md
+++ b/docs/content/examples/html-sanitizer.md
@@ -6,7 +6,8 @@ description: Sanitize rendered HTML with configurable allow lists.
 # HTML Sanitizer
 
 The sanitizer is opt-in. When enabled with `true`, it uses safe defaults for
-common documentation HTML.
+common documentation HTML, including embedded media elements such as `video`,
+`audio`, `source`, `track`, and `picture`.
 
 ```ts
 import { oxContent } from "@ox-content/vite-plugin";

--- a/npm/vite-plugin-ox-content/src/transform.test.ts
+++ b/npm/vite-plugin-ox-content/src/transform.test.ts
@@ -131,6 +131,45 @@ describe("transformMarkdown", () => {
     expect(optInResult.html).toContain("pnpm add -D vite");
   });
 
+  it("preserves wrapped continuation lines inside list items", async () => {
+    const result = await transformMarkdown(
+      [
+        "- [Blacksmith](https://www.blacksmith.sh/) for sponsoring CI and",
+        "  Testbox infrastructure across projects.",
+        "- [Mates Inc.](https://eng.mates.education/) for supporting OSS and",
+        "  adopting Vize in production.",
+      ].join("\n"),
+      "docs/credits.md",
+      createResolvedOptions(),
+    );
+
+    expect(result.html).toContain("Testbox infrastructure across projects.");
+    expect(result.html).toContain("adopting Vize in production.");
+    expect(result.html).toContain('<a href="https://www.blacksmith.sh/"');
+    expect(result.html).toContain('<a href="https://eng.mates.education/"');
+  });
+
+  it("preserves safe raw media tags when sanitizing", async () => {
+    const result = await transformMarkdown(
+      [
+        '<video controls muted playsinline poster="/poster.jpg">',
+        '  <source src="/demo.webm" type="video/webm">',
+        '  <track src="/captions.vtt" kind="captions" srclang="en" label="English" default>',
+        "  Fallback",
+        "</video>",
+        '<picture><source media="(min-width: 800px)" srcset="/hero-large.jpg 2x, /hero.jpg 1x"><img src="/hero.jpg" alt="Hero"></picture>',
+      ].join("\n"),
+      "docs/media.md",
+      createResolvedOptions({ sanitize: { enabled: true } }),
+    );
+
+    expect(result.html).toContain("<video controls muted playsinline");
+    expect(result.html).toContain('poster="/poster.jpg"');
+    expect(result.html).toContain('<source src="/demo.webm" type="video/webm">');
+    expect(result.html).toContain('<track src="/captions.vtt"');
+    expect(result.html).toContain('srcset="/hero-large.jpg 2x, /hero.jpg 1x"');
+  });
+
   it("sanitizes after opt-in embeds are rendered", async () => {
     const result = await transformMarkdown(
       [


### PR DESCRIPTION
## Summary

- allow safe raw media elements through the opt-in HTML sanitizer (`video`, `audio`, `source`, `track`, `picture`)
- validate URL-bearing media attributes such as `poster` and `srcset` against the sanitizer URL scheme allow-list
- add regression coverage for wrapped Markdown list-item continuation lines in parser, renderer, and Vite plugin transform paths
- document media elements in the sanitizer safe defaults

Closes #340.
Closes #341.

## Verification

- `cargo test -p ox_content_napi sanitize`
- `cargo test -p ox_content_parser snapshot_wrapped_list_item_continuation`
- `cargo test -p ox_content_renderer html_wrapped_list_item_continuation`
- `vp exec --filter @ox-content/vite-plugin -- vp test src/transform.test.ts`
- `vp fmt --check`
- `cargo fmt --all -- --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783436451&installation_id=136613492&pr_number=342&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F342&signature=150ddfb9f6d6625486658323aec86cc10b1a3e3912c949cda69bef0ff2c508b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->