### PR TITLE
feat(lsp): add folding ranges for headings, code blocks, and frontmatter

### DIFF
--- a/crates/ox_content_lsp/src/backend/features.rs
+++ b/crates/ox_content_lsp/src/backend/features.rs
@@ -219,6 +219,19 @@ impl Backend {
             _ => None,
         }
     }
+
+    pub(super) async fn folding_range_response(&self, uri: &Url) -> Option<Vec<FoldingRange>> {
+        let Ok(path) = uri.to_file_path() else {
+            return None;
+        };
+        if !is_markdown_path(&path) {
+            return None;
+        }
+
+        let document = self.state.document(uri).await?;
+        let ranges = crate::folding::folding_ranges(&document);
+        (!ranges.is_empty()).then_some(ranges)
+    }
 }
 
 fn push_fmt(output: &mut String, args: std::fmt::Arguments<'_>) {

--- a/crates/ox_content_lsp/src/backend/handlers.rs
+++ b/crates/ox_content_lsp/src/backend/handlers.rs
@@ -55,6 +55,7 @@ impl LanguageServer for Backend {
                 definition_provider: Some(OneOf::Left(true)),
                 inlay_hint_provider: Some(OneOf::Left(true)),
                 document_symbol_provider: Some(OneOf::Left(true)),
+                folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
                 code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
                 execute_command_provider: Some(ExecuteCommandOptions {
                     commands: vec![
@@ -145,6 +146,10 @@ impl LanguageServer for Backend {
         params: DocumentSymbolParams,
     ) -> Result<Option<DocumentSymbolResponse>> {
         Ok(self.document_symbols_response(&params.text_document.uri).await)
+    }
+
+    async fn folding_range(&self, params: FoldingRangeParams) -> Result<Option<Vec<FoldingRange>>> {
+        Ok(self.folding_range_response(&params.text_document.uri).await)
     }
 
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {

--- a/crates/ox_content_lsp/src/folding.rs
+++ b/crates/ox_content_lsp/src/folding.rs
@@ -1,0 +1,192 @@
+//! Folding range computation for Markdown / MDC documents.
+//!
+//! Surfaces the regions an author expects a Markdown editor to fold:
+//!   * the YAML frontmatter block at the top of the file,
+//!   * each fenced / indented code block,
+//!   * every heading section — a heading folds down to the line before
+//!     the next heading of equal-or-shallower depth (or the end of the
+//!     document), with trailing blank lines trimmed.
+//!
+//! Ranges are line-based: `start_character` / `end_character` are left
+//! unset so editors fold whole lines, matching the LSP default.
+
+use ox_content_allocator::Allocator;
+use ox_content_ast::Node;
+use ox_content_parser::{Parser, ParserOptions};
+use tower_lsp::lsp_types::{FoldingRange, FoldingRangeKind};
+
+use crate::document::TextDocumentState;
+use crate::frontmatter::parse_frontmatter;
+
+/// Computes every foldable region in `document`.
+#[must_use]
+pub fn folding_ranges(document: &TextDocumentState) -> Vec<FoldingRange> {
+    let source = document.text();
+    let frontmatter = parse_frontmatter(document);
+
+    let mut ranges = Vec::new();
+
+    // Frontmatter folds as a single region spanning the opening `---`
+    // through the closing `---`.
+    if let Some(block) = &frontmatter.block {
+        push_span_fold(&mut ranges, document, 0, block.block_end_offset);
+    }
+
+    // Heading sections and code blocks come from the parsed body. The
+    // parser only sees the markdown after the frontmatter, so every
+    // span is shifted back into document coordinates via `base_offset`
+    // — the same trick the outline (`preview::document_symbols`) uses.
+    let (content, base_offset) = match &frontmatter.block {
+        Some(block) => (&source[block.block_end_offset..], block.block_end_offset),
+        None => (source, 0),
+    };
+
+    let allocator = Allocator::for_source_len(content.len());
+    let parser = Parser::with_options(&allocator, content, ParserOptions::gfm());
+    let Ok(ast) = parser.parse() else {
+        return ranges;
+    };
+
+    // One pass collects code-block folds (independent of each other)
+    // and the heading skeleton; sections are resolved afterwards once
+    // every heading's successor is known.
+    let mut headings: Vec<(u8, u32)> = Vec::new();
+    for node in &ast.children {
+        match node {
+            Node::CodeBlock(code) => push_span_fold(
+                &mut ranges,
+                document,
+                base_offset + code.span.start as usize,
+                base_offset + code.span.end as usize,
+            ),
+            Node::Heading(heading) => {
+                let start = base_offset + heading.span.start as usize;
+                headings.push((heading.depth, document.offset_to_position(start).line));
+            }
+            _ => {}
+        }
+    }
+
+    append_heading_sections(&mut ranges, document, &headings);
+    ranges
+}
+
+/// Resolves the flat heading list into section folds. Each heading owns
+/// the lines down to (but not including) the next heading whose depth is
+/// equal or shallower; trailing blank lines are trimmed so the fold hugs
+/// the section's real content.
+fn append_heading_sections(
+    ranges: &mut Vec<FoldingRange>,
+    document: &TextDocumentState,
+    headings: &[(u8, u32)],
+) {
+    let last_line = (document.line_count().saturating_sub(1)) as u32;
+    for (index, &(depth, start_line)) in headings.iter().enumerate() {
+        let mut end_line = headings[index + 1..]
+            .iter()
+            .find(|&&(next_depth, _)| next_depth <= depth)
+            .map_or(last_line, |&(_, next_line)| next_line.saturating_sub(1));
+
+        while end_line > start_line && document.line_text(end_line).trim().is_empty() {
+            end_line -= 1;
+        }
+
+        if end_line > start_line {
+            ranges.push(region(start_line, end_line));
+        }
+    }
+}
+
+/// Pushes a fold covering the lines touched by `[start_offset,
+/// end_offset)`, skipping single-line spans the editor cannot collapse.
+fn push_span_fold(
+    ranges: &mut Vec<FoldingRange>,
+    document: &TextDocumentState,
+    start_offset: usize,
+    end_offset: usize,
+) {
+    let start_line = document.offset_to_position(start_offset).line;
+    // `end_offset` is exclusive and often lands at the start of the
+    // following line; step back one byte so the fold ends on the
+    // block's last line rather than the line after it.
+    let end_line = document.offset_to_position(end_offset.saturating_sub(1)).line;
+    if end_line > start_line {
+        ranges.push(region(start_line, end_line));
+    }
+}
+
+fn region(start_line: u32, end_line: u32) -> FoldingRange {
+    FoldingRange {
+        start_line,
+        end_line,
+        kind: Some(FoldingRangeKind::Region),
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fmt::Write as _;
+
+    fn fold(source: &str) -> String {
+        let document = TextDocumentState::new(source.to_string());
+        let mut ranges = folding_ranges(&document);
+        ranges.sort_by_key(|range| (range.start_line, range.end_line));
+        let mut out = String::new();
+        for range in ranges {
+            let _ = writeln!(&mut out, "{}..{}", range.start_line, range.end_line);
+        }
+        out
+    }
+
+    #[test]
+    fn folds_heading_section_to_next_sibling() {
+        // The h2 section ends on the line before the next h2; the file's
+        // final h2 runs to the last content line.
+        let source = "# Title\n\n## First\n\nbody\n\n## Second\n\nmore\n";
+        assert_eq!(fold(source), "0..8\n2..4\n6..8\n");
+    }
+
+    #[test]
+    fn deeper_heading_nests_inside_its_parent() {
+        // The h3 is part of the h2 section, so the h2 still extends past
+        // it; the h3 owns only its own lines.
+        let source = "## Parent\n\ntext\n\n### Child\n\nleaf\n";
+        assert_eq!(fold(source), "0..6\n4..6\n");
+    }
+
+    #[test]
+    fn single_line_heading_is_not_foldable() {
+        // A heading with no body underneath produces no range — there's
+        // nothing to collapse.
+        let source = "# Lonely\n";
+        assert_eq!(fold(source), "");
+    }
+
+    #[test]
+    fn folds_fenced_code_block() {
+        let source = "para\n\n```rust\nfn main() {}\nlet x = 1;\n```\n";
+        assert_eq!(fold(source), "2..5\n");
+    }
+
+    #[test]
+    fn folds_frontmatter_block() {
+        let source = "---\ntitle: Doc\ntags: [a, b]\n---\n\n# Heading\n\nbody\n";
+        // Frontmatter (lines 0..3) plus the heading section (5..7).
+        assert_eq!(fold(source), "0..3\n5..7\n");
+    }
+
+    #[test]
+    fn trims_trailing_blank_lines_from_section() {
+        // Three trailing blank lines should not be swallowed into the
+        // fold; it stops at the last line with content.
+        let source = "## Section\n\nbody\n\n\n\n";
+        assert_eq!(fold(source), "0..2\n");
+    }
+
+    #[test]
+    fn empty_document_has_no_folds() {
+        assert_eq!(fold(""), "");
+    }
+}

--- a/crates/ox_content_lsp/src/main.rs
+++ b/crates/ox_content_lsp/src/main.rs
@@ -8,10 +8,12 @@
 //! - editor-triggered insertion commands
 //! - preview HTML generation via `workspace/executeCommand`
 //! - heading symbols for document outline navigation
+//! - folding ranges for headings, code blocks, and frontmatter
 
 mod backend;
 mod config;
 mod document;
+mod folding;
 mod frontmatter;
 mod i18n;
 mod preview;

--- a/docs/content/editor-extension-roadmap.md
+++ b/docs/content/editor-extension-roadmap.md
@@ -41,6 +41,7 @@ must not depend on a later one in the list.
 | 6   | Dead link checker                               | diagnostics              | `ox-content-link-check`      | diagnostics              | diagnostics                 | local: shipped   |
 | 7   | textlint integration                            | on-save diagnostics      | via configured command       | enabled per setting      | enabled per setting         | shipped (opt-in) |
 | 8   | Frontmatter schema completion + diagnostics     | present                  | none (validated through LSP) | present                  | present                     | needs CLI        |
+| 9   | Document structure (outline + folding)          | symbols + folding ranges | none (unit-tested headless)  | outline + folding        | outline + folding           | shipped          |
 
 ## PR Sequence
 


### PR DESCRIPTION
## What

Implements `textDocument/foldingRange` in `ox_content_lsp`, so Markdown / MDC documents fold in any LSP client (VS Code, Neovim, Zed).

Three kinds of foldable regions:

- **Heading sections** — a heading folds down to the line before the next heading of equal-or-shallower depth (or end of document), with trailing blank lines trimmed so the fold hugs real content.
- **Code blocks** — fenced / indented code blocks fold as regions.
- **Frontmatter** — the YAML block at the top folds as a region.

## How

- New `crate::folding` module computes ranges from the parsed AST, reusing the same frontmatter-offset rebasing the document outline (`preview::document_symbols`) already relies on.
- Ranges are line-based (`start_character` / `end_character` unset) so editors fold whole lines.
- Capability advertised via `folding_range_provider`; handler wired in `backend/handlers.rs`.

## Testing

- 7 headless unit tests in `folding.rs` (sibling/nested headings, single-line heading no-op, code fence, frontmatter, trailing-blank trimming, empty doc).
- `cargo test -p ox_content_lsp` → 71 passed.
- `cargo clippy -p ox_content_lsp --all-targets` clean; `cargo fmt --check` clean.

Roadmap feature matrix updated (row 9: Document structure).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783436587&installation_id=136613492&pr_number=343&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F343&signature=5ec2db6c9fa9af8541b143bfee64bd3545906f12398dd36f92c52a6685bf6767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->