### PR TITLE
test(vscode): unit-test server-command precedence and init options

### DIFF
--- a/npm/vscode-ox-content/src/config.ts
+++ b/npm/vscode-ox-content/src/config.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import type { ServerOptions } from "vscode-languageclient/node";
 
 import { localServerBinaryCandidates, resolveFilePath } from "./internal/paths";
+import { buildInitializationOptions, selectServerCommand } from "./internal/server-options";
 
 export function getConfig(): vscode.WorkspaceConfiguration {
   return vscode.workspace.getConfiguration("oxContent");
@@ -13,73 +14,30 @@ export function resolveServerOptions(
   workspaceRoot?: string,
 ): ServerOptions {
   const configuredPath = getConfig().get<string>("server.path", "").trim();
-  const resolvedConfiguredPath = configuredPath
-    ? resolveFilePath(configuredPath, workspaceRoot)
-    : undefined;
 
-  if (resolvedConfiguredPath && fs.existsSync(resolvedConfiguredPath)) {
-    return { command: resolvedConfiguredPath, args: [] };
-  }
-
-  // Escape hatch for CI and the integration test runner: an absolute path
-  // in `OX_CONTENT_LSP_PATH` wins over the local-binary probe so the test
-  // host can use a freshly built `target/release/ox-content-lsp` without
-  // synthesizing a workspace `.vscode/settings.json`.
-  const envBinary = process.env.OX_CONTENT_LSP_PATH?.trim();
-  if (envBinary && fs.existsSync(envBinary)) {
-    return { command: envBinary, args: [] };
-  }
-
-  const localBinary = findLocalServerBinary(context, workspaceRoot);
-  if (localBinary) {
-    return { command: localBinary, args: [] };
-  }
-
-  return {
-    command: "cargo",
-    args: ["run", "-p", "ox_content_lsp", "--bin", "ox-content-lsp"],
-  };
+  // The `OX_CONTENT_LSP_PATH` escape hatch lets CI and the integration
+  // test runner point at a freshly built `target/release/ox-content-lsp`
+  // without synthesizing a workspace `.vscode/settings.json`.
+  return selectServerCommand({
+    configuredPath: configuredPath ? resolveFilePath(configuredPath, workspaceRoot) : undefined,
+    envBinary: process.env.OX_CONTENT_LSP_PATH?.trim(),
+    localCandidates: localServerBinaryCandidates({
+      workspaceRoot,
+      extensionPath: context.extensionPath,
+      platform: process.platform,
+    }),
+    exists: fs.existsSync,
+  });
 }
 
 export function resolveInitializationOptions(
   workspaceRoot?: string,
 ): Record<string, string | boolean> {
-  const options: Record<string, string | boolean> = {};
-
-  const schemaSetting = getConfig().get<string>("frontmatter.schema", "").trim();
-  if (schemaSetting) {
-    options.frontmatterSchema = resolveFilePath(schemaSetting, workspaceRoot);
-  }
-
-  // textlint defaults to off; only forward the flag when explicitly
-  // enabled to keep the init payload small for users who haven't
-  // opted in.
-  const textlintEnabled = getConfig().get<boolean>("textlint.enabled", false);
-  if (textlintEnabled) {
-    options.textlintEnabled = true;
-  }
-  const textlintCommand = getConfig().get<string>("textlint.command", "").trim();
-  if (textlintCommand) {
-    options.textlintCommand = textlintCommand;
-  }
-
-  const mdcComponents = getConfig().get<string>("mdc.components", "").trim();
-  if (mdcComponents) {
-    options.mdcComponents = resolveFilePath(mdcComponents, workspaceRoot);
-  }
-
-  return options;
-}
-
-function findLocalServerBinary(
-  context: vscode.ExtensionContext,
-  workspaceRoot?: string,
-): string | undefined {
-  const candidates = localServerBinaryCandidates({
-    workspaceRoot,
-    extensionPath: context.extensionPath,
-    platform: process.platform,
+  return buildInitializationOptions({
+    schema: getConfig().get<string>("frontmatter.schema", "").trim(),
+    textlintEnabled: getConfig().get<boolean>("textlint.enabled", false),
+    textlintCommand: getConfig().get<string>("textlint.command", "").trim(),
+    mdcComponents: getConfig().get<string>("mdc.components", "").trim(),
+    resolvePath: (value) => resolveFilePath(value, workspaceRoot),
   });
-
-  return candidates.find((candidate) => fs.existsSync(candidate));
 }

--- a/npm/vscode-ox-content/src/internal/server-options.ts
+++ b/npm/vscode-ox-content/src/internal/server-options.ts
@@ -1,0 +1,89 @@
+/**
+ * Pure decision logic extracted from `config.ts`.
+ *
+ * Keeping the precedence rules (which binary wins) and the
+ * initialization-options mapping (which settings get forwarded to the
+ * LSP) free of `vscode` and `node:fs` lets them be unit-tested under
+ * vitest without a VS Code Electron host — the same split that
+ * `paths.ts` already follows.
+ */
+
+/** The minimal shape of a `vscode-languageclient` `Executable`. */
+export interface ServerCommand {
+  command: string;
+  args: string[];
+}
+
+export interface ServerCommandInputs {
+  /** `oxContent.server.path`, already resolved to an absolute path. */
+  configuredPath?: string;
+  /** `OX_CONTENT_LSP_PATH`, trimmed. */
+  envBinary?: string;
+  /** Ordered local-binary probe locations (debug, release, bundled). */
+  localCandidates: string[];
+  /** Existence predicate, injected so tests stay off the filesystem. */
+  exists: (candidate: string) => boolean;
+}
+
+/**
+ * Picks the server command by precedence: an explicitly configured path
+ * wins, then `OX_CONTENT_LSP_PATH`, then the first local build that
+ * exists, and finally `cargo run` as the develop-from-source fallback.
+ * Every path-based option is gated on `exists` so a stale setting never
+ * points the client at a missing binary.
+ */
+export function selectServerCommand(inputs: ServerCommandInputs): ServerCommand {
+  const { configuredPath, envBinary, localCandidates, exists } = inputs;
+
+  if (configuredPath && exists(configuredPath)) {
+    return { command: configuredPath, args: [] };
+  }
+  if (envBinary && exists(envBinary)) {
+    return { command: envBinary, args: [] };
+  }
+  const localBinary = localCandidates.find(exists);
+  if (localBinary) {
+    return { command: localBinary, args: [] };
+  }
+  return { command: "cargo", args: ["run", "-p", "ox_content_lsp", "--bin", "ox-content-lsp"] };
+}
+
+export interface InitializationInputs {
+  /** `oxContent.frontmatter.schema`, trimmed. */
+  schema?: string;
+  /** `oxContent.textlint.enabled`. */
+  textlintEnabled: boolean;
+  /** `oxContent.textlint.command`, trimmed. */
+  textlintCommand?: string;
+  /** `oxContent.mdc.components`, trimmed. */
+  mdcComponents?: string;
+  /** Resolves a possibly-relative path against the workspace root. */
+  resolvePath: (value: string) => string;
+}
+
+/**
+ * Builds the `initializationOptions` payload sent to the LSP. Only
+ * non-empty / opted-in settings are forwarded so the handshake stays
+ * minimal for users who haven't configured anything — textlint in
+ * particular is omitted entirely unless explicitly enabled.
+ */
+export function buildInitializationOptions(
+  inputs: InitializationInputs,
+): Record<string, string | boolean> {
+  const options: Record<string, string | boolean> = {};
+
+  if (inputs.schema) {
+    options.frontmatterSchema = inputs.resolvePath(inputs.schema);
+  }
+  if (inputs.textlintEnabled) {
+    options.textlintEnabled = true;
+  }
+  if (inputs.textlintCommand) {
+    options.textlintCommand = inputs.textlintCommand;
+  }
+  if (inputs.mdcComponents) {
+    options.mdcComponents = inputs.resolvePath(inputs.mdcComponents);
+  }
+
+  return options;
+}

--- a/npm/vscode-ox-content/src/test/unit/server-options.test.ts
+++ b/npm/vscode-ox-content/src/test/unit/server-options.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Pure-node unit tests for the server-command precedence and
+ * initialization-options mapping extracted from `config.ts`.
+ *
+ * These run under vitest with no VS Code Electron host, exercising the
+ * branches `extension.test.ts` cannot reach without a real filesystem
+ * of fake binaries or mutated `process.env`.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { buildInitializationOptions, selectServerCommand } from "../../internal/server-options";
+
+const CARGO_FALLBACK = {
+  command: "cargo",
+  args: ["run", "-p", "ox_content_lsp", "--bin", "ox-content-lsp"],
+};
+
+describe("selectServerCommand", () => {
+  const localCandidates = [
+    "/work/target/debug/ox-content-lsp",
+    "/work/target/release/ox-content-lsp",
+  ];
+
+  it("prefers a configured path that exists over everything else", () => {
+    const result = selectServerCommand({
+      configuredPath: "/custom/ox-content-lsp",
+      envBinary: "/env/ox-content-lsp",
+      localCandidates,
+      exists: () => true,
+    });
+    expect(result).toEqual({ command: "/custom/ox-content-lsp", args: [] });
+  });
+
+  it("falls through to the env binary when the configured path is missing", () => {
+    const result = selectServerCommand({
+      configuredPath: "/custom/ox-content-lsp",
+      envBinary: "/env/ox-content-lsp",
+      localCandidates,
+      exists: (candidate) => candidate !== "/custom/ox-content-lsp",
+    });
+    expect(result).toEqual({ command: "/env/ox-content-lsp", args: [] });
+  });
+
+  it("prefers the env binary over local candidates", () => {
+    const result = selectServerCommand({
+      envBinary: "/env/ox-content-lsp",
+      localCandidates,
+      exists: () => true,
+    });
+    expect(result).toEqual({ command: "/env/ox-content-lsp", args: [] });
+  });
+
+  it("uses the first local candidate that exists", () => {
+    const result = selectServerCommand({
+      localCandidates,
+      // debug build is absent; release build is present.
+      exists: (candidate) => candidate === "/work/target/release/ox-content-lsp",
+    });
+    expect(result).toEqual({ command: "/work/target/release/ox-content-lsp", args: [] });
+  });
+
+  it("falls back to cargo run when nothing exists", () => {
+    const result = selectServerCommand({
+      configuredPath: "/custom/ox-content-lsp",
+      envBinary: "/env/ox-content-lsp",
+      localCandidates,
+      exists: () => false,
+    });
+    expect(result).toEqual(CARGO_FALLBACK);
+  });
+
+  it("ignores an empty configured path and env binary", () => {
+    const result = selectServerCommand({
+      configuredPath: undefined,
+      envBinary: undefined,
+      localCandidates: [],
+      exists: () => true,
+    });
+    expect(result).toEqual(CARGO_FALLBACK);
+  });
+});
+
+describe("buildInitializationOptions", () => {
+  const resolvePath = (value: string) => `/work/${value}`;
+
+  it("returns an empty object when nothing is configured", () => {
+    const options = buildInitializationOptions({
+      textlintEnabled: false,
+      resolvePath,
+    });
+    expect(options).toEqual({});
+  });
+
+  it("resolves the schema and mdc paths against the workspace root", () => {
+    const options = buildInitializationOptions({
+      schema: "schema.json",
+      mdcComponents: "components.json",
+      textlintEnabled: false,
+      resolvePath,
+    });
+    expect(options).toEqual({
+      frontmatterSchema: "/work/schema.json",
+      mdcComponents: "/work/components.json",
+    });
+  });
+
+  it("forwards textlint only when enabled", () => {
+    const disabled = buildInitializationOptions({
+      textlintEnabled: false,
+      textlintCommand: "pnpm exec textlint",
+      resolvePath,
+    });
+    // The command is still forwarded so a user can pre-seed it, but the
+    // enabled flag must be absent so the server stays opted-out.
+    expect(disabled.textlintEnabled).toBeUndefined();
+    expect(disabled.textlintCommand).toBe("pnpm exec textlint");
+
+    const enabled = buildInitializationOptions({
+      textlintEnabled: true,
+      resolvePath,
+    });
+    expect(enabled.textlintEnabled).toBe(true);
+  });
+
+  it("omits empty-string settings", () => {
+    const options = buildInitializationOptions({
+      schema: "",
+      textlintEnabled: false,
+      textlintCommand: "",
+      mdcComponents: "",
+      resolvePath,
+    });
+    expect(options).toEqual({});
+  });
+});


### PR DESCRIPTION
## What

Fills the unit-test gap for `config.ts` — the binary-resolution precedence and the `initializationOptions` mapping were previously only reachable through the Electron integration host, which can't easily fake missing binaries or mutate `process.env`.

## How

Following the existing `paths.ts` pattern, the two pure decision points move into `internal/server-options.ts`:

- **`selectServerCommand`** — picks the server command by precedence: configured `server.path` → `OX_CONTENT_LSP_PATH` → first existing local build (debug, release, bundled) → `cargo run` fallback. Every path option is gated on an injected `exists` predicate, so a stale setting never points at a missing binary.
- **`buildInitializationOptions`** — forwards only non-empty / opted-in settings; textlint stays omitted unless explicitly enabled.

`config.ts` becomes a thin adapter that reads `vscode` config + `process.env` + `fs` and delegates. No behavior change.

## Testing

- 10 new vitest tests (`server-options.test.ts`); the pure-node unit suite is now **35 passed**.
- `vp run vscode:build` (tsc) clean; `vp run fmt:ts-check` clean.
- Runs in the existing CI `VS Code extension tests` job via `vp run test:vscode-unit` — no workflow change needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783437953&installation_id=136613492&pr_number=346&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F346&signature=28bd83db233d27cdb527d4a64edc58e613b90a674e70779d148e847cb08436db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->