### PR TITLE
test(vscode): unit-test preview title and seed-command policy

### DIFF
--- a/npm/vscode-ox-content/src/internal/preview-state.ts
+++ b/npm/vscode-ox-content/src/internal/preview-state.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure preview policy extracted from `preview.ts`: which server command
+ * seeds a panel, and how a panel title is chosen. Free of `vscode` so it
+ * can be unit-tested under plain Node, the same split `paths.ts` and
+ * `server-options.ts` follow.
+ */
+
+import * as path from "node:path";
+
+import { SERVER_COMMAND_PREVIEW_HTML, SERVER_COMMAND_PREVIEW_SUBSCRIBE } from "../constants";
+
+/**
+ * Picks the server command used to seed a freshly opened preview panel.
+ * Auto-refresh subscribes for pushed updates; otherwise we do a one-shot
+ * HTML fetch.
+ */
+export function previewSeedCommand(autoRefresh: boolean): string {
+  return autoRefresh ? SERVER_COMMAND_PREVIEW_SUBSCRIBE : SERVER_COMMAND_PREVIEW_HTML;
+}
+
+/**
+ * Title for a freshly rendered preview. The LSP-supplied title wins;
+ * when it's empty we fall back to the document's basename (or `Untitled`
+ * for a buffer with no filename) plus a ` Preview` suffix.
+ */
+export function previewPanelTitle(payloadTitle: string, fileName: string): string {
+  if (payloadTitle) {
+    return payloadTitle;
+  }
+  return `${path.basename(fileName) || "Untitled"} Preview`;
+}
+
+/**
+ * Title for a pushed `previewDidChange` update. The server only re-titles
+ * when it has something to say; an empty pushed title leaves the existing
+ * panel title untouched.
+ */
+export function pushedPreviewTitle(pushedTitle: string, currentTitle: string): string {
+  return pushedTitle || currentTitle;
+}

--- a/npm/vscode-ox-content/src/preview.ts
+++ b/npm/vscode-ox-content/src/preview.ts
@@ -1,15 +1,14 @@
-import * as path from "node:path";
 import * as vscode from "vscode";
 
 import { getConfig } from "./config";
-import {
-  NOTIFICATION_PREVIEW_DID_CHANGE,
-  SERVER_COMMAND_PREVIEW_HTML,
-  SERVER_COMMAND_PREVIEW_SUBSCRIBE,
-  SERVER_COMMAND_PREVIEW_UNSUBSCRIBE,
-} from "./constants";
+import { NOTIFICATION_PREVIEW_DID_CHANGE, SERVER_COMMAND_PREVIEW_UNSUBSCRIBE } from "./constants";
 import { onServerNotification, sendServerCommand } from "./client";
 import { errorHtml } from "./internal/preview-html";
+import {
+  previewPanelTitle,
+  previewSeedCommand,
+  pushedPreviewTitle,
+} from "./internal/preview-state";
 import type { PreviewEntry, PreviewPayload } from "./types";
 
 const previewEntries = new Map<string, PreviewEntry>();
@@ -84,9 +83,7 @@ async function renderInitialPreview(
   panel: vscode.WebviewPanel,
   document: vscode.TextDocument,
 ): Promise<void> {
-  const command = previewAutoRefreshEnabled()
-    ? SERVER_COMMAND_PREVIEW_SUBSCRIBE
-    : SERVER_COMMAND_PREVIEW_HTML;
+  const command = previewSeedCommand(previewAutoRefreshEnabled());
 
   try {
     const payload = await sendServerCommand<PreviewPayload>(command, [document.uri.toString()]);
@@ -107,7 +104,7 @@ function applyPushedPreview(params: PreviewDidChangeParams): void {
   if (!entry) {
     return;
   }
-  entry.panel.title = params.title || entry.panel.title;
+  entry.panel.title = pushedPreviewTitle(params.title, entry.panel.title);
   entry.panel.webview.html = params.html;
 }
 
@@ -116,7 +113,7 @@ function applyPayload(
   document: vscode.TextDocument,
   payload: PreviewPayload,
 ): void {
-  panel.title = payload.title || `${path.basename(document.fileName) || "Untitled"} Preview`;
+  panel.title = previewPanelTitle(payload.title, document.fileName);
   panel.webview.html = payload.html;
 }
 

--- a/npm/vscode-ox-content/src/test/unit/preview-state.test.ts
+++ b/npm/vscode-ox-content/src/test/unit/preview-state.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure-node unit tests for the preview policy extracted from
+ * `preview.ts`. The webview lifecycle itself is covered by the Electron
+ * integration suite; these pin the title/command decisions that don't
+ * need a host.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { SERVER_COMMAND_PREVIEW_HTML, SERVER_COMMAND_PREVIEW_SUBSCRIBE } from "../../constants";
+import {
+  previewPanelTitle,
+  previewSeedCommand,
+  pushedPreviewTitle,
+} from "../../internal/preview-state";
+
+describe("previewSeedCommand", () => {
+  it("subscribes for pushed updates when auto-refresh is on", () => {
+    expect(previewSeedCommand(true)).toBe(SERVER_COMMAND_PREVIEW_SUBSCRIBE);
+  });
+
+  it("does a one-shot HTML fetch when auto-refresh is off", () => {
+    expect(previewSeedCommand(false)).toBe(SERVER_COMMAND_PREVIEW_HTML);
+  });
+});
+
+describe("previewPanelTitle", () => {
+  it("uses the payload title when present", () => {
+    expect(previewPanelTitle("Getting Started", "/docs/guide.md")).toBe("Getting Started");
+  });
+
+  it("falls back to the basename plus suffix when the payload title is empty", () => {
+    expect(previewPanelTitle("", "/docs/guide.md")).toBe("guide.md Preview");
+  });
+
+  it("uses Untitled for a buffer with no filename", () => {
+    expect(previewPanelTitle("", "")).toBe("Untitled Preview");
+  });
+});
+
+describe("pushedPreviewTitle", () => {
+  it("adopts the pushed title when the server provides one", () => {
+    expect(pushedPreviewTitle("New Title", "Old Title")).toBe("New Title");
+  });
+
+  it("keeps the current title when the pushed title is empty", () => {
+    expect(pushedPreviewTitle("", "Old Title")).toBe("Old Title");
+  });
+});


### PR DESCRIPTION
## What

Adds unit coverage for `preview.ts`. The webview lifecycle is exercised by the Electron integration suite; this pins the host-free decisions that the integration suite can't easily assert (title fallbacks, command selection).

## How

Following the `paths.ts` / `server-options.ts` pattern, the pure preview policy moves into `internal/preview-state.ts`:

- **`previewSeedCommand`** — subscribe for pushed updates when auto-refresh is on, else a one-shot HTML fetch.
- **`previewPanelTitle`** — the LSP-supplied title wins; otherwise the document basename + `" Preview"`, or `"Untitled Preview"` for a buffer with no filename.
- **`pushedPreviewTitle`** — an empty pushed title leaves the existing panel title untouched.

`preview.ts` delegates to these. No behavior change.

## Testing

- 7 new vitest tests (`preview-state.test.ts`); the pure-node unit suite is now **42 passed**.
- `vp run vscode:build` (tsc) clean; `vp run fmt:ts-check` clean.
- Runs in the existing CI `VS Code extension tests` job — no workflow change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783438851&installation_id=136613492&pr_number=347&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F347&signature=8f4ebc9e8a995f0123c02ce858760e8becbe95c5147b83bb7c4db722aee064b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->