### PR TITLE
feat(lsp): add smart selection ranges (expand selection)

### DIFF
--- a/crates/ox_content_lsp/src/backend/features.rs
+++ b/crates/ox_content_lsp/src/backend/features.rs
@@ -246,6 +246,22 @@ impl Backend {
         let links = crate::document_link::document_links(&document, &path, root.as_deref());
         (!links.is_empty()).then_some(links)
     }
+
+    pub(super) async fn selection_range_response(
+        &self,
+        uri: &Url,
+        positions: &[Position],
+    ) -> Option<Vec<SelectionRange>> {
+        let Ok(path) = uri.to_file_path() else {
+            return None;
+        };
+        if !is_markdown_path(&path) {
+            return None;
+        }
+
+        let document = self.state.document(uri).await?;
+        Some(crate::selection_range::selection_ranges(&document, positions))
+    }
 }
 
 fn push_fmt(output: &mut String, args: std::fmt::Arguments<'_>) {

--- a/crates/ox_content_lsp/src/backend/handlers.rs
+++ b/crates/ox_content_lsp/src/backend/handlers.rs
@@ -60,6 +60,7 @@ impl LanguageServer for Backend {
                     resolve_provider: Some(false),
                     work_done_progress_options: WorkDoneProgressOptions::default(),
                 }),
+                selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
                 code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
                 execute_command_provider: Some(ExecuteCommandOptions {
                     commands: vec![
@@ -158,6 +159,13 @@ impl LanguageServer for Backend {
 
     async fn document_link(&self, params: DocumentLinkParams) -> Result<Option<Vec<DocumentLink>>> {
         Ok(self.document_link_response(&params.text_document.uri).await)
+    }
+
+    async fn selection_range(
+        &self,
+        params: SelectionRangeParams,
+    ) -> Result<Option<Vec<SelectionRange>>> {
+        Ok(self.selection_range_response(&params.text_document.uri, &params.positions).await)
     }
 
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {

--- a/crates/ox_content_lsp/src/main.rs
+++ b/crates/ox_content_lsp/src/main.rs
@@ -10,6 +10,7 @@
 //! - heading symbols for document outline navigation
 //! - folding ranges for headings, code blocks, and frontmatter
 //! - document links for Markdown links and images
+//! - smart selection ranges for expand-selection
 
 mod backend;
 mod config;
@@ -19,6 +20,7 @@ mod folding;
 mod frontmatter;
 mod i18n;
 mod preview;
+mod selection_range;
 mod state;
 mod textlint;
 

--- a/crates/ox_content_lsp/src/selection_range.rs
+++ b/crates/ox_content_lsp/src/selection_range.rs
@@ -1,0 +1,263 @@
+//! Smart selection ranges for Markdown / MDC documents.
+//!
+//! Powers the editor's "expand selection" command: from the word under
+//! the cursor outward through the inline node, the block, and finally the
+//! whole document. Each level is a strictly nested range, as the LSP
+//! `textDocument/selectionRange` response requires.
+//!
+//! Ranges come straight from the AST (every node whose span covers the
+//! cursor), plus a word range for the innermost step and the document
+//! range for the outermost. They're rebased through the same
+//! frontmatter-offset trick the outline and folding code use.
+
+use ox_content_allocator::Allocator;
+use ox_content_ast::{
+    walk_list_item, walk_node, walk_table_cell, walk_table_row, ListItem, Node, Span, TableCell,
+    TableRow, Visit,
+};
+use ox_content_parser::{Parser, ParserOptions};
+use tower_lsp::lsp_types::{Position, SelectionRange};
+
+use crate::document::TextDocumentState;
+use crate::frontmatter::parse_frontmatter;
+
+/// Computes a nested selection range for each requested position.
+#[must_use]
+pub fn selection_ranges(
+    document: &TextDocumentState,
+    positions: &[Position],
+) -> Vec<SelectionRange> {
+    let source = document.text();
+    let (content, base_offset) = match parse_frontmatter(document).block {
+        Some(block) => (&source[block.block_end_offset..], block.block_end_offset),
+        None => (source, 0),
+    };
+
+    // Parse once and reuse the AST across every requested position.
+    let allocator = Allocator::for_source_len(content.len());
+    let parser = Parser::with_options(&allocator, content, ParserOptions::gfm());
+    let parsed = parser.parse();
+    let children: &[Node] = match &parsed {
+        Ok(document) => &document.children,
+        Err(_) => &[],
+    };
+
+    positions
+        .iter()
+        .map(|&position| {
+            let target = document.position_to_offset(position);
+            let mut ranges: Vec<(usize, usize)> = Vec::new();
+
+            // Innermost step: the identifier-like word under the cursor.
+            let word = document.word_range_at(position, |ch| ch.is_alphanumeric() || ch == '_');
+            let word_start = document.position_to_offset(word.start);
+            let word_end = document.position_to_offset(word.end);
+            if word_end > word_start {
+                ranges.push((word_start, word_end));
+            }
+
+            // Every AST node whose span covers the cursor, rebased to
+            // document coordinates.
+            if target >= base_offset {
+                let mut collector = SpanCollector::new((target - base_offset) as u32);
+                for child in children {
+                    collector.visit_node(child);
+                }
+                for span in collector.spans {
+                    ranges
+                        .push((base_offset + span.start as usize, base_offset + span.end as usize));
+                }
+            }
+
+            // Outermost step: the whole document.
+            ranges.push((0, source.len()));
+
+            build_chain(document, target, ranges)
+        })
+        .collect()
+}
+
+/// Collects the span of every node whose range covers `offset`. The
+/// `visit_node` override catches block and inline nodes; list items and
+/// table rows/cells are dispatched through their own visit methods, so
+/// they're recorded explicitly to keep those selection steps available.
+struct SpanCollector {
+    offset: u32,
+    spans: Vec<Span>,
+}
+
+impl SpanCollector {
+    fn new(offset: u32) -> Self {
+        Self { offset, spans: Vec::new() }
+    }
+
+    fn record(&mut self, span: Span) {
+        if span.start <= self.offset && self.offset < span.end {
+            self.spans.push(span);
+        }
+    }
+}
+
+impl<'a> Visit<'a> for SpanCollector {
+    fn visit_node(&mut self, node: &Node<'a>) {
+        self.record(node.span());
+        walk_node(self, node);
+    }
+
+    fn visit_list_item(&mut self, item: &ListItem<'a>) {
+        self.record(item.span);
+        walk_list_item(self, item);
+    }
+
+    fn visit_table_row(&mut self, row: &TableRow<'a>) {
+        self.record(row.span);
+        walk_table_row(self, row);
+    }
+
+    fn visit_table_cell(&mut self, cell: &TableCell<'a>) {
+        self.record(cell.span);
+        walk_table_cell(self, cell);
+    }
+}
+
+/// Builds the nested `SelectionRange` chain (innermost returned, parents
+/// pointing outward) from the collected candidate ranges. Ranges that
+/// don't cover the cursor are dropped, and each step must be strictly
+/// contained in its parent so the chain is always well-formed.
+fn build_chain(
+    document: &TextDocumentState,
+    target: usize,
+    mut ranges: Vec<(usize, usize)>,
+) -> SelectionRange {
+    ranges.retain(|&(start, end)| start <= target && target <= end);
+    ranges.sort_by_key(|&(start, end)| end - start);
+    ranges.dedup();
+
+    let mut selection: Option<SelectionRange> = None;
+    let mut parent_bounds: Option<(usize, usize)> = None;
+    for &(start, end) in ranges.iter().rev() {
+        if let Some((parent_start, parent_end)) = parent_bounds {
+            let strictly_inside = start >= parent_start
+                && end <= parent_end
+                && (start > parent_start || end < parent_end);
+            if !strictly_inside {
+                continue;
+            }
+        }
+        selection = Some(SelectionRange {
+            range: document.range_from_offsets(start, end),
+            parent: selection.take().map(Box::new),
+        });
+        parent_bounds = Some((start, end));
+    }
+
+    selection.unwrap_or_else(|| SelectionRange {
+        range: document.range_from_offsets(target, target),
+        parent: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fmt::Write as _;
+
+    /// Returns the source substring covered by each step of the chain,
+    /// innermost first — a readable proxy for the nested ranges.
+    fn chain_texts(source: &str, position: Position) -> Vec<String> {
+        let document = TextDocumentState::new(source.to_string());
+        let ranges = selection_ranges(&document, &[position]);
+        assert_eq!(ranges.len(), 1, "one selection range per position");
+
+        let mut texts = Vec::new();
+        let mut current = Some(&ranges[0]);
+        while let Some(selection) = current {
+            let start = document.position_to_offset(selection.range.start);
+            let end = document.position_to_offset(selection.range.end);
+            texts.push(source[start..end].to_string());
+            current = selection.parent.as_deref();
+        }
+        texts
+    }
+
+    fn position(line: u32, character: u32) -> Position {
+        Position { line, character }
+    }
+
+    #[test]
+    fn expands_word_to_paragraph_to_document() {
+        let source = "Hello world\n";
+        // Cursor inside "world".
+        let texts = chain_texts(source, position(0, 8));
+        assert_eq!(texts, vec!["world", "Hello world", "Hello world\n"]);
+    }
+
+    #[test]
+    fn expands_through_inline_emphasis() {
+        let source = "a **bold** word\n";
+        // Cursor inside "bold": word -> the strong inline node -> the
+        // surrounding block. (Here the paragraph span already covers the
+        // whole single-line document, so there's no separate block step.)
+        let texts = chain_texts(source, position(0, 5));
+        assert_eq!(texts, vec!["bold", "**bold**", "a **bold** word\n"]);
+    }
+
+    #[test]
+    fn steps_are_strictly_nested() {
+        let source = "# Heading\n\nFirst paragraph with words.\n";
+        let document = TextDocumentState::new(source.to_string());
+        let ranges = selection_ranges(&document, &[position(2, 6)]);
+        let selection = &ranges[0];
+
+        // Walk the chain and assert each parent strictly contains its child.
+        let mut current = Some(selection);
+        let mut child_bounds: Option<(usize, usize)> = None;
+        while let Some(node) = current {
+            let start = document.position_to_offset(node.range.start);
+            let end = document.position_to_offset(node.range.end);
+            if let Some((cs, ce)) = child_bounds {
+                assert!(start <= cs && ce <= end, "parent must contain child");
+                assert!(start < cs || ce < end, "parent must be strictly larger");
+            }
+            child_bounds = Some((start, end));
+            current = node.parent.as_deref();
+        }
+    }
+
+    #[test]
+    fn returns_one_range_per_position() {
+        let source = "one two three\n";
+        let document = TextDocumentState::new(source.to_string());
+        let positions = [position(0, 1), position(0, 5), position(0, 9)];
+        let ranges = selection_ranges(&document, &positions);
+        assert_eq!(ranges.len(), 3);
+
+        // Sanity: each innermost range is the word at that cursor.
+        let mut innermost = String::new();
+        for (selection, expected) in ranges.iter().zip(["one", "two", "three"]) {
+            let start = document.position_to_offset(selection.range.start);
+            let end = document.position_to_offset(selection.range.end);
+            let _ = write!(innermost, "{} ", &source[start..end]);
+            assert_eq!(&source[start..end], expected);
+        }
+    }
+
+    #[test]
+    fn position_inside_frontmatter_still_yields_a_range() {
+        let source = "---\ntitle: Doc\n---\n\n# Body\n";
+        let document = TextDocumentState::new(source.to_string());
+        // Cursor on the frontmatter `title` key (before the body the
+        // parser sees) should not panic and should return the document
+        // range at minimum.
+        let ranges = selection_ranges(&document, &[position(1, 2)]);
+        assert_eq!(ranges.len(), 1);
+        // Outermost step covers the whole document.
+        let mut outer = &ranges[0];
+        while let Some(parent) = outer.parent.as_deref() {
+            outer = parent;
+        }
+        let start = document.position_to_offset(outer.range.start);
+        let end = document.position_to_offset(outer.range.end);
+        assert_eq!((start, end), (0, source.len()));
+    }
+}

--- a/docs/content/editor-extension-roadmap.md
+++ b/docs/content/editor-extension-roadmap.md
@@ -43,6 +43,7 @@ must not depend on a later one in the list.
 | 8   | Frontmatter schema completion + diagnostics     | present                  | none (validated through LSP) | present                  | present                     | needs CLI        |
 | 9   | Document structure (outline + folding)          | symbols + folding ranges | none (unit-tested headless)  | outline + folding        | outline + folding           | shipped          |
 | 10  | Document links (Markdown links + images)        | document link provider   | none (unit-tested headless)  | clickable links          | clickable links             | shipped          |
+| 11  | Selection ranges (expand selection)             | selection range provider | none (unit-tested headless)  | expand/shrink selection  | expand/shrink selection     | shipped          |
 
 ## PR Sequence
 


### PR DESCRIPTION
## What

Implements `textDocument/selectionRange` in `ox_content_lsp`, powering the editor's **expand / shrink selection** command in any LSP client (VS Code: ⌃⇧→ / ⌃⇧←).

For each requested position the selection grows in strictly nested steps: the word under the cursor → the inline mark (`**bold**`, `[link]`, `` `code` ``) → the block (paragraph, heading, list item, table cell) → the whole document.

## How

- A `Visit` walk records every AST node whose span covers the cursor. `visit_node` catches block + inline nodes; list items and table rows/cells are dispatched through their own visit methods, so they're recorded explicitly to keep those steps available.
- A word range (identifier-like chars) supplies the innermost step; the document range supplies the outermost.
- Candidates are rebased through the usual frontmatter offset, deduped, and assembled outermost→innermost with a strict-containment guard so the chain is always well-formed.
- Capability advertised via `selection_range_provider`; handler returns one nested range per requested position.

## Testing

- 5 headless unit tests (word→block→document, inline emphasis, strict nesting invariant, one range per position, cursor inside frontmatter doesn't panic).
- `cargo test -p ox_content_lsp` → 85 unit + 8 e2e passed.
- `cargo clippy --all-targets` clean; `cargo fmt --check` clean.

Roadmap feature matrix updated (row 11: Selection ranges).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783440759&installation_id=136613492&pr_number=350&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F350&signature=dc20f7548b8d5663dd06c1a82a2670dbb865c44e6198811160d0bf976434dcfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->