### PR TITLE
feat(docs): render jsdoc member default values

### DIFF
--- a/crates/ox_content_docs/benches/markdown.rs
+++ b/crates/ox_content_docs/benches/markdown.rs
@@ -127,6 +127,7 @@ fn member(module: usize, entry: usize, index: usize) -> ApiDocMember {
         description,
         signature,
         type_annotation: (kind == "property").then(|| "Record<string, unknown>".to_string()),
+        default_value: None,
         params: if kind != "property" {
             Vec::from([param(module, entry, index)])
         } else {

--- a/crates/ox_content_docs/src/data.rs
+++ b/crates/ox_content_docs/src/data.rs
@@ -185,6 +185,9 @@ fn member_to_json(member: &ApiDocMember) -> Value {
     if let Some(type_annotation) = &member.type_annotation {
         value.insert("type".to_string(), json!(type_annotation));
     }
+    if let Some(default_value) = &member.default_value {
+        value.insert("default".to_string(), json!(default_value));
+    }
     if !member.params.is_empty() {
         value.insert(
             "params".to_string(),
@@ -487,6 +490,7 @@ mod tests {
                         description: String::new(),
                         signature: None,
                         type_annotation: Some("ArgValues<A>".to_string()),
+                        default_value: Some("{}".to_string()),
                         params: vec![],
                         type_parameters: vec![],
                         returns: None,
@@ -523,6 +527,7 @@ mod tests {
         assert_eq!(returns["type"], "object");
         assert_eq!(returns["members"][0]["name"], "values");
         assert_eq!(returns["members"][0]["type"], "ArgValues<A>");
+        assert_eq!(returns["members"][0]["default"], "{}");
     }
 
     #[test]
@@ -555,6 +560,7 @@ mod tests {
                     description: "HTTP options.".to_string(),
                     signature: None,
                     type_annotation: Some("{ timeout?: number }".to_string()),
+                    default_value: None,
                     params: vec![],
                     type_parameters: vec![],
                     returns: None,
@@ -564,6 +570,7 @@ mod tests {
                         description: "Request timeout.".to_string(),
                         signature: None,
                         type_annotation: Some("number".to_string()),
+                        default_value: None,
                         params: vec![],
                         type_parameters: vec![],
                         returns: None,
@@ -631,6 +638,7 @@ mod tests {
                     description: "Argument schema by option name.".to_string(),
                     signature: Some("readonly [option: string]: ArgSchema".to_string()),
                     type_annotation: Some("ArgSchema".to_string()),
+                    default_value: None,
                     params: vec![ApiParamDoc {
                         name: "option".to_string(),
                         type_annotation: "string".to_string(),
@@ -697,6 +705,7 @@ mod tests {
                     description: "Parses a raw value.".to_string(),
                     signature: None,
                     type_annotation: Some("(value: string) => any".to_string()),
+                    default_value: None,
                     params: vec![ApiParamDoc {
                         name: "value".to_string(),
                         type_annotation: "string".to_string(),
@@ -896,6 +905,7 @@ mod tests {
                             .to_string(),
                     ),
                     type_annotation: None,
+                    default_value: None,
                     params: vec![],
                     type_parameters: vec![],
                     returns: None,

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -2891,6 +2891,7 @@ mod tests {
                         description: "Runs it.".to_string(),
                         signature: Some("run(): void".to_string()),
                         type_annotation: None,
+                        default_value: None,
                         params: vec![],
                         type_parameters: vec![],
                         returns: None,
@@ -3304,6 +3305,7 @@ mod tests {
                             .to_string(),
                         signature: None,
                         type_annotation: Some("Record<string, unknown>".to_string()),
+                        default_value: None,
                         params: vec![],
                         type_parameters: vec![],
                         returns: None,
@@ -3441,6 +3443,7 @@ mod tests {
                         description: "Suppress usage output.".to_string(),
                         signature: None,
                         type_annotation: Some("boolean".to_string()),
+                        default_value: None,
                         params: vec![],
                         type_parameters: vec![],
                         returns: None,
@@ -4053,6 +4056,7 @@ mod tests {
             description: "Command name.".to_string(),
             signature: None,
             type_annotation: Some("string".to_string()),
+            default_value: None,
             params: vec![],
             type_parameters: vec![],
             returns: None,
@@ -4104,6 +4108,66 @@ mod tests {
     }
 
     #[test]
+    fn markdown_renders_member_default_values() {
+        let mut entry = test_entry("Command", "interface", "src/types.ts", "Command options.");
+        entry.members = vec![ApiDocMember {
+            name: "timeout".to_string(),
+            kind: "property".to_string(),
+            description: "Request timeout.".to_string(),
+            signature: None,
+            type_annotation: Some("number".to_string()),
+            default_value: Some("5000".to_string()),
+            params: vec![],
+            type_parameters: vec![],
+            returns: None,
+            members: vec![],
+            optional: true,
+            readonly: false,
+            r#static: false,
+            private: false,
+            tags: vec![],
+            implementation_of: vec![],
+            line: 2,
+            end_line: 2,
+        }];
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "mod".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![entry],
+        }];
+
+        let html = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                interface_properties_format: MarkdownDisplayFormat::Table,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let html_page = html.get("mod/interfaces/Command.md").unwrap();
+        assert!(html_page.contains("ox-api-entry__member-default"));
+        assert!(html_page
+            .contains("<span>Default</span> <code class=\"language-typescript\">5000</code>"));
+
+        let markdown = generate_markdown(
+            &docs,
+            &MarkdownDocsOptions {
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                render_style: MarkdownRenderStyle::Markdown,
+                interface_properties_format: MarkdownDisplayFormat::Table,
+                ..MarkdownDocsOptions::default()
+            },
+        );
+        let markdown_page = markdown.get("mod/interfaces/Command.md").unwrap();
+        assert!(markdown_page.contains(
+            "| `timeout` _(optional)_ | `number` | Request timeout. **Default:** `5000` |"
+        ));
+    }
+
+    #[test]
     fn markdown_member_parameters_follow_parameters_format() {
         let mut entry = test_entry("Command", "interface", "src/types.ts", "Command options.");
         entry.members = vec![ApiDocMember {
@@ -4112,6 +4176,7 @@ mod tests {
             description: "Runs the command.".to_string(),
             signature: Some("run(ctx: Context): Promise<void>".to_string()),
             type_annotation: None,
+            default_value: None,
             params: vec![ApiParamDoc {
                 name: "ctx".to_string(),
                 type_annotation: "Context".to_string(),
@@ -4182,6 +4247,7 @@ mod tests {
                     .to_string(),
             ),
             type_annotation: None,
+            default_value: None,
             params: vec![ApiParamDoc {
                 name: "decorator".to_string(),
                 type_annotation: "(value: L) => void".to_string(),
@@ -4268,6 +4334,7 @@ mod tests {
                 "getResource(locale: string): Record<string, string> | undefined".to_string(),
             ),
             type_annotation: None,
+            default_value: None,
             params: vec![ApiParamDoc {
                 name: "locale".to_string(),
                 type_annotation: "string".to_string(),
@@ -4310,6 +4377,7 @@ mod tests {
                     "constructor(options: TranslationAdapterFactoryOptions)".to_string(),
                 ),
                 type_annotation: None,
+                default_value: None,
                 params: vec![ApiParamDoc {
                     name: "options".to_string(),
                     type_annotation: "TranslationAdapterFactoryOptions".to_string(),
@@ -4337,6 +4405,7 @@ mod tests {
                     "getResource(locale: string): Record<string, string> | undefined".to_string(),
                 ),
                 type_annotation: None,
+                default_value: None,
                 params: vec![ApiParamDoc {
                     name: "locale".to_string(),
                     type_annotation: "string".to_string(),
@@ -4459,6 +4528,7 @@ mod tests {
                 description: "Command name.".to_string(),
                 signature: None,
                 type_annotation: Some("string".to_string()),
+                default_value: None,
                 params: vec![],
                 type_parameters: vec![],
                 returns: None,
@@ -4478,6 +4548,7 @@ mod tests {
                 description: "Runs the command.".to_string(),
                 signature: Some("run(ctx: Context): Promise<void>".to_string()),
                 type_annotation: None,
+                default_value: None,
                 params: vec![ApiParamDoc {
                     name: "ctx".to_string(),
                     type_annotation: "Context".to_string(),
@@ -5269,6 +5340,7 @@ mod tests {
                 "getResource(locale: string): Record<string, string> | undefined".to_string(),
             ),
             type_annotation: None,
+            default_value: None,
             params: vec![ApiParamDoc {
                 name: "locale".to_string(),
                 type_annotation: "string".to_string(),
@@ -5310,6 +5382,7 @@ mod tests {
                 "getResource(locale: string): Record<string, string> | undefined".to_string(),
             ),
             type_annotation: None,
+            default_value: None,
             params: vec![ApiParamDoc {
                 name: "locale".to_string(),
                 type_annotation: "string".to_string(),
@@ -5362,6 +5435,7 @@ mod tests {
             description: String::new(),
             signature: None,
             type_annotation: Some("unknown".to_string()),
+            default_value: None,
             params: vec![],
             type_parameters: vec![],
             returns: None,
@@ -5384,6 +5458,7 @@ mod tests {
             description: "Parses a raw value.".to_string(),
             signature: None,
             type_annotation: Some("(value: string) => string | undefined".to_string()),
+            default_value: None,
             params: vec![ApiParamDoc {
                 name: "value".to_string(),
                 type_annotation: "string".to_string(),
@@ -5518,6 +5593,7 @@ mod tests {
             description: String::new(),
             signature: None,
             type_annotation: Some(type_annotation.to_string()),
+            default_value: None,
             params: vec![],
             type_parameters: vec![],
             returns: None,
@@ -5550,6 +5626,7 @@ mod tests {
                 format!("{name}: {value_type}")
             }),
             type_annotation: Some(value_type.to_string()),
+            default_value: None,
             params: vec![param(param_name, param_type)],
             type_parameters: vec![],
             returns: None,
@@ -6168,6 +6245,7 @@ mod tests {
             description: "The mode.".to_string(),
             signature: None,
             type_annotation: Some("string".to_string()),
+            default_value: None,
             params: vec![],
             type_parameters: vec![],
             returns: None,
@@ -6545,6 +6623,7 @@ mod tests {
             description: "Minimum string length.".to_string(),
             signature: None,
             type_annotation: Some("number".to_string()),
+            default_value: None,
             params: vec![],
             type_parameters: vec![],
             returns: None,
@@ -6612,6 +6691,7 @@ mod tests {
             description: "Whether this is an entry command.".to_string(),
             signature: None,
             type_annotation: Some("boolean".to_string()),
+            default_value: None,
             params: vec![],
             type_parameters: vec![],
             returns: None,
@@ -6963,6 +7043,7 @@ mod tests {
                         description: "Strict mode.".to_string(),
                         signature: None,
                         type_annotation: Some("\"strict\"".to_string()),
+                        default_value: None,
                         params: vec![],
                         type_parameters: vec![],
                         returns: None,
@@ -7052,6 +7133,7 @@ mod tests {
                         description: "Command name.".to_string(),
                         signature: None,
                         type_annotation: Some("string".to_string()),
+                        default_value: None,
                         params: vec![],
                         type_parameters: vec![],
                         returns: None,
@@ -7071,6 +7153,7 @@ mod tests {
                         description: "Runs the command.".to_string(),
                         signature: Some("run(ctx: Context): Promise<void>".to_string()),
                         type_annotation: None,
+                        default_value: None,
                         params: vec![ApiParamDoc {
                             name: "ctx".to_string(),
                             type_annotation: "Context".to_string(),

--- a/crates/ox_content_docs/src/markdown/markdown_html.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_html.rs
@@ -923,6 +923,12 @@ fn render_member_description_html(
         ));
     }
 
+    if let Some(default_value) =
+        member.default_value.as_deref().map(str::trim).filter(|value| !value.is_empty())
+    {
+        blocks.push(render_member_default_html(default_value));
+    }
+
     if !member.type_parameters.is_empty() {
         blocks.push(render_member_type_parameters_html(&member.type_parameters, options, context));
     }
@@ -959,6 +965,15 @@ fn render_member_description_html(
     }
 
     blocks.join("")
+}
+
+fn render_member_default_html(default_value: &str) -> String {
+    let mut out = StringBuilder::with_capacity(default_value.len() + 102);
+    out.push_str("<div class=\"ox-api-entry__member-default\"><span>Default</span> ");
+    out.push_str("<code class=\"language-typescript\">");
+    out.push_str(&escape_html(default_value));
+    out.push_str("</code></div>");
+    out.into_string()
 }
 
 fn render_member_param_description(param: &ApiParamDoc) -> String {

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -1170,6 +1170,17 @@ fn member_description(
     if !member.description.is_empty() {
         push_part(&mut description, &inline(&member.description, context));
     }
+    if let Some(default_value) =
+        member.default_value.as_deref().map(str::trim).filter(|value| !value.is_empty())
+    {
+        let default = code_span(default_value);
+        if !default.is_empty() {
+            let mut part = StringBuilder::with_capacity(default.len() + 14);
+            part.push_str("**Default:** ");
+            part.push_str(&default);
+            push_part(&mut description, &part.into_string());
+        }
+    }
     if include_returns {
         if let Some(returns) = &member.returns {
             if !returns.description.is_empty() {

--- a/crates/ox_content_docs/src/model.rs
+++ b/crates/ox_content_docs/src/model.rs
@@ -96,6 +96,9 @@ pub struct ApiDocMember {
     pub signature: Option<String>,
     /// Property or enum member type/value annotation.
     pub type_annotation: Option<String>,
+    /// Default value extracted from `@default` / `@defaultValue`.
+    #[serde(default)]
+    pub default_value: Option<String>,
     /// Parameters.
     #[serde(default)]
     pub params: Vec<ApiParamDoc>,

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -199,6 +199,9 @@ pub struct NormalizedMember {
     pub signature: Option<String>,
     /// Property or enum member type/value annotation.
     pub type_annotation: Option<String>,
+    /// Default value extracted from `@default` / `@defaultValue`.
+    #[serde(default)]
+    pub default_value: Option<String>,
     /// Parameters, if any.
     #[serde(default)]
     pub params: Vec<NormalizedParamDoc>,
@@ -340,6 +343,10 @@ fn normalize_member(item: DocItem, type_parameters: bool) -> Option<NormalizedMe
     let include_type_parameters = type_parameters;
     let kind = NormalizedMemberKind::from_doc_item_kind(item.kind)?;
     let mut metadata = normalize_doc_metadata(&item.tags, type_parameters);
+    let default_value = member_default_value_from_tags(&item.tags);
+    if default_value.is_some() {
+        remove_member_default_tags(&mut metadata.tags);
+    }
     let has_extracted_params = !item.params.is_empty();
     let has_extracted_return = item.return_type.is_some() || !item.return_members.is_empty();
     let has_callable_shape = matches!(
@@ -389,6 +396,7 @@ fn normalize_member(item: DocItem, type_parameters: bool) -> Option<NormalizedMe
         description: item.doc.unwrap_or_default(),
         signature,
         type_annotation,
+        default_value,
         params: metadata.params,
         type_parameters,
         returns: metadata.returns,
@@ -401,6 +409,33 @@ fn normalize_member(item: DocItem, type_parameters: bool) -> Option<NormalizedMe
         line: item.line,
         end_line: item.end_line,
     })
+}
+
+fn member_default_value_from_tags(tags: &[DocTag]) -> Option<String> {
+    for tag in tags {
+        if !matches!(tag.tag.as_str(), "default" | "defaultValue" | "defaultvalue") {
+            continue;
+        }
+
+        let value = tag.value.trim();
+        let value = if value.is_empty() {
+            tag.default_value.as_deref().unwrap_or("").trim()
+        } else {
+            value
+        };
+
+        if !value.is_empty() {
+            return Some(value.to_string());
+        }
+    }
+
+    None
+}
+
+fn remove_member_default_tags(tags: &mut BTreeMap<String, String>) {
+    tags.remove("default");
+    tags.remove("defaultValue");
+    tags.remove("defaultvalue");
 }
 
 struct NormalizedDocMetadata {
@@ -768,6 +803,94 @@ export interface Command {
         assert_eq!(members[1].name, "args");
         assert_eq!(members[1].type_annotation.as_deref(), Some("string[]"));
         assert!(members[1].optional);
+    }
+
+    #[test]
+    fn property_default_tags_are_normalized_to_member_defaults() {
+        let source = r#"
+/**
+ * Runtime options.
+ */
+export interface Options {
+    /**
+     * Request timeout.
+     * @default 5000
+     */
+    timeout?: number;
+    /**
+     * Retry mode.
+     * @defaultValue "exponential"
+     */
+    retryMode?: "none" | "linear" | "exponential";
+    /** HTTP options. */
+    http: {
+        /**
+         * Request headers.
+         * @defaultValue {}
+         */
+        headers: Record<string, string>;
+    };
+}
+"#;
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "options.ts", SourceType::ts()).unwrap();
+        let entries = normalize_doc_items(items, false);
+        let members = &entries[0].members;
+
+        assert_eq!(members[0].name, "timeout");
+        assert_eq!(members[0].default_value.as_deref(), Some("5000"));
+        assert!(!members[0].tags.contains_key("default"));
+
+        assert_eq!(members[1].name, "retryMode");
+        assert_eq!(members[1].default_value.as_deref(), Some("\"exponential\""));
+        assert!(!members[1].tags.contains_key("defaultValue"));
+
+        assert_eq!(members[2].name, "http");
+        assert_eq!(members[2].members[0].name, "headers");
+        assert_eq!(members[2].members[0].default_value.as_deref(), Some("{}"));
+        assert!(!members[2].members[0].tags.contains_key("defaultValue"));
+    }
+
+    #[test]
+    fn class_and_type_alias_property_default_tags_are_normalized() {
+        let source = r"
+/**
+ * Runtime options.
+ */
+export class RuntimeOptions {
+    /**
+     * Enables cache.
+     * @default true
+     */
+    cache?: boolean;
+}
+
+/**
+ * Retry options.
+ */
+export type RetryOptions = {
+    /**
+     * Retry count.
+     * @defaultValue 3
+     */
+    retries?: number;
+};
+";
+
+        let extractor = DocExtractor::new();
+        let items = extractor.extract_source(source, "options.ts", SourceType::ts()).unwrap();
+        let entries = normalize_doc_items(items, false);
+
+        let class = entries.iter().find(|entry| entry.name == "RuntimeOptions").unwrap();
+        assert_eq!(class.members[0].name, "cache");
+        assert_eq!(class.members[0].default_value.as_deref(), Some("true"));
+        assert!(!class.members[0].tags.contains_key("default"));
+
+        let alias = entries.iter().find(|entry| entry.name == "RetryOptions").unwrap();
+        assert_eq!(alias.members[0].name, "retries");
+        assert_eq!(alias.members[0].default_value.as_deref(), Some("3"));
+        assert!(!alias.members[0].tags.contains_key("defaultValue"));
     }
 
     #[test]

--- a/crates/ox_content_docs/src/output.rs
+++ b/crates/ox_content_docs/src/output.rs
@@ -299,6 +299,7 @@ mod tests {
                         description: "Strict mode.".to_string(),
                         signature: None,
                         type_annotation: Some("\"strict\"".to_string()),
+                        default_value: None,
                         params: vec![],
                         type_parameters: vec![],
                         returns: None,

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -278,6 +278,7 @@ export interface JsDocMember {
   description: string
   signature?: string
   type?: string
+  default?: string
   params?: Array<JsDocParam>
   typeParameters?: Array<JsTypeParam>
   returns?: JsDocReturn

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -204,6 +204,7 @@ pub struct JsDocMember {
     pub description: String,
     pub signature: Option<String>,
     pub r#type: Option<String>,
+    pub r#default: Option<String>,
     pub params: Option<Vec<JsDocParam>>,
     pub type_parameters: Option<Vec<JsTypeParam>>,
     pub returns: Option<JsDocReturn>,
@@ -982,6 +983,7 @@ fn map_normalized_member(member: NormalizedMember) -> JsDocMember {
         description: member.description,
         signature: member.signature,
         r#type: member.type_annotation,
+        r#default: member.default_value,
         params: (!member.params.is_empty())
             .then(|| member.params.into_iter().map(map_normalized_param_doc).collect()),
         type_parameters: (!member.type_parameters.is_empty())
@@ -1229,6 +1231,7 @@ fn convert_markdown_member(member: JsDocMember) -> ApiDocMember {
         description: member.description,
         signature: member.signature,
         type_annotation: member.r#type,
+        default_value: member.r#default,
         params: member.params.unwrap_or_default().into_iter().map(convert_markdown_param).collect(),
         type_parameters: member
             .type_parameters
@@ -3608,6 +3611,7 @@ mod tests {
                 description: "Command name.".to_string(),
                 signature: None,
                 type_annotation: Some("string".to_string()),
+                default_value: Some("\"cli\"".to_string()),
                 params: vec![],
                 type_parameters: vec![NormalizedTypeParam {
                     name: "T".to_string(),
@@ -3622,6 +3626,7 @@ mod tests {
                     description: "Request timeout.".to_string(),
                     signature: None,
                     type_annotation: Some("number".to_string()),
+                    default_value: Some("5000".to_string()),
                     params: vec![],
                     type_parameters: vec![],
                     returns: None,
@@ -3651,6 +3656,7 @@ mod tests {
         assert_eq!(member.name, "name");
         assert_eq!(member.kind, "property");
         assert_eq!(member.r#type.as_deref(), Some("string"));
+        assert_eq!(member.r#default.as_deref(), Some("\"cli\""));
         let type_param = &member.type_parameters.as_ref().unwrap()[0];
         assert_eq!(type_param.name, "T");
         assert_eq!(type_param.constraint.as_deref(), Some("Base"));
@@ -3662,6 +3668,7 @@ mod tests {
         assert_eq!(nested_member.name, "timeout");
         assert_eq!(nested_member.kind, "property");
         assert_eq!(nested_member.r#type.as_deref(), Some("number"));
+        assert_eq!(nested_member.r#default.as_deref(), Some("5000"));
         assert_eq!(nested_member.description, "Request timeout.");
         assert_eq!(nested_member.optional, Some(true));
     }
@@ -3690,6 +3697,7 @@ mod tests {
                 description: "Argument schema by option name.".to_string(),
                 signature: Some("readonly [option: string]: ArgSchema".to_string()),
                 type_annotation: Some("ArgSchema".to_string()),
+                default_value: None,
                 params: vec![ox_content_docs::NormalizedParamDoc {
                     name: "option".to_string(),
                     type_annotation: "string".to_string(),
@@ -3767,6 +3775,7 @@ mod tests {
                     description: String::new(),
                     signature: None,
                     type_annotation: Some("ArgValues<A>".to_string()),
+                    default_value: None,
                     params: vec![],
                     type_parameters: vec![],
                     returns: None,
@@ -4010,6 +4019,7 @@ export function plugin<Id, PluginExt>(options: {
                     "getResource(locale: string): Record<string, string> | undefined".to_string(),
                 ),
                 r#type: None,
+                r#default: Some("undefined".to_string()),
                 params: None,
                 type_parameters: Some(vec![JsTypeParam {
                     name: "L".to_string(),
@@ -4036,6 +4046,7 @@ export function plugin<Id, PluginExt>(options: {
         assert_eq!(converted.extends, vec!["BaseTranslation"]);
         assert_eq!(converted.implements, vec!["TranslationAdapter"]);
         assert_eq!(converted.members[0].implementation_of, vec!["TranslationAdapter.getResource"]);
+        assert_eq!(converted.members[0].default_value.as_deref(), Some("undefined"));
         assert_eq!(converted.members[0].type_parameters[0].name, "L");
         assert_eq!(converted.members[0].type_parameters[0].constraint.as_deref(), Some("Base"));
     }
@@ -4207,6 +4218,7 @@ export function plugin<Id, PluginExt>(options: {
                             description: "Resolved values.".to_string(),
                             signature: None,
                             r#type: Some("ArgValues<A>".to_string()),
+                            r#default: None,
                             params: None,
                             type_parameters: None,
                             returns: None,
@@ -4304,6 +4316,7 @@ export function plugin<Id, PluginExt>(options: {
                     description: "HTTP options.".to_string(),
                     signature: None,
                     r#type: Some("{ timeout?: number }".to_string()),
+                    r#default: None,
                     params: None,
                     type_parameters: None,
                     returns: None,
@@ -4313,6 +4326,7 @@ export function plugin<Id, PluginExt>(options: {
                         description: "Request timeout.".to_string(),
                         signature: None,
                         r#type: Some("number".to_string()),
+                        r#default: None,
                         params: None,
                         type_parameters: None,
                         returns: None,
@@ -4389,6 +4403,7 @@ export function plugin<Id, PluginExt>(options: {
                         description: "All {@linkcode Command.args} names.".to_string(),
                         signature: None,
                         r#type: Some("Record<string, unknown>".to_string()),
+                        r#default: None,
                         params: None,
                         type_parameters: None,
                         returns: None,
@@ -4876,6 +4891,7 @@ export function plugin<Id, PluginExt>(options: {
                             description: String::new(),
                             signature: None,
                             r#type: Some("ArgValues<A>".to_string()),
+                            r#default: None,
                             params: None,
                             type_parameters: None,
                             returns: None,
@@ -5205,6 +5221,7 @@ export function plugin<Id, PluginExt>(options: {
                         description: "Argument schema by option name.".to_string(),
                         signature: Some("readonly [option: string]: ArgSchema".to_string()),
                         r#type: Some("ArgSchema".to_string()),
+                        r#default: None,
                         params: Some(vec![JsDocParam {
                             name: "option".to_string(),
                             r#type: "string".to_string(),

--- a/crates/ox_content_profile_cli/src/main.rs
+++ b/crates/ox_content_profile_cli/src/main.rs
@@ -478,6 +478,7 @@ fn to_api_member(member: NormalizedMember) -> ApiDocMember {
         description: member.description,
         signature: member.signature,
         type_annotation: member.type_annotation,
+        default_value: member.default_value,
         params: member.params.into_iter().map(to_api_param).collect(),
         type_parameters: member.type_parameters.into_iter().map(to_api_type_param).collect(),
         returns: member.returns.map(to_api_return),

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -1204,6 +1204,7 @@ export interface DocMember {
   description: string;
   signature?: string;
   type?: string;
+  default?: string;
   params?: ParamDoc[];
   returns?: ReturnDoc;
   optional?: boolean;


### PR DESCRIPTION
## Summary
- Render member defaults from `@default` / `@defaultValue`.
- Propagate defaults through docs IR, JSON, NAPI/types, and HTML/Markdown output.
- Add tests for class, interface, type-alias, and nested members.

## Background
Member property defaults were kept only as generic JSDoc tags, while parameter defaults had a structured field. This made API docs unable to show property defaults consistently. The change adds a dedicated member default field and suppresses duplicate tag output.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783481140&installation_id=136613492&pr_number=356&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F356&signature=f13cf52eefed4aa81ff21aecf7ae4dcf95c5efddd8d1a9f8411f846d0e53d611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->