### PR TITLE
fix: preserve napi declaration docs

### DIFF
--- a/crates/ox_content_napi/src/docs_source_types.rs
+++ b/crates/ox_content_napi/src/docs_source_types.rs
@@ -1,5 +1,6 @@
 use napi_derive::napi;
 
+/// Raw JSDoc tag extracted from source code.
 #[napi(object)]
 #[derive(Clone)]
 pub struct JsSourceDocTag {

--- a/crates/ox_content_napi/src/i18n_bindings.rs
+++ b/crates/ox_content_napi/src/i18n_bindings.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use napi_derive::napi;
 
+/// Result of loading dictionaries.
 #[napi(object)]
 pub struct I18nLoadResult {
     /// Number of locales loaded.

--- a/crates/ox_content_napi/src/mermaid_bindings.rs
+++ b/crates/ox_content_napi/src/mermaid_bindings.rs
@@ -1,5 +1,6 @@
 use napi_derive::napi;
 
+/// Mermaid transform result.
 #[napi(object)]
 pub struct MermaidTransformResult {
     /// The transformed HTML with mermaid code blocks replaced by rendered SVGs.

--- a/crates/ox_content_napi/src/og_image_bindings.rs
+++ b/crates/ox_content_napi/src/og_image_bindings.rs
@@ -1,5 +1,6 @@
 use napi_derive::napi;
 
+/// OG image configuration for JavaScript.
 #[napi(object)]
 #[derive(Default, Clone)]
 pub struct JsOgImageConfig {

--- a/crates/ox_content_napi/src/parse_bindings.rs
+++ b/crates/ox_content_napi/src/parse_bindings.rs
@@ -8,6 +8,7 @@ use ox_content_renderer::HtmlRenderer;
 
 use crate::{create_allocator_for_source, mdast, mdast_raw, transfer::TransferPayloadKind};
 
+/// Parse result containing the AST as JSON.
 #[napi(object)]
 pub struct ParseResult {
     /// The AST as a JSON string.
@@ -76,7 +77,7 @@ pub struct PreparedSourceResult {
     pub source_offset: JsSourceOrigin,
 }
 
-/// Raw JSDoc tag extracted from source code.
+/// Source preparation options for JavaScript.
 #[napi(object)]
 #[derive(Default, Clone)]
 pub struct JsSourceOptions {

--- a/crates/ox_content_napi/src/search_bindings.rs
+++ b/crates/ox_content_napi/src/search_bindings.rs
@@ -11,6 +11,7 @@ use ox_content_search::{
 
 use crate::{create_allocator_for_source, transformer::parse_frontmatter, JsParserOptions};
 
+/// Search document for JavaScript.
 #[napi(object)]
 #[derive(Clone)]
 pub struct JsSearchDocument {
@@ -298,7 +299,6 @@ pub fn write_search_index(index_json: String, out_dir: String) -> Result<()> {
 // SSG HTML Generation API
 // =============================================================================
 
-/// Navigation item for SSG.
 /// Extracts searchable content from Markdown source.
 ///
 /// Parses the Markdown and extracts title, body text, headings, and code.

--- a/crates/ox_content_napi/src/ssg_page_types.rs
+++ b/crates/ox_content_napi/src/ssg_page_types.rs
@@ -2,6 +2,7 @@ use napi_derive::napi;
 
 use crate::TocEntry;
 
+/// Navigation item for SSG.
 #[napi(object)]
 #[derive(Clone)]
 pub struct JsSsgNavItem {


### PR DESCRIPTION
## Summary
- restore NAPI object documentation comments after module splitting
- remove the misplaced SSG navigation comment from the search extraction binding
- keep generated `crates/ox_content_napi/index.d.ts` stable for package dry-run

## Verification
- cargo fmt --all -- --check
- git diff --check
- vp run build:npm && git diff --exit-code -- crates/ox_content_napi/index.d.ts
- cargo clippy -p ox_content_docs -p ox_content_napi --all-targets -- -D warnings
- cargo test -p ox_content_docs -p ox_content_napi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783517685&installation_id=136613492&pr_number=359&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F359&signature=e753202a02bb5051e30a4a9c769e83663edf2b4a2d9903e47c733782a7c9de5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->