### PR TITLE
feat(docs): support flattened single entry roots

### DIFF
--- a/crates/ox_content_docs/src/lib.rs
+++ b/crates/ox_content_docs/src/lib.rs
@@ -57,13 +57,14 @@ pub use graph::{
 };
 pub use markdown::{
     generate_markdown, MarkdownDisplayFormat, MarkdownDocsOptions, MarkdownLinkStyle,
-    MarkdownPathStrategy, MarkdownRenderStyle,
+    MarkdownPathStrategy, MarkdownRenderStyle, MarkdownSingleEntryRoot,
 };
 pub use model::{
     ApiDocEntry, ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc, ApiReturnDoc, ApiTypeParamDoc,
 };
 pub use nav::{
-    generate_nav_code, generate_nav_metadata, generate_nav_metadata_from_docs, DocsNavItem,
+    generate_nav_code, generate_nav_metadata, generate_nav_metadata_from_docs,
+    generate_nav_metadata_from_docs_with_options, DocsNavItem, DocsNavMetadataOptions,
 };
 pub use normalize::{
     normalize_doc_item, normalize_doc_items, NormalizedDocEntry, NormalizedDocKind,

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -111,6 +111,13 @@ pub struct MarkdownDocsOptions {
     /// (before `group_order` is applied). `None` keeps the historical kind order.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kind_sort_order: Option<Vec<String>>,
+    /// Single-entry root handling for TypeDoc-style file output.
+    ///
+    /// `Preserve` keeps the historical root index plus module index hierarchy.
+    /// `Flatten` uses the root index as the single module landing page when only
+    /// one module is present, while keeping symbol page paths stable.
+    #[serde(default)]
+    pub single_entry_root: MarkdownSingleEntryRoot,
 }
 
 /// Internal documentation link style.
@@ -133,6 +140,17 @@ pub enum MarkdownPathStrategy {
     Flat,
     /// Emit TypeDoc-style module/kind/symbol pages.
     TypeDoc,
+}
+
+/// Single-entry root handling for generated TypeDoc-style API docs.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum MarkdownSingleEntryRoot {
+    /// Preserve the historical root/module hierarchy.
+    #[default]
+    Preserve,
+    /// Flatten a single module's groups into the root page/nav level.
+    Flatten,
 }
 
 /// API documentation rendering style.
@@ -185,6 +203,7 @@ impl Default for MarkdownDocsOptions {
             sort: None,
             sort_entry_points: default_sort_entry_points(),
             kind_sort_order: None,
+            single_entry_root: MarkdownSingleEntryRoot::Preserve,
         }
     }
 }
@@ -1426,16 +1445,42 @@ fn generate_typedoc_markdown(
     profile_span!("docs::render_typedoc");
     let mut result = BTreeMap::new();
     let owners = CanonicalOwners::compute(docs);
+    let flatten_single_entry =
+        options.single_entry_root == MarkdownSingleEntryRoot::Flatten && docs.len() == 1;
 
-    result.insert("index.md".to_string(), generate_typedoc_root_index(docs, options, symbol_map));
+    if flatten_single_entry {
+        if let Some(doc) = docs.first() {
+            let module_name = module_file_name(&doc.file);
+            result.insert(
+                "index.md".to_string(),
+                generate_typedoc_module_index_for_file(
+                    doc,
+                    options,
+                    &module_name,
+                    TypedocModuleIndexPage {
+                        current_file_name: "index",
+                        title: "API Documentation",
+                        include_generated_by: true,
+                    },
+                    symbol_map,
+                    &owners,
+                ),
+            );
+        }
+    } else {
+        result
+            .insert("index.md".to_string(), generate_typedoc_root_index(docs, options, symbol_map));
+    }
 
     for doc in docs {
         let module_name = module_file_name(&doc.file);
-        let module_index_file_name = typedoc_module_index_file_name(&module_name);
-        result.insert(
-            join2(&module_index_file_name, ".md"),
-            generate_typedoc_module_index(doc, options, &module_name, symbol_map, &owners),
-        );
+        if !flatten_single_entry {
+            let module_index_file_name = typedoc_module_index_file_name(&module_name);
+            result.insert(
+                join2(&module_index_file_name, ".md"),
+                generate_typedoc_module_index(doc, options, &module_name, symbol_map, &owners),
+            );
+        }
 
         // Both render styles group a symbol's overload signatures onto a single
         // page so every public call signature survives (TypeDoc parity); see
@@ -1642,20 +1687,51 @@ fn generate_typedoc_module_index(
     symbol_map: &HashMap<String, Vec<SymbolLocation>>,
     owners: &CanonicalOwners,
 ) -> String {
-    profile_span!("docs::render_module_index");
     let current_file_name = typedoc_module_index_file_name(module_name);
+    let display_name = module_display_name(doc);
+    generate_typedoc_module_index_for_file(
+        doc,
+        options,
+        module_name,
+        TypedocModuleIndexPage {
+            current_file_name: &current_file_name,
+            title: &display_name,
+            include_generated_by: false,
+        },
+        symbol_map,
+        owners,
+    )
+}
+
+struct TypedocModuleIndexPage<'a> {
+    current_file_name: &'a str,
+    title: &'a str,
+    include_generated_by: bool,
+}
+
+fn generate_typedoc_module_index_for_file(
+    doc: &ApiDocModule,
+    options: &MarkdownDocsOptions,
+    module_name: &str,
+    page: TypedocModuleIndexPage<'_>,
+    symbol_map: &HashMap<String, Vec<SymbolLocation>>,
+    owners: &CanonicalOwners,
+) -> String {
+    profile_span!("docs::render_module_index");
     let link_context = MarkdownLinkContext {
         options,
-        current_file_name: &current_file_name,
+        current_file_name: page.current_file_name,
         current_module_name: module_name,
         symbol_map,
     };
-    let display_name = module_display_name(doc);
-    let mut builder = StringBuilder::with_capacity(display_name.len() + 4);
+    let mut builder = StringBuilder::with_capacity(page.title.len() + 4);
     builder.push_str("# ");
-    builder.push_str(&display_name);
+    builder.push_str(page.title);
     builder.push_str("\n\n");
     let mut markdown = builder.into_string();
+    if page.include_generated_by {
+        push_generated_by(&mut markdown, options);
+    }
 
     // Module-level `@experimental` / `@deprecated`: GitHub alerts in markdown,
     // a badge row in HTML — so both styles surface module lifecycle state.

--- a/crates/ox_content_docs/src/markdown/tests/typedoc_indexes.rs
+++ b/crates/ox_content_docs/src/markdown/tests/typedoc_indexes.rs
@@ -88,6 +88,43 @@ fn typedoc_index_uses_module_description_not_symbol_description() {
 }
 
 #[test]
+fn typedoc_single_entry_root_flatten_uses_root_as_module_index() {
+    let docs = vec![ApiDocModule {
+        description: "Runtime API.".to_string(),
+        file: "default".to_string(),
+        source_path: String::new(),
+        examples: vec![],
+        tags: vec![],
+        entries: vec![
+            test_entry("cli", "function", "/repo/src/cli.ts", "Run the CLI."),
+            test_entry("Command", "interface", "/repo/src/types.ts", "Runtime command."),
+        ],
+    }];
+
+    let markdown = generate_markdown(
+        &docs,
+        &MarkdownDocsOptions {
+            path_strategy: MarkdownPathStrategy::TypeDoc,
+            render_style: MarkdownRenderStyle::Markdown,
+            single_entry_root: MarkdownSingleEntryRoot::Flatten,
+            ..MarkdownDocsOptions::default()
+        },
+    );
+
+    assert!(markdown.contains_key("index.md"));
+    assert!(!markdown.contains_key("default/index.md"));
+    assert!(markdown.contains_key("default/functions/cli.md"));
+    assert!(markdown.contains_key("default/interfaces/Command.md"));
+
+    let index = markdown.get("index.md").unwrap();
+    assert!(index.starts_with("# API Documentation\n\n"));
+    assert!(index.contains("Runtime API."));
+    assert!(index.contains("## Functions"));
+    assert!(index.contains("[cli](./default/functions/cli.md)"));
+    assert!(index.contains("[Command](./default/interfaces/Command.md)"));
+}
+
+#[test]
 fn typedoc_module_index_renders_module_examples_in_html_style() {
     let docs = vec![ApiDocModule {
         description: "Parser combinator entry point.".to_string(),

--- a/crates/ox_content_docs/src/nav.rs
+++ b/crates/ox_content_docs/src/nav.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::markdown::{
     compare_entries, kind_order_slice, order_by_group_title, ordered_entry_kinds,
-    parse_sort_strategies, CanonicalOwners, MarkdownPathStrategy,
+    parse_sort_strategies, CanonicalOwners, MarkdownPathStrategy, MarkdownSingleEntryRoot,
 };
 use crate::model::ApiDocModule;
 #[allow(unused_imports)]
@@ -28,6 +28,25 @@ pub struct DocsNavItem {
     /// Child navigation items.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<DocsNavItem>>,
+}
+
+/// Options for generated navigation metadata from extracted docs.
+#[derive(Debug, Clone, Copy)]
+pub struct DocsNavMetadataOptions<'a> {
+    /// Route prefix for generated navigation links.
+    pub base_path: Option<&'a str>,
+    /// Output path strategy the nav should mirror.
+    pub path_strategy: MarkdownPathStrategy,
+    /// TypeDoc-style group order for nav groups.
+    pub group_order: Option<&'a [String]>,
+    /// TypeDoc-style sort strategies for nav leaves.
+    pub sort: Option<&'a [String]>,
+    /// Whether to sort entry points alphabetically.
+    pub sort_entry_points: bool,
+    /// TypeDoc-style kind ranking for nav groups.
+    pub kind_sort_order: Option<&'a [String]>,
+    /// Single-entry root handling for TypeDoc-style nav.
+    pub single_entry_root: MarkdownSingleEntryRoot,
 }
 
 /// Generates sidebar navigation metadata from documentation file paths.
@@ -69,20 +88,59 @@ pub fn generate_nav_metadata_from_docs(
     sort_entry_points: bool,
     kind_sort_order: Option<&[String]>,
 ) -> Vec<DocsNavItem> {
-    profile_span!("docs::generate_nav");
-    match path_strategy {
-        MarkdownPathStrategy::Flat => {
-            let files = docs.iter().map(|doc| doc.file.clone()).collect::<Vec<_>>();
-            generate_nav_metadata(&files, base_path)
-        }
-        MarkdownPathStrategy::TypeDoc => generate_typedoc_nav_metadata(
-            docs,
+    generate_nav_metadata_from_docs_with_options(
+        docs,
+        &DocsNavMetadataOptions {
             base_path,
+            path_strategy,
             group_order,
             sort,
             sort_entry_points,
             kind_sort_order,
-        ),
+            single_entry_root: MarkdownSingleEntryRoot::Preserve,
+        },
+    )
+}
+
+/// Generates sidebar navigation metadata with explicit nav options.
+pub fn generate_nav_metadata_from_docs_with_options(
+    docs: &[ApiDocModule],
+    options: &DocsNavMetadataOptions<'_>,
+) -> Vec<DocsNavItem> {
+    profile_span!("docs::generate_nav");
+    match options.path_strategy {
+        MarkdownPathStrategy::Flat => {
+            let files = docs.iter().map(|doc| doc.file.clone()).collect::<Vec<_>>();
+            generate_nav_metadata(&files, options.base_path)
+        }
+        MarkdownPathStrategy::TypeDoc => {
+            let nav = generate_typedoc_nav_metadata(
+                docs,
+                options.base_path,
+                options.group_order,
+                options.sort,
+                options.sort_entry_points,
+                options.kind_sort_order,
+            );
+            if options.single_entry_root == MarkdownSingleEntryRoot::Flatten {
+                flatten_single_entry_typedoc_nav(nav)
+            } else {
+                nav
+            }
+        }
+    }
+}
+
+fn flatten_single_entry_typedoc_nav(mut nav: Vec<DocsNavItem>) -> Vec<DocsNavItem> {
+    if nav.len() != 1 {
+        return nav;
+    }
+
+    let children = nav[0].children.take();
+    if let Some(children) = children.filter(|children| !children.is_empty()) {
+        children
+    } else {
+        nav
     }
 }
 
@@ -704,6 +762,40 @@ mod tests {
             children[1].children.as_ref().unwrap()[0].path,
             "/api/default/interfaces/Command"
         );
+    }
+
+    #[test]
+    fn typedoc_nav_single_entry_root_flatten_promotes_kind_groups() {
+        let docs = vec![ApiDocModule {
+            description: String::new(),
+            file: "default".to_string(),
+            source_path: String::new(),
+            examples: vec![],
+            tags: vec![],
+            entries: vec![nav_entry("cli", "function"), nav_entry("Command", "interface")],
+        }];
+
+        let nav = generate_nav_metadata_from_docs_with_options(
+            &docs,
+            &DocsNavMetadataOptions {
+                base_path: Some("/api"),
+                path_strategy: MarkdownPathStrategy::TypeDoc,
+                group_order: None,
+                sort: None,
+                sort_entry_points: true,
+                kind_sort_order: None,
+                single_entry_root: MarkdownSingleEntryRoot::Flatten,
+            },
+        );
+
+        assert_eq!(
+            nav.iter().map(|item| item.title.as_str()).collect::<Vec<_>>(),
+            vec!["Functions", "Interfaces"]
+        );
+        assert_eq!(nav[0].path, "/api/default/functions");
+        assert_eq!(nav[0].children.as_ref().unwrap()[0].path, "/api/default/functions/cli");
+        assert_eq!(nav[1].path, "/api/default/interfaces");
+        assert_eq!(nav[1].children.as_ref().unwrap()[0].path, "/api/default/interfaces/Command");
     }
 
     #[test]

--- a/crates/ox_content_docs/src/output.rs
+++ b/crates/ox_content_docs/src/output.rs
@@ -7,9 +7,11 @@ use std::path::Path;
 use thiserror::Error;
 
 use crate::data::generate_docs_data_json;
-use crate::markdown::MarkdownPathStrategy;
+use crate::markdown::{MarkdownPathStrategy, MarkdownSingleEntryRoot};
 use crate::model::ApiDocModule;
-use crate::nav::{generate_nav_code, generate_nav_metadata_from_docs};
+use crate::nav::{
+    generate_nav_code, generate_nav_metadata_from_docs_with_options, DocsNavMetadataOptions,
+};
 #[allow(unused_imports)]
 use crate::profile_span;
 
@@ -40,6 +42,8 @@ pub struct DocsOutputOptions {
     pub sort_entry_points: bool,
     /// TypeDoc-style kind ranking for nav groups.
     pub kind_sort_order: Option<Vec<String>>,
+    /// Single-entry root handling for generated nav metadata.
+    pub single_entry_root: MarkdownSingleEntryRoot,
 }
 
 /// Error returned while writing generated docs.
@@ -90,14 +94,17 @@ pub fn write_docs_output(
     if let Some(extracted_docs) = extracted_docs {
         if options.generate_nav && options.group_by == "file" {
             let base_path = options.base_path.as_deref().unwrap_or(DOCS_NAV_BASE_PATH);
-            let nav_items = generate_nav_metadata_from_docs(
+            let nav_items = generate_nav_metadata_from_docs_with_options(
                 extracted_docs,
-                Some(base_path),
-                options.path_strategy,
-                options.group_order.as_deref(),
-                options.sort.as_deref(),
-                options.sort_entry_points,
-                options.kind_sort_order.as_deref(),
+                &DocsNavMetadataOptions {
+                    base_path: Some(base_path),
+                    path_strategy: options.path_strategy,
+                    group_order: options.group_order.as_deref(),
+                    sort: options.sort.as_deref(),
+                    sort_entry_points: options.sort_entry_points,
+                    kind_sort_order: options.kind_sort_order.as_deref(),
+                    single_entry_root: options.single_entry_root,
+                },
             );
             fs::write(
                 out_dir.join(DOCS_NAV_FILE),
@@ -198,6 +205,7 @@ mod tests {
             sort: None,
             sort_entry_points: true,
             kind_sort_order: None,
+            single_entry_root: MarkdownSingleEntryRoot::Preserve,
         }
     }
 
@@ -335,6 +343,7 @@ mod tests {
             sort: None,
             sort_entry_points: true,
             kind_sort_order: None,
+            single_entry_root: MarkdownSingleEntryRoot::Preserve,
         };
         write_docs_output(&docs, &out_dir, Some(&extracted), &output_options).unwrap();
 

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -107,7 +107,6 @@ export declare function extractFileDocEntries(filePath: string, includePrivate?:
 export declare function extractFileDocs(filePath: string, includePrivate?: boolean | undefined | null, includeInternal?: boolean | undefined | null): Array<JsSourceDocItem>
 
 /**
- * Navigation item for SSG.
  * Extracts searchable content from Markdown source.
  *
  * Parses the Markdown and extracts title, body text, headings, and code.
@@ -224,6 +223,7 @@ export interface I18NKeyUsage {
   endColumn: number
 }
 
+/** Result of loading dictionaries. */
 export interface I18NLoadResult {
   /** Number of locales loaded. */
   localeCount: number
@@ -474,6 +474,8 @@ export interface JsDocsMarkdownOptions {
    * sort strategy.
    */
   kindSortOrder?: Array<string>
+  /** Single-entry root handling for TypeDoc-style Markdown output. */
+  singleEntryRoot?: 'preserve' | 'flatten'
 }
 
 /** Ordered JSDoc tag used by generated API Markdown. */
@@ -513,6 +515,8 @@ export interface JsDocsNavOptions {
    * `groupOrder`) and the `kind` sort strategy.
    */
   kindSortOrder?: Array<string>
+  /** Single-entry root handling for TypeDoc-style nav. */
+  singleEntryRoot?: 'preserve' | 'flatten'
 }
 
 /** Options for writing generated API documentation files. */
@@ -530,6 +534,8 @@ export interface JsDocsOutputOptions {
   sortEntryPoints?: boolean
   /** TypeDoc-style kind ranking for generated nav groups. */
   kindSortOrder?: Array<string>
+  /** Single-entry root handling for generated nav metadata. */
+  singleEntryRoot?: 'preserve' | 'flatten'
 }
 
 /** Docs-as-tests extraction options. */
@@ -827,6 +833,7 @@ export interface JsMediaEmbedsOptions {
   webContainer?: boolean
 }
 
+/** OG image configuration for JavaScript. */
 export interface JsOgImageConfig {
   /** Image width in pixels. */
   width?: number
@@ -926,6 +933,7 @@ export interface JsScopedSearchQuery {
   scopes: Array<string>
 }
 
+/** Search document for JavaScript. */
 export interface JsSearchDocument {
   /** Unique document identifier. */
   id: string
@@ -1036,12 +1044,13 @@ export interface JsSourceDocParam {
   description?: string
 }
 
+/** Raw JSDoc tag extracted from source code. */
 export interface JsSourceDocTag {
   tag: string
   value: string
 }
 
-/** Raw JSDoc tag extracted from source code. */
+/** Source preparation options for JavaScript. */
 export interface JsSourceOptions {
   /** Parse YAML frontmatter before returning the content payload. */
   frontmatter?: boolean
@@ -1115,6 +1124,7 @@ export interface JsSsgNavigationItem {
   href?: string
 }
 
+/** Navigation item for SSG. */
 export interface JsSsgNavItem {
   /** Display title. */
   title: string
@@ -1436,6 +1446,7 @@ export declare function matchesSearchScopes(id: string, url: string, scopes: Arr
 /** Restores code block metadata after JavaScript-side syntax highlighting. */
 export declare function mergeHighlightedCodeBlocks(originalHtml: string, highlightedHtml: string): string
 
+/** Mermaid transform result. */
 export interface MermaidTransformResult {
   /** The transformed HTML with mermaid code blocks replaced by rendered SVGs. */
   html: string
@@ -1472,6 +1483,7 @@ export declare function parseAndRenderAsync(source: string, options?: JsParserOp
 /** Parses Markdown source into a raw mdast memory block for JavaScript-side deserialization. */
 export declare function parseMdastRaw(source: string, options?: JsParserOptions | undefined | null): Uint8Array
 
+/** Parse result containing the AST as JSON. */
 export interface ParseResult {
   /** The AST as a JSON string. */
   ast: string

--- a/crates/ox_content_napi/src/docs_bindings.rs
+++ b/crates/ox_content_napi/src/docs_bindings.rs
@@ -6,14 +6,15 @@ use napi_derive::napi;
 use ox_content_docs::{
     build_export_graph, extract_docs_from_directories, extract_docs_from_entry_points,
     generate_docs_data_json, generate_markdown, generate_nav_code, generate_nav_metadata,
-    generate_nav_metadata_from_docs, normalize_doc_items, write_docs_output, ApiDocEntry,
-    ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc, ApiReturnDoc, ApiTypeParamDoc,
+    generate_nav_metadata_from_docs_with_options, normalize_doc_items, write_docs_output,
+    ApiDocEntry, ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc, ApiReturnDoc, ApiTypeParamDoc,
     DocExtractor, DocItem, DocItemKind, DocTag, DocsDiagnostic, DocsDiagnosticCode, DocsNavItem,
-    DocsOutputOptions, EntryPointDocsOptions, EntryPointSpec, ExportGraph, ExportKind,
-    ExportSource, ExternalDocsOptions, ExternalPackageSource, ExtractedDocModule, GraphOptions,
-    MarkdownDisplayFormat, MarkdownDocsOptions, MarkdownLinkStyle, MarkdownPathStrategy,
-    MarkdownRenderStyle, NormalizedDocEntry, NormalizedMember, NormalizedParamDoc,
-    NormalizedReturnDoc, NormalizedTypeParam, ParamDoc, PublicExport,
+    DocsNavMetadataOptions, DocsOutputOptions, EntryPointDocsOptions, EntryPointSpec, ExportGraph,
+    ExportKind, ExportSource, ExternalDocsOptions, ExternalPackageSource, ExtractedDocModule,
+    GraphOptions, MarkdownDisplayFormat, MarkdownDocsOptions, MarkdownLinkStyle,
+    MarkdownPathStrategy, MarkdownRenderStyle, MarkdownSingleEntryRoot, NormalizedDocEntry,
+    NormalizedMember, NormalizedParamDoc, NormalizedReturnDoc, NormalizedTypeParam, ParamDoc,
+    PublicExport,
 };
 
 use crate::{
@@ -461,6 +462,7 @@ fn convert_docs_output_options(options: Option<JsDocsOutputOptions>) -> DocsOutp
         sort: options.sort,
         sort_entry_points: options.sort_entry_points.unwrap_or(true),
         kind_sort_order: options.kind_sort_order,
+        single_entry_root: parse_single_entry_root(options.single_entry_root.as_deref()),
     }
 }
 
@@ -525,14 +527,17 @@ pub fn generate_docs_nav_metadata_from_docs_napi(
     let options = options.unwrap_or_default();
     let strategy = parse_markdown_path_strategy(options.path_strategy.as_deref());
     let modules = docs.into_iter().map(convert_markdown_module).collect::<Vec<_>>();
-    generate_nav_metadata_from_docs(
+    generate_nav_metadata_from_docs_with_options(
         &modules,
-        options.base_path.as_deref(),
-        strategy,
-        options.group_order.as_deref(),
-        options.sort.as_deref(),
-        options.sort_entry_points.unwrap_or(true),
-        options.kind_sort_order.as_deref(),
+        &DocsNavMetadataOptions {
+            base_path: options.base_path.as_deref(),
+            path_strategy: strategy,
+            group_order: options.group_order.as_deref(),
+            sort: options.sort.as_deref(),
+            sort_entry_points: options.sort_entry_points.unwrap_or(true),
+            kind_sort_order: options.kind_sort_order.as_deref(),
+            single_entry_root: parse_single_entry_root(options.single_entry_root.as_deref()),
+        },
     )
     .into_iter()
     .map(map_docs_nav_item)
@@ -661,6 +666,7 @@ pub fn generate_docs_markdown(
             sort: options.sort,
             sort_entry_points: options.sort_entry_points.unwrap_or(true),
             kind_sort_order: options.kind_sort_order,
+            single_entry_root: parse_single_entry_root(options.single_entry_root.as_deref()),
         });
     generate_markdown(&docs.into_iter().map(convert_markdown_module).collect::<Vec<_>>(), &options)
         .into_iter()
@@ -678,6 +684,13 @@ fn parse_markdown_path_strategy(path_strategy: Option<&str>) -> MarkdownPathStra
     match path_strategy {
         Some("typedoc") => MarkdownPathStrategy::TypeDoc,
         _ => MarkdownPathStrategy::Flat,
+    }
+}
+
+fn parse_single_entry_root(value: Option<&str>) -> MarkdownSingleEntryRoot {
+    match value {
+        Some("flatten") => MarkdownSingleEntryRoot::Flatten,
+        _ => MarkdownSingleEntryRoot::Preserve,
     }
 }
 

--- a/crates/ox_content_napi/src/docs_markdown_types.rs
+++ b/crates/ox_content_napi/src/docs_markdown_types.rs
@@ -109,6 +109,9 @@ pub struct JsDocsNavOptions {
     /// TypeDoc-style `kindSortOrder`: kind ranking used for nav group order (before
     /// `groupOrder`) and the `kind` sort strategy.
     pub kind_sort_order: Option<Vec<String>>,
+    /// Single-entry root handling for TypeDoc-style nav.
+    #[napi(ts_type = "'preserve' | 'flatten'")]
+    pub single_entry_root: Option<String>,
 }
 
 /// Ordered JSDoc tag used by generated API Markdown.
@@ -222,6 +225,9 @@ pub struct JsDocsMarkdownOptions {
     /// for module index sections / nav groups (before `groupOrder`) and the `kind`
     /// sort strategy.
     pub kind_sort_order: Option<Vec<String>>,
+    /// Single-entry root handling for TypeDoc-style Markdown output.
+    #[napi(ts_type = "'preserve' | 'flatten'")]
+    pub single_entry_root: Option<String>,
 }
 
 /// Options for writing generated API documentation files.
@@ -242,4 +248,7 @@ pub struct JsDocsOutputOptions {
     pub sort_entry_points: Option<bool>,
     /// TypeDoc-style kind ranking for generated nav groups.
     pub kind_sort_order: Option<Vec<String>>,
+    /// Single-entry root handling for generated nav metadata.
+    #[napi(ts_type = "'preserve' | 'flatten'")]
+    pub single_entry_root: Option<String>,
 }

--- a/crates/ox_content_napi/src/tests/docs_nav_output.rs
+++ b/crates/ox_content_napi/src/tests/docs_nav_output.rs
@@ -59,6 +59,7 @@ fn generate_docs_nav_metadata_from_docs_returns_typedoc_tree() {
             sort: None,
             sort_entry_points: None,
             kind_sort_order: None,
+            single_entry_root: None,
         }),
     );
 
@@ -69,6 +70,78 @@ fn generate_docs_nav_metadata_from_docs_returns_typedoc_tree() {
     assert_eq!(children[0].children.as_ref().unwrap()[0].path, "/api/default/functions/cli");
     assert_eq!(children[1].title, "Enumerations");
     assert_eq!(children[1].children.as_ref().unwrap()[0].path, "/api/default/enumerations/Mode");
+}
+
+#[test]
+fn generate_docs_nav_metadata_from_docs_flattens_single_typedoc_entry() {
+    let docs = vec![JsDocsMarkdownModule {
+        description: None,
+        file: "default".to_string(),
+        source_path: None,
+        examples: None,
+        tags: None,
+        entries: vec![
+            JsDocsMarkdownEntry {
+                name: "cli".to_string(),
+                kind: "function".to_string(),
+                description: String::new(),
+                params: None,
+                returns: None,
+                examples: None,
+                tags: None,
+                private: false,
+                file: "/repo/src/cli.ts".to_string(),
+                line: 1,
+                end_line: 1,
+                signature: None,
+                extends: None,
+                implements: None,
+                has_body: None,
+                members: None,
+                type_parameters: None,
+            },
+            JsDocsMarkdownEntry {
+                name: "Command".to_string(),
+                kind: "interface".to_string(),
+                description: String::new(),
+                params: None,
+                returns: None,
+                examples: None,
+                tags: None,
+                private: false,
+                file: "/repo/src/types.ts".to_string(),
+                line: 1,
+                end_line: 1,
+                signature: None,
+                extends: None,
+                implements: None,
+                has_body: None,
+                members: None,
+                type_parameters: None,
+            },
+        ],
+    }];
+
+    let nav = generate_docs_nav_metadata_from_docs_napi(
+        docs,
+        Some(JsDocsNavOptions {
+            base_path: Some("/api".to_string()),
+            path_strategy: Some("typedoc".to_string()),
+            group_order: None,
+            sort: None,
+            sort_entry_points: None,
+            kind_sort_order: None,
+            single_entry_root: Some("flatten".to_string()),
+        }),
+    );
+
+    assert_eq!(
+        nav.iter().map(|item| item.title.as_str()).collect::<Vec<_>>(),
+        vec!["Functions", "Interfaces"]
+    );
+    assert_eq!(nav[0].path, "/api/default/functions");
+    assert_eq!(nav[0].children.as_ref().unwrap()[0].path, "/api/default/functions/cli");
+    assert_eq!(nav[1].children.as_ref().unwrap()[0].path, "/api/default/interfaces/Command");
 }
 
 #[test]
@@ -173,6 +246,7 @@ fn write_generated_docs_writes_typedoc_nested_files() {
             sort: None,
             sort_entry_points: None,
             kind_sort_order: None,
+            single_entry_root: None,
         }),
     )
     .unwrap();
@@ -188,6 +262,87 @@ fn write_generated_docs_writes_typedoc_nested_files() {
     assert!(
         nav.find(r#""title": "Variables""#).unwrap() < nav.find(r#""title": "Functions""#).unwrap()
     );
+
+    fs::remove_dir_all(&out_dir).unwrap();
+}
+
+#[test]
+fn write_generated_docs_writes_flattened_single_entry_nav() {
+    use crate::{write_generated_docs, JsDocsOutputOptions};
+
+    let unique =
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos();
+    let out_dir = std::env::temp_dir()
+        .join(format!("ox-content-napi-flatten-write-{}-{unique}", std::process::id()));
+
+    let extracted = vec![JsDocsMarkdownModule {
+        description: Some("Runtime API.".to_string()),
+        file: "default".to_string(),
+        source_path: None,
+        examples: None,
+        tags: None,
+        entries: vec![JsDocsMarkdownEntry {
+            name: "cli".to_string(),
+            kind: "function".to_string(),
+            description: "Runs the CLI.".to_string(),
+            params: None,
+            returns: None,
+            examples: None,
+            tags: None,
+            private: false,
+            file: "/repo/src/cli.ts".to_string(),
+            line: 1,
+            end_line: 1,
+            signature: Some("export function cli(): void".to_string()),
+            extends: None,
+            implements: None,
+            has_body: None,
+            members: None,
+            type_parameters: None,
+        }],
+    }];
+
+    let markdown = generate_docs_markdown(
+        extracted.clone(),
+        Some(JsDocsMarkdownOptions {
+            group_by: Some("file".to_string()),
+            github_url: None,
+            link_style: Some("clean".to_string()),
+            base_path: Some("/api".to_string()),
+            path_strategy: Some("typedoc".to_string()),
+            render_style: Some("markdown".to_string()),
+            single_entry_root: Some("flatten".to_string()),
+            ..Default::default()
+        }),
+    );
+
+    write_generated_docs(
+        markdown,
+        out_dir.to_string_lossy().to_string(),
+        Some(extracted),
+        Some(JsDocsOutputOptions {
+            generate_nav: Some(true),
+            group_by: Some("file".to_string()),
+            generated_at: Some("2026-01-01T00:00:00.000Z".to_string()),
+            base_path: Some("/api".to_string()),
+            path_strategy: Some("typedoc".to_string()),
+            group_order: None,
+            sort: None,
+            sort_entry_points: None,
+            kind_sort_order: None,
+            single_entry_root: Some("flatten".to_string()),
+        }),
+    )
+    .unwrap();
+
+    assert!(out_dir.join("index.md").exists());
+    assert!(!out_dir.join("default/index.md").exists());
+    assert!(out_dir.join("default/functions/cli.md").exists());
+
+    let nav = fs::read_to_string(out_dir.join("nav.ts")).unwrap();
+    assert!(!nav.contains(r#""title": "default""#));
+    assert!(nav.contains(r#""title": "Functions""#));
+    assert!(nav.contains("\"/api/default/functions/cli\""));
 
     fs::remove_dir_all(&out_dir).unwrap();
 }

--- a/npm/vite-plugin-ox-content/src/docs.test.ts
+++ b/npm/vite-plugin-ox-content/src/docs.test.ts
@@ -200,6 +200,64 @@ describe("writeDocs", () => {
     expect(nav).toContain('"path": "/api/default/variables/version"');
     expect(nav.indexOf('"title": "Variables"')).toBeLessThan(nav.indexOf('"title": "Functions"'));
   });
+
+  it("flattens single typedoc entry root when singleEntryRoot is flatten", async () => {
+    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-docs-"));
+    tempDirs.push(outDir);
+
+    const extractedDocs: ExtractedDocs[] = [
+      {
+        file: "default",
+        description: "Runtime API.",
+        entries: [
+          {
+            name: "cli",
+            kind: "function",
+            description: "Runs the CLI.",
+            file: "/repo/src/cli.ts",
+            line: 1,
+            endLine: 1,
+            signature: "export function cli(): void",
+          },
+          {
+            name: "Command",
+            kind: "interface",
+            description: "Runtime command.",
+            file: "/repo/src/types.ts",
+            line: 1,
+            endLine: 1,
+            signature: "export interface Command",
+          },
+        ],
+      },
+    ];
+
+    const options = resolveDocsOptions({
+      generateNav: true,
+      basePath: "/api",
+      pathStrategy: "typedoc",
+      linkStyle: "clean",
+      renderStyle: "markdown",
+      singleEntryRoot: "flatten",
+    });
+    const markdown = generateMarkdown(extractedDocs, options);
+
+    expect(markdown["index.md"]).toContain("# API Documentation");
+    expect(markdown["index.md"]).toContain("Runtime API.");
+    expect(markdown["index.md"]).toContain("[cli](/api/default/functions/cli)");
+    expect(markdown["default/index.md"]).toBeUndefined();
+
+    await writeDocs(markdown, outDir, extractedDocs, options);
+
+    await expect(fs.access(path.join(outDir, "index.md"))).resolves.not.toThrow();
+    await expect(fs.access(path.join(outDir, "default/index.md"))).rejects.toThrow();
+    await expect(fs.access(path.join(outDir, "default/functions/cli.md"))).resolves.not.toThrow();
+
+    const nav = await fs.readFile(path.join(outDir, "nav.ts"), "utf-8");
+    expect(nav).not.toContain('"title": "default"');
+    expect(nav).toContain('"title": "Functions"');
+    expect(nav).toContain('"path": "/api/default/functions/cli"');
+  });
 });
 
 describe("generateMarkdown", () => {

--- a/npm/vite-plugin-ox-content/src/docs.ts
+++ b/npm/vite-plugin-ox-content/src/docs.ts
@@ -250,6 +250,7 @@ export function generateMarkdown(
     sort: options.sort,
     sortEntryPoints: options.sortEntryPoints,
     kindSortOrder: options.kindSortOrder,
+    singleEntryRoot: options.singleEntryRoot,
   });
 }
 
@@ -284,6 +285,7 @@ export async function writeDocs(
       sort: options?.sort,
       sortEntryPoints: options?.sortEntryPoints,
       kindSortOrder: options?.kindSortOrder,
+      singleEntryRoot: options?.singleEntryRoot,
     },
   );
 }
@@ -373,6 +375,7 @@ export function resolveDocsOptions(
     sort: opts.sort,
     sortEntryPoints: opts.sortEntryPoints ?? true,
     kindSortOrder: opts.kindSortOrder,
+    singleEntryRoot: opts.singleEntryRoot ?? "preserve",
     generateNav: opts.generateNav ?? true,
   };
 }

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -1132,6 +1132,16 @@ export interface DocsOptions {
   kindSortOrder?: string[];
 
   /**
+   * Single-entry root handling for TypeDoc-style generated docs.
+   *
+   * When set to `'flatten'`, a single TypeDoc entry point uses the root
+   * `index.md` as its landing page and omits the extra module level from
+   * generated nav metadata. Symbol page paths stay under the entry point.
+   * @default 'preserve'
+   */
+  singleEntryRoot?: "preserve" | "flatten";
+
+  /**
    * Generate navigation metadata file.
    * @default true
    */
@@ -1173,6 +1183,7 @@ export interface ResolvedDocsOptions {
   sort?: DocsSortStrategy[];
   sortEntryPoints: boolean;
   kindSortOrder?: string[];
+  singleEntryRoot: "preserve" | "flatten";
   generateNav: boolean;
 }
 


### PR DESCRIPTION
## Summary
Add `singleEntryRoot: "flatten"` support for TypeDoc-style docs so a single entry point uses the root `index.md` as its module landing page while symbol paths remain stable. The option is wired through Rust, NAPI, and the Vite plugin, with tests for markdown output, nav metadata, and plugin behavior.