### PR TITLE
fix(release): detect helper-based cargo publish targets

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -113,12 +113,25 @@ function updateRustDocsVersion(version: string): void {
   }
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function hasCargoPublishTarget(workflow: string, pkg: string): boolean {
+  const escapedPkg = escapeRegExp(pkg);
+  const packageRef = `(?:"${escapedPkg}"|'${escapedPkg}'|${escapedPkg})`;
+  const directCargoPublish = new RegExp(
+    `\\bcargo\\s+publish\\b[^\\n]*(?:-p|--package)\\s+${packageRef}(?=\\s|$)`,
+  );
+  const publishHelperCall = new RegExp(`\\bpublish_crate\\s+${packageRef}(?=\\s|$)`);
+
+  return directCargoPublish.test(workflow) || publishHelperCall.test(workflow);
+}
+
 function verifyCargoPublishPackages(): void {
   const fullPath = path.join(ROOT, PUBLISH_WORKFLOW);
   const workflow = fs.readFileSync(fullPath, "utf-8");
-  const missing = CARGO_PUBLISH_PACKAGES.filter(
-    (pkg) => !workflow.includes(`cargo publish -p ${pkg}`),
-  );
+  const missing = CARGO_PUBLISH_PACKAGES.filter((pkg) => !hasCargoPublishTarget(workflow, pkg));
 
   if (missing.length) {
     throw new Error(


### PR DESCRIPTION
## Summary
Fix release validation so it detects crates.io publish targets declared through the `publish_crate` helper in `publish.yml`, not only direct `cargo publish -p` commands.

## Background
The publish workflow already lists all crate targets, but the release script checked only literal `cargo publish -p <crate>` strings. This caused `vpr release minor` to fail with false missing-target errors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783575727&installation_id=136613492&pr_number=362&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F362&signature=3c040abd70b9d826ad0b0cb6da93734752148e59deb3039402862b0a4e5ea9d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->