### PR TITLE
fix(napi): lower linux x64 binding glibc baseline

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,7 +47,7 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             platform: darwin-arm64
-          - os: blacksmith-32vcpu-ubuntu-2404
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             platform: linux-x64-gnu
           - os: blacksmith-32vcpu-ubuntu-2404

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
             target: x86_64-apple-darwin
           - os: macos-latest
             target: aarch64-apple-darwin
-          - os: blacksmith-32vcpu-ubuntu-2404
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
           - os: blacksmith-32vcpu-ubuntu-2404
             target: aarch64-unknown-linux-gnu

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -1,7 +1,28 @@
 const { existsSync } = require("fs");
 const path = require("path");
 
+function getErrorCode(error) {
+  if (error && typeof error === "object" && "code" in error) {
+    return error.code;
+  }
+}
+
+function getErrorMessage(error) {
+  if (error && typeof error === "object" && "message" in error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function formatLoadError(target, error) {
+  const code = getErrorCode(error);
+  const suffix = code ? ` [${code}]` : "";
+  return `  - ${target}${suffix}: ${getErrorMessage(error)}`;
+}
+
 function loadBinding() {
+  const loadErrors = [];
+
   // 1. Try loading the local binary (napi build output)
   const napiOutput = path.join(__dirname, "ox-content.node");
   if (existsSync(napiOutput)) {
@@ -56,12 +77,19 @@ function loadBinding() {
   if (subPackage) {
     try {
       return require(subPackage);
-    } catch {}
+    } catch (error) {
+      loadErrors.push(formatLoadError(subPackage, error));
+    }
   }
+
+  const details = loadErrors.length
+    ? `\n\nNative load attempts failed:\n${loadErrors.join("\n")}`
+    : "";
 
   throw new Error(
     `@ox-content/napi: No compatible binary found for ${platform}-${arch}. ` +
-      `If you're working from the repository, run 'nix develop -c vp run build:napi' from the repository root.`,
+      `If you're working from the repository, run 'nix develop -c vp run build:napi' from the repository root.` +
+      details,
   );
 }
 

--- a/crates/ox_content_napi/src/tests/runtime_features.rs
+++ b/crates/ox_content_napi/src/tests/runtime_features.rs
@@ -98,6 +98,16 @@ fn javascript_wrapper_and_declarations_cover_expected_exports() {
 }
 
 #[test]
+fn javascript_wrapper_reports_native_load_errors() {
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let index_js = fs::read_to_string(manifest_dir.join("index.js")).unwrap();
+
+    assert!(!index_js.contains("catch {}"));
+    assert!(index_js.contains("Native load attempts failed:"));
+    assert!(index_js.contains("formatLoadError(subPackage, error)"));
+}
+
+#[test]
 fn transform_passes_toc_depth_to_inline_toc() {
     let result = crate::transform(
         "[[toc]]\n\n## Intro\n### API".to_string(),


### PR DESCRIPTION
## Summary
Fixes #368 by building the Linux x64 GNU NAPI binary on Ubuntu 22.04 for release and nightly artifacts, avoiding a glibc 2.39 dependency from Ubuntu 24.04 runners. The loader now preserves failed platform-package require errors and appends them to the final @ox-content/napi message, so incompatible native addons report the underlying GLIBC or shared-library failure instead of looking missing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783607050&installation_id=136613492&pr_number=369&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F369&signature=3083a77b370f181c3c09129f8d7ea6262c74bf69d86bd42443a39d906b1ea1dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->