### PR TITLE
feat(default-theme): persist sticky sidebar state

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -1109,6 +1109,7 @@ export interface JsSsgNavGroup {
   /** Navigation items. */
   items: Array<JsSsgNavItem>
   collapsed?: boolean
+  stickyCollapsed?: boolean
 }
 
 /** Manual SSG navigation group supplied by user configuration. */
@@ -1134,6 +1135,7 @@ export interface JsSsgNavItem {
   href: string
   children?: Array<JsSsgNavItem>
   collapsed?: boolean
+  stickyCollapsed?: boolean
 }
 
 /** Page data for SSG. */
@@ -1188,6 +1190,8 @@ export interface JsSsgSidebarItem {
   items?: Array<JsSsgSidebarItem>
   /** Whether this group is collapsed by default. */
   collapsed?: boolean
+  /** Whether this group's open state persists across page navigations. */
+  stickyCollapsed?: boolean
 }
 
 /** Result of [`transform_tabs_embeds`]. */

--- a/crates/ox_content_napi/src/ssg_bindings.rs
+++ b/crates/ox_content_napi/src/ssg_bindings.rs
@@ -156,6 +156,7 @@ fn convert_nav_item(item: JsSsgNavItem) -> ox_content_ssg::NavItem {
         href: item.href,
         children: item.children.unwrap_or_default().into_iter().map(convert_nav_item).collect(),
         collapsed: item.collapsed,
+        sticky_collapsed: item.sticky_collapsed,
     }
 }
 
@@ -170,6 +171,7 @@ fn map_nav_item(item: ox_content_ssg::NavItem) -> JsSsgNavItem {
             Some(item.children.into_iter().map(map_nav_item).collect())
         },
         collapsed: item.collapsed,
+        sticky_collapsed: item.sticky_collapsed,
     }
 }
 
@@ -178,6 +180,7 @@ fn map_nav_group(group: ox_content_ssg::NavGroup) -> JsSsgNavGroup {
         title: group.title,
         items: group.items.into_iter().map(map_nav_item).collect(),
         collapsed: group.collapsed,
+        sticky_collapsed: group.sticky_collapsed,
     }
 }
 
@@ -187,6 +190,7 @@ fn convert_sidebar_item(item: JsSsgSidebarItem) -> ox_content_ssg::SidebarItem {
         link: item.link,
         items: item.items.unwrap_or_default().into_iter().map(convert_sidebar_item).collect(),
         collapsed: item.collapsed,
+        sticky_collapsed: item.sticky_collapsed,
     }
 }
 
@@ -388,6 +392,7 @@ pub fn generate_ssg_html(
             title: g.title,
             items: g.items.into_iter().map(convert_nav_item).collect(),
             collapsed: g.collapsed,
+            sticky_collapsed: g.sticky_collapsed,
         })
         .collect();
 

--- a/crates/ox_content_napi/src/ssg_page_types.rs
+++ b/crates/ox_content_napi/src/ssg_page_types.rs
@@ -14,6 +14,7 @@ pub struct JsSsgNavItem {
     pub href: String,
     pub children: Option<Vec<JsSsgNavItem>>,
     pub collapsed: Option<bool>,
+    pub sticky_collapsed: Option<bool>,
 }
 
 /// Navigation group for SSG.
@@ -25,6 +26,7 @@ pub struct JsSsgNavGroup {
     /// Navigation items.
     pub items: Vec<JsSsgNavItem>,
     pub collapsed: Option<bool>,
+    pub sticky_collapsed: Option<bool>,
 }
 
 /// Resolved SSG output and public route paths.
@@ -54,6 +56,8 @@ pub struct JsSsgSidebarItem {
     pub items: Option<Vec<JsSsgSidebarItem>>,
     /// Whether this group is collapsed by default.
     pub collapsed: Option<bool>,
+    /// Whether this group's open state persists across page navigations.
+    pub sticky_collapsed: Option<bool>,
 }
 
 /// Manual SSG navigation item supplied by user configuration.

--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -267,6 +267,8 @@ pub struct NavItem {
     pub children: Vec<NavItem>,
     #[serde(default)]
     pub collapsed: Option<bool>,
+    #[serde(default)]
+    pub sticky_collapsed: Option<bool>,
 }
 
 /// Navigation group for SSG.
@@ -278,6 +280,8 @@ pub struct NavGroup {
     pub items: Vec<NavItem>,
     #[serde(default)]
     pub collapsed: Option<bool>,
+    #[serde(default)]
+    pub sticky_collapsed: Option<bool>,
 }
 
 /// Table of contents entry.
@@ -1191,14 +1195,22 @@ fn validate_social_svg(svg: &str) -> Option<&str> {
 
 fn generate_nav_html(nav_groups: &[NavGroup], current_path: &str) -> String {
     let mut html = String::new();
-    for group in nav_groups {
+    for (group_index, group) in nav_groups.iter().enumerate() {
         if group.collapsed.is_some() {
             let open = if group.collapsed == Some(true) { "" } else { " open" };
+            let state_key = format!("group:{group_index}:{}", group.title);
+            let state_attr = nav_state_attr(group.sticky_collapsed, &state_key);
             push_fmt(&mut html, format_args!(
-                "<details class=\"nav-section nav-section--collapsible\"{open}>\n  <summary class=\"nav-title nav-title--summary\">{}</summary>\n",
+                "<details class=\"nav-section nav-section--collapsible\"{open}{state_attr}>\n  <summary class=\"nav-title nav-title--summary\">{}</summary>\n",
                 escape_html(&group.title)
             ));
-            render_nav_list(&mut html, &group.items, current_path, false);
+            render_nav_list(
+                &mut html,
+                &group.items,
+                current_path,
+                false,
+                &format!("group:{group_index}"),
+            );
             html.push_str("</details>\n");
         } else {
             push_fmt(
@@ -1208,23 +1220,35 @@ fn generate_nav_html(nav_groups: &[NavGroup], current_path: &str) -> String {
                     escape_html(&group.title)
                 ),
             );
-            render_nav_list(&mut html, &group.items, current_path, false);
+            render_nav_list(
+                &mut html,
+                &group.items,
+                current_path,
+                false,
+                &format!("group:{group_index}"),
+            );
             html.push_str("</div>\n");
         }
     }
     html
 }
 
-fn render_nav_list(html: &mut String, items: &[NavItem], current_path: &str, nested: bool) {
+fn render_nav_list(
+    html: &mut String,
+    items: &[NavItem],
+    current_path: &str,
+    nested: bool,
+    key_prefix: &str,
+) {
     let class_name = if nested { "nav-list nav-list--nested" } else { "nav-list" };
     push_fmt(html, format_args!("  <ul class=\"{class_name}\">\n"));
-    for item in items {
-        render_nav_item(html, item, current_path);
+    for (index, item) in items.iter().enumerate() {
+        render_nav_item(html, item, current_path, &format!("{key_prefix}.{index}"));
     }
     html.push_str("  </ul>\n");
 }
 
-fn render_nav_item(html: &mut String, item: &NavItem, current_path: &str) {
+fn render_nav_item(html: &mut String, item: &NavItem, current_path: &str, key_path: &str) {
     let href = safe_nav_href(&item.href);
     let title = escape_html(&item.title);
     let active_class = if item.path == current_path { " active" } else { "" };
@@ -1236,11 +1260,21 @@ fn render_nav_item(html: &mut String, item: &NavItem, current_path: &str) {
     }
 
     let open = if item.collapsed == Some(true) { "" } else { " open" };
+    let state_key = format!("item:{key_path}:{}:{}", item.path, item.title);
+    let state_attr = nav_state_attr(item.sticky_collapsed, &state_key);
     push_fmt(html, format_args!(
-        "    <li class=\"nav-item nav-item--group\"><details class=\"nav-details\"{open}><summary class=\"nav-summary\"><a href=\"{href}\" class=\"nav-link nav-link--summary{active_class}\">{title}</a></summary>\n"
+        "    <li class=\"nav-item nav-item--group\"><details class=\"nav-details\"{open}{state_attr}><summary class=\"nav-summary\"><a href=\"{href}\" class=\"nav-link nav-link--summary{active_class}\">{title}</a></summary>\n"
     ));
-    render_nav_list(html, &item.children, current_path, true);
+    render_nav_list(html, &item.children, current_path, true, key_path);
     html.push_str("    </details></li>\n");
+}
+
+fn nav_state_attr(sticky_collapsed: Option<bool>, key: &str) -> String {
+    if sticky_collapsed == Some(true) {
+        format!(" data-ox-nav-state-key=\"{}\"", escape_html(key))
+    } else {
+        String::new()
+    }
 }
 
 fn safe_nav_href(href: &str) -> String {
@@ -1285,8 +1319,10 @@ mod tests {
                 href: "/docs/test/index.html".to_string(),
                 children: vec![],
                 collapsed: None,
+                sticky_collapsed: None,
             }],
             collapsed: None,
+            sticky_collapsed: None,
         }];
 
         let config = SsgConfig {
@@ -1340,23 +1376,31 @@ mod tests {
         let nav_groups = vec![NavGroup {
             title: "Guide & API".to_string(),
             collapsed: Some(true),
+            sticky_collapsed: Some(true),
             items: vec![NavItem {
                 title: "Runtime <Core>".to_string(),
                 path: "runtime".to_string(),
                 href: "javascript:alert(1)".to_string(),
                 collapsed: Some(false),
+                sticky_collapsed: Some(true),
                 children: vec![NavItem {
                     title: "Setup".to_string(),
                     path: "runtime/setup".to_string(),
                     href: "/docs/runtime/setup/index.html".to_string(),
                     children: vec![],
                     collapsed: None,
+                    sticky_collapsed: None,
                 }],
             }],
         }];
 
         let html = generate_nav_html(&nav_groups, "runtime/setup");
-        assert!(html.contains("<details class=\"nav-section nav-section--collapsible\">"));
+        assert!(html.contains(
+            "<details class=\"nav-section nav-section--collapsible\" data-ox-nav-state-key=\"group:0:Guide &amp; API\">"
+        ));
+        assert!(html.contains(
+            "<details class=\"nav-details\" open data-ox-nav-state-key=\"item:group:0.0:runtime:Runtime &lt;Core&gt;\">"
+        ));
         assert!(html.contains("Guide &amp; API"));
         assert!(html.contains("Runtime &lt;Core&gt;"));
         assert!(html.contains("href=\"#\""));

--- a/crates/ox_content_ssg/src/routes.rs
+++ b/crates/ox_content_ssg/src/routes.rs
@@ -42,6 +42,8 @@ pub struct SidebarItem {
     pub items: Vec<SidebarItem>,
     /// Whether this group is collapsed by default.
     pub collapsed: Option<bool>,
+    /// Whether this group's open state persists across page navigations.
+    pub sticky_collapsed: Option<bool>,
 }
 
 /// Manual navigation group supplied by user configuration.
@@ -249,6 +251,7 @@ pub fn build_nav_items(
             href: get_href(file, src_dir, base, extension),
             children: Vec::new(),
             collapsed: None,
+            sticky_collapsed: None,
         });
     }
 
@@ -264,6 +267,7 @@ pub fn build_nav_items(
                     },
                     items: sort_nav_items(items),
                     collapsed: None,
+                    sticky_collapsed: None,
                 });
             }
         }
@@ -275,6 +279,7 @@ pub fn build_nav_items(
                 title: format_title(&key),
                 items: sort_nav_items(items),
                 collapsed: None,
+                sticky_collapsed: None,
             });
         }
     }
@@ -299,6 +304,7 @@ pub fn build_theme_nav_items(
             href: sidebar_href(item.link.as_deref(), base, extension),
             children: item.items.iter().map(|child| to_nav_item(child, base, extension)).collect(),
             collapsed: item.collapsed,
+            sticky_collapsed: item.sticky_collapsed,
         }
     }
 
@@ -312,6 +318,7 @@ pub fn build_theme_nav_items(
                 title: item.text.clone().unwrap_or_else(|| DEFAULT_ROOT_GROUP_TITLE.to_string()),
                 items: item.items.iter().map(|child| to_nav_item(child, base, extension)).collect(),
                 collapsed: item.collapsed,
+                sticky_collapsed: item.sticky_collapsed,
             });
         } else {
             loose_items.push(to_nav_item(item, base, extension));
@@ -338,6 +345,7 @@ pub fn resolve_navigation_groups(
                 .filter_map(|item| resolve_manual_nav_item(item, base, extension))
                 .collect(),
             collapsed: None,
+            sticky_collapsed: None,
         })
         .collect()
 }
@@ -348,6 +356,7 @@ fn flush_loose_items(groups: &mut Vec<NavGroup>, loose_items: &mut Vec<NavItem>)
             title: DEFAULT_ROOT_GROUP_TITLE.to_string(),
             items: std::mem::take(loose_items),
             collapsed: None,
+            sticky_collapsed: None,
         });
     }
 }
@@ -412,6 +421,7 @@ fn resolve_manual_nav_item(
             href: raw_href.to_string(),
             children: Vec::new(),
             collapsed: None,
+            sticky_collapsed: None,
         });
     }
 
@@ -434,6 +444,7 @@ fn resolve_manual_nav_item(
         href,
         children: Vec::new(),
         collapsed: None,
+        sticky_collapsed: None,
     })
 }
 

--- a/crates/ox_content_ssg/src/ssg.js
+++ b/crates/ox_content_ssg/src/ssg.js
@@ -24,6 +24,36 @@ if (sidebar) {
   );
 }
 
+const navStateStoragePrefix = "ox-content:nav:{{base}}:";
+const getNavState = (key) => {
+  try {
+    return localStorage.getItem(navStateStoragePrefix + key);
+  } catch {
+    return null;
+  }
+};
+const setNavState = (key, open) => {
+  try {
+    localStorage.setItem(navStateStoragePrefix + key, open ? "open" : "closed");
+  } catch {
+    // Ignore storage failures so navigation remains usable.
+  }
+};
+
+document.querySelectorAll("details[data-ox-nav-state-key]").forEach((details) => {
+  const key = details.getAttribute("data-ox-nav-state-key");
+  if (!key) return;
+
+  const savedState = getNavState(key);
+  if (savedState === "open") {
+    details.open = true;
+  } else if (savedState === "closed") {
+    details.open = false;
+  }
+
+  details.addEventListener("toggle", () => setNavState(key, details.open));
+});
+
 const themeToggle = document.querySelector(".theme-toggle"),
   setTheme = (theme) => {
     document.documentElement.setAttribute("data-theme", theme);

--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -96,6 +96,7 @@ describe("SSG route helpers", () => {
         {
           text: "Guide",
           collapsed: true,
+          stickyCollapsed: true,
           items: [{ text: "Install", link: "guide/install.md#cli" }],
         },
         { text: "Unsafe", link: "javascript:alert(1)" },
@@ -108,6 +109,7 @@ describe("SSG route helpers", () => {
     expect(groups[1]).toMatchObject({
       title: "Guide",
       collapsed: true,
+      stickyCollapsed: true,
       items: [
         { title: "Install", path: "guide/install", href: "/docs/guide/install/index.html#cli" },
       ],

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -36,6 +36,7 @@ export interface SsgNavItem {
   href: string;
   children?: SsgNavItem[];
   collapsed?: boolean;
+  stickyCollapsed?: boolean;
 }
 
 /**
@@ -141,6 +142,7 @@ export function generateBareHtmlPage(content: string, title: string): string {
 interface RustNavGroup {
   title: string;
   collapsed?: boolean;
+  stickyCollapsed?: boolean;
   items: SsgNavItem[];
 }
 
@@ -158,6 +160,7 @@ function toRustNavItem(item: SsgNavItem): SsgNavItem {
     href: item.href,
     children: item.children?.map(toRustNavItem),
     collapsed: item.collapsed,
+    stickyCollapsed: item.stickyCollapsed,
   };
 }
 
@@ -169,6 +172,7 @@ function convertNavGroupsForRust(navGroups: NavGroup[]): RustNavGroup[] {
   const converted = navGroups.map((group) => ({
     title: group.title,
     collapsed: group.collapsed,
+    stickyCollapsed: group.stickyCollapsed,
     items: group.items.map(toRustNavItem),
   }));
   navGroupsForRustCache.set(navGroups, converted);
@@ -458,6 +462,7 @@ export interface NavGroup {
   title: string;
   items: SsgNavItem[];
   collapsed?: boolean;
+  stickyCollapsed?: boolean;
 }
 
 /**

--- a/npm/vite-plugin-ox-content/src/theme.test.ts
+++ b/npm/vite-plugin-ox-content/src/theme.test.ts
@@ -110,10 +110,22 @@ describe("theme", () => {
 
     it("should preserve explicit sidebar config", () => {
       const resolved = resolveTheme({
-        sidebar: [{ text: "Guide", items: [{ text: "Intro", link: "/intro" }], collapsed: true }],
+        sidebar: [
+          {
+            text: "Guide",
+            items: [{ text: "Intro", link: "/intro" }],
+            collapsed: true,
+            stickyCollapsed: true,
+          },
+        ],
       });
       expect(resolved.sidebar).toEqual([
-        { text: "Guide", items: [{ text: "Intro", link: "/intro" }], collapsed: true },
+        {
+          text: "Guide",
+          items: [{ text: "Intro", link: "/intro" }],
+          collapsed: true,
+          stickyCollapsed: true,
+        },
       ]);
     });
   });

--- a/npm/vite-plugin-ox-content/src/theme.ts
+++ b/npm/vite-plugin-ox-content/src/theme.ts
@@ -138,6 +138,7 @@ export interface SidebarItem {
   link?: string;
   items?: SidebarItem[];
   collapsed?: boolean;
+  stickyCollapsed?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add an opt-in `stickyCollapsed` sidebar item flag for the default theme.
- Preserve sticky sidebar `<details>` open/closed state in `localStorage` across page navigations.
- Thread the flag through TypeScript, NAPI, Rust SSG navigation types, and generated declarations.

## Validation

- `corepack pnpm exec vp exec --filter @ox-content/vite-plugin -- vp test src/ssg.test.ts src/theme.test.ts`
- `corepack pnpm --filter @ox-content/vite-plugin run typecheck`
- `cargo test -p ox_content_ssg`
- `cargo test -p ox_content_napi runtime_features --lib`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #370

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783666411&installation_id=136613492&pr_number=371&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F371&signature=bba76d7766e51bcf77a8beb434be742e7f7e19fd4b60b19af24f94ad0f9b489f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->