### PR TITLE
chore: improve docs comments

### DIFF
--- a/crates/ox_content_napi/src/parse_bindings.rs
+++ b/crates/ox_content_napi/src/parse_bindings.rs
@@ -13,6 +13,7 @@ use crate::{create_allocator_for_source, mdast, mdast_raw, transfer::TransferPay
 pub struct ParseResult {
     /// The AST as a JSON string.
     pub ast: String,
+
     /// Parse errors, if any.
     pub errors: Vec<String>,
 }
@@ -22,6 +23,7 @@ pub struct ParseResult {
 pub struct RenderResult {
     /// The rendered HTML.
     pub html: String,
+
     /// Render errors, if any.
     pub errors: Vec<String>,
 }
@@ -32,10 +34,13 @@ pub struct RenderResult {
 pub struct TocEntry {
     /// Heading depth (1-6).
     pub depth: u8,
+
     /// Heading text.
     pub text: String,
+
     /// URL-friendly slug.
     pub slug: String,
+
     /// Child entries.
     pub children: Vec<TocEntry>,
 }
@@ -45,10 +50,13 @@ pub struct TocEntry {
 pub struct TransformResult {
     /// The rendered HTML.
     pub html: String,
+
     /// Parsed frontmatter as JSON string.
     pub frontmatter: String,
+
     /// Table of contents entries.
     pub toc: Vec<TocEntry>,
+
     /// Parse/render errors, if any.
     pub errors: Vec<String>,
 }
@@ -58,10 +66,13 @@ pub struct TransformResult {
 pub struct JsSourceOrigin {
     /// UTF-8 byte offset.
     pub byte_offset: u32,
+
     /// UTF-16 code-unit offset.
     pub offset: u32,
+
     /// 1-based line number.
     pub line: u32,
+
     /// 1-based column number.
     pub column: u32,
 }
@@ -71,8 +82,10 @@ pub struct JsSourceOrigin {
 pub struct PreparedSourceResult {
     /// Markdown content after optional frontmatter removal.
     pub content: String,
+
     /// Parsed frontmatter object.
     pub frontmatter: HashMap<String, serde_json::Value>,
+
     /// Source position where `content` starts in the original source.
     pub source_offset: JsSourceOrigin,
 }
@@ -82,24 +95,45 @@ pub struct PreparedSourceResult {
 #[derive(Default, Clone)]
 pub struct JsSourceOptions {
     /// Parse YAML frontmatter before returning the content payload.
+    ///
+    /// Default: `false`.
     pub frontmatter: Option<bool>,
 }
 
 /// Parser options for JavaScript.
+///
+/// When `gfm` is `true`, omitted extension flags inherit the GFM profile.
 #[napi(object)]
 #[derive(Default, Clone)]
 pub struct JsParserOptions {
-    /// Enable GFM extensions.
+    /// Enable the GFM convenience profile.
+    ///
+    /// Default: `false`.
     pub gfm: Option<bool>,
-    /// Enable footnotes.
+
+    /// Enable footnote references and definitions.
+    ///
+    /// Default: `false`, or `true` when `gfm` is `true`.
     pub footnotes: Option<bool>,
-    /// Enable task lists.
+
+    /// Enable GFM task-list item markers.
+    ///
+    /// Default: `false`, or `true` when `gfm` is `true`.
     pub task_lists: Option<bool>,
-    /// Enable tables.
+
+    /// Enable GFM pipe tables.
+    ///
+    /// Default: `false`, or `true` when `gfm` is `true`.
     pub tables: Option<bool>,
-    /// Enable strikethrough.
+
+    /// Enable GFM strikethrough spans.
+    ///
+    /// Default: `false`, or `true` when `gfm` is `true`.
     pub strikethrough: Option<bool>,
-    /// Enable autolinks.
+
+    /// Enable GFM autolinks.
+    ///
+    /// Default: `false`, or `true` when `gfm` is `true`.
     pub autolinks: Option<bool>,
 }
 

--- a/crates/ox_content_napi/src/transform_bindings.rs
+++ b/crates/ox_content_napi/src/transform_bindings.rs
@@ -14,8 +14,13 @@ use crate::{
 #[derive(Default, Clone)]
 pub struct JsWikiLinkOptions {
     /// Enable `[[target]]` and `[[target|label]]` expansion.
+    ///
+    /// Default: `false`.
     pub enabled: Option<bool>,
+
     /// Base URL used for site-relative wiki links.
+    ///
+    /// Default: `"/"`.
     pub base_url: Option<String>,
 }
 
@@ -24,8 +29,13 @@ pub struct JsWikiLinkOptions {
 #[derive(Default, Clone)]
 pub struct JsEmojiShortcodeOptions {
     /// Enable `:shortcode:` expansion.
+    ///
+    /// Default: `false`.
     pub enabled: Option<bool>,
+
     /// Custom shortcode map. Values are emitted verbatim.
+    ///
+    /// Default: `{}`.
     pub custom: Option<HashMap<String, String>>,
 }
 
@@ -34,6 +44,8 @@ pub struct JsEmojiShortcodeOptions {
 #[derive(Default, Clone)]
 pub struct JsAttrsOptions {
     /// Enable markdown-it-attrs style `{#id .class key=value}`.
+    ///
+    /// Default: `false`.
     pub enabled: Option<bool>,
 }
 
@@ -42,8 +54,13 @@ pub struct JsAttrsOptions {
 #[derive(Default, Clone)]
 pub struct JsCodeImportOptions {
     /// Enable `<<< path{selector}` snippet injection.
+    ///
+    /// Default: `false`.
     pub enabled: Option<bool>,
+
     /// Root directory used for `@/` and absolute snippet imports.
+    ///
+    /// Default: project root from the JavaScript caller.
     pub root_dir: Option<String>,
 }
 
@@ -52,12 +69,23 @@ pub struct JsCodeImportOptions {
 #[derive(Default, Clone)]
 pub struct JsSanitizeOptions {
     /// Enable sanitizer. When omitted, passing this object enables it.
+    ///
+    /// Default: `false` when the whole option is omitted; `true` when this object is present.
     pub enabled: Option<bool>,
+
     /// Allowed tag names. Omit for safe defaults.
+    ///
+    /// Default: built-in safe tag allow list.
     pub allowed_tags: Option<Vec<String>>,
+
     /// Allowed attribute names. Omit for safe defaults.
+    ///
+    /// Default: built-in safe attribute allow list.
     pub allowed_attributes: Option<Vec<String>>,
+
     /// Allowed URL schemes for URL-bearing attributes. Omit for safe defaults.
+    ///
+    /// Default: built-in safe URL scheme allow list.
     pub allowed_url_schemes: Option<Vec<String>>,
 }
 
@@ -66,14 +94,26 @@ pub struct JsSanitizeOptions {
 #[derive(Default, Clone)]
 pub struct JsEditThisPageOptions {
     /// Enable edit link generation.
+    ///
+    /// Default: `false` unless `repo_url` is provided by the JavaScript resolver.
     pub enabled: Option<bool>,
+
     /// GitHub repository URL, e.g. `https://github.com/owner/repo`.
     pub repo_url: Option<String>,
+
     /// Branch used in edit URLs.
+    ///
+    /// Default: `"main"`.
     pub branch: Option<String>,
+
     /// Root directory used to relativize `sourcePath`.
+    ///
+    /// Default: no extra root prefix.
     pub root_dir: Option<String>,
+
     /// Link label.
+    ///
+    /// Default: `"Edit this page"`.
     pub label: Option<String>,
 }
 
@@ -82,12 +122,23 @@ pub struct JsEditThisPageOptions {
 #[derive(Default, Clone)]
 pub struct JsCodeBlockLintOptions {
     /// Enable code block linting.
+    ///
+    /// Default: `false` when the whole option is omitted.
     pub enabled: Option<bool>,
+
     /// Restrict linting to these language identifiers.
+    ///
+    /// Default: all fenced block languages.
     pub languages: Option<Vec<String>>,
+
     /// Report fences without a language identifier.
+    ///
+    /// Default: `false`.
     pub require_language: Option<bool>,
+
     /// Report trailing whitespace in code block lines.
+    ///
+    /// Default: `true`.
     pub trailing_spaces: Option<bool>,
 }
 
@@ -96,10 +147,18 @@ pub struct JsCodeBlockLintOptions {
 #[derive(Default, Clone)]
 pub struct JsDocsTestOptions {
     /// Enable docs test extraction.
+    ///
+    /// Default: `false` when the whole option is omitted.
     pub enabled: Option<bool>,
+
     /// Languages that can be emitted as test cases.
+    ///
+    /// Default: `["js", "jsx", "ts", "tsx", "mjs", "mts"]`.
     pub languages: Option<Vec<String>>,
+
     /// Require fence meta such as `test`, `runnable`, or `vitest`.
+    ///
+    /// Default: `true`.
     pub require_meta: Option<bool>,
 }
 
@@ -108,14 +167,28 @@ pub struct JsDocsTestOptions {
 #[derive(Default, Clone)]
 pub struct JsMediaEmbedsOptions {
     /// Render `<Spotify>` embeds.
+    ///
+    /// Default: `false`.
     pub spotify: Option<bool>,
+
     /// Render `<StackBlitz>` embeds.
+    ///
+    /// Default: `false`.
     pub stack_blitz: Option<bool>,
+
     /// Render `<Tweet>` / `<XPost>` static cards.
+    ///
+    /// Default: `false`.
     pub twitter: Option<bool>,
+
     /// Render `<Bluesky>` static cards.
+    ///
+    /// Default: `false`.
     pub bluesky: Option<bool>,
+
     /// Render `<WebContainer>` lazy placeholder blocks.
+    ///
+    /// Default: `false`.
     pub web_container: Option<bool>,
 }
 
@@ -172,63 +245,139 @@ impl From<features::CodeBlockDiagnostic> for JsCodeBlockDiagnostic {
 }
 
 /// Transform options for JavaScript.
+///
+/// Omitted parser flags inherit the GFM profile when `gfm` is `true`; otherwise
+/// they use the parser defaults.
 #[napi(object)]
 #[derive(Default, Clone)]
 pub struct JsTransformOptions {
-    /// Enable GFM extensions.
+    /// Enable the GFM convenience profile.
+    ///
+    /// Default: `false`.
     pub gfm: Option<bool>,
-    /// Enable footnotes.
+
+    /// Enable footnote references and definitions.
+    ///
+    /// Default: `false`, or `true` when `gfm` is `true`.
     pub footnotes: Option<bool>,
-    /// Enable task lists.
+
+    /// Enable GFM task-list item markers.
+    ///
+    /// Default: `false`, or `true` when `gfm` is `true`.
     pub task_lists: Option<bool>,
-    /// Enable tables.
+
+    /// Enable GFM pipe tables.
+    ///
+    /// Default: `false`, or `true` when `gfm` is `true`.
     pub tables: Option<bool>,
-    /// Enable strikethrough.
+
+    /// Enable GFM strikethrough spans.
+    ///
+    /// Default: `false`, or `true` when `gfm` is `true`.
     pub strikethrough: Option<bool>,
-    /// Enable autolinks.
+
+    /// Enable GFM autolinks.
+    ///
+    /// Default: `false`, or `true` when `gfm` is `true`.
     pub autolinks: Option<bool>,
+
     /// Parse YAML frontmatter before transforming.
+    ///
+    /// Default: `false`.
     pub frontmatter: Option<bool>,
+
     /// Maximum TOC depth (1-6).
+    ///
+    /// Default: `3`.
     pub toc_max_depth: Option<u8>,
+
     /// Convert `.md` links to `.html` links for SSG output.
+    ///
+    /// Default: `false`.
     pub convert_md_links: Option<bool>,
+
     /// Base URL for absolute link conversion (e.g., "/" or "/docs/").
+    ///
+    /// Default: `"/"`.
     pub base_url: Option<String>,
+
     /// Source file path for relative link resolution.
+    ///
+    /// Default: empty string.
     pub source_path: Option<String>,
+
     /// Enable line annotations for code blocks using fence meta.
+    ///
+    /// Default: `false`.
     pub code_annotations: Option<bool>,
+
     /// Fence meta key used to read code annotations.
+    ///
+    /// Default: `"annotate"`.
     pub code_annotation_meta_key: Option<String>,
+
     /// Code annotation syntax mode.
+    ///
+    /// Default: `"attribute"`.
     pub code_annotation_syntax: Option<String>,
+
     /// Enable line numbers for all code blocks by default.
+    ///
+    /// Default: `false`.
     pub code_annotation_default_line_numbers: Option<bool>,
+
     /// Auto-link bare URLs in text. When enabled, the renderer wraps any
     /// text occurrence starting with a registered pattern (default `http://`
     /// and `https://`) in an `<a>` tag.
+    ///
+    /// Default: `false`.
     pub autolink_urls: Option<bool>,
+
     /// URL prefix patterns for [`Self::autolink_urls`]. Overrides the
     /// default `["http://", "https://"]` when set.
+    ///
+    /// Default: `["http://", "https://"]`.
     pub autolink_patterns: Option<Vec<String>>,
+
     /// Add `target="_blank" rel="noopener noreferrer"` to auto-linked URLs.
-    /// Defaults to true; ignored when [`Self::autolink_urls`] is off.
+    ///
+    /// Default: `true`; ignored when [`Self::autolink_urls`] is off.
     pub autolink_target_blank: Option<bool>,
+
     /// Opt-in Obsidian-style wiki links.
+    ///
+    /// Default: disabled.
     pub wiki_links: Option<JsWikiLinkOptions>,
+
     /// Opt-in emoji shortcode expansion.
+    ///
+    /// Default: disabled.
     pub emoji_shortcodes: Option<JsEmojiShortcodeOptions>,
+
     /// Opt-in markdown-it-attrs style attributes.
+    ///
+    /// Default: disabled.
     pub attributes: Option<JsAttrsOptions>,
+
     /// Opt-in CJK emphasis compatibility flag. The parser is already CJK-friendly;
     /// this keeps the feature explicit in the public API.
+    ///
+    /// Default: `false`.
     pub cjk_emphasis: Option<bool>,
+
     /// Opt-in VitePress-style code import/snippet injection.
+    ///
+    /// Default: disabled.
     pub code_imports: Option<JsCodeImportOptions>,
+
     /// Opt-in HTML sanitizer.
+    ///
+    /// Default: disabled.
     pub sanitize: Option<JsSanitizeOptions>,
+
     /// Opt-in edit-this-page link generation.
+    ///
+    /// Default: disabled.
     pub edit_this_page: Option<JsEditThisPageOptions>,
 }
 
@@ -242,13 +391,24 @@ pub fn merge_highlighted_code_blocks(original_html: String, highlighted_html: St
 /// `YouTubeOptions` defaults when omitted.
 #[napi(object)]
 pub struct JsYouTubeOptions {
-    /// Use privacy-enhanced mode (youtube-nocookie.com). Default: true.
+    /// Use privacy-enhanced mode (`youtube-nocookie.com`).
+    ///
+    /// Default: `true`.
     pub privacy_enhanced: Option<bool>,
-    /// Default aspect ratio. Default: "16/9".
+
+    /// Default iframe aspect ratio.
+    ///
+    /// Default: `"16/9"`.
     pub aspect_ratio: Option<String>,
-    /// Allow fullscreen. Default: true.
+
+    /// Allow fullscreen playback.
+    ///
+    /// Default: `true`.
     pub allow_fullscreen: Option<bool>,
-    /// Lazy-load the iframe. Default: true.
+
+    /// Lazy-load the iframe.
+    ///
+    /// Default: `true`.
     pub lazy_load: Option<bool>,
 }
 
@@ -274,6 +434,7 @@ pub fn transform_youtube_embeds(html: String, options: Option<JsYouTubeOptions>)
 pub struct JsTabsTransformResult {
     /// HTML with every `<tabs>` block expanded.
     pub html: String,
+
     /// Number of tab groups expanded; the caller advances its group counter by
     /// this amount so generated CSS covers exactly the emitted groups.
     pub group_count: u32,
@@ -304,6 +465,7 @@ pub struct JsPmOptions {
 pub struct JsPmTransformResult {
     /// HTML with every `<pm>` block expanded into a package-manager tab widget.
     pub html: String,
+
     /// Number of tab groups expanded; the caller advances its shared tab-group
     /// counter by this amount.
     pub group_count: u32,

--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -26,21 +26,47 @@ mod table;
 mod tests;
 
 /// Parser options.
+///
+/// `Default::default()` keeps optional Markdown extensions disabled. Use
+/// [`ParserOptions::gfm`] to enable the GitHub Flavored Markdown profile.
 #[derive(Debug, Clone, Default)]
 pub struct ParserOptions {
-    /// Enable GFM (GitHub Flavored Markdown) extensions.
+    /// Enable the GFM convenience profile.
+    ///
+    /// When set through [`ParserOptions::gfm`], this also enables footnotes,
+    /// task lists, tables, strikethrough, and autolinks.
+    ///
+    /// Default: `false`; [`ParserOptions::gfm`] sets this to `true`.
     pub gfm: bool,
-    /// Enable footnotes.
+
+    /// Enable footnote references and definitions.
+    ///
+    /// Default: `false`; [`ParserOptions::gfm`] sets this to `true`.
     pub footnotes: bool,
-    /// Enable task lists.
+
+    /// Enable GFM task-list item markers such as `- [x]`.
+    ///
+    /// Default: `false`; [`ParserOptions::gfm`] sets this to `true`.
     pub task_lists: bool,
-    /// Enable tables.
+
+    /// Enable GFM pipe tables.
+    ///
+    /// Default: `false`; [`ParserOptions::gfm`] sets this to `true`.
     pub tables: bool,
-    /// Enable strikethrough.
+
+    /// Enable GFM strikethrough spans.
+    ///
+    /// Default: `false`; [`ParserOptions::gfm`] sets this to `true`.
     pub strikethrough: bool,
-    /// Enable autolinks.
+
+    /// Enable GFM autolinks.
+    ///
+    /// Default: `false`; [`ParserOptions::gfm`] sets this to `true`.
     pub autolinks: bool,
+
     /// Maximum nesting depth for block elements.
+    ///
+    /// Default: `0`; [`ParserOptions::gfm`] sets this to `100`.
     pub max_nesting_depth: usize,
 }
 
@@ -64,12 +90,16 @@ impl ParserOptions {
 pub struct Parser<'a> {
     /// Arena allocator.
     allocator: &'a Allocator,
+
     /// Source text.
     source: &'a str,
+
     /// Parser options.
     options: ParserOptions,
+
     /// Current position in the source.
     position: usize,
+
     /// Current nesting depth.
     nesting_depth: usize,
 }

--- a/crates/ox_content_renderer/src/html/options.rs
+++ b/crates/ox_content_renderer/src/html/options.rs
@@ -4,46 +4,96 @@
 //! to scan: this module owns only user-supplied configuration and lightweight enums.
 
 /// HTML renderer options.
+///
+/// Use [`HtmlRendererOptions::new`] or [`Default::default`] for the documented
+/// defaults.
 #[derive(Debug, Clone)]
 pub struct HtmlRendererOptions {
     /// Use XHTML-style self-closing tags (e.g., `<br />`).
+    ///
+    /// Default: `false`.
     pub xhtml: bool,
+
     /// Add soft breaks between inline elements.
+    ///
+    /// Default: `"\n"`.
     pub soft_break: String,
+
     /// Add hard breaks.
+    ///
+    /// Default: `"<br>\n"`.
     pub hard_break: String,
+
     /// Enable syntax highlighting for code blocks.
+    ///
+    /// Default: `false`.
     pub highlight: bool,
+
     /// Sanitize HTML output.
+    ///
+    /// Default: `false`.
     pub sanitize: bool,
+
     /// Convert `.md` links to `.html` links for SSG output.
+    ///
+    /// Default: `false`.
     pub convert_md_links: bool,
+
     /// Base URL for absolute link conversion (e.g., "/" or "/docs/").
+    ///
+    /// Default: `"/"`.
     pub base_url: String,
+
     /// Source file path for relative link resolution.
     /// Used to determine if the current file is an index file.
+    ///
+    /// Default: empty string.
     pub source_path: String,
+
     /// Enable line annotations for code blocks using fence meta.
+    ///
+    /// Default: `false`.
     pub code_annotations: bool,
+
     /// Fence meta key used to read code annotations.
+    ///
+    /// Default: `"annotate"`.
     pub code_annotation_meta_key: String,
+
     /// Code annotation syntax mode.
+    ///
+    /// Default: [`CodeAnnotationSyntax::Attribute`].
     pub code_annotation_syntax: CodeAnnotationSyntax,
+
     /// Enable line numbers for all code blocks by default.
+    ///
+    /// Default: `false`.
     pub code_annotation_default_line_numbers: bool,
+
     /// Maximum heading depth included in inline TOCs.
+    ///
+    /// Default: `3`.
     pub toc_max_depth: u8,
+
     /// Auto-link bare URLs in text. When enabled, any occurrence in a text
     /// node that starts with one of [`Self::autolink_patterns`] is wrapped
     /// in an `<a>` tag. Auto-linking is suppressed inside an existing link.
+    ///
+    /// Default: `false`.
     pub autolink_urls: bool,
+
     /// URL prefix patterns recognised by [`Self::autolink_urls`]. Defaults
     /// to `["http://", "https://"]`. Register additional schemes (e.g.
     /// `"ftp://"`, `"mailto:"`) by pushing onto this vec.
+    ///
+    /// Default: `["http://", "https://"]`.
     pub autolink_patterns: Vec<String>,
+
     /// When auto-linking, emit `target="_blank" rel="noopener noreferrer"`.
     /// Independent from the existing markdown-link behaviour, which always
     /// adds the attributes for http/https hrefs.
+    ///
+    /// Default: `true`.
     pub autolink_target_blank: bool,
 }
 
@@ -85,11 +135,13 @@ pub enum CodeAnnotationSyntax {
     /// This is the stable ox-content syntax and is useful when authored Markdown should
     /// stay independent from a particular documentation theme.
     Attribute,
+
     /// Read VitePress-compatible fence metadata and inline `// [!code ...]` directives.
     ///
     /// Use this when importing or sharing Markdown with VitePress projects that already
     /// use `{1,3}`, `[title]`, `:line-numbers`, or inline diff/focus annotations.
     VitePress,
+
     /// Accept both ox-content attributes and VitePress-compatible directives.
     ///
     /// Attribute annotations are applied first, then VitePress metadata can add titles,

--- a/crates/ox_content_search/src/query.rs
+++ b/crates/ox_content_search/src/query.rs
@@ -8,18 +8,31 @@ use crate::index::SearchIndex;
 use crate::tokenizer::tokenize_query;
 
 /// Search options.
+///
+/// Defaults match the client-side search runtime defaults.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchOptions {
     /// Maximum number of results to return.
+    ///
+    /// Default: `10`.
     #[serde(default = "default_limit")]
     pub limit: usize,
+
     /// Enable prefix matching for the last token.
+    ///
+    /// Default: `true`.
     #[serde(default = "default_prefix")]
     pub prefix: bool,
+
     /// Enable fuzzy matching (edit distance).
+    ///
+    /// Default: `false`.
     #[serde(default)]
     pub fuzzy: bool,
+
     /// Minimum score threshold (0.0 - 1.0).
+    ///
+    /// Default: `0.0`.
     #[serde(default)]
     pub threshold: f64,
 }
@@ -43,14 +56,19 @@ impl Default for SearchOptions {
 pub struct SearchResult {
     /// Document ID.
     pub id: String,
+
     /// Document title.
     pub title: String,
+
     /// Document URL.
     pub url: String,
+
     /// Relevance score.
     pub score: f64,
+
     /// Matched terms.
     pub matches: Vec<String>,
+
     /// Content snippet with highlights.
     pub snippet: String,
 }

--- a/crates/ox_content_search/src/runtime.rs
+++ b/crates/ox_content_search/src/runtime.rs
@@ -8,14 +8,28 @@ const SEARCH_RUNTIME_MODULE: &str = include_str!("search-runtime.js");
 #[derive(Clone, Debug, Serialize)]
 pub struct SearchRuntimeOptions {
     /// Whether search is enabled.
+    ///
+    /// Default from the Vite plugin resolver: `true`.
     pub enabled: bool,
+
     /// Maximum number of results.
+    ///
+    /// Default from the Vite plugin resolver: `10`.
     pub limit: u32,
+
     /// Enable prefix matching.
+    ///
+    /// Default from the Vite plugin resolver: `true`.
     pub prefix: bool,
+
     /// Search input placeholder.
+    ///
+    /// Default from the Vite plugin resolver: `"Search documentation..."`.
     pub placeholder: String,
+
     /// Keyboard shortcut to focus search.
+    ///
+    /// Default from the Vite plugin resolver: `"/"`.
     pub hotkey: String,
 }
 

--- a/crates/ox_content_wasm/src/lib.rs
+++ b/crates/ox_content_wasm/src/lib.rs
@@ -30,7 +30,10 @@ pub struct TransformResult {
     pub errors: Vec<String>,
 }
 
-/// Parser options.
+/// Parser and renderer options exposed to JavaScript.
+///
+/// `new WasmParserOptions()` disables optional Markdown extensions by default
+/// and uses renderer defaults for TOC and auto-link handling.
 #[wasm_bindgen]
 #[derive(Default)]
 pub struct WasmParserOptions {
@@ -48,6 +51,11 @@ pub struct WasmParserOptions {
 
 #[wasm_bindgen]
 impl WasmParserOptions {
+    /// Creates options with all Markdown extension flags disabled.
+    ///
+    /// Defaults: `gfm = false`, `tocMaxDepth = 3`, `autolinkUrls = false`,
+    /// `autolinkPatterns = ["http://", "https://"]`, and
+    /// `autolinkTargetBlank = true`.
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
         Self {
@@ -64,36 +72,57 @@ impl WasmParserOptions {
         }
     }
 
+    /// Enables the GFM convenience profile.
+    ///
+    /// Default: `false`.
     #[wasm_bindgen(setter)]
     pub fn set_gfm(&mut self, value: bool) {
         self.gfm = value;
     }
 
+    /// Enables footnote references and definitions.
+    ///
+    /// Default: `false`.
     #[wasm_bindgen(setter)]
     pub fn set_footnotes(&mut self, value: bool) {
         self.footnotes = value;
     }
 
+    /// Enables GFM task-list item markers such as `- [x]`.
+    ///
+    /// Default: `false`.
     #[wasm_bindgen(setter = taskLists)]
     pub fn set_task_lists(&mut self, value: bool) {
         self.task_lists = value;
     }
 
+    /// Enables GFM pipe tables.
+    ///
+    /// Default: `false`.
     #[wasm_bindgen(setter)]
     pub fn set_tables(&mut self, value: bool) {
         self.tables = value;
     }
 
+    /// Enables GFM strikethrough spans.
+    ///
+    /// Default: `false`.
     #[wasm_bindgen(setter)]
     pub fn set_strikethrough(&mut self, value: bool) {
         self.strikethrough = value;
     }
 
+    /// Enables GFM autolinks in the parser.
+    ///
+    /// Default: `false`.
     #[wasm_bindgen(setter)]
     pub fn set_autolinks(&mut self, value: bool) {
         self.autolinks = value;
     }
 
+    /// Sets the maximum heading depth included in inline TOCs.
+    ///
+    /// Default: `3`.
     #[wasm_bindgen(setter = tocMaxDepth)]
     pub fn set_toc_max_depth(&mut self, value: u8) {
         self.toc_max_depth = value;
@@ -101,6 +130,8 @@ impl WasmParserOptions {
 
     /// Enables the renderer's URL auto-linking builtin. Bare URLs matching
     /// any registered pattern are wrapped in an `<a>` tag.
+    ///
+    /// Default: `false`.
     #[wasm_bindgen(setter = autolinkUrls)]
     pub fn set_autolink_urls(&mut self, value: bool) {
         self.autolink_urls = value;
@@ -108,6 +139,8 @@ impl WasmParserOptions {
 
     /// Replaces the URL prefix patterns used by auto-linking. Pass a JS
     /// array of strings such as `["http://", "https://", "ftp://"]`.
+    ///
+    /// Default: `["http://", "https://"]`.
     #[wasm_bindgen(setter = autolinkPatterns)]
     pub fn set_autolink_patterns(&mut self, value: Vec<String>) {
         self.autolink_patterns = value;
@@ -115,6 +148,8 @@ impl WasmParserOptions {
 
     /// Toggles `target="_blank" rel="noopener noreferrer"` on auto-linked
     /// URLs. Has no effect when `autolinkUrls` is off.
+    ///
+    /// Default: `true`.
     #[wasm_bindgen(setter = autolinkTargetBlank)]
     pub fn set_autolink_target_blank(&mut self, value: bool) {
         self.autolink_target_blank = value;

--- a/npm/unplugin-ox-content/src/types.ts
+++ b/npm/unplugin-ox-content/src/types.ts
@@ -169,7 +169,15 @@ export type RehypePlugin = UnifiedAttacher | UnifiedPluginTuple | UnifiedPreset;
  */
 export type OxContentPlugin = (html: string) => string | Promise<string>;
 
+/**
+ * Code annotation options for the framework-agnostic unplugin package.
+ */
 export interface CodeAnnotationsOptions {
+  /**
+   * Attribute name read from the code fence meta string.
+   *
+   * @default 'annotate'
+   */
   metaKey?: string;
 }
 
@@ -180,7 +188,10 @@ export interface ResolvedCodeAnnotationsOptions {
 
 /**
  * API documentation generation configuration.
- * Similar to cargo docs for Rust.
+ *
+ * The unplugin package keeps this surface smaller than the Vite plugin's docs
+ * generator, but follows the same convention: provide `true` for defaults or an
+ * object to customize scanning and output.
  */
 export interface DocsConfig {
   /**
@@ -191,6 +202,10 @@ export interface DocsConfig {
 
   /**
    * Source directories to scan for documentation.
+   *
+   * Paths are resolved from the bundler project root before include/exclude
+   * matching.
+   *
    * @default ['./src']
    */
   src?: string[];
@@ -203,6 +218,9 @@ export interface DocsConfig {
 
   /**
    * File patterns to include.
+   *
+   * Patterns are evaluated inside each configured `src` directory.
+   *
    * @default ['**\/*.ts', '**\/*.tsx', '**\/*.js', '**\/*.jsx']
    */
   include?: string[];
@@ -233,17 +251,23 @@ export interface DocsConfig {
 }
 
 /**
- * Plugin configuration for various markdown ecosystems.
+ * Plugin configuration for various Markdown ecosystems.
+ *
+ * Plugins run in the order listed for their respective pipeline stage. Use this
+ * when migrating from markdown-it, remark, or rehype based stacks while keeping
+ * ox-content as the parser/renderer bridge.
  */
 export interface PluginConfig {
   /**
    * Ox-content native plugins.
    * Transform HTML after rendering.
+   * @default []
    */
   oxContent?: OxContentPlugin[];
 
   /**
    * Markdown-it plugins.
+   * @default []
    * @see https://www.npmjs.com/search?q=markdown-it-plugin
    */
   markdownIt?: MarkdownItPlugin[];
@@ -251,29 +275,39 @@ export interface PluginConfig {
   /**
    * mdast plugins.
    * Accepts both Ox Content-native mdast plugins and existing remark plugins.
+   * @default []
    */
   mdast?: MdastPlugin[];
 
   /**
    * Remark plugins (unified ecosystem).
    * Kept for compatibility; runs in the same mdast stage as `plugin.mdast`.
+   * @default []
    * @see https://github.com/remarkjs/remark/blob/main/doc/plugins.md
    */
   remark?: RemarkPlugin[];
 
   /**
    * Rehype plugins (unified ecosystem).
+   * @default []
    * @see https://github.com/rehypejs/rehype/blob/main/doc/plugins.md
    */
   rehype?: RehypePlugin[];
 }
 
 /**
- * Plugin options.
+ * Options for the framework-agnostic ox-content unplugin.
+ *
+ * This package is intended for bundlers such as webpack, Rollup, esbuild,
+ * Rspack, and Vite. It exposes a compact subset of the core Vite plugin options
+ * plus ecosystem plugin hooks.
  */
 export interface OxContentOptions {
   /**
    * Source directory for Markdown files.
+   *
+   * Used as the logical content root for generated modules and docs output.
+   *
    * @default 'docs'
    */
   srcDir?: string;
@@ -322,7 +356,16 @@ export interface OxContentOptions {
 
   /**
    * Opt-in line annotations for fenced code blocks.
-   * Example: `annotate="highlight:1,3-4;warning:6"`
+   *
+   * Pass `true` to enable the default `annotate` meta key, or pass an object to
+   * configure the key.
+   *
+   * @example
+   * ~~~md
+   * ```ts annotate="highlight:1,3-4;warning:6"
+   * ```
+   * ~~~
+   *
    * @default false
    */
   codeAnnotations?: boolean | CodeAnnotationsOptions;
@@ -359,16 +402,22 @@ export interface OxContentOptions {
 
   /**
    * Files/patterns to include.
+   * Empty by default, which lets the Markdown extension filter decide.
+   * @default []
    */
   include?: string | RegExp | RegExp[];
 
   /**
    * Files/patterns to exclude.
+   * Empty by default.
+   * @default []
    */
   exclude?: string | RegExp | RegExp[];
 
   /**
    * Plugin configuration for markdown processing.
+   * Each plugin list defaults to an empty array.
+   * @default {}
    */
   plugin?: PluginConfig;
 

--- a/npm/vite-plugin-ox-content-react/src/types.ts
+++ b/npm/vite-plugin-ox-content-react/src/types.ts
@@ -1,6 +1,18 @@
 import type { OxContentOptions } from "@ox-content/vite-plugin";
 
+/**
+ * Code annotation options for the React integration.
+ *
+ * The React integration supports the same opt-in fence metadata as the core
+ * plugin, but only exposes the attribute key because rendering is handled by
+ * the React markdown transform.
+ */
 export interface CodeAnnotationsOptions {
+  /**
+   * Attribute name read from the code fence meta string.
+   *
+   * @default 'annotate'
+   */
   metaKey?: string;
 }
 
@@ -9,25 +21,45 @@ export interface ResolvedCodeAnnotationsOptions {
   metaKey: string;
 }
 
+/**
+ * Map from Markdown component names to import paths.
+ */
 export type ComponentsMap = Record<string, string>;
 
 /**
  * Component registration options.
+ *
  * Can be a map, a glob pattern, or an array of glob patterns.
+ * Globbed components are resolved relative to the Vite project root during
+ * `configResolved`.
  */
 export type ComponentsOption = ComponentsMap | string | string[];
 
+/**
+ * React integration plugin options.
+ *
+ * This extends the core ox-content options with React component registration and
+ * JSX runtime controls. Markdown files are transformed into React-aware modules
+ * while the core plugin still provides shared parsing, embeds, and environment
+ * setup.
+ */
 export interface ReactIntegrationOptions extends OxContentOptions {
   /**
    * Markdown-like file extensions to process.
+   *
+   * Values are normalized with a leading dot before matching file paths.
+   *
    * @default ['.md', '.markdown', '.mdx']
    */
   extensions?: string[];
 
   /**
    * Components to register for use in Markdown.
+   *
    * Can be a map of names to paths, a glob pattern, or an array of globs.
    * When using glob patterns, component names are derived from file names.
+   *
+   * @default {}
    *
    * @example
    * ```ts
@@ -39,28 +71,115 @@ export interface ReactIntegrationOptions extends OxContentOptions {
    * ```
    */
   components?: ComponentsOption;
+
+  /**
+   * Enable opt-in line annotations for fenced code blocks.
+   *
+   * Pass `true` to use the default `annotate` meta key, or an object to change it.
+   *
+   * @default false
+   */
   codeAnnotations?: boolean | CodeAnnotationsOptions;
+
+  /**
+   * JSX runtime used by generated React modules.
+   *
+   * `automatic` matches modern React setups. Use `classic` only for projects
+   * that still require explicit `React.createElement` output.
+   *
+   * @default 'automatic'
+   */
   jsxRuntime?: "automatic" | "classic";
+
+  /**
+   * Built-in static embeds rendered during Markdown transformation.
+   *
+   * Set to `false` to disable all built-in embeds.
+   * Configure individual fetch-related options under `github` and `openGraph`.
+   *
+   * @default { github: true, openGraph: true }
+   */
   embeds?: BuiltinEmbedOptions | false;
 }
 
+/**
+ * Fetch options for React GitHub embeds.
+ */
 export interface GitHubEmbedOptions {
+  /**
+   * GitHub API token used for higher rate limits and private repository access.
+   * @default ''
+   */
   token?: string;
+
+  /**
+   * Cache fetched repository and source data in memory for the current process.
+   * @default true
+   */
   cache?: boolean;
+
+  /**
+   * Cache TTL in milliseconds.
+   * @default 3600000
+   */
   cacheTTL?: number;
+
+  /**
+   * Maximum source file size to inline in bytes.
+   * @default 200000
+   */
   maxSourceBytes?: number;
+
+  /**
+   * Maximum source lines to inline when no line range is specified.
+   * @default 120
+   */
   maxSourceLines?: number;
 }
 
+/**
+ * Fetch options for React Open Graph embeds.
+ */
 export interface OpenGraphEmbedOptions {
+  /**
+   * Request timeout in milliseconds.
+   * @default 10000
+   */
   timeout?: number;
+
+  /**
+   * Cache fetched Open Graph metadata in memory for the current process.
+   * @default true
+   */
   cache?: boolean;
+
+  /**
+   * Cache TTL in milliseconds.
+   * @default 3600000
+   */
   cacheTTL?: number;
+
+  /**
+   * User agent sent with metadata fetch requests.
+   * @default 'ox-content-ogp-bot/1.0 (compatible; +https://github.com/ubugeeei-prod/ox-content)'
+   */
   userAgent?: string;
 }
 
+/**
+ * Built-in embed options for the React integration.
+ */
 export interface BuiltinEmbedOptions {
+  /**
+   * Render `<GitHub repo="owner/name" />` repository cards.
+   * @default true
+   */
   github?: boolean | GitHubEmbedOptions;
+
+  /**
+   * Render `<OgCard url="https://example.com" />` Open Graph link cards.
+   * @default true
+   */
   openGraph?: boolean | OpenGraphEmbedOptions;
 }
 

--- a/npm/vite-plugin-ox-content-svelte/src/types.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/types.ts
@@ -1,6 +1,17 @@
 import type { OxContentOptions } from "@ox-content/vite-plugin";
 
+/**
+ * Code annotation options for the Svelte integration.
+ *
+ * The Svelte integration supports opt-in fence metadata and exposes the
+ * attribute key used by the Svelte markdown transform.
+ */
 export interface CodeAnnotationsOptions {
+  /**
+   * Attribute name read from the code fence meta string.
+   *
+   * @default 'annotate'
+   */
   metaKey?: string;
 }
 
@@ -9,25 +20,44 @@ export interface ResolvedCodeAnnotationsOptions {
   metaKey: string;
 }
 
+/**
+ * Map from Markdown component names to import paths.
+ */
 export type ComponentsMap = Record<string, string>;
 
 /**
  * Component registration options.
+ *
  * Can be a map, a glob pattern, or an array of glob patterns.
+ * Globbed components are resolved relative to the Vite project root during
+ * `configResolved`.
  */
 export type ComponentsOption = ComponentsMap | string | string[];
 
+/**
+ * Svelte integration plugin options.
+ *
+ * This extends the core ox-content options with Svelte component registration
+ * and runtime mode controls. Markdown files are transformed into Svelte-aware
+ * modules while the core plugin provides shared parsing and embeds.
+ */
 export interface SvelteIntegrationOptions extends OxContentOptions {
   /**
    * Markdown-like file extensions to process.
+   *
+   * Values are normalized with a leading dot before matching file paths.
+   *
    * @default ['.md', '.markdown', '.mdx']
    */
   extensions?: string[];
 
   /**
    * Components to register for use in Markdown.
+   *
    * Can be a map of names to paths, a glob pattern, or an array of globs.
    * When using glob patterns, component names are derived from file names.
+   *
+   * @default {}
    *
    * @example
    * ```ts
@@ -39,28 +69,115 @@ export interface SvelteIntegrationOptions extends OxContentOptions {
    * ```
    */
   components?: ComponentsOption;
+
+  /**
+   * Enable opt-in line annotations for fenced code blocks.
+   *
+   * Pass `true` to use the default `annotate` meta key, or an object to change it.
+   *
+   * @default false
+   */
   codeAnnotations?: boolean | CodeAnnotationsOptions;
+
+  /**
+   * Generate Svelte 5 runes-compatible runtime integration.
+   *
+   * Keep this enabled for Svelte 5 projects. Disable it only for compatibility
+   * with older runtime assumptions.
+   *
+   * @default true
+   */
   runes?: boolean;
+
+  /**
+   * Built-in static embeds rendered during Markdown transformation.
+   *
+   * Set to `false` to disable all built-in embeds.
+   * Configure individual fetch-related options under `github` and `openGraph`.
+   *
+   * @default { github: true, openGraph: true }
+   */
   embeds?: BuiltinEmbedOptions | false;
 }
 
+/**
+ * Fetch options for Svelte GitHub embeds.
+ */
 export interface GitHubEmbedOptions {
+  /**
+   * GitHub API token used for higher rate limits and private repository access.
+   * @default ''
+   */
   token?: string;
+
+  /**
+   * Cache fetched repository and source data in memory for the current process.
+   * @default true
+   */
   cache?: boolean;
+
+  /**
+   * Cache TTL in milliseconds.
+   * @default 3600000
+   */
   cacheTTL?: number;
+
+  /**
+   * Maximum source file size to inline in bytes.
+   * @default 200000
+   */
   maxSourceBytes?: number;
+
+  /**
+   * Maximum source lines to inline when no line range is specified.
+   * @default 120
+   */
   maxSourceLines?: number;
 }
 
+/**
+ * Fetch options for Svelte Open Graph embeds.
+ */
 export interface OpenGraphEmbedOptions {
+  /**
+   * Request timeout in milliseconds.
+   * @default 10000
+   */
   timeout?: number;
+
+  /**
+   * Cache fetched Open Graph metadata in memory for the current process.
+   * @default true
+   */
   cache?: boolean;
+
+  /**
+   * Cache TTL in milliseconds.
+   * @default 3600000
+   */
   cacheTTL?: number;
+
+  /**
+   * User agent sent with metadata fetch requests.
+   * @default 'ox-content-ogp-bot/1.0 (compatible; +https://github.com/ubugeeei-prod/ox-content)'
+   */
   userAgent?: string;
 }
 
+/**
+ * Built-in embed options for the Svelte integration.
+ */
 export interface BuiltinEmbedOptions {
+  /**
+   * Render `<GitHub repo="owner/name" />` repository cards.
+   * @default true
+   */
   github?: boolean | GitHubEmbedOptions;
+
+  /**
+   * Render `<OgCard url="https://example.com" />` Open Graph link cards.
+   * @default true
+   */
   openGraph?: boolean | OpenGraphEmbedOptions;
 }
 

--- a/npm/vite-plugin-ox-content-vue/src/types.ts
+++ b/npm/vite-plugin-ox-content-vue/src/types.ts
@@ -4,7 +4,18 @@
 
 import type { OxContentOptions } from "@ox-content/vite-plugin";
 
+/**
+ * Code annotation options for the Vue integration.
+ *
+ * The Vue integration supports opt-in fence metadata and exposes the attribute
+ * key used by the Vue markdown transform.
+ */
 export interface CodeAnnotationsOptions {
+  /**
+   * Attribute name read from the code fence meta string.
+   *
+   * @default 'annotate'
+   */
   metaKey?: string;
 }
 
@@ -21,7 +32,10 @@ export type ComponentsMap = Record<string, string>;
 
 /**
  * Component registration options.
+ *
  * Can be a map, a glob pattern, or an array of glob patterns.
+ * Globbed components are resolved relative to the Vite project root during
+ * `configResolved`.
  *
  * @example
  * ```ts
@@ -41,18 +55,28 @@ export type ComponentsOption = ComponentsMap | string | string[];
 
 /**
  * Vue integration plugin options.
+ *
+ * This extends the core ox-content options with Vue component registration and
+ * Vue-specific markdown behavior. Markdown files are transformed into Vue-aware
+ * modules while the core plugin provides shared parsing and embeds.
  */
 export interface VueIntegrationOptions extends OxContentOptions {
   /**
    * Markdown-like file extensions to process.
+   *
+   * Values are normalized with a leading dot before matching file paths.
+   *
    * @default ['.md', '.markdown', '.mdx']
    */
   extensions?: string[];
 
   /**
    * Components to register for use in Markdown.
+   *
    * Can be a map of names to paths, a glob pattern, or an array of globs.
    * When using glob patterns, component names are derived from file names.
+   *
+   * @default {}
    *
    * @example
    * ```ts
@@ -65,40 +89,126 @@ export interface VueIntegrationOptions extends OxContentOptions {
    * }
    * ```
    */
+  components?: ComponentsOption;
+
+  /**
+   * Enable opt-in line annotations for fenced code blocks.
+   *
+   * Pass `true` to use the default `annotate` meta key, or an object to change it.
+   *
+   * @default false
+   */
+  codeAnnotations?: boolean | CodeAnnotationsOptions;
 
   /**
    * Enable Vue Reactivity Transform.
+   *
+   * Keep this disabled unless the project still relies on Vue's experimental
+   * reactivity transform syntax.
+   *
    * @default false
    */
+  reactivityTransform?: boolean;
 
   /**
    * Enable custom blocks in Markdown (e.g., `:::tip`).
+   *
+   * Disable this only when another Markdown plugin owns the same container
+   * syntax.
+   *
    * @default true
    */
-  components?: ComponentsOption;
-  codeAnnotations?: boolean | CodeAnnotationsOptions;
-  reactivityTransform?: boolean;
   customBlocks?: boolean;
+
+  /**
+   * Built-in static embeds rendered during Markdown transformation.
+   *
+   * Set to `false` to disable all built-in embeds.
+   * Configure individual fetch-related options under `github` and `openGraph`.
+   *
+   * @default { github: true, openGraph: true }
+   */
   embeds?: BuiltinEmbedOptions | false;
 }
 
+/**
+ * Fetch options for Vue GitHub embeds.
+ */
 export interface GitHubEmbedOptions {
+  /**
+   * GitHub API token used for higher rate limits and private repository access.
+   * @default ''
+   */
   token?: string;
+
+  /**
+   * Cache fetched repository and source data in memory for the current process.
+   * @default true
+   */
   cache?: boolean;
+
+  /**
+   * Cache TTL in milliseconds.
+   * @default 3600000
+   */
   cacheTTL?: number;
+
+  /**
+   * Maximum source file size to inline in bytes.
+   * @default 200000
+   */
   maxSourceBytes?: number;
+
+  /**
+   * Maximum source lines to inline when no line range is specified.
+   * @default 120
+   */
   maxSourceLines?: number;
 }
 
+/**
+ * Fetch options for Vue Open Graph embeds.
+ */
 export interface OpenGraphEmbedOptions {
+  /**
+   * Request timeout in milliseconds.
+   * @default 10000
+   */
   timeout?: number;
+
+  /**
+   * Cache fetched Open Graph metadata in memory for the current process.
+   * @default true
+   */
   cache?: boolean;
+
+  /**
+   * Cache TTL in milliseconds.
+   * @default 3600000
+   */
   cacheTTL?: number;
+
+  /**
+   * User agent sent with metadata fetch requests.
+   * @default 'ox-content-ogp-bot/1.0 (compatible; +https://github.com/ubugeeei-prod/ox-content)'
+   */
   userAgent?: string;
 }
 
+/**
+ * Built-in embed options for the Vue integration.
+ */
 export interface BuiltinEmbedOptions {
+  /**
+   * Render `<GitHub repo="owner/name" />` repository cards.
+   * @default true
+   */
   github?: boolean | GitHubEmbedOptions;
+
+  /**
+   * Render `<OgCard url="https://example.com" />` Open Graph link cards.
+   * @default true
+   */
   openGraph?: boolean | OpenGraphEmbedOptions;
 }
 
@@ -132,10 +242,12 @@ export interface ResolvedVueOptions {
 export interface VueTransformResult {
   code: string;
   map: null;
+
   /**
    * List of components used in the Markdown.
    */
   usedComponents: string[];
+
   /**
    * Extracted frontmatter.
    */
@@ -150,18 +262,22 @@ export interface ComponentIsland {
    * Component name.
    */
   name: string;
+
   /**
    * Props to pass to the component.
    */
   props: Record<string, unknown>;
+
   /**
    * Position in the HTML output.
    */
   position: number;
+
   /**
    * Island placeholder ID.
    */
   id: string;
+
   /**
    * Raw island content extracted from Markdown.
    */
@@ -176,14 +292,17 @@ export interface ParsedMarkdownContent {
    * HTML content with island placeholders.
    */
   html: string;
+
   /**
    * Component islands to render.
    */
   islands: ComponentIsland[];
+
   /**
    * Frontmatter data.
    */
   frontmatter: Record<string, unknown>;
+
   /**
    * Table of contents.
    */

--- a/npm/vite-plugin-ox-content/src/code-blocks.ts
+++ b/npm/vite-plugin-ox-content/src/code-blocks.ts
@@ -27,19 +27,56 @@ export interface CodeBlockDiagnostic {
 }
 
 export interface CodeBlockLintOptions {
+  /**
+   * Languages to lint. Omit to lint every fenced block language.
+   * @default undefined
+   */
   languages?: string[];
+
+  /**
+   * Report fences without a language identifier.
+   * @default false
+   */
   requireLanguage?: boolean;
+
+  /**
+   * Report trailing whitespace in code block lines.
+   * @default true
+   */
   trailingSpaces?: boolean;
 }
 
 export interface DocsTestOptions {
+  /**
+   * Fence languages to collect as runnable examples.
+   * @default ['js', 'jsx', 'ts', 'tsx', 'mjs', 'mts']
+   */
   languages?: string[];
+
+  /**
+   * Require fence meta such as `test`, `runnable`, `vitest`, or `docs-test`.
+   * @default true
+   */
   requireMeta?: boolean;
 }
 
 export interface TypecheckCodeBlockOptions {
+  /**
+   * Fence languages to type-check.
+   * @default ['ts', 'tsx']
+   */
   languages?: string[];
+
+  /**
+   * Require fence meta such as `typecheck`, `twoslash`, or `typecheck=...`.
+   * @default true
+   */
   requireMeta?: boolean;
+
+  /**
+   * Command used to run the TypeScript checker.
+   * @default 'tsgo'
+   */
   tsgoCommand?: string;
 }
 

--- a/npm/vite-plugin-ox-content/src/incremental.ts
+++ b/npm/vite-plugin-ox-content/src/incremental.ts
@@ -11,24 +11,56 @@ export interface IncrementalMarkdownParserOptions {
    * @default true
    */
   gfm?: boolean;
-  /** Enable footnotes. */
+
+  /**
+   * Enable footnotes.
+   * @default true
+   */
   footnotes?: boolean;
-  /** Enable task list items. */
+
+  /**
+   * Enable task list items.
+   * @default true
+   */
   taskLists?: boolean;
-  /** Enable GFM tables. */
+
+  /**
+   * Enable GFM tables.
+   * @default true
+   */
   tables?: boolean;
-  /** Enable strikethrough. */
+
+  /**
+   * Enable strikethrough.
+   * @default true
+   */
   strikethrough?: boolean;
-  /** Enable Markdown autolinks. */
+
+  /**
+   * Enable Markdown autolinks.
+   * @default true
+   */
   autolinks?: boolean;
 }
 
 export interface IncrementalMarkdownParseAppendOptions {
-  /** Commit the current chunk as the final stream input. */
+  /**
+   * Commit the current chunk as the final stream input.
+   * @default false
+   */
   final?: boolean;
-  /** Include a provisional AST for the current replaceable tail. */
+
+  /**
+   * Include a provisional AST for the current replaceable tail.
+   * The constructor-level value is reused when omitted on `append`.
+   * @default false
+   */
   includePendingAst?: boolean;
-  /** Temporarily close unmatched inline delimiters in the provisional AST. */
+
+  /**
+   * Temporarily close unmatched inline delimiters in the provisional AST.
+   * @default true
+   */
   completeInline?: boolean;
 }
 
@@ -38,6 +70,7 @@ export interface IncrementalMarkdownRendererOptions extends IncrementalMarkdownP
    * @default true
    */
   renderPending?: boolean;
+
   /**
    * Temporarily close unmatched inline delimiters in provisional HTML.
    * @default true
@@ -46,11 +79,23 @@ export interface IncrementalMarkdownRendererOptions extends IncrementalMarkdownP
 }
 
 export interface IncrementalMarkdownRenderAppendOptions {
-  /** Commit the current chunk as the final stream input. */
+  /**
+   * Commit the current chunk as the final stream input.
+   * @default false
+   */
   final?: boolean;
-  /** Render the unstable tail as replaceable provisional HTML. */
+
+  /**
+   * Render the unstable tail as replaceable provisional HTML.
+   * The constructor-level value is reused when omitted on `append`.
+   * @default true
+   */
   renderPending?: boolean;
-  /** Temporarily close unmatched inline delimiters in provisional HTML. */
+
+  /**
+   * Temporarily close unmatched inline delimiters in provisional HTML.
+   * @default true
+   */
   completeInline?: boolean;
 }
 
@@ -63,10 +108,13 @@ export interface IncrementalMarkdownParseResult<TAst = unknown> extends Omit<
 > {
   /** Parsed mdast for the newly committed Markdown prefix, or null when nothing committed. */
   ast: TAst | null;
+
   /** Raw mdast JSON for the newly committed Markdown prefix. */
   astJson: string;
+
   /** Provisional parsed mdast for the current replaceable tail, or null when not requested. */
   pendingAst: TAst | null;
+
   /** Raw provisional mdast JSON for the current replaceable tail. */
   pendingAstJson: string;
 }

--- a/npm/vite-plugin-ox-content/src/lint-files.ts
+++ b/npm/vite-plugin-ox-content/src/lint-files.ts
@@ -40,6 +40,8 @@ export interface MarkdownLintFileOptions extends MarkdownLintOptions {
 
   /**
    * Alias of `exclude`.
+   * When omitted, only `exclude` is used.
+   * @default undefined
    */
   ignore?: string[];
 }

--- a/npm/vite-plugin-ox-content/src/lint.ts
+++ b/npm/vite-plugin-ox-content/src/lint.ts
@@ -54,6 +54,7 @@ export interface MarkdownLintStandardDictionaryOptions {
    *
    * This can point at installed packages like
    * `@cspell/dict-fr-fr/cspell-ext.json` or local CSpell config files.
+   * @default []
    */
   imports?: string[];
 
@@ -71,16 +72,19 @@ export interface MarkdownLintStandardDictionaryOptions {
 export interface MarkdownLintDictionaryOptions {
   /**
    * Words ignored across all configured languages.
+   * @default []
    */
   words?: string[];
 
   /**
    * Extra words to allow per language.
+   * @default {}
    */
   byLanguage?: Partial<Record<MarkdownLintLanguage, string[]>>;
 
   /**
    * Words that should never produce diagnostics.
+   * @default []
    */
   ignoredWords?: string[];
 
@@ -89,6 +93,7 @@ export interface MarkdownLintDictionaryOptions {
    *
    * By default the linter stays on a minimal built-in dictionary. Enable this
    * to load larger locale dictionaries from a standard external source.
+   * @default false
    */
   standard?: MarkdownLintStandardDictionaryOptions | false;
 }
@@ -156,11 +161,14 @@ export interface MarkdownLintOptions {
 
   /**
    * Rule configuration.
+   * Omitted fields use `MarkdownLintRuleOptions` defaults.
+   * @default {}
    */
   rules?: MarkdownLintRuleOptions;
 
   /**
    * Built-in and opt-in standard dictionary overrides.
+   * @default {}
    */
   dictionary?: MarkdownLintDictionaryOptions;
 }

--- a/npm/vite-plugin-ox-content/src/nav-generator.ts
+++ b/npm/vite-plugin-ox-content/src/nav-generator.ts
@@ -3,11 +3,40 @@ import { toRustDocsModules } from "./docs";
 import { importNapiModuleSync } from "./napi";
 
 export interface GenerateNavMetadataOptions {
+  /**
+   * Route prefix used by generated navigation links.
+   * @default '/api'
+   */
   basePath?: string;
+
+  /**
+   * Generated Markdown output path strategy.
+   * @default 'flat'
+   */
   pathStrategy?: "flat" | "typedoc";
+
+  /**
+   * TypeDoc-style group order for nav groups.
+   * @default undefined
+   */
   groupOrder?: string[];
+
+  /**
+   * TypeDoc-style sort strategies applied to nav leaf entries.
+   * @default undefined
+   */
   sort?: DocsSortStrategy[];
+
+  /**
+   * Sort entry points alphabetically instead of preserving caller order.
+   * @default true
+   */
   sortEntryPoints?: boolean;
+
+  /**
+   * TypeDoc-style declaration kind ranking for nav groups.
+   * @default undefined
+   */
   kindSortOrder?: string[];
 }
 

--- a/npm/vite-plugin-ox-content/src/plugins/github.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/github.ts
@@ -50,15 +50,34 @@ export interface GitHubSourceData {
 }
 
 export interface GitHubOptions {
-  /** GitHub API token for higher rate limits. */
+  /**
+   * GitHub API token used for higher rate limits and private repository access.
+   * @default ''
+   */
   token?: string;
-  /** Cache fetched data. Default: true */
+
+  /**
+   * Cache fetched repository and source data in memory for the current process.
+   * @default true
+   */
   cache?: boolean;
-  /** Cache TTL in milliseconds. Default: 3600000 (1 hour) */
+
+  /**
+   * Cache TTL in milliseconds.
+   * @default 3600000
+   */
   cacheTTL?: number;
-  /** Maximum source file size to inline in bytes. Default: 200000 */
+
+  /**
+   * Maximum source file size to inline in bytes.
+   * @default 200000
+   */
   maxSourceBytes?: number;
-  /** Maximum source lines to inline when no line range is specified. Default: 120 */
+
+  /**
+   * Maximum source lines to inline when no line range is specified.
+   * @default 120
+   */
   maxSourceLines?: number;
 }
 

--- a/npm/vite-plugin-ox-content/src/plugins/media.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/media.ts
@@ -1,10 +1,34 @@
 import { importNapiModule } from "../napi";
 
 export interface MediaEmbedOptions {
+  /**
+   * Render `<Spotify>` embeds.
+   * @default false
+   */
   spotify?: boolean;
+
+  /**
+   * Render `<StackBlitz>` embeds.
+   * @default false
+   */
   stackBlitz?: boolean;
+
+  /**
+   * Render `<Tweet>` / `<XPost>` static cards.
+   * @default false
+   */
   twitter?: boolean;
+
+  /**
+   * Render `<Bluesky>` static cards.
+   * @default false
+   */
   bluesky?: boolean;
+
+  /**
+   * Render `<WebContainer>` lazy placeholder blocks.
+   * @default false
+   */
   webContainer?: boolean;
 }
 

--- a/npm/vite-plugin-ox-content/src/plugins/mermaid.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/mermaid.ts
@@ -12,7 +12,10 @@ import { dirname, join } from "node:path";
 import { importNapiModule } from "../napi";
 
 export interface MermaidOptions {
-  /** Mermaid theme. Default: "neutral" */
+  /**
+   * Mermaid theme used by the CLI renderer.
+   * @default 'neutral'
+   */
   theme?: "default" | "dark" | "forest" | "neutral" | "base";
 }
 

--- a/npm/vite-plugin-ox-content/src/plugins/ogp.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/ogp.ts
@@ -20,13 +20,28 @@ export interface OgpData {
 }
 
 export interface OgpOptions {
-  /** Request timeout in milliseconds. Default: 10000 */
+  /**
+   * Request timeout in milliseconds.
+   * @default 10000
+   */
   timeout?: number;
-  /** Cache fetched data. Default: true */
+
+  /**
+   * Cache fetched Open Graph metadata in memory for the current process.
+   * @default true
+   */
   cache?: boolean;
-  /** Cache TTL in milliseconds. Default: 3600000 (1 hour) */
+
+  /**
+   * Cache TTL in milliseconds.
+   * @default 3600000
+   */
   cacheTTL?: number;
-  /** User agent for requests */
+
+  /**
+   * User agent sent with metadata fetch requests.
+   * @default 'ox-content-ogp-bot/1.0 (compatible; +https://github.com/ubugeeei-prod/ox-content)'
+   */
   userAgent?: string;
 }
 

--- a/npm/vite-plugin-ox-content/src/plugins/pm.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/pm.ts
@@ -24,7 +24,8 @@ export interface PmOptions {
    * Enable opt-in synced package-manager tab groups. When `true`, a
    * `data-ox-tab-group="pkg-manager"` attribute is emitted so the client runtime
    * syncs the active package manager across every pm group on the page and
-   * persists the choice in localStorage. Default: false.
+   * persists the choice in localStorage.
+   * @default false
    */
   sync?: boolean;
 }

--- a/npm/vite-plugin-ox-content/src/plugins/youtube.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/youtube.ts
@@ -13,13 +13,28 @@
 import { importNapiModule } from "../napi";
 
 export interface YouTubeOptions {
-  /** Use privacy-enhanced mode (youtube-nocookie.com). Default: true */
+  /**
+   * Use privacy-enhanced mode (`youtube-nocookie.com`).
+   * @default true
+   */
   privacyEnhanced?: boolean;
-  /** Default aspect ratio. Default: "16/9" */
+
+  /**
+   * Default iframe aspect ratio.
+   * @default '16/9'
+   */
   aspectRatio?: string;
-  /** Allow fullscreen. Default: true */
+
+  /**
+   * Allow fullscreen playback.
+   * @default true
+   */
   allowFullscreen?: boolean;
-  /** Lazy load iframe. Default: true */
+
+  /**
+   * Lazy load the iframe.
+   * @default true
+   */
   lazyLoad?: boolean;
 }
 

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -16,8 +16,10 @@ import type { GitHubOptions, OgpOptions } from "./plugins";
 export interface HeroAction {
   /** Button theme: 'brand' (primary) or 'alt' (secondary) */
   theme?: "brand" | "alt";
+
   /** Button text */
   text: string;
+
   /** Link URL */
   link: string;
 }
@@ -28,14 +30,19 @@ export interface HeroAction {
 export interface HeroImage {
   /** Image source URL */
   src: string;
+
   /** Light mode image source URL */
   lightSrc?: string;
+
   /** Dark mode image source URL */
   darkSrc?: string;
+
   /** Alt text */
   alt?: string;
+
   /** Image width */
   width?: number;
+
   /** Image height */
   height?: number;
 }
@@ -46,6 +53,7 @@ export interface HeroImage {
 export interface HeroNotice {
   /** Notice title */
   title?: string;
+
   /** Notice paragraphs */
   body?: string[];
 }
@@ -56,14 +64,19 @@ export interface HeroNotice {
 export interface HeroConfig {
   /** Main title (large, gradient text) */
   name?: string;
+
   /** Secondary text (medium size) */
   text?: string;
+
   /** Tagline (smaller, muted) */
   tagline?: string;
+
   /** Notice shown near the top of the hero */
   notice?: HeroNotice;
+
   /** Hero image */
   image?: HeroImage;
+
   /** Action buttons */
   actions?: HeroAction[];
 }
@@ -74,12 +87,16 @@ export interface HeroConfig {
 export interface FeatureConfig {
   /** Icon - supports: "mdi:icon-name" (Iconify), image URL, or emoji */
   icon?: string;
+
   /** Feature title */
   title: string;
+
   /** Feature description */
   details?: string;
+
   /** Optional link */
   link?: string;
+
   /** Link text */
   linkText?: string;
 }
@@ -90,8 +107,10 @@ export interface FeatureConfig {
 export interface EntryPageConfig {
   /** Layout type - set to 'entry' for entry page */
   layout: "entry";
+
   /** Hero section */
   hero?: HeroConfig;
+
   /** Feature cards */
   features?: FeatureConfig[];
 }
@@ -102,11 +121,13 @@ export interface EntryPageConfig {
 export interface SsgNavigationItem {
   /** Display title */
   title: string;
+
   /**
    * Route path used for active-state matching.
    * Internal links should use site-relative paths such as `/getting-started`.
    */
   path?: string;
+
   /**
    * Final href used in the rendered HTML.
    * When omitted for internal links, ox-content derives it from `path`.
@@ -120,53 +141,88 @@ export interface SsgNavigationItem {
 export interface SsgNavigationGroup {
   /** Group heading */
   title: string;
+
   /** Navigation items within this group */
   items: SsgNavigationItem[];
 }
 
 /**
- * SSG (Static Site Generation) options.
+ * Static Site Generation options.
+ *
+ * These options control the HTML files emitted at build time and the matching
+ * dev-server preview behavior. Pass `false` to the top-level `ssg` option to
+ * disable the whole SSG pipeline, or pass an object to customize the defaults.
  */
 export interface SsgOptions {
   /**
-   * Enable SSG mode.
+   * Enable the SSG pipeline.
+   *
+   * Keep this enabled when ox-content owns page rendering. Disable it only when
+   * another framework integration will consume the Markdown modules directly.
+   *
    * @default true
    */
   enabled?: boolean;
 
   /**
-   * Output file extension.
+   * File extension used for generated routes.
+   *
+   * The value should include the leading dot. For example, `.html` emits
+   * `guide.html`, while an empty string can be used by custom deployments that
+   * map extensionless output themselves.
+   *
    * @default '.html'
    */
   extension?: string;
 
   /**
-   * Clean output directory before build.
+   * Remove previously generated files from the output directory before writing
+   * the new SSG result.
+   *
+   * Leave this disabled when the output directory also contains assets produced
+   * by other Vite plugins or external build steps.
+   *
    * @default false
    */
   clean?: boolean;
 
   /**
-   * Bare HTML output (no navigation, no styles).
-   * Useful for benchmarking or when using custom layouts.
+   * Emit bare HTML with only the rendered Markdown body.
+   *
+   * This skips the default navigation, layout shell, and theme styles. It is
+   * mainly useful for benchmarking, fixture generation, or projects that wrap
+   * the output in their own shell.
+   *
    * @default false
    */
   bare?: boolean;
 
   /**
-   * Site name for header and title suffix.
+   * Site name shown in the default theme header and title suffix.
+   *
+   * When omitted, the renderer falls back to project metadata where available.
+   *
+   * @default undefined
    */
   siteName?: string;
 
   /**
-   * OG image URL for social sharing (static URL).
-   * If generateOgImage is enabled, this serves as the fallback.
+   * Static Open Graph image URL used for social sharing.
+   *
+   * When `generateOgImage` is enabled, this value is still useful as a fallback
+   * for pages that cannot produce a generated image.
+   *
+   * @default undefined
    */
   ogImage?: string;
 
   /**
-   * Generate OG images per page using Rust-based generator.
-   * When enabled, each page will have a unique OG image.
+   * Generate one Open Graph image per page.
+   *
+   * Generated images are written alongside the SSG output and referenced from
+   * each page's metadata. Configure rendering details with the top-level
+   * `ogImageOptions` option.
+   *
    * @default false
    */
   generateOgImage?: boolean;
@@ -178,21 +234,38 @@ export interface SsgOptions {
   lastUpdated?: boolean;
 
   /**
-   * Site URL for generating absolute OG image URLs.
-   * Required for proper SNS sharing.
-   * Example: 'https://example.com'
+   * Absolute site URL used when generating social metadata.
+   *
+   * Set this when pages need absolute Open Graph image URLs. Include the origin
+   * and any deployment base path, without a trailing page path.
+   *
+   * @example
+   * ```ts
+   * siteUrl: 'https://example.com/docs'
+   * ```
+   *
+   * @default undefined
    */
   siteUrl?: string;
 
   /**
-   * Theme configuration for customizing the SSG output.
-   * Use defineTheme() to create a theme configuration.
+   * Theme configuration for generated pages.
+   *
+   * Use `defineTheme()` to build this object so custom theme modules and the
+   * default theme extension points keep their expected shape.
+   *
+   * @default defaultTheme
    */
   theme?: ThemeConfig;
 
   /**
-   * Override the auto-generated sidebar navigation.
-   * Useful when migrating from tools with explicit navigation config such as VitePress.
+   * Sidebar navigation override.
+   *
+   * When omitted, ox-content derives navigation from the Markdown file tree.
+   * Provide this when migrating from systems such as VitePress where navigation
+   * is intentionally hand-authored.
+   *
+   * @default undefined
    */
   navigation?: SsgNavigationGroup[];
 }
@@ -215,36 +288,65 @@ export interface ResolvedSsgOptions {
 }
 
 /**
- * Plugin options.
+ * Options for the core `oxContent()` Vite plugin.
+ *
+ * The top-level options describe where content lives, which Markdown features
+ * are enabled, and which build-time features should run. Feature toggles that
+ * accept `boolean | Options` follow the same convention:
+ *
+ * - `false` disables the feature.
+ * - `true` enables the feature with its documented defaults.
+ * - an object enables the feature and overrides only the provided fields.
  */
 export interface OxContentOptions {
   /**
-   * Source directory for Markdown files.
+   * Directory containing Markdown source files.
+   *
+   * The path is resolved from the Vite project root. SSG, search indexing, and
+   * dev-server routing all use this directory as the content root.
+   *
    * @default 'content'
    */
   srcDir?: string;
 
   /**
-   * Output directory for built files.
+   * Directory where generated files are written.
+   *
+   * SSG HTML, search indexes, and generated assets are emitted under this
+   * directory during production builds.
+   *
    * @default 'dist'
    */
   outDir?: string;
 
   /**
-   * Base path for the site.
+   * Base path prepended to generated internal URLs.
+   *
+   * Use this when the site is deployed below a sub-path, such as GitHub Pages or
+   * a documentation route inside a larger application.
+   *
    * @default '/'
    */
   base?: string;
 
   /**
    * Markdown-like file extensions to process.
+   *
+   * Extensions are normalized with a leading dot and matched case-insensitively.
+   * Add custom extensions when another authoring format is compiled to Markdown
+   * before ox-content sees it.
+   *
    * @default ['.md', '.markdown', '.mdx']
    */
   extensions?: string[];
 
   /**
-   * SSG (Static Site Generation) options.
-   * Set to false to disable SSG completely.
+   * Static Site Generation options.
+   *
+   * Passing `true` or omitting this option enables SSG with defaults. Passing
+   * `false` disables the SSG plugin while still allowing Markdown module
+   * transforms to run.
+   *
    * @default { enabled: true }
    */
   ssg?: SsgOptions | boolean;
@@ -295,17 +397,23 @@ export interface OxContentOptions {
    * Additional languages for syntax highlighting.
    * Accepts Shiki LanguageRegistration objects (e.g., TextMate grammars).
    * These are loaded alongside the built-in languages.
+   * @default []
    */
   highlightLangs?: LanguageRegistration[];
 
   /**
-   * Opt-in code block annotations for fenced code blocks.
+   * Code block line annotations for fenced code blocks.
    *
-   * Supports the configurable attribute syntax by default, and can also opt
-   * into VitePress-compatible fence metadata and inline notation.
+   * This feature is opt-in because it changes rendered code-block markup. Pass
+   * `true` to enable ox-content's attribute syntax, or pass an options object to
+   * change the meta key or enable VitePress-compatible notation.
    *
-   * Example:
-   * ` ```ts annotate="highlight:1,3-4;warning:6;error:7" `
+   * @example
+   * ~~~md
+   * ```ts annotate="highlight:1,3-4;warning:6;error:7"
+   * const value = compute()
+   * ```
+   * ~~~
    *
    * @default false
    */
@@ -313,36 +421,64 @@ export interface OxContentOptions {
 
   /**
    * Expand Obsidian-style `[[page]]` and `[[page|label]]` links.
+   *
+   * Use this for knowledge-base style content where authors prefer short,
+   * document-relative link syntax. Pass an object to override the base URL used
+   * when resolving generated hrefs.
+   *
    * @default false
    */
   wikiLinks?: boolean | WikiLinkOptions;
 
   /**
    * Expand `:shortcode:` emoji aliases to Unicode.
+   *
+   * Built-in aliases cover common emoji names. Provide `custom` entries for
+   * project-specific aliases or to override a built-in mapping.
+   *
    * @default false
    */
   emojiShortcodes?: boolean | EmojiShortcodeOptions;
 
   /**
    * Enable markdown-it-attrs style `{#id .class key=value}` attributes.
+   *
+   * Attribute blocks can be attached to headings, paragraphs, links, images, and
+   * other supported Markdown nodes depending on parser context.
+   *
    * @default false
    */
   attrs?: boolean | AttrsOptions;
 
   /**
    * Import source snippets into fences with `<<< @/path/to/file.ts{region}`.
+   *
+   * This is useful for documentation that must stay synchronized with examples
+   * in the repository. Use `rootDir` when snippets should resolve from a
+   * directory other than the Vite project root.
+   *
    * @default false
    */
   codeImports?: boolean | CodeImportOptions;
 
   /**
    * Sanitize rendered HTML with safe defaults or explicit allow lists.
+   *
+   * Enable this for untrusted Markdown. The default allow lists are conservative;
+   * pass an options object only when the content model intentionally needs extra
+   * tags, attributes, or URL schemes.
+   *
    * @default false
    */
   sanitize?: boolean | SanitizeOptions;
 
   /**
    * Append an "edit this page" link to rendered Markdown.
+   *
+   * The feature is enabled only when `repoUrl` is provided in the options object.
+   * Passing `true` keeps the feature disabled because there is not enough
+   * repository information to generate valid links.
+   *
    * @default false
    */
   editThisPage?: boolean | EditThisPageOptions;
@@ -356,18 +492,32 @@ export interface OxContentOptions {
 
   /**
    * Lint fenced code blocks during Markdown transforms.
+   *
+   * Use this as a lightweight authoring check for missing languages or trailing
+   * whitespace inside fences. For project-wide linting, prefer the exported
+   * `lintCodeBlocks()` helper or the Markdown lint APIs.
+   *
    * @default false
    */
   codeBlockLint?: boolean | CodeBlockLintOptions;
 
   /**
    * Type-check TypeScript/TSX code fences via tsgo.
+   *
+   * By default only fences with explicit opt-in metadata are checked. This keeps
+   * incidental examples cheap while allowing docs-as-code snippets to fail the
+   * build when configured with `mode: 'error'`.
+   *
    * @default false
    */
   codeBlockTypecheck?: boolean | CodeBlockTypecheckOptions;
 
   /**
    * Extract runnable fenced examples for Vitest docs-as-tests harnesses.
+   *
+   * Collected examples can be written by the docs test helpers and executed as
+   * part of a normal Vitest suite.
+   *
    * @default false
    */
   docsTests?: boolean | DocsTestOptions;
@@ -404,11 +554,15 @@ export interface OxContentOptions {
 
   /**
    * OG image generation options.
+   * Ignored unless `ogImage` or `ssg.generateOgImage` is enabled.
+   * @default { vuePlugin: 'vitejs', width: 1200, height: 630, cache: true, concurrency: 1 }
    */
   ogImageOptions?: OgImageOptions;
 
   /**
    * Custom AST transformers.
+   * Transformers run after parsing and before the final JavaScript module is emitted.
+   * @default []
    */
   transformers?: MarkdownTransformer[];
 
@@ -575,47 +729,160 @@ export interface ResolvedBuiltinEmbedOptions {
   webContainer: boolean;
 }
 
+/**
+ * Options for expanding Obsidian-style wiki links.
+ *
+ * The transform accepts `[[target]]` and `[[target|label]]` syntax and rewrites
+ * it to regular links before rendering. It is intentionally small: path
+ * resolution is based on the configured base URL rather than a full backlink
+ * graph.
+ */
 export interface WikiLinkOptions {
+  /**
+   * Base URL prepended to resolved wiki-link targets.
+   *
+   * When omitted, the top-level `base` option is used.
+   *
+   * @default options.base
+   */
   baseUrl?: string;
 }
 
+/**
+ * Resolved wiki-link transform options.
+ */
 export interface ResolvedWikiLinkOptions {
   enabled: boolean;
   baseUrl: string;
 }
 
+/**
+ * Options for expanding `:shortcode:` emoji aliases.
+ *
+ * The transform replaces recognized shortcode tokens with their Unicode emoji
+ * equivalents during Markdown transformation. Unknown shortcodes are left
+ * untouched so colon-delimited text can still be used by other tools.
+ */
 export interface EmojiShortcodeOptions {
+  /**
+   * Custom shortcode map merged with the built-in emoji aliases.
+   *
+   * Keys should omit the surrounding colons.
+   *
+   * @example
+   * ```ts
+   * custom: { shipit: '\u{1F6A2}' }
+   * ```
+   *
+   * @default {}
+   */
   custom?: Record<string, string>;
 }
 
+/**
+ * Resolved emoji-shortcode transform options.
+ */
 export interface ResolvedEmojiShortcodeOptions {
   enabled: boolean;
   custom: Record<string, string>;
 }
 
+/**
+ * Options for markdown-it-attrs style attribute blocks.
+ *
+ * Attribute blocks let authors attach IDs, classes, and key/value attributes to
+ * nearby Markdown nodes with syntax such as `{#install .lead}`.
+ */
 export interface AttrsOptions {
+  /**
+   * Enable the attrs transform when an options object is supplied.
+   *
+   * Set to `false` to keep the object shape while disabling the transform.
+   * This is mainly useful for config merging where callers want to preserve a
+   * stable object structure.
+   *
+   * @default true
+   */
   enabled?: boolean;
 }
 
+/**
+ * Resolved attrs transform options.
+ */
 export interface ResolvedAttrsOptions {
   enabled: boolean;
 }
 
+/**
+ * Options for importing source snippets into code fences.
+ *
+ * The transform resolves `<<<` imports before code highlighting and other
+ * code-block features run. Imported snippets therefore behave like ordinary
+ * fenced code in later stages.
+ */
 export interface CodeImportOptions {
+  /**
+   * Directory used to resolve `<<<` imports.
+   *
+   * When omitted, imports resolve from the Vite project root and configured aliases.
+   *
+   * @example
+   * ```ts
+   * rootDir: 'examples'
+   * ```
+   *
+   * @default undefined
+   */
   rootDir?: string;
 }
 
+/**
+ * Resolved code-import transform options.
+ */
 export interface ResolvedCodeImportOptions {
   enabled: boolean;
   rootDir?: string;
 }
 
+/**
+ * Options for sanitizing rendered HTML.
+ *
+ * Sanitization happens after Markdown is rendered to HTML. This makes it useful
+ * for user-authored content, but consumers should avoid enabling extra tags or
+ * schemes unless the rendered output explicitly requires them.
+ */
 export interface SanitizeOptions {
+  /**
+   * Allowed HTML tag names. Omit to use the built-in safe tag allow list.
+   *
+   * Provide a full replacement list, not a list of additions.
+   *
+   * @default undefined
+   */
   allowedTags?: string[];
+
+  /**
+   * Allowed HTML attribute names. Omit to use the built-in safe attribute allow list.
+   *
+   * Provide a full replacement list, not a list of additions.
+   *
+   * @default undefined
+   */
   allowedAttributes?: string[];
+
+  /**
+   * Allowed URL schemes for link-like attributes.
+   *
+   * Omit to use the built-in safe scheme allow list.
+   *
+   * @default undefined
+   */
   allowedUrlSchemes?: string[];
 }
 
+/**
+ * Resolved sanitize transform options.
+ */
 export interface ResolvedSanitizeOptions {
   enabled: boolean;
   allowedTags?: string[];
@@ -623,13 +890,58 @@ export interface ResolvedSanitizeOptions {
   allowedUrlSchemes?: string[];
 }
 
+/**
+ * Options for appending an "edit this page" link.
+ *
+ * The generated link points at the source Markdown file rather than the emitted
+ * HTML route. Configure `branch` and `rootDir` to match the repository layout
+ * users should edit.
+ */
 export interface EditThisPageOptions {
+  /**
+   * Repository URL used to build edit links.
+   *
+   * The transform is enabled only when this value is provided.
+   *
+   * @example
+   * ```ts
+   * repoUrl: 'https://github.com/owner/project'
+   * ```
+   */
   repoUrl: string;
+
+  /**
+   * Branch used in generated edit links.
+   *
+   * Use the branch that accepts documentation changes, not necessarily the
+   * branch that produced the deployed site.
+   *
+   * @default 'main'
+   */
   branch?: string;
+
+  /**
+   * Source root inside the repository, used before the page path.
+   *
+   * Set this when `srcDir` is nested in a package or docs workspace.
+   *
+   * @default undefined
+   */
   rootDir?: string;
+
+  /**
+   * Link text rendered in the page footer.
+   *
+   * Keep this short; the default theme renders it as a compact footer action.
+   *
+   * @default 'Edit this page'
+   */
   label?: string;
 }
 
+/**
+ * Resolved edit-link transform options.
+ */
 export interface ResolvedEditThisPageOptions {
   enabled: boolean;
   repoUrl?: string;
@@ -638,13 +950,55 @@ export interface ResolvedEditThisPageOptions {
   label: string;
 }
 
+/**
+ * Options for linting fenced code blocks during Markdown transforms.
+ *
+ * These checks are intentionally local to each fence. They do not execute code
+ * or parse a project graph, so they are safe to run during normal Markdown
+ * transformation.
+ */
 export interface CodeBlockLintOptions {
+  /**
+   * Languages to lint. Omit to lint every fenced block language.
+   *
+   * Language names are compared case-insensitively.
+   *
+   * @default undefined
+   */
   languages?: string[];
+
+  /**
+   * Require every fenced code block to declare a language.
+   *
+   * This is helpful for documentation sites where every example should be
+   * highlighted and searchable by language.
+   *
+   * @default false
+   */
   requireLanguage?: boolean;
+
+  /**
+   * Report trailing whitespace inside fenced code blocks.
+   *
+   * The check reports the exact line and column range inside the fence content.
+   *
+   * @default true
+   */
   trailingSpaces?: boolean;
+
+  /**
+   * Diagnostic severity for lint failures.
+   *
+   * Use `'error'` when code-block lint failures should fail the build.
+   *
+   * @default 'warn'
+   */
   mode?: "warn" | "error";
 }
 
+/**
+ * Resolved code-block lint options.
+ */
 export interface ResolvedCodeBlockLintOptions {
   enabled: boolean;
   languages?: string[];
@@ -653,13 +1007,55 @@ export interface ResolvedCodeBlockLintOptions {
   mode: "warn" | "error";
 }
 
+/**
+ * Options for type-checking TypeScript and TSX fenced code blocks.
+ *
+ * Type-checking writes matching snippets to a temporary directory and invokes
+ * `tsgo`. It is best suited for concise examples that should stay synchronized
+ * with the public TypeScript API.
+ */
 export interface CodeBlockTypecheckOptions {
+  /**
+   * Fence languages to type-check.
+   *
+   * Language names are compared case-insensitively.
+   *
+   * @default ['ts', 'tsx']
+   */
   languages?: string[];
+
+  /**
+   * Require an opt-in fence meta marker before type-checking.
+   *
+   * When enabled, only fences with metadata such as `typecheck` or `twoslash`
+   * are checked.
+   *
+   * @default true
+   */
   requireMeta?: boolean;
+
+  /**
+   * Command used to run the TypeScript checker.
+   *
+   * Override this for package-manager scripts or workspace-local binaries.
+   *
+   * @default 'tsgo'
+   */
   tsgoCommand?: string;
+
+  /**
+   * Diagnostic severity for type-check failures.
+   *
+   * Use `'error'` to fail the Markdown transform on broken snippets.
+   *
+   * @default 'warn'
+   */
   mode?: "warn" | "error";
 }
 
+/**
+ * Resolved code-block type-check options.
+ */
 export interface ResolvedCodeBlockTypecheckOptions {
   enabled: boolean;
   languages: string[];
@@ -668,11 +1064,36 @@ export interface ResolvedCodeBlockTypecheckOptions {
   mode: "warn" | "error";
 }
 
+/**
+ * Options for extracting fenced examples into docs-as-tests fixtures.
+ *
+ * The extractor collects code fences that can be written into test files and
+ * executed by the exported docs test harness helpers.
+ */
 export interface DocsTestOptions {
+  /**
+   * Fence languages to collect as runnable examples.
+   *
+   * Language names are compared case-insensitively.
+   *
+   * @default ['js', 'jsx', 'ts', 'tsx']
+   */
   languages?: string[];
+
+  /**
+   * Require an opt-in fence meta marker before collecting an example.
+   *
+   * When enabled, only fences marked with metadata such as `test`, `runnable`,
+   * `vitest`, or `docs-test` are collected.
+   *
+   * @default true
+   */
   requireMeta?: boolean;
 }
 
+/**
+ * Resolved docs-as-tests extraction options.
+ */
 export interface ResolvedDocsTestOptions {
   enabled: boolean;
   languages: string[];
@@ -936,45 +1357,82 @@ export interface ResolvedDocsEntryPoint {
 
 /**
  * Options for source documentation generation.
+ *
+ * The generator extracts JSDoc/TSDoc comments from JavaScript and TypeScript
+ * source files, normalizes the declarations, and writes Markdown plus optional
+ * navigation metadata. The defaults are optimized for documenting a package's
+ * public `src` tree without exposing private implementation details.
  */
 export interface DocsOptions {
   /**
-   * Enable/disable docs generation.
-   * @default true (opt-out)
+   * Enable source documentation generation.
+   *
+   * The top-level `docs` option is opt-out: omitting it enables docs generation
+   * with defaults, while `docs: false` disables the docs plugin entirely.
+   *
+   * @default true
    */
   enabled?: boolean;
 
   /**
    * Source directories to scan for documentation.
+   *
+   * Paths are resolved from the Vite project root before applying `include` and
+   * `exclude` patterns.
+   *
    * @default ['./src']
    */
   src?: string[];
 
   /**
    * Output directory for generated documentation.
+   *
+   * The path is resolved from the Vite project root. Markdown pages, `docs.json`,
+   * and generated navigation metadata are written under this directory.
+   *
    * @default 'docs/api'
    */
   out?: string;
 
   /**
    * Glob patterns for files to include.
+   *
+   * Patterns are evaluated inside each `src` directory.
+   *
    * @default ['**\/*.ts', '**\/*.tsx', '**\/*.js', '**\/*.jsx', '**\/*.mts', '**\/*.mjs', '**\/*.cts', '**\/*.cjs']
    */
   include?: string[];
 
   /**
    * Glob patterns for files to exclude.
+   *
+   * Excludes run after `include` matching and should cover tests, generated
+   * files, and implementation-only entry points.
+   *
    * @default ['**\/*.test.*', '**\/*.spec.*', 'node_modules']
    */
   exclude?: string[];
 
   /**
    * Public API entry points used to group re-exported docs.
+   *
+   * When omitted, docs are generated from the discovered source files without
+   * entry-point grouping.
+   *
+   * Use entry points when a package exposes a smaller public surface than its
+   * source tree. Re-exported declarations are grouped under the entry point that
+   * exposes them.
+   *
+   * @default undefined
    */
   entryPoints?: DocsEntryPoint[];
 
   /**
    * Output format.
+   *
+   * `markdown` is the primary supported format. `json` and `html` are reserved
+   * for consumers that want to post-process extracted documentation data.
+   *
    * @default 'markdown'
    */
   format?: "markdown" | "json" | "html";
@@ -993,7 +1451,8 @@ export interface DocsOptions {
 
   /**
    * Generate table of contents for each file.
-   * @default true
+   * Reserved for future use; current generated API pages do not emit this TOC.
+   * @default false
    */
   toc?: boolean;
 
@@ -1005,25 +1464,44 @@ export interface DocsOptions {
 
   /**
    * GitHub repository URL for source code links.
-   * When provided, generated documentation will include links to source code.
-   * Example: 'https://github.com/ubugeeei-prod/ox-content'
+   *
+   * When provided, generated documentation includes links back to the source
+   * declaration lines.
+   *
+   * @example
+   * ```ts
+   * githubUrl: 'https://github.com/ubugeeei-prod/ox-content'
+   * ```
+   *
+   * @default undefined
    */
   githubUrl?: string;
 
   /**
    * Internal documentation link style.
+   *
+   * Use `markdown` for generated `.md` targets and `clean` for route-style links
+   * consumed by static-site frameworks.
+   *
    * @default 'markdown'
    */
   linkStyle?: "markdown" | "clean";
 
   /**
    * Route prefix used by generated documentation links and nav metadata.
-   * Nav metadata falls back to '/api' when this is not set.
+   *
+   * Nav metadata falls back to `/api` when this is not set.
+   *
+   * @default undefined
    */
   basePath?: string;
 
   /**
    * Generated Markdown output path strategy.
+   *
+   * `flat` emits one page per source module or category. `typedoc` emits
+   * TypeDoc-like module, kind, and symbol pages for larger API references.
+   *
    * @default 'flat'
    */
   pathStrategy?: "flat" | "typedoc";
@@ -1112,11 +1590,15 @@ export interface DocsOptions {
 
   /**
    * TypeDoc-style group order for module index sections and nav groups.
+   * Use `*` as the insertion point for unlisted groups.
+   * @default undefined
    */
   groupOrder?: string[];
 
   /**
    * TypeDoc-style sort strategies applied to entries and members.
+   * Strategies run in order; later strategies break ties from earlier ones.
+   * @default undefined
    */
   sort?: DocsSortStrategy[];
 
@@ -1128,6 +1610,7 @@ export interface DocsOptions {
 
   /**
    * TypeDoc-style declaration kind ranking for module sections and nav groups.
+   * @default undefined
    */
   kindSortOrder?: string[];
 
@@ -1189,20 +1672,49 @@ export interface ResolvedDocsOptions {
 
 /**
  * A single documentation entry extracted from source.
+ *
+ * Entries represent top-level declarations such as functions, classes,
+ * interfaces, type aliases, enums, variables, and modules. Members of compound
+ * declarations are stored in `members`.
  */
 export interface DocEntry {
+  /** Exported or declared symbol name. */
   name: string;
+
+  /** Normalized declaration kind used for grouping and rendering. */
   kind: "function" | "class" | "interface" | "type" | "enum" | "variable" | "module";
+
+  /** Main prose extracted from the leading JSDoc/TSDoc block. */
   description: string;
+
+  /** Function, method, or constructor parameter documentation. */
   params?: ParamDoc[];
+
+  /** Return value documentation for callable declarations. */
   returns?: ReturnDoc;
+
+  /** Code examples collected from `@example` tags. */
   examples?: string[];
+
+  /** Additional tags preserved by tag name after known tags are normalized. */
   tags?: Record<string, string>;
+
+  /** True when the entry is marked private or matched by private filtering. */
   private?: boolean;
+
+  /** Source file path relative to the extraction root when available. */
   file: string;
+
+  /** 1-based start line of the declaration in the source file. */
   line: number;
+
+  /** 1-based end line of the declaration in the source file. */
   endLine: number;
-  signature?: string; // Full function/type signature (for functions and type aliases)
+
+  /** Full declaration signature, when the renderer can extract one. */
+  signature?: string;
+
+  /** Members belonging to classes, interfaces, object types, and enums. */
   members?: DocMember[];
 }
 
@@ -1210,20 +1722,49 @@ export interface DocEntry {
  * A member belonging to a class, interface, type alias, or enum entry.
  */
 export interface DocMember {
+  /** Member name as it appears in the containing declaration. */
   name: string;
+
+  /** Normalized member kind used for rendering and sorting. */
   kind: "property" | "method" | "constructor" | "getter" | "setter" | "enumMember";
+
+  /** Main prose extracted from the member's documentation comment. */
   description: string;
+
+  /** Full member signature, when available. */
   signature?: string;
+
+  /** Rendered TypeScript type text for properties and enum members. */
   type?: string;
+
+  /** Default value extracted from syntax or `@default` tags. */
   default?: string;
+
+  /** Parameter documentation for methods and constructors. */
   params?: ParamDoc[];
+
+  /** Return value documentation for methods and accessors. */
   returns?: ReturnDoc;
+
+  /** True when the member is optional in the source declaration. */
   optional?: boolean;
+
+  /** True when the member is declared readonly. */
   readonly?: boolean;
+
+  /** True when the member is static. */
   static?: boolean;
+
+  /** True when the member is marked private or matched by private filtering. */
   private?: boolean;
+
+  /** Additional tags preserved by tag name after known tags are normalized. */
   tags?: Record<string, string>;
+
+  /** 1-based start line of the member declaration. */
   line: number;
+
+  /** 1-based end line of the member declaration. */
   endLine: number;
 }
 
@@ -1231,10 +1772,19 @@ export interface DocMember {
  * Parameter documentation.
  */
 export interface ParamDoc {
+  /** Parameter name, including dotted names for destructured properties. */
   name: string;
+
+  /** Rendered TypeScript type text. */
   type: string;
+
+  /** Prose extracted from `@param` / `@arg` documentation. */
   description: string;
+
+  /** True when the parameter is optional. */
   optional?: boolean;
+
+  /** Default value extracted from syntax or `@default` tags. */
   default?: string;
 }
 
@@ -1242,7 +1792,10 @@ export interface ParamDoc {
  * Return type documentation.
  */
 export interface ReturnDoc {
+  /** Rendered TypeScript type text for the return value. */
   type: string;
+
+  /** Prose extracted from `@returns` / `@return` documentation. */
   description: string;
 }
 
@@ -1250,11 +1803,22 @@ export interface ReturnDoc {
  * Extracted documentation for a single file.
  */
 export interface ExtractedDocs {
+  /** Source module or file identifier used by generated output. */
   file: string;
+
+  /** Optional module-level description extracted from a file header comment. */
   description?: string;
+
+  /** Absolute source path, when available for source links and diagnostics. */
   sourcePath?: string;
+
+  /** Module-level examples collected from a file header comment. */
   examples?: string[];
+
+  /** Module-level tags preserved by tag name. */
   tags?: Record<string, string>;
+
+  /** Top-level documented declarations found in this module. */
   entries: DocEntry[];
 }
 
@@ -1262,12 +1826,25 @@ export interface ExtractedDocs {
  * Summary counts emitted with generated documentation data.
  */
 export interface DocsSummary {
+  /** Number of modules included in the generated payload. */
   modules: number;
+
+  /** Number of top-level entries across all modules. */
   entries: number;
+
+  /** Entry counts grouped by normalized declaration kind. */
   byKind: Record<string, number>;
+
+  /** Number of documented parameters. */
   params: number;
+
+  /** Number of documented return values. */
   returns: number;
+
+  /** Number of collected examples. */
   examples: number;
+
+  /** Number of entries or members marked with `@deprecated`. */
   deprecated: number;
 }
 
@@ -1275,9 +1852,16 @@ export interface DocsSummary {
  * Machine-readable payload emitted alongside generated docs.
  */
 export interface GeneratedDocsData {
+  /** Payload schema version. Increment when the JSON shape changes incompatibly. */
   version: 1;
+
+  /** ISO timestamp for the generation run. */
   generatedAt: string;
+
+  /** Aggregate counts useful for dashboards and generated index pages. */
   summary: DocsSummary;
+
+  /** Extracted documentation modules in render order. */
   modules: ExtractedDocs[];
 }
 
@@ -1307,34 +1891,57 @@ export interface NavItem {
 
 /**
  * Options for full-text search.
+ *
+ * Search indexes are built from Markdown content at build time and loaded by
+ * the client runtime from `search-index.json`. Pass `false` to the top-level
+ * `search` option to disable both index generation and the virtual search
+ * module.
  */
 export interface SearchOptions {
   /**
    * Enable search functionality.
+   *
+   * Set this to `false` when config merging requires an object shape but search
+   * should be disabled.
+   *
    * @default true
    */
   enabled?: boolean;
 
   /**
    * Maximum number of search results.
+   *
+   * This controls client-side result truncation, not the number of documents in
+   * the generated index.
+   *
    * @default 10
    */
   limit?: number;
 
   /**
    * Enable prefix matching for autocomplete.
+   *
+   * Prefix matching applies to the final query token, which keeps normal terms
+   * precise while still supporting typeahead-style interactions.
+   *
    * @default true
    */
   prefix?: boolean;
 
   /**
    * Placeholder text for the search input.
+   *
+   * This value is embedded in the virtual search module for UI consumers.
+   *
    * @default 'Search documentation...'
    */
   placeholder?: string;
 
   /**
    * Keyboard shortcut to focus search (without modifier).
+   *
+   * Use an empty string to let the UI opt out of registering a shortcut.
+   *
    * @default '/'
    */
   hotkey?: string;
@@ -1355,11 +1962,22 @@ export interface ResolvedSearchOptions {
  * Search document structure.
  */
 export interface SearchDocument {
+  /** Stable document identifier used by the search index. */
   id: string;
+
+  /** Human-readable document title. */
   title: string;
+
+  /** URL returned to search consumers. */
   url: string;
+
+  /** Plain-text body content used for scoring and snippets. */
   body: string;
+
+  /** Headings extracted from the document. */
   headings: string[];
+
+  /** Code block text extracted from the document. */
   code: string[];
 }
 
@@ -1367,12 +1985,25 @@ export interface SearchDocument {
  * Search result structure.
  */
 export interface SearchResult {
+  /** Matching document identifier. */
   id: string;
+
+  /** Matching document title. */
   title: string;
+
+  /** URL to open when the result is selected. */
   url: string;
+
+  /** Relevance score returned by the BM25 search engine. */
   score: number;
+
+  /** Query terms that matched the document. */
   matches: string[];
+
+  /** Context snippet with highlighted terms when available. */
   snippet: string;
+
+  /** Hierarchical scopes derived from the result URL or document id. */
   scopes?: string[];
 }
 
@@ -1380,7 +2011,10 @@ export interface SearchResult {
  * Parsed search query with optional scope prefixes.
  */
 export interface ScopedSearchQuery {
+  /** Query text after `@scope` prefixes have been removed. */
   text: string;
+
+  /** Deduplicated lowercase scope prefixes requested by the query. */
   scopes: string[];
 }
 
@@ -1390,59 +2024,96 @@ export interface ScopedSearchQuery {
 
 /**
  * Locale configuration.
+ *
+ * Locales define the routing and display metadata used by the i18n plugin.
  */
 export interface LocaleConfig {
   /** BCP 47 locale tag (e.g., 'en', 'ja', 'zh-Hans'). */
   code: string;
+
   /** Display name for this locale (e.g., 'English', '日本語'). */
   name: string;
-  /** Text direction. @default 'ltr' */
+
+  /**
+   * Text direction for rendered pages.
+   *
+   * @default 'ltr'
+   */
   dir?: "ltr" | "rtl";
 }
 
 /**
  * i18n (internationalization) options.
+ *
+ * i18n is opt-in because it changes routing and build-time validation. Set
+ * `enabled: true` and configure at least `defaultLocale` / `locales` when the
+ * same content tree should serve multiple languages.
  */
 export interface I18nOptions {
   /**
    * Enable i18n.
+   *
+   * The resolver returns `false` unless this is explicitly set to `true`.
+   *
    * @default false
    */
   enabled?: boolean;
 
   /**
    * Path to i18n dictionary directory (relative to project root).
+   *
+   * Dictionary files are watched in development and checked during builds when
+   * `check` is enabled.
+   *
    * @default 'content/i18n'
    */
   dir?: string;
 
   /**
    * Default locale tag.
+   *
+   * The default locale is added to `locales` automatically when omitted from the
+   * list.
+   *
    * @default 'en'
    */
   defaultLocale?: string;
 
   /**
    * Available locales.
+   *
+   * When omitted, ox-content creates a single locale from `defaultLocale`.
+   *
+   * @default [{ code: defaultLocale, name: defaultLocale }]
    */
   locales?: LocaleConfig[];
 
   /**
    * Hide default locale prefix in URLs.
+   *
    * When true, `/page` serves the default locale and `/ja/page` serves Japanese.
    * When false, all locales get prefixed: `/en/page`, `/ja/page`.
+   *
    * @default true
    */
   hideDefaultLocale?: boolean;
 
   /**
    * Run i18n checks during build.
+   *
+   * Checks validate dictionary coverage and translation function usage when the
+   * native i18n checker is available.
+   *
    * @default true
    */
   check?: boolean;
 
   /**
    * Translation function names to detect in source code.
+   *
+   * Add framework-specific wrappers here so build-time checks can find all
+   * translation keys.
+   *
    * @default ['t', '$t']
    */
   functionNames?: string[];


### PR DESCRIPTION
## Summary

-

## Risk

- Risk level: low / medium / high
- User or production impact:
- Rollback plan:

## Validation

- [ ] Automated tests or checks run:
- [ ] Manual verification completed:
- [ ] Edge cases or failure modes considered:

## Release and docs checklist

- [ ] Documentation, comments, or runbooks updated, or not needed.
- [ ] Configuration, migration, or environment changes documented, or not needed.
- [ ] Observability, logging, and alerting impact considered, or not needed.
- [ ] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783669233&installation_id=136613492&pr_number=372&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F372&signature=eecc075f8634dff5e7015797de8029689bf7d07519e61462bfbaef0a0cbbe6c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->