### PR TITLE
refactor: prefer fx hash collections

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -4,10 +4,17 @@ disallowed-macros = [
 ]
 
 disallowed-methods = [
+  { path = "alloc::string::ToString::to_string", reason = "prefer borrowed strings, CompactString, or allocator-owned strings instead of creating std::String temporaries" },
   { path = "std::string::ToString::to_string", reason = "prefer borrowed strings, CompactString, or allocator-owned strings instead of creating std::String temporaries" },
 ]
 
 disallowed-types = [
+  { path = "alloc::string::String", reason = "prefer CompactString, Cow<str>, arena strings, or direct buffer writes unless an owned API boundary requires std::String" },
+  { path = "alloc::vec::Vec", reason = "prefer SmallVec, slices, iterators, or arena-owned ox_content_allocator::Vec unless an owned API boundary requires std::Vec" },
+  { path = "std::collections::BTreeMap", reason = "avoid tree maps in hot paths unless ordering is required and documented" },
+  { path = "std::collections::BTreeSet", reason = "avoid tree sets in hot paths unless ordering is required and documented" },
+  { path = "std::collections::HashMap", reason = "prefer rustc_hash::FxHashMap for hot paths" },
+  { path = "std::collections::HashSet", reason = "prefer rustc_hash::FxHashSet for hot paths" },
   { path = "std::boxed::Box", reason = "prefer concrete/static dispatch or arena-owned ox_content_allocator::Box in hot paths" },
   { path = "std::string::String", reason = "prefer CompactString, Cow<str>, arena strings, or direct buffer writes unless an owned API boundary requires std::String" },
   { path = "std::vec::Vec", reason = "prefer SmallVec, slices, iterators, or arena-owned ox_content_allocator::Vec unless an owned API boundary requires std::Vec" },

--- a/crates/ox_content_docs/src/graph.rs
+++ b/crates/ox_content_docs/src/graph.rs
@@ -515,6 +515,7 @@ fn module_tags_from_normalized_entry(entry: &NormalizedDocEntry) -> Vec<ApiDocTa
 }
 
 fn explicit_module_name_from_tags(
+    // Normalized doc tags are ordered for deterministic generated output.
     tags: &std::collections::BTreeMap<String, String>,
 ) -> Option<&str> {
     tags.get("module")

--- a/crates/ox_content_docs/src/markdown.rs
+++ b/crates/ox_content_docs/src/markdown.rs
@@ -1,8 +1,10 @@
 //! Markdown rendering for generated API reference documentation.
 
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use std::borrow::Cow;
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, HashMap, HashSet};
+// BTreeMap keeps generated API section and tag output deterministic.
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::OnceLock;
@@ -258,7 +260,7 @@ struct MarkdownLinkContext<'a> {
     options: &'a MarkdownDocsOptions,
     current_file_name: &'a str,
     current_module_name: &'a str,
-    symbol_map: &'a HashMap<String, Vec<SymbolLocation>>,
+    symbol_map: &'a FxHashMap<String, Vec<SymbolLocation>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -292,7 +294,7 @@ pub fn generate_markdown(
             return generate_typedoc_markdown(&sorted_docs, options, &symbol_map);
         }
 
-        let mut doc_to_file = HashMap::new();
+        let mut doc_to_file = FxHashMap::default();
 
         for doc in &sorted_docs {
             let file_name = module_file_name(&doc.file);
@@ -1121,7 +1123,7 @@ fn sort_extracted_docs(docs: &[ApiDocModule], options: &MarkdownDocsOptions) -> 
 }
 
 fn annotate_implementation_relationships(docs: &mut [ApiDocModule]) {
-    let mut implemented_names = HashSet::new();
+    let mut implemented_names = FxHashSet::default();
     for doc in docs.iter() {
         for entry in &doc.entries {
             if entry.kind != "class" || entry.implements.is_empty() {
@@ -1137,8 +1139,8 @@ fn annotate_implementation_relationships(docs: &mut [ApiDocModule]) {
         return;
     }
 
-    let mut implementable_members: HashMap<String, HashSet<String>> =
-        HashMap::with_capacity(implemented_names.len());
+    let mut implementable_members: FxHashMap<String, FxHashSet<String>> =
+        FxHashMap::with_capacity_and_hasher(implemented_names.len(), FxBuildHasher);
     for doc in docs.iter() {
         for entry in &doc.entries {
             if !matches!(entry.kind.as_str(), "interface" | "type") {
@@ -1148,7 +1150,7 @@ fn annotate_implementation_relationships(docs: &mut [ApiDocModule]) {
                 continue;
             }
             let members =
-                entry.members.iter().map(|member| member.name.clone()).collect::<HashSet<_>>();
+                entry.members.iter().map(|member| member.name.clone()).collect::<FxHashSet<_>>();
             implementable_members.insert(entry.name.clone(), members);
         }
     }
@@ -1331,7 +1333,7 @@ fn generate_file_markdown(
     doc: &ApiDocModule,
     options: &MarkdownDocsOptions,
     current_file_name: &str,
-    symbol_map: &HashMap<String, Vec<SymbolLocation>>,
+    symbol_map: &FxHashMap<String, Vec<SymbolLocation>>,
 ) -> String {
     profile_span!("docs::render_file");
     let display_name = file_name(&doc.file);
@@ -1390,7 +1392,7 @@ fn generate_file_markdown(
 ///    defining file (i.e. the symbol is declared in that entry point), else
 /// 2. the first module that exports it, in the same order pages are emitted.
 pub struct CanonicalOwners {
-    owners: HashMap<(String, String), String>,
+    owners: FxHashMap<(String, String), String>,
 }
 
 impl CanonicalOwners {
@@ -1405,8 +1407,8 @@ impl CanonicalOwners {
             (name.to_lowercase(), name)
         });
 
-        let mut owners: HashMap<(String, String), String> = HashMap::new();
-        let mut fallback: HashMap<(String, String), String> = HashMap::new();
+        let mut owners: FxHashMap<(String, String), String> = FxHashMap::default();
+        let mut fallback: FxHashMap<(String, String), String> = FxHashMap::default();
         for doc in order {
             let module_name = module_file_name(&doc.file);
             for entry in &doc.entries {
@@ -1442,7 +1444,7 @@ impl CanonicalOwners {
 fn generate_typedoc_markdown(
     docs: &[ApiDocModule],
     options: &MarkdownDocsOptions,
-    symbol_map: &HashMap<String, Vec<SymbolLocation>>,
+    symbol_map: &FxHashMap<String, Vec<SymbolLocation>>,
 ) -> BTreeMap<String, String> {
     profile_span!("docs::render_typedoc");
     let mut result = BTreeMap::new();
@@ -1514,7 +1516,7 @@ fn typedoc_canonical_groups<'a>(
     module_name: &str,
 ) -> Vec<(String, Vec<&'a ApiDocEntry>)> {
     let mut order: Vec<String> = Vec::new();
-    let mut groups: HashMap<String, Vec<&ApiDocEntry>> = HashMap::new();
+    let mut groups: FxHashMap<String, Vec<&ApiDocEntry>> = FxHashMap::default();
     for entry in &doc.entries {
         if !owners.is_canonical(doc, entry) {
             continue;
@@ -1545,7 +1547,7 @@ fn generate_typedoc_entry_page_grouped(
     options: &MarkdownDocsOptions,
     module_name: &str,
     file_name: &str,
-    symbol_map: &HashMap<String, Vec<SymbolLocation>>,
+    symbol_map: &FxHashMap<String, Vec<SymbolLocation>>,
 ) -> String {
     profile_span!("docs::render_entry_page");
     if entries.len() == 1 {
@@ -1619,7 +1621,7 @@ fn generate_typedoc_entry_page_grouped(
 fn generate_typedoc_root_index(
     docs: &[ApiDocModule],
     options: &MarkdownDocsOptions,
-    symbol_map: &HashMap<String, Vec<SymbolLocation>>,
+    symbol_map: &FxHashMap<String, Vec<SymbolLocation>>,
 ) -> String {
     let link_context = MarkdownLinkContext {
         options,
@@ -1686,7 +1688,7 @@ fn generate_typedoc_module_index(
     doc: &ApiDocModule,
     options: &MarkdownDocsOptions,
     module_name: &str,
-    symbol_map: &HashMap<String, Vec<SymbolLocation>>,
+    symbol_map: &FxHashMap<String, Vec<SymbolLocation>>,
     owners: &CanonicalOwners,
 ) -> String {
     let current_file_name = typedoc_module_index_file_name(module_name);
@@ -1716,7 +1718,7 @@ fn generate_typedoc_module_index_for_file(
     options: &MarkdownDocsOptions,
     module_name: &str,
     page: TypedocModuleIndexPage<'_>,
-    symbol_map: &HashMap<String, Vec<SymbolLocation>>,
+    symbol_map: &FxHashMap<String, Vec<SymbolLocation>>,
     owners: &CanonicalOwners,
 ) -> String {
     profile_span!("docs::render_module_index");
@@ -1797,7 +1799,7 @@ fn generate_typedoc_module_index_for_file(
     // Symbols this module re-exports but does not own: link to the canonical page
     // instead of emitting a duplicate (matches TypeDoc's "References" section).
     // Overloads share a name, so collapse them to a single reference.
-    let mut seen_references = std::collections::HashSet::new();
+    let mut seen_references = rustc_hash::FxHashSet::default();
     let references = doc
         .entries
         .iter()
@@ -1848,7 +1850,7 @@ fn render_typedoc_kind_section(
     markdown.push_str("## ");
     markdown.push_str(typedoc_kind_title(kind));
     markdown.push_str("\n\n");
-    let mut seen = std::collections::HashSet::new();
+    let mut seen = rustc_hash::FxHashSet::default();
     if index_format == MarkdownDisplayFormat::List {
         for entry in entries {
             // Overloads share a name (and page); collapse them to one row.
@@ -1943,7 +1945,7 @@ fn generate_typedoc_entry_page(
     options: &MarkdownDocsOptions,
     module_name: &str,
     current_file_name: &str,
-    symbol_map: &HashMap<String, Vec<SymbolLocation>>,
+    symbol_map: &FxHashMap<String, Vec<SymbolLocation>>,
 ) -> String {
     let link_context = MarkdownLinkContext {
         options,
@@ -2356,7 +2358,7 @@ fn generate_entry_markdown(
     options: &MarkdownDocsOptions,
     current_file_name: Option<&str>,
     current_module_name: Option<&str>,
-    symbol_map: Option<&HashMap<String, Vec<SymbolLocation>>>,
+    symbol_map: Option<&FxHashMap<String, Vec<SymbolLocation>>>,
 ) -> String {
     let link_context = current_file_name.zip(current_module_name).zip(symbol_map).map(
         |((current_file_name, current_module_name), symbol_map)| MarkdownLinkContext {
@@ -2389,8 +2391,8 @@ fn generate_entry_markdown(
 fn generate_index(
     docs: &[ApiDocModule],
     options: &MarkdownDocsOptions,
-    doc_to_file: Option<&HashMap<String, String>>,
-    symbol_map: Option<&HashMap<String, Vec<SymbolLocation>>>,
+    doc_to_file: Option<&FxHashMap<String, String>>,
+    symbol_map: Option<&FxHashMap<String, Vec<SymbolLocation>>>,
 ) -> String {
     let link_context = symbol_map.map(|symbol_map| MarkdownLinkContext {
         options,
@@ -2489,7 +2491,7 @@ fn generate_category_markdown(
     kind: &str,
     entries: &[ApiDocEntry],
     options: &MarkdownDocsOptions,
-    symbol_map: &HashMap<String, Vec<SymbolLocation>>,
+    symbol_map: &FxHashMap<String, Vec<SymbolLocation>>,
 ) -> String {
     let category_file_name = plural_kind_file_name(kind);
     let link_context = MarkdownLinkContext {
@@ -2551,7 +2553,7 @@ fn generate_category_markdown(
 fn generate_category_index(
     by_kind: &BTreeMap<String, Vec<ApiDocEntry>>,
     options: &MarkdownDocsOptions,
-    symbol_map: &HashMap<String, Vec<SymbolLocation>>,
+    symbol_map: &FxHashMap<String, Vec<SymbolLocation>>,
 ) -> String {
     let link_context = MarkdownLinkContext {
         options,
@@ -2694,7 +2696,7 @@ fn is_type_ident_part(byte: u8) -> bool {
 fn resolve_type_fragments(
     value: &str,
     context: Option<&MarkdownLinkContext<'_>>,
-    skip: &HashSet<&str>,
+    skip: &FxHashSet<&str>,
 ) -> Option<Vec<TypeFragment>> {
     let context = context?;
     let bytes = value.as_bytes();
@@ -2763,9 +2765,9 @@ fn resolve_type_fragments(
 fn build_symbol_map(
     docs: &[ApiDocModule],
     options: &MarkdownDocsOptions,
-) -> HashMap<String, Vec<SymbolLocation>> {
+) -> FxHashMap<String, Vec<SymbolLocation>> {
     profile_span!("docs::build_symbol_map");
-    let mut map = HashMap::new();
+    let mut map = FxHashMap::default();
     // In the TypeDoc strategy a re-exported symbol has a single canonical page;
     // resolve every reference to that owner module so cross-links never point at
     // a duplicate page that is no longer emitted.
@@ -2819,7 +2821,7 @@ fn build_symbol_map(
 }
 
 fn insert_symbol_location(
-    map: &mut HashMap<String, Vec<SymbolLocation>>,
+    map: &mut FxHashMap<String, Vec<SymbolLocation>>,
     symbol_name: String,
     location: SymbolLocation,
 ) {

--- a/crates/ox_content_docs/src/markdown/markdown_html.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_html.rs
@@ -5,7 +5,7 @@
 //! extraction/formatting/link helpers via `super::` and emits the ox-content theme
 //! HTML structures (`<details>`, stats, member tables, prose blocks, …).
 
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 use std::sync::OnceLock;
 
 use regex::Regex;
@@ -23,7 +23,7 @@ use crate::model::{
     ApiTypeParamDoc,
 };
 use crate::string_builder::{join3, StringBuilder};
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 fn escape_html(value: &str) -> String {
     // Most inputs here are symbol names, type annotations, and kind labels,
@@ -372,7 +372,7 @@ fn render_highlighted_inline_code_html(code: &str, class_name: &str, language: &
 fn render_type_inner_html(
     value: &str,
     context: Option<&MarkdownLinkContext<'_>>,
-    skip: &HashSet<&str>,
+    skip: &FxHashSet<&str>,
 ) -> String {
     let value = collapse_type_annotation_whitespace(value);
     match resolve_type_fragments(&value, context, skip) {
@@ -628,7 +628,11 @@ fn render_params_list_html(
         rows.push_str("<li class=\"ox-api-entry__param\">\n  <div class=\"ox-api-entry__param-heading\">\n    <code class=\"ox-api-entry__param-name\">");
         rows.push_str(&escape_html(&param.name));
         rows.push_str("</code>\n    <code class=\"ox-api-entry__param-type\">");
-        rows.push_str(&render_type_inner_html(&param.type_annotation, context, &HashSet::new()));
+        rows.push_str(&render_type_inner_html(
+            &param.type_annotation,
+            context,
+            &FxHashSet::default(),
+        ));
         rows.push_str("</code>\n  </div>\n  ");
         if !description.is_empty() {
             rows.push_str("<p class=\"ox-api-entry__param-description\">");
@@ -668,7 +672,11 @@ fn render_params_table_html(
         rows.push_str("<tr>\n  <td><code>");
         rows.push_str(&escape_html(&param.name));
         rows.push_str("</code></td>\n  <td><code>");
-        rows.push_str(&render_type_inner_html(&param.type_annotation, context, &HashSet::new()));
+        rows.push_str(&render_type_inner_html(
+            &param.type_annotation,
+            context,
+            &FxHashSet::default(),
+        ));
         rows.push_str("</code></td>\n  <td>");
         rows.push_str(&render_doc_inline_html(&description, context));
         rows.push_str("</td>\n</tr>");
@@ -697,7 +705,7 @@ fn render_params_table_html(
 fn render_type_parameter_name_html(
     type_param: &ApiTypeParamDoc,
     context: Option<&MarkdownLinkContext<'_>>,
-    skip: &HashSet<&str>,
+    skip: &FxHashSet<&str>,
 ) -> String {
     let mut name = StringBuilder::new();
     name.push_str("<code>");
@@ -718,7 +726,7 @@ fn render_type_parameter_name_html(
 
 /// Names of all type parameters in a list (never linked inside their own siblings'
 /// constraints/defaults).
-fn type_parameter_skip_set(type_parameters: &[ApiTypeParamDoc]) -> HashSet<&str> {
+fn type_parameter_skip_set(type_parameters: &[ApiTypeParamDoc]) -> FxHashSet<&str> {
     type_parameters.iter().map(|param| param.name.as_str()).collect()
 }
 
@@ -876,7 +884,7 @@ fn render_member_flags(member: &ApiDocMember) -> String {
 fn render_member_type_html(
     member: &ApiDocMember,
     context: Option<&MarkdownLinkContext<'_>>,
-    skip: &HashSet<&str>,
+    skip: &FxHashSet<&str>,
 ) -> String {
     let value = member
         .signature
@@ -1024,7 +1032,7 @@ fn render_member_params_html(
             rows.push_str(&render_type_inner_html(
                 &param.type_annotation,
                 context,
-                &HashSet::new(),
+                &FxHashSet::default(),
             ));
             rows.push_str("</code></td><td>");
             rows.push_str(&render_doc_inline_html(&description, context));
@@ -1144,7 +1152,7 @@ fn render_member_table_html(
             rows.push_str("</span></td>\n  ");
         }
         rows.push_str("<td>");
-        rows.push_str(&render_member_type_html(member, context, &HashSet::new()));
+        rows.push_str(&render_member_type_html(member, context, &FxHashSet::default()));
         rows.push_str("</td>\n  <td>");
         rows.push_str(&render_member_description_html(member, options, context));
         rows.push_str("</td>\n</tr>");
@@ -1222,7 +1230,7 @@ fn render_member_list_html(
         items.push_str("\n    <span class=\"ox-api-entry__member-kind\">");
         items.push_str(&escape_html(&member.kind));
         items.push_str("</span>\n    ");
-        items.push_str(&render_member_type_html(member, context, &HashSet::new()));
+        items.push_str(&render_member_type_html(member, context, &FxHashSet::default()));
         items.push_str("\n  </div>\n  ");
         items.push_str(&render_member_description_html(member, options, context));
         let property_members = render_property_members_html(&member.members, options, context);
@@ -1435,7 +1443,7 @@ fn render_member_detail_returns_html(
 ) -> String {
     let mut out = StringBuilder::new();
     out.push_str("<div class=\"ox-api-entry__member-detail-section ox-api-entry__member-detail-section--returns\">\n<h6>Returns</h6>\n<code class=\"ox-api-entry__return-type\">");
-    out.push_str(&render_type_inner_html(&returns.type_annotation, context, &HashSet::new()));
+    out.push_str(&render_type_inner_html(&returns.type_annotation, context, &FxHashSet::default()));
     out.push_str("</code>");
     if !returns.description.is_empty() {
         out.push_str("<p class=\"ox-api-entry__return-description\">");
@@ -1685,14 +1693,14 @@ fn push_index_signature_code_html(
     out.push_char('[');
     out.push_str(&escape_html(&param.name));
     out.push_str(": ");
-    out.push_str(&render_type_inner_html(&param.type_annotation, context, &HashSet::new()));
+    out.push_str(&render_type_inner_html(&param.type_annotation, context, &FxHashSet::default()));
     out.push_str("]: ");
     let member_type = member
         .type_annotation
         .as_deref()
         .or_else(|| member.returns.as_ref().map(|returns| returns.type_annotation.as_str()))
         .unwrap_or("unknown");
-    out.push_str(&render_type_inner_html(member_type, context, &HashSet::new()));
+    out.push_str(&render_type_inner_html(member_type, context, &FxHashSet::default()));
 }
 
 fn render_entry_body_html(
@@ -1781,7 +1789,7 @@ fn push_heritage_section_html(
     body.push_str("</h4>\n<ul class=\"ox-api-entry__heritage-list\">");
     for item in items {
         body.push_str("<li><code>");
-        body.push_str(&render_type_inner_html(item, link_context, &HashSet::new()));
+        body.push_str(&render_type_inner_html(item, link_context, &FxHashSet::default()));
         body.push_str("</code></li>");
     }
     body.push_str("</ul>\n</div>\n");
@@ -1836,7 +1844,11 @@ fn push_returns_html(
 <div class=\"ox-api-entry__return\">
   <code class=\"ox-api-entry__return-type\">",
     );
-    body.push_str(&render_type_inner_html(&returns.type_annotation, link_context, &HashSet::new()));
+    body.push_str(&render_type_inner_html(
+        &returns.type_annotation,
+        link_context,
+        &FxHashSet::default(),
+    ));
     body.push_str(
         "</code>
   ",
@@ -1934,7 +1946,7 @@ fn render_throws_item_html(
     let mut out = StringBuilder::new();
     if let Some(type_annotation) = type_annotation {
         out.push_str("<code class=\"ox-api-entry__throws-type\">");
-        out.push_str(&render_type_inner_html(type_annotation, link_context, &HashSet::new()));
+        out.push_str(&render_type_inner_html(type_annotation, link_context, &FxHashSet::default()));
         out.push_str("</code>");
         if !description.is_empty() {
             out.push_str(" <span class=\"ox-api-entry__throws-description\">");
@@ -2144,7 +2156,7 @@ fn render_nested_member_type_html(
 
     let mut out = StringBuilder::new();
     out.push_str("<code class=\"ox-api-entry__member-type language-typescript\">");
-    out.push_str(&render_type_inner_html(member_type, link_context, &HashSet::new()));
+    out.push_str(&render_type_inner_html(member_type, link_context, &FxHashSet::default()));
     out.push_str("</code>");
     out.into_string()
 }
@@ -2182,7 +2194,7 @@ fn push_return_member_signature_html(
         .as_deref()
         .or_else(|| member.returns.as_ref().map(|returns| returns.type_annotation.as_str()))
         .unwrap_or("unknown");
-    out.push_str(&render_type_inner_html(member_type, link_context, &HashSet::new()));
+    out.push_str(&render_type_inner_html(member_type, link_context, &FxHashSet::default()));
     out.push_char(';');
 }
 
@@ -2461,7 +2473,7 @@ pub(super) fn render_module_section_html(
 pub(super) fn render_module_index_html(
     docs: &[ApiDocModule],
     options: &MarkdownDocsOptions,
-    doc_to_file: Option<&HashMap<String, String>>,
+    doc_to_file: Option<&FxHashMap<String, String>>,
     display_format: MarkdownDisplayFormat,
     link_context: Option<&MarkdownLinkContext<'_>>,
 ) -> String {

--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -6,7 +6,7 @@
 //! same per-entry information as the HTML renderer — but as Markdown headings,
 //! tables and fenced code blocks (no `<details>`, no theme-specific HTML).
 
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 
 use super::{
     collapse_inline_whitespace, collapse_type_annotation_whitespace, effective_members_format,
@@ -334,7 +334,7 @@ fn push_type_parameters(
     }
     out.push_str(heading);
     out.push_str(" Type Parameters\n\n");
-    let skip: HashSet<&str> = type_parameters.iter().map(|param| param.name.as_str()).collect();
+    let skip: FxHashSet<&str> = type_parameters.iter().map(|param| param.name.as_str()).collect();
     match effective_parameters_format(options) {
         MarkdownDisplayFormat::Table => {
             let has_description = type_parameters_have_descriptions(type_parameters);
@@ -845,7 +845,7 @@ fn render_member_parameter_sections_pure(
             out.push(' ');
             out.push_str(&member.name);
             out.push_str(" Type Parameters\n\n");
-            let skip: HashSet<&str> =
+            let skip: FxHashSet<&str> =
                 member.type_parameters.iter().map(|param| param.name.as_str()).collect();
             match effective_parameters_format(options) {
                 MarkdownDisplayFormat::Table => {
@@ -1411,7 +1411,7 @@ fn escape_type_text(text: &str, in_cell: bool) -> String {
 fn linked_type(
     value: &str,
     context: Option<&MarkdownLinkContext<'_>>,
-    skip: &HashSet<&str>,
+    skip: &FxHashSet<&str>,
     code: fn(&str) -> String,
     in_cell: bool,
 ) -> String {
@@ -1439,11 +1439,11 @@ fn linked_type(
 }
 
 fn linked_type_cell(value: &str, context: Option<&MarkdownLinkContext<'_>>) -> String {
-    linked_type(value, context, &HashSet::new(), code_cell, true)
+    linked_type(value, context, &FxHashSet::default(), code_cell, true)
 }
 
 fn linked_type_span(value: &str, context: Option<&MarkdownLinkContext<'_>>) -> String {
-    linked_type(value, context, &HashSet::new(), code_span, false)
+    linked_type(value, context, &FxHashSet::default(), code_span, false)
 }
 
 /// Builds the Name cell for a type parameter: `` `T` `` plus optional `*extends*`
@@ -1452,7 +1452,7 @@ fn linked_type_span(value: &str, context: Option<&MarkdownLinkContext<'_>>) -> S
 fn type_param_name_cell(
     type_param: &ApiTypeParamDoc,
     context: Option<&MarkdownLinkContext<'_>>,
-    skip: &HashSet<&str>,
+    skip: &FxHashSet<&str>,
 ) -> String {
     type_param_name(type_param, context, skip, code_cell, true)
 }
@@ -1460,7 +1460,7 @@ fn type_param_name_cell(
 fn type_param_name_span(
     type_param: &ApiTypeParamDoc,
     context: Option<&MarkdownLinkContext<'_>>,
-    skip: &HashSet<&str>,
+    skip: &FxHashSet<&str>,
 ) -> String {
     type_param_name(type_param, context, skip, code_span, false)
 }
@@ -1468,7 +1468,7 @@ fn type_param_name_span(
 fn type_param_name(
     type_param: &ApiTypeParamDoc,
     context: Option<&MarkdownLinkContext<'_>>,
-    skip: &HashSet<&str>,
+    skip: &FxHashSet<&str>,
     code: fn(&str) -> String,
     in_cell: bool,
 ) -> String {

--- a/crates/ox_content_docs/src/nav.rs
+++ b/crates/ox_content_docs/src/nav.rs
@@ -220,7 +220,7 @@ fn generate_typedoc_nav_metadata(
                 let kind_path = nav_route_path(&base_path, &kind_file_name);
                 // Overloads share a name and resolve to one typedoc page, so collapse
                 // them to a single sidebar leaf (matching the module index).
-                let mut seen = std::collections::HashSet::new();
+                let mut seen = rustc_hash::FxHashSet::default();
                 let entry_children = entries
                     .into_iter()
                     .filter(|entry| seen.insert(entry.name.as_str()))

--- a/crates/ox_content_docs/src/normalize.rs
+++ b/crates/ox_content_docs/src/normalize.rs
@@ -1,5 +1,6 @@
 //! Normalized documentation entries for JavaScript-facing generators.
 
+// BTreeMap/BTreeSet keep generated tag and type-parameter output deterministic.
 use std::collections::BTreeMap;
 
 use phf::phf_set;

--- a/crates/ox_content_docs/src/output.rs
+++ b/crates/ox_content_docs/src/output.rs
@@ -1,5 +1,6 @@
 //! Generated API documentation output writing.
 
+// BTreeMap keeps generated file output deterministic across runs.
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;

--- a/crates/ox_content_i18n/Cargo.toml
+++ b/crates/ox_content_i18n/Cargo.toml
@@ -15,6 +15,7 @@ description = "i18n core library for Ox Content — MF2 parser, dictionary manag
 workspace = true
 
 [dependencies]
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/ox_content_i18n/src/checker.rs
+++ b/crates/ox_content_i18n/src/checker.rs
@@ -1,6 +1,8 @@
 use std::collections::HashSet;
 use std::hash::BuildHasher;
 
+use rustc_hash::FxHashSet;
+
 use crate::dictionary::DictionarySet;
 use crate::mf2;
 
@@ -41,6 +43,7 @@ impl std::fmt::Display for Diagnostic {
 
 /// Checks for keys used in source code that are missing from dictionaries.
 #[must_use]
+#[allow(clippy::disallowed_types)]
 pub fn check_missing_keys<S: BuildHasher>(
     used_keys: &HashSet<String, S>,
     dict_set: &DictionarySet,
@@ -67,6 +70,7 @@ pub fn check_missing_keys<S: BuildHasher>(
 
 /// Checks for keys in dictionaries that are not used in source code.
 #[must_use]
+#[allow(clippy::disallowed_types)]
 pub fn check_unused_keys<S: BuildHasher>(
     used_keys: &HashSet<String, S>,
     dict_set: &DictionarySet,
@@ -97,7 +101,7 @@ pub fn check_type_mismatch(dict_set: &DictionarySet) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
 
     // Collect all keys from all locales
-    let mut all_keys: HashSet<String> = HashSet::new();
+    let mut all_keys: FxHashSet<String> = FxHashSet::default();
     for locale in dict_set.locales() {
         if let Some(dict) = dict_set.get(locale) {
             for key in dict.keys() {
@@ -108,7 +112,7 @@ pub fn check_type_mismatch(dict_set: &DictionarySet) -> Vec<Diagnostic> {
 
     // For each key, compare variable sets across locales
     for key in &all_keys {
-        let mut locale_vars: Vec<(String, HashSet<String>)> = Vec::new();
+        let mut locale_vars: Vec<(String, FxHashSet<String>)> = Vec::new();
 
         for locale in dict_set.locales() {
             if let Some(dict) = dict_set.get(locale) {
@@ -195,6 +199,7 @@ pub fn check_syntax_errors(dict_set: &DictionarySet) -> Vec<Diagnostic> {
 
 /// Runs all checks and returns combined diagnostics.
 #[must_use]
+#[allow(clippy::disallowed_types)]
 pub fn check_all<S: BuildHasher>(
     used_keys: &HashSet<String, S>,
     dict_set: &DictionarySet,
@@ -234,7 +239,7 @@ mod tests {
     #[test]
     fn missing_keys() {
         let dict_set = make_dict_set();
-        let mut used = HashSet::new();
+        let mut used = FxHashSet::default();
         used.insert("common.greeting".to_string());
         used.insert("common.unknown".to_string());
 
@@ -246,7 +251,7 @@ mod tests {
     #[test]
     fn unused_keys() {
         let dict_set = make_dict_set();
-        let used: HashSet<String> = HashSet::new(); // nothing used
+        let used: FxHashSet<String> = FxHashSet::default(); // nothing used
 
         let diags = check_unused_keys(&used, &dict_set);
         assert!(!diags.is_empty());
@@ -266,7 +271,7 @@ mod tests {
 
         let diags = check_type_mismatch(&set);
         assert!(!diags.is_empty());
-        // Depending on HashMap iteration order, the diagnostic may report
+        // Depending on hash iteration order, the diagnostic may report
         // "missing variables" or "extra variables".
         assert!(diags
             .iter()

--- a/crates/ox_content_i18n/src/dictionary.rs
+++ b/crates/ox_content_i18n/src/dictionary.rs
@@ -1,7 +1,7 @@
 pub mod json;
 pub mod yaml;
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::Path;
 
 use crate::error::{I18nError, I18nResult};
@@ -11,7 +11,7 @@ use crate::locale::Locale;
 /// A flat map of translation keys to their MF2 message strings for one locale.
 #[derive(Debug, Clone, Default)]
 pub struct Dictionary {
-    entries: HashMap<String, String>,
+    entries: FxHashMap<String, String>,
 }
 
 impl Dictionary {
@@ -58,7 +58,7 @@ impl Dictionary {
 /// A collection of dictionaries, one per locale.
 #[derive(Debug, Clone, Default)]
 pub struct DictionarySet {
-    dictionaries: HashMap<String, Dictionary>,
+    dictionaries: FxHashMap<String, Dictionary>,
     default_locale: Option<Locale>,
 }
 

--- a/crates/ox_content_i18n/src/mf2/validator.rs
+++ b/crates/ox_content_i18n/src/mf2/validator.rs
@@ -3,20 +3,20 @@ use crate::mf2::ast::{
     ComplexBody, ComplexMessage, Declaration, Expression, Message, Operand, Pattern, PatternPart,
     Variant,
 };
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 
 /// Performs semantic validation on a parsed MF2 message.
 pub fn validate(message: &Message) -> Vec<I18nError> {
     let mut errors = Vec::new();
     match message {
-        Message::Simple(pattern) => validate_pattern(pattern, &HashSet::new(), &mut errors),
+        Message::Simple(pattern) => validate_pattern(pattern, &FxHashSet::default(), &mut errors),
         Message::Complex(complex) => validate_complex(complex, &mut errors),
     }
     errors
 }
 
 fn validate_complex(complex: &ComplexMessage, errors: &mut Vec<I18nError>) {
-    let mut declared_vars: HashSet<String> = HashSet::new();
+    let mut declared_vars: FxHashSet<String> = FxHashSet::default();
 
     // Collect declared variables
     for decl in &complex.declarations {
@@ -85,7 +85,7 @@ fn validate_complex(complex: &ComplexMessage, errors: &mut Vec<I18nError>) {
 
 fn validate_pattern(
     pattern: &Pattern,
-    declared_vars: &HashSet<String>,
+    declared_vars: &FxHashSet<String>,
     errors: &mut Vec<I18nError>,
 ) {
     for part in &pattern.parts {
@@ -97,12 +97,12 @@ fn validate_pattern(
 
 fn validate_expression(
     expr: &Expression,
-    _declared_vars: &HashSet<String>,
+    _declared_vars: &FxHashSet<String>,
     errors: &mut Vec<I18nError>,
 ) {
     // Validate that annotation options are not duplicated
     if let Some(ann) = &expr.annotation {
-        let mut seen_opts: HashSet<String> = HashSet::new();
+        let mut seen_opts: FxHashSet<String> = FxHashSet::default();
         for opt in &ann.options {
             if !seen_opts.insert(opt.name.clone()) {
                 errors.push(I18nError::Mf2Validation {
@@ -136,8 +136,8 @@ fn validate_catch_all(variants: &[Variant], selector_count: usize, errors: &mut 
 
 /// Extracts all variable names referenced in a message.
 #[must_use]
-pub fn extract_variables(message: &Message) -> HashSet<String> {
-    let mut vars = HashSet::new();
+pub fn extract_variables(message: &Message) -> FxHashSet<String> {
+    let mut vars = FxHashSet::default();
     match message {
         Message::Simple(pattern) => extract_pattern_vars(pattern, &mut vars),
         Message::Complex(complex) => {
@@ -167,7 +167,7 @@ pub fn extract_variables(message: &Message) -> HashSet<String> {
     vars
 }
 
-fn extract_pattern_vars(pattern: &Pattern, vars: &mut HashSet<String>) {
+fn extract_pattern_vars(pattern: &Pattern, vars: &mut FxHashSet<String>) {
     for part in &pattern.parts {
         if let PatternPart::Expression(expr) = part {
             extract_expression_vars(expr, vars);
@@ -175,7 +175,7 @@ fn extract_pattern_vars(pattern: &Pattern, vars: &mut HashSet<String>) {
     }
 }
 
-fn extract_expression_vars(expr: &Expression, vars: &mut HashSet<String>) {
+fn extract_expression_vars(expr: &Expression, vars: &mut FxHashSet<String>) {
     if let Some(Operand::Variable(name)) = &expr.operand {
         vars.insert(name.clone());
     }

--- a/crates/ox_content_i18n/src/runtime.rs
+++ b/crates/ox_content_i18n/src/runtime.rs
@@ -1,6 +1,6 @@
 //! JavaScript runtime module generation for Ox Content i18n.
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -39,17 +39,19 @@ pub struct I18nRuntimeConfig {
 }
 
 /// Flat dictionaries keyed by locale, then translation key.
-pub type FlatDictionaries = HashMap<String, HashMap<String, String>>;
+pub type FlatDictionaries = FxHashMap<String, FxHashMap<String, String>>;
 
 /// Converts a dictionary set into the flat shape consumed by the JS runtime.
 #[must_use]
 pub fn flatten_dictionary_set(set: &DictionarySet) -> FlatDictionaries {
-    let mut result = HashMap::new();
+    let mut result = FxHashMap::default();
 
     for locale in set.locales() {
         if let Some(dict) = set.get(locale) {
-            let flat =
-                dict.iter().map(|(key, value)| (key.to_string(), value.to_string())).collect();
+            let flat = dict
+                .iter()
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .collect::<FxHashMap<_, _>>();
             result.insert(locale.to_string(), flat);
         }
     }
@@ -108,10 +110,10 @@ mod tests {
 
     #[test]
     fn runtime_module_embeds_config_and_dictionaries() {
-        let mut dictionaries = FlatDictionaries::new();
+        let mut dictionaries = FlatDictionaries::default();
         dictionaries.insert(
             "en-US".to_string(),
-            HashMap::from([("common.greeting".to_string(), "Hello".to_string())]),
+            std::iter::once(("common.greeting".to_string(), "Hello".to_string())).collect(),
         );
 
         let module = generate_runtime_module(&test_config(), &dictionaries);

--- a/crates/ox_content_i18n_checker/Cargo.toml
+++ b/crates/ox_content_i18n_checker/Cargo.toml
@@ -22,6 +22,7 @@ oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_span = { workspace = true }
 miette = { workspace = true }
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/ox_content_i18n_checker/src/lib.rs
+++ b/crates/ox_content_i18n_checker/src/lib.rs
@@ -21,7 +21,7 @@ pub mod diagnostic;
 pub mod key_collector;
 pub mod md_key_collector;
 
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 use std::path::Path;
 
 use ox_content_i18n::checker::{self, Diagnostic};
@@ -65,7 +65,7 @@ impl Default for CheckConfig {
 /// Result of running the i18n check.
 pub struct CheckResult {
     pub diagnostics: Vec<Diagnostic>,
-    pub used_keys: HashSet<String>,
+    pub used_keys: FxHashSet<String>,
     pub error_count: usize,
     pub warning_count: usize,
 }
@@ -90,7 +90,7 @@ pub fn check(config: &CheckConfig) -> Result<CheckResult, String> {
         KeyCollector::with_function_names(config.function_names.clone())
     };
 
-    let mut used_keys = HashSet::new();
+    let mut used_keys = FxHashSet::default();
 
     for src_dir in &config.src_dirs {
         collect_keys_recursive(Path::new(src_dir), &collector, &config.extensions, &mut used_keys)?;
@@ -111,7 +111,7 @@ fn collect_keys_recursive(
     dir: &Path,
     collector: &KeyCollector,
     extensions: &[String],
-    keys: &mut HashSet<String>,
+    keys: &mut FxHashSet<String>,
 ) -> Result<(), String> {
     if !dir.exists() {
         return Ok(());

--- a/crates/ox_content_i18n_lsp/Cargo.toml
+++ b/crates/ox_content_i18n_lsp/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/main.rs"
 ox_content_i18n = { workspace = true }
 ox_content_i18n_checker = { workspace = true }
 oxc_span = { workspace = true }
+rustc-hash = { workspace = true }
 tower-lsp = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/ox_content_i18n_lsp/src/state.rs
+++ b/crates/ox_content_i18n_lsp/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -21,11 +21,11 @@ struct Inner {
     /// Loaded dictionaries.
     dict_set: DictionarySet,
     /// Cache of file → collected key usages.
-    file_keys: HashMap<String, Vec<KeyUsage>>,
+    file_keys: FxHashMap<String, Vec<KeyUsage>>,
     /// All used keys (union of file_keys values).
-    all_keys: HashSet<String>,
+    all_keys: FxHashSet<String>,
     /// Text content of currently open documents.
-    document_texts: HashMap<String, String>,
+    document_texts: FxHashMap<String, String>,
     /// URIs of currently open documents.
     open_uris: Vec<Url>,
 }
@@ -38,9 +38,9 @@ impl LspState {
                 root: None,
                 dict_dir: None,
                 dict_set: DictionarySet::new(),
-                file_keys: HashMap::new(),
-                all_keys: HashSet::new(),
-                document_texts: HashMap::new(),
+                file_keys: FxHashMap::default(),
+                all_keys: FxHashSet::default(),
+                document_texts: FxHashMap::default(),
                 open_uris: Vec::new(),
             })),
         }
@@ -107,7 +107,7 @@ impl LspState {
     /// Returns all translation keys from all locales' dictionaries.
     pub async fn all_dictionary_keys(&self) -> Vec<String> {
         let inner = self.inner.read().await;
-        let mut keys = HashSet::new();
+        let mut keys = FxHashSet::default();
         for locale in inner.dict_set.locales() {
             if let Some(dict) = inner.dict_set.get(locale) {
                 for key in dict.keys() {

--- a/crates/ox_content_link_checker/Cargo.toml
+++ b/crates/ox_content_link_checker/Cargo.toml
@@ -23,5 +23,6 @@ ox_content_allocator = { workspace = true }
 ox_content_ast = { workspace = true }
 ox_content_parser = { workspace = true }
 clap = { workspace = true }
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/ox_content_link_checker/src/lib.rs
+++ b/crates/ox_content_link_checker/src/lib.rs
@@ -19,7 +19,7 @@
 //! assert_eq!(diagnostics.len(), 1);
 //! ```
 
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 use std::path::{Path, PathBuf};
 
 use ox_content_allocator::Allocator;
@@ -118,7 +118,7 @@ pub fn check_source(source: &str, options: &CheckOptions) -> Vec<Diagnostic> {
 struct Walker<'src, 'opts> {
     diagnostics: Vec<Diagnostic>,
     line_index: &'src LineIndex,
-    anchors: &'src HashSet<String>,
+    anchors: &'src FxHashSet<String>,
     base_dir: Option<&'opts Path>,
     src_dir: Option<&'opts Path>,
     ignore_patterns: &'opts [String],
@@ -321,13 +321,17 @@ fn anchor_of(target: &str) -> Option<&str> {
     target.strip_prefix('#')
 }
 
-fn collect_anchors<'src>(source: &str, document: &'src Document<'src>) -> HashSet<String> {
-    let mut anchors = HashSet::new();
+fn collect_anchors<'src>(source: &str, document: &'src Document<'src>) -> FxHashSet<String> {
+    let mut anchors = FxHashSet::default();
     collect_anchors_into(source, &document.children, &mut anchors);
     anchors
 }
 
-fn collect_anchors_into<'src>(source: &str, nodes: &'src [Node<'src>], out: &mut HashSet<String>) {
+fn collect_anchors_into<'src>(
+    source: &str,
+    nodes: &'src [Node<'src>],
+    out: &mut FxHashSet<String>,
+) {
     for node in nodes {
         if let Node::Heading(heading) = node {
             let text = inline_text(source, &heading.children);

--- a/crates/ox_content_lsp/Cargo.toml
+++ b/crates/ox_content_lsp/Cargo.toml
@@ -28,6 +28,7 @@ ox_content_link_checker = { workspace = true }
 ox_content_parser = { workspace = true }
 ox_content_renderer = { workspace = true }
 oxc_span = { workspace = true }
+rustc-hash = { workspace = true }
 tower-lsp = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/ox_content_lsp/src/backend/commands.rs
+++ b/crates/ox_content_lsp/src/backend/commands.rs
@@ -30,6 +30,7 @@ struct EditCommandPayload {
 }
 
 impl Backend {
+    #[allow(clippy::disallowed_types)]
     pub(super) async fn insert_template(
         &self,
         command: &str,
@@ -49,6 +50,7 @@ impl Backend {
             _ => return Ok(None),
         };
 
+        // `WorkspaceEdit` comes from lsp-types and its public shape requires std::HashMap.
         let mut changes = HashMap::new();
         changes.insert(
             uri,

--- a/crates/ox_content_lsp/src/frontmatter/complete.rs
+++ b/crates/ox_content_lsp/src/frontmatter/complete.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 
 use tower_lsp::lsp_types::{
     CompletionItem, CompletionItemKind, Documentation, Hover, HoverContents, InsertTextFormat,
@@ -74,7 +74,7 @@ fn property_items(
     block: &FrontmatterBlock,
     schema: &FrontmatterSchema,
 ) -> Vec<CompletionItem> {
-    let existing: HashSet<&str> =
+    let existing: FxHashSet<&str> =
         block.top_level_keys.iter().map(|key| key.name.as_str()).collect();
     let replace = document.word_range_at(position, |ch| {
         ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '"'

--- a/crates/ox_content_lsp/src/frontmatter/types.rs
+++ b/crates/ox_content_lsp/src/frontmatter/types.rs
@@ -1,3 +1,4 @@
+// BTreeMap keeps frontmatter schema properties deterministic in completions.
 use std::collections::BTreeMap;
 
 use serde::Deserialize;

--- a/crates/ox_content_lsp/src/i18n/state.rs
+++ b/crates/ox_content_lsp/src/i18n/state.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -18,8 +18,8 @@ pub struct I18nState {
 struct Inner {
     dict_dir: Option<PathBuf>,
     dict_set: DictionarySet,
-    file_keys: HashMap<String, Vec<KeyUsage>>,
-    all_keys: HashSet<String>,
+    file_keys: FxHashMap<String, Vec<KeyUsage>>,
+    all_keys: FxHashSet<String>,
     open_uris: Vec<Url>,
 }
 
@@ -78,7 +78,7 @@ impl I18nState {
 
     pub async fn all_dictionary_keys(&self) -> Vec<String> {
         let inner = self.inner.read().await;
-        let mut keys = HashSet::new();
+        let mut keys = FxHashSet::default();
         for locale in inner.dict_set.locales() {
             if let Some(dict) = inner.dict_set.get(locale) {
                 keys.extend(dict.keys().map(std::string::ToString::to_string));

--- a/crates/ox_content_lsp/src/state.rs
+++ b/crates/ox_content_lsp/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -15,14 +15,14 @@ pub struct LspState {
 
 #[derive(Default)]
 struct Inner {
-    documents: HashMap<Url, TextDocumentState>,
+    documents: FxHashMap<Url, TextDocumentState>,
     root: Option<PathBuf>,
     init_options: InitializationOptions,
     /// Set of document URIs the client has subscribed to preview updates
     /// for. When a subscribed document changes, the backend re-renders
     /// and pushes a `oxContent/previewDidChange` notification, replacing
     /// the polling-style refresh editors used to do client-side.
-    preview_subscriptions: HashSet<Url>,
+    preview_subscriptions: FxHashSet<Url>,
 }
 
 impl LspState {

--- a/crates/ox_content_napi/Cargo.toml
+++ b/crates/ox_content_napi/Cargo.toml
@@ -33,6 +33,7 @@ ox_content_i18n_checker = { workspace = true }
 oxc_span = { workspace = true }
 napi = { workspace = true }
 napi-derive = { workspace = true }
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/ox_content_napi/src/docs_bindings.rs
+++ b/crates/ox_content_napi/src/docs_bindings.rs
@@ -1,3 +1,4 @@
+// BTreeMap keeps JavaScript-facing docs output deterministic.
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
@@ -648,6 +649,7 @@ pub fn extract_docs_from_entry_points_napi(
 
 /// Generates Markdown API reference pages from extracted documentation entries.
 #[napi(js_name = "generateDocsMarkdown")]
+#[allow(clippy::disallowed_types)]
 pub fn generate_docs_markdown(
     docs: Vec<JsDocsMarkdownModule>,
     options: Option<JsDocsMarkdownOptions>,
@@ -744,7 +746,7 @@ pub fn generate_docs_data_json_napi(
 
 /// Writes generated API documentation files and native sidecars.
 #[napi(js_name = "writeGeneratedDocs")]
-#[allow(clippy::implicit_hasher)]
+#[allow(clippy::disallowed_types, clippy::implicit_hasher)]
 pub fn write_generated_docs(
     docs: HashMap<String, String>,
     out_dir: String,

--- a/crates/ox_content_napi/src/docs_markdown_types.rs
+++ b/crates/ox_content_napi/src/docs_markdown_types.rs
@@ -43,6 +43,7 @@ pub struct JsTypeParam {
 /// Normalized member documentation used by generated API docs.
 #[napi(object)]
 #[derive(Clone)]
+#[allow(clippy::disallowed_types)]
 pub struct JsDocMember {
     pub name: String,
     pub kind: String,
@@ -94,6 +95,7 @@ impl Default for JsDocMember {
 /// Normalized documentation entry used by generated API docs.
 #[napi(object)]
 #[derive(Clone)]
+#[allow(clippy::disallowed_types)]
 pub struct JsDocEntry {
     pub name: String,
     pub kind: String,

--- a/crates/ox_content_napi/src/features.rs
+++ b/crates/ox_content_napi/src/features.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::redundant_pub_crate)]
 
+use rustc_hash::FxHashMap;
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::{
@@ -35,7 +35,7 @@ struct WikiLinkOptions {
 
 #[derive(Clone)]
 struct EmojiShortcodeOptions {
-    custom: HashMap<String, String>,
+    custom: FxHashMap<String, String>,
 }
 
 #[derive(Clone)]
@@ -171,7 +171,9 @@ fn resolve_emoji_shortcodes(
     if options.enabled == Some(false) {
         return None;
     }
-    Some(EmojiShortcodeOptions { custom: options.custom.clone().unwrap_or_default() })
+    Some(EmojiShortcodeOptions {
+        custom: options.custom.clone().unwrap_or_default().into_iter().collect(),
+    })
 }
 
 fn resolve_attrs(options: Option<&JsAttrsOptions>) -> bool {
@@ -880,7 +882,7 @@ mod tests {
     #[test]
     fn emoji_shortcodes_use_defaults_and_custom_values() {
         let options = EmojiShortcodeOptions {
-            custom: HashMap::from([("shipit".to_string(), "ship".to_string())]),
+            custom: std::iter::once(("shipit".to_string(), "ship".to_string())).collect(),
         };
         let mut out = String::new();
         replace_emoji_shortcodes(":smile: :shipit: :octocat: :unknown:", &options, &mut out);

--- a/crates/ox_content_napi/src/features/code_blocks.rs
+++ b/crates/ox_content_napi/src/features/code_blocks.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::redundant_pub_crate)]
 
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 
 use crate::{JsCodeBlockLintOptions, JsDocsTestOptions};
 
@@ -85,7 +85,7 @@ pub(crate) fn lint_code_blocks(
     }
 
     let languages = options.languages.as_ref().map(|values| {
-        values.iter().map(|value| value.to_ascii_lowercase()).collect::<HashSet<_>>()
+        values.iter().map(|value| value.to_ascii_lowercase()).collect::<FxHashSet<_>>()
     });
     let require_language = options.require_language.unwrap_or(false);
     let trailing_spaces = options.trailing_spaces.unwrap_or(true);
@@ -152,7 +152,7 @@ pub(crate) fn extract_docs_tests(
 
     let languages = options.languages.as_ref().map_or_else(
         || ["js", "jsx", "ts", "tsx", "mjs", "mts"].into_iter().map(ToString::to_string).collect(),
-        |values| values.iter().map(|value| value.to_ascii_lowercase()).collect::<HashSet<_>>(),
+        |values| values.iter().map(|value| value.to_ascii_lowercase()).collect::<FxHashSet<_>>(),
     );
     let require_meta = options.require_meta.unwrap_or(true);
 

--- a/crates/ox_content_napi/src/i18n_bindings.rs
+++ b/crates/ox_content_napi/src/i18n_bindings.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use rustc_hash::FxHashSet;
+
 use napi_derive::napi;
 
 /// Result of loading dictionaries.
@@ -136,9 +138,14 @@ pub fn load_dictionaries(dir: String) -> I18nLoadResult {
 /// Each locale maps to a flat `{ "namespace.key": "value" }` structure.
 /// Supports both JSON and YAML dictionary files.
 #[napi]
+#[allow(clippy::disallowed_types, clippy::implicit_hasher)]
 pub fn load_dictionaries_flat(dir: String) -> HashMap<String, HashMap<String, String>> {
     let path = std::path::Path::new(&dir);
-    ox_content_i18n::runtime::load_flat_dictionaries(path).unwrap_or_default()
+    ox_content_i18n::runtime::load_flat_dictionaries(path)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(locale, dictionary)| (locale, dictionary.into_iter().collect()))
+        .collect()
 }
 
 /// Generates the `virtual:ox-content/i18n` runtime module.
@@ -191,7 +198,7 @@ pub fn check_i18n(dict_dir: String, used_keys: Vec<String>) -> I18nCheckResult {
         Err(e) => return i18n_check_error(e.to_string()),
     };
 
-    let keys_set: std::collections::HashSet<String> = used_keys.into_iter().collect();
+    let keys_set: FxHashSet<String> = used_keys.into_iter().collect();
     let diagnostics = ox_content_i18n::checker::check_all(&keys_set, &dict_set);
 
     i18n_check_result_from_diagnostics(diagnostics)

--- a/crates/ox_content_napi/src/lint.rs
+++ b/crates/ox_content_napi/src/lint.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(test, allow(dead_code))]
 
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::LazyLock;
 
 use napi_derive::napi;
@@ -41,19 +41,19 @@ static LINT_DICTIONARY_DATA: LazyLock<Option<LintDictionaryData>> = LazyLock::ne
 struct LintDictionaryData {
     global: Vec<String>,
     #[serde(rename = "byLanguage")]
-    by_language: HashMap<String, Vec<String>>,
+    by_language: FxHashMap<String, Vec<String>>,
 }
 
 #[derive(Default)]
 struct PreparedLintDictionaryData {
-    global_words: HashSet<String>,
-    by_language: HashMap<String, PreparedLanguageDictionary>,
+    global_words: FxHashSet<String>,
+    by_language: FxHashMap<String, PreparedLanguageDictionary>,
 }
 
 struct PreparedLanguageDictionary {
     has_base_words: bool,
     cjk_segment_words: Vec<SegmentWord>,
-    words: HashSet<String>,
+    words: FxHashSet<String>,
 }
 
 #[derive(Clone)]
@@ -72,7 +72,7 @@ static PREPARED_LINT_DICTIONARY_DATA: LazyLock<PreparedLintDictionaryData> = Laz
         .iter()
         .map(|word| normalize_word_for_set(word))
         .filter(|word| !word.is_empty())
-        .collect::<HashSet<_>>();
+        .collect::<FxHashSet<_>>();
 
     let by_language = SUPPORTED_MARKDOWN_LINT_LANGUAGES
         .iter()
@@ -84,7 +84,7 @@ static PREPARED_LINT_DICTIONARY_DATA: LazyLock<PreparedLintDictionaryData> = Laz
                 .flatten()
                 .map(|word| normalize_word_for_set(word))
                 .filter(|word| !word.is_empty())
-                .collect::<HashSet<_>>();
+                .collect::<FxHashSet<_>>();
 
             let mut cjk_segment_words = words
                 .iter()
@@ -179,7 +179,7 @@ struct InternalMarkdownLintOptions {
 #[derive(Clone, Default)]
 struct InternalMarkdownLintDictionary {
     words: Vec<String>,
-    by_language: HashMap<String, Vec<String>>,
+    by_language: FxHashMap<String, Vec<String>>,
     ignored_words: Vec<String>,
 }
 
@@ -195,12 +195,12 @@ struct InternalMarkdownLintRules {
 }
 
 struct DictionaryBundle {
-    active_languages: HashSet<String>,
-    cjk_segment_words: HashMap<String, Vec<SegmentWord>>,
-    extra_by_language: HashMap<String, HashSet<String>>,
-    extra_global_words: HashSet<String>,
-    ignored_words: HashSet<String>,
-    latin_words: HashSet<String>,
+    active_languages: FxHashSet<String>,
+    cjk_segment_words: FxHashMap<String, Vec<SegmentWord>>,
+    extra_by_language: FxHashMap<String, FxHashSet<String>>,
+    extra_global_words: FxHashSet<String>,
+    ignored_words: FxHashSet<String>,
+    latin_words: FxHashSet<String>,
     latin_suggestion_words: Vec<String>,
 }
 
@@ -295,7 +295,7 @@ fn collect_markdown_lint_state(
 ) -> MarkdownLintState {
     let mut diagnostics = Vec::new();
     let mut masked_lines = Vec::new();
-    let mut seen_headings = HashMap::new();
+    let mut seen_headings = FxHashMap::default();
 
     let mut blank_line_streak = 0_u32;
     let mut html_comment_open = false;
@@ -534,7 +534,7 @@ fn create_dictionary_bundle(options: &InternalMarkdownLintOptions) -> Dictionary
         .iter()
         .map(|word| normalize_word_for_set(word))
         .filter(|word| !word.is_empty())
-        .collect::<HashSet<_>>();
+        .collect::<FxHashSet<_>>();
 
     let extra_by_language = options
         .dictionary
@@ -547,14 +547,14 @@ fn create_dictionary_bundle(options: &InternalMarkdownLintOptions) -> Dictionary
                     .iter()
                     .map(|word| normalize_word_for_set(word))
                     .filter(|word| !word.is_empty())
-                    .collect::<HashSet<_>>(),
+                    .collect::<FxHashSet<_>>(),
             )
         })
         .filter(|(_, words)| !words.is_empty())
-        .collect::<HashMap<_, _>>();
+        .collect::<FxHashMap<_, _>>();
 
-    let mut latin_words = HashSet::new();
-    let mut latin_suggestion_words = HashSet::new();
+    let mut latin_words = FxHashSet::default();
+    let mut latin_suggestion_words = FxHashSet::default();
 
     for language in &options.languages {
         if language == "ja" || language == "zh" {
@@ -604,7 +604,7 @@ fn create_dictionary_bundle(options: &InternalMarkdownLintOptions) -> Dictionary
         .cloned()
         .collect();
 
-    let mut cjk_segment_words = HashMap::new();
+    let mut cjk_segment_words = FxHashMap::default();
 
     for language in
         options.languages.iter().filter(|language| *language == "ja" || *language == "zh")
@@ -838,7 +838,7 @@ fn assign_latin_languages(
     fallback_language: &str,
 ) -> Vec<Token> {
     let mut scores =
-        languages.iter().map(|language| (language.clone(), 0_usize)).collect::<HashMap<_, _>>();
+        languages.iter().map(|language| (language.clone(), 0_usize)).collect::<FxHashMap<_, _>>();
 
     let matching_languages = tokens
         .iter()
@@ -1369,7 +1369,7 @@ fn count_code_points(text: &str) -> usize {
 }
 
 fn dedupe_strings(values: Vec<String>) -> Vec<String> {
-    let mut seen = HashSet::new();
+    let mut seen = FxHashSet::default();
     let mut deduped = Vec::new();
 
     for value in values {

--- a/crates/ox_content_napi/src/parse_bindings.rs
+++ b/crates/ox_content_napi/src/parse_bindings.rs
@@ -79,6 +79,7 @@ pub struct JsSourceOrigin {
 
 /// Prepared Markdown source with parsed frontmatter.
 #[napi(object)]
+#[allow(clippy::disallowed_types)]
 pub struct PreparedSourceResult {
     /// Markdown content after optional frontmatter removal.
     pub content: String,

--- a/crates/ox_content_napi/src/sanitize.rs
+++ b/crates/ox_content_napi/src/sanitize.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 
 use crate::JsSanitizeOptions;
 
@@ -13,9 +13,9 @@ pub fn sanitize_html(html: &str, options: Option<&JsSanitizeOptions>) -> String 
 }
 
 struct SanitizeConfig {
-    tags: HashSet<String>,
-    attributes: HashSet<String>,
-    url_schemes: HashSet<String>,
+    tags: FxHashSet<String>,
+    attributes: FxHashSet<String>,
+    url_schemes: FxHashSet<String>,
 }
 
 impl Default for SanitizeConfig {

--- a/crates/ox_content_napi/src/transform_bindings.rs
+++ b/crates/ox_content_napi/src/transform_bindings.rs
@@ -27,6 +27,7 @@ pub struct JsWikiLinkOptions {
 /// Emoji-shortcode transform options.
 #[napi(object)]
 #[derive(Default, Clone)]
+#[allow(clippy::disallowed_types)]
 pub struct JsEmojiShortcodeOptions {
     /// Enable `:shortcode:` expansion.
     ///
@@ -562,7 +563,7 @@ pub fn prepare_source(source: String, options: Option<JsSourceOptions>) -> Prepa
 
     PreparedSourceResult {
         content: prepared.content,
-        frontmatter: prepared.frontmatter,
+        frontmatter: prepared.frontmatter.into_iter().collect(),
         source_offset: JsSourceOrigin {
             byte_offset: prepared.source_origin.byte_offset,
             offset: prepared.source_origin.offset,

--- a/crates/ox_content_napi/src/transformer.rs
+++ b/crates/ox_content_napi/src/transformer.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use napi::bindgen_prelude::Uint8Array;
 use ox_content_allocator::Allocator;
@@ -31,7 +31,7 @@ pub struct MarkdownTransformer {
 
 pub struct PreparedMarkdownSource {
     pub content: String,
-    pub frontmatter: HashMap<String, serde_json::Value>,
+    pub frontmatter: FxHashMap<String, serde_json::Value>,
     pub source_origin: SourceOrigin,
 }
 
@@ -181,20 +181,20 @@ impl MarkdownTransformer {
             // path borrows from this string rather than reparsing YAML.
             PreparedMarkdownSource {
                 content: source.to_string(),
-                frontmatter: HashMap::new(),
+                frontmatter: FxHashMap::default(),
                 source_origin: SourceOrigin { line: 1, column: 1, ..SourceOrigin::default() },
             }
         }
     }
 }
 
-pub fn parse_frontmatter(source: &str) -> (String, HashMap<String, serde_json::Value>) {
+pub fn parse_frontmatter(source: &str) -> (String, FxHashMap<String, serde_json::Value>) {
     let prepared = parse_frontmatter_with_origin(source);
     (prepared.content, prepared.frontmatter)
 }
 
 fn parse_frontmatter_with_origin(source: &str) -> PreparedMarkdownSource {
-    let mut frontmatter = HashMap::new();
+    let mut frontmatter = FxHashMap::default();
 
     if !source.starts_with("---") {
         return PreparedMarkdownSource {
@@ -247,7 +247,7 @@ fn source_origin_for_content(source: &str, content: &str) -> SourceOrigin {
 
 fn extract_toc(doc: &Document, max_depth: u8) -> Vec<TocEntry> {
     let mut entries = Vec::new();
-    let mut slug_counts = HashMap::new();
+    let mut slug_counts = FxHashMap::default();
 
     for node in &doc.children {
         if let Node::Heading(heading) = node {
@@ -332,7 +332,7 @@ fn slugify(text: &str) -> String {
     slug
 }
 
-fn unique_slug(slug: String, counts: &mut HashMap<String, usize>) -> String {
+fn unique_slug(slug: String, counts: &mut FxHashMap<String, usize>) -> String {
     let slug = if slug.is_empty() { "section".to_string() } else { slug };
     let count = counts.entry(slug.clone()).or_insert(0);
     let unique = if *count == 0 { slug } else { format!("{slug}-{count}") };

--- a/crates/ox_content_renderer/src/html/code_annotations/attribute.rs
+++ b/crates/ox_content_renderer/src/html/code_annotations/attribute.rs
@@ -5,6 +5,7 @@
 //! stays independent from VitePress metadata so users can opt into a stable native
 //! grammar without changing their code fence language token.
 
+// BTreeMap preserves ascending code line order during annotation rendering.
 use std::collections::BTreeMap;
 
 use smallvec::SmallVec;

--- a/crates/ox_content_renderer/src/html/code_annotations/meta.rs
+++ b/crates/ox_content_renderer/src/html/code_annotations/meta.rs
@@ -4,6 +4,7 @@
 //! syntax reads it. The token splitter preserves bracketed and braced VitePress
 //! sections as independent tokens so later stages do not need to rescan raw strings.
 
+// BTreeMap preserves ascending code line order during annotation rendering.
 use std::collections::BTreeMap;
 
 use compact_str::CompactString;

--- a/crates/ox_content_search/Cargo.toml
+++ b/crates/ox_content_search/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 
 [dependencies]
 ox_content_ast = { workspace = true }
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/ox_content_search/src/index.rs
+++ b/crates/ox_content_search/src/index.rs
@@ -1,6 +1,6 @@
 //! Search index data structures.
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use serde::{Deserialize, Serialize};
 
@@ -67,9 +67,9 @@ pub struct SearchIndex {
     /// All indexed documents.
     pub documents: Vec<SearchDocument>,
     /// Inverted index: term -> list of postings.
-    pub index: HashMap<String, Vec<Posting>>,
+    pub index: FxHashMap<String, Vec<Posting>>,
     /// Document frequency: term -> number of documents containing term.
-    pub df: HashMap<String, usize>,
+    pub df: FxHashMap<String, usize>,
     /// Average document length (for BM25).
     pub avg_dl: f64,
     /// Total number of documents.
@@ -142,12 +142,12 @@ impl SearchIndexBuilder {
     /// Builds the search index.
     #[must_use]
     pub fn build(self) -> SearchIndex {
-        let mut index: HashMap<String, Vec<Posting>> = HashMap::new();
-        let mut df: HashMap<String, usize> = HashMap::new();
+        let mut index: FxHashMap<String, Vec<Posting>> = FxHashMap::default();
+        let mut df: FxHashMap<String, usize> = FxHashMap::default();
         let mut total_length = 0usize;
 
         for (doc_idx, doc) in self.documents.iter().enumerate() {
-            let mut doc_terms: HashMap<String, (u32, Field)> = HashMap::new();
+            let mut doc_terms: FxHashMap<String, (u32, Field)> = FxHashMap::default();
 
             // Index title
             for token in tokenize(&doc.title) {

--- a/crates/ox_content_search/src/query.rs
+++ b/crates/ox_content_search/src/query.rs
@@ -1,6 +1,6 @@
 //! Search query engine with BM25 scoring.
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use serde::{Deserialize, Serialize};
 
@@ -95,7 +95,7 @@ impl SearchIndex {
         }
 
         // Calculate scores for each document
-        let mut doc_scores: HashMap<usize, (f64, Vec<String>)> = HashMap::new();
+        let mut doc_scores: FxHashMap<usize, (f64, Vec<String>)> = FxHashMap::default();
 
         for (i, token) in tokens.iter().enumerate() {
             let is_last = i == tokens.len() - 1;
@@ -155,7 +155,11 @@ impl SearchIndex {
         ((n - df + 0.5) / (df + 0.5)).ln_1p()
     }
 
-    fn score_matching_term(&self, term: &str, doc_scores: &mut HashMap<usize, (f64, Vec<String>)>) {
+    fn score_matching_term(
+        &self,
+        term: &str,
+        doc_scores: &mut FxHashMap<usize, (f64, Vec<String>)>,
+    ) {
         let Some(postings) = self.index.get(term) else {
             return;
         };

--- a/crates/ox_content_ssg/Cargo.toml
+++ b/crates/ox_content_ssg/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 
 [dependencies]
 askama = "0.16"
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/ox_content_ssg/src/assets.rs
+++ b/crates/ox_content_ssg/src/assets.rs
@@ -1,6 +1,6 @@
 //! Shared asset extraction for generated SSG pages.
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -84,7 +84,7 @@ struct BlockMatch {
 
 #[derive(Default)]
 struct AssetCache {
-    indexes_by_content: HashMap<String, usize>,
+    indexes_by_content: FxHashMap<String, usize>,
     chunks: Vec<SharedAsset>,
 }
 

--- a/crates/ox_content_ssg/src/routes.rs
+++ b/crates/ox_content_ssg/src/routes.rs
@@ -1,6 +1,7 @@
 //! Routing and navigation helpers for SSG builds.
 
 use std::cmp::Ordering;
+// BTreeMap keeps nav groups sorted deterministically before rendering.
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/ox_content_wasm/Cargo.toml
+++ b/crates/ox_content_wasm/Cargo.toml
@@ -23,6 +23,7 @@ ox_content_allocator = { workspace = true }
 ox_content_ast = { workspace = true }
 ox_content_parser = { workspace = true }
 ox_content_renderer = { workspace = true }
+rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 wasm-bindgen = "0.2"

--- a/crates/ox_content_wasm/src/lib.rs
+++ b/crates/ox_content_wasm/src/lib.rs
@@ -3,8 +3,8 @@
 //! This crate provides WASM bindings for using Ox Content in browsers
 //! and other WebAssembly environments.
 
+use rustc_hash::FxHashMap;
 use std::borrow::Cow;
-use std::collections::HashMap;
 
 use wasm_bindgen::prelude::*;
 
@@ -25,7 +25,7 @@ pub struct TocEntry {
 #[derive(serde::Serialize)]
 pub struct TransformResult {
     pub html: String,
-    pub frontmatter: HashMap<String, serde_json::Value>,
+    pub frontmatter: FxHashMap<String, serde_json::Value>,
     pub toc: Vec<TocEntry>,
     pub errors: Vec<String>,
 }
@@ -244,7 +244,7 @@ pub fn transform(source: &str, options: Option<WasmParserOptions>) -> JsValue {
         Err(e) => {
             let transform_result = TransformResult {
                 html: String::new(),
-                frontmatter: HashMap::new(),
+                frontmatter: FxHashMap::default(),
                 toc: vec![],
                 errors: vec![e.to_string()],
             };
@@ -261,11 +261,11 @@ pub fn version() -> String {
 }
 
 /// Parses YAML frontmatter from Markdown content.
-fn parse_frontmatter(source: &str) -> (Cow<'_, str>, HashMap<String, serde_json::Value>) {
+fn parse_frontmatter(source: &str) -> (Cow<'_, str>, FxHashMap<String, serde_json::Value>) {
     // wasm-bindgen exposes the JS string as `&str` for this call. Return
     // `Cow::Borrowed` for the Markdown body so stripping frontmatter adjusts
     // slice boundaries instead of copying the body into a new `String`.
-    let mut frontmatter = HashMap::new();
+    let mut frontmatter = FxHashMap::default();
 
     if !source.starts_with("---") {
         return (Cow::Borrowed(source), frontmatter);
@@ -315,7 +315,7 @@ fn parse_frontmatter(source: &str) -> (Cow<'_, str>, HashMap<String, serde_json:
 /// Extracts table of contents from document headings.
 fn extract_toc(doc: &Document, max_depth: u8) -> Vec<TocEntry> {
     let mut entries = Vec::new();
-    let mut slug_counts = HashMap::new();
+    let mut slug_counts = FxHashMap::default();
 
     for node in &doc.children {
         if let Node::Heading(heading) = node {
@@ -379,7 +379,7 @@ fn slugify(text: &str) -> String {
         .join("-")
 }
 
-fn unique_slug(slug: String, counts: &mut HashMap<String, usize>) -> String {
+fn unique_slug(slug: String, counts: &mut FxHashMap<String, usize>) -> String {
     let slug = if slug.is_empty() { "section".to_string() } else { slug };
     let count = counts.entry(slug.clone()).or_insert(0);
     let unique = if *count == 0 { slug } else { format!("{slug}-{count}") };


### PR DESCRIPTION
## Summary
- extend clippy disallowed lists for std collections and alloc aliases
- replace std HashMap/HashSet usage with rustc_hash FxHashMap/FxHashSet in implementation code
- document intentional BTreeMap/BTreeSet ordering cases and keep public boundary exceptions explicit
- keep N-API public map types on Record-compatible std HashMap boundaries

## Validation
- cargo fmt --all --check
- cargo clippy --workspace --all-targets
- cargo test --workspace
- vp run build:npm
- node scripts/package-dry-run.mjs
