### PR TITLE
refactor: use compact strings for small state

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -4,7 +4,9 @@ disallowed-macros = [
 ]
 
 disallowed-methods = [
+  { path = "alloc::string::String::new", reason = "avoid std::String for small rule state; use CompactString, or keep std::String only for explicit output buffers and ABI boundaries" },
   { path = "alloc::string::ToString::to_string", reason = "prefer borrowed strings, CompactString, or allocator-owned strings instead of creating std::String temporaries" },
+  { path = "std::string::String::new", reason = "avoid std::String for small rule state; use CompactString, or keep std::String only for explicit output buffers and ABI boundaries" },
   { path = "std::string::ToString::to_string", reason = "prefer borrowed strings, CompactString, or allocator-owned strings instead of creating std::String temporaries" },
 ]
 

--- a/crates/ox_content_incremental/Cargo.toml
+++ b/crates/ox_content_incremental/Cargo.toml
@@ -15,6 +15,7 @@ description = "Incremental Markdown parsing and rendering for Ox Content"
 workspace = true
 
 [dependencies]
+compact_str = { workspace = true }
 ox_content_allocator = { workspace = true }
 ox_content_ast = { workspace = true }
 ox_content_parser = { workspace = true }

--- a/crates/ox_content_incremental/src/provisional.rs
+++ b/crates/ox_content_incremental/src/provisional.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use compact_str::CompactString;
 use memchr::memchr;
 use ox_content_parser::ParserOptions;
 
@@ -96,7 +97,7 @@ fn provisional_inline_closers(source: &str, options: &ParserOptions) -> String {
 }
 
 fn inline_closers(mut stack: Vec<InlineDelimiter>) -> String {
-    let mut closers = String::new();
+    let mut closers = CompactString::default();
     while let Some(delimiter) = stack.pop() {
         match delimiter {
             InlineDelimiter::Strong(b'*') => closers.push_str("**"),
@@ -113,7 +114,7 @@ fn inline_closers(mut stack: Vec<InlineDelimiter>) -> String {
             }
         }
     }
-    closers
+    closers.into_string()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ox_content_lsp/Cargo.toml
+++ b/crates/ox_content_lsp/Cargo.toml
@@ -19,6 +19,7 @@ name = "ox-content-lsp"
 path = "src/main.rs"
 
 [dependencies]
+compact_str = { workspace = true }
 ox_content_allocator = { workspace = true }
 ox_content_ast = { workspace = true }
 ox_content_i18n = { workspace = true }

--- a/crates/ox_content_lsp/src/textlint.rs
+++ b/crates/ox_content_lsp/src/textlint.rs
@@ -20,6 +20,7 @@
 
 use std::path::Path;
 
+use compact_str::CompactString;
 use serde::Deserialize;
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 
@@ -168,7 +169,7 @@ pub async fn run(source: &str, file_path: &Path, config: &TextlintConfig) -> Vec
 /// three arguments).
 fn shlex_split(input: &str) -> Vec<String> {
     let mut out = Vec::new();
-    let mut current = String::new();
+    let mut current = CompactString::default();
     let mut quote: Option<char> = None;
     for ch in input.chars() {
         if let Some(q) = quote {
@@ -183,14 +184,14 @@ fn shlex_split(input: &str) -> Vec<String> {
             '"' | '\'' => quote = Some(ch),
             c if c.is_whitespace() => {
                 if !current.is_empty() {
-                    out.push(std::mem::take(&mut current));
+                    out.push(std::mem::take(&mut current).into_string());
                 }
             }
             c => current.push(c),
         }
     }
     if !current.is_empty() {
-        out.push(current);
+        out.push(current.into_string());
     }
     out
 }

--- a/crates/ox_content_napi/Cargo.toml
+++ b/crates/ox_content_napi/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+compact_str = { workspace = true }
 ox_content_allocator = { workspace = true }
 ox_content_ast = { workspace = true }
 ox_content_parser = { workspace = true }

--- a/crates/ox_content_napi/src/features.rs
+++ b/crates/ox_content_napi/src/features.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::redundant_pub_crate)]
 
+use compact_str::CompactString;
 use rustc_hash::FxHashMap;
 use std::borrow::Cow;
 use std::path::PathBuf;
@@ -707,8 +708,8 @@ fn percent_encode_path(path: &str) -> String {
 struct FenceOpen {
     fence_char: u8,
     fence_len: usize,
-    language: String,
-    meta: String,
+    language: CompactString,
+    meta: CompactString,
 }
 
 fn parse_opening_fence(line: &str) -> Option<FenceOpen> {
@@ -724,8 +725,8 @@ fn parse_opening_fence(line: &str) -> Option<FenceOpen> {
     }
     let rest = trimmed[fence_len..].trim();
     let mut parts = rest.splitn(2, char::is_whitespace);
-    let language = parts.next().unwrap_or_default().to_string();
-    let meta = parts.next().unwrap_or_default().trim().to_string();
+    let language = CompactString::from(parts.next().unwrap_or_default());
+    let meta = CompactString::from(parts.next().unwrap_or_default().trim());
     Some(FenceOpen { fence_char, fence_len, language, meta })
 }
 

--- a/crates/ox_content_napi/src/features/code_blocks.rs
+++ b/crates/ox_content_napi/src/features/code_blocks.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::redundant_pub_crate)]
 
+use compact_str::CompactString;
 use rustc_hash::FxHashSet;
 
 use crate::{JsCodeBlockLintOptions, JsDocsTestOptions};
@@ -30,8 +31,8 @@ pub(crate) fn extract_code_blocks(source: &str) -> Vec<ExtractedCodeBlock> {
     let mut in_fence = false;
     let mut fence_char = b'\0';
     let mut fence_len = 0usize;
-    let mut language = String::new();
-    let mut meta = String::new();
+    let mut language = CompactString::default();
+    let mut meta = CompactString::default();
     let mut code = String::new();
     let mut start_line = 0u32;
     let mut line_number = 0u32;
@@ -41,17 +42,15 @@ pub(crate) fn extract_code_blocks(source: &str) -> Vec<ExtractedCodeBlock> {
         if in_fence {
             if super::is_closing_fence(line, fence_char, fence_len) {
                 blocks.push(ExtractedCodeBlock {
-                    language: language.clone(),
-                    meta: meta.clone(),
-                    code: code.trim_end_matches('\n').to_string(),
+                    language: std::mem::take(&mut language).into_string(),
+                    meta: std::mem::take(&mut meta).into_string(),
+                    code: String::from(code.trim_end_matches('\n')),
                     start_line,
                     end_line: line_number.saturating_sub(1),
                 });
                 in_fence = false;
                 fence_char = b'\0';
                 fence_len = 0;
-                language.clear();
-                meta.clear();
                 code.clear();
             } else {
                 code.push_str(line);

--- a/crates/ox_content_napi/src/lint.rs
+++ b/crates/ox_content_napi/src/lint.rs
@@ -3,6 +3,7 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::LazyLock;
 
+use compact_str::CompactString;
 use napi_derive::napi;
 use regex::Regex;
 use serde::Deserialize;
@@ -1350,7 +1351,7 @@ fn normalize_latin_word(word: &str) -> String {
 }
 
 fn collapse_whitespace(text: &str) -> String {
-    let mut collapsed = String::new();
+    let mut collapsed = CompactString::default();
     let mut needs_space = false;
 
     for part in text.split_whitespace() {
@@ -1361,7 +1362,7 @@ fn collapse_whitespace(text: &str) -> String {
         needs_space = true;
     }
 
-    collapsed
+    collapsed.into_string()
 }
 
 fn count_code_points(text: &str) -> usize {

--- a/crates/ox_content_search/Cargo.toml
+++ b/crates/ox_content_search/Cargo.toml
@@ -15,6 +15,7 @@ description = "Full-text search engine for Ox Content"
 workspace = true
 
 [dependencies]
+compact_str = { workspace = true }
 ox_content_ast = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }

--- a/crates/ox_content_search/src/scope.rs
+++ b/crates/ox_content_search/src/scope.rs
@@ -1,5 +1,6 @@
 //! Scoped search query helpers.
 
+use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
 
 /// Parsed free-text query and requested search scopes.
@@ -41,14 +42,14 @@ pub fn get_search_document_scopes(id: &str, url: &str) -> Vec<String> {
     }
 
     let mut scopes = Vec::new();
-    let mut current = String::new();
+    let mut current = CompactString::default();
 
     for segment in &segments[..segments.len() - 1] {
         if !current.is_empty() {
             current.push('/');
         }
         current.push_str(segment);
-        scopes.push(current.clone());
+        scopes.push(current.clone().into_string());
     }
 
     scopes

--- a/crates/ox_content_search/src/tokenizer.rs
+++ b/crates/ox_content_search/src/tokenizer.rs
@@ -1,5 +1,7 @@
 //! Text tokenization for search indexing.
 
+use compact_str::CompactString;
+
 /// Tokenizes text into searchable terms.
 ///
 /// This tokenizer:
@@ -9,7 +11,7 @@
 /// - Handles CJK characters (Japanese, Chinese, Korean)
 pub fn tokenize(text: &str) -> Vec<String> {
     let mut tokens = Vec::new();
-    let mut current_token = String::new();
+    let mut current_token = CompactString::default();
 
     for c in text.chars() {
         if is_cjk_char(c) {
@@ -17,17 +19,17 @@ pub fn tokenize(text: &str) -> Vec<String> {
             if !current_token.is_empty() {
                 let token = current_token.to_lowercase();
                 if !is_stopword(&token) && token.len() >= 2 {
-                    tokens.push(token);
+                    tokens.push(token.into_string());
                 }
                 current_token.clear();
             }
-            tokens.push(c.to_string());
+            tokens.push(String::from(c));
         } else if c.is_alphanumeric() || c == '_' {
             current_token.push(c);
         } else if !current_token.is_empty() {
             let token = current_token.to_lowercase();
             if !is_stopword(&token) && token.len() >= 2 {
-                tokens.push(token);
+                tokens.push(token.into_string());
             }
             current_token.clear();
         }
@@ -37,7 +39,7 @@ pub fn tokenize(text: &str) -> Vec<String> {
     if !current_token.is_empty() {
         let token = current_token.to_lowercase();
         if !is_stopword(&token) && token.len() >= 2 {
-            tokens.push(token);
+            tokens.push(token.into_string());
         }
     }
 
@@ -47,25 +49,28 @@ pub fn tokenize(text: &str) -> Vec<String> {
 /// Tokenizes text for query (less strict than indexing).
 pub fn tokenize_query(text: &str) -> Vec<String> {
     let mut tokens = Vec::new();
-    let mut current_token = String::new();
+    let mut current_token = CompactString::default();
 
     for c in text.chars() {
         if is_cjk_char(c) {
             if !current_token.is_empty() {
-                tokens.push(current_token.to_lowercase());
+                let token = current_token.to_lowercase();
+                tokens.push(token.into_string());
                 current_token.clear();
             }
-            tokens.push(c.to_string());
+            tokens.push(String::from(c));
         } else if c.is_alphanumeric() || c == '_' {
             current_token.push(c);
         } else if !current_token.is_empty() {
-            tokens.push(current_token.to_lowercase());
+            let token = current_token.to_lowercase();
+            tokens.push(token.into_string());
             current_token.clear();
         }
     }
 
     if !current_token.is_empty() {
-        tokens.push(current_token.to_lowercase());
+        let token = current_token.to_lowercase();
+        tokens.push(token.into_string());
     }
 
     tokens


### PR DESCRIPTION
## Summary
- add `String::new` to the disallowed-methods guidance with an explicit CompactString/boundary rationale
- move small transient string state in search tokenization/scopes, textlint command parsing, code fence metadata, whitespace collapsing, and incremental inline closers to `CompactString`
- keep public ABI values and large output buffers as `String`

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `vp run build:npm`
- `git diff --exit-code -- crates/ox_content_napi/index.d.ts`
- `node scripts/package-dry-run.mjs`