### PR TITLE
refactor: split docs pure member rendering

### DIFF
--- a/crates/ox_content_docs/src/markdown/markdown_pure.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure.rs
@@ -19,15 +19,19 @@ use crate::model::{
 use crate::string_builder::{join2, StringBuilder};
 
 mod format;
+mod index_signatures;
 mod lifecycle;
+mod member_details;
 mod stats;
 
 use format::{
     code_cell, code_span, inline, linked_type_cell, linked_type_span, push_table_cell,
     type_param_name_cell, type_param_name_span,
 };
+use index_signatures::{push_index_signature_detail_pure, render_index_signature_group_pure};
 pub(super) use lifecycle::push_lifecycle_alerts;
 use lifecycle::render_since_section;
+use member_details::{is_callable_member, render_callable_member_details_pure};
 pub(super) use stats::render_stats_markdown;
 
 fn type_parameters_have_descriptions(type_parameters: &[ApiTypeParamDoc]) -> bool {
@@ -654,64 +658,6 @@ fn render_members_pure(
     out
 }
 
-fn push_index_signature_detail_pure(
-    out: &mut String,
-    member: &ApiDocMember,
-    context: Option<&MarkdownLinkContext<'_>>,
-    detail_heading: &str,
-) {
-    out.push_str("```ts\n");
-    push_index_signature_code_pure(out, member);
-    out.push_str("\n```\n\n");
-
-    push_lifecycle_alerts(out, &member.tags, context);
-    let description = process_doc_text(&member.description, context);
-    let description = description.trim();
-    if !description.is_empty() {
-        out.push_str(description);
-        out.push_str("\n\n");
-    }
-    out.push_str(&render_since_section(&member.tags, context, detail_heading));
-    let throws = super::rendered_throws(&member.throws, &member.tags);
-    push_throws(out, throws.as_ref(), context, detail_heading);
-    push_generic_tags(out, &member.tags, context, detail_heading);
-}
-
-fn render_index_signature_group_pure(
-    out: &mut String,
-    heading: &str,
-    members: &[&ApiDocMember],
-    context: &MemberGroupRenderContext<'_, '_>,
-) {
-    if members.is_empty() {
-        return;
-    }
-    let detail_heading = "#".repeat(context.parameter_section_level);
-    out.push_str(heading);
-    out.push_str(" Indexable\n\n");
-    for member in members {
-        push_index_signature_detail_pure(out, member, context.link_context, &detail_heading);
-    }
-}
-
-fn push_index_signature_code_pure(out: &mut String, member: &ApiDocMember) {
-    if let Some(signature) = member.signature.as_deref().filter(|signature| !signature.is_empty()) {
-        out.push_str(signature.trim().trim_end_matches(';').trim_end());
-        return;
-    }
-    if member.readonly {
-        out.push_str("readonly ");
-    }
-    out.push_str(&member.name);
-    out.push_str(": ");
-    let member_type = member
-        .type_annotation
-        .as_deref()
-        .or_else(|| member.returns.as_ref().map(|returns| returns.type_annotation.as_str()))
-        .unwrap_or("unknown");
-    out.push_str(member_type);
-}
-
 struct MemberGroupRenderContext<'a, 'ctx> {
     entry_name: &'a str,
     entry_kind: &'a str,
@@ -954,124 +900,6 @@ fn render_member_group_pure(
         context.link_context,
         context.parameter_section_level,
     ));
-}
-
-fn render_callable_member_details_pure(
-    out: &mut String,
-    title: &str,
-    members: &[&ApiDocMember],
-    context: &MemberGroupRenderContext<'_, '_>,
-) {
-    let member_heading = "#".repeat(context.parameter_section_level);
-    let detail_heading = "#".repeat(context.parameter_section_level + 1);
-
-    for (index, member) in members.iter().enumerate() {
-        if index > 0 {
-            out.push_str("***\n\n");
-        }
-        out.push_str(&member_heading);
-        out.push(' ');
-        push_callable_member_heading(out, member, title);
-        out.push_str("\n\n");
-
-        if let Some(signature) = callable_member_signature(member, context.entry_name) {
-            out.push_str("```ts\n");
-            out.push_str(&signature);
-            out.push_str("\n```\n\n");
-        }
-
-        push_lifecycle_alerts(out, &member.tags, context.link_context);
-
-        let description = process_doc_text(&member.description, context.link_context);
-        let description = description.trim();
-        if !description.is_empty() {
-            out.push_str(description);
-            out.push_str("\n\n");
-        }
-
-        out.push_str(&render_since_section(&member.tags, context.link_context, &detail_heading));
-        push_type_parameters(
-            out,
-            &member.type_parameters,
-            context.options,
-            context.link_context,
-            &detail_heading,
-        );
-        push_parameters(
-            out,
-            &member.params,
-            context.options,
-            context.link_context,
-            &detail_heading,
-        );
-        if let Some(returns) = &member.returns {
-            push_returns(out, returns, context.link_context, &detail_heading);
-        } else if member.kind == "constructor" {
-            let returns = ApiReturnDoc {
-                type_annotation: context.entry_name.to_string(),
-                description: String::new(),
-                members: Vec::new(),
-            };
-            push_returns(out, &returns, context.link_context, &detail_heading);
-        }
-        let throws = super::rendered_throws(&member.throws, &member.tags);
-        push_throws(out, throws.as_ref(), context.link_context, &detail_heading);
-        push_implementation_of(out, &member.implementation_of, &detail_heading);
-        push_generic_tags(out, &member.tags, context.link_context, &detail_heading);
-    }
-}
-
-fn is_callable_member(member: &ApiDocMember) -> bool {
-    matches!(member.kind.as_str(), "constructor" | "method" | "getter" | "setter")
-}
-
-fn push_callable_member_heading(out: &mut String, member: &ApiDocMember, title: &str) {
-    if member.kind == "constructor" {
-        out.push_str("Constructor");
-        return;
-    }
-    out.push_str(&member.name);
-    if !matches!(member.kind.as_str(), "getter" | "setter") && title.contains("Methods") {
-        out.push_str("()");
-    }
-}
-
-fn callable_member_signature(member: &ApiDocMember, entry_name: &str) -> Option<String> {
-    let signature = member.signature.as_deref()?.trim();
-    if signature.is_empty() {
-        return None;
-    }
-
-    let signature = signature.trim_end_matches(';').trim_end();
-    let mut out = StringBuilder::new();
-    if member.kind == "constructor" {
-        if let Some(args) = signature.strip_prefix("constructor") {
-            out.push_str("new ");
-            out.push_str(entry_name);
-            out.push_str(args.trim());
-            out.push_str(": ");
-            out.push_str(entry_name);
-        } else {
-            out.push_str(signature);
-        }
-    } else {
-        out.push_str(signature);
-    }
-    out.push_char(';');
-    Some(out.into_string())
-}
-
-fn push_implementation_of(out: &mut String, implementation_of: &[String], heading: &str) {
-    if implementation_of.is_empty() {
-        return;
-    }
-    out.push_str(heading);
-    out.push_str(" Implementation of\n\n");
-    for implementation in implementation_of {
-        out.push_str("```ts\n");
-        out.push_str(implementation.trim());
-        out.push_str("\n```\n\n");
-    }
 }
 
 fn member_name_cell(member: &ApiDocMember) -> String {

--- a/crates/ox_content_docs/src/markdown/markdown_pure/index_signatures.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure/index_signatures.rs
@@ -1,0 +1,63 @@
+use super::{
+    push_generic_tags, push_lifecycle_alerts, push_throws, render_since_section,
+    MarkdownLinkContext, MemberGroupRenderContext,
+};
+use crate::model::ApiDocMember;
+
+pub(super) fn push_index_signature_detail_pure(
+    out: &mut String,
+    member: &ApiDocMember,
+    context: Option<&MarkdownLinkContext<'_>>,
+    detail_heading: &str,
+) {
+    out.push_str("```ts\n");
+    push_index_signature_code_pure(out, member);
+    out.push_str("\n```\n\n");
+
+    push_lifecycle_alerts(out, &member.tags, context);
+    let description = super::process_doc_text(&member.description, context);
+    let description = description.trim();
+    if !description.is_empty() {
+        out.push_str(description);
+        out.push_str("\n\n");
+    }
+    out.push_str(&render_since_section(&member.tags, context, detail_heading));
+    let throws = super::super::rendered_throws(&member.throws, &member.tags);
+    push_throws(out, throws.as_ref(), context, detail_heading);
+    push_generic_tags(out, &member.tags, context, detail_heading);
+}
+
+pub(super) fn render_index_signature_group_pure(
+    out: &mut String,
+    heading: &str,
+    members: &[&ApiDocMember],
+    context: &MemberGroupRenderContext<'_, '_>,
+) {
+    if members.is_empty() {
+        return;
+    }
+    let detail_heading = "#".repeat(context.parameter_section_level);
+    out.push_str(heading);
+    out.push_str(" Indexable\n\n");
+    for member in members {
+        push_index_signature_detail_pure(out, member, context.link_context, &detail_heading);
+    }
+}
+
+fn push_index_signature_code_pure(out: &mut String, member: &ApiDocMember) {
+    if let Some(signature) = member.signature.as_deref().filter(|signature| !signature.is_empty()) {
+        out.push_str(signature.trim().trim_end_matches(';').trim_end());
+        return;
+    }
+    if member.readonly {
+        out.push_str("readonly ");
+    }
+    out.push_str(&member.name);
+    out.push_str(": ");
+    let member_type = member
+        .type_annotation
+        .as_deref()
+        .or_else(|| member.returns.as_ref().map(|returns| returns.type_annotation.as_str()))
+        .unwrap_or("unknown");
+    out.push_str(member_type);
+}

--- a/crates/ox_content_docs/src/markdown/markdown_pure/member_details.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_pure/member_details.rs
@@ -1,0 +1,124 @@
+use super::{
+    push_generic_tags, push_lifecycle_alerts, push_parameters, push_returns, push_throws,
+    push_type_parameters, render_since_section, MemberGroupRenderContext,
+};
+use crate::model::{ApiDocMember, ApiReturnDoc};
+use crate::string_builder::StringBuilder;
+
+pub(super) fn render_callable_member_details_pure(
+    out: &mut String,
+    title: &str,
+    members: &[&ApiDocMember],
+    context: &MemberGroupRenderContext<'_, '_>,
+) {
+    let member_heading = "#".repeat(context.parameter_section_level);
+    let detail_heading = "#".repeat(context.parameter_section_level + 1);
+
+    for (index, member) in members.iter().enumerate() {
+        if index > 0 {
+            out.push_str("***\n\n");
+        }
+        out.push_str(&member_heading);
+        out.push(' ');
+        push_callable_member_heading(out, member, title);
+        out.push_str("\n\n");
+
+        if let Some(signature) = callable_member_signature(member, context.entry_name) {
+            out.push_str("```ts\n");
+            out.push_str(&signature);
+            out.push_str("\n```\n\n");
+        }
+
+        push_lifecycle_alerts(out, &member.tags, context.link_context);
+
+        let description = super::process_doc_text(&member.description, context.link_context);
+        let description = description.trim();
+        if !description.is_empty() {
+            out.push_str(description);
+            out.push_str("\n\n");
+        }
+
+        out.push_str(&render_since_section(&member.tags, context.link_context, &detail_heading));
+        push_type_parameters(
+            out,
+            &member.type_parameters,
+            context.options,
+            context.link_context,
+            &detail_heading,
+        );
+        push_parameters(
+            out,
+            &member.params,
+            context.options,
+            context.link_context,
+            &detail_heading,
+        );
+        if let Some(returns) = &member.returns {
+            push_returns(out, returns, context.link_context, &detail_heading);
+        } else if member.kind == "constructor" {
+            let returns = ApiReturnDoc {
+                type_annotation: context.entry_name.to_string(),
+                description: String::new(),
+                members: Vec::new(),
+            };
+            push_returns(out, &returns, context.link_context, &detail_heading);
+        }
+        let throws = super::super::rendered_throws(&member.throws, &member.tags);
+        push_throws(out, throws.as_ref(), context.link_context, &detail_heading);
+        push_implementation_of(out, &member.implementation_of, &detail_heading);
+        push_generic_tags(out, &member.tags, context.link_context, &detail_heading);
+    }
+}
+
+pub(super) fn is_callable_member(member: &ApiDocMember) -> bool {
+    matches!(member.kind.as_str(), "constructor" | "method" | "getter" | "setter")
+}
+
+fn push_callable_member_heading(out: &mut String, member: &ApiDocMember, title: &str) {
+    if member.kind == "constructor" {
+        out.push_str("Constructor");
+        return;
+    }
+    out.push_str(&member.name);
+    if !matches!(member.kind.as_str(), "getter" | "setter") && title.contains("Methods") {
+        out.push_str("()");
+    }
+}
+
+fn callable_member_signature(member: &ApiDocMember, entry_name: &str) -> Option<String> {
+    let signature = member.signature.as_deref()?.trim();
+    if signature.is_empty() {
+        return None;
+    }
+
+    let signature = signature.trim_end_matches(';').trim_end();
+    let mut out = StringBuilder::new();
+    if member.kind == "constructor" {
+        if let Some(args) = signature.strip_prefix("constructor") {
+            out.push_str("new ");
+            out.push_str(entry_name);
+            out.push_str(args.trim());
+            out.push_str(": ");
+            out.push_str(entry_name);
+        } else {
+            out.push_str(signature);
+        }
+    } else {
+        out.push_str(signature);
+    }
+    out.push_char(';');
+    Some(out.into_string())
+}
+
+fn push_implementation_of(out: &mut String, implementation_of: &[String], heading: &str) {
+    if implementation_of.is_empty() {
+        return;
+    }
+    out.push_str(heading);
+    out.push_str(" Implementation of\n\n");
+    for implementation in implementation_of {
+        out.push_str("```ts\n");
+        out.push_str(implementation.trim());
+        out.push_str("\n```\n\n");
+    }
+}


### PR DESCRIPTION
## Summary
- Move pure Markdown index-signature rendering into `markdown_pure/index_signatures.rs`.
- Move pure Markdown callable member detail rendering into `markdown_pure/member_details.rs`.
- Keep the new pure Markdown helper modules under the 250-line target.

Refs #380

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p ox_content_docs`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p ox_content_docs`
- `pnpm check:file-lines`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->