### PR TITLE
refactor: split docs graph resolver

### DIFF
--- a/crates/ox_content_docs/src/graph.rs
+++ b/crates/ox_content_docs/src/graph.rs
@@ -8,13 +8,13 @@ use oxc_ast::ast::{
     ImportOrExportKind, ModuleExportName, Statement,
 };
 use oxc_parser::Parser;
-use oxc_resolver::{ResolveOptions, Resolver, TsconfigOptions, TsconfigReferences};
 use oxc_span::SourceType;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 mod error;
 mod model;
 mod options;
+mod resolver;
 
 pub use error::GraphError;
 pub use model::{
@@ -24,6 +24,7 @@ pub use model::{
 pub use options::{
     EntryPointDocsOptions, EntryPointSpec, ExternalDocsOptions, ExternalPackageSource, GraphOptions,
 };
+use resolver::{ExternalModuleRef, ModuleResolver, ResolvedModuleRef};
 
 #[allow(unused_imports)]
 use crate::profile_span;
@@ -376,159 +377,11 @@ fn export_entrypoint_message(export_name: &str, entrypoint_name: &str, suffix: &
     message.into_string()
 }
 
-struct ModuleResolver {
-    root: PathBuf,
-    resolver: Resolver,
-    external_docs_enabled: bool,
-    external_sources: FxHashMap<String, PathBuf>,
-}
-
-#[derive(Debug, Clone)]
-struct ResolvedModuleRef {
-    path: PathBuf,
-    external: Option<ExternalModuleRef>,
-}
-
-#[derive(Debug, Clone)]
-struct ExternalModuleRef {
-    package: String,
-    specifier: String,
-}
-
 #[derive(Debug, Clone)]
 struct ImportBinding {
     specifier: String,
     imported_name: String,
     type_only: bool,
-}
-
-impl ModuleResolver {
-    fn new(root: &Path, options: &GraphOptions) -> Self {
-        let mut resolve_options = ResolveOptions {
-            extensions: Vec::from([
-                String::from(".d.ts"),
-                String::from(".d.mts"),
-                String::from(".d.cts"),
-                String::from(".ts"),
-                String::from(".tsx"),
-                String::from(".mts"),
-                String::from(".cts"),
-                String::from(".js"),
-                String::from(".jsx"),
-                String::from(".mjs"),
-                String::from(".cjs"),
-                String::from(".json"),
-                String::from(".node"),
-            ]),
-            extension_alias: Vec::from([
-                (
-                    String::from(".js"),
-                    Vec::from([
-                        String::from(".ts"),
-                        String::from(".tsx"),
-                        String::from(".d.ts"),
-                        String::from(".js"),
-                    ]),
-                ),
-                (
-                    String::from(".mjs"),
-                    Vec::from([String::from(".mts"), String::from(".d.mts"), String::from(".mjs")]),
-                ),
-                (
-                    String::from(".cjs"),
-                    Vec::from([String::from(".cts"), String::from(".d.cts"), String::from(".cjs")]),
-                ),
-            ]),
-            condition_names: Vec::from([
-                String::from("types"),
-                String::from("import"),
-                String::from("module"),
-                String::from("default"),
-            ]),
-            main_fields: Vec::from([
-                String::from("types"),
-                String::from("module"),
-                String::from("main"),
-            ]),
-            ..ResolveOptions::default()
-        };
-
-        if let Some(tsconfig) = &options.tsconfig {
-            resolve_options.tsconfig = Some(TsconfigOptions {
-                config_file: absolutize(root, tsconfig),
-                references: TsconfigReferences::Auto,
-            });
-        }
-
-        let external_sources = options
-            .external_docs
-            .package_sources
-            .iter()
-            .map(|source| {
-                (source.package.clone(), normalize_existing_path(&absolutize(root, &source.entry)))
-            })
-            .collect();
-
-        Self {
-            root: root.to_path_buf(),
-            resolver: Resolver::new(resolve_options),
-            external_docs_enabled: options.external_docs.enabled,
-            external_sources,
-        }
-    }
-
-    fn resolve_specifier(
-        &self,
-        importer: &Path,
-        specifier: &str,
-    ) -> Result<Option<ResolvedModuleRef>, GraphError> {
-        profile_span!("docs::resolve_specifier");
-        if !is_local_specifier(specifier) && !self.external_docs_enabled {
-            return Ok(None);
-        }
-
-        if let Some(path) = self.resolve_external_source_override(specifier) {
-            return Ok(Some(ResolvedModuleRef {
-                path,
-                external: Some(ExternalModuleRef {
-                    package: external_package_name(specifier),
-                    specifier: specifier.to_string(),
-                }),
-            }));
-        }
-
-        let directory = importer.parent().unwrap_or_else(|| Path::new("."));
-        match self.resolver.resolve(directory, specifier) {
-            Ok(resolution) => {
-                let path = normalize_existing_path(resolution.path());
-                let external = (!is_local_specifier(specifier)).then(|| ExternalModuleRef {
-                    package: external_package_name(specifier),
-                    specifier: specifier.to_string(),
-                });
-                Ok(Some(ResolvedModuleRef { path, external }))
-            }
-            Err(error) if is_local_specifier(specifier) => Err(GraphError::Resolve {
-                importer: importer.to_path_buf(),
-                specifier: specifier.to_string(),
-                message: error.to_string(),
-            }),
-            Err(_) => Ok(None),
-        }
-    }
-
-    fn resolve_external_source_override(&self, specifier: &str) -> Option<PathBuf> {
-        if !self.external_docs_enabled || is_local_specifier(specifier) {
-            return None;
-        }
-
-        let package = external_package_name(specifier);
-        self.external_sources
-            .get(specifier)
-            .or_else(|| {
-                (specifier == package).then(|| self.external_sources.get(&package)).flatten()
-            })
-            .map(|path| normalize_existing_path(&absolutize(&self.root, path)))
-    }
 }
 
 struct GraphBuilder {

--- a/crates/ox_content_docs/src/graph/resolver.rs
+++ b/crates/ox_content_docs/src/graph/resolver.rs
@@ -1,0 +1,159 @@
+use std::path::{Path, PathBuf};
+
+use oxc_resolver::{ResolveOptions, Resolver, TsconfigOptions, TsconfigReferences};
+use rustc_hash::FxHashMap;
+
+use super::{
+    absolutize, external_package_name, is_local_specifier, normalize_existing_path, GraphError,
+    GraphOptions,
+};
+#[allow(unused_imports)]
+use crate::profile_span;
+
+pub(super) struct ModuleResolver {
+    root: PathBuf,
+    resolver: Resolver,
+    external_docs_enabled: bool,
+    external_sources: FxHashMap<String, PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ResolvedModuleRef {
+    pub(super) path: PathBuf,
+    pub(super) external: Option<ExternalModuleRef>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ExternalModuleRef {
+    pub(super) package: String,
+    pub(super) specifier: String,
+}
+
+impl ModuleResolver {
+    pub(super) fn new(root: &Path, options: &GraphOptions) -> Self {
+        let mut resolve_options = ResolveOptions {
+            extensions: Vec::from([
+                String::from(".d.ts"),
+                String::from(".d.mts"),
+                String::from(".d.cts"),
+                String::from(".ts"),
+                String::from(".tsx"),
+                String::from(".mts"),
+                String::from(".cts"),
+                String::from(".js"),
+                String::from(".jsx"),
+                String::from(".mjs"),
+                String::from(".cjs"),
+                String::from(".json"),
+                String::from(".node"),
+            ]),
+            extension_alias: Vec::from([
+                (
+                    String::from(".js"),
+                    Vec::from([
+                        String::from(".ts"),
+                        String::from(".tsx"),
+                        String::from(".d.ts"),
+                        String::from(".js"),
+                    ]),
+                ),
+                (
+                    String::from(".mjs"),
+                    Vec::from([String::from(".mts"), String::from(".d.mts"), String::from(".mjs")]),
+                ),
+                (
+                    String::from(".cjs"),
+                    Vec::from([String::from(".cts"), String::from(".d.cts"), String::from(".cjs")]),
+                ),
+            ]),
+            condition_names: Vec::from([
+                String::from("types"),
+                String::from("import"),
+                String::from("module"),
+                String::from("default"),
+            ]),
+            main_fields: Vec::from([
+                String::from("types"),
+                String::from("module"),
+                String::from("main"),
+            ]),
+            ..ResolveOptions::default()
+        };
+
+        if let Some(tsconfig) = &options.tsconfig {
+            resolve_options.tsconfig = Some(TsconfigOptions {
+                config_file: absolutize(root, tsconfig),
+                references: TsconfigReferences::Auto,
+            });
+        }
+
+        let external_sources = options
+            .external_docs
+            .package_sources
+            .iter()
+            .map(|source| {
+                (source.package.clone(), normalize_existing_path(&absolutize(root, &source.entry)))
+            })
+            .collect();
+
+        Self {
+            root: root.to_path_buf(),
+            resolver: Resolver::new(resolve_options),
+            external_docs_enabled: options.external_docs.enabled,
+            external_sources,
+        }
+    }
+
+    pub(super) fn resolve_specifier(
+        &self,
+        importer: &Path,
+        specifier: &str,
+    ) -> Result<Option<ResolvedModuleRef>, GraphError> {
+        profile_span!("docs::resolve_specifier");
+        if !is_local_specifier(specifier) && !self.external_docs_enabled {
+            return Ok(None);
+        }
+
+        if let Some(path) = self.resolve_external_source_override(specifier) {
+            return Ok(Some(ResolvedModuleRef {
+                path,
+                external: Some(ExternalModuleRef {
+                    package: external_package_name(specifier),
+                    specifier: specifier.to_string(),
+                }),
+            }));
+        }
+
+        let directory = importer.parent().unwrap_or_else(|| Path::new("."));
+        match self.resolver.resolve(directory, specifier) {
+            Ok(resolution) => {
+                let path = normalize_existing_path(resolution.path());
+                let external = (!is_local_specifier(specifier)).then(|| ExternalModuleRef {
+                    package: external_package_name(specifier),
+                    specifier: specifier.to_string(),
+                });
+                Ok(Some(ResolvedModuleRef { path, external }))
+            }
+            Err(error) if is_local_specifier(specifier) => Err(GraphError::Resolve {
+                importer: importer.to_path_buf(),
+                specifier: specifier.to_string(),
+                message: error.to_string(),
+            }),
+            Err(_) => Ok(None),
+        }
+    }
+
+    fn resolve_external_source_override(&self, specifier: &str) -> Option<PathBuf> {
+        if !self.external_docs_enabled || is_local_specifier(specifier) {
+            return None;
+        }
+
+        let package = external_package_name(specifier);
+        self.external_sources
+            .get(specifier)
+            .or_else(|| {
+                (specifier == package).then(|| self.external_sources.get(&package)).flatten()
+            })
+            .map(|path| normalize_existing_path(&absolutize(&self.root, path)))
+    }
+}


### PR DESCRIPTION
## Summary
- Move the docs export-graph module resolver structs and implementation into `graph/resolver.rs`.
- Keep graph path/specifier helpers in `graph.rs` where the builder and resolver both use them.
- Keep the new resolver module under the 250-line target.

Refs #380

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p ox_content_docs`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p ox_content_docs`
- `pnpm check:file-lines`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->