### PR TITLE
feat(lsp): wire textlint editor integration

### DIFF
--- a/crates/ox_content_lsp/src/textlint/tests.rs
+++ b/crates/ox_content_lsp/src/textlint/tests.rs
@@ -122,3 +122,37 @@ async fn run_returns_empty_when_command_is_missing() {
     let diagnostics = run("# heading\n", std::path::Path::new("/tmp/doc.md"), &config).await;
     assert!(diagnostics.is_empty());
 }
+
+#[cfg(unix)]
+#[tokio::test]
+async fn run_parses_stdout_from_configured_command_even_when_it_exits_one() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut script = std::env::temp_dir();
+    script.push("ox-content-textlint-tests");
+    std::fs::create_dir_all(&script).expect("create temp dir");
+    script.push("fake-textlint.sh");
+    std::fs::write(
+        &script,
+        r#"#!/bin/sh
+cat >/dev/null
+printf '%s\n' '[{"filePath":"doc.md","messages":[{"ruleId":"fixture/rule","message":"fixture message","line":2,"column":4,"severity":2}]}]'
+exit 1
+"#,
+    )
+    .expect("write fake textlint command");
+
+    let mut permissions = std::fs::metadata(&script).expect("fake command metadata").permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&script, permissions).expect("chmod fake textlint command");
+
+    let config = TextlintConfig { enabled: true, command: Some(script.display().to_string()) };
+    let diagnostics = run("# heading\n", std::path::Path::new("/tmp/doc.md"), &config).await;
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].source.as_deref(), Some("textlint"));
+    assert_eq!(diagnostics[0].message, "fixture message");
+    assert_eq!(diagnostics[0].range.start.line, 1);
+    assert_eq!(diagnostics[0].range.start.character, 3);
+    assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
+}

--- a/crates/ox_content_lsp/tests/protocol.rs
+++ b/crates/ox_content_lsp/tests/protocol.rs
@@ -168,6 +168,42 @@ fn diagnostics_report_a_dead_relative_link() {
     server.shutdown();
 }
 
+#[cfg(unix)]
+#[test]
+fn did_save_publishes_textlint_diagnostics_when_enabled() {
+    let command = write_fake_textlint_command("protocol-textlint");
+
+    let mut server = Server::start();
+    let uri = temp_uri("textlint.md");
+    server.initialize_and_open_with(
+        &uri,
+        "Textlint fixture\n",
+        json!({
+            "textlintEnabled": true,
+            "textlintCommand": command,
+        }),
+    );
+
+    // Drain the normal on-open diagnostics first so the next publish is
+    // the save-triggered textlint run.
+    let _ = server.await_notification("textDocument/publishDiagnostics");
+    server.notify("textDocument/didSave", json!({ "textDocument": { "uri": uri } }));
+
+    let params = server.await_notification("textDocument/publishDiagnostics");
+    assert_eq!(params["uri"].as_str(), Some(uri.as_str()));
+    let diagnostics = params["diagnostics"].as_array().expect("diagnostics array");
+    assert!(
+        diagnostics.iter().any(|diag| {
+            diag["source"].as_str() == Some("textlint")
+                && diag["code"].as_str() == Some("fixture/no-textlint")
+                && diag["message"].as_str() == Some("fixture textlint diagnostic")
+        }),
+        "expected a textlint diagnostic, got {diagnostics:?}"
+    );
+
+    server.shutdown();
+}
+
 #[test]
 fn hover_describes_a_frontmatter_field() {
     // Hover over a frontmatter key only resolves when a schema is
@@ -202,4 +238,28 @@ fn hover_describes_a_frontmatter_field() {
     assert!(value.contains("string"), "hover should state the type, got {value:?}");
 
     server.shutdown();
+}
+
+#[cfg(unix)]
+fn write_fake_textlint_command(name: &str) -> String {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut path = std::env::temp_dir();
+    path.push("ox-content-lsp-e2e");
+    std::fs::create_dir_all(&path).expect("create temp dir");
+    path.push(format!("{name}.sh"));
+    std::fs::write(
+        &path,
+        r#"#!/bin/sh
+cat >/dev/null
+printf '%s\n' '[{"filePath":"doc.md","messages":[{"ruleId":"fixture/no-textlint","message":"fixture textlint diagnostic","line":1,"column":4,"severity":1}]}]'
+exit 1
+"#,
+    )
+    .expect("write fake textlint command");
+
+    let mut permissions = std::fs::metadata(&path).expect("fake command metadata").permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&path, permissions).expect("chmod fake textlint command");
+    path.display().to_string()
 }

--- a/crates/ox_content_lsp/tests/protocol_support.rs
+++ b/crates/ox_content_lsp/tests/protocol_support.rs
@@ -117,7 +117,7 @@ impl Server {
     }
 
     /// Sends a notification with no response expected.
-    fn notify(&mut self, method: &str, params: Value) {
+    pub fn notify(&mut self, method: &str, params: Value) {
         let mut message = json!({ "jsonrpc": "2.0", "method": method });
         if !params.is_null() {
             message["params"] = params;

--- a/docs/content/editor-extension-roadmap.md
+++ b/docs/content/editor-extension-roadmap.md
@@ -202,10 +202,17 @@ Split into three sequential PRs:
 - ✅ VS Code: `oxContent.textlint.enabled` /
   `oxContent.textlint.command` settings forward into the
   initialization options.
-- ✅ 11 unit tests cover JSON parsing, severity mapping,
+- ✅ Neovim: `textlint.enabled` / `textlint.command` in
+  `require("ox-content").setup(...)` forward the same LSP
+  initialization options.
+- ✅ Zed: `lsp.ox-content-lsp.initialization_options.textlintEnabled`
+  and `textlintCommand` are documented and forwarded by the extension.
+- ✅ 12 unit tests cover JSON parsing, severity mapping,
   zero-indexed coordinates, the missing-rule-id and unknown-severity
   cases, shlex-style command splitting, and the disabled /
   missing-binary subprocess paths.
+- ✅ Protocol coverage pins the `textDocument/didSave` path that
+  publishes textlint diagnostics through LSP.
 - Pending follow-ups: code actions for textlint `--fix` suggestions,
   dedicated `ox-content-textlint` CLI (currently the user runs
   textlint directly), debounce / cancellation between rapid saves.

--- a/editors/neovim/README.md
+++ b/editors/neovim/README.md
@@ -10,6 +10,10 @@ Example with `lazy.nvim`:
   config = function()
     require("ox-content").setup({
       frontmatter_schema = "./content/frontmatter.schema.json",
+      textlint = {
+        enabled = true,
+        command = "pnpm exec textlint",
+      },
     })
   end,
 }
@@ -23,3 +27,6 @@ Commands:
 - `:OxContentPreview`
 
 The plugin maps `*.mdc` to `markdown`, starts `ox-content-lsp` for Markdown and JS/TS/JSON/YAML buffers, and uses the same server for insertion commands, preview rendering, and i18n key intelligence.
+
+`textlint` is opt-in and runs through the LSP on save. Leave
+`textlint.command` unset to use the server default (`npx textlint`).

--- a/editors/neovim/lua/ox-content/client.lua
+++ b/editors/neovim/lua/ox-content/client.lua
@@ -60,16 +60,30 @@ local function resolve_cmd(bufnr)
 end
 
 local function resolve_init_options(bufnr)
+  local options = {}
+
   local schema = config.get().frontmatter_schema
-  if type(schema) ~= "string" or schema == "" then
-    return {}
+  if type(schema) == "string" and schema ~= "" then
+    if vim.startswith(schema, "/") or schema:match("^%a:[/\\]") then
+      options.frontmatterSchema = schema
+    else
+      options.frontmatterSchema = vim.fs.joinpath(resolve_root(bufnr), schema)
+    end
   end
 
-  if vim.startswith(schema, "/") or schema:match("^%a:[/\\]") then
-    return { frontmatterSchema = schema }
+  local textlint = config.get().textlint
+  if type(textlint) ~= "table" then
+    textlint = {}
+  end
+  if textlint.enabled == true then
+    options.textlintEnabled = true
   end
 
-  return { frontmatterSchema = vim.fs.joinpath(resolve_root(bufnr), schema) }
+  if type(textlint.command) == "string" and textlint.command ~= "" then
+    options.textlintCommand = textlint.command
+  end
+
+  return options
 end
 
 local function position_from_cursor()

--- a/editors/neovim/lua/ox-content/config.lua
+++ b/editors/neovim/lua/ox-content/config.lua
@@ -3,6 +3,10 @@ local M = {}
 local defaults = {
   cmd = nil,
   frontmatter_schema = nil,
+  textlint = {
+    enabled = false,
+    command = nil,
+  },
   auto_start = true,
 }
 

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -15,7 +15,9 @@ Recommended Zed settings:
         "path": "/absolute/path/to/ox-content-lsp"
       },
       "initialization_options": {
-        "frontmatterSchema": "./content/frontmatter.schema.json"
+        "frontmatterSchema": "./content/frontmatter.schema.json",
+        "textlintEnabled": true,
+        "textlintCommand": "pnpm exec textlint"
       }
     }
   }
@@ -23,3 +25,7 @@ Recommended Zed settings:
 ```
 
 Once `.mdc` is associated with `Markdown`, you get Zed's native Markdown preview/highlighting together with Ox Content frontmatter completion and diagnostics, plus i18n key intelligence in JS/TS.
+
+`textlintEnabled` is optional and off by default. When enabled, the
+language server runs textlint on save and publishes diagnostics with
+`source: "textlint"`; omit `textlintCommand` to use `npx textlint`.

--- a/npm/vscode-ox-content/README.md
+++ b/npm/vscode-ox-content/README.md
@@ -12,6 +12,7 @@ Features:
   the document with the LSP, and the panel reloads on every
   `oxContent/previewDidChange` notification (no client-side polling)
 - `.mdc` files associated with Markdown and component tag diagnostics
+- optional textlint diagnostics on save
 
 ## Configuration
 
@@ -20,11 +21,22 @@ Features:
 | `oxContent.server.path`         | string  | Absolute or workspace-relative path to `ox-content-lsp`. Empty falls back to `target/debug` → `target/release` → `cargo run`. |
 | `oxContent.frontmatter.schema`  | string  | Path to a frontmatter schema (Markdown + `.mdc`).                                                                             |
 | `oxContent.preview.autoRefresh` | boolean | Re-render the preview as you type (default `true`).                                                                           |
+| `oxContent.textlint.enabled`    | boolean | Run textlint through the LSP on save (default `false`).                                                                       |
+| `oxContent.textlint.command`    | string  | Optional textlint command. Empty falls back to `npx textlint`; common value: `pnpm exec textlint`.                            |
 
 The environment variable `OX_CONTENT_LSP_PATH` is honored as an override
 between `oxContent.server.path` and the local-binary probe. CI and the
 integration test runner use it so they can point at a freshly built
 `target/release/ox-content-lsp` without writing per-workspace settings.
+
+## textlint
+
+Set `oxContent.textlint.enabled: true` to have the LSP run textlint for
+Markdown and `.mdc` files on save. Findings are published as normal LSP
+diagnostics with `source: "textlint"`.
+
+The command override is passed to the server as-is before the standard
+`--format json --stdin --stdin-filename <path>` arguments are appended.
 
 ## Preview HMR
 


### PR DESCRIPTION
## Summary

- Forward Neovim textlint settings into the Ox Content LSP initialization options.
- Document textlint enablement for VS Code, Zed, and Neovim.
- Add unit and protocol coverage for configured textlint subprocess output and `textDocument/didSave` diagnostics.

## Validation

- `cargo test -p ox_content_lsp`
- `cargo clippy -p ox_content_lsp --all-targets -- -D warnings`
- `vp run test:vscode-unit`
- `vp exec --filter vscode-ox-content -- tsc -p tsconfig.json`
- `cargo fmt --all -- --check`
- `vp fmt --check editors/neovim/lua/ox-content/config.lua editors/neovim/lua/ox-content/client.lua editors/neovim/README.md editors/zed/README.md npm/vscode-ox-content/README.md docs/content/editor-extension-roadmap.md crates/ox_content_lsp/tests/protocol_support.rs crates/ox_content_lsp/tests/protocol.rs crates/ox_content_lsp/src/textlint/tests.rs`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->