### PR TITLE
fix: generate valid docs nav TypeScript

### DIFF
--- a/crates/ox_content_docs/src/nav.rs
+++ b/crates/ox_content_docs/src/nav.rs
@@ -156,11 +156,11 @@ pub fn generate_nav_code(nav_items: &[DocsNavItem], export_name: Option<&str>) -
  * Do not edit manually.
  */
 
-export interface NavItem {{
+export interface NavItem {
   title: string;
   path: string;
   children?: NavItem[];
-}}
+}
 
 export const ",
     );

--- a/crates/ox_content_docs/src/nav/tests/paths.rs
+++ b/crates/ox_content_docs/src/nav/tests/paths.rs
@@ -52,6 +52,10 @@ fn generates_nav_code() {
     );
 
     assert!(code.contains("export const apiNav: NavItem[] = ["));
+    assert!(code.contains("export interface NavItem {\n"));
+    assert!(code.contains("children?: NavItem[];\n}\n\nexport const apiNav"));
+    assert!(!code.contains("NavItem {{"));
+    assert!(!code.contains("children?: NavItem[];\n}}"));
     assert!(code.contains(r#""title": "Docs""#));
     assert!(code.ends_with(" as const;\n"));
 }


### PR DESCRIPTION
## Summary

- Emit the generated `NavItem` interface with normal TypeScript braces.
- Add regression assertions for `generate_nav_code` so doubled interface braces do not return.

Fixes #432

## Validation

- `cargo fmt --check`
- `cargo test -p ox_content_docs`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->