### PR TITLE
test(renderer): add framework codegen modes

### DIFF
--- a/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__escapes_raw_html_literals_without_changing_runtime_html.snap
+++ b/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__escapes_raw_html_literals_without_changing_runtime_html.snap
@@ -1,0 +1,38 @@
+---
+source: crates/ox_content_renderer/src/frameworks/tests.rs
+expression: "format!(\"react:\\n{react}\\n\\nvue:\\n{vue}\\n\\nsvelte:\\n{svelte}\")"
+---
+react:
+import { createElement } from 'react';
+
+const rawHtml = "\x3C/script>\x3Cp title=\"line\nnext\">{ ok }\x3C/p>";
+
+export default function MarkdownContent() {
+  return createElement('div', {
+    className: 'ox-content',
+    dangerouslySetInnerHTML: { __html: rawHtml },
+  });
+}
+
+
+vue:
+import { defineComponent, h } from 'vue';
+
+const rawHtml = "\x3C/script>\x3Cp title=\"line\nnext\">{ ok }\x3C/p>";
+
+export default defineComponent({
+  name: 'MarkdownContent',
+  setup() {
+    return () => h('div', { class: 'ox-content', innerHTML: rawHtml });
+  },
+});
+
+
+svelte:
+<script>
+  const rawHtml = "\x3C/script>\x3Cp title=\"line\nnext\">{ ok }\x3C/p>";
+</script>
+
+<div class="ox-content">
+  {@html rawHtml}
+</div>

--- a/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_component_and_render_function_modules.snap
+++ b/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_component_and_render_function_modules.snap
@@ -1,0 +1,18 @@
+---
+source: crates/ox_content_renderer/src/frameworks/tests.rs
+expression: "format!(\"component:\\n{component}\\n\\nrender_function:\\n{render_function}\")"
+---
+component:
+import { createElement } from 'react';
+
+export default function MarkdownContent() {
+  return createElement('div', { className: 'ox-content' }, createElement("p", null, "Hello"));
+}
+
+
+render_function:
+import { h } from 'vue';
+
+export function renderMarkdownContent() {
+  return h('div', { class: 'ox-content' }, h("p", null, "Hello"));
+}

--- a/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_escaped_js_string_literals_for_text_and_attributes.snap
+++ b/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_escaped_js_string_literals_for_text_and_attributes.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ox_content_renderer/src/frameworks/tests.rs
+expression: code
+---
+createElement('div', { className: 'ox-content' }, createElement("p", { "title": "quote \" slash \\" }, "line\nnext"))

--- a/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_inner_html_component_modules.snap
+++ b/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_inner_html_component_modules.snap
@@ -1,0 +1,28 @@
+---
+source: crates/ox_content_renderer/src/frameworks/tests.rs
+expression: "format!(\"react:\\n{react}\\n\\nvue:\\n{vue}\")"
+---
+react:
+import { createElement } from 'react';
+
+const rawHtml = "\x3Cp>Hello\x3C/p>";
+
+export default function MarkdownContent() {
+  return createElement('div', {
+    className: 'ox-content',
+    dangerouslySetInnerHTML: { __html: rawHtml },
+  });
+}
+
+
+vue:
+import { defineComponent, h } from 'vue';
+
+const rawHtml = "\x3Cp>Hello\x3C/p>";
+
+export default defineComponent({
+  name: 'MarkdownContent',
+  setup() {
+    return () => h('div', { class: 'ox-content', innerHTML: rawHtml });
+  },
+});

--- a/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_nested_json_props_in_stable_top_level_order.snap
+++ b/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_nested_json_props_in_stable_top_level_order.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ox_content_renderer/src/frameworks/tests.rs
+expression: code
+---
+createElement('div', { className: 'ox-content' }, createElement(Widget, { "a": {"nested":true}, "z": [3,2,1] }, "child"))

--- a/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_react_data_and_aria_camel_case_as_attributes.snap
+++ b/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_react_data_and_aria_camel_case_as_attributes.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ox_content_renderer/src/frameworks/tests.rs
+expression: code
+---
+createElement('div', { className: 'ox-content' }, createElement("button", { "data-test-id": "save", "aria-label": "Save" }, "Save"))

--- a/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_svelte_component_modes.snap
+++ b/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_svelte_component_modes.snap
@@ -1,0 +1,18 @@
+---
+source: crates/ox_content_renderer/src/frameworks/tests.rs
+expression: "format!(\"component:\\n{component}\\n\\ninner_html:\\n{inner_html}\")"
+---
+component:
+<div class="ox-content">
+<p>&#123;count&#125;</p>
+</div>
+
+
+inner_html:
+<script>
+  const rawHtml = "\x3Cp>{count}\x3C/p>";
+</script>
+
+<div class="ox-content">
+  {@html rawHtml}
+</div>

--- a/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_void_and_self_closing_elements_without_children.snap
+++ b/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_void_and_self_closing_elements_without_children.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ox_content_renderer/src/frameworks/tests.rs
+expression: code
+---
+createElement('div', { className: 'ox-content' }, createElement("p", null, "Image ", createElement("img", { "src": "/logo.png" }), createElement("br", null), createElement("input", { "disabled": true })))

--- a/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_vue_single_child_without_array_and_multiple_children_with_array.snap
+++ b/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_vue_single_child_without_array_and_multiple_children_with_array.snap
@@ -1,0 +1,9 @@
+---
+source: crates/ox_content_renderer/src/frameworks/tests.rs
+expression: "format!(\"single:\\n{single}\\n\\nmany:\\n{many}\")"
+---
+single:
+h('div', { class: 'ox-content' }, h("p", null, h("span", null, "one")))
+
+many:
+h('div', { class: 'ox-content' }, h("p", null, [h("span", null, "one"), h("span", null, "two")]))

--- a/crates/ox_content_renderer/src/frameworks/tests.rs
+++ b/crates/ox_content_renderer/src/frameworks/tests.rs
@@ -41,9 +41,7 @@ fn renders_void_and_self_closing_elements_without_children() {
         &[],
     );
 
-    assert!(code.contains(r#"createElement("img", { "src": "/logo.png" })"#));
-    assert!(code.contains(r#"createElement("br", null)"#));
-    assert!(code.contains(r#"createElement("input", { "disabled": true })"#));
+    insta::assert_snapshot!(code);
 }
 
 #[test]
@@ -54,8 +52,7 @@ fn renders_escaped_js_string_literals_for_text_and_attributes() {
         &[],
     );
 
-    assert!(code.contains(r#""title": "quote \" slash \\""#));
-    assert!(code.contains(r#""line\nnext""#));
+    insta::assert_snapshot!(code);
 }
 
 #[test]
@@ -66,8 +63,7 @@ fn renders_react_data_and_aria_camel_case_as_attributes() {
         &[],
     );
 
-    assert!(code.contains(r#""data-test-id": "save""#));
-    assert!(code.contains(r#""aria-label": "Save""#));
+    insta::assert_snapshot!(code);
 }
 
 #[test]
@@ -83,8 +79,7 @@ fn renders_vue_single_child_without_array_and_multiple_children_with_array() {
         &[],
     );
 
-    assert!(single.contains(r#"h("p", null, h("span", null, "one"))"#));
-    assert!(many.contains(r#"h("p", null, [h("span", null, "one"), h("span", null, "two")])"#));
+    insta::assert_snapshot!(format!("single:\n{single}\n\nmany:\n{many}"));
 }
 
 #[test]
@@ -146,9 +141,7 @@ fn renders_nested_json_props_in_stable_top_level_order() {
         &islands,
     );
 
-    assert!(
-        code.contains(r#"createElement(Widget, { "a": {"nested":true}, "z": [3,2,1] }, "child")"#)
-    );
+    insta::assert_snapshot!(code);
 }
 
 #[test]
@@ -168,8 +161,7 @@ fn renders_inner_html_component_modules() {
     )
     .unwrap();
 
-    assert!(react.contains("dangerouslySetInnerHTML: { __html: rawHtml }"));
-    assert!(vue.contains("innerHTML: rawHtml"));
+    insta::assert_snapshot!(format!("react:\n{react}\n\nvue:\n{vue}"));
 }
 
 #[test]
@@ -197,12 +189,7 @@ fn escapes_raw_html_literals_without_changing_runtime_html() {
     )
     .unwrap();
 
-    assert!(!react.contains("</script>"));
-    assert!(!vue.contains("</script>"));
-    assert_eq!(svelte.matches("</script>").count(), 1);
-    assert!(react.contains(r#"\x3C/script>\x3Cp title=\"line\nnext\">{ ok }\x3C/p>"#));
-    assert!(vue.contains(r#"\x3C/script>\x3Cp title=\"line\nnext\">{ ok }\x3C/p>"#));
-    assert!(svelte.contains(r#"\x3C/script>\x3Cp title=\"line\nnext\">{ ok }\x3C/p>"#));
+    insta::assert_snapshot!(format!("react:\n{react}\n\nvue:\n{vue}\n\nsvelte:\n{svelte}"));
 }
 
 #[test]
@@ -222,10 +209,9 @@ fn renders_component_and_render_function_modules() {
     )
     .unwrap();
 
-    assert!(component.contains("export default function MarkdownContent()"));
-    assert!(component.contains(r#"createElement("p", null, "Hello")"#));
-    assert!(render_function.contains("export function renderMarkdownContent()"));
-    assert!(render_function.contains(r"return h('div', { class: 'ox-content' }"));
+    insta::assert_snapshot!(format!(
+        "component:\n{component}\n\nrender_function:\n{render_function}"
+    ));
 }
 
 #[test]
@@ -245,8 +231,7 @@ fn renders_svelte_component_modes() {
     )
     .unwrap();
 
-    assert!(component.contains("<p>&#123;count&#125;</p>"));
-    assert!(inner_html.contains("{@html rawHtml}"));
+    insta::assert_snapshot!(format!("component:\n{component}\n\ninner_html:\n{inner_html}"));
 }
 
 #[test]

--- a/npm/vite-plugin-ox-content/src/__snapshots__/framework.test.ts.snap
+++ b/npm/vite-plugin-ox-content/src/__snapshots__/framework.test.ts.snap
@@ -1,6 +1,48 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`framework Markdown utilities > escapes raw HTML literals without breaking component scripts 1`] = `
+{
+  "react": "import { createElement } from 'react';
+
+const rawHtml = "\\x3C/script>\\x3Cp title=\\"line\\nnext\\">{ ok }\\x3C/p>";
+
+export default function MarkdownContent() {
+  return createElement('div', {
+    className: 'ox-content',
+    dangerouslySetInnerHTML: { __html: rawHtml },
+  });
+}
+",
+  "svelte": "<script>
+  const rawHtml = "\\x3C/script>\\x3Cp title=\\"line\\nnext\\">{ ok }\\x3C/p>";
+</script>
+
+<div class="ox-content">
+  {@html rawHtml}
+</div>
+",
+  "vue": "import { defineComponent, h } from 'vue';
+
+const rawHtml = "\\x3C/script>\\x3Cp title=\\"line\\nnext\\">{ ok }\\x3C/p>";
+
+export default defineComponent({
+  name: 'MarkdownContent',
+  setup() {
+    return () => h('div', { class: 'ox-content', innerHTML: rawHtml });
+  },
+});
+",
+}
+`;
+
 exports[`framework Markdown utilities > renders React VDOM code with React-compatible attributes 1`] = `"createElement('div', { className: 'ox-content' }, createElement("section", { "className": "lead", "htmlFor": "name", "data-id": "42", "aria-label": "Intro" }, createElement("p", { "style": { "fontWeight": "bold", "--brand": "red" } }, "Hello ", createElement("strong", null, "world"))))"`;
+
+exports[`framework Markdown utilities > renders Svelte component code without innerHTML 1`] = `
+"<div class="ox-content">
+<p>&#123;count&#125;</p>
+</div>
+"
+`;
 
 exports[`framework Markdown utilities > renders Vue VDOM code with Vue-compatible attributes 1`] = `"h('div', { class: 'ox-content' }, h("label", { "class": "field", "for": "name" }, [h("span", null, "Name"), h("input", { "disabled": true, "type": "text" })]))"`;
 

--- a/npm/vite-plugin-ox-content/src/docs-tests.ts
+++ b/npm/vite-plugin-ox-content/src/docs-tests.ts
@@ -505,7 +505,7 @@ function rewriteImports(source: string, rewrites: Record<string, string> | undef
  * const blocks = await extractDocsTests(markdown);
  *
  * expect(blocks).toHaveLength(1);
- * expect(blocks[0]?.code).toContain("1 + 1");
+ * expect(blocks[0]?.code).toMatchInlineSnapshot('"expect(1 + 1).toBe(2);"');
  * ```
  */
 function rewriteSpecifier(specifier: string, rewrites: Record<string, string> | undefined): string {

--- a/npm/vite-plugin-ox-content/src/framework.test.ts
+++ b/npm/vite-plugin-ox-content/src/framework.test.ts
@@ -94,9 +94,7 @@ describe("framework Markdown utilities", () => {
   });
 
   it("renders Svelte component code without innerHTML", () => {
-    expect(renderHtmlToSvelteComponent("<p>{count}</p>")).toBe(
-      '<div class="ox-content">\n<p>&#123;count&#125;</p>\n</div>\n',
-    );
+    expect(renderHtmlToSvelteComponent("<p>{count}</p>")).toMatchSnapshot();
   });
 
   it("escapes raw HTML literals without breaking component scripts", () => {
@@ -105,12 +103,7 @@ describe("framework Markdown utilities", () => {
     const vue = renderHtmlToFrameworkCode(html, "vue", "innerHtml");
     const svelte = renderHtmlToFrameworkCode(html, "svelte", "innerHtml");
 
-    expect(react).not.toContain("</script>");
-    expect(vue).not.toContain("</script>");
-    expect(svelte.match(/<\/script>/g)).toHaveLength(1);
-    expect(react).toContain(String.raw`\x3C/script>\x3Cp title=\"line\nnext\">{ ok }\x3C/p>`);
-    expect(vue).toContain(String.raw`\x3C/script>\x3Cp title=\"line\nnext\">{ ok }\x3C/p>`);
-    expect(svelte).toContain(String.raw`\x3C/script>\x3Cp title=\"line\nnext\">{ ok }\x3C/p>`);
+    expect({ react, vue, svelte }).toMatchSnapshot();
   });
 
   it("escapes Svelte expression delimiters before emitting static markup", () => {


### PR DESCRIPTION
## Summary

- Move framework HTML code generation into the renderer behind the `frameworks` feature.
- Add React, Vue, and Svelte framework codegen modes and expose them through the npm plugin API.
- Replace loose framework codegen assertions with full Rust and Vitest snapshots.

## Why

Framework output is generated code, so partial substring assertions could miss regressions in imports, wrappers, escaping, or render-mode structure. Full snapshots make those contracts explicit.

## Impact

Consumers can generate framework-specific component or innerHTML modules while tests now cover the complete emitted code shape.

## Validation

- `cargo test -p ox_content_renderer --features frameworks frameworks::tests`
- `pnpm exec vp exec --filter @ox-content/vite-plugin -- vp test src/framework.test.ts src/docs-tests.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->