### PR TITLE
fix: handle IME search and crate publish order

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -404,6 +404,8 @@ jobs:
           sleep 30
           publish_crate ox_content_og_image
           sleep 30
+          publish_crate ox_content_transform
+          sleep 30
           publish_crate ox_content_search
           sleep 30
           publish_crate ox_content_ssg

--- a/crates/ox_content_ssg/src/html/tests.rs
+++ b/crates/ox_content_ssg/src/html/tests.rs
@@ -21,3 +21,8 @@ fn snapshot_text(value: &str) -> String {
 
 mod rendering;
 mod theme;
+
+#[test]
+fn search_keydown_ignores_ime_composition() {
+    assert!(super::SSG_JS.contains("if (e.isComposing || e.keyCode === 229) return;"));
+}

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -2182,6 +2182,8 @@ const registerOxContentSearchEvents = (elements, state, closeSearch) => {
 };
 
 const handleOxContentSearchKeydown = (e, elements, state, closeSearch) => {
+  if (e.isComposing || e.keyCode === 229) return;
+
   if (e.key === "Escape") closeSearch();
   else if (e.key === "ArrowDown") {
     e.preventDefault();

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -2154,6 +2154,8 @@ const registerOxContentSearchEvents = (elements, state, closeSearch) => {
 };
 
 const handleOxContentSearchKeydown = (e, elements, state, closeSearch) => {
+  if (e.isComposing || e.keyCode === 229) return;
+
   if (e.key === "Escape") closeSearch();
   else if (e.key === "ArrowDown") {
     e.preventDefault();

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -2154,6 +2154,8 @@ const registerOxContentSearchEvents = (elements, state, closeSearch) => {
 };
 
 const handleOxContentSearchKeydown = (e, elements, state, closeSearch) => {
+  if (e.isComposing || e.keyCode === 229) return;
+
   if (e.key === "Escape") closeSearch();
   else if (e.key === "ArrowDown") {
     e.preventDefault();

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -2156,6 +2156,8 @@ const registerOxContentSearchEvents = (elements, state, closeSearch) => {
 };
 
 const handleOxContentSearchKeydown = (e, elements, state, closeSearch) => {
+  if (e.isComposing || e.keyCode === 229) return;
+
   if (e.key === "Escape") closeSearch();
   else if (e.key === "ArrowDown") {
     e.preventDefault();

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -2189,6 +2189,8 @@ const registerOxContentSearchEvents = (elements, state, closeSearch) => {
 };
 
 const handleOxContentSearchKeydown = (e, elements, state, closeSearch) => {
+  if (e.isComposing || e.keyCode === 229) return;
+
   if (e.key === "Escape") closeSearch();
   else if (e.key === "ArrowDown") {
     e.preventDefault();

--- a/crates/ox_content_ssg/src/ssg.js
+++ b/crates/ox_content_ssg/src/ssg.js
@@ -438,6 +438,8 @@ const registerOxContentSearchEvents = (elements, state, closeSearch) => {
 };
 
 const handleOxContentSearchKeydown = (e, elements, state, closeSearch) => {
+  if (e.isComposing || e.keyCode === 229) return;
+
   if (e.key === "Escape") closeSearch();
   else if (e.key === "ArrowDown") {
     e.preventDefault();

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -29,6 +29,7 @@ const CARGO_PUBLISH_PACKAGES = [
   "ox_content_renderer",
   "ox_content_incremental",
   "ox_content_og_image",
+  "ox_content_transform",
   "ox_content_search",
   "ox_content_ssg",
   "ox_content_docs",


### PR DESCRIPTION
## Summary

- Ignore search modal keydown handling while an IME composition is active, including the legacy keyCode 229 fallback.
- Add `ox_content_transform` to the crates.io publish order before `ox_content_search`.
- Keep release target verification aligned with the publish workflow.

Closes #441

## Validation

- `cargo test -p ox_content_ssg`
- `cargo fmt --all -- --check`
- `cargo clippy -p ox_content_ssg --all-targets -- -D warnings`
- `vp run fmt:ts-check`
- `vp run check:ts` (passes with existing warnings)
- `node scripts/check-file-lines.ts`
- Verified all crates.io publish targets are present in `.github/workflows/publish.yml`

## Notes

The latest `Publish` workflow failure was in `Publish to crates.io`: `ox_content_search` was published before its `ox_content_transform` dependency existed on crates.io.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->