### PR TITLE
fix: support older glibc and musl NAPI builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  LINUX_GLIBC_VERSION: "2.17"
   STICKY_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
 
 jobs:
@@ -50,9 +51,15 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             platform: linux-x64-gnu
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
+            platform: linux-x64-musl
           - os: blacksmith-32vcpu-ubuntu-2404
             target: aarch64-unknown-linux-gnu
             platform: linux-arm64-gnu
+          - os: blacksmith-32vcpu-ubuntu-2404
+            target: aarch64-unknown-linux-musl
+            platform: linux-arm64-musl
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             platform: win32-x64-msvc
@@ -91,20 +98,71 @@ jobs:
           # Only save cache on main pushes to prevent PR runs from poisoning the cache used by release builds.
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
-      - name: Install zig (Linux ARM64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
+      - name: Install zig (Linux)
+        if: contains(matrix.target, 'unknown-linux')
         run: |
           curl -fsSL https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz -o zig.tar.xz
           tar -xf zig.tar.xz
           echo "$PWD/zig-linux-x86_64-0.13.0" >> "$GITHUB_PATH"
 
-      - name: Install cargo-zigbuild (Linux ARM64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
+      - name: Install cargo-zigbuild (Linux)
+        if: contains(matrix.target, 'unknown-linux')
         run: cargo install cargo-zigbuild
 
-      - name: Build NAPI
+      - name: Build NAPI (Linux)
+        if: contains(matrix.target, 'unknown-linux')
         working-directory: crates/ox_content_napi
-        run: vp exec -- napi build --release --target ${{ matrix.target }} ${{ matrix.target == 'aarch64-unknown-linux-gnu' && '--cross-compile' || '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          build_target="${{ matrix.target }}"
+          if [[ "${{ matrix.target }}" == *-unknown-linux-gnu ]]; then
+            build_target="${build_target}.${LINUX_GLIBC_VERSION}"
+          else
+            export RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=-crt-static"
+          fi
+
+          cargo zigbuild --release --target "$build_target"
+
+          src="../../target/${{ matrix.target }}/release/libox_content_napi.so"
+          if [[ ! -f "$src" ]]; then
+            src="../../target/${build_target}/release/libox_content_napi.so"
+          fi
+          cp "$src" "ox-content.${{ matrix.platform }}.node"
+
+      - name: Verify Linux native dependencies
+        if: contains(matrix.target, 'unknown-linux')
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          node_file="crates/ox_content_napi/ox-content.${{ matrix.platform }}.node"
+
+          if [[ "${{ matrix.target }}" == *-unknown-linux-gnu ]]; then
+            max_glibc="$(
+              readelf --version-info "$node_file" |
+                sed -n 's/.*Name: GLIBC_\([0-9.]*\).*/\1/p' |
+                sort -V |
+                tail -1
+            )"
+            echo "max GLIBC version: ${max_glibc:-none}"
+            if [[ -n "$max_glibc" ]] &&
+              [[ "$(printf '%s\n' "$LINUX_GLIBC_VERSION" "$max_glibc" | sort -V | tail -1)" != "$LINUX_GLIBC_VERSION" ]]; then
+              echo "::error::${node_file} requires GLIBC_${max_glibc}, expected <= GLIBC_${LINUX_GLIBC_VERSION}"
+              exit 1
+            fi
+          else
+            if readelf --version-info "$node_file" | grep -q 'GLIBC_'; then
+              echo "::error::${node_file} unexpectedly references GLIBC symbols"
+              exit 1
+            fi
+          fi
+
+      - name: Build NAPI
+        if: ${{ !contains(matrix.target, 'unknown-linux') }}
+        working-directory: crates/ox_content_napi
+        run: vp exec -- napi build --release --target ${{ matrix.target }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -173,7 +231,9 @@ jobs:
             ["x86_64-apple-darwin"]="darwin-x64"
             ["aarch64-apple-darwin"]="darwin-arm64"
             ["x86_64-unknown-linux-gnu"]="linux-x64-gnu"
+            ["x86_64-unknown-linux-musl"]="linux-x64-musl"
             ["aarch64-unknown-linux-gnu"]="linux-arm64-gnu"
+            ["aarch64-unknown-linux-musl"]="linux-arm64-musl"
             ["x86_64-pc-windows-msvc"]="win32-x64-msvc"
           )
           for dir in artifacts/napi-*; do
@@ -226,7 +286,9 @@ jobs:
             ./binding-packages/darwin-x64 \
             ./binding-packages/darwin-arm64 \
             ./binding-packages/linux-x64-gnu \
+            ./binding-packages/linux-x64-musl \
             ./binding-packages/linux-arm64-gnu \
+            ./binding-packages/linux-arm64-musl \
             ./binding-packages/win32-x64-msvc \
             ./npm/ox-content-islands \
             ./npm/unplugin-ox-content \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  LINUX_GLIBC_VERSION: "2.17"
 
 jobs:
   build-napi:
@@ -21,14 +22,25 @@ jobs:
         include:
           - os: macos-latest
             target: x86_64-apple-darwin
+            platform: darwin-x64
           - os: macos-latest
             target: aarch64-apple-darwin
+            platform: darwin-arm64
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
+            platform: linux-x64-gnu
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
+            platform: linux-x64-musl
           - os: blacksmith-32vcpu-ubuntu-2404
             target: aarch64-unknown-linux-gnu
+            platform: linux-arm64-gnu
+          - os: blacksmith-32vcpu-ubuntu-2404
+            target: aarch64-unknown-linux-musl
+            platform: linux-arm64-musl
           - os: windows-2025
             target: x86_64-pc-windows-msvc
+            platform: win32-x64-msvc
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -55,20 +67,71 @@ jobs:
           cargo: "true"
           target: target
 
-      - name: Install zig (Linux ARM64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
+      - name: Install zig (Linux)
+        if: contains(matrix.target, 'unknown-linux')
         run: |
           curl --retry 5 --retry-delay 5 --retry-all-errors -fsSL https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz -o zig.tar.xz
           tar -xf zig.tar.xz
           echo "$PWD/zig-linux-x86_64-0.13.0" >> "$GITHUB_PATH"
 
-      - name: Install cargo-zigbuild (Linux ARM64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
+      - name: Install cargo-zigbuild (Linux)
+        if: contains(matrix.target, 'unknown-linux')
         run: cargo install cargo-zigbuild
 
-      - name: Build NAPI
+      - name: Build NAPI (Linux)
+        if: contains(matrix.target, 'unknown-linux')
         working-directory: crates/ox_content_napi
-        run: vp exec -- napi build --release --target ${{ matrix.target }} ${{ matrix.target == 'aarch64-unknown-linux-gnu' && '--cross-compile' || '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          build_target="${{ matrix.target }}"
+          if [[ "${{ matrix.target }}" == *-unknown-linux-gnu ]]; then
+            build_target="${build_target}.${LINUX_GLIBC_VERSION}"
+          else
+            export RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=-crt-static"
+          fi
+
+          cargo zigbuild --release --target "$build_target"
+
+          src="../../target/${{ matrix.target }}/release/libox_content_napi.so"
+          if [[ ! -f "$src" ]]; then
+            src="../../target/${build_target}/release/libox_content_napi.so"
+          fi
+          cp "$src" "ox-content.${{ matrix.platform }}.node"
+
+      - name: Verify Linux native dependencies
+        if: contains(matrix.target, 'unknown-linux')
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          node_file="crates/ox_content_napi/ox-content.${{ matrix.platform }}.node"
+
+          if [[ "${{ matrix.target }}" == *-unknown-linux-gnu ]]; then
+            max_glibc="$(
+              readelf --version-info "$node_file" |
+                sed -n 's/.*Name: GLIBC_\([0-9.]*\).*/\1/p' |
+                sort -V |
+                tail -1
+            )"
+            echo "max GLIBC version: ${max_glibc:-none}"
+            if [[ -n "$max_glibc" ]] &&
+              [[ "$(printf '%s\n' "$LINUX_GLIBC_VERSION" "$max_glibc" | sort -V | tail -1)" != "$LINUX_GLIBC_VERSION" ]]; then
+              echo "::error::${node_file} requires GLIBC_${max_glibc}, expected <= GLIBC_${LINUX_GLIBC_VERSION}"
+              exit 1
+            fi
+          else
+            if readelf --version-info "$node_file" | grep -q 'GLIBC_'; then
+              echo "::error::${node_file} unexpectedly references GLIBC symbols"
+              exit 1
+            fi
+          fi
+
+      - name: Build NAPI
+        if: ${{ !contains(matrix.target, 'unknown-linux') }}
+        working-directory: crates/ox_content_napi
+        run: vp exec -- napi build --release --target ${{ matrix.target }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -120,7 +183,9 @@ jobs:
             ["x86_64-apple-darwin"]="darwin-x64"
             ["aarch64-apple-darwin"]="darwin-arm64"
             ["x86_64-unknown-linux-gnu"]="linux-x64-gnu"
+            ["x86_64-unknown-linux-musl"]="linux-x64-musl"
             ["aarch64-unknown-linux-gnu"]="linux-arm64-gnu"
+            ["aarch64-unknown-linux-musl"]="linux-arm64-musl"
             ["x86_64-pc-windows-msvc"]="win32-x64-msvc"
           )
           for dir in artifacts/napi-*; do

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -1,4 +1,5 @@
-const { existsSync } = require("fs");
+const { execSync } = require("child_process");
+const { existsSync, readFileSync } = require("fs");
 const path = require("path");
 
 function getErrorCode(error) {
@@ -18,6 +19,60 @@ function formatLoadError(target, error) {
   const code = getErrorCode(error);
   const suffix = code ? ` [${code}]` : "";
   return `  - ${target}${suffix}: ${getErrorMessage(error)}`;
+}
+
+function isFileMusl(file) {
+  return file.includes("libc.musl-") || file.includes("ld-musl-");
+}
+
+function isMuslFromFilesystem() {
+  try {
+    return readFileSync("/usr/bin/ldd", "utf8").includes("musl");
+  } catch {
+    return null;
+  }
+}
+
+function isMuslFromReport() {
+  if (typeof process.report?.getReport !== "function") {
+    return null;
+  }
+
+  const report = process.report.getReport();
+  if (report.header?.glibcVersionRuntime) {
+    return false;
+  }
+  if (Array.isArray(report.sharedObjects)) {
+    return report.sharedObjects.some(isFileMusl);
+  }
+
+  return false;
+}
+
+function isMuslFromChildProcess() {
+  try {
+    return execSync("ldd --version", { encoding: "utf8" }).includes("musl");
+  } catch {
+    return false;
+  }
+}
+
+function isMusl() {
+  if (process.platform !== "linux") {
+    return false;
+  }
+
+  const filesystemResult = isMuslFromFilesystem();
+  if (filesystemResult !== null) {
+    return filesystemResult;
+  }
+
+  const reportResult = isMuslFromReport();
+  if (reportResult !== null) {
+    return reportResult;
+  }
+
+  return isMuslFromChildProcess();
 }
 
 function loadBinding() {
@@ -43,7 +98,9 @@ function loadBinding() {
     "darwin-arm64": "ox-content.darwin-arm64.node",
     "darwin-x64": "ox-content.darwin-x64.node",
     "linux-x64-gnu": "ox-content.linux-x64-gnu.node",
+    "linux-x64-musl": "ox-content.linux-x64-musl.node",
     "linux-arm64-gnu": "ox-content.linux-arm64-gnu.node",
+    "linux-arm64-musl": "ox-content.linux-arm64-musl.node",
     "win32-x64-msvc": "ox-content.win32-x64-msvc.node",
   };
 
@@ -51,7 +108,7 @@ function loadBinding() {
   if (platform === "darwin") {
     key = `darwin-${arch}`;
   } else if (platform === "linux") {
-    key = `linux-${arch}-gnu`;
+    key = `linux-${arch}-${isMusl() ? "musl" : "gnu"}`;
   } else if (platform === "win32") {
     key = `win32-${arch}-msvc`;
   }
@@ -69,7 +126,9 @@ function loadBinding() {
     "darwin-arm64": "@ox-content/binding-darwin-arm64",
     "darwin-x64": "@ox-content/binding-darwin-x64",
     "linux-x64-gnu": "@ox-content/binding-linux-x64-gnu",
+    "linux-x64-musl": "@ox-content/binding-linux-x64-musl",
     "linux-arm64-gnu": "@ox-content/binding-linux-arm64-gnu",
+    "linux-arm64-musl": "@ox-content/binding-linux-arm64-musl",
     "win32-x64-msvc": "@ox-content/binding-win32-x64-msvc",
   };
 

--- a/crates/ox_content_napi/package.json
+++ b/crates/ox_content_napi/package.json
@@ -40,7 +40,9 @@
       "x86_64-apple-darwin",
       "aarch64-apple-darwin",
       "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-linux-musl",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-linux-musl",
       "x86_64-pc-windows-msvc"
     ]
   }

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
@@ -2,7 +2,8 @@
 source: crates/ox_content_napi/src/tests/runtime_features.rs
 expression: index_js
 ---
-const { existsSync } = require("fs");
+const { execSync } = require("child_process");
+const { existsSync, readFileSync } = require("fs");
 const path = require("path");
 
 function getErrorCode(error) {
@@ -22,6 +23,60 @@ function formatLoadError(target, error) {
   const code = getErrorCode(error);
   const suffix = code ? ` [${code}]` : "";
   return `  - ${target}${suffix}: ${getErrorMessage(error)}`;
+}
+
+function isFileMusl(file) {
+  return file.includes("libc.musl-") || file.includes("ld-musl-");
+}
+
+function isMuslFromFilesystem() {
+  try {
+    return readFileSync("/usr/bin/ldd", "utf8").includes("musl");
+  } catch {
+    return null;
+  }
+}
+
+function isMuslFromReport() {
+  if (typeof process.report?.getReport !== "function") {
+    return null;
+  }
+
+  const report = process.report.getReport();
+  if (report.header?.glibcVersionRuntime) {
+    return false;
+  }
+  if (Array.isArray(report.sharedObjects)) {
+    return report.sharedObjects.some(isFileMusl);
+  }
+
+  return false;
+}
+
+function isMuslFromChildProcess() {
+  try {
+    return execSync("ldd --version", { encoding: "utf8" }).includes("musl");
+  } catch {
+    return false;
+  }
+}
+
+function isMusl() {
+  if (process.platform !== "linux") {
+    return false;
+  }
+
+  const filesystemResult = isMuslFromFilesystem();
+  if (filesystemResult !== null) {
+    return filesystemResult;
+  }
+
+  const reportResult = isMuslFromReport();
+  if (reportResult !== null) {
+    return reportResult;
+  }
+
+  return isMuslFromChildProcess();
 }
 
 function loadBinding() {
@@ -47,7 +102,9 @@ function loadBinding() {
     "darwin-arm64": "ox-content.darwin-arm64.node",
     "darwin-x64": "ox-content.darwin-x64.node",
     "linux-x64-gnu": "ox-content.linux-x64-gnu.node",
+    "linux-x64-musl": "ox-content.linux-x64-musl.node",
     "linux-arm64-gnu": "ox-content.linux-arm64-gnu.node",
+    "linux-arm64-musl": "ox-content.linux-arm64-musl.node",
     "win32-x64-msvc": "ox-content.win32-x64-msvc.node",
   };
 
@@ -55,7 +112,7 @@ function loadBinding() {
   if (platform === "darwin") {
     key = `darwin-${arch}`;
   } else if (platform === "linux") {
-    key = `linux-${arch}-gnu`;
+    key = `linux-${arch}-${isMusl() ? "musl" : "gnu"}`;
   } else if (platform === "win32") {
     key = `win32-${arch}-msvc`;
   }
@@ -73,7 +130,9 @@ function loadBinding() {
     "darwin-arm64": "@ox-content/binding-darwin-arm64",
     "darwin-x64": "@ox-content/binding-darwin-x64",
     "linux-x64-gnu": "@ox-content/binding-linux-x64-gnu",
+    "linux-x64-musl": "@ox-content/binding-linux-x64-musl",
     "linux-arm64-gnu": "@ox-content/binding-linux-arm64-gnu",
+    "linux-arm64-musl": "@ox-content/binding-linux-arm64-musl",
     "win32-x64-msvc": "@ox-content/binding-win32-x64-msvc",
   };
 

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
@@ -2,7 +2,8 @@
 source: crates/ox_content_napi/src/tests/runtime_features.rs
 expression: index_js
 ---
-const { existsSync } = require("fs");
+const { execSync } = require("child_process");
+const { existsSync, readFileSync } = require("fs");
 const path = require("path");
 
 function getErrorCode(error) {
@@ -22,6 +23,60 @@ function formatLoadError(target, error) {
   const code = getErrorCode(error);
   const suffix = code ? ` [${code}]` : "";
   return `  - ${target}${suffix}: ${getErrorMessage(error)}`;
+}
+
+function isFileMusl(file) {
+  return file.includes("libc.musl-") || file.includes("ld-musl-");
+}
+
+function isMuslFromFilesystem() {
+  try {
+    return readFileSync("/usr/bin/ldd", "utf8").includes("musl");
+  } catch {
+    return null;
+  }
+}
+
+function isMuslFromReport() {
+  if (typeof process.report?.getReport !== "function") {
+    return null;
+  }
+
+  const report = process.report.getReport();
+  if (report.header?.glibcVersionRuntime) {
+    return false;
+  }
+  if (Array.isArray(report.sharedObjects)) {
+    return report.sharedObjects.some(isFileMusl);
+  }
+
+  return false;
+}
+
+function isMuslFromChildProcess() {
+  try {
+    return execSync("ldd --version", { encoding: "utf8" }).includes("musl");
+  } catch {
+    return false;
+  }
+}
+
+function isMusl() {
+  if (process.platform !== "linux") {
+    return false;
+  }
+
+  const filesystemResult = isMuslFromFilesystem();
+  if (filesystemResult !== null) {
+    return filesystemResult;
+  }
+
+  const reportResult = isMuslFromReport();
+  if (reportResult !== null) {
+    return reportResult;
+  }
+
+  return isMuslFromChildProcess();
 }
 
 function loadBinding() {
@@ -47,7 +102,9 @@ function loadBinding() {
     "darwin-arm64": "ox-content.darwin-arm64.node",
     "darwin-x64": "ox-content.darwin-x64.node",
     "linux-x64-gnu": "ox-content.linux-x64-gnu.node",
+    "linux-x64-musl": "ox-content.linux-x64-musl.node",
     "linux-arm64-gnu": "ox-content.linux-arm64-gnu.node",
+    "linux-arm64-musl": "ox-content.linux-arm64-musl.node",
     "win32-x64-msvc": "ox-content.win32-x64-msvc.node",
   };
 
@@ -55,7 +112,7 @@ function loadBinding() {
   if (platform === "darwin") {
     key = `darwin-${arch}`;
   } else if (platform === "linux") {
-    key = `linux-${arch}-gnu`;
+    key = `linux-${arch}-${isMusl() ? "musl" : "gnu"}`;
   } else if (platform === "win32") {
     key = `win32-${arch}-msvc`;
   }
@@ -73,7 +130,9 @@ function loadBinding() {
     "darwin-arm64": "@ox-content/binding-darwin-arm64",
     "darwin-x64": "@ox-content/binding-darwin-x64",
     "linux-x64-gnu": "@ox-content/binding-linux-x64-gnu",
+    "linux-x64-musl": "@ox-content/binding-linux-x64-musl",
     "linux-arm64-gnu": "@ox-content/binding-linux-arm64-gnu",
+    "linux-arm64-musl": "@ox-content/binding-linux-arm64-musl",
     "win32-x64-msvc": "@ox-content/binding-win32-x64-msvc",
   };
 

--- a/scripts/package-dry-run.mjs
+++ b/scripts/package-dry-run.mjs
@@ -127,7 +127,9 @@ function checkNapiPackage(packageDir, pkg, files) {
     "x86_64-apple-darwin",
     "aarch64-apple-darwin",
     "x86_64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
     "aarch64-unknown-linux-gnu",
+    "aarch64-unknown-linux-musl",
     "x86_64-pc-windows-msvc",
   ]) {
     if (!targets.has(target)) {
@@ -140,7 +142,9 @@ function checkNapiPackage(packageDir, pkg, files) {
     "@ox-content/binding-darwin-arm64",
     "@ox-content/binding-darwin-x64",
     "@ox-content/binding-linux-x64-gnu",
+    "@ox-content/binding-linux-x64-musl",
     "@ox-content/binding-linux-arm64-gnu",
+    "@ox-content/binding-linux-arm64-musl",
     "@ox-content/binding-win32-x64-msvc",
   ]) {
     if (!wrapper.includes(bindingPackage)) {


### PR DESCRIPTION
## Summary

- Build Linux GNU NAPI artifacts with cargo-zigbuild using a GLIBC 2.17 target suffix.
- Add linux x64/arm64 musl NAPI targets and publish them as optional binding packages.
- Teach the Node loader to select gnu or musl bindings at runtime and extend package dry-run coverage.
- Add release/nightly readelf checks so GNU artifacts fail if they require newer GLIBC symbols and musl artifacts fail if they reference GLIBC symbols.

## Root Cause

The published Linux NAPI artifacts were built as GNU-only binaries on current Linux runners, so consumers on older glibc distributions could hit runtime loader failures from newer GLIBC symbol requirements. Alpine/musl environments also had no matching binding package.

## Validation

- `node --check crates/ox_content_napi/index.js`
- `node --check scripts/package-dry-run.mjs`
- `cargo test -p ox_content_napi javascript_wrapper -- --nocapture`
- `node scripts/package-dry-run.mjs`
- Generated NAPI sub-package directories in a temp dir and confirmed linux-*-musl packages include `libc: musl`.
- Parsed `.github/workflows/publish.yml` and `.github/workflows/nightly.yml` as YAML.
- Ran `actionlint`; it only reported the existing custom `blacksmith-32vcpu-ubuntu-2404` runner label as unknown.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785689228&installation_id=136613492&pr_number=460&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F460&signature=4f1ad8067adf28a4d8ade433cd06529107236d9634d32e9c2f0286421bc20219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional Linux musl prebuilt binaries, including x64 and arm64 variants.
  * Linux package loading now selects the correct binary for musl or glibc systems automatically.

* **Bug Fixes**
  * Improved release and publish workflows to validate Linux builds more reliably.
  * Added checks to prevent incompatible Linux binaries from being published.

* **Tests**
  * Updated dry-run validation to include the new Linux musl targets and packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->