### PR TITLE
ci: deploy docs to void with oidc

### DIFF
--- a/.github/workflows/void-deploy.yml
+++ b/.github/workflows/void-deploy.yml
@@ -1,0 +1,60 @@
+name: Deploy docs to Void
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Latest push wins for the Void deployment. The GitHub Pages workflow remains
+# separate in deploy.yml.
+concurrency:
+  group: void-deploy-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# id-token: write lets `void deploy` exchange GitHub OIDC for a short-lived
+# project-scoped deploy token. No long-lived VOID_TOKEN secret is required.
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  STICKY_CACHE_SCOPE: ${{ github.ref_name }}
+  VOID_API_URL: ${{ vars.VOID_API_URL || 'https://api.void.cloud' }}
+  VOID_PROJECT: ${{ vars.VOID_PROJECT || 'ox-content' }}
+  OX_CONTENT_DOCS_BASE: /
+  OX_CONTENT_DOCS_SITE_URL: https://ox-content.void.app
+
+jobs:
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: true
+
+      - name: Mount sticky cache
+        uses: ./.github/actions/mount-sticky-cache
+        with:
+          key-prefix: ${{ github.repository }}-void-deploy-${{ github.job }}-${{ env.STICKY_CACHE_SCOPE }}
+          cargo: "true"
+          target: target
+          browsers: "true"
+
+      - name: Install browsers for docs rendering
+        run: |
+          vp exec --filter @ox-content/vite-plugin -- playwright install --with-deps chromium
+          vp exec --filter @ox-content/vite-plugin -- puppeteer browsers install chrome-headless-shell
+
+      - name: Deploy docs to Void
+        run: vp run deploy#docs

--- a/docs/content/deployment.md
+++ b/docs/content/deployment.md
@@ -5,8 +5,12 @@ description: Deploy the Ox Content documentation site to Void.
 
 # Docs Deployment
 
-The repository exposes a dedicated workspace task for deploying the docs site to
-Void:
+The repository deploys the docs site to Void from GitHub Actions on pushes to
+`main`. The workflow uses GitHub OIDC, so it does not require a long-lived
+`VOID_TOKEN` secret.
+
+For local deployments, the same deploy path is exposed as a dedicated workspace
+task:
 
 ```bash
 vp run deploy#docs
@@ -25,7 +29,7 @@ whatever is already published to the registry.
 3. `vp pack` in `npm/ox-content-islands`
 4. `vp pack` in `npm/vite-plugin-ox-content`
 5. `vp build` in `docs`
-6. `vpx void@0.9.0 deploy`
+6. `vpx void@0.10.8 deploy`
 
 The deploy command defaults to the Void project and docs output directory used
 by this repository.
@@ -40,6 +44,26 @@ by this repository.
 Void hosts `https://ox-content.void.app` at the root path, so the deploy task
 sets the docs base to `/` by default. A normal production docs build without
 that override still uses the GitHub Pages base configured in `docs/vite.config.ts`.
+
+## GitHub Actions OIDC
+
+The tokenless deploy workflow lives at `.github/workflows/void-deploy.yml`.
+It grants `id-token: write` and runs `vp run deploy#docs`, which lets
+`void deploy` exchange GitHub OIDC for a short-lived Void deploy token at run
+time.
+
+The repository must be connected to the Void project once:
+
+```bash
+vpx void@0.10.8 github connect ox-content \
+  --repo ubugeeei-prod/ox-content \
+  --branch main \
+  --executor github_actions \
+  --workflow .github/workflows/void-deploy.yml
+```
+
+If the GitHub App is not installed for the organization yet, run
+`vpx void@0.10.8 github install` first.
 
 ## Overrides
 

--- a/docs/content/release.md
+++ b/docs/content/release.md
@@ -103,5 +103,5 @@ vp run deploy#docs
 ```
 
 The task builds the local workspace, builds docs with the Void base path, and
-then runs `vpx void@0.9.0 deploy`. Use `VOID_PROJECT` or forwarded Void CLI
+then runs `vpx void@0.10.8 deploy`. Use `VOID_PROJECT` or forwarded Void CLI
 flags for preview deployments.

--- a/scripts/deploy-docs-to-void.mjs
+++ b/scripts/deploy-docs-to-void.mjs
@@ -49,7 +49,7 @@ const run = (command, args, options = {}) => {
   }
 };
 
-const voidArgs = ["void@0.9.0", "deploy"];
+const voidArgs = ["void@0.10.8", "deploy"];
 
 if (!hasOption(extraArgs, "--project")) {
   voidArgs.push("--project", defaultProject);


### PR DESCRIPTION
## Summary
- Add a tokenless GitHub Actions workflow for deploying docs to Void with OIDC.
- Update the docs deploy script to use `void@0.10.8`, which includes `void github` support.
- Document the one-time `void github connect` setup and local deploy path.

Void project setup has also been connected for `ubugeeei-prod/ox-content` on `main` with the `github_actions` executor and `.github/workflows/void-deploy.yml`.

## Verification
- `vpx void@0.10.8 github status ox-content`
- `vp fmt --check .github/workflows/void-deploy.yml scripts/deploy-docs-to-void.mjs docs/content/deployment.md docs/content/release.md`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "blacksmith-32vcpu-ubuntu-2404" is unknown' .github/workflows/void-deploy.yml`\n- `vp run build:docs`\n\nNote: local `vp run build:docs` completed successfully after a frozen install repaired missing local type packages; it emitted Mermaid Chrome warnings because local Puppeteer Chrome is not installed. The new workflow installs both Playwright Chromium and Puppeteer chrome-headless-shell before deploying.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786075920&installation_id=136613492&pr_number=465&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F465&signature=0f8a4b4e2335952a22b42cb23acb9ae8ec25e371d7cff1297422ebe9820e2bc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GitHub Actions workflow to deploy the docs site to Void on pushes to `main` and via manual runs.
  * Introduced a GitHub OIDC-based deployment flow using short-lived credentials.
* **Documentation**
  * Updated deployment instructions to use the newer Void deploy tooling version.
  * Expanded setup guidance for connecting the repository to the Void project and running the required connect/install steps.
  * Clarified how local deployments follow the same deploy path as CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->