### PR TITLE
ci: preserve void oidc deploy env

### DIFF
--- a/.github/workflows/void-deploy.yml
+++ b/.github/workflows/void-deploy.yml
@@ -57,4 +57,4 @@ jobs:
           vp exec --filter @ox-content/vite-plugin -- puppeteer browsers install chrome-headless-shell
 
       - name: Deploy docs to Void
-        run: vp run deploy#docs
+        run: node scripts/deploy-docs-to-void.mjs

--- a/docs/content/deployment.md
+++ b/docs/content/deployment.md
@@ -48,9 +48,9 @@ that override still uses the GitHub Pages base configured in `docs/vite.config.t
 ## GitHub Actions OIDC
 
 The tokenless deploy workflow lives at `.github/workflows/void-deploy.yml`.
-It grants `id-token: write` and runs `vp run deploy#docs`, which lets
-`void deploy` exchange GitHub OIDC for a short-lived Void deploy token at run
-time.
+It grants `id-token: write` and runs `scripts/deploy-docs-to-void.mjs`
+directly from the GitHub Actions shell step, which lets `void deploy` exchange
+GitHub OIDC for a short-lived Void deploy token at run time.
 
 The repository must be connected to the Void project once:
 


### PR DESCRIPTION
## Summary
- Run the Void docs deploy script directly from the GitHub Actions shell step instead of through `vp run deploy#docs`.
- Keep the documentation aligned with the workflow path.

## Root cause
The merged `Deploy docs to Void` run built the docs successfully, then `void deploy` exited with `No auth token found. Run void auth login first.`. The CLI requires `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN` for tokenless OIDC deploys; running the deploy through the Vite+ task boundary dropped those GitHub-provided OIDC variables before `void deploy` executed.

## Verification
- `vp fmt --check .github/workflows/void-deploy.yml docs/content/deployment.md`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "blacksmith-32vcpu-ubuntu-2404" is unknown' .github/workflows/void-deploy.yml`\n- `zizmor .github/workflows/void-deploy.yml`\n- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786077272&installation_id=136613492&pr_number=466&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F466&signature=6afb97c29aa7822cf06029fb4beba72814a17de85cce3b1e932765f7c5eed0b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment docs to reflect the current GitHub Actions OIDC flow and how Void tokens are obtained at runtime.
  * Clarified that the docs deployment workflow now runs directly from the shell step, matching the latest automation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->