### PR TITLE
fix(parser): preserve escaped table pipes

### DIFF
--- a/crates/ox_content_parser/src/parser/table.rs
+++ b/crates/ox_content_parser/src/parser/table.rs
@@ -123,10 +123,43 @@ impl<'a> Parser<'a> {
     pub(super) fn parse_table_row(&self, line: &'a str) -> ParseResult<TableRow<'a>> {
         let mut cells: Vec<'a, TableCell<'a>> = self.allocator.new_vec();
         for cell_content in Self::table_row_cells(line) {
+            let cell_content = self.unescape_table_pipes(cell_content);
             let cell_children = self.parse_inline(cell_content, 0)?;
             cells.push(TableCell { children: cell_children, span: Span::new(0, 0) });
         }
         Ok(TableRow { children: cells, span: Span::new(0, 0) })
+    }
+
+    /// Removes the table-level escape from pipes before inline parsing.
+    ///
+    /// GFM treats `\|` as a literal pipe even inside code spans. Normal inline
+    /// parsing already handles the escape in prose, but code spans preserve
+    /// backslashes, so the table parser must consume it first.
+    fn unescape_table_pipes(&self, content: &'a str) -> &'a str {
+        let bytes = content.as_bytes();
+        if !bytes
+            .iter()
+            .enumerate()
+            .any(|(index, &byte)| byte == b'|' && is_escaped_table_pipe(bytes, index))
+        {
+            return content;
+        }
+
+        let mut unescaped =
+            ox_content_allocator::String::with_capacity_in(content.len(), self.allocator.bump());
+        let mut copied_through = 0;
+        let mut search_start = 0;
+        while let Some(relative) = memchr(b'|', &bytes[search_start..]) {
+            let pipe = search_start + relative;
+            if is_escaped_table_pipe(bytes, pipe) {
+                unescaped.push_str(&content[copied_through..pipe - 1]);
+                unescaped.push('|');
+                copied_through = pipe + 1;
+            }
+            search_start = pipe + 1;
+        }
+        unescaped.push_str(&content[copied_through..]);
+        unescaped.into_bump_str()
     }
 
     /// Iterates table row cells from a line.
@@ -136,7 +169,39 @@ impl<'a> Parser<'a> {
     pub(super) fn table_row_cells(line: &'a str) -> impl Iterator<Item = &'a str> {
         let trimmed = line.trim();
         let trimmed = trimmed.strip_prefix('|').unwrap_or(trimmed);
-        let trimmed = trimmed.strip_suffix('|').unwrap_or(trimmed);
-        trimmed.split('|').map(str::trim)
+        let trimmed = if trimmed.ends_with('|')
+            && !is_escaped_table_pipe(trimmed.as_bytes(), trimmed.len() - 1)
+        {
+            &trimmed[..trimmed.len() - 1]
+        } else {
+            trimmed
+        };
+        let bytes = trimmed.as_bytes();
+        let mut cell_start = 0;
+
+        std::iter::from_fn(move || {
+            if cell_start > bytes.len() {
+                return None;
+            }
+
+            let mut search_start = cell_start;
+            while let Some(relative) = memchr(b'|', &bytes[search_start..]) {
+                let pipe = search_start + relative;
+                if !is_escaped_table_pipe(bytes, pipe) {
+                    let cell = trimmed[cell_start..pipe].trim();
+                    cell_start = pipe + 1;
+                    return Some(cell);
+                }
+                search_start = pipe + 1;
+            }
+
+            let cell = trimmed[cell_start..].trim();
+            cell_start = bytes.len() + 1;
+            Some(cell)
+        })
     }
+}
+
+fn is_escaped_table_pipe(bytes: &[u8], pipe: usize) -> bool {
+    bytes[..pipe].iter().rev().take_while(|&&byte| byte == b'\\').count() % 2 == 1
 }

--- a/crates/ox_content_parser/src/parser/tests.rs
+++ b/crates/ox_content_parser/src/parser/tests.rs
@@ -173,6 +173,24 @@ fn test_parse_table() {
 }
 
 #[test]
+fn test_parse_table_preserves_escaped_pipes() {
+    let allocator = Allocator::new();
+    let table_md = "| Description |\n| --- |\n| Disallow filters (the `\\|` pipe) |";
+    let parser = Parser::with_options(&allocator, table_md, ParserOptions::gfm());
+    let doc = parser.parse().unwrap();
+
+    let Node::Table(table) = &doc.children[0] else {
+        panic!("expected table, got {:?}", doc.children[0]);
+    };
+    assert_eq!(table.children[1].children.len(), 1);
+    let inline_code = table.children[1].children[0].children.iter().find_map(|node| match node {
+        Node::InlineCode(code) => Some(code.value),
+        _ => None,
+    });
+    assert_eq!(inline_code, Some("|"));
+}
+
+#[test]
 fn test_parse_unordered_list() {
     let allocator = Allocator::new();
     let list_md = "- Item 1\n- Item 2\n- Item 3";


### PR DESCRIPTION
## Summary

- split GFM table rows only on unescaped pipe delimiters
- consume the table-level pipe escape before inline parsing, including inside code spans
- cover the reported one-cell regression with a parser test

## Validation

- `cargo test -p ox_content_parser`
- `cargo clippy -p ox_content_parser --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Closes #475

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786678898&installation_id=136613492&pr_number=476&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F476&signature=85ee1c3683be00fb7fa509a2cef937a69dc9011e4917ed5fcb47929482779f16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Markdown table parsing to preserve escaped pipe characters (`\|`) as literal content within table cells.
  * Corrected how escaped pipes are handled when splitting rows and trimming cell boundaries, preventing accidental delimiter treatment.
* **Tests**
  * Added a unit test to confirm escaped pipes inside table cell content are retained and parsed as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->