### PR TITLE
fix(theme): derive code block gradient color

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -1405,6 +1405,8 @@ export interface JsThemeColors {
   border?: string
   /** Code block background color. */
   codeBackground?: string
+  /** Code block gradient color at the top. */
+  codeBackgroundTop?: string
   /** Code block text color. */
   codeText?: string
 }

--- a/crates/ox_content_napi/src/ssg_bindings/converters.rs
+++ b/crates/ox_content_napi/src/ssg_bindings/converters.rs
@@ -15,6 +15,7 @@ fn convert_theme_colors(colors: Option<JsThemeColors>) -> Option<ox_content_ssg:
         text_muted: c.text_muted,
         border: c.border,
         code_background: c.code_background,
+        code_background_top: c.code_background_top,
         code_text: c.code_text,
     })
 }

--- a/crates/ox_content_napi/src/ssg_theme_types.rs
+++ b/crates/ox_content_napi/src/ssg_theme_types.rs
@@ -20,6 +20,8 @@ pub struct JsThemeColors {
     pub border: Option<String>,
     /// Code block background color.
     pub code_background: Option<String>,
+    /// Code block gradient color at the top.
+    pub code_background_top: Option<String>,
     /// Code block text color.
     pub code_text: Option<String>,
 }

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -1409,6 +1409,8 @@ export interface JsThemeColors {
   border?: string
   /** Code block background color. */
   codeBackground?: string
+  /** Code block gradient color at the top. */
+  codeBackgroundTop?: string
   /** Code block text color. */
   codeText?: string
 }

--- a/crates/ox_content_ssg/src/html/tests/theme.rs
+++ b/crates/ox_content_ssg/src/html/tests/theme.rs
@@ -101,6 +101,20 @@ fn test_generate_theme_css() {
 }
 
 #[test]
+fn test_code_background_also_updates_gradient_top() {
+    let css = generate_theme_css(&ThemeConfig {
+        colors: Some(ThemeColors {
+            code_background: Some("#f6f8fa".to_string()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    assert!(css.contains("--octc-color-code-bg: #f6f8fa;"));
+    assert!(css.contains("--octc-color-code-bg-top: #f6f8fa;"));
+}
+
+#[test]
 fn test_generate_footer_html() {
     let theme = ThemeConfig {
         footer: Some(ThemeFooter {

--- a/crates/ox_content_ssg/src/html/theme.rs
+++ b/crates/ox_content_ssg/src/html/theme.rs
@@ -19,6 +19,8 @@ pub struct ThemeColors {
     pub border: Option<String>,
     /// Code block background color.
     pub code_background: Option<String>,
+    /// Code block gradient color at the top.
+    pub code_background_top: Option<String>,
     /// Code block text color.
     pub code_text: Option<String>,
 }

--- a/crates/ox_content_ssg/src/html/theme_css.rs
+++ b/crates/ox_content_ssg/src/html/theme_css.rs
@@ -31,6 +31,9 @@ pub(super) fn generate_theme_css(theme: &ThemeConfig) -> String {
         if let Some(ref v) = colors.code_background {
             vars.push(format!("--octc-color-code-bg: {v};"));
         }
+        if let Some(v) = colors.code_background_top.as_ref().or(colors.code_background.as_ref()) {
+            vars.push(format!("--octc-color-code-bg-top: {v};"));
+        }
         if let Some(ref v) = colors.code_text {
             vars.push(format!("--octc-color-code-text: {v};"));
         }
@@ -67,6 +70,9 @@ pub(super) fn generate_theme_css(theme: &ThemeConfig) -> String {
         }
         if let Some(ref v) = colors.code_background {
             vars.push(format!("--octc-color-code-bg: {v};"));
+        }
+        if let Some(v) = colors.code_background_top.as_ref().or(colors.code_background.as_ref()) {
+            vars.push(format!("--octc-color-code-bg-top: {v};"));
         }
         if let Some(ref v) = colors.code_text {
             vars.push(format!("--octc-color-code-text: {v};"));

--- a/docs/content/theming.md
+++ b/docs/content/theming.md
@@ -103,17 +103,18 @@ theme config (below) or override them directly from [custom CSS](#custom-css-and
 
 ### Colors
 
-| Option                  | CSS Variable                 | Description                                   |
-| ----------------------- | ---------------------------- | --------------------------------------------- |
-| `colors.primary`        | `--octc-color-primary`       | Primary accent color for links, active states |
-| `colors.primaryHover`   | `--octc-color-primary-hover` | Primary color on hover                        |
-| `colors.background`     | `--octc-color-bg`            | Main background color                         |
-| `colors.backgroundAlt`  | `--octc-color-bg-alt`        | Alternative background (sidebar, code blocks) |
-| `colors.text`           | `--octc-color-text`          | Main text color                               |
-| `colors.textMuted`      | `--octc-color-text-muted`    | Muted/secondary text color                    |
-| `colors.border`         | `--octc-color-border`        | Border color                                  |
-| `colors.codeBackground` | `--octc-color-code-bg`       | Code block background                         |
-| `colors.codeText`       | `--octc-color-code-text`     | Code block text color                         |
+| Option                     | CSS Variable                 | Description                                                    |
+| -------------------------- | ---------------------------- | -------------------------------------------------------------- |
+| `colors.primary`           | `--octc-color-primary`       | Primary accent color for links, active states                  |
+| `colors.primaryHover`      | `--octc-color-primary-hover` | Primary color on hover                                         |
+| `colors.background`        | `--octc-color-bg`            | Main background color                                          |
+| `colors.backgroundAlt`     | `--octc-color-bg-alt`        | Alternative background (sidebar, code blocks)                  |
+| `colors.text`              | `--octc-color-text`          | Main text color                                                |
+| `colors.textMuted`         | `--octc-color-text-muted`    | Muted/secondary text color                                     |
+| `colors.border`            | `--octc-color-border`        | Border color                                                   |
+| `colors.codeBackground`    | `--octc-color-code-bg`       | Code block background                                          |
+| `colors.codeBackgroundTop` | `--octc-color-code-bg-top`   | Code block gradient top; follows `codeBackground` when omitted |
+| `colors.codeText`          | `--octc-color-code-text`     | Code block text color                                          |
 
 ### Layout
 

--- a/npm/vite-plugin-ox-content/src/theme.test.ts
+++ b/npm/vite-plugin-ox-content/src/theme.test.ts
@@ -85,6 +85,24 @@ describe("theme", () => {
       expect(resolved.entryPage.mode).toBe("subtle");
     });
 
+    it("should derive the code gradient top from a customized background", () => {
+      const resolved = resolveTheme({
+        extends: defaultTheme,
+        colors: { codeBackground: "#f6f8fa", codeText: "#1f2328" },
+      });
+
+      expect(resolved.colors.codeBackgroundTop).toBe("#f6f8fa");
+      expect(themeToNapi(resolved).colors?.codeBackgroundTop).toBe("#f6f8fa");
+    });
+
+    it("should preserve an explicit code gradient top", () => {
+      const resolved = resolveTheme({
+        colors: { codeBackground: "#f6f8fa", codeBackgroundTop: "#ffffff" },
+      });
+
+      expect(resolved.colors.codeBackgroundTop).toBe("#ffffff");
+    });
+
     it("should resolve nested extends", () => {
       const baseTheme: ThemeConfig = {
         name: "base",

--- a/npm/vite-plugin-ox-content/src/theme.ts
+++ b/npm/vite-plugin-ox-content/src/theme.ts
@@ -24,6 +24,8 @@ export interface ThemeColors {
   border?: string;
   /** Code block background color */
   codeBackground?: string;
+  /** Code block gradient color at the top; defaults to `codeBackground` when customized */
+  codeBackgroundTop?: string;
   /** Code block text color */
   codeText?: string;
 }
@@ -208,6 +210,7 @@ export const defaultTheme: ThemeConfig = {
     textMuted: "#4f607b",
     border: "#d2dbea",
     codeBackground: "#101a31",
+    codeBackgroundTop: "#18264a",
     codeText: "#edf3ff",
   },
   darkColors: {
@@ -219,6 +222,7 @@ export const defaultTheme: ThemeConfig = {
     textMuted: "#8ea0bf",
     border: "#223252",
     codeBackground: "#0a1020",
+    codeBackgroundTop: "#0a1020",
     codeText: "#e7f0ff",
   },
   fonts: {
@@ -351,7 +355,7 @@ export function resolveTheme(config?: ThemeConfig): ResolvedThemeConfig {
   }
 
   // Merge all themes in the chain
-  const merged = mergeThemes(...chain);
+  const merged = mergeThemes(...chain.map(withDerivedCodeBackgroundTop));
 
   // Return resolved config with all required fields
   return {
@@ -368,6 +372,21 @@ export function resolveTheme(config?: ThemeConfig): ResolvedThemeConfig {
     embed: merged.embed ?? {},
     css: merged.css ?? "",
     js: merged.js ?? "",
+  };
+}
+
+function withDerivedCodeBackgroundTop(theme: ThemeConfig): ThemeConfig {
+  const derive = (colors: ThemeColors | undefined): ThemeColors | undefined => {
+    if (colors?.codeBackground !== undefined && colors.codeBackgroundTop === undefined) {
+      return { ...colors, codeBackgroundTop: colors.codeBackground };
+    }
+    return colors;
+  };
+
+  return {
+    ...theme,
+    colors: derive(theme.colors),
+    darkColors: derive(theme.darkColors),
   };
 }
 
@@ -388,6 +407,7 @@ export function themeToNapi(theme: ResolvedThemeConfig): NapiThemeConfig {
           textMuted: theme.colors.textMuted,
           border: theme.colors.border,
           codeBackground: theme.colors.codeBackground,
+          codeBackgroundTop: theme.colors.codeBackgroundTop,
           codeText: theme.colors.codeText,
         }
       : undefined,
@@ -401,6 +421,7 @@ export function themeToNapi(theme: ResolvedThemeConfig): NapiThemeConfig {
           textMuted: theme.darkColors.textMuted,
           border: theme.darkColors.border,
           codeBackground: theme.darkColors.codeBackground,
+          codeBackgroundTop: theme.darkColors.codeBackgroundTop,
           codeText: theme.darkColors.codeText,
         }
       : undefined,
@@ -474,6 +495,7 @@ export interface NapiThemeColors {
   textMuted?: string;
   border?: string;
   codeBackground?: string;
+  codeBackgroundTop?: string;
   codeText?: string;
 }
 


### PR DESCRIPTION
## Summary

- expose `codeBackgroundTop` through the TypeScript, NAPI, and Rust theme APIs
- derive the gradient top from `codeBackground` when only the background is customized
- preserve the existing default gradient and explicit top-color overrides
- document and test the light-theme behavior

## Validation

- `vp exec --filter @ox-content/vite-plugin -- vp test src/theme.test.ts`
- `corepack pnpm --filter @ox-content/vite-plugin run typecheck`
- `cargo test -p ox_content_ssg`
- `cargo test -p ox_content_napi tests::runtime_features::javascript_wrapper_and_declarations_cover_expected_exports`
- `cargo clippy -p ox_content_ssg -p ox_content_napi --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Closes #431

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786679092&installation_id=136613492&pr_number=477&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F477&signature=8bc6a3a7b605f0b5ef0a0f4e8773ab6360a7d771af83e163427d929365d00ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `codeBackgroundTop` theme customization for controlling the top color of code block gradients.
  * Code block gradients now fall back to `codeBackground` when no top color is specified.
  * Added support for the setting across light and dark themes.

* **Documentation**
  * Documented the new theme option and corresponding CSS variable.

* **Tests**
  * Added coverage for default fallback and explicit gradient-top colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->