### PR TITLE
fix(vite-plugin): forward autolinks option

### DIFF
--- a/docs/content/built-in-features.md
+++ b/docs/content/built-in-features.md
@@ -15,23 +15,23 @@ enabled explicitly.
 
 ## Default vs Opt-in
 
-| Area             | Option                                                                | Default       | Notes                                               |
-| ---------------- | --------------------------------------------------------------------- | ------------- | --------------------------------------------------- |
-| Markdown base    | `gfm`, `footnotes`, `tables`, `taskLists`, `strikethrough`            | `true`        | Common GitHub-flavored Markdown behavior.           |
-| Page metadata    | `frontmatter`                                                         | `true`        | Parses YAML frontmatter before rendering.           |
-| Navigation       | `toc`, `tocMaxDepth`                                                  | `true`, `3`   | Builds a page table of contents from headings.      |
-| Static site      | `ssg`                                                                 | `{ enabled }` | Generates static HTML pages during build.           |
-| API docs         | `docs`                                                                | `{ enabled }` | Generates package API docs unless set to `false`.   |
-| Search           | `search`                                                              | `{ enabled }` | Builds a static BM25 index for client-side search.  |
-| Collections      | `collections`                                                         | `{ content }` | Rust-native lazy query manifest for Markdown files. |
-| Syntax highlight | `highlight`                                                           | `false`       | Opt in when the site needs highlighted code blocks. |
-| OG images        | `ogImage`                                                             | `false`       | Opt in because image rendering adds build work.     |
-| Extra syntax     | `wikiLinks`, `emojiShortcodes`, `attrs`, `codeImports`, `cjkEmphasis` | `false`       | Non-standard authoring features are opt-in.         |
-| HTML safety      | `sanitize`                                                            | `false`       | Opt in when rendering untrusted or mixed HTML.      |
-| Editing links    | `editThisPage`                                                        | `false`       | Opt in with a repository URL.                       |
-| Code checks      | `codeAnnotations`, `codeBlockLint`, `codeBlockTypecheck`, `docsTests` | `false`       | Opt in per documentation workflow.                  |
-| Diagrams         | `mermaid`                                                             | `false`       | Opt in for diagram rendering.                       |
-| Custom pipeline  | `transformers`                                                        | `[]`          | Add project-specific Markdown AST transforms.       |
+| Area             | Option                                                                  | Default       | Notes                                               |
+| ---------------- | ----------------------------------------------------------------------- | ------------- | --------------------------------------------------- |
+| Markdown base    | `gfm`, `footnotes`, `tables`, `taskLists`, `strikethrough`, `autolinks` | `true`        | Common GitHub-flavored Markdown behavior.           |
+| Page metadata    | `frontmatter`                                                           | `true`        | Parses YAML frontmatter before rendering.           |
+| Navigation       | `toc`, `tocMaxDepth`                                                    | `true`, `3`   | Builds a page table of contents from headings.      |
+| Static site      | `ssg`                                                                   | `{ enabled }` | Generates static HTML pages during build.           |
+| API docs         | `docs`                                                                  | `{ enabled }` | Generates package API docs unless set to `false`.   |
+| Search           | `search`                                                                | `{ enabled }` | Builds a static BM25 index for client-side search.  |
+| Collections      | `collections`                                                           | `{ content }` | Rust-native lazy query manifest for Markdown files. |
+| Syntax highlight | `highlight`                                                             | `false`       | Opt in when the site needs highlighted code blocks. |
+| OG images        | `ogImage`                                                               | `false`       | Opt in because image rendering adds build work.     |
+| Extra syntax     | `wikiLinks`, `emojiShortcodes`, `attrs`, `codeImports`, `cjkEmphasis`   | `false`       | Non-standard authoring features are opt-in.         |
+| HTML safety      | `sanitize`                                                              | `false`       | Opt in when rendering untrusted or mixed HTML.      |
+| Editing links    | `editThisPage`                                                          | `false`       | Opt in with a repository URL.                       |
+| Code checks      | `codeAnnotations`, `codeBlockLint`, `codeBlockTypecheck`, `docsTests`   | `false`       | Opt in per documentation workflow.                  |
+| Diagrams         | `mermaid`                                                               | `false`       | Opt in for diagram rendering.                       |
+| Custom pipeline  | `transformers`                                                          | `[]`          | Add project-specific Markdown AST transforms.       |
 
 Use explicit options when a site needs non-standard behavior:
 

--- a/npm/vite-plugin-ox-content-react/src/index.ts
+++ b/npm/vite-plugin-ox-content-react/src/index.ts
@@ -221,6 +221,7 @@ function resolveReactOptions(
     base: options.base ?? "/",
     extensions: normalizeMarkdownExtensions(options.extensions),
     gfm: options.gfm ?? true,
+    autolinks: options.autolinks ?? options.gfm ?? true,
     frontmatter: options.frontmatter ?? true,
     toc: options.toc ?? true,
     tocMaxDepth: options.tocMaxDepth ?? 3,

--- a/npm/vite-plugin-ox-content-react/src/transform.ts
+++ b/npm/vite-plugin-ox-content-react/src/transform.ts
@@ -93,6 +93,7 @@ export async function transformMarkdownWithReact(
     tables: true,
     taskLists: true,
     strikethrough: true,
+    autolinks: options.autolinks,
     highlight: false,
     highlightTheme: "github-dark",
     highlightLangs: [],

--- a/npm/vite-plugin-ox-content-react/src/types.ts
+++ b/npm/vite-plugin-ox-content-react/src/types.ts
@@ -194,6 +194,7 @@ export interface ResolvedReactOptions {
   base: string;
   extensions: string[];
   gfm: boolean;
+  autolinks: boolean;
   frontmatter: boolean;
   toc: boolean;
   tocMaxDepth: number;

--- a/npm/vite-plugin-ox-content-svelte/src/index.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/index.ts
@@ -217,6 +217,7 @@ function resolveSvelteOptions(
     base: options.base ?? "/",
     extensions: normalizeMarkdownExtensions(options.extensions),
     gfm: options.gfm ?? true,
+    autolinks: options.autolinks ?? options.gfm ?? true,
     frontmatter: options.frontmatter ?? true,
     toc: options.toc ?? true,
     tocMaxDepth: options.tocMaxDepth ?? 3,

--- a/npm/vite-plugin-ox-content-svelte/src/transform.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/transform.ts
@@ -94,6 +94,7 @@ export async function transformMarkdownWithSvelte(
     tables: true,
     taskLists: true,
     strikethrough: true,
+    autolinks: options.autolinks,
     highlight: false,
     highlightTheme: "github-dark",
     highlightLangs: [],

--- a/npm/vite-plugin-ox-content-svelte/src/types.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/types.ts
@@ -192,6 +192,7 @@ export interface ResolvedSvelteOptions {
   base: string;
   extensions: string[];
   gfm: boolean;
+  autolinks: boolean;
   frontmatter: boolean;
   toc: boolean;
   tocMaxDepth: number;

--- a/npm/vite-plugin-ox-content-vue/src/index.ts
+++ b/npm/vite-plugin-ox-content-vue/src/index.ts
@@ -249,6 +249,7 @@ function resolveVueOptions(options: VueIntegrationOptions): ResolvedVueOptions {
     base: options.base ?? "/",
     extensions: normalizeMarkdownExtensions(options.extensions),
     gfm: options.gfm ?? true,
+    autolinks: options.autolinks ?? options.gfm ?? true,
     frontmatter: options.frontmatter ?? true,
     toc: options.toc ?? true,
     tocMaxDepth: options.tocMaxDepth ?? 3,

--- a/npm/vite-plugin-ox-content-vue/src/transform.ts
+++ b/npm/vite-plugin-ox-content-vue/src/transform.ts
@@ -112,6 +112,7 @@ export async function transformMarkdownWithVue(
     tables: true,
     taskLists: true,
     strikethrough: true,
+    autolinks: options.autolinks,
     highlight: false,
     highlightTheme: "github-dark",
     highlightLangs: [],

--- a/npm/vite-plugin-ox-content-vue/src/types.ts
+++ b/npm/vite-plugin-ox-content-vue/src/types.ts
@@ -226,6 +226,7 @@ export interface ResolvedVueOptions {
   base: string;
   extensions: string[];
   gfm: boolean;
+  autolinks: boolean;
   frontmatter: boolean;
   toc: boolean;
   tocMaxDepth: number;

--- a/npm/vite-plugin-ox-content/src/code-annotations.test.ts
+++ b/npm/vite-plugin-ox-content/src/code-annotations.test.ts
@@ -130,6 +130,7 @@ function createResolvedOptions(overrides: Partial<ResolvedOptions> = {}): Resolv
     tables: true,
     taskLists: true,
     strikethrough: true,
+    autolinks: true,
     highlight: true,
     highlightTheme: "github-dark",
     highlightLangs: [],

--- a/npm/vite-plugin-ox-content/src/collections.ts
+++ b/npm/vite-plugin-ox-content/src/collections.ts
@@ -24,6 +24,8 @@ type NativeTransformOptions = {
   taskLists?: boolean;
   tables?: boolean;
   strikethrough?: boolean;
+  autolinks?: boolean;
+  autolinkUrls?: boolean;
   frontmatter?: boolean;
   tocMaxDepth?: number;
   codeAnnotations?: boolean;
@@ -144,6 +146,8 @@ function createNativeTransformOptions(options: ResolvedOptions): NativeTransform
     taskLists: options.taskLists,
     tables: options.tables,
     strikethrough: options.strikethrough,
+    autolinks: options.autolinks,
+    autolinkUrls: options.autolinks,
     frontmatter: options.frontmatter,
     tocMaxDepth: options.tocMaxDepth,
     codeAnnotations: options.codeAnnotations?.enabled ?? false,

--- a/npm/vite-plugin-ox-content/src/framework.ts
+++ b/npm/vite-plugin-ox-content/src/framework.ts
@@ -65,6 +65,7 @@ export function createFrameworkMarkdownOptions(options: FrameworkMarkdownOptions
     tables: true,
     taskLists: true,
     strikethrough: true,
+    autolinks: options.gfm,
     highlight: false,
     highlightTheme: "github-dark",
     highlightLangs: [],

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -539,6 +539,7 @@ function resolveOptions(options: OxContentOptions): ResolvedOptions {
     tables: options.tables ?? true,
     taskLists: options.taskLists ?? true,
     strikethrough: options.strikethrough ?? true,
+    autolinks: options.autolinks ?? options.gfm ?? true,
     highlight: options.highlight ?? false,
     highlightTheme: options.highlightTheme ?? "github-dark",
     highlightLangs: options.highlightLangs ?? [],

--- a/npm/vite-plugin-ox-content/src/transform.test.ts
+++ b/npm/vite-plugin-ox-content/src/transform.test.ts
@@ -132,6 +132,23 @@ describe("transformMarkdown", () => {
     expect(result.html).toMatchSnapshot();
   });
 
+  it("forwards the autolinks option to bare URL rendering", async () => {
+    const markdown = "See https://example.com/foo here.";
+    const enabled = await transformMarkdown(
+      markdown,
+      "docs/autolinks.md",
+      createResolvedOptions({ autolinks: true }),
+    );
+    const disabled = await transformMarkdown(
+      markdown,
+      "docs/autolinks.md",
+      createResolvedOptions({ autolinks: false }),
+    );
+
+    expect(enabled.html).toContain('<a href="https://example.com/foo"');
+    expect(disabled.html).toBe("<p>See https://example.com/foo here.</p>\n");
+  });
+
   it("preserves safe raw media tags when sanitizing", async () => {
     const result = await transformMarkdown(
       [
@@ -194,6 +211,7 @@ function createResolvedOptions(overrides: Partial<ResolvedOptions> = {}): Resolv
     tables: true,
     taskLists: true,
     strikethrough: true,
+    autolinks: true,
     highlight: false,
     highlightTheme: "github-dark",
     highlightLangs: [],

--- a/npm/vite-plugin-ox-content/src/transform.ts
+++ b/npm/vite-plugin-ox-content/src/transform.ts
@@ -179,6 +179,12 @@ interface JsTransformOptions {
   autolinks?: boolean;
 
   /**
+   * Linkify bare URLs while rendering.
+   * @default true
+   */
+  autolinkUrls?: boolean;
+
+  /**
    * Parse YAML frontmatter before transforming.
    * @default true
    */
@@ -485,6 +491,8 @@ export async function transformMarkdown(
     taskLists: options.taskLists,
     tables: options.tables,
     strikethrough: options.strikethrough,
+    autolinks: options.autolinks,
+    autolinkUrls: options.autolinks,
     frontmatter: options.frontmatter,
     tocMaxDepth: options.tocMaxDepth,
     convertMdLinks: ssgOptions?.convertMdLinks,

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -382,6 +382,12 @@ export interface OxContentOptions {
   strikethrough?: boolean;
 
   /**
+   * Enable GFM autolinks and linkify bare URLs.
+   * @default true
+   */
+  autolinks?: boolean;
+
+  /**
    * Enable syntax highlighting for code blocks.
    * @default false
    */
@@ -628,6 +634,7 @@ export interface ResolvedOptions {
   tables: boolean;
   taskLists: boolean;
   strikethrough: boolean;
+  autolinks: boolean;
   highlight: boolean;
   highlightTheme: string | ThemeRegistration;
   highlightLangs: LanguageRegistration[];

--- a/npm/vite-plugin-ox-content/test/fixtures/docs-fixture.ts
+++ b/npm/vite-plugin-ox-content/test/fixtures/docs-fixture.ts
@@ -111,6 +111,7 @@ export function createDocsResolvedOptions(
     tables: true,
     taskLists: true,
     strikethrough: true,
+    autolinks: true,
     highlight: true,
     highlightTheme: "vitesse-dark",
     highlightLangs: [],

--- a/npm/vite-plugin-ox-content/test/vrt/code-highlighting.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/code-highlighting.spec.ts
@@ -23,6 +23,7 @@ function createResolvedOptions(): ResolvedOptions {
     tables: true,
     taskLists: true,
     strikethrough: true,
+    autolinks: true,
     highlight: true,
     highlightTheme: "vitesse-dark",
     highlightLangs: [],


### PR DESCRIPTION
## Summary

- expose `autolinks` on the Vite plugin's public and resolved options
- forward it to both GFM parsing and bare-URL rendering
- keep React, Svelte, Vue, collection, and framework transforms aligned
- verify enabled and disabled bare-URL output

The current NAPI build already linkifies the issue reproduction with `gfm: true` and `autolinks: true`; this closes the missing Vite-plugin propagation reported in the same issue.

## Validation

- `vp run check:ts`
- `vp exec --filter @ox-content/vite-plugin -- vp test src/transform.test.ts`
- `vp run test:framework-integrations`
- `vp run build:vite-plugin`

Closes #430

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786679501&installation_id=136613492&pr_number=478&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F478&signature=df8ee9e74218cb0ff83c2515dbce21293cb0453fc9ea1368ef78eafd9f06af48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable autolink support for Markdown, including automatic linking of bare URLs.
  * Autolinks are enabled by default and can be disabled independently from other GFM features.
  * Added consistent autolink handling across React, Vue, and Svelte integrations.

* **Documentation**
  * Updated feature documentation to reflect autolinks among the default GFM behaviors.

* **Tests**
  * Added coverage verifying URL conversion when autolinks are enabled or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->