### PR TITLE
feat(vite-plugin): fetch static tweet content

### DIFF
--- a/docs/content/built-in-features.md
+++ b/docs/content/built-in-features.md
@@ -49,7 +49,7 @@ export default defineConfig({
       },
       embeds: {
         pm: { sync: true },
-        twitter: true,
+        twitter: { fetch: true },
         bluesky: true,
       },
     }),

--- a/docs/content/examples/twitter-embed.md
+++ b/docs/content/examples/twitter-embed.md
@@ -5,8 +5,9 @@ description: Render X posts as privacy-conscious static cards.
 
 # Twitter/X Embed
 
-Twitter/X embeds are opt-in and render static cards by default. No third-party
-widget script is loaded.
+Twitter/X embeds are opt-in and never load a third-party widget script.
+`twitter: true` renders the privacy-conscious link card. Use the object form to
+fetch the post body, author, avatar, and photos at build time:
 
 ```ts
 import { oxContent } from "@ox-content/vite-plugin";
@@ -15,7 +16,12 @@ export default {
   plugins: [
     oxContent({
       embeds: {
-        twitter: true,
+        twitter: {
+          fetch: true,
+          lang: "en",
+          mediaOutputDir: "public/ox-content/twitter",
+          mediaPublicPath: "/ox-content/twitter",
+        },
       },
     }),
   ],
@@ -23,5 +29,21 @@ export default {
 ```
 
 ```html
-<Tweet id="1234567890">Post summary shown in the static card.</Tweet>
+<XPost url="https://x.com/ox_content/status/1234567890" />
 ```
+
+Fetched metadata is cached in memory and under `.cache/ox-content/twitter` by
+default. Avatars and photos are copied into the configured output directory, so
+the generated page can use a strict `img-src 'self'` policy. If the post is
+deleted, private, or unavailable during a build, Ox Content falls back to the
+link-only card instead of failing the build.
+
+| Option            | Default                     | Purpose                                      |
+| ----------------- | --------------------------- | -------------------------------------------- |
+| `fetch`           | `false`                     | Fetch post content from X at build time.     |
+| `lang`            | `"en"`                      | Syndication language and displayed date.     |
+| `timeout`         | `10000`                     | Metadata request timeout in milliseconds.    |
+| `cache`           | `true`                      | Enable in-memory and persistent JSON caches. |
+| `cacheDir`        | `.cache/ox-content/twitter` | Persistent metadata cache directory.         |
+| `mediaOutputDir`  | `public/ox-content/twitter` | Local directory for avatars and photos.      |
+| `mediaPublicPath` | `/ox-content/twitter`       | URL prefix emitted for downloaded media.     |

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -30,8 +30,10 @@ import { resolveI18nOptions, createI18nPlugin } from "./i18n";
 import { isMarkdownFilePath, normalizeMarkdownExtensions } from "./markdown";
 import { generateCollectionsVirtualModule, resolveCollectionsOptions } from "./collections";
 import type { BuiltinPmOptions, OxContentOptions, ResolvedOptions } from "./types";
+import type { TwitterEmbedOptions } from "./plugins";
 
 export type { OxContentOptions } from "./types";
+export type { TwitterEmbedOptions } from "./plugins";
 export type { LanguageRegistration, ThemeRegistration } from "shiki";
 export type {
   CodeAnnotationSyntax,
@@ -592,7 +594,7 @@ export function resolveBuiltinEmbedOptions(
     pm: resolvePmOptions(options?.pm),
     spotify: options?.spotify === true,
     stackBlitz: options?.stackBlitz === true,
-    twitter: options?.twitter === true,
+    twitter: resolveTwitterEmbedOptions(options?.twitter),
     bluesky: options?.bluesky === true,
     webContainer: options?.webContainer === true,
   };
@@ -601,6 +603,14 @@ export function resolveBuiltinEmbedOptions(
 function resolveSingleEmbedOptions<T extends object>(options: boolean | T | undefined): T | false {
   if (options === false) return false;
   if (options === true || options === undefined) return {} as T;
+  return options;
+}
+
+function resolveTwitterEmbedOptions(
+  options: boolean | TwitterEmbedOptions | undefined,
+): TwitterEmbedOptions | false {
+  if (options === false || options === undefined) return false;
+  if (options === true) return {};
   return options;
 }
 

--- a/npm/vite-plugin-ox-content/src/plugins/index.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/index.ts
@@ -7,6 +7,7 @@
 
 import type { GitHubOptions } from "./github";
 import type { MediaEmbedOptions } from "./media";
+import type { TwitterEmbedOptions } from "./twitter";
 import type { OgpOptions } from "./ogp";
 import type { PmOptions } from "./pm";
 
@@ -22,6 +23,12 @@ export { transformPm, type PmOptions } from "./pm";
 
 export { transformYouTube, extractVideoId, type YouTubeOptions } from "./youtube";
 export { transformMediaEmbeds, type MediaEmbedOptions } from "./media";
+export {
+  createSyndicationToken,
+  parseTweetReference,
+  type TweetData,
+  type TwitterEmbedOptions,
+} from "./twitter";
 
 export {
   transformGitHub,
@@ -71,7 +78,7 @@ export interface TransformAllOptions {
   githubToken?: string;
   spotify?: boolean;
   stackBlitz?: boolean;
-  twitter?: boolean;
+  twitter?: boolean | TwitterEmbedOptions;
   bluesky?: boolean;
   webContainer?: boolean;
 }
@@ -167,7 +174,7 @@ export async function transformBuiltinEmbeds(
     pm?: PmOptions | false;
     spotify?: boolean;
     stackBlitz?: boolean;
-    twitter?: boolean;
+    twitter?: boolean | TwitterEmbedOptions;
     bluesky?: boolean;
     webContainer?: boolean;
   },

--- a/npm/vite-plugin-ox-content/src/plugins/media.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/media.ts
@@ -1,4 +1,6 @@
 import { importNapiModule } from "../napi";
+import { transformFetchedTweets } from "./twitter";
+import type { TwitterEmbedOptions } from "./twitter";
 
 export interface MediaEmbedOptions {
   /**
@@ -14,10 +16,11 @@ export interface MediaEmbedOptions {
   stackBlitz?: boolean;
 
   /**
-   * Render `<Tweet>` / `<XPost>` static cards.
+   * Render `<Tweet>` / `<XPost>` static cards. Pass `{ fetch: true }` to
+   * resolve the post content and self-host its media at build time.
    * @default false
    */
-  twitter?: boolean;
+  twitter?: boolean | TwitterEmbedOptions;
 
   /**
    * Render `<Bluesky>` static cards.
@@ -40,11 +43,17 @@ export async function transformMediaEmbeds(
     return html;
   }
 
+  let result = html;
+  if (typeof options.twitter === "object") {
+    result = await transformFetchedTweets(result, options.twitter);
+  }
+  if (!hasMediaMarker(result)) return result;
+
   const mod = await importNapiModule();
-  return mod.transformMediaEmbeds(html, {
+  return mod.transformMediaEmbeds(result, {
     spotify: options.spotify,
     stackBlitz: options.stackBlitz,
-    twitter: options.twitter,
+    twitter: Boolean(options.twitter),
     bluesky: options.bluesky,
     webContainer: options.webContainer,
   });

--- a/npm/vite-plugin-ox-content/src/plugins/twitter.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter.test.ts
@@ -1,0 +1,134 @@
+import { Buffer } from "node:buffer";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { transformMediaEmbeds } from "./media";
+import { clearTweetCache } from "./twitter/fetch";
+import { transformFetchedTweets } from "./twitter/transform";
+import { createSyndicationToken, parseTweetReference } from "./twitter/url";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  clearTweetCache();
+});
+
+describe("fetched Twitter embeds", () => {
+  it("normalizes post references and creates the widgets.js token", () => {
+    expect(parseTweetReference("https://mobile.twitter.com/ox_content/status/123456?s=20")).toEqual(
+      {
+        id: "123456",
+        url: "https://x.com/ox_content/status/123456",
+      },
+    );
+    expect(parseTweetReference("123456")).toEqual({
+      id: "123456",
+      url: "https://x.com/i/web/status/123456",
+    });
+    expect(createSyndicationToken("1234567890123456789")).toBe(
+      ((Number("1234567890123456789") / 1e15) * Math.PI).toString(36).replaceAll(/(0+|\.)/g, ""),
+    );
+  });
+
+  it("renders fetched content, rewrites links, downloads media, and reuses disk cache", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "ox-content-twitter-"));
+    const cacheDir = path.join(root, "cache");
+    const mediaOutputDir = path.join(root, "public", "tweets");
+    const text = "Hello https://t.co/docs https://t.co/photo";
+    const link = "https://t.co/docs";
+    const photo = "https://t.co/photo";
+    let requests = 0;
+
+    globalThis.fetch = async (input) => {
+      requests += 1;
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.startsWith("https://cdn.syndication.twimg.com/")) {
+        return {
+          ok: true,
+          json: async () => ({
+            text,
+            display_text_range: [0, text.length],
+            entities: {
+              urls: [
+                {
+                  url: link,
+                  expanded_url: "https://example.com/docs",
+                  display_url: "example.com/docs",
+                  indices: [text.indexOf(link), text.indexOf(link) + link.length],
+                },
+              ],
+              media: [
+                {
+                  url: photo,
+                  indices: [text.indexOf(photo), text.indexOf(photo) + photo.length],
+                },
+              ],
+            },
+            mediaDetails: [
+              {
+                type: "photo",
+                media_url_https: "https://pbs.twimg.com/media/post.jpg",
+                ext_alt_text: "A release chart",
+                original_info: { width: 1200, height: 675 },
+              },
+            ],
+            user: {
+              name: "Ox <Content>",
+              screen_name: "ox_content",
+              profile_image_url_https: "https://pbs.twimg.com/profile_images/avatar_normal.jpg",
+            },
+            created_at: "Tue Jul 15 03:00:00 +0000 2026",
+          }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+      } as Response;
+    };
+
+    const input = '<XPost url="https://x.com/ox_content/status/123456?s=20" />';
+    const options = {
+      fetch: true,
+      cacheDir,
+      mediaOutputDir,
+      mediaPublicPath: "/tweets",
+    };
+
+    try {
+      const html = await transformMediaEmbeds(input, { twitter: options });
+      expect(html).toContain('class="ox-tweet ox-tweet--fetched"');
+      expect(html).toContain("Ox &lt;Content&gt;");
+      expect(html).toContain('href="https://example.com/docs"');
+      expect(html).toContain(">example.com/docs</a>");
+      expect(html).not.toContain(photo);
+      expect(html).toContain('src="/tweets/123456-avatar.jpg"');
+      expect(html).toContain('src="/tweets/123456-media-1.jpg"');
+      expect(html).toContain('data-count="1"');
+
+      await expect(readFile(path.join(mediaOutputDir, "123456-avatar.jpg"))).resolves.toEqual(
+        Buffer.from([1, 2, 3]),
+      );
+      await expect(readFile(path.join(cacheDir, "123456-en.json"), "utf8")).resolves.toContain(
+        '"screen_name":"ox_content"',
+      );
+      expect(requests).toBe(3);
+
+      clearTweetCache();
+      await expect(transformFetchedTweets(input, options)).resolves.toContain(
+        'class="ox-tweet ox-tweet--fetched"',
+      );
+      expect(requests).toBe(3);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves the source element when the post cannot be fetched", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 404 }) as Response;
+    const input = '<Tweet id="987654">fallback summary</Tweet>';
+    await expect(transformFetchedTweets(input, { fetch: true, cache: false })).resolves.toBe(input);
+  });
+});

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/fetch.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/fetch.ts
@@ -1,0 +1,160 @@
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { createSyndicationToken } from "./url";
+import type { ResolvedTwitterEmbedOptions, TweetAssets, TweetData, TweetMedia } from "./types";
+
+const tweetCache = new Map<string, TweetData>();
+
+export function clearTweetCache(): void {
+  tweetCache.clear();
+}
+
+export async function fetchTweetData(
+  id: string,
+  options: ResolvedTwitterEmbedOptions,
+): Promise<TweetData | null> {
+  const key = `${id}-${sanitizeSegment(options.lang)}`;
+  if (options.cache) {
+    const memory = tweetCache.get(key);
+    if (memory) return memory;
+    const disk = await readCachedTweet(key, options.cacheDir);
+    if (disk) {
+      tweetCache.set(key, disk);
+      return disk;
+    }
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeout);
+  const endpoint = new URL("https://cdn.syndication.twimg.com/tweet-result");
+  endpoint.searchParams.set("id", id);
+  endpoint.searchParams.set("lang", options.lang);
+  endpoint.searchParams.set("token", createSyndicationToken(id));
+
+  try {
+    const response = await fetch(endpoint, {
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
+    if (!response.ok) return null;
+    const data: unknown = await response.json();
+    if (!isTweetData(data)) return null;
+    if (options.cache) {
+      tweetCache.set(key, data);
+      await writeCachedTweet(key, data, options.cacheDir);
+    }
+    return data;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function materializeTweetAssets(
+  id: string,
+  data: TweetData,
+  options: ResolvedTwitterEmbedOptions,
+): Promise<TweetAssets> {
+  const assets: TweetAssets = { media: [] };
+  const avatarUrl = data.user.profile_image_url_https?.replace(/_normal(?=\.[^.]+$)/, "_bigger");
+  if (avatarUrl) {
+    assets.avatar = await downloadAsset(avatarUrl, `${id}-avatar`, options);
+  }
+
+  const media = data.mediaDetails ?? data.entities?.media ?? [];
+  for (const [index, item] of media.entries()) {
+    if (item.type && item.type !== "photo") continue;
+    if (!item.media_url_https) continue;
+    const src = await downloadAsset(item.media_url_https, `${id}-media-${index + 1}`, options);
+    if (src) assets.media.push(assetRecord(src, item));
+  }
+  return assets;
+}
+
+async function downloadAsset(
+  source: string,
+  basename: string,
+  options: ResolvedTwitterEmbedOptions,
+): Promise<string | undefined> {
+  let url: URL;
+  try {
+    url = new URL(source);
+  } catch {
+    return undefined;
+  }
+  if (url.protocol !== "https:" || url.hostname.toLowerCase() !== "pbs.twimg.com") {
+    return undefined;
+  }
+
+  const extension = extensionFromUrl(url);
+  const filename = `${basename}${extension}`;
+  const output = path.join(options.mediaOutputDir, filename);
+  try {
+    await access(output);
+    return joinPublicPath(options.mediaPublicPath, filename);
+  } catch {
+    // Download the missing asset below.
+  }
+
+  try {
+    const response = await fetch(url, { headers: { Accept: "image/*" } });
+    if (!response.ok) return undefined;
+    await mkdir(options.mediaOutputDir, { recursive: true });
+    await writeFile(output, new Uint8Array(await response.arrayBuffer()));
+    return joinPublicPath(options.mediaPublicPath, filename);
+  } catch {
+    return undefined;
+  }
+}
+
+async function readCachedTweet(key: string, directory: string): Promise<TweetData | null> {
+  try {
+    const data: unknown = JSON.parse(await readFile(path.join(directory, `${key}.json`), "utf8"));
+    return isTweetData(data) ? data : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCachedTweet(key: string, data: TweetData, directory: string): Promise<void> {
+  try {
+    await mkdir(directory, { recursive: true });
+    await writeFile(path.join(directory, `${key}.json`), `${JSON.stringify(data)}\n`);
+  } catch {
+    // A read-only cache directory must not fail the build.
+  }
+}
+
+function isTweetData(data: unknown): data is TweetData {
+  if (!data || typeof data !== "object") return false;
+  const value = data as Partial<TweetData>;
+  return (
+    typeof value.text === "string" &&
+    Boolean(value.user) &&
+    typeof value.user?.name === "string" &&
+    typeof value.user.screen_name === "string"
+  );
+}
+
+function extensionFromUrl(url: URL): string {
+  const match = url.pathname.match(/\.(jpe?g|png|webp|gif)$/i);
+  return match ? `.${match[1].toLowerCase().replace("jpeg", "jpg")}` : ".jpg";
+}
+
+function joinPublicPath(prefix: string, filename: string): string {
+  return `${prefix.replace(/\/$/, "")}/${filename}`;
+}
+
+function sanitizeSegment(value: string): string {
+  return value.replaceAll(/[^a-zA-Z0-9_-]/g, "-");
+}
+
+function assetRecord(src: string, media: TweetMedia): TweetAssets["media"][number] {
+  return {
+    src,
+    alt: media.ext_alt_text,
+    width: media.original_info?.width,
+    height: media.original_info?.height,
+  };
+}

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/index.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/index.ts
@@ -1,0 +1,11 @@
+export { fetchTweetData } from "./fetch";
+export { renderFetchedTweet, renderTweetText } from "./render";
+export { resolveTwitterEmbedOptions, transformFetchedTweets } from "./transform";
+export { createSyndicationToken, parseTweetReference } from "./url";
+export type {
+  ResolvedTwitterEmbedOptions,
+  TweetData,
+  TweetEntity,
+  TweetMedia,
+  TwitterEmbedOptions,
+} from "./types";

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/render.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/render.ts
@@ -1,0 +1,116 @@
+import type { ResolvedTwitterEmbedOptions, TweetAssets, TweetData, TweetEntity } from "./types";
+
+export function renderFetchedTweet(
+  permalink: string,
+  data: TweetData,
+  assets: TweetAssets,
+  options: ResolvedTwitterEmbedOptions,
+): string {
+  const profile = `https://x.com/${encodeURIComponent(data.user.screen_name)}`;
+  const author = escapeHtml(data.user.name);
+  const handle = escapeHtml(data.user.screen_name);
+  const avatar = assets.avatar
+    ? `<img class="ox-tweet__avatar" src="${escapeAttribute(assets.avatar)}" alt="" width="48" height="48" loading="lazy" decoding="async">`
+    : "";
+  const media = renderMedia(assets);
+  const footer = renderFooter(permalink, data.created_at, options.lang);
+
+  return [
+    '<figure class="ox-tweet ox-tweet--fetched">',
+    '<header class="ox-tweet__header">',
+    `<a class="ox-tweet__profile" href="${escapeAttribute(profile)}" target="_blank" rel="noopener noreferrer">`,
+    avatar,
+    `<span class="ox-tweet__author-name">${author}</span>`,
+    `<span class="ox-tweet__author-handle">@${handle}</span>`,
+    "</a></header>",
+    `<div class="ox-tweet__body">${renderTweetText(data)}</div>`,
+    media,
+    footer,
+    "</figure>",
+  ].join("");
+}
+
+export function renderTweetText(data: TweetData): string {
+  const [start, end] = data.display_text_range ?? [0, data.text.length];
+  const entities = collectEntities(data)
+    .filter((entity) => validRange(entity.indices, start, end))
+    .sort((left, right) => left.indices![0] - right.indices![0]);
+
+  let cursor = start;
+  let output = "";
+  for (const entity of entities) {
+    const [entityStart, entityEnd] = entity.indices!;
+    if (entityStart < cursor) continue;
+    output += escapeText(data.text.slice(cursor, entityStart));
+    if (entity.kind === "url") {
+      const href = entity.expanded_url ?? entity.url;
+      const label = entity.display_url ?? href;
+      output += `<a href="${escapeAttribute(href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a>`;
+    }
+    cursor = entityEnd;
+  }
+  output += escapeText(data.text.slice(cursor, end));
+  return output.trim();
+}
+
+function collectEntities(data: TweetData): Array<TweetEntity & { kind: "url" | "media" }> {
+  return [
+    ...(data.entities?.urls ?? []).map((entity) => ({ ...entity, kind: "url" as const })),
+    ...(data.entities?.media ?? []).map((entity) => ({ ...entity, kind: "media" as const })),
+  ];
+}
+
+function validRange(
+  indices: [number, number] | undefined,
+  start: number,
+  end: number,
+): indices is [number, number] {
+  return Boolean(indices && indices[0] >= start && indices[1] <= end && indices[0] < indices[1]);
+}
+
+function renderMedia(assets: TweetAssets): string {
+  if (assets.media.length === 0) return "";
+  const images = assets.media
+    .map((item) => {
+      const size = [
+        item.width ? ` width="${item.width}"` : "",
+        item.height ? ` height="${item.height}"` : "",
+      ].join("");
+      return `<img class="ox-tweet__media-item" src="${escapeAttribute(item.src)}" alt="${escapeAttribute(item.alt ?? "")}"${size} loading="lazy" decoding="async">`;
+    })
+    .join("");
+  return `<div class="ox-tweet__media" data-count="${assets.media.length}">${images}</div>`;
+}
+
+function renderFooter(permalink: string, createdAt: string | undefined, lang: string): string {
+  if (!createdAt) {
+    return `<footer class="ox-tweet__footer"><a class="ox-tweet__permalink" href="${escapeAttribute(permalink)}" target="_blank" rel="noopener noreferrer">View on X</a></footer>`;
+  }
+  const date = new Date(createdAt);
+  if (Number.isNaN(date.valueOf())) return renderFooter(permalink, undefined, lang);
+  const iso = date.toISOString();
+  let label: string;
+  try {
+    label = new Intl.DateTimeFormat(lang, { dateStyle: "medium", timeZone: "UTC" }).format(date);
+  } catch {
+    label = new Intl.DateTimeFormat("en", { dateStyle: "medium", timeZone: "UTC" }).format(date);
+  }
+  return `<footer class="ox-tweet__footer"><a class="ox-tweet__permalink" href="${escapeAttribute(permalink)}" target="_blank" rel="noopener noreferrer"><time datetime="${iso}">${escapeHtml(label)}</time></a></footer>`;
+}
+
+function escapeText(value: string): string {
+  return escapeHtml(value).replaceAll("\n", "<br>");
+}
+
+function escapeAttribute(value: string): string {
+  return escapeHtml(value).replaceAll("`", "&#96;");
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/transform.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/transform.ts
@@ -1,0 +1,54 @@
+import path from "node:path";
+import { fetchTweetData, materializeTweetAssets } from "./fetch";
+import { renderFetchedTweet } from "./render";
+import type { ResolvedTwitterEmbedOptions, TwitterEmbedOptions } from "./types";
+import { referenceFromAttributes } from "./url";
+
+const TWEET_ELEMENT = /<(tweet|xpost)\b([^>]*?)(?:\/\s*>|>[\s\S]*?<\/\1\s*>)/gi;
+
+export function resolveTwitterEmbedOptions(
+  options: TwitterEmbedOptions,
+): ResolvedTwitterEmbedOptions {
+  return {
+    fetch: options.fetch ?? false,
+    lang: options.lang ?? "en",
+    timeout: options.timeout ?? 10000,
+    cache: options.cache ?? true,
+    cacheDir: path.resolve(options.cacheDir ?? ".cache/ox-content/twitter"),
+    mediaOutputDir: path.resolve(options.mediaOutputDir ?? "public/ox-content/twitter"),
+    mediaPublicPath: options.mediaPublicPath ?? "/ox-content/twitter",
+  };
+}
+
+export async function transformFetchedTweets(
+  html: string,
+  options: TwitterEmbedOptions,
+): Promise<string> {
+  const resolved = resolveTwitterEmbedOptions(options);
+  if (!resolved.fetch) return html;
+
+  let output = "";
+  let cursor = 0;
+  for (const match of html.matchAll(TWEET_ELEMENT)) {
+    const index = match.index ?? 0;
+    output += html.slice(cursor, index);
+    const reference = referenceFromAttributes(match[2]);
+    if (!reference) {
+      output += match[0];
+      cursor = index + match[0].length;
+      continue;
+    }
+
+    const data = await fetchTweetData(reference.id, resolved);
+    if (!data) {
+      output += match[0];
+      cursor = index + match[0].length;
+      continue;
+    }
+
+    const assets = await materializeTweetAssets(reference.id, data, resolved);
+    output += renderFetchedTweet(reference.url, data, assets, resolved);
+    cursor = index + match[0].length;
+  }
+  return output + html.slice(cursor);
+}

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/types.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/types.ts
@@ -1,0 +1,63 @@
+export interface TwitterEmbedOptions {
+  /** Fetch the post body, author, and media from X at build time. */
+  fetch?: boolean;
+  /** Language sent to the syndication endpoint. @default "en" */
+  lang?: string;
+  /** Request timeout in milliseconds. @default 10000 */
+  timeout?: number;
+  /** Cache syndication responses in memory and on disk. @default true */
+  cache?: boolean;
+  /** Directory used for the persistent metadata cache. @default ".cache/ox-content/twitter" */
+  cacheDir?: string;
+  /** Directory where avatars and photos are written. @default "public/ox-content/twitter" */
+  mediaOutputDir?: string;
+  /** Public URL prefix for downloaded media. @default "/ox-content/twitter" */
+  mediaPublicPath?: string;
+}
+
+export interface ResolvedTwitterEmbedOptions {
+  fetch: boolean;
+  lang: string;
+  timeout: number;
+  cache: boolean;
+  cacheDir: string;
+  mediaOutputDir: string;
+  mediaPublicPath: string;
+}
+
+export interface TweetEntity {
+  url: string;
+  expanded_url?: string;
+  display_url?: string;
+  indices?: [number, number];
+}
+
+export interface TweetMedia extends TweetEntity {
+  media_url_https?: string;
+  ext_alt_text?: string;
+  type?: string;
+  original_info?: { width?: number; height?: number };
+}
+
+export interface TweetData {
+  text: string;
+  display_text_range?: [number, number];
+  entities?: { urls?: TweetEntity[]; media?: TweetMedia[] };
+  mediaDetails?: TweetMedia[];
+  user: {
+    name: string;
+    screen_name: string;
+    profile_image_url_https?: string;
+  };
+  created_at?: string;
+}
+
+export interface TweetReference {
+  id: string;
+  url: string;
+}
+
+export interface TweetAssets {
+  avatar?: string;
+  media: Array<{ src: string; alt?: string; width?: number; height?: number }>;
+}

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/url.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/url.ts
@@ -1,0 +1,43 @@
+import type { TweetReference } from "./types";
+
+const STATUS_PATH = /^\/(?:[^/]+|i\/web)\/status\/(\d+)(?:\/.*)?$/;
+
+export function createSyndicationToken(id: string): string {
+  return ((Number(id) / 1e15) * Math.PI).toString(36).replaceAll(/(0+|\.)/g, "");
+}
+
+export function parseTweetReference(value: string): TweetReference | null {
+  const trimmed = value.trim();
+  if (/^\d+$/.test(trimmed)) {
+    return { id: trimmed, url: `https://x.com/i/web/status/${trimmed}` };
+  }
+
+  try {
+    const url = new URL(trimmed);
+    const hostname = url.hostname.toLowerCase().replace(/^(?:www\.|mobile\.)/, "");
+    if (url.protocol !== "https:" || (hostname !== "x.com" && hostname !== "twitter.com")) {
+      return null;
+    }
+
+    const match = url.pathname.match(STATUS_PATH);
+    if (!match) return null;
+    const screenName = url.pathname.startsWith("/i/web/status/")
+      ? "i/web"
+      : url.pathname.split("/")[1];
+    return {
+      id: match[1],
+      url: `https://x.com/${screenName}/status/${match[1]}`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function referenceFromAttributes(attributes: string): TweetReference | null {
+  const values = new Map<string, string>();
+  const pattern = /\b(url|href|id)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/gi;
+  for (const match of attributes.matchAll(pattern)) {
+    values.set(match[1].toLowerCase(), match[2] ?? match[3] ?? match[4] ?? "");
+  }
+  return parseTweetReference(values.get("url") ?? values.get("href") ?? values.get("id") ?? "");
+}

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -4,7 +4,7 @@
 
 import type { LanguageRegistration, ThemeRegistration } from "shiki";
 import type { ThemeConfig, ResolvedThemeConfig } from "./theme";
-import type { GitHubOptions, OgpOptions } from "./plugins";
+import type { GitHubOptions, OgpOptions, TwitterEmbedOptions } from "./plugins";
 
 // =============================================================================
 // Entry Page Types (VitePress-like)
@@ -707,9 +707,11 @@ export interface BuiltinEmbedOptions {
 
   /**
    * Render `<Tweet>` / `<XPost>` as static privacy-conscious cards.
+   * Pass `{ fetch: true }` to fetch the post body, author, and self-hosted
+   * media at build time. Fetch failures fall back to the link-only card.
    * @default false
    */
-  twitter?: boolean;
+  twitter?: boolean | TwitterEmbedOptions;
 
   /**
    * Render `<Bluesky>` as static cards.
@@ -744,7 +746,7 @@ export interface ResolvedBuiltinEmbedOptions {
   pm: BuiltinPmOptions | false;
   spotify: boolean;
   stackBlitz: boolean;
-  twitter: boolean;
+  twitter: TwitterEmbedOptions | false;
   bluesky: boolean;
   webContainer: boolean;
 }


### PR DESCRIPTION
## Summary

- add an opt-in `twitter: { fetch: true }` build-time syndication pass
- render post body, author, avatar, date, and photos as static HTML
- self-host media with memory/disk caching and fall back to the existing link card on failure
- document the configuration and preserve `twitter: true` behavior

## Validation

- `vp run check:ts`
- `vp exec --filter @ox-content/vite-plugin -- vp test src`
- `corepack pnpm --filter @ox-content/vite-plugin run typecheck`
- `corepack pnpm --filter @ox-content/vite-plugin run build`
- `vp run check:file-lines`

Closes #459

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786680119&installation_id=136613492&pr_number=479&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F479&signature=c11442dac8c4e62bc5523245230cf8722440ec9770689ef47f6f9c64d2d27353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in build-time fetching for Twitter/X embeds.
  * Supports configurable language, timeouts, caching, and local avatar/media assets.
  * Fetched posts render with formatted text, links, images, author details, and localized dates.
  * Unavailable or private posts gracefully fall back to link-only cards.
  * Twitter/X embed settings now support a structured configuration object.

* **Documentation**
  * Updated configuration examples and added comprehensive Twitter/X embed options documentation.

* **Tests**
  * Added coverage for URL handling, rendering, asset downloads, caching, and fetch failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->