### PR TITLE
fix(parser): align table rendering with GFM

### DIFF
--- a/crates/ox_content_parser/src/parser/table.rs
+++ b/crates/ox_content_parser/src/parser/table.rs
@@ -40,17 +40,16 @@ impl<'a> Parser<'a> {
             return false;
         }
 
-        // Check delimiter row pattern: |---|---|
-        let is_delimiter = second_line.split('|').filter(|s| !s.is_empty()).all(|cell| {
-            let trimmed = cell.trim();
-            if trimmed.is_empty() {
-                return true;
+        let header_cells = Self::table_row_cells(first_line).count();
+        let mut delimiter_cells = 0;
+        for cell in Self::table_row_cells(second_line) {
+            if delimiter_alignment(cell).is_none() {
+                return false;
             }
-            // Allow :---:, :---, ---:, ---
-            trimmed.chars().all(|c| c == '-' || c == ':')
-        });
+            delimiter_cells += 1;
+        }
 
-        is_delimiter
+        header_cells > 0 && header_cells == delimiter_cells
     }
 
     pub(super) fn parse_table(&mut self, start: usize) -> ParseResult<Option<Node<'a>>> {
@@ -62,25 +61,19 @@ impl<'a> Parser<'a> {
 
         // Parse delimiter row to get alignment
         let delimiter_line = self.consume_line();
-        for cell in delimiter_line.split('|').filter(|s| !s.trim().is_empty()) {
-            let cell = cell.trim();
-            let starts_colon = cell.starts_with(':');
-            let ends_colon = cell.ends_with(':');
-            let alignment = match (starts_colon, ends_colon) {
-                (true, true) => AlignKind::Center,
-                (true, false) => AlignKind::Left,
-                (false, true) => AlignKind::Right,
-                (false, false) => AlignKind::None,
-            };
-            align.push(alignment);
+        for cell in Self::table_row_cells(delimiter_line) {
+            if let Some(alignment) = delimiter_alignment(cell) {
+                align.push(alignment);
+            }
         }
+        let column_count = align.len();
 
         // Build the table AST directly instead of first collecting row slices
         // into short-lived heap Vecs. Each consumed source line is parsed into
         // arena-backed cells immediately, which keeps the table path linear in
         // the input and avoids throwaway row containers.
         let mut children: Vec<'a, TableRow<'a>> = self.allocator.new_vec();
-        children.push(self.parse_table_row(header_line)?);
+        children.push(self.parse_table_row(header_line, column_count)?);
 
         // Parse body rows
         loop {
@@ -88,26 +81,16 @@ impl<'a> Parser<'a> {
                 break;
             }
 
-            let line_start = self.position;
-            self.skip_whitespace();
-
-            // Check for blank line or non-table line
-            if self.peek() == Some('\n') || self.is_at_end() {
-                self.position = line_start;
+            // A blank line or another block-level construct terminates the
+            // table. Ordinary lines remain data rows even without a pipe.
+            if self.first_non_whitespace_in_line(self.position).is_none()
+                || self.line_starts_block()
+            {
                 break;
             }
 
-            // Check if line contains | (table continuation)
-            let remaining = self.remaining();
-            let line = remaining.lines().next().unwrap_or("");
-            if !line.contains('|') {
-                self.position = line_start;
-                break;
-            }
-
-            self.position = line_start;
             let row_line = self.consume_line();
-            children.push(self.parse_table_row(row_line)?);
+            children.push(self.parse_table_row(row_line, column_count)?);
         }
 
         let span = Span::new(start as u32, self.position as u32);
@@ -120,12 +103,19 @@ impl<'a> Parser<'a> {
     /// The row iterator yields borrowed cell slices from the original line.
     /// Inline parsing then writes cell children into the parser arena, so no
     /// intermediate `Vec<&str>` or owned cell text is needed.
-    pub(super) fn parse_table_row(&self, line: &'a str) -> ParseResult<TableRow<'a>> {
+    pub(super) fn parse_table_row(
+        &self,
+        line: &'a str,
+        column_count: usize,
+    ) -> ParseResult<TableRow<'a>> {
         let mut cells: Vec<'a, TableCell<'a>> = self.allocator.new_vec();
-        for cell_content in Self::table_row_cells(line) {
+        for cell_content in Self::table_row_cells(line).take(column_count) {
             let cell_content = self.unescape_table_pipes(cell_content);
             let cell_children = self.parse_inline(cell_content, 0)?;
             cells.push(TableCell { children: cell_children, span: Span::new(0, 0) });
+        }
+        while cells.len() < column_count {
+            cells.push(TableCell { children: self.allocator.new_vec(), span: Span::new(0, 0) });
         }
         Ok(TableRow { children: cells, span: Span::new(0, 0) })
     }
@@ -204,4 +194,23 @@ impl<'a> Parser<'a> {
 
 fn is_escaped_table_pipe(bytes: &[u8], pipe: usize) -> bool {
     bytes[..pipe].iter().rev().take_while(|&&byte| byte == b'\\').count() % 2 == 1
+}
+
+fn delimiter_alignment(cell: &str) -> Option<AlignKind> {
+    let trimmed = cell.trim();
+    let left = trimmed.starts_with(':');
+    let right = trimmed.ends_with(':');
+    let hyphens = trimmed.strip_prefix(':').unwrap_or(trimmed);
+    let hyphens = hyphens.strip_suffix(':').unwrap_or(hyphens);
+
+    if hyphens.is_empty() || !hyphens.bytes().all(|byte| byte == b'-') {
+        return None;
+    }
+
+    Some(match (left, right) {
+        (true, true) => AlignKind::Center,
+        (true, false) => AlignKind::Left,
+        (false, true) => AlignKind::Right,
+        (false, false) => AlignKind::None,
+    })
 }

--- a/crates/ox_content_parser/tests/edge_cases/tables.rs
+++ b/crates/ox_content_parser/tests/edge_cases/tables.rs
@@ -23,3 +23,54 @@ fn table_alignment_variants_are_parsed() {
         other => panic!("expected table, got {other:?}"),
     }
 }
+
+#[test]
+fn table_header_and_delimiter_must_have_matching_valid_cells() {
+    let allocator = Allocator::new();
+    for source in [
+        "| a | b |\n| --- |",
+        "| a | b |\n| --- | --- | --- |",
+        "| a | b |\n| : | --- |",
+        "| a | b |\n| --:-- | --- |",
+    ] {
+        let doc = parse_with_options(&allocator, source, ParserOptions::gfm());
+        assert!(
+            matches!(doc.children.first(), Some(Node::Paragraph(_))),
+            "invalid delimiter must remain paragraph text: {source:?}"
+        );
+    }
+}
+
+#[test]
+fn table_body_rows_are_normalized_to_header_width() {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(
+        &allocator,
+        "| a | b |\n| --- | --- |\n| one |\n| two | three | ignored |",
+        ParserOptions::gfm(),
+    );
+
+    let Node::Table(table) = &doc.children[0] else {
+        panic!("expected table, got {:?}", doc.children[0]);
+    };
+    assert_eq!(table.children.len(), 3);
+    assert!(table.children.iter().all(|row| row.children.len() == 2));
+    assert!(table.children[1].children[1].children.is_empty());
+}
+
+#[test]
+fn table_accepts_pipe_less_rows_and_stops_at_block_starts() {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(
+        &allocator,
+        "| a | b |\n| --- | --- |\nplain\n> quote | value",
+        ParserOptions::gfm(),
+    );
+
+    let Node::Table(table) = &doc.children[0] else {
+        panic!("expected table, got {:?}", doc.children[0]);
+    };
+    assert_eq!(table.children.len(), 2);
+    assert_eq!(table.children[1].children.len(), 2);
+    assert!(matches!(doc.children.get(1), Some(Node::BlockQuote(_))));
+}

--- a/crates/ox_content_renderer/src/html/renderer/blocks.rs
+++ b/crates/ox_content_renderer/src/html/renderer/blocks.rs
@@ -197,7 +197,7 @@ impl HtmlRenderer {
                 self.write("</thead>\n");
             }
         }
-        if !table.children.is_empty() {
+        if table.children.len() > 1 {
             self.write("</tbody>\n");
         }
         self.write("</table>\n");

--- a/crates/ox_content_renderer/tests/snapshot_tables_html.rs
+++ b/crates/ox_content_renderer/tests/snapshot_tables_html.rs
@@ -25,6 +25,56 @@ fn html_table_with_inline_formatting() {
     );
 }
 
+#[test]
+fn html_table_preserves_escaped_pipes() {
+    check(
+        "table_preserves_escaped_pipes",
+        "| f\\|oo |\n| ------ |\n| b `\\|` az |\n| b **\\|** im |\n",
+        ParserOptions::gfm(),
+        HtmlRendererOptions::default(),
+    );
+}
+
+#[test]
+fn html_table_body_width_matches_header() {
+    check(
+        "table_body_width_matches_header",
+        "| abc | def |\n| --- | --- |\n| bar |\n| bar | baz | boo |\n",
+        ParserOptions::gfm(),
+        HtmlRendererOptions::default(),
+    );
+}
+
+#[test]
+fn html_table_without_body_omits_tbody() {
+    check(
+        "table_without_body",
+        "| abc | def |\n| --- | --- |\n",
+        ParserOptions::gfm(),
+        HtmlRendererOptions::default(),
+    );
+}
+
+#[test]
+fn html_table_accepts_pipe_less_body_row() {
+    check(
+        "table_accepts_pipe_less_body_row",
+        "| abc | def |\n| --- | --- |\nplain\n",
+        ParserOptions::gfm(),
+        HtmlRendererOptions::default(),
+    );
+}
+
+#[test]
+fn html_table_stops_before_block_with_pipe() {
+    check(
+        "table_stops_before_block_with_pipe",
+        "| abc | def |\n| --- | --- |\n> quote | value\n",
+        ParserOptions::gfm(),
+        HtmlRendererOptions::default(),
+    );
+}
+
 // --- HTML block behaviors ---
 
 #[test]

--- a/crates/ox_content_renderer/tests/snapshots/renderer/table_accepts_pipe_less_body_row.snap
+++ b/crates/ox_content_renderer/tests/snapshots/renderer/table_accepts_pipe_less_body_row.snap
@@ -1,0 +1,18 @@
+---
+source: crates/ox_content_renderer/tests/support/snapshot.rs
+description: "| abc | def |\n| --- | --- |\nplain\n"
+---
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>plain</td>
+<td></td>
+</tr>
+</tbody>
+</table>

--- a/crates/ox_content_renderer/tests/snapshots/renderer/table_body_width_matches_header.snap
+++ b/crates/ox_content_renderer/tests/snapshots/renderer/table_body_width_matches_header.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ox_content_renderer/tests/support/snapshot.rs
+description: "| abc | def |\n| --- | --- |\n| bar |\n| bar | baz | boo |\n"
+---
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>bar</td>
+<td></td>
+</tr>
+<tr>
+<td>bar</td>
+<td>baz</td>
+</tr>
+</tbody>
+</table>

--- a/crates/ox_content_renderer/tests/snapshots/renderer/table_preserves_escaped_pipes.snap
+++ b/crates/ox_content_renderer/tests/snapshots/renderer/table_preserves_escaped_pipes.snap
@@ -1,0 +1,19 @@
+---
+source: crates/ox_content_renderer/tests/support/snapshot.rs
+description: "| f\\|oo |\n| ------ |\n| b `\\|` az |\n| b **\\|** im |\n"
+---
+<table>
+<thead>
+<tr>
+<th>f|oo</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>b <code>|</code> az</td>
+</tr>
+<tr>
+<td>b <strong>|</strong> im</td>
+</tr>
+</tbody>
+</table>

--- a/crates/ox_content_renderer/tests/snapshots/renderer/table_stops_before_block_with_pipe.snap
+++ b/crates/ox_content_renderer/tests/snapshots/renderer/table_stops_before_block_with_pipe.snap
@@ -1,0 +1,15 @@
+---
+source: crates/ox_content_renderer/tests/support/snapshot.rs
+description: "| abc | def |\n| --- | --- |\n> quote | value\n"
+---
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+</table>
+<blockquote>
+<p>quote | value</p>
+</blockquote>

--- a/crates/ox_content_renderer/tests/snapshots/renderer/table_without_body.snap
+++ b/crates/ox_content_renderer/tests/snapshots/renderer/table_without_body.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ox_content_renderer/tests/support/snapshot.rs
+description: "| abc | def |\n| --- | --- |\n"
+---
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+</table>


### PR DESCRIPTION
## Summary

- validate GFM delimiter cells and require the header width to match
- normalize short and long body rows to the header width
- keep pipe-less data rows while stopping before block-level constructs
- omit `<tbody>` when the table has no body rows
- add parser regressions and end-to-end snapshots for GFM examples 200–205

## Root cause

The table recognizer accepted any combination of colons and hyphens, did not compare header and delimiter widths, and treated the presence of a pipe as the body continuation rule. The renderer also closed `<tbody>` whenever a header existed, even if no body was opened.

## Impact

Native GFM rendering now matches `markdown-it@14.2.0` for escaped pipes, empty bodies, ragged rows, invalid delimiters, pipe-less data rows, and block boundaries.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `vp run check:file-lines`
- `vp run fmt:check`
- `vp run check:ts`
- `vp run test`
- NAPI parity corpus matched `markdown-it@14.2.0` for 10 table cases

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786864334&installation_id=136613492&pr_number=482&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F482&signature=149cd493188a0ee16c4f15048c423d8c2f14fb3646e08b80b88cb107db8da3d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Markdown table parsing in GFM mode, including pipe-less rows and consistent column widths.
  * Table rows are now normalized to match the header structure, with missing cells filled automatically.
  * Table parsing correctly stops before following block content.

* **Bug Fixes**
  * Invalid delimiter rows are no longer interpreted as tables.
  * Escaped pipes in table cells are preserved.
  * Header-only tables no longer include an empty `<tbody>` element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->