### PR TITLE
chore(release): v2.78.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.78.1] - 2026-07-17
+
+### Bug Fixes
+
+- align table rendering with GFM (#482)
+- configure npm release authentication (#481)
+
 ## [2.78.0] - 2026-07-15
 
 ### Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "2.78.0"
+version = "2.78.1"
 authors = ["ubugeeei"]
 categories = ["development-tools"]
 edition = "2021"
@@ -73,27 +73,27 @@ use_self = "allow"
 
 [workspace.dependencies]
 # Internal crates (version is used for crates.io publish, path for local dev)
-ox_content_allocator = { version = "2.78.0", path = "crates/ox_content_allocator" }
-ox_content_ast = { version = "2.78.0", path = "crates/ox_content_ast" }
-ox_content_parser = { version = "2.78.0", path = "crates/ox_content_parser" }
-ox_content_renderer = { version = "2.78.0", path = "crates/ox_content_renderer" }
-ox_content_incremental = { version = "2.78.0", path = "crates/ox_content_incremental" }
-ox_content_mdast = { version = "2.78.0", path = "crates/ox_content_mdast" }
-ox_content_napi = { version = "2.78.0", path = "crates/ox_content_napi" }
-ox_content_vite = { version = "2.78.0", path = "crates/ox_content_vite" }
-ox_content_og_image = { version = "2.78.0", path = "crates/ox_content_og_image" }
-ox_content_docs = { version = "2.78.0", path = "crates/ox_content_docs" }
-ox_content_search = { version = "2.78.0", path = "crates/ox_content_search" }
-ox_content_ssg = { version = "2.78.0", path = "crates/ox_content_ssg" }
-ox_content_transform = { version = "2.78.0", path = "crates/ox_content_transform" }
-ox_content_i18n = { version = "2.78.0", path = "crates/ox_content_i18n" }
-ox_content_i18n_checker = { version = "2.78.0", path = "crates/ox_content_i18n_checker" }
-ox_content_markdown_lint = { version = "2.78.0", path = "crates/ox_content_markdown_lint" }
-ox_content_mdc_checker = { version = "2.78.0", path = "crates/ox_content_mdc_checker" }
-ox_content_mermaid = { version = "2.78.0", path = "crates/ox_content_mermaid" }
-ox_content_link_checker = { version = "2.78.0", path = "crates/ox_content_link_checker" }
-ox_content_component_resolver = { version = "2.78.0", path = "crates/ox_content_component_resolver" }
-ox_content_profiler = { version = "2.78.0", path = "crates/ox_content_profiler" }
+ox_content_allocator = { version = "2.78.1", path = "crates/ox_content_allocator" }
+ox_content_ast = { version = "2.78.1", path = "crates/ox_content_ast" }
+ox_content_parser = { version = "2.78.1", path = "crates/ox_content_parser" }
+ox_content_renderer = { version = "2.78.1", path = "crates/ox_content_renderer" }
+ox_content_incremental = { version = "2.78.1", path = "crates/ox_content_incremental" }
+ox_content_mdast = { version = "2.78.1", path = "crates/ox_content_mdast" }
+ox_content_napi = { version = "2.78.1", path = "crates/ox_content_napi" }
+ox_content_vite = { version = "2.78.1", path = "crates/ox_content_vite" }
+ox_content_og_image = { version = "2.78.1", path = "crates/ox_content_og_image" }
+ox_content_docs = { version = "2.78.1", path = "crates/ox_content_docs" }
+ox_content_search = { version = "2.78.1", path = "crates/ox_content_search" }
+ox_content_ssg = { version = "2.78.1", path = "crates/ox_content_ssg" }
+ox_content_transform = { version = "2.78.1", path = "crates/ox_content_transform" }
+ox_content_i18n = { version = "2.78.1", path = "crates/ox_content_i18n" }
+ox_content_i18n_checker = { version = "2.78.1", path = "crates/ox_content_i18n_checker" }
+ox_content_markdown_lint = { version = "2.78.1", path = "crates/ox_content_markdown_lint" }
+ox_content_mdc_checker = { version = "2.78.1", path = "crates/ox_content_mdc_checker" }
+ox_content_mermaid = { version = "2.78.1", path = "crates/ox_content_mermaid" }
+ox_content_link_checker = { version = "2.78.1", path = "crates/ox_content_link_checker" }
+ox_content_component_resolver = { version = "2.78.1", path = "crates/ox_content_component_resolver" }
+ox_content_profiler = { version = "2.78.1", path = "crates/ox_content_profiler" }
 ox_jsdoc = "0.0.16"
 
 # Memory allocation

--- a/crates/ox_content_napi/package.json
+++ b/crates/ox_content_napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/napi",
-  "version": "2.78.0",
+  "version": "2.78.1",
   "description": "Node.js bindings for Ox Content - High-performance Markdown parser",
   "keywords": [
     "markdown",

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -219,10 +219,10 @@ If you want the lowest-level building blocks directly, use the Rust crates.
 
 ```toml
 [dependencies]
-ox_content_allocator = "2.78.0"
-ox_content_ast = "2.78.0"
-ox_content_parser = "2.78.0"
-ox_content_renderer = "2.78.0"
+ox_content_allocator = "2.78.1"
+ox_content_ast = "2.78.1"
+ox_content_parser = "2.78.1"
+ox_content_renderer = "2.78.1"
 ```
 
 ### Parse and Render in Rust

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ox-content-zed"
-version = "2.78.0"
+version = "2.78.1"
 edition = "2021"
 publish = false
 

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "ox-content"
 name = "Ox Content"
-version = "2.78.0"
+version = "2.78.1"
 schema_version = 1
 authors = ["ubugeeei"]
 description = "Ox Content authoring support for Zed"

--- a/npm/ox-content-islands/package.json
+++ b/npm/ox-content-islands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/islands",
-  "version": "2.78.0",
+  "version": "2.78.1",
   "description": "Framework-agnostic Island Architecture for ox-content",
   "keywords": [
     "framework-agnostic",

--- a/npm/unplugin-ox-content/package.json
+++ b/npm/unplugin-ox-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/unplugin",
-  "version": "2.78.0",
+  "version": "2.78.1",
   "description": "Universal plugin for Ox Content - Markdown processing for webpack, rollup, esbuild, vite, and more",
   "keywords": [
     "esbuild",

--- a/npm/vite-plugin-ox-content-react/package.json
+++ b/npm/vite-plugin-ox-content-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/vite-plugin-react",
-  "version": "2.78.0",
+  "version": "2.78.1",
   "description": "React integration for Ox Content - Embed React components in Markdown",
   "keywords": [
     "markdown",

--- a/npm/vite-plugin-ox-content-svelte/package.json
+++ b/npm/vite-plugin-ox-content-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/vite-plugin-svelte",
-  "version": "2.78.0",
+  "version": "2.78.1",
   "description": "Svelte integration for Ox Content - Embed Svelte components in Markdown",
   "keywords": [
     "markdown",

--- a/npm/vite-plugin-ox-content-vue/package.json
+++ b/npm/vite-plugin-ox-content-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/vite-plugin-vue",
-  "version": "2.78.0",
+  "version": "2.78.1",
   "description": "Vue integration for Ox Content - Embed Vue components in Markdown",
   "keywords": [
     "markdown",

--- a/npm/vite-plugin-ox-content/package.json
+++ b/npm/vite-plugin-ox-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ox-content/vite-plugin",
-  "version": "2.78.0",
+  "version": "2.78.1",
   "description": "Vite plugin for Ox Content - High-performance Markdown processing with Environment API",
   "keywords": [
     "environment-api",

--- a/npm/vscode-ox-content/package.json
+++ b/npm/vscode-ox-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-ox-content",
-  "version": "2.78.0",
+  "version": "2.78.1",
   "private": true,
   "description": "VS Code extension for Ox Content authoring and i18n workflows",
   "categories": [


### PR DESCRIPTION
## Summary

- bump workspace, npm, and editor package versions to 2.78.1
- add release notes for the npm authentication and GFM table fixes
- update Rust dependency examples to 2.78.1

## Validation

- cargo check --workspace --all-targets
- vp run check:file-lines
- vp run fmt:check
- vp run check:ts (0 errors; 6 pre-existing warnings)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786865044&installation_id=136613492&pr_number=483&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F483&signature=9d413f0b5d19bcdaa9c6888beeb64da202e4f3cbeb319572faa5436cab0cbc8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table rendering to align with GitHub-Flavored Markdown.
  * Updated npm release authentication configuration.

* **Release**
  * Released version 2.78.1 across packages, integrations, and editor extensions.
  * Updated getting-started dependency examples to reference version 2.78.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->