### PR TITLE
fix(parser): stop panicking on backslash before multibyte chars

### DIFF
--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -59,10 +59,20 @@ impl<'a> Parser<'a> {
                 *pos += 2;
             }
             b'<' => Self::parse_inline_html_or_text(content, offset, children, pos),
-            b'\\' if *pos + 1 < content.len() => {
+            b'\\' if *pos + 1 < content.len() && bytes[*pos + 1].is_ascii_punctuation() => {
+                // A backslash escapes only ASCII punctuation (CommonMark
+                // "Backslash escapes"). The escaped character is emitted as
+                // literal text so it can't open any inline construct.
                 *pos += 1;
                 let span_start = offset + *pos - 1;
                 Self::push_text(children, &content[*pos..*pos + 1], span_start, offset + *pos + 1);
+                *pos += 1;
+            }
+            b'\\' => {
+                // Backslash before anything else (letters, digits, spaces,
+                // multibyte characters, or end of input) is a literal
+                // backslash; the following character is parsed normally.
+                Self::push_text(children, "\\", offset + *pos, offset + *pos + 1);
                 *pos += 1;
             }
             b'~' if self.options.strikethrough

--- a/crates/ox_content_parser/tests/edge_cases/inline.rs
+++ b/crates/ox_content_parser/tests/edge_cases/inline.rs
@@ -113,6 +113,28 @@ fn escaped_marker_remains_literal_text() {
 }
 
 #[test]
+fn backslash_before_non_punctuation_stays_literal() {
+    let allocator = Allocator::new();
+    // CommonMark example 13: only ASCII punctuation is escapable; before
+    // anything else (including multibyte characters, which used to panic
+    // on a byte-index slice) the backslash is literal text.
+    let doc = parse_with_options(&allocator, "\\\t\\A\\a\\ \\3\\φ\\«", ParserOptions::default());
+
+    match &doc.children[0] {
+        Node::Paragraph(paragraph) => {
+            let text = paragraph
+                .children
+                .iter()
+                .filter_map(first_text)
+                .collect::<std::vec::Vec<_>>()
+                .join("");
+            assert_eq!(text, "\\\t\\A\\a\\ \\3\\φ\\«");
+        }
+        other => panic!("expected paragraph, got {other:?}"),
+    }
+}
+
+#[test]
 fn unmatched_strikethrough_remains_text() {
     let allocator = Allocator::new();
     let doc = parse_with_options(&allocator, "~~open", ParserOptions::gfm());

--- a/crates/ox_content_renderer/tests/spec_fixtures/commonmark-known-failures.txt
+++ b/crates/ox_content_renderer/tests/spec_fixtures/commonmark-known-failures.txt
@@ -9,7 +9,6 @@ core 6 Tabs
 core 7 Tabs
 core 8 Tabs
 core 9 Tabs
-core 13 Backslash-escapes
 core 14 Backslash-escapes
 core 17 Backslash-escapes
 core 18 Backslash-escapes
@@ -401,7 +400,6 @@ gfm 6 Tabs
 gfm 7 Tabs
 gfm 8 Tabs
 gfm 9 Tabs
-gfm 13 Backslash-escapes
 gfm 14 Backslash-escapes
 gfm 17 Backslash-escapes
 gfm 18 Backslash-escapes


### PR DESCRIPTION
## Summary

The inline backslash-escape path sliced exactly one byte after the backslash, which **panicked on multibyte characters** (`\φ` → "byte index is not a char boundary"), and it stripped the backslash before *every* character.

Per CommonMark (Backslash escapes), only ASCII punctuation is escapable. This PR:

- escapes (drops the backslash before) ASCII punctuation only,
- treats a backslash before anything else — letters, digits, whitespace, multibyte characters — as a literal backslash, letting the following character parse normally.

Spec example 13 now passes in both core and GFM modes (baseline shrinks by 2); a parser edge-case regression test covers the former panic input.

## Verification

- `cargo test -p ox_content_parser` / `-p ox_content_renderer` pass
- `cargo clippy -p ox_content_parser --all-targets` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->