### PR TITLE
feat(parser): support CommonMark autolinks

### DIFF
--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -7,6 +7,7 @@ use crate::error::ParseResult;
 #[allow(unused_imports)]
 use crate::profile_span;
 
+mod autolink;
 mod link_target;
 mod scan;
 
@@ -64,7 +65,7 @@ impl<'a> Parser<'a> {
                 }
             }
             b'\n' => Self::parse_line_break(content, offset, children, pos),
-            b'<' => Self::parse_inline_html_or_text(content, offset, children, pos),
+            b'<' => self.parse_inline_html_or_text(content, offset, children, pos),
             b'\\' if *pos + 1 < content.len() && bytes[*pos + 1].is_ascii_punctuation() => {
                 // A backslash escapes only ASCII punctuation (CommonMark
                 // "Backslash escapes"). The escaped character is emitted as
@@ -150,12 +151,16 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_inline_html_or_text(
+        &self,
         content: &'a str,
         offset: usize,
         children: &mut Vec<'a, Node<'a>>,
         pos: &mut usize,
     ) {
-        if let Some((html, end)) = Self::parse_inline_html(content, *pos, offset) {
+        if let Some((link, end)) = self.parse_autolink(content, *pos, offset) {
+            children.push(link);
+            *pos = end;
+        } else if let Some((html, end)) = Self::parse_inline_html(content, *pos, offset) {
             children.push(Node::Html(html));
             *pos = end;
         } else {

--- a/crates/ox_content_parser/src/parser/inline/autolink.rs
+++ b/crates/ox_content_parser/src/parser/inline/autolink.rs
@@ -1,0 +1,93 @@
+//! CommonMark autolinks: `<scheme:uri>` and `<email@host>`.
+//!
+//! These are the core-spec autolinks (absolute URIs and email addresses
+//! between angle brackets), independent from the GFM bare-URL extension.
+
+use memchr::memchr;
+use ox_content_ast::{Link, Node, Span};
+
+use crate::parser::Parser;
+
+impl<'a> Parser<'a> {
+    /// Tries to parse an autolink at `pos` (which points at `<`).
+    /// Returns the link node and the position just past the closing `>`.
+    pub(in crate::parser) fn parse_autolink(
+        &self,
+        content: &'a str,
+        pos: usize,
+        offset: usize,
+    ) -> Option<(Node<'a>, usize)> {
+        let bytes = content.as_bytes();
+        let inner_start = pos + 1;
+        let close = memchr(b'>', bytes.get(inner_start..)?)? + inner_start;
+        let inner = &content[inner_start..close];
+
+        if inner.is_empty()
+            || inner
+                .bytes()
+                .any(|byte| byte == b'<' || byte.is_ascii_whitespace() || byte.is_ascii_control())
+        {
+            return None;
+        }
+
+        let url = if is_absolute_uri(inner) {
+            inner
+        } else if is_email_address(inner) {
+            let mut url = self.allocator.new_string_from("mailto:");
+            url.push_str(inner);
+            url.into_bump_str()
+        } else {
+            return None;
+        };
+
+        let mut children = self.allocator.new_vec();
+        children.push(Node::Text(ox_content_ast::Text {
+            value: inner,
+            span: Span::new((offset + inner_start) as u32, (offset + close) as u32),
+        }));
+        let link = Link {
+            url,
+            title: None,
+            children,
+            span: Span::new((offset + pos) as u32, (offset + close + 1) as u32),
+        };
+        Some((Node::Link(link), close + 1))
+    }
+}
+
+/// `scheme:rest` where scheme is 2–32 characters, starts with a letter,
+/// and continues with letters, digits, `+`, `.`, or `-`.
+fn is_absolute_uri(s: &str) -> bool {
+    let Some(colon) = s.find(':') else {
+        return false;
+    };
+    let scheme = &s[..colon];
+    (2..=32).contains(&scheme.len())
+        && scheme.as_bytes()[0].is_ascii_alphabetic()
+        && scheme
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'.' | b'-'))
+}
+
+/// The spec's email autolink shape: `local@domain` with dot-separated
+/// domain labels of up to 63 characters that don't start or end with `-`.
+fn is_email_address(s: &str) -> bool {
+    let Some((local, domain)) = s.split_once('@') else {
+        return false;
+    };
+    if local.is_empty()
+        || !local
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b".!#$%&'*+/=?^_`{|}~-".contains(&byte))
+    {
+        return false;
+    }
+    !domain.is_empty()
+        && domain.split('.').all(|label| {
+            !label.is_empty()
+                && label.len() <= 63
+                && label.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+                && !label.starts_with('-')
+                && !label.ends_with('-')
+        })
+}

--- a/crates/ox_content_renderer/tests/spec_fixtures/commonmark-known-failures.txt
+++ b/crates/ox_content_renderer/tests/spec_fixtures/commonmark-known-failures.txt
@@ -6,7 +6,6 @@ core 6 Tabs
 core 7 Tabs
 core 9 Tabs
 core 14 Backslash-escapes
-core 20 Backslash-escapes
 core 21 Backslash-escapes
 core 23 Backslash-escapes
 core 24 Backslash-escapes
@@ -100,7 +99,6 @@ core 318 Lists
 core 319 Lists
 core 341 Code-spans
 core 342 Code-spans
-core 346 Code-spans
 core 347 Code-spans
 core 351 Emphasis-and-strong-emphasis
 core 352 Emphasis-and-strong-emphasis
@@ -254,17 +252,6 @@ core 589 Images
 core 591 Images
 core 592 Images
 core 593 Images
-core 594 Autolinks
-core 595 Autolinks
-core 596 Autolinks
-core 597 Autolinks
-core 598 Autolinks
-core 599 Autolinks
-core 600 Autolinks
-core 601 Autolinks
-core 603 Autolinks
-core 604 Autolinks
-core 605 Autolinks
 core 615 Raw-HTML
 core 616 Raw-HTML
 core 619 Raw-HTML
@@ -278,7 +265,6 @@ gfm 6 Tabs
 gfm 7 Tabs
 gfm 9 Tabs
 gfm 14 Backslash-escapes
-gfm 20 Backslash-escapes
 gfm 21 Backslash-escapes
 gfm 23 Backslash-escapes
 gfm 24 Backslash-escapes
@@ -372,7 +358,6 @@ gfm 318 Lists
 gfm 319 Lists
 gfm 341 Code-spans
 gfm 342 Code-spans
-gfm 346 Code-spans
 gfm 347 Code-spans
 gfm 351 Emphasis-and-strong-emphasis
 gfm 352 Emphasis-and-strong-emphasis
@@ -526,17 +511,6 @@ gfm 589 Images
 gfm 591 Images
 gfm 592 Images
 gfm 593 Images
-gfm 594 Autolinks
-gfm 595 Autolinks
-gfm 596 Autolinks
-gfm 597 Autolinks
-gfm 598 Autolinks
-gfm 599 Autolinks
-gfm 600 Autolinks
-gfm 601 Autolinks
-gfm 603 Autolinks
-gfm 604 Autolinks
-gfm 605 Autolinks
 gfm 615 Raw-HTML
 gfm 616 Raw-HTML
 gfm 619 Raw-HTML


### PR DESCRIPTION
## Summary

Angle-bracketed absolute URIs (`<https://x>`, `<irc://y>`, `<MAILTO:Z>`) and email addresses (`<foo@bar.example>`) now become links with the URI as both destination and text (mailto: prefixed for emails), instead of falling through to escaped literal text. These are the core-spec autolinks — independent from the GFM bare-URL extension and from the renderer's optional URL autolinking.

Fixes 13 CommonMark spec examples in both modes (known-failures baseline 544 → 518).

## Verification

- `cargo test --workspace` green
- `cargo clippy --workspace --all-targets` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->