### PR TITLE
fix(parser): enforce the spec grammar for inline raw HTML

### DIFF
--- a/crates/ox_content_parser/src/parser/inline_html.rs
+++ b/crates/ox_content_parser/src/parser/inline_html.rs
@@ -1,3 +1,12 @@
+//! Inline raw HTML (CommonMark "Raw HTML").
+//!
+//! Only text matching the spec's tag grammar passes through as raw HTML;
+//! anything else stays literal text. Open/closing tags may span line
+//! endings, attribute names are restricted to the spec's character set,
+//! attributes must be separated by whitespace, and comments, processing
+//! instructions, declarations, and CDATA sections use their own
+//! terminators.
+
 use ox_content_ast::{Html, Span};
 
 use super::Parser;
@@ -8,10 +17,29 @@ impl<'a> Parser<'a> {
         pos: usize,
         offset: usize,
     ) -> Option<(Html<'a>, usize)> {
+        let rest = &content[pos..];
         let bytes = content.as_bytes();
 
-        if content[pos..].starts_with("<!--") {
-            let end = content[pos + 4..].find("-->").map(|found| pos + 4 + found + 3)?;
+        // Comments, with the 0.31.2 empty forms `<!-->` and `<!--->`.
+        for empty in ["<!-->", "<!--->"] {
+            if rest.starts_with(empty) {
+                let end = pos + empty.len();
+                return Some((Self::inline_html_node(content, pos, end, offset), end));
+            }
+        }
+        if let Some(comment_body) = rest.strip_prefix("<!--") {
+            let end = comment_body.find("-->").map(|found| pos + 4 + found + 3)?;
+            return Some((Self::inline_html_node(content, pos, end, offset), end));
+        }
+        // Processing instructions, CDATA, then other declarations.
+        for (open, close) in [("<?", "?>"), ("<![CDATA[", "]]>")] {
+            if let Some(body) = rest.strip_prefix(open) {
+                let end = body.find(close).map(|found| pos + open.len() + found + close.len())?;
+                return Some((Self::inline_html_node(content, pos, end, offset), end));
+            }
+        }
+        if rest.starts_with("<!") && rest.as_bytes().get(2).is_some_and(u8::is_ascii_alphabetic) {
+            let end = rest.find('>').map(|found| pos + found + 1)?;
             return Some((Self::inline_html_node(content, pos, end, offset), end));
         }
 
@@ -25,7 +53,7 @@ impl<'a> Parser<'a> {
         let mut cursor = tag_end;
 
         if closing {
-            while cursor < bytes.len() && matches!(bytes[cursor], b' ' | b'\t') {
+            while matches!(bytes.get(cursor), Some(b' ' | b'\t' | b'\n')) {
                 cursor += 1;
             }
             return (bytes.get(cursor) == Some(&b'>')).then(|| {
@@ -34,12 +62,8 @@ impl<'a> Parser<'a> {
             });
         }
 
-        if !matches!(bytes.get(cursor), Some(b' ' | b'\t' | b'/' | b'>')) {
-            return None;
-        }
-
-        Self::find_inline_html_end(bytes, cursor)
-            .map(|end| (Self::inline_html_node(content, pos, end, offset), end))
+        let end = scan_open_tag_rest(bytes, cursor)?;
+        Some((Self::inline_html_node(content, pos, end, offset), end))
     }
 
     fn inline_tag_name_end(bytes: &[u8], start: usize) -> usize {
@@ -50,30 +74,78 @@ impl<'a> Parser<'a> {
         end
     }
 
-    fn find_inline_html_end(bytes: &[u8], mut cursor: usize) -> Option<usize> {
-        let mut quote = None;
-        while cursor < bytes.len() {
-            let byte = bytes[cursor];
-            if let Some(quote_byte) = quote {
-                if byte == quote_byte {
-                    quote = None;
-                }
-            } else if matches!(byte, b'"' | b'\'') {
-                quote = Some(byte);
-            } else if byte == b'>' {
-                return Some(cursor + 1);
-            } else if byte == b'\n' {
-                return None;
-            }
-            cursor += 1;
-        }
-        None
-    }
-
     fn inline_html_node(content: &'a str, start: usize, end: usize, offset: usize) -> Html<'a> {
         Html {
             value: &content[start..end],
             span: Span::new((offset + start) as u32, (offset + end) as u32),
         }
     }
+}
+
+/// Scans the remainder of an open tag after its name: whitespace-separated
+/// attributes, optional `/`, and the closing `>`. Returns the index just
+/// past `>`.
+fn scan_open_tag_rest(bytes: &[u8], mut cursor: usize) -> Option<usize> {
+    loop {
+        let ws_start = cursor;
+        while matches!(bytes.get(cursor), Some(b' ' | b'\t' | b'\n')) {
+            cursor += 1;
+        }
+        match bytes.get(cursor)? {
+            b'/' if bytes.get(cursor + 1) == Some(&b'>') => return Some(cursor + 2),
+            b'>' => return Some(cursor + 1),
+            _ => {
+                // Attributes require separating whitespace.
+                if cursor == ws_start {
+                    return None;
+                }
+                cursor = scan_attribute(bytes, cursor)?;
+            }
+        }
+    }
+}
+
+/// Scans one attribute: a spec-charset name plus an optional
+/// `= value` (unquoted, single-, or double-quoted).
+fn scan_attribute(bytes: &[u8], mut cursor: usize) -> Option<usize> {
+    let first = *bytes.get(cursor)?;
+    if !(first.is_ascii_alphabetic() || matches!(first, b'_' | b':')) {
+        return None;
+    }
+    cursor += 1;
+    while bytes.get(cursor).is_some_and(|byte| {
+        byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b':' | b'-')
+    }) {
+        cursor += 1;
+    }
+
+    let mut look = cursor;
+    while matches!(bytes.get(look), Some(b' ' | b'\t' | b'\n')) {
+        look += 1;
+    }
+    if bytes.get(look) != Some(&b'=') {
+        // Boolean attribute; the (skipped) whitespace still separates the
+        // next attribute because the caller re-scans from `cursor`.
+        return Some(cursor);
+    }
+    cursor = look + 1;
+    while matches!(bytes.get(cursor), Some(b' ' | b'\t' | b'\n')) {
+        cursor += 1;
+    }
+
+    if let quote @ (b'"' | b'\'') = *bytes.get(cursor)? {
+        cursor += 1;
+        while *bytes.get(cursor)? != quote {
+            cursor += 1;
+        }
+        return Some(cursor + 1);
+    }
+
+    let value_start = cursor;
+    while bytes.get(cursor).is_some_and(|byte| {
+        !matches!(byte, b' ' | b'\t' | b'\n' | b'"' | b'\'' | b'=' | b'<' | b'>' | b'`')
+    }) {
+        cursor += 1;
+    }
+    (cursor > value_start).then_some(cursor)
 }

--- a/crates/ox_content_renderer/tests/spec_fixtures/commonmark-known-failures.txt
+++ b/crates/ox_content_renderer/tests/spec_fixtures/commonmark-known-failures.txt
@@ -17,7 +17,6 @@ core 315 Lists
 core 318 Lists
 core 319 Lists
 core 342 Code-spans
-core 491 Links
 core 524 Links
 core 525 Links
 core 526 Links
@@ -29,14 +28,6 @@ core 573 Images
 core 576 Images
 core 585 Images
 core 589 Images
-core 615 Raw-HTML
-core 616 Raw-HTML
-core 619 Raw-HTML
-core 622 Raw-HTML
-core 626 Raw-HTML
-core 627 Raw-HTML
-core 628 Raw-HTML
-core 629 Raw-HTML
 gfm 5 Tabs
 gfm 6 Tabs
 gfm 7 Tabs
@@ -53,7 +44,6 @@ gfm 315 Lists
 gfm 318 Lists
 gfm 319 Lists
 gfm 342 Code-spans
-gfm 491 Links
 gfm 524 Links
 gfm 525 Links
 gfm 526 Links
@@ -65,11 +55,3 @@ gfm 573 Images
 gfm 576 Images
 gfm 585 Images
 gfm 589 Images
-gfm 615 Raw-HTML
-gfm 616 Raw-HTML
-gfm 619 Raw-HTML
-gfm 622 Raw-HTML
-gfm 626 Raw-HTML
-gfm 627 Raw-HTML
-gfm 628 Raw-HTML
-gfm 629 Raw-HTML


### PR DESCRIPTION
## Summary

Inline tags may now span line endings, and only spec-valid tags pass through as raw HTML: attribute names restricted to their character set, attributes separated by whitespace, and quoted/unquoted value rules enforced — invalid constructs like `<a h*#ref="hi">` or `<a href='b'title=t>` stay escaped text. Processing instructions, declarations, and CDATA parse inline, and comments follow the 0.31.2 rules including the empty `<!-->` and `<!--->` forms.

Fixes 9 CommonMark spec examples in both modes (known-failures baseline 72 → 54).

## Verification

- `cargo test --workspace` green
- `cargo clippy --workspace --all-targets` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->