### PR TITLE
fix(parser): preserve tab stops when stripping list and quote markers

### DIFF
--- a/crates/ox_content_parser/src/parser/block_quote.rs
+++ b/crates/ox_content_parser/src/parser/block_quote.rs
@@ -55,12 +55,39 @@ impl<'a> Parser<'a> {
             let trimmed = &line[trimmed_offset..];
 
             if let Some(after_gt) = trimmed.strip_prefix('>') {
-                // Strip the optional single space after `>`
-                let stripped = after_gt.strip_prefix(' ').unwrap_or(after_gt);
-                inner.push_str(stripped);
+                // The marker consumes `>` plus one column of following
+                // whitespace. Expanding the rest of that whitespace run to
+                // spaces (with original column arithmetic) keeps tab stops
+                // aligned through the re-parse: `>\t\tfoo` becomes six
+                // spaces + foo, i.e. indented code with two extra columns.
+                let mut column = 0usize;
+                for &byte in &line.as_bytes()[..trimmed_offset] {
+                    column = if byte == b'\t' { (column / 4 + 1) * 4 } else { column + 1 };
+                }
+                let after_marker_column = column + 1;
+                let ws_bytes = after_gt.as_bytes();
+                let mut ws_len = 0usize;
+                let mut ws_end_column = after_marker_column;
+                while ws_len < ws_bytes.len() && matches!(ws_bytes[ws_len], b' ' | b'\t') {
+                    ws_end_column = if ws_bytes[ws_len] == b'\t' {
+                        (ws_end_column / 4 + 1) * 4
+                    } else {
+                        ws_end_column + 1
+                    };
+                    ws_len += 1;
+                }
+                let indent_columns = if ws_len > 0 {
+                    ws_end_column.saturating_sub(after_marker_column + 1)
+                } else {
+                    0
+                };
+                for _ in 0..indent_columns {
+                    inner.push(' ');
+                }
+                let stripped_trimmed = &after_gt[ws_len..];
+                inner.push_str(stripped_trimmed);
                 inner.push('\n');
 
-                let stripped_trimmed = stripped.trim_start_matches([' ', '\t']);
                 match fence {
                     Some((fence_byte, fence_len)) => {
                         if is_fence_close(stripped_trimmed, fence_byte, fence_len) {
@@ -74,8 +101,8 @@ impl<'a> Parser<'a> {
                 // and heading/thematic lines close it too. Deeper markers
                 // (nested quotes, list items) keep a paragraph open.
                 paragraph_open = fence.is_none()
-                    && !stripped.trim().is_empty()
-                    && Self::indentation_columns(stripped) < 4
+                    && !stripped_trimmed.trim().is_empty()
+                    && indent_columns < 4
                     && !stripped_trimmed.starts_with('#')
                     && !closes_paragraph_context(stripped_trimmed);
 

--- a/crates/ox_content_parser/src/parser/list.rs
+++ b/crates/ox_content_parser/src/parser/list.rs
@@ -191,8 +191,7 @@ impl<'a> Parser<'a> {
                     item_source = Some(self.init_list_item_source(item.content, consumed_newline));
                 }
                 let item_source = item_source.as_mut().expect("item source initialized");
-                let stripped = Self::strip_indent_columns(continuation_line, content_indent);
-                item_source.push_str(stripped);
+                Self::push_line_without_indent(item_source, continuation_line, content_indent);
                 item_source.push('\n');
                 self.position = continuation_next;
                 item_end = self.position;
@@ -218,7 +217,7 @@ impl<'a> Parser<'a> {
                 item_source = Some(self.init_list_item_source(item.content, consumed_newline));
             }
             let source = item_source.as_mut().expect("item source initialized");
-            source.push_str(Self::strip_indent_columns(continuation_line, content_indent));
+            Self::push_line_without_indent(source, continuation_line, content_indent);
             source.push('\n');
             self.position = continuation_next;
             item_end = self.position;

--- a/crates/ox_content_parser/src/parser/list_item.rs
+++ b/crates/ox_content_parser/src/parser/list_item.rs
@@ -161,6 +161,36 @@ impl<'a> Parser<'a> {
         })
     }
 
+    /// Pushes `line` minus its first `columns` columns onto `out`,
+    /// expanding the whole leading whitespace run to spaces so tab stops
+    /// keep their original alignment through item/quote re-parsing.
+    pub(super) fn push_line_without_indent(
+        out: &mut ox_content_allocator::String<'a>,
+        line: &str,
+        columns: usize,
+    ) {
+        let bytes = line.as_bytes();
+        let mut col = 0usize;
+        let mut i = 0usize;
+        while i < bytes.len() {
+            match bytes[i] {
+                b' ' => {
+                    col += 1;
+                    i += 1;
+                }
+                b'\t' => {
+                    col = (col / 4 + 1) * 4;
+                    i += 1;
+                }
+                _ => break,
+            }
+        }
+        for _ in columns..col {
+            out.push(' ');
+        }
+        out.push_str(&line[i..]);
+    }
+
     pub(super) fn strip_indent_columns(line: &str, columns: usize) -> &str {
         let mut consumed = 0;
         let mut byte_index = 0;

--- a/crates/ox_content_renderer/tests/spec_fixtures/commonmark-known-failures.txt
+++ b/crates/ox_content_renderer/tests/spec_fixtures/commonmark-known-failures.txt
@@ -1,10 +1,7 @@
 # CommonMark 0.31.2 examples that ox-content does not render per spec yet.
 # Format: <mode> <example-number> <section>
 # Regenerate: UPDATE_SPEC_BASELINE=1 cargo test -p ox_content_renderer --test spec_commonmark
-core 5 Tabs
-core 6 Tabs
 core 7 Tabs
-core 9 Tabs
 core 93 Setext-headings
 core 147 Fenced-code-blocks
 core 148 HTML-blocks
@@ -28,10 +25,7 @@ core 573 Images
 core 576 Images
 core 585 Images
 core 589 Images
-gfm 5 Tabs
-gfm 6 Tabs
 gfm 7 Tabs
-gfm 9 Tabs
 gfm 93 Setext-headings
 gfm 147 Fenced-code-blocks
 gfm 148 HTML-blocks


### PR DESCRIPTION
## Summary

Stripping list item content indent or block quote markers now expands the line's leading whitespace run to spaces using the original column arithmetic before dropping the marker columns, so tabs straddling the strip boundary keep their alignment through sub-parsing: `- foo` + a `\t\tbar` continuation yields two-space-indented code, and `>\t\tfoo` likewise.

Fixes 3 CommonMark spec examples in both modes (known-failures baseline 54 → 48).

## Verification

- `cargo test --workspace` green
- `cargo clippy --workspace --all-targets` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->