### PR TITLE
fix(parser): reach full CommonMark 0.31.2 conformance

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -109,6 +109,12 @@ pub struct Parser<'a> {
     /// pre-pass, shared with sub-parsers (block quote and list item
     /// contents) so references resolve document-wide.
     definitions: std::rc::Rc<reference::ReferenceMap<'a>>,
+
+    /// Byte offsets (in `source`) of lines that entered this sub-source
+    /// via lazy continuation. Such lines are paragraph text by
+    /// construction and must not be reinterpreted as setext underlines
+    /// during the re-parse.
+    lazy_lines: std::rc::Rc<rustc_hash::FxHashSet<u32>>,
 }
 
 impl<'a> Parser<'a> {
@@ -128,6 +134,7 @@ impl<'a> Parser<'a> {
             position: 0,
             nesting_depth: 0,
             definitions: std::rc::Rc::new(reference::ReferenceMap::default()),
+            lazy_lines: std::rc::Rc::default(),
         };
         parser.definitions = parser.build_definitions();
         parser
@@ -136,7 +143,13 @@ impl<'a> Parser<'a> {
     /// Creates a parser for re-parsing a stripped sub-source (block quote
     /// or list item content) that shares this parser's reference
     /// definitions instead of re-collecting them.
-    pub(crate) fn sub_parser(&self, source: &'a str) -> Parser<'a> {
+    /// Sub-parser that also knows which of its lines were added by lazy
+    /// continuation (offsets into `source`).
+    pub(crate) fn sub_parser_with_lazy_lines(
+        &self,
+        source: &'a str,
+        lazy_lines: rustc_hash::FxHashSet<u32>,
+    ) -> Parser<'a> {
         Self {
             allocator: self.allocator,
             source,
@@ -144,6 +157,7 @@ impl<'a> Parser<'a> {
             position: 0,
             nesting_depth: 0,
             definitions: std::rc::Rc::clone(&self.definitions),
+            lazy_lines: std::rc::Rc::new(lazy_lines),
         }
     }
 

--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -209,6 +209,11 @@ impl<'a> Parser<'a> {
     /// trailing whitespace. `first_non_ws` is the position of the line's
     /// first non-space/tab byte (already computed by the paragraph loop).
     fn setext_underline_depth(&self, line_start: usize, first_non_ws: usize) -> Option<u8> {
+        // A lazily-continued line is paragraph text by construction and
+        // can never underline the paragraph it continues.
+        if self.lazy_lines.contains(&(line_start as u32)) {
+            return None;
+        }
         let bytes = self.source.as_bytes();
         // A tab in the indent always reaches column 4+, so spaces only.
         if first_non_ws - line_start > 3

--- a/crates/ox_content_parser/src/parser/block_quote.rs
+++ b/crates/ox_content_parser/src/parser/block_quote.rs
@@ -31,6 +31,7 @@ impl<'a> Parser<'a> {
         // the stripped content to know when that is the case.
         let mut fence: Option<(u8, usize)> = None;
         let mut paragraph_open = false;
+        let mut lazy_lines = rustc_hash::FxHashSet::default();
 
         loop {
             if self.position >= bytes.len() {
@@ -114,8 +115,12 @@ impl<'a> Parser<'a> {
                 && !self.line_starts_block()
             {
                 // Lazy continuation: the line joins the quote's open
-                // paragraph as if the `>` marker were present.
-                inner.push_str(trimmed);
+                // paragraph as if the `>` marker were present. Keeping the
+                // original indentation means the re-parse still sees it as
+                // paragraph continuation (an indented `- x` stays text),
+                // and recording the offset stops setext reinterpretation.
+                lazy_lines.insert(inner.len() as u32);
+                inner.push_str(line);
                 inner.push('\n');
                 self.position = if line_end < bytes.len() { line_end + 1 } else { line_end };
             } else {
@@ -126,7 +131,7 @@ impl<'a> Parser<'a> {
 
         // Recursively parse the inner content from the same arena — no copy.
         let inner_str = inner.into_bump_str();
-        let sub_parser = self.sub_parser(inner_str);
+        let sub_parser = self.sub_parser_with_lazy_lines(inner_str, lazy_lines);
         let sub_doc = sub_parser.parse()?;
 
         self.nesting_depth -= 1;
@@ -136,15 +141,10 @@ impl<'a> Parser<'a> {
     }
 
     /// Lines that must not lazily continue a block quote paragraph even
-    /// though they cannot interrupt a paragraph either: a setext
-    /// underline lookalike would otherwise turn the lazy paragraph into
-    /// a heading during re-parse, and a bare list marker opens an (empty)
-    /// list block when the quote marker is imagined present.
+    /// though they cannot interrupt one: a bare list marker opens an
+    /// (empty) list block when the quote marker is imagined present.
     fn quote_lazy_blocked(trimmed: &str) -> bool {
         let line = trimmed.trim_end();
-        if !line.is_empty() && line.bytes().all(|byte| byte == b'=') {
-            return true;
-        }
         Self::try_parse_list_line(line) && {
             let after_digits = line.trim_start_matches(|ch: char| ch.is_ascii_digit());
             let after_marker = after_digits.trim_start_matches(['-', '*', '+', '.', ')']);

--- a/crates/ox_content_parser/src/parser/fenced_code.rs
+++ b/crates/ox_content_parser/src/parser/fenced_code.rs
@@ -40,13 +40,20 @@ impl<'a> Parser<'a> {
             let count = cursor - fence_start;
 
             if count >= fence_len {
-                // Found the closing fence. Body ends at `line_start`;
-                // fence line ends at the next `\n` (inclusive) or EOF.
-                let after_fence = match memchr(b'\n', &bytes[cursor..]) {
-                    Some(off) => cursor + off + 1,
+                // A closing fence carries nothing but trailing whitespace
+                // (``` aaa is content, not a closer).
+                let line_end = match memchr(b'\n', &bytes[cursor..]) {
+                    Some(off) => cursor + off,
                     None => bytes.len(),
                 };
-                return (line_start, after_fence);
+                let only_ws =
+                    bytes[cursor..line_end].iter().all(|byte| matches!(byte, b' ' | b'\t' | b'\r'));
+                if only_ws {
+                    // Body ends at `line_start`; the fence line ends at
+                    // the next newline (inclusive) or EOF.
+                    let after_fence = if line_end < bytes.len() { line_end + 1 } else { line_end };
+                    return (line_start, after_fence);
+                }
             }
 
             // Not a closing fence — move to the next line.

--- a/crates/ox_content_parser/src/parser/html/start.rs
+++ b/crates/ox_content_parser/src/parser/html/start.rs
@@ -67,7 +67,13 @@ impl<'a> Parser<'a> {
         }
 
         let tag_name = Self::parse_html_block_tag_name_from_trimmed(trimmed)?;
-        Self::html_block_start_for_tag(tag_name)
+        let closing = trimmed.as_bytes().get(1) == Some(&b'/');
+        match Self::html_block_start_for_tag(tag_name) {
+            // Type 1 starts only on open tags; a lone `</pre>` is a
+            // type-7 candidate that must not interrupt paragraphs.
+            Some(HtmlBlockStart::Type1(_)) if closing => None,
+            other => other,
+        }
     }
 
     /// Type-7 HTML block: a line holding one complete open or closing tag

--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -15,6 +15,7 @@ mod scan;
 
 use self::scan::next_inline_special;
 
+pub(in crate::parser) use self::autolink::autolink_end;
 pub(in crate::parser) use self::link_target::{
     parse_destination as parse_link_destination, parse_title as parse_link_title,
 };

--- a/crates/ox_content_parser/src/parser/inline/autolink.rs
+++ b/crates/ox_content_parser/src/parser/inline/autolink.rs
@@ -8,6 +8,23 @@ use ox_content_ast::{Link, Node, Span};
 
 use crate::parser::Parser;
 
+/// Validation-only scan: returns the index just past `>` when an
+/// autolink starts at `pos`, without building nodes.
+pub(in crate::parser) fn autolink_end(content: &str, pos: usize) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let inner_start = pos + 1;
+    let close = memchr(b'>', bytes.get(inner_start..)?)? + inner_start;
+    let inner = &content[inner_start..close];
+    if inner.is_empty()
+        || inner
+            .bytes()
+            .any(|byte| byte == b'<' || byte.is_ascii_whitespace() || byte.is_ascii_control())
+    {
+        return None;
+    }
+    (is_absolute_uri(inner) || is_email_address(inner)).then_some(close + 1)
+}
+
 impl<'a> Parser<'a> {
     /// Tries to parse an autolink at `pos` (which points at `<`).
     /// Returns the link node and the position just past the closing `>`.

--- a/crates/ox_content_parser/src/parser/inline_helpers.rs
+++ b/crates/ox_content_parser/src/parser/inline_helpers.rs
@@ -17,7 +17,7 @@ impl<'a> Parser<'a> {
         let link_start = *pos;
         *pos += 1;
         let text_start = *pos;
-        *pos = Self::scan_balanced(bytes, *pos, b'[', b']');
+        *pos = Self::scan_balanced(content, *pos, b'[', b']');
 
         if *pos < content.len() && bytes[*pos] == b']' {
             let close = *pos;
@@ -49,7 +49,7 @@ impl<'a> Parser<'a> {
             let mut well_formed_reference = false;
             if !inner_has_link && bytes.get(close + 1) == Some(&b'[') {
                 let label_start = close + 2;
-                let label_end = Self::scan_balanced(bytes, label_start, b'[', b']');
+                let label_end = Self::scan_balanced(content, label_start, b'[', b']');
                 if label_end < content.len() && bytes[label_end] == b']' {
                     well_formed_reference = true;
                     let raw_label = &content[label_start..label_end];
@@ -114,11 +114,12 @@ impl<'a> Parser<'a> {
         let image_start = *pos;
         *pos += 2;
         let alt_start = *pos;
-        *pos = Self::scan_balanced(bytes, *pos, b'[', b']');
+        *pos = Self::scan_balanced(content, *pos, b'[', b']');
 
         if *pos < content.len() && bytes[*pos] == b']' {
             let close = *pos;
-            let alt = self.flatten_image_alt(&content[alt_start..close], offset + alt_start)?;
+            let raw_alt = &content[alt_start..close];
+            let alt = self.flatten_image_alt(raw_alt, offset + alt_start)?;
 
             if bytes.get(close + 1) == Some(&b'(') {
                 if let Some(target) = self.parse_link_target(content, close + 1) {
@@ -139,11 +140,11 @@ impl<'a> Parser<'a> {
             let mut well_formed_reference = false;
             if bytes.get(close + 1) == Some(&b'[') {
                 let label_start = close + 2;
-                let label_end = Self::scan_balanced(bytes, label_start, b'[', b']');
+                let label_end = Self::scan_balanced(content, label_start, b'[', b']');
                 if label_end < content.len() && bytes[label_end] == b']' {
                     well_formed_reference = true;
                     let raw_label = &content[label_start..label_end];
-                    let key = if raw_label.trim().is_empty() { alt } else { raw_label };
+                    let key = if raw_label.trim().is_empty() { raw_alt } else { raw_label };
                     if let Some(reference) = self.lookup_reference(key) {
                         children.push(Node::Image(Image {
                             url: reference.url,
@@ -161,7 +162,7 @@ impl<'a> Parser<'a> {
             }
 
             if !well_formed_reference {
-                if let Some(reference) = self.lookup_reference(alt) {
+                if let Some(reference) = self.lookup_reference(raw_alt) {
                     children.push(Node::Image(Image {
                         url: reference.url,
                         alt,
@@ -216,39 +217,62 @@ impl<'a> Parser<'a> {
 
     /// Scans a balanced delimiter region and returns the matching close byte.
     ///
-    /// Link labels only care about nested `open`/`close` delimiters and
-    /// backslash escapes; every other byte is inert. `memchr3` moves directly
-    /// to the next byte that can affect the scan, which keeps deeply textual
-    /// labels from paying a branch for each character.
-    fn scan_balanced(bytes: &[u8], mut cursor: usize, open: u8, close: u8) -> usize {
+    /// Constructs that bind tighter than brackets are skipped whole:
+    /// backslash escapes, code spans (an unmatched opener stays literal),
+    /// autolinks, and inline raw HTML. This is what makes
+    /// `[not a `link](/foo`)` a code span instead of a link.
+    fn scan_balanced(content: &str, mut cursor: usize, open: u8, close: u8) -> usize {
+        let bytes = content.as_bytes();
         let mut depth = 1;
         while cursor < bytes.len() {
-            // Only `open`/`close` change depth and `\` can hide one of them,
-            // so jump straight to the next such byte; the skipped bytes were
-            // a no-op in the original loop.
-            let Some(off) = memchr3(open, close, b'\\', &bytes[cursor..]) else {
-                return bytes.len();
-            };
-            cursor += off;
-            if bytes[cursor] == b'\\' {
-                // An escaped ASCII punctuation byte (which covers both
-                // delimiters) is inert for bracket matching.
-                let escapes_next =
-                    cursor + 1 < bytes.len() && bytes[cursor + 1].is_ascii_punctuation();
-                cursor += if escapes_next { 2 } else { 1 };
-                continue;
-            }
-            if bytes[cursor] == open {
-                depth += 1;
-            } else {
-                depth -= 1;
-                // Stop AT the closing delimiter (matching the original, which
-                // skipped its trailing `cursor += 1` once depth hit 0).
-                if depth == 0 {
-                    return cursor;
+            match bytes[cursor] {
+                b'\\' => {
+                    // An escaped ASCII punctuation byte (which covers both
+                    // delimiters) is inert for bracket matching.
+                    let escapes_next =
+                        cursor + 1 < bytes.len() && bytes[cursor + 1].is_ascii_punctuation();
+                    cursor += if escapes_next { 2 } else { 1 };
                 }
+                b'`' => {
+                    let run = Self::marker_run_len(bytes, cursor, b'`');
+                    cursor += run;
+                    let mut scan = cursor;
+                    while scan < bytes.len() {
+                        let Some(off) = memchr(b'`', &bytes[scan..]) else {
+                            break;
+                        };
+                        scan += off;
+                        let closer = Self::marker_run_len(bytes, scan, b'`');
+                        if closer == run {
+                            cursor = scan + closer;
+                            break;
+                        }
+                        scan += closer;
+                    }
+                }
+                b'<' => {
+                    if let Some(end) = super::inline::autolink_end(content, cursor) {
+                        cursor = end;
+                    } else if let Some((_, end)) = Parser::parse_inline_html(content, cursor, 0) {
+                        cursor = end;
+                    } else {
+                        cursor += 1;
+                    }
+                }
+                byte if byte == open => {
+                    depth += 1;
+                    cursor += 1;
+                }
+                byte if byte == close => {
+                    depth -= 1;
+                    // Stop AT the closing delimiter.
+                    if depth == 0 {
+                        return cursor;
+                    }
+                    cursor += 1;
+                }
+                _ => cursor += 1,
             }
-            cursor += 1;
         }
         cursor
     }

--- a/crates/ox_content_parser/src/parser/list.rs
+++ b/crates/ox_content_parser/src/parser/list.rs
@@ -66,8 +66,13 @@ impl<'a> Parser<'a> {
                 self.advance();
             }
 
-            let (gap_spread, item_end, item_source) =
-                self.consume_item_continuation(&item, baseline_indent, consumed_newline);
+            let mut lazy_lines = rustc_hash::FxHashSet::default();
+            let (gap_spread, item_end, item_source) = self.consume_item_continuation(
+                &item,
+                baseline_indent,
+                consumed_newline,
+                &mut lazy_lines,
+            );
 
             let mut content_spread = false;
             let item_children = if item_source.is_none()
@@ -78,7 +83,7 @@ impl<'a> Parser<'a> {
                 let item_source = item_source
                     .unwrap_or_else(|| self.init_list_item_source(item.content, consumed_newline))
                     .into_bump_str();
-                let sub_parser = self.sub_parser(item_source);
+                let sub_parser = self.sub_parser_with_lazy_lines(item_source, lazy_lines);
                 let sub_doc = sub_parser.parse()?;
                 // The item directly contains blank-separated blocks iff a
                 // gap between consecutive top-level children spans a line
@@ -121,6 +126,7 @@ impl<'a> Parser<'a> {
         item: &ParsedListItem<'a>,
         baseline_indent: usize,
         consumed_newline: bool,
+        lazy_lines: &mut rustc_hash::FxHashSet<u32>,
     ) -> (bool, usize, Option<ox_content_allocator::String<'a>>) {
         let content_indent = item.content_indent;
         let item_is_empty = item.content.trim().is_empty();
@@ -225,7 +231,12 @@ impl<'a> Parser<'a> {
                 item_source = Some(self.init_list_item_source(item.content, consumed_newline));
             }
             let source = item_source.as_mut().expect("item source initialized");
-            Self::push_line_without_indent(source, continuation_line, content_indent);
+            // Keep the lazy line's own indentation: the sub-parse then
+            // treats it as paragraph continuation even when it looks like
+            // an (over-indented) marker, e.g. `- e` five columns deep.
+            // Recording the offset stops setext reinterpretation.
+            lazy_lines.insert(source.len() as u32);
+            source.push_str(continuation_line);
             source.push('\n');
             self.position = continuation_next;
             item_end = self.position;

--- a/crates/ox_content_parser/src/parser/list/item_source.rs
+++ b/crates/ox_content_parser/src/parser/list/item_source.rs
@@ -43,6 +43,19 @@ impl<'a> Parser<'a> {
     /// a block stay on the old path so cases such as `- # heading`, nested
     /// lists, fenced code, thematic breaks, and HTML blocks keep their AST.
     pub(super) fn can_inline_parse_list_item(content: &str) -> bool {
+        // Leading indentation of four or more columns means the item
+        // starts with indented code — that needs the block sub-parser.
+        let mut columns = 0usize;
+        for byte in content.bytes() {
+            match byte {
+                b' ' => columns += 1,
+                b'\t' => columns = (columns / 4 + 1) * 4,
+                _ => break,
+            }
+        }
+        if columns >= 4 {
+            return false;
+        }
         let Some(&first) = content.trim_start().as_bytes().first() else {
             return true;
         };

--- a/crates/ox_content_parser/src/parser/list_item.rs
+++ b/crates/ox_content_parser/src/parser/list_item.rs
@@ -134,11 +134,42 @@ impl<'a> Parser<'a> {
             Some(_) => return None,
         };
 
+        let marker_indent = line.len() - trimmed.len();
+        let ws_run = after_marker.iter().take_while(|&&byte| matches!(byte, b' ' | b'\t')).count();
+        if after_marker[..ws_run].contains(&b'\t') {
+            // Tabs after the marker expand from the marker's original
+            // column; everything beyond the single separator column
+            // becomes content spaces so alignment survives the item
+            // re-parse (`-\t\tfoo` is an item holding two-space-indented
+            // code).
+            let marker_end_col = marker_indent + marker_width;
+            let mut end_col = marker_end_col;
+            for &byte in &after_marker[..ws_run] {
+                end_col = if byte == b'\t' { (end_col / 4 + 1) * 4 } else { end_col + 1 };
+            }
+            let extra_columns = end_col.saturating_sub(marker_end_col + 1);
+            let rest = &trimmed[marker_width + ws_run..];
+            let mut expanded = self.allocator.new_string();
+            for _ in 0..extra_columns {
+                expanded.push(' ');
+            }
+            expanded.push_str(rest);
+            let content: &'a str = expanded.into_bump_str();
+            return Some(ParsedListItem {
+                ordered,
+                marker,
+                start,
+                content,
+                content_offset: trimmed_offset + marker_width + 1,
+                content_indent: marker_end_col + 1,
+                checked: None,
+            });
+        }
+
         let mut content = &trimmed[marker_width + content_skip..];
         let mut content_offset = trimmed_offset + marker_width + content_skip;
         // Continuation indent counts the marker's own indent plus the
         // marker and its separating spaces; empty items count one column.
-        let marker_indent = trimmed_offset - line_start;
         let content_indent = marker_indent
             + marker_width
             + if content.trim().is_empty() { 1 } else { content_skip.max(1) };

--- a/crates/ox_content_parser/src/parser/reference.rs
+++ b/crates/ox_content_parser/src/parser/reference.rs
@@ -55,7 +55,13 @@ impl<'a> Parser<'a> {
                     pending_space = false;
                 }
                 for lowered in ch.to_lowercase() {
-                    out.push(lowered);
+                    // Case folding (not just lowercasing): the sharp s
+                    // folds to "ss", so [SS] and [ẞ] label-match.
+                    if lowered == 'ß' {
+                        out.push_str("ss");
+                    } else {
+                        out.push(lowered);
+                    }
                 }
             }
         }

--- a/crates/ox_content_renderer/src/html/renderer/blocks.rs
+++ b/crates/ox_content_renderer/src/html/renderer/blocks.rs
@@ -205,7 +205,11 @@ impl HtmlRenderer {
 
     pub(in crate::html::renderer) fn render_html(&mut self, html: &Html<'_>) {
         self.write_html_value(html.value);
-        self.write("\n");
+        // Block-level HTML values captured from full source lines already
+        // end with their newline; don't double it.
+        if !self.output.ends_with('\n') {
+            self.write("\n");
+        }
     }
 
     pub(in crate::html::renderer) fn render_table(&mut self, table: &Table<'_>) {

--- a/crates/ox_content_renderer/tests/snapshots/edge_blocks__html_type6_details_allows_markdown_after_blank_line.snap
+++ b/crates/ox_content_renderer/tests/snapshots/edge_blocks__html_type6_details_allows_markdown_after_blank_line.snap
@@ -3,9 +3,7 @@ source: crates/ox_content_renderer/tests/edge_blocks.rs
 expression: html
 ---
 <details>
-
 <summary>Click to expand</summary>
-
 <p><strong>bold should be markdown</strong></p>
 <ul>
 <li>list</li>

--- a/crates/ox_content_renderer/tests/snapshots/renderer/html_type6_details_resumes_markdown_after_blank.snap
+++ b/crates/ox_content_renderer/tests/snapshots/renderer/html_type6_details_resumes_markdown_after_blank.snap
@@ -3,9 +3,7 @@ source: crates/ox_content_renderer/tests/support/snapshot.rs
 description: "<details>\n\n<summary>Click</summary>\n\n**bold**\n\n- list\n\n```js\nconsole.log(\"x\");\n```\n\n</details>\n"
 ---
 <details>
-
 <summary>Click</summary>
-
 <p><strong>bold</strong></p>
 <ul>
 <li>list</li>

--- a/crates/ox_content_renderer/tests/spec_fixtures/commonmark-known-failures.txt
+++ b/crates/ox_content_renderer/tests/spec_fixtures/commonmark-known-failures.txt
@@ -1,39 +1,3 @@
 # CommonMark 0.31.2 examples that ox-content does not render per spec yet.
 # Format: <mode> <example-number> <section>
 # Regenerate: UPDATE_SPEC_BASELINE=1 cargo test -p ox_content_renderer --test spec_commonmark
-core 7 Tabs
-core 93 Setext-headings
-core 147 Fenced-code-blocks
-core 148 HTML-blocks
-core 238 Block-quotes
-core 312 Lists
-core 342 Code-spans
-core 524 Links
-core 525 Links
-core 526 Links
-core 536 Links
-core 537 Links
-core 538 Links
-core 540 Links
-core 573 Images
-core 576 Images
-core 585 Images
-core 589 Images
-gfm 7 Tabs
-gfm 93 Setext-headings
-gfm 147 Fenced-code-blocks
-gfm 148 HTML-blocks
-gfm 238 Block-quotes
-gfm 312 Lists
-gfm 342 Code-spans
-gfm 524 Links
-gfm 525 Links
-gfm 526 Links
-gfm 536 Links
-gfm 537 Links
-gfm 538 Links
-gfm 540 Links
-gfm 573 Images
-gfm 576 Images
-gfm 585 Images
-gfm 589 Images

--- a/npm/vite-plugin-ox-content/src/__snapshots__/docs.snapshot.test.ts.snap
+++ b/npm/vite-plugin-ox-content/src/__snapshots__/docs.snapshot.test.ts.snap
@@ -28,7 +28,6 @@ exports[`docs generation snapshots > keeps generated accordion blocks as HTML th
   <span>examples</span>
 </span>
 </div>
-
 <h2 id="reference">Reference</h2>
 <details id="capitalize" class="ox-api-entry">
   <summary><span class="ox-api-entry__kind">fn</span><span class="ox-api-entry__summary-main"><code class="ox-api-entry__signature ox-api-entry__signature--highlighted language-typescript shiki-inline" data-language="typescript"><span class="line"><span style="color:#80A665">capitalize</span><span style="color:#666666">(</span><span style="color:#BD976A">value</span><span style="color:#DBD7CAEE">: </span><span style="color:#BD976A">string</span><span style="color:#666666">)</span><span style="color:#DBD7CAEE">: </span><span style="color:#BD976A">string</span></span></code><span class="ox-api-entry__description">Capitalizes user-facing labels before they are passed to RoundMode-aware format…</span><span class="ox-api-entry__meta"><span class="ox-api-badge">1 param</span><span class="ox-api-badge">returns string</span><span class="ox-api-badge">1 example</span><span class="ox-api-badge">since 1.4.0</span></span></span></summary>
@@ -71,7 +70,6 @@ exports[`docs generation snapshots > keeps generated accordion blocks as HTML th
 </div>
   </div>
 </details>
-
 "
 `;
 


### PR DESCRIPTION
## Summary

Closes out the remaining conformance clusters:

- Image reference lookups use the raw bracket text while the alt attribute keeps the flattened inline text.
- Reference labels case-fold the sharp s (`[SS]` matches `[ẞ]`).
- Bracket scanning skips constructs that bind tighter than links: code spans, autolinks, and inline raw HTML, so `[foo`](/uri)`` is a code span and `[foo <bar attr="](baz)">` stays raw HTML.
- A closing code fence may carry only trailing whitespace.
- Closing type-1 tags (`</pre>`) no longer open HTML blocks, so they join open paragraphs like other type-7 candidates.
- Tabs directly after list markers expand from their original columns (`-\t\tfoo` is an item holding two-space-indented code), and item content starting at four columns takes the block sub-parser.
- Lazy continuation lines keep their raw indentation, and their offsets ride along to sub-parsers so a lazy `===` stays paragraph text instead of becoming a setext underline.

**The `commonmark-known-failures` baseline is now empty: all 652 spec examples pass in both core and GFM modes**, and the conformance suite enforces that from here on.

## Verification

- `cargo test --workspace` green
- `cargo clippy --workspace --all-targets` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->