### PR TITLE
feat(parser): GFM autolink extension and extension spec suite

### DIFF
--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -10,6 +10,7 @@ use crate::profile_span;
 mod autolink;
 mod emphasis;
 mod entity;
+mod gfm_autolink;
 mod link_target;
 mod scan;
 
@@ -53,6 +54,9 @@ impl<'a> Parser<'a> {
 
         if !delimiters.is_empty() {
             self.process_emphasis(&mut children, &mut delimiters);
+        }
+        if self.options.autolinks {
+            self.apply_gfm_autolinks(&mut children);
         }
         Ok(children)
     }

--- a/crates/ox_content_parser/src/parser/inline/gfm_autolink.rs
+++ b/crates/ox_content_parser/src/parser/inline/gfm_autolink.rs
@@ -1,0 +1,266 @@
+//! GFM autolink extension: bare `www.`, `http(s)://`, and email
+//! addresses in plain text become links (GFM spec "Autolinks
+//! (extension)").
+//!
+//! Runs as a post-pass over a parsed inline sequence so it cannot
+//! interfere with emphasis pairing, and recurses into emphasis-like
+//! containers while never descending into existing links.
+
+use memchr::memmem;
+use ox_content_allocator::Vec;
+use ox_content_ast::{Link, Node, Span, Text};
+
+use crate::parser::Parser;
+
+struct Candidate {
+    start: usize,
+    end: usize,
+    href_prefix: &'static str,
+}
+
+impl<'a> Parser<'a> {
+    pub(in crate::parser) fn apply_gfm_autolinks(&self, children: &mut Vec<'a, Node<'a>>) {
+        // Entity, escape, and unpaired-delimiter handling fragment plain
+        // prose into adjacent text nodes; autolinks must see the joined
+        // run (`...?q=x&hl=en` is one URL despite the `&` split).
+        self.coalesce_adjacent_text(children);
+        let mut i = 0;
+        while i < children.len() {
+            match &mut children[i] {
+                Node::Emphasis(node) => self.apply_gfm_autolinks(&mut node.children),
+                Node::Strong(node) => self.apply_gfm_autolinks(&mut node.children),
+                Node::Delete(node) => self.apply_gfm_autolinks(&mut node.children),
+                Node::Text(text) => {
+                    let value = text.value;
+                    if let Some(candidate) = find_candidate(value) {
+                        let span_start = text.span.start;
+                        let link_value = &value[candidate.start..candidate.end];
+                        let url: &'a str = if candidate.href_prefix.is_empty() {
+                            link_value
+                        } else {
+                            let mut url = self.allocator.new_string_from(candidate.href_prefix);
+                            url.push_str(link_value);
+                            url.into_bump_str()
+                        };
+
+                        let link_span = Span::new(
+                            span_start + candidate.start as u32,
+                            span_start + candidate.end as u32,
+                        );
+                        let mut link_children = self.allocator.new_vec();
+                        link_children.push(Node::Text(Text { value: link_value, span: link_span }));
+                        let link_node = Node::Link(Link {
+                            url,
+                            title: None,
+                            children: link_children,
+                            span: link_span,
+                        });
+
+                        let after = &value[candidate.end..];
+                        let after_node = (!after.is_empty()).then(|| {
+                            Node::Text(Text {
+                                value: after,
+                                span: Span::new(span_start + candidate.end as u32, text.span.end),
+                            })
+                        });
+
+                        if candidate.start == 0 {
+                            children[i] = link_node;
+                        } else {
+                            text.value = &value[..candidate.start];
+                            text.span = Span::new(span_start, span_start + candidate.start as u32);
+                            i += 1;
+                            children.insert(i, link_node);
+                        }
+                        if let Some(after_node) = after_node {
+                            children.insert(i + 1, after_node);
+                        }
+                        // Continue scanning in the remainder text node.
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+    }
+}
+
+impl<'a> Parser<'a> {
+    fn coalesce_adjacent_text(&self, children: &mut Vec<'a, Node<'a>>) {
+        let mut i = 0;
+        while i + 1 < children.len() {
+            if !matches!(children[i], Node::Text(_)) || !matches!(children[i + 1], Node::Text(_)) {
+                i += 1;
+                continue;
+            }
+            let mut j = i + 1;
+            while j < children.len() && matches!(children[j], Node::Text(_)) {
+                j += 1;
+            }
+            let mut merged = self.allocator.new_string();
+            let mut span = Span::new(0, 0);
+            for (index, node) in children[i..j].iter().enumerate() {
+                if let Node::Text(text) = node {
+                    if index == 0 {
+                        span = text.span;
+                    }
+                    span = Span::new(span.start, text.span.end);
+                    merged.push_str(text.value);
+                }
+            }
+            let merged_node = Node::Text(Text { value: merged.into_bump_str(), span });
+            children.drain(i..j);
+            children.insert(i, merged_node);
+            i += 1;
+        }
+    }
+}
+
+/// Finds the earliest valid autolink candidate in `value`.
+fn find_candidate(value: &str) -> Option<Candidate> {
+    let mut best: Option<Candidate> = None;
+    for (needle, _href, is_email) in [
+        ("www.", "http://", false),
+        ("http://", "", false),
+        ("https://", "", false),
+        ("ftp://", "", false),
+        ("@", "mailto:", true),
+    ] {
+        let mut from = 0;
+        while let Some(offset) = memmem::find(&value.as_bytes()[from..], needle.as_bytes()) {
+            let at = from + offset;
+            let candidate = if is_email {
+                validate_email(value, at)
+            } else {
+                validate_url(value, at, needle.len())
+            };
+            if let Some(candidate) = candidate {
+                if best.as_ref().is_none_or(|current| candidate.start < current.start) {
+                    best = Some(candidate);
+                }
+                break;
+            }
+            from = at + needle.len();
+        }
+    }
+    best
+}
+
+/// Start-of-text, whitespace, or `*`, `_`, `~`, `(` may precede an
+/// autolink.
+fn valid_boundary(value: &str, start: usize) -> bool {
+    value[..start]
+        .chars()
+        .next_back()
+        .is_none_or(|ch| ch.is_whitespace() || matches!(ch, '*' | '_' | '~' | '('))
+}
+
+fn validate_url(value: &str, start: usize, prefix_len: usize) -> Option<Candidate> {
+    if !valid_boundary(value, start) {
+        return None;
+    }
+    let bytes = value.as_bytes();
+    // Validate the domain: alphanumerics, `-`, `_`, `.`; at least one
+    // dot; no underscore in the last two segments.
+    let domain_start = start + prefix_len;
+    let mut domain_end = domain_start;
+    while domain_end < bytes.len()
+        && (bytes[domain_end].is_ascii_alphanumeric()
+            || matches!(bytes[domain_end], b'-' | b'_' | b'.'))
+    {
+        domain_end += 1;
+    }
+    // Trailing dots belong to the surrounding sentence, not the domain.
+    let domain = value[domain_start..domain_end].trim_end_matches('.');
+    if domain.split('.').count() < 2
+        || domain.rsplit('.').take(2).any(|segment| segment.is_empty() || segment.contains('_'))
+    {
+        return None;
+    }
+
+    // The link runs to whitespace or `<`, then trailing punctuation is
+    // trimmed (unbalanced `)` and entity-like `&x;` suffixes included).
+    let mut end = domain_end;
+    while end < bytes.len() && !bytes[end].is_ascii_whitespace() && bytes[end] != b'<' {
+        end += 1;
+    }
+    let end = trim_trailing_punctuation(value, start, end);
+    (end > domain_start).then_some(Candidate {
+        start,
+        end,
+        href_prefix: if prefix_len == 4 { "http://" } else { "" },
+    })
+}
+
+fn trim_trailing_punctuation(value: &str, start: usize, mut end: usize) -> usize {
+    let bytes = value.as_bytes();
+    loop {
+        if end <= start {
+            return end;
+        }
+        match bytes[end - 1] {
+            b'?' | b'!' | b'.' | b',' | b':' | b'*' | b'_' | b'~' | b'\'' | b'"' => end -= 1,
+            b')' => {
+                let opens = value[start..end].bytes().filter(|&b| b == b'(').count();
+                let closes = value[start..end].bytes().filter(|&b| b == b')').count();
+                if closes > opens {
+                    end -= 1;
+                } else {
+                    return end;
+                }
+            }
+            b';' => {
+                // Strip an entity-like `&name;` suffix entirely.
+                let entity_start = value[start..end - 1].rfind('&').map(|found| start + found);
+                match entity_start {
+                    Some(amp)
+                        if value[amp + 1..end - 1]
+                            .bytes()
+                            .all(|byte| byte.is_ascii_alphanumeric())
+                            && amp + 1 < end - 1 =>
+                    {
+                        end = amp;
+                    }
+                    _ => end -= 1,
+                }
+            }
+            _ => return end,
+        }
+    }
+}
+
+fn validate_email(value: &str, at: usize) -> Option<Candidate> {
+    let bytes = value.as_bytes();
+    // Local part: alphanumerics plus `.`, `-`, `_`, `+`.
+    let mut start = at;
+    while start > 0 {
+        let byte = bytes[start - 1];
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_' | b'+') {
+            start -= 1;
+        } else {
+            break;
+        }
+    }
+    if start == at || !valid_boundary(value, start) {
+        return None;
+    }
+
+    // Domain: alphanumerics plus `.`, `-`, `_`, with at least one dot;
+    // trailing dots are trimmed; a trailing `-` or `_` invalidates.
+    let mut end = at + 1;
+    while end < bytes.len()
+        && (bytes[end].is_ascii_alphanumeric() || matches!(bytes[end], b'.' | b'-' | b'_'))
+    {
+        end += 1;
+    }
+    while end > at + 1 && bytes[end - 1] == b'.' {
+        end -= 1;
+    }
+    if end <= at + 1 || matches!(bytes[end - 1], b'-' | b'_') {
+        return None;
+    }
+    if !value[at + 1..end].contains('.') {
+        return None;
+    }
+    Some(Candidate { start, end, href_prefix: "mailto:" })
+}

--- a/crates/ox_content_parser/tests/edge_cases/inline.rs
+++ b/crates/ox_content_parser/tests/edge_cases/inline.rs
@@ -142,7 +142,9 @@ fn unmatched_strikethrough_remains_text() {
     match &doc.children[0] {
         Node::Paragraph(paragraph) => {
             assert!(matches!(&paragraph.children[0], Node::Text(_)));
-            assert_eq!(first_text(&paragraph.children[0]), Some("~~"));
+            // GFM post-processing coalesces adjacent text nodes, so the
+            // unmatched marker merges with the following prose.
+            assert_eq!(first_text(&paragraph.children[0]), Some("~~open"));
         }
         other => panic!("expected paragraph, got {other:?}"),
     }

--- a/crates/ox_content_parser/tests/snapshots/parser/footnote_reference_and_definition.snap
+++ b/crates/ox_content_parser/tests/snapshots/parser/footnote_reference_and_definition.snap
@@ -1,13 +1,9 @@
 ---
 source: crates/ox_content_parser/tests/snapshot_parse.rs
-assertion_line: 32
 description: "See[^1].\n\n[^1]: The footnote body.\n"
 ---
 Document [0..35]
   Paragraph [0..9]
-    Text "See" [0..3]
-    Text "[" [3..4]
-    Text "^1]." [4..8]
+    Text "See[^1]." [0..8]
   Paragraph [10..35]
-    Text "[" [10..11]
-    Text "^1]: The footnote body." [11..34]
+    Text "[^1]: The footnote body." [10..34]

--- a/crates/ox_content_parser/tests/snapshots/parser/inline_strikethrough_unmatched.snap
+++ b/crates/ox_content_parser/tests/snapshots/parser/inline_strikethrough_unmatched.snap
@@ -1,9 +1,7 @@
 ---
 source: crates/ox_content_parser/tests/snapshot_parse.rs
-assertion_line: 32
 description: "~~open\n"
 ---
 Document [0..7]
   Paragraph [0..7]
-    Text "~~" [0..2]
-    Text "open" [2..6]
+    Text "~~open" [0..6]

--- a/crates/ox_content_renderer/tests/spec_fixtures/README.md
+++ b/crates/ox_content_renderer/tests/spec_fixtures/README.md
@@ -6,11 +6,22 @@
   licensed under [CC-BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
   It is used here only as test data for the conformance suite in
   `tests/spec_commonmark.rs`.
-- `commonmark-known-failures.txt` tracks the spec examples ox-content does
-  not render per spec yet. The conformance test fails when an entry starts
-  passing (remove the line) or when a conforming example regresses.
-  Regenerate with:
+- `gfm-extensions-spec.txt` holds the extension examples (tables, task
+  list items, strikethrough, autolinks) extracted from the GitHub
+  Flavored Markdown spec (0.29-gfm, also CC-BY-SA 4.0), driven by
+  `tests/spec_gfm.rs`.
+- `commonmark-known-failures.txt` and `gfm-known-failures.txt` track the
+  examples that do not render per their spec. The conformance tests fail
+  when an entry starts passing (remove the line) or when a conforming
+  example regresses. Regenerate with:
 
   ```sh
   UPDATE_SPEC_BASELINE=1 cargo test -p ox_content_renderer --test spec_commonmark
+  UPDATE_SPEC_BASELINE=1 cargo test -p ox_content_renderer --test spec_gfm
   ```
+
+  The remaining `gfm <n> Autolinks` entries in the CommonMark baseline
+  are not defects: with the GFM profile enabled, the autolink extension
+  deliberately linkifies bare URLs/emails that plain CommonMark keeps as
+  text (spec examples 608/611/612). Core mode matches CommonMark on all
+  652 examples.

--- a/crates/ox_content_renderer/tests/spec_fixtures/commonmark-known-failures.txt
+++ b/crates/ox_content_renderer/tests/spec_fixtures/commonmark-known-failures.txt
@@ -1,3 +1,6 @@
 # CommonMark 0.31.2 examples that ox-content does not render per spec yet.
 # Format: <mode> <example-number> <section>
 # Regenerate: UPDATE_SPEC_BASELINE=1 cargo test -p ox_content_renderer --test spec_commonmark
+gfm 608 Autolinks
+gfm 611 Autolinks
+gfm 612 Autolinks

--- a/crates/ox_content_renderer/tests/spec_fixtures/gfm-extensions-spec.txt
+++ b/crates/ox_content_renderer/tests/spec_fixtures/gfm-extensions-spec.txt
@@ -1,0 +1,489 @@
+# GFM extension examples
+
+Extracted from the GitHub Flavored Markdown Spec (version 0.29-gfm),
+<https://github.com/github/cmark-gfm/blob/master/test/spec.txt>,
+sections "Tables", "Task list items", "Strikethrough", and "Autolinks"
+(all marked "extension"). Licensed under CC-BY-SA 4.0 by GitHub and
+John MacFarlane. Used only as test data for tests/spec_gfm.rs.
+
+## Tables (extension)
+
+
+GFM enables the `table` extension, where an additional leaf block type is
+available.
+
+A [table](@) is an arrangement of data with rows and columns, consisting of a
+single header row, a [delimiter row] separating the header from the data, and
+zero or more data rows.
+
+Each row consists of cells containing arbitrary text, in which [inlines] are
+parsed, separated by pipes (`|`).  A leading and trailing pipe is also
+recommended for clarity of reading, and if there's otherwise parsing ambiguity.
+Spaces between pipes and cell content are trimmed.  Block-level elements cannot
+be inserted in a table.
+
+The [delimiter row](@) consists of cells whose only content are hyphens (`-`),
+and optionally, a leading or trailing colon (`:`), or both, to indicate left,
+right, or center alignment respectively.
+
+```````````````````````````````` example table
+| foo | bar |
+| --- | --- |
+| baz | bim |
+.
+<table>
+<thead>
+<tr>
+<th>foo</th>
+<th>bar</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>baz</td>
+<td>bim</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+Cells in one column don't need to match length, though it's easier to read if
+they are. Likewise, use of leading and trailing pipes may be inconsistent:
+
+```````````````````````````````` example table
+| abc | defghi |
+:-: | -----------:
+bar | baz
+.
+<table>
+<thead>
+<tr>
+<th align="center">abc</th>
+<th align="right">defghi</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="center">bar</td>
+<td align="right">baz</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+Include a pipe in a cell's content by escaping it, including inside other
+inline spans:
+
+```````````````````````````````` example table
+| f\|oo  |
+| ------ |
+| b `\|` az |
+| b **\|** im |
+.
+<table>
+<thead>
+<tr>
+<th>f|oo</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>b <code>|</code> az</td>
+</tr>
+<tr>
+<td>b <strong>|</strong> im</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+The table is broken at the first empty line, or beginning of another
+block-level structure:
+
+```````````````````````````````` example table
+| abc | def |
+| --- | --- |
+| bar | baz |
+> bar
+.
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>bar</td>
+<td>baz</td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p>bar</p>
+</blockquote>
+````````````````````````````````
+
+```````````````````````````````` example table
+| abc | def |
+| --- | --- |
+| bar | baz |
+bar
+
+bar
+.
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>bar</td>
+<td>baz</td>
+</tr>
+<tr>
+<td>bar</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+<p>bar</p>
+````````````````````````````````
+
+The header row must match the [delimiter row] in the number of cells.  If not,
+a table will not be recognized:
+
+```````````````````````````````` example table
+| abc | def |
+| --- |
+| bar |
+.
+<p>| abc | def |
+| --- |
+| bar |</p>
+````````````````````````````````
+
+The remainder of the table's rows may vary in the number of cells.  If there
+are a number of cells fewer than the number of cells in the header row, empty
+cells are inserted.  If there are greater, the excess is ignored:
+
+```````````````````````````````` example table
+| abc | def |
+| --- | --- |
+| bar |
+| bar | baz | boo |
+.
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>bar</td>
+<td></td>
+</tr>
+<tr>
+<td>bar</td>
+<td>baz</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+If there are no rows in the body, no `<tbody>` is generated in HTML output:
+
+```````````````````````````````` example table
+| abc | def |
+| --- | --- |
+.
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+</table>
+````````````````````````````````
+
+</div>
+
+# Container blocks
+
+A [container block](#container-blocks) is a block that has other
+blocks as its contents.  There are two basic kinds of container blocks:
+[block quotes] and [list items].
+[Lists] are meta-containers for [list items].
+
+We define the syntax for container blocks recursively.  The general
+form of the definition is:
+
+> If X is a sequence of blocks, then the result of
+> transforming X in such-and-such a way is a container of type Y
+> with these blocks as its content.
+
+So, we explain what counts as a block quote or list item by explaining
+how these can be *generated* from their contents. This should suffice
+to define the syntax, although it does not give a recipe for *parsing*
+these constructions.  (A recipe is provided below in the section entitled
+[A parsing strategy](#appendix-a-parsing-strategy).)
+
+## Task list items (extension)
+
+
+GFM enables the `tasklist` extension, where an additional processing step is
+performed on [list items].
+
+A [task list item](@) is a [list item][list items] where the first block in it
+is a paragraph which begins with a [task list item marker] and at least one
+whitespace character before any other content.
+
+A [task list item marker](@) consists of an optional number of spaces, a left
+bracket (`[`), either a whitespace character or the letter `x` in either
+lowercase or uppercase, and then a right bracket (`]`).
+
+When rendered, the [task list item marker] is replaced with a semantic checkbox element;
+in an HTML output, this would be an `<input type="checkbox">` element.
+
+If the character between the brackets is a whitespace character, the checkbox
+is unchecked.  Otherwise, the checkbox is checked.
+
+This spec does not define how the checkbox elements are interacted with: in practice,
+implementors are free to render the checkboxes as disabled or inmutable elements,
+or they may dynamically handle dynamic interactions (i.e. checking, unchecking) in
+the final rendered document.
+
+```````````````````````````````` example disabled
+- [ ] foo
+- [x] bar
+.
+<ul>
+<li><input disabled="" type="checkbox"> foo</li>
+<li><input checked="" disabled="" type="checkbox"> bar</li>
+</ul>
+````````````````````````````````
+
+Task lists can be arbitrarily nested:
+
+```````````````````````````````` example disabled
+- [x] foo
+  - [ ] bar
+  - [x] baz
+- [ ] bim
+.
+<ul>
+<li><input checked="" disabled="" type="checkbox"> foo
+<ul>
+<li><input disabled="" type="checkbox"> bar</li>
+<li><input checked="" disabled="" type="checkbox"> baz</li>
+</ul>
+</li>
+<li><input disabled="" type="checkbox"> bim</li>
+</ul>
+````````````````````````````````
+
+</div>
+
+## Strikethrough (extension)
+
+
+GFM enables the `strikethrough` extension, where an additional emphasis type is
+available.
+
+Strikethrough text is any text wrapped in two tildes (`~`).
+
+```````````````````````````````` example strikethrough
+~~Hi~~ Hello, world!
+.
+<p><del>Hi</del> Hello, world!</p>
+````````````````````````````````
+
+As with regular emphasis delimiters, a new paragraph will cause strikethrough
+parsing to cease:
+
+```````````````````````````````` example strikethrough
+This ~~has a
+
+new paragraph~~.
+.
+<p>This ~~has a</p>
+<p>new paragraph~~.</p>
+````````````````````````````````
+
+</div>
+
+## Autolinks (extension)
+
+
+GFM enables the `autolink` extension, where autolinks will be recognised in a
+greater number of conditions.
+
+[Autolink]s can also be constructed without requiring the use of `<` and to `>`
+to delimit them, although they will be recognized under a smaller set of
+circumstances.  All such recognized autolinks can only come at the beginning of
+a line, after whitespace, or any of the delimiting characters `*`, `_`, `~`,
+and `(`.
+
+An [extended www autolink](@) will be recognized
+when the text `www.` is found followed by a [valid domain].
+A [valid domain](@) consists of segments
+of alphanumeric characters, underscores (`_`) and hyphens (`-`)
+separated by periods (`.`).
+There must be at least one period,
+and no underscores may be present in the last two segments of the domain.
+
+The scheme `http` will be inserted automatically:
+
+```````````````````````````````` example autolink
+www.commonmark.org
+.
+<p><a href="http://www.commonmark.org">www.commonmark.org</a></p>
+````````````````````````````````
+
+After a [valid domain], zero or more non-space non-`<` characters may follow:
+
+```````````````````````````````` example autolink
+Visit www.commonmark.org/help for more information.
+.
+<p>Visit <a href="http://www.commonmark.org/help">www.commonmark.org/help</a> for more information.</p>
+````````````````````````````````
+
+We then apply [extended autolink path validation](@) as follows:
+
+Trailing punctuation (specifically, `?`, `!`, `.`, `,`, `:`, `*`, `_`, and `~`)
+will not be considered part of the autolink, though they may be included in the
+interior of the link:
+
+```````````````````````````````` example autolink
+Visit www.commonmark.org.
+
+Visit www.commonmark.org/a.b.
+.
+<p>Visit <a href="http://www.commonmark.org">www.commonmark.org</a>.</p>
+<p>Visit <a href="http://www.commonmark.org/a.b">www.commonmark.org/a.b</a>.</p>
+````````````````````````````````
+
+When an autolink ends in `)`, we scan the entire autolink for the total number
+of parentheses.  If there is a greater number of closing parentheses than
+opening ones, we don't consider the unmatched trailing parentheses part of the
+autolink, in order to facilitate including an autolink inside a parenthesis:
+
+```````````````````````````````` example autolink
+www.google.com/search?q=Markup+(business)
+
+www.google.com/search?q=Markup+(business)))
+
+(www.google.com/search?q=Markup+(business))
+
+(www.google.com/search?q=Markup+(business)
+.
+<p><a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a></p>
+<p><a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a>))</p>
+<p>(<a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a>)</p>
+<p>(<a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a></p>
+````````````````````````````````
+
+This check is only done when the link ends in a closing parentheses `)`, so if
+the only parentheses are in the interior of the autolink, no special rules are
+applied:
+
+```````````````````````````````` example autolink
+www.google.com/search?q=(business))+ok
+.
+<p><a href="http://www.google.com/search?q=(business))+ok">www.google.com/search?q=(business))+ok</a></p>
+````````````````````````````````
+
+If an autolink ends in a semicolon (`;`), we check to see if it appears to
+resemble an [entity reference][entity references]; if the preceding text is `&`
+followed by one or more alphanumeric characters.  If so, it is excluded from
+the autolink:
+
+```````````````````````````````` example autolink
+www.google.com/search?q=commonmark&hl=en
+
+www.google.com/search?q=commonmark&hl;
+.
+<p><a href="http://www.google.com/search?q=commonmark&amp;hl=en">www.google.com/search?q=commonmark&amp;hl=en</a></p>
+<p><a href="http://www.google.com/search?q=commonmark">www.google.com/search?q=commonmark</a>&amp;hl;</p>
+````````````````````````````````
+
+`<` immediately ends an autolink.
+
+```````````````````````````````` example autolink
+www.commonmark.org/he<lp
+.
+<p><a href="http://www.commonmark.org/he">www.commonmark.org/he</a>&lt;lp</p>
+````````````````````````````````
+
+An [extended url autolink](@) will be recognised when one of the schemes
+`http://`, `https://`, or `ftp://`, followed by a [valid domain], then zero or
+more non-space non-`<` characters according to
+[extended autolink path validation]:
+
+```````````````````````````````` example autolink
+http://commonmark.org
+
+(Visit https://encrypted.google.com/search?q=Markup+(business))
+
+Anonymous FTP is available at ftp://foo.bar.baz.
+.
+<p><a href="http://commonmark.org">http://commonmark.org</a></p>
+<p>(Visit <a href="https://encrypted.google.com/search?q=Markup+(business)">https://encrypted.google.com/search?q=Markup+(business)</a>)</p>
+<p>Anonymous FTP is available at <a href="ftp://foo.bar.baz">ftp://foo.bar.baz</a>.</p>
+````````````````````````````````
+
+
+An [extended email autolink](@) will be recognised when an email address is
+recognised within any text node.  Email addresses are recognised according to
+the following rules:
+
+* One ore more characters which are alphanumeric, or `.`, `-`, `_`, or `+`.
+* An `@` symbol.
+* One or more characters which are alphanumeric, or `-` or `_`,
+  separated by periods (`.`).
+  There must be at least one period.
+  The last character must not be one of `-` or `_`.
+
+The scheme `mailto:` will automatically be added to the generated link:
+
+```````````````````````````````` example autolink
+foo@bar.baz
+.
+<p><a href="mailto:foo@bar.baz">foo@bar.baz</a></p>
+````````````````````````````````
+
+`+` can occur before the `@`, but not after.
+
+```````````````````````````````` example autolink
+hello@mail+xyz.example isn't valid, but hello+xyz@mail.example is.
+.
+<p>hello@mail+xyz.example isn't valid, but <a href="mailto:hello+xyz@mail.example">hello+xyz@mail.example</a> is.</p>
+````````````````````````````````
+
+`.`, `-`, and `_` can occur on both sides of the `@`, but only `.` may occur at
+the end of the email address, in which case it will not be considered part of
+the address:
+
+```````````````````````````````` example autolink
+a.b-c_d@a.b
+
+a.b-c_d@a.b.
+
+a.b-c_d@a.b-
+
+a.b-c_d@a.b_
+.
+<p><a href="mailto:a.b-c_d@a.b">a.b-c_d@a.b</a></p>
+<p><a href="mailto:a.b-c_d@a.b">a.b-c_d@a.b</a>.</p>
+<p>a.b-c_d@a.b-</p>
+<p>a.b-c_d@a.b_</p>
+````````````````````````````````
+
+</div>

--- a/crates/ox_content_renderer/tests/spec_fixtures/gfm-known-failures.txt
+++ b/crates/ox_content_renderer/tests/spec_fixtures/gfm-known-failures.txt
@@ -1,0 +1,3 @@
+# GFM extension examples that ox-content does not render per spec yet.
+# Format: <example-number>
+# Regenerate: UPDATE_SPEC_BASELINE=1 cargo test -p ox_content_renderer --test spec_gfm

--- a/crates/ox_content_renderer/tests/spec_gfm.rs
+++ b/crates/ox_content_renderer/tests/spec_gfm.rs
@@ -1,0 +1,120 @@
+//! GFM extension conformance suite (tables, task list items,
+//! strikethrough, autolinks).
+//!
+//! Runs the extension examples extracted from the GitHub Flavored
+//! Markdown spec through parse+render with the GFM profile, comparing
+//! via the same normalizer as the CommonMark suite. Failures are pinned
+//! in `spec_fixtures/gfm-known-failures.txt` with the same ratchet
+//! semantics: regressions fail, and so do stale baseline entries.
+//! Regenerate with:
+//!
+//! ```text
+//! UPDATE_SPEC_BASELINE=1 cargo test -p ox_content_renderer --test spec_gfm
+//! ```
+
+#[path = "spec_support/normalize.rs"]
+mod normalize;
+#[path = "spec_support/spec_txt.rs"]
+mod spec_txt;
+
+use std::fmt::Write as _;
+
+use normalize::normalize_html;
+use ox_content_allocator::Allocator;
+use ox_content_parser::{Parser, ParserOptions};
+use ox_content_renderer::{HtmlRenderer, HtmlRendererOptions};
+use spec_txt::{parse_spec, SpecExample};
+
+const SPEC: &str = include_str!("spec_fixtures/gfm-extensions-spec.txt");
+const BASELINE: &str = include_str!("spec_fixtures/gfm-known-failures.txt");
+
+fn render(markdown: &str) -> String {
+    let allocator = Allocator::new();
+    let mut renderer_options = HtmlRendererOptions::new();
+    renderer_options.autolink_urls = false;
+    let parser = Parser::with_options(&allocator, markdown, ParserOptions::gfm());
+    let parsed = parser.parse();
+    let rendered = match parsed {
+        Ok(ref document) => HtmlRenderer::with_options(renderer_options).render(document),
+        Err(ref error) => format!("<!-- PARSE ERROR: {error:?} -->"),
+    };
+    rendered
+}
+
+fn failures(examples: &[SpecExample]) -> Vec<(usize, String)> {
+    examples
+        .iter()
+        .filter_map(|example| {
+            let actual = render(&example.markdown);
+            (normalize_html(&actual) != normalize_html(&example.html)).then(|| {
+                let mut detail = String::new();
+                let _ = writeln!(detail, "=== example {} ({})", example.number, example.section);
+                let _ = writeln!(detail, "--- markdown\n{}", example.markdown);
+                let _ = writeln!(detail, "--- expected\n{}", example.html);
+                let _ = writeln!(detail, "--- actual\n{actual}");
+                (example.number, detail)
+            })
+        })
+        .collect()
+}
+
+fn baseline_numbers() -> Vec<usize> {
+    BASELINE
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(|line| {
+            line.split_whitespace()
+                .next()
+                .and_then(|token| token.parse().ok())
+                .unwrap_or_else(|| panic!("malformed baseline line: {line:?}"))
+        })
+        .collect()
+}
+
+#[test]
+fn gfm_extension_conformance() {
+    let examples = parse_spec(SPEC);
+    assert_eq!(examples.len(), 23, "expected the vendored GFM extension examples");
+
+    let failing = failures(&examples);
+
+    if std::env::var_os("UPDATE_SPEC_BASELINE").is_some() {
+        let mut content = String::from(
+            "# GFM extension examples that ox-content does not render per spec yet.\n\
+             # Format: <example-number>\n\
+             # Regenerate: UPDATE_SPEC_BASELINE=1 cargo test -p ox_content_renderer --test spec_gfm\n",
+        );
+        for (number, _) in &failing {
+            let _ = writeln!(content, "{number}");
+        }
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/spec_fixtures/gfm-known-failures.txt");
+        std::fs::write(path, content).expect("baseline file is writable");
+        return;
+    }
+
+    let known = baseline_numbers();
+    let mut report = String::new();
+    for (number, detail) in &failing {
+        if !known.contains(number) {
+            let _ = writeln!(report, "regressed:\n{detail}");
+        }
+    }
+    for number in &known {
+        if !failing.iter().any(|(failing_number, _)| failing_number == number) {
+            let _ = writeln!(
+                report,
+                "baseline example {number} now passes — remove it from gfm-known-failures.txt"
+            );
+        }
+    }
+
+    assert!(
+        report.is_empty(),
+        "GFM extension conformance drifted ({} of {} examples fail).\n{}",
+        failing.len(),
+        examples.len(),
+        report
+    );
+}


### PR DESCRIPTION
## Summary

Bare `www.`, `http(s)://`, `ftp://` URLs and email addresses in plain text now become links under the GFM profile (`options.autolinks`), following the extension's rules: boundary characters, domain validation with trailing-dot handling, trailing-punctuation and unbalanced-paren trimming, entity-like suffix stripping, and `mailto:`/`http://` href prefixes. The pass runs after emphasis processing, coalesces the text nodes fragmented by entity/escape/delimiter handling, and never descends into existing links.

Adds a **GFM extension conformance suite** (tables, task list items, strikethrough, autolinks — 23 examples extracted from the GFM spec) with the same empty-baseline ratchet as the CommonMark suite: **all 23 pass**. The three gfm-mode entries remaining in the CommonMark baseline document where the autolink extension deliberately diverges from plain CommonMark (bare URLs stay text without the extension).

## Verification

- `cargo test --workspace` green
- `cargo clippy --workspace --all-targets` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->