### PR TITLE
feat(renderer): implement the GFM tagfilter extension

### DIFF
--- a/crates/ox_content_renderer/src/html.rs
+++ b/crates/ox_content_renderer/src/html.rs
@@ -13,6 +13,7 @@ mod heading;
 mod html_attr;
 mod options;
 mod renderer;
+mod tagfilter;
 mod toc;
 
 #[cfg(test)]

--- a/crates/ox_content_renderer/src/html/options.rs
+++ b/crates/ox_content_renderer/src/html/options.rs
@@ -34,6 +34,18 @@ pub struct HtmlRendererOptions {
     /// Default: `false`.
     pub sanitize: bool,
 
+    /// Apply the GFM `tagfilter` extension ("Disallowed Raw HTML"):
+    /// neutralize `<title>`, `<textarea>`, `<style>`, `<xmp>`, `<iframe>`,
+    /// `<noembed>`, `<noframes>`, `<script>`, and `<plaintext>` by escaping
+    /// their leading `<`, leaving all other raw HTML untouched.
+    ///
+    /// Unlike [`Self::sanitize`], which escapes every raw HTML node, this
+    /// keeps ordinary markup working. It is off by default because raw HTML
+    /// passthrough is standard Markdown behaviour that embeds rely on.
+    ///
+    /// Default: `false`.
+    pub disallow_raw_html: bool,
+
     /// Convert `.md` links to `.html` links for SSG output.
     ///
     /// Default: `false`.
@@ -107,6 +119,7 @@ impl HtmlRendererOptions {
             hard_break: "<br>\n".to_string(),
             highlight: false,
             sanitize: false,
+            disallow_raw_html: false,
             convert_md_links: false,
             base_url: "/".to_string(),
             source_path: String::new(),

--- a/crates/ox_content_renderer/src/html/renderer/write.rs
+++ b/crates/ox_content_renderer/src/html/renderer/write.rs
@@ -127,9 +127,20 @@ impl HtmlRenderer {
     pub(in crate::html::renderer) fn write_html_value(&mut self, value: &str) {
         if self.options.sanitize {
             self.write_escaped(value);
-        } else if self.options.convert_md_links {
-            let rewritten = self.rewrite_html_root_urls(value);
-            self.write(&rewritten);
+            return;
+        }
+
+        // URL rewriting produces an owned string; the tag filter then runs
+        // over whichever form we ended up with so both paths get filtered.
+        let rewritten = if self.options.convert_md_links {
+            Some(self.rewrite_html_root_urls(value))
+        } else {
+            None
+        };
+        let value = rewritten.as_deref().unwrap_or(value);
+
+        if self.options.disallow_raw_html && crate::html::tagfilter::needs_filtering(value) {
+            crate::html::tagfilter::write_filtered_into(&mut self.output, value);
         } else {
             self.write(value);
         }

--- a/crates/ox_content_renderer/src/html/tagfilter.rs
+++ b/crates/ox_content_renderer/src/html/tagfilter.rs
@@ -1,0 +1,116 @@
+//! GFM `tagfilter` extension — "Disallowed Raw HTML".
+//!
+//! GFM neutralizes a small set of raw HTML tags that change how the rest of
+//! the document is interpreted (a stray `<style>` or `<xmp>` swallows the
+//! markup after it, and `<script>`/`<iframe>` execute or embed). Filtering
+//! replaces only the leading `<` with `&lt;`, so the tag becomes visible
+//! text while everything else in the raw HTML is preserved.
+//!
+//! Enabled via [`HtmlRendererOptions::disallow_raw_html`](super::options::HtmlRendererOptions::disallow_raw_html);
+//! it is off by default because passing raw HTML through is the documented
+//! Markdown behaviour that embeds (`<iframe>` video players, `<style>`
+//! blocks) rely on.
+
+/// Tags filtered by the extension, in the order the spec lists them.
+const DISALLOWED: [&str; 9] =
+    ["title", "textarea", "style", "xmp", "iframe", "noembed", "noframes", "script", "plaintext"];
+
+/// Writes `value` into `out`, escaping the `<` of every disallowed tag.
+pub(super) fn write_filtered_into(out: &mut String, value: &str) {
+    let bytes = value.as_bytes();
+    let mut copied = 0;
+    let mut i = 0;
+
+    while let Some(offset) = memchr::memchr(b'<', &bytes[i..]) {
+        let lt = i + offset;
+        // A closing tag (`</style>`) is filtered exactly like an opening one.
+        let name_start = if bytes.get(lt + 1) == Some(&b'/') { lt + 2 } else { lt + 1 };
+
+        if let Some(name) = matching_tag(&value[name_start.min(value.len())..]) {
+            out.push_str(&value[copied..lt]);
+            out.push_str("&lt;");
+            copied = lt + 1;
+            i = name_start + name.len();
+        } else {
+            i = lt + 1;
+        }
+    }
+
+    out.push_str(&value[copied..]);
+}
+
+/// Returns the disallowed tag name at the start of `rest`, if any.
+///
+/// The match is case-insensitive and must end at a tag boundary so that
+/// longer names starting with a disallowed one (`<titlebar>`) pass through.
+fn matching_tag(rest: &str) -> Option<&'static str> {
+    DISALLOWED.into_iter().find(|tag| {
+        let Some(after) = rest.get(..tag.len()) else {
+            return false;
+        };
+        if !after.eq_ignore_ascii_case(tag) {
+            return false;
+        }
+        // End of input counts as a boundary: cmark-gfm filters a trailing
+        // `<script` with no `>` just as it filters a complete tag.
+        rest.as_bytes()
+            .get(tag.len())
+            .is_none_or(|byte| byte.is_ascii_whitespace() || matches!(byte, b'>' | b'/'))
+    })
+}
+
+/// Whether `value` contains anything the filter would rewrite. Lets callers
+/// skip allocating a filtered copy for the overwhelmingly common case of
+/// raw HTML that holds no disallowed tag.
+pub(super) fn needs_filtering(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    let mut i = 0;
+    while let Some(offset) = memchr::memchr(b'<', &bytes[i..]) {
+        let lt = i + offset;
+        let name_start = if bytes.get(lt + 1) == Some(&b'/') { lt + 2 } else { lt + 1 };
+        if matching_tag(&value[name_start.min(value.len())..]).is_some() {
+            return true;
+        }
+        i = lt + 1;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn filter(value: &str) -> String {
+        let mut out = String::new();
+        write_filtered_into(&mut out, value);
+        out
+    }
+
+    #[test]
+    fn filters_disallowed_tags_case_insensitively() {
+        assert_eq!(filter("<strong> <title>"), "<strong> &lt;title>");
+        assert_eq!(filter("<XMP> and <xmp>"), "&lt;XMP> and &lt;xmp>");
+        assert_eq!(filter("</script>"), "&lt;/script>");
+        assert_eq!(filter("<script src=\"a.js\">"), "&lt;script src=\"a.js\">");
+    }
+
+    #[test]
+    fn leaves_other_markup_untouched() {
+        assert_eq!(filter("<em>hi</em>"), "<em>hi</em>");
+        assert_eq!(filter("a < b and c > d"), "a < b and c > d");
+        // Longer names that merely start with a disallowed tag are allowed.
+        assert_eq!(filter("<titlebar> <styles>"), "<titlebar> <styles>");
+    }
+
+    #[test]
+    fn detects_whether_filtering_is_needed() {
+        assert!(needs_filtering("<p><iframe></p>"));
+        assert!(!needs_filtering("<p><em>plain</em></p>"));
+        assert!(!needs_filtering("no tags at all"));
+    }
+
+    #[test]
+    fn filters_truncated_trailing_tag() {
+        assert_eq!(filter("text <script"), "text &lt;script");
+    }
+}

--- a/crates/ox_content_renderer/tests/edge_sanitize.rs
+++ b/crates/ox_content_renderer/tests/edge_sanitize.rs
@@ -93,3 +93,46 @@ fn inline_raw_html_is_escaped_when_sanitize_is_enabled() {
 
     assert_eq!(html, "<p>&lt;span&gt;ok&lt;/span&gt;</p>\n");
 }
+
+#[test]
+fn disallow_raw_html_filters_only_the_gfm_tag_list() {
+    let html = render(
+        "<strong> <title> <style> <em>\n",
+        ParserOptions::gfm(),
+        HtmlRendererOptions { disallow_raw_html: true, ..Default::default() },
+    );
+
+    // Only the leading `<` of a disallowed tag is escaped; `<strong>` and
+    // `<em>` pass through untouched.
+    assert_eq!(html, "<p><strong> &lt;title> &lt;style> <em></p>\n");
+}
+
+#[test]
+fn disallow_raw_html_is_off_by_default() {
+    let html = render("<strong> <title>\n", ParserOptions::gfm(), HtmlRendererOptions::default());
+
+    assert_eq!(html, "<p><strong> <title></p>\n");
+}
+
+#[test]
+fn disallow_raw_html_filters_closing_tags_and_html_blocks() {
+    let html = render(
+        "<blockquote>\n  <xmp> is disallowed.  <XMP> is also disallowed.\n</blockquote>\n",
+        ParserOptions::gfm(),
+        HtmlRendererOptions { disallow_raw_html: true, ..Default::default() },
+    );
+
+    assert!(html.contains("&lt;xmp> is disallowed.  &lt;XMP> is also disallowed."), "{html}");
+    assert!(html.contains("<blockquote>"), "{html}");
+}
+
+#[test]
+fn disallow_raw_html_leaves_similar_tag_names_alone() {
+    let html = render(
+        "<titlebar> and <scripted>\n",
+        ParserOptions::gfm(),
+        HtmlRendererOptions { disallow_raw_html: true, ..Default::default() },
+    );
+
+    assert_eq!(html, "<p><titlebar> and <scripted></p>\n");
+}

--- a/crates/ox_content_renderer/tests/spec_fixtures/README.md
+++ b/crates/ox_content_renderer/tests/spec_fixtures/README.md
@@ -6,10 +6,12 @@
   licensed under [CC-BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
   It is used here only as test data for the conformance suite in
   `tests/spec_commonmark.rs`.
-- `gfm-extensions-spec.txt` holds the extension examples (tables, task
-  list items, strikethrough, autolinks) extracted from the GitHub
-  Flavored Markdown spec (0.29-gfm, also CC-BY-SA 4.0), driven by
-  `tests/spec_gfm.rs`.
+- `gfm-extensions-spec.txt` holds every `(extension)` section of the
+  GitHub Flavored Markdown spec (0.29-gfm, also CC-BY-SA 4.0) verbatim —
+  tables, task list items, strikethrough, autolinks, and disallowed raw
+  HTML — driven by `tests/spec_gfm.rs`. The disallowed-raw-HTML section
+  needs the opt-in `disallow_raw_html` renderer option, which the suite
+  enables for that section only.
 - `commonmark-known-failures.txt` and `gfm-known-failures.txt` track the
   examples that do not render per their spec. The conformance tests fail
   when an entry starts passing (remove the line) or when a conforming

--- a/crates/ox_content_renderer/tests/spec_fixtures/gfm-extensions-spec.txt
+++ b/crates/ox_content_renderer/tests/spec_fixtures/gfm-extensions-spec.txt
@@ -487,3 +487,38 @@ a.b-c_d@a.b_
 ````````````````````````````````
 
 </div>
+
+## Disallowed Raw HTML (extension)
+
+GFM enables the `tagfilter` extension, where the following HTML tags will be
+filtered when rendering HTML output:
+
+* `<title>`
+* `<textarea>`
+* `<style>`
+* `<xmp>`
+* `<iframe>`
+* `<noembed>`
+* `<noframes>`
+* `<script>`
+* `<plaintext>`
+
+Filtering is done by replacing the leading `<` with the entity `&lt;`.  These
+tags are chosen in particular as they change how HTML is interpreted in a way
+unique to them (i.e. nested HTML is interpreted differently), and this is
+usually undesireable in the context of other rendered Markdown content.
+
+All other HTML tags are left untouched.
+
+```````````````````````````````` example tagfilter
+<strong> <title> <style> <em>
+
+<blockquote>
+  <xmp> is disallowed.  <XMP> is also disallowed.
+</blockquote>
+.
+<p><strong> &lt;title> &lt;style> <em></p>
+<blockquote>
+  &lt;xmp> is disallowed.  &lt;XMP> is also disallowed.
+</blockquote>
+````````````````````````````````

--- a/crates/ox_content_renderer/tests/spec_gfm.rs
+++ b/crates/ox_content_renderer/tests/spec_gfm.rs
@@ -28,10 +28,13 @@ use spec_txt::{parse_spec, SpecExample};
 const SPEC: &str = include_str!("spec_fixtures/gfm-extensions-spec.txt");
 const BASELINE: &str = include_str!("spec_fixtures/gfm-known-failures.txt");
 
-fn render(markdown: &str) -> String {
+fn render(markdown: &str, section: &str) -> String {
     let allocator = Allocator::new();
     let mut renderer_options = HtmlRendererOptions::new();
     renderer_options.autolink_urls = false;
+    // The tagfilter extension is opt-in on the renderer (raw HTML normally
+    // passes through), so enable it for the section that specifies it.
+    renderer_options.disallow_raw_html = section.starts_with("Disallowed Raw HTML");
     let parser = Parser::with_options(&allocator, markdown, ParserOptions::gfm());
     let parsed = parser.parse();
     let rendered = match parsed {
@@ -45,7 +48,7 @@ fn failures(examples: &[SpecExample]) -> Vec<(usize, String)> {
     examples
         .iter()
         .filter_map(|example| {
-            let actual = render(&example.markdown);
+            let actual = render(&example.markdown, &example.section);
             (normalize_html(&actual) != normalize_html(&example.html)).then(|| {
                 let mut detail = String::new();
                 let _ = writeln!(detail, "=== example {} ({})", example.number, example.section);
@@ -75,7 +78,7 @@ fn baseline_numbers() -> Vec<usize> {
 #[test]
 fn gfm_extension_conformance() {
     let examples = parse_spec(SPEC);
-    assert_eq!(examples.len(), 23, "expected the vendored GFM extension examples");
+    assert_eq!(examples.len(), 24, "expected the vendored GFM extension examples");
 
     let failing = failures(&examples);
 


### PR DESCRIPTION
## Summary

Implements the last unimplemented GFM extension, **Disallowed Raw HTML** (`tagfilter`): the nine tags that change how the surrounding document is interpreted — `<title>`, `<textarea>`, `<style>`, `<xmp>`, `<iframe>`, `<noembed>`, `<noframes>`, `<script>`, `<plaintext>` — get their leading `<` escaped, while all other raw HTML passes through untouched. Matching is case-insensitive, covers closing tags, and requires a tag boundary so `<titlebar>` is left alone.

Exposed as the opt-in `HtmlRendererOptions::disallow_raw_html`. It defaults to **off**: unlike `sanitize` (which escapes raw HTML wholesale), this is a targeted filter, but raw HTML passthrough is standard Markdown behaviour that this project's embed features (iframe video players, style blocks) depend on — so enabling it by default would break legitimate documents.

Also completes GFM extension coverage: the vendored fixture now contains **every `(extension)` section of the 0.29-gfm spec verbatim (24 examples, up from 23)** and all pass. The suite enables the option only for the section that specifies it.

## Verification

- `cargo test --workspace`: 875 passed, 0 failed
- `cargo clippy --workspace --all-targets` clean, `cargo fmt --check` clean
- New unit tests cover the boundary/case rules; new integration tests cover option on/off, closing tags in HTML blocks, and similar-but-allowed tag names

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->