### PR TITLE
chore(fuzz): cover the tagfilter option in parse_render

### DIFF
--- a/fuzz/fuzz_targets/parse_render.rs
+++ b/fuzz/fuzz_targets/parse_render.rs
@@ -46,6 +46,9 @@ fn derive_options(data: &[u8]) -> (ParserOptions, HtmlRendererOptions, &[u8]) {
     if renderer & 0b1000 != 0 {
         renderer_options.highlight = true;
     }
+    if renderer & 0b0001_0000 != 0 {
+        renderer_options.disallow_raw_html = true;
+    }
 
     (parser_options, renderer_options, rest)
 }


### PR DESCRIPTION
## Summary

The renderer's `disallow_raw_html` (GFM tagfilter) path rewrites raw HTML byte ranges, so it belongs in the option matrix the `parse_render` fuzz target explores. Adds it as bit 4 of the renderer-option prefix byte.

## Verification

- `cargo +nightly fuzz build parse_render` succeeds
- A 13-minute run seeded with 827 inputs (all CommonMark spec examples plus every markdown file in the repo) produced no crashes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->