### PR TITLE
fix(parser): stop hanging on whitespace-only input

### DIFF
--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -26,6 +26,11 @@ impl<'a> Parser<'a> {
         let start = self.position;
         let bytes = self.source.as_bytes();
         let Some(trimmed_start) = self.first_non_whitespace_in_line(start) else {
+            // Nothing but whitespace remains on this line. `skip_blank_lines`
+            // normally consumes it, so reaching here means the line ends at
+            // EOF; advance past it regardless so the caller's
+            // `while !is_at_end` loop always makes progress.
+            self.position = self.source.len();
             return Ok(None);
         };
 

--- a/crates/ox_content_parser/src/parser/cursor.rs
+++ b/crates/ox_content_parser/src/parser/cursor.rs
@@ -54,7 +54,18 @@ impl<'a> Parser<'a> {
             }
             if pos < bytes.len() && bytes[pos] == b'\n' {
                 pos += 1;
+            } else if pos >= bytes.len() {
+                // Spaces/tabs running to end of input with no newline are
+                // a blank final line: consume them. Rewinding instead
+                // would park the position on whitespace that no block
+                // parser consumes, and the block loop — which runs until
+                // `is_at_end` — would spin forever.
+                self.position = pos;
+                return;
             } else {
+                // Content follows the indentation; rewind so the caller
+                // still sees the leading whitespace (indented code and
+                // list markers depend on it).
                 self.position = line_start;
                 return;
             }

--- a/crates/ox_content_parser/tests/edge_cases/blocks.rs
+++ b/crates/ox_content_parser/tests/edge_cases/blocks.rs
@@ -118,3 +118,41 @@ fn blockquote_supports_multiple_paragraphs_when_blank_quote_line_is_used() {
         other => panic!("expected blockquote, got {other:?}"),
     }
 }
+
+#[test]
+fn whitespace_only_document_without_trailing_newline_terminates() {
+    // Regression: a document holding only spaces/tabs and no final
+    // newline left the block loop parked on whitespace that no block
+    // parser consumed, spinning forever. Every variant must parse to an
+    // empty document.
+    for source in ["  ", "\t", "  \t", "   \t", "    \t", " \t \t"] {
+        let allocator = Allocator::new();
+        let doc = parse_with_options(&allocator, source, ParserOptions::default());
+        assert!(doc.children.is_empty(), "expected no blocks for {source:?}");
+    }
+}
+
+#[test]
+fn trailing_whitespace_line_does_not_swallow_preceding_content() {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(&allocator, "text\n  ", ParserOptions::default());
+
+    assert_eq!(doc.children.len(), 1);
+    assert_eq!(first_text_in_nodes(&doc.children), Some("text"));
+}
+
+#[test]
+fn indented_content_at_end_of_input_still_parses() {
+    // The blank-line skipper must only consume a trailing whitespace run
+    // when nothing follows it; indentation before real content is
+    // meaningful.
+    let allocator = Allocator::new();
+    let doc = parse_with_options(&allocator, "    code", ParserOptions::default());
+
+    assert_eq!(doc.children.len(), 1);
+    assert!(
+        matches!(&doc.children[0], Node::CodeBlock(_)),
+        "expected indented code, got {:?}",
+        doc.children[0]
+    );
+}


### PR DESCRIPTION
## Summary

**A markdown document containing only spaces/tabs with no trailing newline hangs the parser forever.** `"  "`, `"\t"`, and `"  \t"` all reproduce; adding a newline (`"  \t\n"`) or any content (`"  \tx"`) does not.

Cause: `skip_blank_lines` rewinds to the start of the whitespace run when it reaches EOF without finding a newline, and `parse_block` then returns `Ok(None)` without consuming anything — so `parse()`'s `while !is_at_end` loop never advances.

Fix: the blank-line skipper consumes a trailing whitespace run that ends at EOF (that is a blank final line), while still rewinding when real content follows so indented code and list markers keep their leading whitespace. `parse_block` additionally advances past a whitespace-only tail, so the block loop cannot spin even if another path parks it there.

This is a pre-existing bug, not a regression — it reproduces on `f31ac95` (v2.79.0, before the recent conformance work). Any caller parsing untrusted or machine-generated markdown can hit it with a 2-byte input.

## Verification

- 3 new regression tests: whitespace-only variants terminate, a trailing whitespace line does not swallow preceding content, and indented content at EOF still parses as code
- A corpus mutation stress pass — **112,932 parse+render cases** over 685 seeds (CommonMark spec examples plus every repo markdown file, with truncations and marker injections, across the parser/renderer option matrix) — reports **0 panics, 0 hangs**. Before this fix the same run hung on the first seed.
- `cargo test --workspace`: 887 passed, 0 failed
- `cargo clippy --workspace --all-targets` clean, `cargo fmt --check` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->