### PR TITLE
feat(profiler): span the parser pre-passes and inline post-passes

### DIFF
--- a/crates/ox_content_parser/src/parser/footnote.rs
+++ b/crates/ox_content_parser/src/parser/footnote.rs
@@ -20,6 +20,8 @@ use rustc_hash::FxHashSet;
 
 use super::Parser;
 use crate::error::ParseResult;
+#[allow(unused_imports)]
+use crate::profile_span;
 
 pub(super) type FootnoteLabels = FxHashSet<CompactString>;
 
@@ -225,6 +227,7 @@ impl<'a> Parser<'a> {
     /// Collects every footnote label in the source so inline references
     /// resolve regardless of definition order.
     pub(super) fn build_footnote_labels(&self) -> Rc<FootnoteLabels> {
+        profile_span!("parser::build_footnote_labels");
         if !self.options.footnotes || !self.source.contains("[^") {
             return Rc::new(FootnoteLabels::default());
         }

--- a/crates/ox_content_parser/src/parser/indented_code.rs
+++ b/crates/ox_content_parser/src/parser/indented_code.rs
@@ -10,11 +10,14 @@ use ox_content_ast::{CodeBlock, Node, Span};
 
 use super::Parser;
 use crate::error::ParseResult;
+#[allow(unused_imports)]
+use crate::profile_span;
 
 impl<'a> Parser<'a> {
     /// Parses an indented code block starting at `start` (the beginning of
     /// a non-blank line whose indentation is at least four columns).
     pub(super) fn parse_indented_code(&mut self, start: usize) -> ParseResult<Option<Node<'a>>> {
+        profile_span!("parser::parse_indented_code");
         let mut value = self.allocator.new_string();
         let mut pos = start;
         let mut end = start;

--- a/crates/ox_content_parser/src/parser/inline/emphasis.rs
+++ b/crates/ox_content_parser/src/parser/inline/emphasis.rs
@@ -11,6 +11,8 @@ use ox_content_allocator::Vec;
 use ox_content_ast::{Node, Span};
 
 use crate::parser::Parser;
+#[allow(unused_imports)]
+use crate::profile_span;
 
 pub(in crate::parser) struct Delimiter {
     /// Index of the run's text node in the children vec.
@@ -68,6 +70,7 @@ impl<'a> Parser<'a> {
         children: &mut Vec<'a, Node<'a>>,
         delimiters: &mut Vec<'a, Delimiter>,
     ) {
+        profile_span!("parser::process_emphasis");
         let mut closer_idx = 0;
         while closer_idx < delimiters.len() {
             if !delimiters[closer_idx].can_close || delimiters[closer_idx].remaining == 0 {

--- a/crates/ox_content_parser/src/parser/inline/gfm_autolink.rs
+++ b/crates/ox_content_parser/src/parser/inline/gfm_autolink.rs
@@ -11,6 +11,8 @@ use ox_content_allocator::Vec;
 use ox_content_ast::{Link, Node, Span, Text};
 
 use crate::parser::Parser;
+#[allow(unused_imports)]
+use crate::profile_span;
 
 struct Candidate {
     start: usize,
@@ -20,6 +22,7 @@ struct Candidate {
 
 impl<'a> Parser<'a> {
     pub(in crate::parser) fn apply_gfm_autolinks(&self, children: &mut Vec<'a, Node<'a>>) {
+        profile_span!("parser::apply_gfm_autolinks");
         // Entity, escape, and unpaired-delimiter handling fragment plain
         // prose into adjacent text nodes; autolinks must see the joined
         // run (`...?q=x&hl=en` is one URL despite the `&` split).

--- a/crates/ox_content_parser/src/parser/reference.rs
+++ b/crates/ox_content_parser/src/parser/reference.rs
@@ -16,6 +16,8 @@ use ox_content_ast::{Definition, Node, Span};
 use rustc_hash::FxHashMap;
 
 use super::Parser;
+#[allow(unused_imports)]
+use crate::profile_span;
 
 mod scan;
 
@@ -288,6 +290,7 @@ impl<'a> Parser<'a> {
 impl<'a> Parser<'a> {
     /// Builds the shared reference map for a root parser.
     pub(super) fn build_definitions(&self) -> Rc<ReferenceMap<'a>> {
+        profile_span!("parser::build_definitions");
         // Cheap bail: no `[` anywhere means no definitions.
         if !self.source.contains('[') {
             return Rc::new(ReferenceMap::default());

--- a/crates/ox_content_renderer/src/html/renderer/inlines.rs
+++ b/crates/ox_content_renderer/src/html/renderer/inlines.rs
@@ -50,6 +50,7 @@ impl HtmlRenderer {
     }
 
     pub(in crate::html::renderer) fn render_link(&mut self, link: &Link<'_>) {
+        crate::profile_span!("renderer::visit_link");
         self.write("<a href=\"");
         let converted_url =
             if self.options.convert_md_links { self.convert_markdown_url(link.url) } else { None };

--- a/crates/ox_content_renderer/src/html/renderer/write.rs
+++ b/crates/ox_content_renderer/src/html/renderer/write.rs
@@ -183,6 +183,7 @@ impl HtmlRenderer {
     /// existing scratch slug is written directly and the numeric suffix is
     /// formatted into `self.output`.
     pub(in crate::html::renderer) fn write_heading_id(&mut self, heading: &Heading<'_>) {
+        crate::profile_span!("renderer::write_heading_id");
         use std::fmt::Write as _;
 
         self.heading_text_scratch.clear();

--- a/crates/ox_content_renderer/src/html/renderer/write.rs
+++ b/crates/ox_content_renderer/src/html/renderer/write.rs
@@ -183,8 +183,9 @@ impl HtmlRenderer {
     /// existing scratch slug is written directly and the numeric suffix is
     /// formatted into `self.output`.
     pub(in crate::html::renderer) fn write_heading_id(&mut self, heading: &Heading<'_>) {
-        crate::profile_span!("renderer::write_heading_id");
         use std::fmt::Write as _;
+
+        crate::profile_span!("renderer::write_heading_id");
 
         self.heading_text_scratch.clear();
         collect_heading_text_into(&heading.children, &mut self.heading_text_scratch);


### PR DESCRIPTION
## What

Adds `profile_span!` instrumentation to the profiler blind spots found while profiling `docs/content/api/types.md` (247 KB):

- `parser::build_definitions` — the reference-definition pre-pass
- `parser::build_footnote_labels` — the footnote-label pre-pass
- `parser::process_emphasis` — delimiter-stack resolution
- `parser::apply_gfm_autolinks` — the GFM autolink post-pass
- `parser::parse_indented_code` — the one uninstrumented block parser
- `renderer::visit_link` — URL sanitize + escape path
- `renderer::write_heading_id` — heading slugify

## Why

Before this, ~50% of pipeline wall time on that document was attributed to no span. With the new spans the picture inverts: `build_definitions` alone is **44.2% self share** (51 µs/iter), ahead of `parse_html_block` (34.1%). That makes the pre-passes the top optimization target, which was invisible in every prior report.

All spans compile to nothing without `--features profile` (macro expands to an empty statement), so the production build is unchanged.

## Verification

- `cargo test -p ox_content_parser -p ox_content_renderer` — all suites green (spec conformance included)
- `cargo clippy --all-targets` / `cargo fmt --check` — clean
- `cargo build --release -p ox_content_profile_cli` + a 200-iter pipeline run shows the new rows

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->