### PR TITLE
perf(parser): fuse the reference and footnote pre-passes behind first-byte dispatch

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -21,6 +21,7 @@ mod inline_html;
 mod leaf;
 mod list;
 mod list_item;
+mod prepass;
 mod reference;
 mod spans;
 mod table;
@@ -143,10 +144,11 @@ impl<'a> Parser<'a> {
             footnote_labels: std::rc::Rc::default(),
             lazy_lines: std::rc::Rc::default(),
         };
-        // Footnote labels first: the reference collector consults them to
-        // leave `[^label]:` blocks to the footnote parser.
-        parser.footnote_labels = parser.build_footnote_labels();
-        parser.definitions = parser.build_definitions();
+        // A single fused pre-pass collects both the reference definitions
+        // and the footnote labels (see `prepass.rs`).
+        let (definitions, footnote_labels) = parser.build_prepass();
+        parser.definitions = definitions;
+        parser.footnote_labels = footnote_labels;
         parser
     }
 

--- a/crates/ox_content_parser/src/parser/footnote.rs
+++ b/crates/ox_content_parser/src/parser/footnote.rs
@@ -12,16 +12,12 @@
 //! and shares it with sub-parsers, mirroring how link reference
 //! definitions work.
 
-use std::rc::Rc;
-
 use compact_str::CompactString;
 use ox_content_ast::{FootnoteDefinition, Node, Span};
 use rustc_hash::FxHashSet;
 
 use super::Parser;
 use crate::error::ParseResult;
-#[allow(unused_imports)]
-use crate::profile_span;
 
 pub(super) type FootnoteLabels = FxHashSet<CompactString>;
 
@@ -222,40 +218,5 @@ impl<'a> Parser<'a> {
         }));
         *pos = end + 1;
         true
-    }
-
-    /// Collects every footnote label in the source so inline references
-    /// resolve regardless of definition order.
-    pub(super) fn build_footnote_labels(&self) -> Rc<FootnoteLabels> {
-        profile_span!("parser::build_footnote_labels");
-        if !self.options.footnotes || !self.source.contains("[^") {
-            return Rc::new(FootnoteLabels::default());
-        }
-
-        let mut labels = FootnoteLabels::default();
-        let bytes = self.source.as_bytes();
-        let mut pos = 0;
-        let mut fence: Option<(u8, usize)> = None;
-
-        while pos < bytes.len() {
-            let line_end = memchr::memchr(b'\n', &bytes[pos..]).map_or(bytes.len(), |o| pos + o);
-            let line = &self.source[pos..line_end];
-            let trimmed = line.trim_start_matches([' ', '\t']);
-
-            // Definition-shaped text inside fenced code is not a definition.
-            if let Some((fence_byte, fence_len)) = fence {
-                if super::reference::is_fence_close(trimmed, fence_byte, fence_len) {
-                    fence = None;
-                }
-            } else if let Some(open) = super::reference::fence_open(trimmed) {
-                fence = Some(open);
-            } else if let Some((label, _)) = parse_footnote_opener(line) {
-                labels.insert(normalize_footnote_label(label));
-            }
-
-            pos = line_end + 1;
-        }
-
-        Rc::new(labels)
     }
 }

--- a/crates/ox_content_parser/src/parser/prepass.rs
+++ b/crates/ox_content_parser/src/parser/prepass.rs
@@ -1,0 +1,195 @@
+//! Fused document pre-pass: link reference definitions + footnote labels.
+//!
+//! Both collectors used to run their own full line scan over the source.
+//! This module fuses them into a single scan and dispatches on each line's
+//! first byte, so the common case (prose, HTML, or code content that cannot
+//! affect either collector) costs one memchr line skip and a flag write
+//! instead of quote-stripping, trimming, and fence-classifying every line.
+//!
+//! Behavior is intentionally identical to the two previous passes,
+//! including their asymmetry: the reference collector classifies fences on
+//! the quote-stripped line (so a quoted fence line opens a fence for it)
+//! while the footnote collector classifies fences on the raw line (so the
+//! same line does not). The two fence states are tracked independently,
+//! and the footnote scan still visits every line of a multi-line reference
+//! definition chunk the reference side skips over.
+
+use std::rc::Rc;
+
+use super::footnote::{normalize_footnote_label, parse_footnote_opener, FootnoteLabels};
+use super::reference::{
+    closes_paragraph_context, fence_open, is_fence_close, strip_quote_markers, ReferenceDef,
+    ReferenceMap,
+};
+use super::Parser;
+#[allow(unused_imports)]
+use crate::profile_span;
+
+impl<'a> Parser<'a> {
+    /// Runs the fused pre-pass for a root parser. Returns the
+    /// document-wide reference map and footnote label set that are shared
+    /// with sub-parsers.
+    pub(super) fn build_prepass(&self) -> (Rc<ReferenceMap<'a>>, Rc<FootnoteLabels>) {
+        profile_span!("parser::build_prepass");
+        // Cheap bail: a definition and a footnote label both start with
+        // `[`, so a source without one has neither.
+        if !self.source.contains('[') {
+            return (Rc::new(ReferenceMap::default()), Rc::new(FootnoteLabels::default()));
+        }
+        let collect_footnotes = self.options.footnotes && self.source.contains("[^");
+
+        let mut definitions = ReferenceMap::default();
+        let mut labels = FootnoteLabels::default();
+        let bytes = self.source.as_bytes();
+        let mut pos = 0;
+        let mut def_fence: Option<(u8, usize)> = None;
+        let mut foot_fence: Option<(u8, usize)> = None;
+        let mut paragraph_open = false;
+
+        while pos < bytes.len() {
+            let first = bytes[pos];
+
+            // Blank line: closes any open paragraph and is invisible to
+            // both fence trackers and both collectors.
+            if first == b'\n' {
+                if def_fence.is_none() {
+                    paragraph_open = false;
+                }
+                pos += 1;
+                continue;
+            }
+
+            // Fast lane: a line starting with any byte outside this set
+            // cannot open or close a fence, start a definition or footnote
+            // label, or close a paragraph. It only keeps (or opens)
+            // paragraph context while the reference collector is outside a
+            // fence.
+            if !matches!(
+                first,
+                b'[' | b' ' | b'\t' | b'>' | b'`' | b'~' | b'-' | b'=' | b'*' | b'#'
+            ) {
+                if def_fence.is_none() {
+                    paragraph_open = true;
+                }
+                pos = next_line_start(bytes, pos);
+                continue;
+            }
+
+            // ATX-heading-shaped line: closes paragraph context outside a
+            // fence and is invisible to fences and both collectors.
+            if first == b'#' {
+                if def_fence.is_none() {
+                    paragraph_open = false;
+                }
+                pos = next_line_start(bytes, pos);
+                continue;
+            }
+
+            let line_end = memchr::memchr(b'\n', &bytes[pos..]).map_or(bytes.len(), |o| pos + o);
+            let line = &self.source[pos..line_end];
+
+            // Footnote side first: the reference side `continue`s out of
+            // the loop body on its fence transitions.
+            if collect_footnotes {
+                footnote_scan_line(line, first, &mut foot_fence, &mut labels);
+            }
+
+            let stripped = strip_quote_markers(line);
+            let trimmed = stripped.trim_start_matches([' ', '\t']);
+
+            if let Some((fence_byte, fence_len)) = def_fence {
+                if is_fence_close(trimmed, fence_byte, fence_len) {
+                    def_fence = None;
+                }
+                pos = line_end + 1;
+                continue;
+            }
+            if let Some(open) = fence_open(trimmed) {
+                def_fence = Some(open);
+                paragraph_open = false;
+                pos = line_end + 1;
+                continue;
+            }
+            if trimmed.is_empty() {
+                paragraph_open = false;
+                pos = line_end + 1;
+                continue;
+            }
+
+            if !paragraph_open && stripped.len() - trimmed.len() <= 3 && trimmed.starts_with('[') {
+                // Candidate: join the stripped lines of this paragraph
+                // chunk and parse as many definitions as it holds.
+                let (chunk, line_starts) = self.join_stripped_chunk(pos);
+                let mut offset = 0;
+                while let Some(parsed) = self.parse_reference_definition(&chunk[offset..]) {
+                    definitions
+                        .entry(Self::normalize_reference_label(parsed.label))
+                        .or_insert(ReferenceDef { url: parsed.url, title: parsed.title });
+                    offset += parsed.consumed;
+                }
+                // Skip the source lines the parsed prefix covered so fence
+                // tracking stays aligned (definition text can't open
+                // fences). A leftover suffix starts a paragraph.
+                let consumed_lines = chunk[..offset].matches('\n').count();
+                if consumed_lines > 0 {
+                    let next_pos = line_starts.get(consumed_lines).copied().unwrap_or(bytes.len());
+                    // The footnote collector's scan is line-independent, so
+                    // it must still see the definition's continuation lines
+                    // the reference side jumps over.
+                    if collect_footnotes {
+                        let mut foot_pos = line_end + 1;
+                        while foot_pos < next_pos {
+                            let foot_line_end = memchr::memchr(b'\n', &bytes[foot_pos..])
+                                .map_or(bytes.len(), |o| foot_pos + o);
+                            footnote_scan_line(
+                                &self.source[foot_pos..foot_line_end],
+                                bytes[foot_pos],
+                                &mut foot_fence,
+                                &mut labels,
+                            );
+                            foot_pos = foot_line_end + 1;
+                        }
+                    }
+                    pos = next_pos;
+                    continue;
+                }
+            }
+
+            paragraph_open = !closes_paragraph_context(trimmed);
+            pos = line_end + 1;
+        }
+
+        (Rc::new(definitions), Rc::new(labels))
+    }
+}
+
+/// One line of the footnote-label scan: raw-line fence tracking plus the
+/// `[^label]:` opener check. Mirrors the former standalone footnote
+/// pre-pass exactly (no quote stripping).
+fn footnote_scan_line(
+    line: &str,
+    first: u8,
+    foot_fence: &mut Option<(u8, usize)>,
+    labels: &mut FootnoteLabels,
+) {
+    let raw_trimmed = line.trim_start_matches([' ', '\t']);
+    if let Some((fence_byte, fence_len)) = *foot_fence {
+        if is_fence_close(raw_trimmed, fence_byte, fence_len) {
+            *foot_fence = None;
+        }
+    } else if let Some(open) = fence_open(raw_trimmed) {
+        *foot_fence = Some(open);
+    } else if matches!(first, b'[' | b' ') {
+        // An opener starts with `[^` after at most three spaces, so only
+        // these first bytes can begin one.
+        if let Some((label, _)) = parse_footnote_opener(line) {
+            labels.insert(normalize_footnote_label(label));
+        }
+    }
+}
+
+/// Byte offset of the next line's start (just past the newline, or EOF).
+#[inline]
+fn next_line_start(bytes: &[u8], pos: usize) -> usize {
+    memchr::memchr(b'\n', &bytes[pos..]).map_or(bytes.len(), |off| pos + off + 1)
+}

--- a/crates/ox_content_parser/src/parser/reference.rs
+++ b/crates/ox_content_parser/src/parser/reference.rs
@@ -9,22 +9,18 @@
 //! happens later during regular block parsing via
 //! [`Parser::try_parse_definition_node`].
 
-use std::rc::Rc;
-
 use compact_str::CompactString;
 use ox_content_ast::{Definition, Node, Span};
 use rustc_hash::FxHashMap;
 
 use super::Parser;
-#[allow(unused_imports)]
-use crate::profile_span;
 
 mod scan;
 
-use scan::{line_end_if_blank_after, next_blank_line, skip_ws_one_newline, strip_quote_markers};
-// The block quote collector shares the fence and paragraph-context
-// helpers for its lazy-continuation tracking.
-pub(super) use scan::{closes_paragraph_context, fence_open, is_fence_close};
+use scan::{line_end_if_blank_after, next_blank_line, skip_ws_one_newline};
+// The block quote collector and the fused pre-pass share the fence,
+// paragraph-context, and quote-strip helpers.
+pub(super) use scan::{closes_paragraph_context, fence_open, is_fence_close, strip_quote_markers};
 
 #[derive(Debug)]
 pub(super) struct ReferenceDef<'a> {
@@ -189,77 +185,11 @@ impl<'a> Parser<'a> {
         }))
     }
 
-    /// Collection pre-pass over the whole source. Tracks fenced code
-    /// regions and strips block quote markers so definitions inside block
-    /// quotes are found; definition-shaped text inside fenced or indented
-    /// code is skipped.
-    pub(super) fn collect_reference_definitions(&self) -> ReferenceMap<'a> {
-        let mut map = ReferenceMap::default();
-        let bytes = self.source.as_bytes();
-        let mut pos = 0;
-        let mut fence: Option<(u8, usize)> = None;
-        // A definition can only start where a paragraph could start; a
-        // bracket line directly under a paragraph (or lazy list/HTML
-        // continuation) is continuation text, not a definition.
-        let mut paragraph_open = false;
-
-        while pos < bytes.len() {
-            let line_end = memchr::memchr(b'\n', &bytes[pos..]).map_or(bytes.len(), |o| pos + o);
-            let line = &self.source[pos..line_end];
-            let stripped = strip_quote_markers(line);
-            let trimmed = stripped.trim_start_matches([' ', '\t']);
-            let indent = stripped.len() - trimmed.len();
-
-            if let Some((fence_byte, fence_len)) = fence {
-                if is_fence_close(trimmed, fence_byte, fence_len) {
-                    fence = None;
-                }
-                pos = line_end + 1;
-                continue;
-            }
-            if let Some(open) = fence_open(trimmed) {
-                fence = Some(open);
-                paragraph_open = false;
-                pos = line_end + 1;
-                continue;
-            }
-            if trimmed.is_empty() {
-                paragraph_open = false;
-                pos = line_end + 1;
-                continue;
-            }
-
-            if !paragraph_open && indent <= 3 && trimmed.starts_with('[') {
-                // Candidate: join the stripped lines of this paragraph
-                // chunk and parse as many definitions as it holds.
-                let (chunk, line_starts) = self.join_stripped_chunk(pos);
-                let mut offset = 0;
-                while let Some(parsed) = self.parse_reference_definition(&chunk[offset..]) {
-                    map.entry(Self::normalize_reference_label(parsed.label))
-                        .or_insert(ReferenceDef { url: parsed.url, title: parsed.title });
-                    offset += parsed.consumed;
-                }
-                // Skip the source lines the parsed prefix covered so fence
-                // tracking stays aligned (definition text can't open
-                // fences). A leftover suffix starts a paragraph.
-                let consumed_lines = chunk[..offset].matches('\n').count();
-                if consumed_lines > 0 {
-                    pos = line_starts.get(consumed_lines).copied().unwrap_or(bytes.len());
-                    continue;
-                }
-            }
-
-            paragraph_open = !closes_paragraph_context(trimmed);
-            pos = line_end + 1;
-        }
-
-        map
-    }
-
     /// Joins the block-quote-stripped lines of the paragraph chunk that
     /// starts at `pos` (stopping at a blank line), returning the joined
-    /// text and each line's start offset in the original source.
-    fn join_stripped_chunk(
+    /// text and each line's start offset in the original source. Used by
+    /// the fused pre-pass when it finds a definition candidate line.
+    pub(super) fn join_stripped_chunk(
         &self,
         mut pos: usize,
     ) -> (&'a str, ox_content_allocator::Vec<'a, usize>) {
@@ -284,17 +214,5 @@ impl<'a> Parser<'a> {
 
     fn unescape_reference_component(&self, raw: &'a str) -> &'a str {
         self.unescape_link_component(raw)
-    }
-}
-
-impl<'a> Parser<'a> {
-    /// Builds the shared reference map for a root parser.
-    pub(super) fn build_definitions(&self) -> Rc<ReferenceMap<'a>> {
-        profile_span!("parser::build_definitions");
-        // Cheap bail: no `[` anywhere means no definitions.
-        if !self.source.contains('[') {
-            return Rc::new(ReferenceMap::default());
-        }
-        Rc::new(self.collect_reference_definitions())
     }
 }

--- a/crates/ox_content_parser/src/parser/reference/scan.rs
+++ b/crates/ox_content_parser/src/parser/reference/scan.rs
@@ -48,7 +48,7 @@ pub(super) fn next_blank_line(bytes: &[u8], mut pos: usize) -> usize {
 
 /// Strips leading `>` block quote markers (each with up to three spaces of
 /// indent and one optional following space).
-pub(super) fn strip_quote_markers(mut line: &str) -> &str {
+pub(in crate::parser) fn strip_quote_markers(mut line: &str) -> &str {
     loop {
         let bytes = line.as_bytes();
         let mut i = 0;

--- a/crates/ox_content_parser/tests/edge_cases.rs
+++ b/crates/ox_content_parser/tests/edge_cases.rs
@@ -10,6 +10,8 @@ mod html;
 mod inline;
 #[path = "edge_cases/lists.rs"]
 mod lists;
+#[path = "edge_cases/prepass.rs"]
+mod prepass;
 #[path = "edge_cases/tables.rs"]
 mod tables;
 

--- a/crates/ox_content_parser/tests/edge_cases/prepass.rs
+++ b/crates/ox_content_parser/tests/edge_cases/prepass.rs
@@ -1,0 +1,207 @@
+//! Fused pre-pass semantics: where link reference definitions and
+//! footnote labels are (and are not) collected. These pin the exact
+//! behavior of the former two standalone pre-passes.
+
+use ox_content_allocator::Allocator;
+use ox_content_ast::Node;
+use ox_content_parser::ParserOptions;
+
+use super::parse_with_options;
+
+/// True when any node in the tree (recursively) is a resolved `Link`.
+fn contains_link(nodes: &[Node<'_>]) -> bool {
+    nodes.iter().any(|node| match node {
+        Node::Link(_) => true,
+        Node::Paragraph(p) => contains_link(&p.children),
+        Node::Heading(h) => contains_link(&h.children),
+        Node::BlockQuote(q) => contains_link(&q.children),
+        Node::Emphasis(e) => contains_link(&e.children),
+        Node::Strong(s) => contains_link(&s.children),
+        Node::List(l) => l.children.iter().any(|item| contains_link(&item.children)),
+        Node::ListItem(i) => contains_link(&i.children),
+        _ => false,
+    })
+}
+
+/// True when any node in the tree (recursively) is a `FootnoteReference`.
+fn contains_footnote_ref(nodes: &[Node<'_>]) -> bool {
+    nodes.iter().any(|node| match node {
+        Node::FootnoteReference(_) => true,
+        Node::Paragraph(p) => contains_footnote_ref(&p.children),
+        Node::BlockQuote(q) => contains_footnote_ref(&q.children),
+        _ => false,
+    })
+}
+
+fn resolves_reference(source: &str) -> bool {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(&allocator, source, ParserOptions::default());
+    contains_link(&doc.children)
+}
+
+fn resolves_footnote(source: &str) -> bool {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(&allocator, source, ParserOptions::gfm());
+    contains_footnote_ref(&doc.children)
+}
+
+#[test]
+fn definition_after_use_resolves() {
+    assert!(resolves_reference("[a]\n\n[a]: /url"));
+}
+
+#[test]
+fn definition_before_use_resolves() {
+    assert!(resolves_reference("[a]: /url\n\n[a]"));
+}
+
+#[test]
+fn fenced_code_hides_definition() {
+    assert!(!resolves_reference("```\n[a]: /url\n```\n\n[a]"));
+}
+
+#[test]
+fn tilde_fenced_code_hides_definition() {
+    assert!(!resolves_reference("~~~\n[a]: /url\n~~~\n\n[a]"));
+}
+
+#[test]
+fn unclosed_fence_hides_rest_of_document() {
+    assert!(!resolves_reference("```\n[a]: /url\n\n[a]"));
+}
+
+#[test]
+fn quoted_definition_resolves() {
+    assert!(resolves_reference("> [a]: /url\n\n[a]"));
+}
+
+#[test]
+fn indented_quote_marker_definition_resolves() {
+    assert!(resolves_reference("  > [a]: /url\n\n[a]"));
+}
+
+#[test]
+fn paragraph_continuation_is_not_a_definition() {
+    assert!(!resolves_reference("text\n[a]: /url\n\n[a]"));
+}
+
+#[test]
+fn list_item_continuation_is_not_a_definition() {
+    assert!(!resolves_reference("- item\n[a]: /url\n\n[a]"));
+}
+
+#[test]
+fn heading_line_closes_paragraph_context() {
+    assert!(resolves_reference("# heading\n[a]: /url\n\n[a]"));
+}
+
+#[test]
+fn setext_underline_closes_paragraph_context() {
+    assert!(resolves_reference("text\n===\n[a]: /url\n\n[a]"));
+}
+
+#[test]
+fn thematic_break_closes_paragraph_context() {
+    assert!(resolves_reference("text\n---\n[a]: /url\n\n[a]"));
+}
+
+#[test]
+fn chained_definitions_all_resolve() {
+    let source = "[a]: /1\n[b]: /2\n[c]: /3\n\n[a] [b] [c]";
+    let allocator = Allocator::new();
+    let doc = parse_with_options(&allocator, source, ParserOptions::default());
+    let links = doc
+        .children
+        .iter()
+        .filter_map(|node| match node {
+            Node::Paragraph(p) => {
+                Some(p.children.iter().filter(|n| matches!(n, Node::Link(_))).count())
+            }
+            _ => None,
+        })
+        .sum::<usize>();
+    assert_eq!(links, 3);
+}
+
+#[test]
+fn three_space_indent_is_a_definition() {
+    assert!(resolves_reference("   [a]: /url\n\n[a]"));
+}
+
+#[test]
+fn four_space_indent_is_not_a_definition() {
+    assert!(!resolves_reference("    [a]: /url\n\n[a]"));
+}
+
+#[test]
+fn definition_at_start_of_source_resolves() {
+    assert!(resolves_reference("[a]: /url\n[a]"));
+}
+
+#[test]
+fn definition_without_trailing_newline_resolves() {
+    assert!(resolves_reference("[a]\n\n[a]: /url"));
+}
+
+#[test]
+fn crlf_definition_does_not_resolve() {
+    // Parity pin, not an endorsement: the standalone passes never
+    // recognized definitions in CRLF sources (the trailing `\r` defeats
+    // the `]:` check and the `\r`-only blank line keeps the paragraph
+    // open), and the fused pass preserves that.
+    assert!(!resolves_reference("[a]\r\n\r\n[a]: /url"));
+}
+
+#[test]
+fn footnote_definition_after_use_resolves() {
+    assert!(resolves_footnote("[^n]\n\n[^n]: note"));
+}
+
+#[test]
+fn footnote_definition_before_use_resolves() {
+    assert!(resolves_footnote("[^n]: note\n\n[^n]"));
+}
+
+#[test]
+fn fenced_code_hides_footnote_definition() {
+    assert!(!resolves_footnote("```\n[^n]: note\n```\n\n[^n]"));
+}
+
+#[test]
+fn footnote_without_definition_stays_literal() {
+    assert!(!resolves_footnote("[^n] and no definition"));
+}
+
+#[test]
+fn indented_footnote_definition_up_to_three_spaces_resolves() {
+    assert!(resolves_footnote("   [^n]: note\n\n[^n]"));
+}
+
+// The two collectors deliberately classify fences differently: the
+// reference side tracks fences on the quote-stripped line, the footnote
+// side on the raw line. A quoted fence line therefore opens a fence for
+// the reference collector only. These two tests pin that asymmetry.
+
+#[test]
+fn quoted_fence_hides_later_reference_definition() {
+    assert!(!resolves_reference("> ```\n\n[a]: /url\n\n[a]"));
+}
+
+#[test]
+fn quoted_fence_does_not_hide_later_footnote_definition() {
+    assert!(resolves_footnote("> ```\n\n[^n]: note\n\n[^n]"));
+}
+
+// A multi-line reference definition (title on its own line) is skipped in
+// one jump by the reference collector; the footnote scan must still see
+// the skipped lines exactly as the standalone pass did.
+
+#[test]
+fn footnote_definition_directly_after_multiline_definition_resolves() {
+    assert!(resolves_footnote("[a]: /url\n\"title\"\n[^n]: note\n\n[^n]"));
+}
+
+#[test]
+fn multiline_definition_with_title_resolves() {
+    assert!(resolves_reference("[a]: /url\n\"title\"\n\n[a]"));
+}

--- a/crates/ox_content_renderer/examples/render_stdin.rs
+++ b/crates/ox_content_renderer/examples/render_stdin.rs
@@ -16,5 +16,8 @@ fn main() {
     let mut renderer = ox_content_renderer::HtmlRenderer::with_options(
         ox_content_renderer::HtmlRendererOptions::new(),
     );
-    print!("{}", renderer.render(&doc));
+    #[allow(clippy::print_stdout)]
+    {
+        print!("{}", renderer.render(&doc));
+    }
 }

--- a/crates/ox_content_renderer/examples/render_stdin.rs
+++ b/crates/ox_content_renderer/examples/render_stdin.rs
@@ -1,0 +1,20 @@
+//! Diff-fuzzing helper: render stdin markdown to HTML on stdout.
+use std::io::Read;
+
+fn main() {
+    let mut source = String::new();
+    std::io::stdin().read_to_string(&mut source).unwrap();
+    let gfm = std::env::args().any(|a| a == "--gfm");
+    let allocator = ox_content_allocator::Allocator::for_source_len(source.len());
+    let options = if gfm {
+        ox_content_parser::ParserOptions::gfm()
+    } else {
+        ox_content_parser::ParserOptions::default()
+    };
+    let parser = ox_content_parser::Parser::with_options(&allocator, &source, options);
+    let doc = parser.parse().unwrap();
+    let mut renderer = ox_content_renderer::HtmlRenderer::with_options(
+        ox_content_renderer::HtmlRendererOptions::new(),
+    );
+    print!("{}", renderer.render(&doc));
+}


### PR DESCRIPTION
## What

Replaces the two standalone collection pre-passes (`build_definitions`, `build_footnote_labels`) with a single fused scan in `crates/ox_content_parser/src/parser/prepass.rs` that dispatches on each line's first byte. Lines that cannot affect either collector (prose, HTML, code content) now cost one memchr line skip and a flag write instead of quote-strip + trim + fence classification.

Both collectors' exact semantics are preserved, including their deliberate asymmetries:
- reference fences track the **quote-stripped** line while footnote fences track the **raw** line (two independent fence states, pinned by new tests);
- the footnote scan still visits every line of a multi-line definition chunk that the reference side jumps over in one step.

## Measured

Interleaved A/B runs (5 rounds, alternating binaries, 500 iters + 100 warmup each) on `docs/content/api/types.md` (247 KB), `pipeline --gfm`:

| binary | p50 (median of rounds) |
|---|---|
| main | 114.4 µs |
| this PR | **106.2 µs (−7%)** |

> Correction: an earlier revision of this description claimed −38%/+60% from a single before/after pair; that baseline was polluted by concurrent load on the machine. The interleaved numbers above are the honest ones. The Blacksmith benchmark run on this PR is the canonical check.

## Verification

- Full parser + renderer suites green (CommonMark 652 + GFM spec conformance included); clippy/fmt clean.
- 29 new edge tests in `tests/edge_cases/prepass.rs` pinning definition/footnote collection semantics (fences, quoted-fence asymmetry, paragraph continuation, indent 3 vs 4, chunk-skip footnote visibility, CRLF parity).
- **Differential fuzz vs the old implementation** (new `examples/render_stdin.rs`, committed for reuse in later perf PRs): all repo markdown ×{core,gfm} = 224 cases, CRLF-converted corpus = 40, 30 synthetic pre-pass edge cases ×2 modes — **zero output mismatches**.