### PR TITLE
ci(bench): install Bun via npm instead of the policy-blocked setup-bun action

### DIFF
--- a/.github/workflows/benchmark-docs.yml
+++ b/.github/workflows/benchmark-docs.yml
@@ -61,9 +61,11 @@ jobs:
       # Bun >= 1.3.8. Pin a version that ships the API so the row is always
       # present (matches .github/workflows/benchmark.yml).
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: "1.3.14"
+        # oven-sh/setup-bun is outside this repo's allowed-actions policy, so
+        # every workflow that referenced it died with a startup_failure before
+        # any job ran. Install the same pinned Bun through npm (Node is set up
+        # by the preceding Setup Vite+ step) instead of widening the policy.
+        run: npm install --global bun@1.3.14
 
       - name: Regenerate benchmark docs
         run: vp run bench:docs

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -57,9 +57,11 @@ jobs:
       # Bun.markdown row. Pin a version that ships the API so the comparison
       # always includes Bun.
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: "1.3.14"
+        # oven-sh/setup-bun is outside this repo's allowed-actions policy, so
+        # every workflow that referenced it died with a startup_failure before
+        # any job ran. Install the same pinned Bun through npm (Node is set up
+        # by the preceding Setup Vite+ step) instead of widening the policy.
+        run: npm install --global bun@1.3.14
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/.github/workflows/testbox.yml
+++ b/.github/workflows/testbox.yml
@@ -47,9 +47,11 @@ jobs:
       # Keep benchmark testboxes aligned with benchmark.yml and
       # benchmark-docs.yml so Bun.markdown.html is included in local remote runs.
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: "1.3.14"
+        # oven-sh/setup-bun is outside this repo's allowed-actions policy, so
+        # every workflow that referenced it died with a startup_failure before
+        # any job ran. Install the same pinned Bun through npm (Node is set up
+        # by the preceding Setup Vite+ step) instead of widening the policy.
+        run: npm install --global bun@1.3.14
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable


### PR DESCRIPTION
## What

Replaces the `oven-sh/setup-bun` action with `npm install --global bun@1.3.14` in the three workflows that referenced it (Benchmark, Testbox, Benchmark docs).

## Why

**The PR benchmark has never actually run.** Every run of those workflows — 200/200 in the visible history, back to at least 2026-06-21 — ended in `startup_failure` with:

> The action oven-sh/setup-bun@… is not allowed in ubugeeei-prod/ox-content because all actions must be from a repository owned by ubugeeei-prod, created by GitHub, or match one of the patterns: Swatinem/rust-cache@*, dtolnay/rust-toolchain@*, goto-bus-stop/setup-zig@*, rust-lang/crates-io-auth-action@*, voidzero-dev/setup-vp@*.

The failure occurs before any job starts, so no benchmark comparison, no Bun.markdown row, and no benchmark PR comment has ever been produced — and because the check never reports as a failed *job*, auto-merge kept working and this went unnoticed.

I deliberately did **not** widen the allowed-actions policy (it is a supply-chain control); installing the same pinned Bun through npm keeps the policy exactly as strict as before. If you'd rather allowlist `oven-sh/setup-bun@*` instead, that's a repo-settings change only you can make.

## Verification

- All three files pass YAML validation; the replaced step is byte-identical in the three workflows (same pinned version 1.3.14).
- Node availability: each workflow runs Setup Vite+ (which provisions Node) before the new npm step.
- **This PR itself is the live test**: the Benchmark workflow should now start, run on Blacksmith, and post the base/head comparison comment — with the Bun.markdown and native competitor rows finally visible.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->