### PR TITLE
perf(parser): skip the pre-pass line scan when the source has no "]:"

### DIFF
--- a/crates/ox_content_parser/src/parser/prepass.rs
+++ b/crates/ox_content_parser/src/parser/prepass.rs
@@ -31,9 +31,16 @@ impl<'a> Parser<'a> {
     /// with sub-parsers.
     pub(super) fn build_prepass(&self) -> (Rc<ReferenceMap<'a>>, Rc<FootnoteLabels>) {
         profile_span!("parser::build_prepass");
-        // Cheap bail: a definition and a footnote label both start with
-        // `[`, so a source without one has neither.
-        if !self.source.contains('[') {
+        // Cheap bails. Both collectors need a `[` somewhere, and both a
+        // literal `]:`: a reference definition's label must be closed by
+        // `]` immediately followed by `:` (`[label]:`), and a footnote
+        // opener requires the same (`[^label]:`). A `]` and `:` split
+        // across a line break never parses as a definition, so absence of
+        // the contiguous needle proves the scan would collect nothing.
+        // Typical link-only documents skip the whole line scan here.
+        if !self.source.contains('[')
+            || memchr::memmem::find(self.source.as_bytes(), b"]:").is_none()
+        {
             return (Rc::new(ReferenceMap::default()), Rc::new(FootnoteLabels::default()));
         }
         let collect_footnotes = self.options.footnotes && self.source.contains("[^");

--- a/crates/ox_content_parser/tests/edge_cases/prepass.rs
+++ b/crates/ox_content_parser/tests/edge_cases/prepass.rs
@@ -205,3 +205,29 @@ fn footnote_definition_directly_after_multiline_definition_resolves() {
 fn multiline_definition_with_title_resolves() {
     assert!(resolves_reference("[a]: /url\n\"title\"\n\n[a]"));
 }
+
+#[test]
+fn bracket_and_colon_split_across_lines_is_not_a_definition() {
+    // `]` at end of one line and `:` starting the next never form a
+    // definition (the joined chunk carries the newline between them), so
+    // the pre-pass may skip sources without a contiguous "]:".
+    assert!(!resolves_reference("[a]\n: /url\n\n[a]"));
+}
+
+#[test]
+fn escaped_bracket_does_not_end_a_label() {
+    // `\]` stays inside the label; the definition's real close is the
+    // unescaped `]:` later, which the needle gate must also see.
+    assert!(resolves_reference("[a\\]b]: /url\n\n[a\\]b]"));
+}
+
+#[test]
+fn link_only_document_resolves_nothing_and_parses_fine() {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(
+        &allocator,
+        "Here's a [link](https://example.com) and [another](/x).",
+        ParserOptions::default(),
+    );
+    assert!(contains_link(&doc.children));
+}


### PR DESCRIPTION
## What

Adds a second cheap bail to `build_prepass`: if the source contains no contiguous `]:`, neither a link reference definition (`[label]:`) nor a footnote opener (`[^label]:`) can exist anywhere, so the whole line scan is skipped after one `memmem` sweep.

**Why the needle is a sound necessary condition:** both parsers require the label's closing `]` to be immediately followed by `:`. A `]` at end-of-line with `:` on the next line never parses (the pre-pass joins chunk lines with the newline preserved), and quote stripping only removes line prefixes, so any collectable definition implies a literal `]:` in the raw source. Pinned by new tests.

## Measured

1 MB JS-harness sample document (link-heavy, no `]:` — the exact shape of the PR benchmark corpus): pipeline p50 **14.92 → 14.40 ms (−3.5%)**, `build_prepass` self 0.45 → 0.03 ms/iter. Documents that do contain `]:` (e.g. `docs/content/api/types.md`) pay one extra memmem sweep (~µs) and are otherwise unchanged.

## Verification

- 3 new edge tests: `]`/`:` split across lines is not a definition; escaped `\]` inside a label keeps the real `]:` visible to the gate; link-only documents parse normally.
- Differential fuzz vs the pre-fusion baseline binary: repo markdown ×{core,gfm} + gate-focused edge docs = **232 cases, zero mismatches**.
- Full parser + renderer suites green (18 suites, spec conformance included); clippy/fmt clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->