### PR TITLE
ci(bench): suppress zizmor adhoc-packages on pinned Bun npm install

### DIFF
--- a/.github/workflows/benchmark-docs.yml
+++ b/.github/workflows/benchmark-docs.yml
@@ -65,7 +65,9 @@ jobs:
         # every workflow that referenced it died with a startup_failure before
         # any job ran. Install the same pinned Bun through npm (Node is set up
         # by the preceding Setup Vite+ step) instead of widening the policy.
-        run: npm install --global bun@1.3.14
+        # Bun is a one-off global CLI tool pinned to an exact version, so there
+        # is no project lockfile to install it from.
+        run: npm install --global bun@1.3.14 # zizmor: ignore[adhoc-packages]
 
       - name: Regenerate benchmark docs
         run: vp run bench:docs

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -61,7 +61,9 @@ jobs:
         # every workflow that referenced it died with a startup_failure before
         # any job ran. Install the same pinned Bun through npm (Node is set up
         # by the preceding Setup Vite+ step) instead of widening the policy.
-        run: npm install --global bun@1.3.14
+        # Bun is a one-off global CLI tool pinned to an exact version, so there
+        # is no project lockfile to install it from.
+        run: npm install --global bun@1.3.14 # zizmor: ignore[adhoc-packages]
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/.github/workflows/testbox.yml
+++ b/.github/workflows/testbox.yml
@@ -51,7 +51,9 @@ jobs:
         # every workflow that referenced it died with a startup_failure before
         # any job ran. Install the same pinned Bun through npm (Node is set up
         # by the preceding Setup Vite+ step) instead of widening the policy.
-        run: npm install --global bun@1.3.14
+        # Bun is a one-off global CLI tool pinned to an exact version, so there
+        # is no project lockfile to install it from.
+        run: npm install --global bun@1.3.14 # zizmor: ignore[adhoc-packages]
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable


### PR DESCRIPTION
## What

Adds an inline `# zizmor: ignore[adhoc-packages]` suppression to the pinned `npm install --global bun@1.3.14` step in the three workflows that install Bun (`benchmark.yml`, `benchmark-docs.yml`, `testbox.yml`).

```yaml
# Bun is a one-off global CLI tool pinned to an exact version, so there
# is no project lockfile to install it from.
run: npm install --global bun@1.3.14 # zizmor: ignore[adhoc-packages]
```

## Why

Follow-up to #516 (already merged), which replaced the policy-blocked `oven-sh/setup-bun` action with an npm install. zizmor's `adhoc-packages` audit now flags those `run:` steps ("installs a package outside of a lockfile"), surfacing as code-scanning alerts 67/68/69.

Bun here is a one-off global CLI tool used only in CI, not a project dependency, so it does not belong in a lockfile-managed manifest. The install is already pinned to an exact version (`1.3.14`), which addresses the audit's core concern (uncontrolled version drift). A documented suppression matches the repo's existing convention (see the `cache-poisoning` ignore in `nightly.yml`) and keeps the change minimal.

The trailing `# zizmor: ignore[...]` is a YAML comment and is not part of the `run:` command; verified the parsed `run:` value is exactly `npm install --global bun@1.3.14` in all three files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->