### PR TITLE
perf(wasm): pre-size the arena from the source length

### DIFF
--- a/crates/ox_content_wasm/src/lib.rs
+++ b/crates/ox_content_wasm/src/lib.rs
@@ -171,7 +171,10 @@ impl From<&WasmParserOptions> for ParserOptions {
 #[wasm_bindgen(js_name = parseAndRender)]
 pub fn parse_and_render(source: &str, options: Option<WasmParserOptions>) -> JsValue {
     let opts = options.unwrap_or_default();
-    let allocator = Allocator::new();
+    // Pre-size the arena from the source length (same policy as the NAPI
+    // binding) so the parse+render fits one bump chunk instead of growing
+    // through repeated chunk doublings.
+    let allocator = Allocator::for_source_len(source.len());
     let parser_options = ParserOptions::from(&opts);
     let parser = Parser::with_options(&allocator, source, parser_options);
 
@@ -212,7 +215,7 @@ pub fn transform(source: &str, options: Option<WasmParserOptions>) -> JsValue {
     let (content, frontmatter) = parse_frontmatter(source);
 
     // Parse markdown
-    let allocator = Allocator::new();
+    let allocator = Allocator::for_source_len(content.len());
     let parser_options = ParserOptions::from(&opts);
     let parser = Parser::with_options(&allocator, &content, parser_options);
 


### PR DESCRIPTION
## What

Both WASM entry points (`parseAndRender`, `transform`) built their bump allocator with `Allocator::new()`, while the NAPI binding has pre-sized with `Allocator::for_source_len` since the arena-presizing work landed. The WASM path therefore paid ~10 chunk-doubling growths per parse on a 64 KB document.

`parseAndRender` now pre-sizes from the raw source length; `transform` from the frontmatter-stripped content slice it actually parses.

## Notes

Behavior-neutral (allocation policy only). `cargo check`/`cargo test -p ox_content_wasm` green; playground/vite-plugin e2e covered by CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->