### PR TITLE
perf(renderer): reject autolink candidates on the second byte before prefix checks

### DIFF
--- a/crates/ox_content_renderer/src/html/autolink.rs
+++ b/crates/ox_content_renderer/src/html/autolink.rs
@@ -18,7 +18,17 @@ pub(super) struct FirstByteIndex {
     needles: [u8; 3],
     needle_len: usize,
     overflow: bool,
+    /// Per-first-byte second-byte filter: `second[b]` holds the lowercased
+    /// byte every pattern starting with `b` continues with, or `ANY_SECOND`
+    /// when patterns disagree (or the pattern is a single byte). Prose hits
+    /// on a frequent first byte — `h` matches "the", "here", … — are
+    /// rejected with one comparison instead of full prefix checks.
+    second: [u8; 256],
 }
+
+/// Sentinel in `FirstByteIndex::second`: no single second byte filters
+/// candidates starting with this first byte.
+const ANY_SECOND: u8 = 0xFF;
 
 impl FirstByteIndex {
     /// Builds a compact candidate-start index for the configured patterns.
@@ -33,11 +43,22 @@ impl FirstByteIndex {
         let mut needles = [0u8; 3];
         let mut needle_len = 0usize;
         let mut overflow = false;
+        let mut second = [0u8; 256];
         for pat in patterns {
             let Some(&first) = pat.as_bytes().first() else {
                 continue;
             };
+            // 0 = unset, ANY_SECOND = conflicting/absent, else the required
+            // lowercased second byte. The default patterns (`http://`,
+            // `https://`) agree on `t`, so `h` candidates filter on it.
+            let pat_second = pat.as_bytes().get(1).map_or(ANY_SECOND, u8::to_ascii_lowercase);
             for cand in [first.to_ascii_lowercase(), first.to_ascii_uppercase()] {
+                let entry = &mut second[cand as usize];
+                *entry = match *entry {
+                    0 => pat_second,
+                    prev if prev == pat_second => prev,
+                    _ => ANY_SECOND,
+                };
                 if table[cand as usize] {
                     continue;
                 }
@@ -52,7 +73,22 @@ impl FirstByteIndex {
         if needle_len > needles.len() {
             overflow = true;
         }
-        Self { table, needles, needle_len, overflow }
+        Self { table, needles, needle_len, overflow, second }
+    }
+
+    /// True when the byte after a first-byte hit rules the candidate out
+    /// without running any full prefix comparison.
+    #[inline]
+    fn rejects_second(&self, first: u8, after: Option<&u8>) -> bool {
+        let expected = self.second[first as usize];
+        if expected == ANY_SECOND {
+            return false;
+        }
+        match after {
+            Some(&byte) => byte.to_ascii_lowercase() != expected,
+            // Pattern needs a second byte but the text ends here.
+            None => true,
+        }
     }
 
     /// Byte offset of the next possible pattern start within `hay`, or `None`.
@@ -97,6 +133,12 @@ pub(super) fn find_autolink_match(
     while base < bytes.len() {
         let rel = index.next(&bytes[base..])?;
         let i = base + rel;
+        // One-byte look-ahead: most prose hits on a frequent candidate byte
+        // ("the", "words"…) die here before any prefix comparison.
+        if index.rejects_second(bytes[i], bytes.get(i + 1)) {
+            base = i + 1;
+            continue;
+        }
         // Word boundary: the previous byte must not be ASCII alphanumeric.
         let is_boundary = i == 0 || !bytes[i - 1].is_ascii_alphanumeric();
         if is_boundary {

--- a/crates/ox_content_renderer/src/html/tests/autolink.rs
+++ b/crates/ox_content_renderer/src/html/tests/autolink.rs
@@ -145,3 +145,61 @@ fn test_autolink_escapes_query_string_safely() {
     let html = renderer.render(&doc);
     insta::assert_snapshot!(html);
 }
+
+#[test]
+fn test_autolink_prose_full_of_candidate_first_bytes_stays_plain() {
+    let allocator = Allocator::new();
+    // Every `h` here hits the first-byte index; the second-byte filter
+    // must reject them all without producing links (and without panicking
+    // when the candidate is the last byte of the text).
+    let doc =
+        Parser::new(&allocator, "the theory holds hereabouts, hush; ends with h").parse().unwrap();
+    let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
+        autolink_urls: true,
+        ..Default::default()
+    });
+    let html = renderer.render(&doc);
+    assert!(!html.contains("<a "), "unexpected link in: {html}");
+}
+
+#[test]
+fn test_autolink_uppercase_prefix_still_matches_through_filter() {
+    let allocator = Allocator::new();
+    let doc = Parser::new(&allocator, "loud HTTPS://CAPS.test here").parse().unwrap();
+    let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
+        autolink_urls: true,
+        ..Default::default()
+    });
+    let html = renderer.render(&doc);
+    assert_eq!(html.matches("<a ").count(), 1, "missing uppercase autolink in: {html}");
+}
+
+#[test]
+fn test_autolink_conflicting_second_bytes_disable_the_filter() {
+    let allocator = Allocator::new();
+    // Two patterns share the first byte but disagree on the second; the
+    // filter must fall back to full prefix checks so both still match.
+    let doc = Parser::new(&allocator, "a http://one.test b hxxp://two.test c").parse().unwrap();
+    let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
+        autolink_urls: true,
+        autolink_patterns: vec!["http://".to_string(), "hxxp://".to_string()],
+        ..Default::default()
+    });
+    let html = renderer.render(&doc);
+    assert_eq!(html.matches("<a ").count(), 2, "expected both schemes in: {html}");
+}
+
+#[test]
+fn test_autolink_single_byte_pattern_bypasses_the_filter() {
+    let allocator = Allocator::new();
+    // A one-byte pattern has no second byte to filter on; candidates must
+    // go straight to the prefix check.
+    let doc = Parser::new(&allocator, "go htail now").parse().unwrap();
+    let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
+        autolink_urls: true,
+        autolink_patterns: vec!["h".to_string()],
+        ..Default::default()
+    });
+    let html = renderer.render(&doc);
+    assert_eq!(html.matches("<a ").count(), 1, "single-byte pattern should link in: {html}");
+}


### PR DESCRIPTION
## What

The bare-URL autolink scanner's first-byte index for the default patterns (`http://`, `https://`) keys on `h` — one of the most frequent letters in English prose. Every `the`, `here`, `hush` hit ran the word-boundary check plus up to two case-insensitive multi-byte prefix comparisons.

`FirstByteIndex` now records the lowercased **second** byte that all patterns sharing a first byte agree on (`ANY_SECOND` when they disagree, or when a pattern is a single byte), and `find_autolink_match` rejects non-candidates with a single byte comparison immediately after the memchr hit. Since `autolink_urls` defaults to on, this path runs for every text node in a default render.

## Measured

Un-instrumented parse+render loop (no profiler spans), 1 MB JS-harness sample document, 60 iters ×3 interleaved rounds: p50 **5.53 → 5.43 ms (−1.8%)**. The win is concentrated exactly where the PR benchmark corpus lives: prose-heavy text with no bare URLs.

## Verification

- 4 new unit tests: candidate-heavy prose stays plain (including a text *ending* on a candidate byte), uppercase prefixes still match through the filter, conflicting second bytes disable the filter (both schemes still link), single-byte custom patterns bypass it.
- Existing autolink suite (word boundary, trailing punctuation, custom patterns, table fallback, nested-link suppression, query-string escaping) green — 14/14.
- Full renderer suite green; clippy/fmt clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->