### PR TITLE
ci(bench): export benchmark-docs refresh as a patch artifact

### DIFF
--- a/.github/workflows/benchmark-docs.yml
+++ b/.github/workflows/benchmark-docs.yml
@@ -2,9 +2,16 @@ name: Benchmark docs
 
 # Regenerate the Markdown benchmark tables (README.md, docs/content/performance.md)
 # and the SVG charts (docs/public/benchmark-*.svg) from a clean CI environment,
-# then open a pull request with the refreshed numbers. Running on a consistent
+# and export the refreshed files as a patch artifact. Running on a consistent
 # runner keeps the committed numbers comparable across refreshes — local
 # machines vary too much to be the source of truth.
+#
+# The refresh used to open a pull request directly, but this repository's
+# Actions policy neither allowlists peter-evans/create-pull-request nor lets
+# workflows create pull requests (can_approve_pull_request_reviews is off).
+# A maintainer downloads the artifact and applies it:
+#   gh run download <run-id> -n benchmark-docs-refresh
+#   git apply benchmark-docs-refresh.patch
 
 on:
   workflow_dispatch:
@@ -33,8 +40,7 @@ jobs:
     # by benchmark.yml so committed numbers track the PR-benchmark environment.
     runs-on: blacksmith-32vcpu-ubuntu-2404
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -72,30 +78,18 @@ jobs:
         env:
           OX_CONTENT_BENCHMARK_RUNS: ${{ github.event.inputs.runs || '7' }}
 
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+      - name: Export refreshed docs as a patch
+        run: |
+          git add README.md docs/content/performance.md \
+            docs/public/benchmark-parse.svg docs/public/benchmark-render.svg \
+            docs/public/benchmark-parse-huge.svg docs/public/benchmark-render-huge.svg
+          git diff --cached --stat
+          git diff --cached --binary > "$RUNNER_TEMP/benchmark-docs-refresh.patch"
+
+      - name: Upload patch artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          commit-message: "docs: refresh benchmark numbers"
-          branch: ci/benchmark-docs-refresh
-          delete-branch: true
-          title: "docs: refresh benchmark numbers"
-          body: |
-            Automated refresh of the Markdown benchmark tables and charts from the
-            Benchmark docs workflow (`blacksmith-32vcpu-ubuntu-2404` runner, Bun 1.3.14
-            so the `Bun.markdown.html` row is included, median of
-            ${{ github.event.inputs.runs || '7' }} runs).
-
-            Updated:
-            - `README.md` and `docs/content/performance.md` benchmark tables
-            - `docs/public/benchmark-*.svg` charts
-
-            Numbers track the runner; the relative ordering between engines is the
-            stable signal. Review the deltas before merging.
-          labels: documentation
-          add-paths: |
-            README.md
-            docs/content/performance.md
-            docs/public/benchmark-parse.svg
-            docs/public/benchmark-render.svg
-            docs/public/benchmark-parse-huge.svg
-            docs/public/benchmark-render-huge.svg
+          name: benchmark-docs-refresh
+          path: ${{ runner.temp }}/benchmark-docs-refresh.patch
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
## What

Fixes the last dead workflow from the allowed-actions audit. `benchmark-docs.yml` (weekly refresh of the README / `docs/content/performance.md` benchmark tables + SVG charts) referenced `peter-evans/create-pull-request`, which is outside the allowed-actions policy — so every scheduled/dispatched run ended in `startup_failure`, and the committed benchmark numbers have gone stale (README still shows the pre-optimization era: napi at 122 MB/s).

Even with an allowlisted mechanism, workflows cannot open PRs in this repo (`can_approve_pull_request_reviews: false`). Rather than loosening either control, the workflow now:

- regenerates the tables/charts on the pinned Blacksmith runner exactly as before (`vp run bench:docs`), and
- uploads the result as a **patch artifact** (`benchmark-docs-refresh`, 14-day retention) that a maintainer downloads and applies:
  ```
  gh run download <run-id> -n benchmark-docs-refresh
  git apply benchmark-docs-refresh.patch
  ```

Job permissions drop from `contents: write` + `pull-requests: write` to `contents: read`.

## Follow-up

Once this merges I'll dispatch the workflow and turn the artifact into the actual "docs: refresh benchmark numbers" PR, so the published tables finally reflect the current engine (including today's parser/renderer optimizations and the new Bun/native competitor rows).

If you'd rather restore the fully automated PR flow, that needs repo settings only a maintainer can change: allowlist `peter-evans/create-pull-request@*` and enable "Allow GitHub Actions to create and approve pull requests".

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->