### PR TITLE
ci(bench): exempt the async runtime row from the regression gate

### DIFF
--- a/benchmarks/bundle-size/compare-pr-benchmark.mjs
+++ b/benchmarks/bundle-size/compare-pr-benchmark.mjs
@@ -4,6 +4,12 @@ import { readFileSync, writeFileSync } from "node:fs";
 
 const COMMENT_MARKER = "<!-- ox-content-benchmark-report -->";
 const TARGET_NAMES = new Set(["@ox-content/napi", "@ox-content/napi (async)"]);
+// Async rows stay in the comparison tables but do not gate the check:
+// worker-scheduling variance on shared runners swung them -12%/-15% on PRs
+// that never touched the async path (2 of the first 6 runs after the
+// workflow revival), while a real async regression necessarily shows on
+// the sync rows the gate keeps.
+const GATE_EXEMPT_TARGET_NAMES = new Set(["@ox-content/napi (async)"]);
 const COMMENT_SIZE_NAMES = new Set(["large"]);
 const NOISE_THRESHOLD_PERCENT = 5;
 const RUNTIME_REGRESSION_THRESHOLD_PERCENT = -10;
@@ -234,7 +240,7 @@ function buildComment({ basePath, headPath, baseBundlePath, headBundlePath, base
   lines.push(
     "### Regression Gate",
     "",
-    `Runtime regressions fail when head throughput is more than ${Math.abs(RUNTIME_REGRESSION_THRESHOLD_PERCENT)}% slower than base. Bundle regressions fail when gzipped size grows by more than ${BUNDLE_REGRESSION_THRESHOLD_PERCENT}%. Maintainers can intentionally override by applying the \`benchmark-regression-accepted\` PR label, which sets \`${BENCHMARK_OVERRIDE_ENV}=1\`.`,
+    `Runtime regressions fail when head throughput is more than ${Math.abs(RUNTIME_REGRESSION_THRESHOLD_PERCENT)}% slower than base (async rows are informational only; their worker-scheduling variance exceeds the threshold on quiet PRs). Bundle regressions fail when gzipped size grows by more than ${BUNDLE_REGRESSION_THRESHOLD_PERCENT}%. Maintainers can intentionally override by applying the \`benchmark-regression-accepted\` PR label, which sets \`${BENCHMARK_OVERRIDE_ENV}=1\`.`,
     "",
   );
 
@@ -491,6 +497,9 @@ function collectRegressions(runtimeRows, bundleRows) {
   const regressions = [];
 
   for (const row of runtimeRows) {
+    if (GATE_EXEMPT_TARGET_NAMES.has(row.targetName)) {
+      continue;
+    }
     if (
       Number.isFinite(row.deltaPercent) &&
       row.deltaPercent < RUNTIME_REGRESSION_THRESHOLD_PERCENT


### PR DESCRIPTION
## What

Excludes `@ox-content/napi (async)` from the pass/fail regression decision in `compare-pr-benchmark.mjs`. The row remains in the Runtime and Competitive Snapshot tables; the report note now states it is informational.

## Why

2 of the first 6 Benchmark runs after the workflow revival failed **only** on the async row:

| PR | async delta | sync rows in the same run |
|---|---|---|
| #519 (WASM-only change — cannot affect the napi async path) | −12.33% | 103% / 100.4% |
| #522 (mdast serializer — not on the async path) | −15.35% | **+7.9% / +7.5%** |

`parseAndRenderAsync` schedules a libuv worker per call, so its latency on a shared 32-vcpu runner is dominated by scheduling noise that a 5-run median cannot tame. A real async-path regression necessarily also moves the sync rows, which keep gating at the same −10% threshold — so this trades false alarms for zero lost coverage.

## Verification

- `node --check` + `vp check` green.
- Field name (`row.targetName`) matches the existing gate-report construction (same object feeds the failure table).