### PR TITLE
feat(bench): add boundary-free ox-content rows to the native competitor runner

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -21,7 +21,7 @@ PATH, skipped otherwise):
   directly by path dependency: a full arena parse producing the AST, and
   parse + HTML render with the same defaults as the `@ox-content/napi`
   `parseAndRender` row. No napi boundary, no mdast serialization — the gap
-  between this row and the `@ox-content/napi` rows *is* the JS hand-off
+  between this row and the `@ox-content/napi` rows _is_ the JS hand-off
   cost. Because the crate is built from the benchmarked checkout, base and
   head runs each measure their own core. Note the comparison asymmetry:
   this row builds a full AST while the pulldown rows only drain a

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -17,6 +17,17 @@ The JS sweep also injects rows from a standalone cargo crate in
 `native-competitors/` (built and run as a subprocess when `cargo` is on the
 PATH, skipped otherwise):
 
+- **`ox-content (native)`** (parse and render) — the engine itself, called
+  directly by path dependency: a full arena parse producing the AST, and
+  parse + HTML render with the same defaults as the `@ox-content/napi`
+  `parseAndRender` row. No napi boundary, no mdast serialization — the gap
+  between this row and the `@ox-content/napi` rows *is* the JS hand-off
+  cost. Because the crate is built from the benchmarked checkout, base and
+  head runs each measure their own core. Note the comparison asymmetry:
+  this row builds a full AST while the pulldown rows only drain a
+  streaming event iterator, and (like the napi rows) it parses with
+  default options, so GFM tables stay off while the Grok option set
+  enables them.
 - **`xai-grok-markdown-core (Grok Build)`** (parse) — drains
   `offset_events()`, the exact parse path of the markdown stack xAI
   open-sourced with [Grok Build](https://github.com/xai-org/grok-build)

--- a/benchmarks/native-competitors/Cargo.lock
+++ b/benchmarks/native-competitors/Cargo.lock
@@ -3,10 +3,60 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getopts"
@@ -24,6 +74,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,9 +115,52 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 name = "ox-content-native-competitors"
 version = "0.0.0"
 dependencies = [
+ "ox_content_allocator",
+ "ox_content_parser",
+ "ox_content_renderer",
  "pulldown-cmark",
  "serde_json",
  "xai-grok-markdown-core",
+]
+
+[[package]]
+name = "ox_content_allocator"
+version = "2.81.0"
+dependencies = [
+ "bumpalo",
+]
+
+[[package]]
+name = "ox_content_ast"
+version = "2.81.0"
+dependencies = [
+ "ox_content_allocator",
+]
+
+[[package]]
+name = "ox_content_parser"
+version = "2.81.0"
+dependencies = [
+ "compact_str",
+ "logos",
+ "memchr",
+ "ox_content_allocator",
+ "ox_content_ast",
+ "rustc-hash",
+ "thiserror",
+]
+
+[[package]]
+name = "ox_content_renderer"
+version = "2.81.0"
+dependencies = [
+ "compact_str",
+ "memchr",
+ "ox_content_allocator",
+ "ox_content_ast",
+ "rustc-hash",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -74,6 +199,41 @@ checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "serde"
@@ -118,6 +278,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +298,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/benchmarks/native-competitors/Cargo.toml
+++ b/benchmarks/native-competitors/Cargo.toml
@@ -20,6 +20,12 @@ pulldown-cmark = { version = "0.13.4", default-features = false, features = ["ht
 # wrapper whose only dependency is pulldown-cmark. Pinned by rev so competitor
 # numbers stay reproducible.
 xai-grok-markdown-core = { git = "https://github.com/xai-org/grok-build", rev = "98c3b2438aa922fbbe6178a5c0a4c48f85edc8ce" }
+# The engine under test, referenced by path so the base and head benchmark
+# checkouts each measure their own core. These rows show the boundary-free
+# engine next to the @ox-content/napi rows the JS harness measures.
+ox_content_allocator = { path = "../../crates/ox_content_allocator" }
+ox_content_parser = { path = "../../crates/ox_content_parser" }
+ox_content_renderer = { path = "../../crates/ox_content_renderer" }
 
 [dev-dependencies]
 # Test-only: proves the hand-rolled JSON output parses and has the row shape

--- a/benchmarks/native-competitors/src/main.rs
+++ b/benchmarks/native-competitors/src/main.rs
@@ -161,6 +161,29 @@ fn render_pulldown_html(input: &str) -> String {
     out
 }
 
+/// ox-content's own core, called directly (no napi boundary, no mdast
+/// serialization): a full arena parse producing the AST. This is a heavier
+/// job than the event-draining rows above — pulldown streams events without
+/// materializing a tree — which is exactly the difference the row exists to
+/// show next to `@ox-content/napi`.
+fn ox_content_parse(input: &str) {
+    let allocator = ox_content_allocator::Allocator::for_source_len(input.len());
+    let parser = ox_content_parser::Parser::new(&allocator, input);
+    let document = parser.parse().expect("benchmark sample must parse");
+    black_box(document.children.len());
+}
+
+/// ox-content parse + HTML render with the same defaults the
+/// `@ox-content/napi` `parseAndRender` row uses (default parser options,
+/// `HtmlRenderer::new()`), minus the napi string hand-off.
+fn ox_content_render_html(input: &str) -> usize {
+    let allocator = ox_content_allocator::Allocator::for_source_len(input.len());
+    let parser = ox_content_parser::Parser::new(&allocator, input);
+    let document = parser.parse().expect("benchmark sample must parse");
+    let mut renderer = ox_content_renderer::HtmlRenderer::new();
+    renderer.render(&document).len()
+}
+
 fn run_benchmarks(sizes: &[(&'static str, usize, u32)], runs: u32) -> SuiteResults {
     let mut parse = Vec::new();
     let mut render = Vec::new();
@@ -170,6 +193,13 @@ fn run_benchmarks(sizes: &[(&'static str, usize, u32)], runs: u32) -> SuiteResul
         parse.push((
             size_name,
             vec![
+                bench(
+                    "ox-content (native)",
+                    || ox_content_parse(&content),
+                    iterations,
+                    runs,
+                    bytes,
+                ),
                 bench(
                     "xai-grok-markdown-core (Grok Build)",
                     || drain_grok_events(&content),
@@ -188,15 +218,26 @@ fn run_benchmarks(sizes: &[(&'static str, usize, u32)], runs: u32) -> SuiteResul
         ));
         render.push((
             size_name,
-            vec![bench(
-                "pulldown-cmark + push_html",
-                || {
-                    black_box(render_pulldown_html(&content));
-                },
-                iterations,
-                runs,
-                bytes,
-            )],
+            vec![
+                bench(
+                    "ox-content (native)",
+                    || {
+                        black_box(ox_content_render_html(&content));
+                    },
+                    iterations,
+                    runs,
+                    bytes,
+                ),
+                bench(
+                    "pulldown-cmark + push_html",
+                    || {
+                        black_box(render_pulldown_html(&content));
+                    },
+                    iterations,
+                    runs,
+                    bytes,
+                ),
+            ],
         ));
     }
     SuiteResults { parse, render }
@@ -226,6 +267,21 @@ mod tests {
     }
 
     #[test]
+    fn ox_content_native_render_matches_sample_expectations() {
+        let allocator = ox_content_allocator::Allocator::for_source_len(SAMPLE_MARKDOWN.len());
+        let parser = ox_content_parser::Parser::new(&allocator, SAMPLE_MARKDOWN);
+        let document = parser.parse().expect("sample must parse");
+        let mut renderer = ox_content_renderer::HtmlRenderer::new();
+        let html = renderer.render(&document);
+        assert!(html.contains("<h1"));
+        // Default parser options (matching the @ox-content/napi rows, which
+        // also pass no options) leave the GFM table extension off — unlike
+        // the pulldown rows, whose Grok option set enables tables. The row
+        // comparison note in benchmarks/README.md documents this.
+        assert!(!html.contains("<table"));
+    }
+
+    #[test]
     fn push_html_renders_sample_non_empty() {
         let rendered = render_pulldown_html(SAMPLE_MARKDOWN);
         assert!(!rendered.is_empty());
@@ -247,10 +303,14 @@ mod tests {
         let parse_names: Vec<_> = parse_rows.iter().map(|row| row["name"].as_str()).collect();
         assert_eq!(
             parse_names,
-            [Some("xai-grok-markdown-core (Grok Build)"), Some("pulldown-cmark")]
+            [
+                Some("ox-content (native)"),
+                Some("xai-grok-markdown-core (Grok Build)"),
+                Some("pulldown-cmark")
+            ]
         );
         let render_names: Vec<_> = render_rows.iter().map(|row| row["name"].as_str()).collect();
-        assert_eq!(render_names, [Some("pulldown-cmark + push_html")]);
+        assert_eq!(render_names, [Some("ox-content (native)"), Some("pulldown-cmark + push_html")]);
 
         for row in parse_rows.iter().chain(render_rows) {
             for field in ["opsPerSec", "avgMs", "throughputMBs"] {


### PR DESCRIPTION
## What

Adds **`ox-content (native)`** parse and render rows to `benchmarks/native-competitors/`, calling the engine directly through path dependencies — no napi boundary, no mdast serialization.

## Why

The parse-only snapshot shows `@ox-content/napi` at 0.77–0.89x of pulldown-cmark, which reads as "the engine is slower." It isn't: the napi row pays the JS hand-off (mdast JSON + string transfer) **and** builds a full AST, while the pulldown row only drains a streaming event iterator inside its own process. The new rows make that visible by putting the boundary-free engine in the same table.

Local large-size numbers (M-series, `--runs 1`):

| row | parse | render |
|---|---|---|
| **ox-content (native)** | **197.0 MB/s** | **178.0 MB/s** |
| pulldown-cmark (event drain) | 191.0 MB/s | — |
| pulldown-cmark + push_html | — | 155.9 MB/s |
| xai-grok-markdown-core (Grok Build) | 136.5 MB/s | — |

ox-content leads parse **despite materializing the AST** the pulldown row never builds. The Blacksmith run on this PR is the canonical version.

Because the crate builds from the benchmarked checkout, base and head benchmark runs each measure their own core — the native rows now also track engine changes per PR (informational; the regression gate still reads only the napi rows).

## Verification

- Runner tests extended (row order/shape incl. the new rows; native render pinned against napi-default expectations — GFM tables off, documented asymmetry vs the Grok option set in `benchmarks/README.md`).
- `cargo test` / `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` on the runner crate; `vp check` green.
- Full JS harness smoke run: the new rows appear in the parse and render tables (`ox-content (native)` takes 1.00x in Parse Only).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->