### PR TITLE
docs: retire the "cargo doc for JavaScript" tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 </p>
 
 <p align="center">
-  <strong>cargo doc for JavaScript</strong><br>
-  Rust-powered document generator and high-performance Markdown toolkit
+  <strong>High-performance Markdown toolkit</strong><br>
+  Rust-powered Markdown engine, documentation generator, and content tooling for the JavaScript ecosystem
 </p>
 
 <p align="center">

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -3,7 +3,7 @@ layout: entry
 title: Ox Content
 description: Rust-powered document generator and high-performance Markdown toolkit for JavaScript, with framework-agnostic pipelines, OG image support, and zero-JavaScript-first MPA output.
 hero:
-  text: cargo doc for JavaScript
+  text: High-performance Markdown toolkit
   tagline: A framework-agnostic document generator and high-performance Markdown toolkit for the Vite era, with OG images, theming, search, Rust speed, and zero-JavaScript-first MPA output.
   notice:
     title: Unofficial project notice
@@ -30,7 +30,7 @@ hero:
       link: https://github.com/sponsors/ubugeeei
 features:
   - icon: "mdi:file-document-outline"
-    title: cargo doc for JavaScript
+    title: API Docs from JSDoc
     details: "Generate docs for JavaScript and TypeScript projects with a docs.rs-like bias, plus first-class Markdown pages."
     link: getting-started.md
   - icon: "mdi:layers-triple"

--- a/docs/content/jsdoc.md
+++ b/docs/content/jsdoc.md
@@ -1,12 +1,12 @@
 ---
 title: API Docs from JSDoc
-description: Generate API documentation from JSDoc and TypeScript types, like cargo doc for JavaScript.
+description: Generate API documentation from JSDoc and TypeScript types.
 ---
 
 # API Docs from JSDoc
 
 Ox Content can generate API documentation directly from your JSDoc comments and
-TypeScript types — "cargo doc for JavaScript". Source files are parsed with the
+TypeScript types. Source files are parsed with the
 [OXC](https://oxc.rs) parser, so extraction is fast and understands real
 TypeScript (generics, overloads, interfaces, enums) without a separate
 type-checker pass.

--- a/npm/vite-plugin-ox-content/src/og-image/template.ts
+++ b/npm/vite-plugin-ox-content/src/og-image/template.ts
@@ -79,7 +79,7 @@ export function getDefaultTemplate(): OgImageTemplateFn {
     const rawBrand = siteName?.trim() ? siteName : "Ox Content";
     const isBrandCard = normalizeBrandValue(title) === normalizeBrandValue(rawBrand);
 
-    const heroTitle = isBrandCard ? "cargo doc for JavaScript" : title;
+    const heroTitle = isBrandCard ? "High-performance Markdown toolkit" : title;
     const heroDescription = isBrandCard
       ? "Rust-powered docs and high-performance Markdown tooling."
       : description && description.trim().length > 0


### PR DESCRIPTION
## What

Removes the "cargo doc for JavaScript" tagline everywhere it appears as project branding, per maintainer direction — the project has outgrown the doc-generator framing (the Markdown engine + toolchain and content pipeline are the core surface today; JSDoc API docs are one feature among them).

| Location | Before | After |
|---|---|---|
| README hero | cargo doc for JavaScript | **High-performance Markdown toolkit** (+ engine/doc-gen/content-tooling subline) |
| Docs landing `hero.text` | cargo doc for JavaScript | High-performance Markdown toolkit |
| Landing feature card title | cargo doc for JavaScript | API Docs from JSDoc (matches the feature page it links to) |
| `jsdoc.md` description + intro | "…, like cargo doc for JavaScript" | metaphor dropped, content unchanged |
| OG brand-card hero (`template.ts`) | cargo doc for JavaScript | High-performance Markdown toolkit |

Out of scope: `examples/gen-source-docs`'s demo line mentions Rust's actual `cargo doc` (the tool, not the tagline).

## Verification

- `grep -rn "cargo doc for JavaScript"` over tracked sources: zero residual matches.
- `docs/content/index.md` frontmatter validates as YAML; `vp check` and `vp run test:ts` green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->