### PR TITLE
ci: stabilize Blacksmith sticky disk cache keys

### DIFF
--- a/.github/actions/mount-sticky-cache/action.yml
+++ b/.github/actions/mount-sticky-cache/action.yml
@@ -3,7 +3,7 @@ description: Mount Blacksmith sticky disks for large CI caches.
 
 inputs:
   key-prefix:
-    description: Prefix shared by all sticky disk keys mounted by this action.
+    description: Stable namespace for job-specific sticky disks.
     required: true
   cargo:
     description: Mount Cargo registry and git caches.
@@ -22,33 +22,33 @@ runs:
       if: inputs.cargo == 'true'
       uses: ./.github/actions/stickydisk
       with:
-        key: ${{ inputs.key-prefix }}-cargo-registry
+        key: ${{ github.repository }}-cargo-registry-${{ runner.os }}-${{ runner.arch }}
         path: ~/.cargo/registry
 
     - name: Mount Cargo git
       if: inputs.cargo == 'true'
       uses: ./.github/actions/stickydisk
       with:
-        key: ${{ inputs.key-prefix }}-cargo-git
+        key: ${{ github.repository }}-cargo-git-${{ runner.os }}-${{ runner.arch }}
         path: ~/.cargo/git
 
     - name: Mount Cargo target
       if: inputs.target != ''
       uses: ./.github/actions/stickydisk
       with:
-        key: ${{ inputs.key-prefix }}-cargo-target
+        key: ${{ inputs.key-prefix }}-cargo-target-${{ runner.os }}-${{ runner.arch }}
         path: ${{ inputs.target }}
 
     - name: Mount Playwright browsers
       if: inputs.browsers == 'true'
       uses: ./.github/actions/stickydisk
       with:
-        key: ${{ inputs.key-prefix }}-playwright-browsers
+        key: ${{ inputs.key-prefix }}-playwright-browsers-${{ runner.os }}-${{ runner.arch }}
         path: ~/.cache/ms-playwright
 
     - name: Mount Puppeteer browsers
       if: inputs.browsers == 'true'
       uses: ./.github/actions/stickydisk
       with:
-        key: ${{ inputs.key-prefix }}-puppeteer-browsers
+        key: ${{ inputs.key-prefix }}-puppeteer-browsers-${{ runner.os }}-${{ runner.arch }}
         path: ~/.cache/puppeteer

--- a/.github/workflows/benchmark-docs.yml
+++ b/.github/workflows/benchmark-docs.yml
@@ -30,7 +30,6 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   OX_CONTENT_BENCHMARK_RUNNER: blacksmith-32vcpu-ubuntu-2404
-  STICKY_CACHE_SCOPE: ${{ github.ref_name }}
 
 jobs:
   refresh:
@@ -59,7 +58,7 @@ jobs:
       - name: Mount sticky cache
         uses: ./.github/actions/mount-sticky-cache
         with:
-          key-prefix: ${{ github.repository }}-benchmark-docs-${{ github.job }}-${{ env.STICKY_CACHE_SCOPE }}
+          key-prefix: ${{ github.repository }}-benchmark-docs-${{ github.job }}
           cargo: "true"
           target: target
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,6 @@ env:
   CARGO_TERM_COLOR: always
   OX_CONTENT_BENCHMARK_RUNNER: blacksmith-32vcpu-ubuntu-2404
   OX_CONTENT_BENCHMARK_RUNS: "5"
-  STICKY_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
 
 jobs:
   benchmark:
@@ -71,7 +70,7 @@ jobs:
       - name: Mount sticky cache
         uses: ./.github/actions/mount-sticky-cache
         with:
-          key-prefix: ${{ github.repository }}-benchmark-${{ github.job }}-${{ env.STICKY_CACHE_SCOPE }}
+          key-prefix: ${{ github.repository }}-benchmark-${{ github.job }}
           cargo: "true"
           target: /tmp/ox-content-cargo-target
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  STICKY_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
 
 jobs:
   rustfmt:
@@ -50,7 +49,7 @@ jobs:
       - name: Mount sticky cache
         uses: ./.github/actions/mount-sticky-cache
         with:
-          key-prefix: ${{ github.repository }}-ci-${{ github.job }}-${{ env.STICKY_CACHE_SCOPE }}
+          key-prefix: ${{ github.repository }}-ci-${{ github.job }}
           cargo: "true"
           target: target
 
@@ -96,7 +95,7 @@ jobs:
       - name: Mount sticky cache
         uses: ./.github/actions/mount-sticky-cache
         with:
-          key-prefix: ${{ github.repository }}-ci-${{ github.job }}-${{ env.STICKY_CACHE_SCOPE }}
+          key-prefix: ${{ github.repository }}-ci-${{ github.job }}
           cargo: "true"
           target: target
 
@@ -127,7 +126,7 @@ jobs:
       - name: Mount sticky cache
         uses: ./.github/actions/mount-sticky-cache
         with:
-          key-prefix: ${{ github.repository }}-ci-${{ github.job }}-${{ env.STICKY_CACHE_SCOPE }}
+          key-prefix: ${{ github.repository }}-ci-${{ github.job }}
           cargo: "true"
           target: target
 
@@ -182,7 +181,7 @@ jobs:
       - name: Mount sticky cache
         uses: ./.github/actions/mount-sticky-cache
         with:
-          key-prefix: ${{ github.repository }}-ci-${{ github.job }}-${{ env.STICKY_CACHE_SCOPE }}
+          key-prefix: ${{ github.repository }}-ci-${{ github.job }}
           cargo: "true"
 
       - name: Install Cargo audit tools
@@ -221,7 +220,7 @@ jobs:
       - name: Mount sticky cache
         uses: ./.github/actions/mount-sticky-cache
         with:
-          key-prefix: ${{ github.repository }}-ci-${{ github.job }}-${{ env.STICKY_CACHE_SCOPE }}
+          key-prefix: ${{ github.repository }}-ci-${{ github.job }}
           cargo: "true"
           target: target
 
@@ -263,7 +262,7 @@ jobs:
         if: startsWith(matrix.os, 'blacksmith-')
         uses: ./.github/actions/mount-sticky-cache
         with:
-          key-prefix: ${{ github.repository }}-ci-${{ github.job }}-${{ matrix.os }}-${{ env.STICKY_CACHE_SCOPE }}
+          key-prefix: ${{ github.repository }}-ci-${{ github.job }}-${{ matrix.os }}
           cargo: "true"
           target: target
 
@@ -316,7 +315,7 @@ jobs:
       - name: Mount sticky cache
         uses: ./.github/actions/mount-sticky-cache
         with:
-          key-prefix: ${{ github.repository }}-ci-${{ github.job }}-${{ env.STICKY_CACHE_SCOPE }}
+          key-prefix: ${{ github.repository }}-ci-${{ github.job }}
           cargo: "true"
           target: target
           browsers: "true"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,9 +12,6 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
-env:
-  STICKY_CACHE_SCOPE: ${{ github.ref_name }}
-
 jobs:
   build:
     runs-on: blacksmith-32vcpu-ubuntu-2404
@@ -36,7 +33,7 @@ jobs:
       - name: Mount sticky cache
         uses: ./.github/actions/mount-sticky-cache
         with:
-          key-prefix: ${{ github.repository }}-deploy-${{ github.job }}-${{ env.STICKY_CACHE_SCOPE }}
+          key-prefix: ${{ github.repository }}-deploy-${{ github.job }}
           cargo: "true"
           target: target
           browsers: "true"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,7 +31,6 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   LINUX_GLIBC_VERSION: "2.17"
-  STICKY_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
 
 jobs:
   build-napi:
@@ -85,7 +84,7 @@ jobs:
         if: startsWith(matrix.os, 'blacksmith-')
         uses: ./.github/actions/mount-sticky-cache
         with:
-          key-prefix: ${{ github.repository }}-nightly-${{ github.job }}-${{ matrix.target }}-${{ env.STICKY_CACHE_SCOPE }}
+          key-prefix: ${{ github.repository }}-nightly-${{ github.job }}-${{ matrix.target }}
           cargo: "true"
           target: target
 
@@ -270,7 +269,7 @@ jobs:
       - name: Mount sticky cache
         uses: ./.github/actions/mount-sticky-cache
         with:
-          key-prefix: ${{ github.repository }}-nightly-${{ github.job }}-${{ env.STICKY_CACHE_SCOPE }}
+          key-prefix: ${{ github.repository }}-nightly-${{ github.job }}
           cargo: "true"
           target: target
 

--- a/.github/workflows/testbox.yml
+++ b/.github/workflows/testbox.yml
@@ -18,7 +18,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  STICKY_CACHE_SCOPE: ${{ github.ref_name }}
   # begin-testbox / run-testbox are JavaScript actions that require Node 24.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
@@ -61,7 +60,7 @@ jobs:
       - name: Mount sticky cache
         uses: ./.github/actions/mount-sticky-cache
         with:
-          key-prefix: ${{ github.repository }}-testbox-${{ github.job }}-${{ env.STICKY_CACHE_SCOPE }}
+          key-prefix: ${{ github.repository }}-testbox-${{ github.job }}
           cargo: "true"
           target: target
           browsers: "true"

--- a/.github/workflows/void-deploy.yml
+++ b/.github/workflows/void-deploy.yml
@@ -18,7 +18,6 @@ permissions:
   contents: read
 
 env:
-  STICKY_CACHE_SCOPE: ${{ github.ref_name }}
   VOID_API_URL: ${{ vars.VOID_API_URL || 'https://api.void.cloud' }}
   VOID_PROJECT: ${{ vars.VOID_PROJECT || 'ox-content' }}
   OX_CONTENT_DOCS_BASE: /
@@ -46,7 +45,7 @@ jobs:
       - name: Mount sticky cache
         uses: ./.github/actions/mount-sticky-cache
         with:
-          key-prefix: ${{ github.repository }}-void-deploy-${{ github.job }}-${{ env.STICKY_CACHE_SCOPE }}
+          key-prefix: ${{ github.repository }}-void-deploy-${{ github.job }}
           cargo: "true"
           target: target
           browsers: "true"


### PR DESCRIPTION
## Summary

- keep Cargo target and browser sticky-disk keys stable across pull requests and branches
- share Cargo registry and git disks repository-wide per runner OS and architecture
- remove the ref/PR-specific `STICKY_CACHE_SCOPE` from workflow cache namespaces

## Why

Blacksmith sticky-disk keys identify persistent disks rather than lookup keys with prefix fallback. Ref- and PR-specific keys provision new disks for otherwise compatible builds, discard warm caches, and increase retained disk instances. This applies the same cache-key strategy as [vize#3353](https://github.com/ubugeeei-prod/vize/pull/3353) to ox-content's composite cache action and workflows.

## Impact

CI jobs can reuse compatible Cargo and browser caches across runs while still separating job-specific caches and incompatible runner OS/architecture combinations.

## Validation

- `actionlint` (excluding the repository's existing custom Blacksmith runner-label and unrelated ShellCheck warnings)
- YAML parse for the composite action and all changed workflows
- `zizmor --no-exit-codes --format plain` on all changed workflows: no findings
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build-cache separation across operating systems and processor architectures.
  * Simplified cache key handling across CI, benchmarking, deployment, nightly, and test workflows.
  * Reduced unnecessary cache fragmentation while preserving job-specific cache isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->