### PR TITLE
feat: add SolidJS integration (#540)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -303,6 +303,7 @@ jobs:
             ./npm/unplugin-ox-content \
             ./npm/vite-plugin-ox-content \
             ./npm/vite-plugin-ox-content-react \
+            ./npm/vite-plugin-ox-content-solid \
             ./npm/vite-plugin-ox-content-svelte \
             ./npm/vite-plugin-ox-content-vue
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -398,6 +398,18 @@ jobs:
           TARBALL=$(vp exec -- pnpm pack --pack-destination /tmp | tail -1)
           npm publish "$TARBALL" --provenance --access public --tag "$NPM_TAG"
 
+      - name: Publish @ox-content/vite-plugin-solid
+        working-directory: npm/vite-plugin-ox-content-solid
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "${PKG_NAME}@${PKG_VERSION}" version >/dev/null 2>&1; then
+            echo "Skipping ${PKG_NAME}@${PKG_VERSION} (already published)"
+            exit 0
+          fi
+          TARBALL=$(vp exec -- pnpm pack --pack-destination /tmp | tail -1)
+          npm publish "$TARBALL" --provenance --access public --tag "$NPM_TAG"
+
       - name: Publish @ox-content/vite-plugin-svelte
         working-directory: npm/vite-plugin-ox-content-svelte
         run: |

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ npm install @ox-content/vite-plugin-react
 # Svelte
 npm install @ox-content/vite-plugin-svelte
 
-# Solid
-npm install @ox-content/vite-plugin-solid
+# Solid (vite-plugin-solid compiles the generated JSX, so it is required)
+npm install @ox-content/vite-plugin-solid solid-js vite-plugin-solid
 ```
 
 ### i18n Static Checker (CLI)

--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ npm install @ox-content/vite-plugin-react
 
 # Svelte
 npm install @ox-content/vite-plugin-svelte
+
+# Solid
+npm install @ox-content/vite-plugin-solid
 ```
 
 ### i18n Static Checker (CLI)

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -1837,7 +1837,7 @@ export declare function render(astJson: string): RenderResult
 /**
  * Renders already-produced Markdown HTML into framework-native component code.
  *
- * The `target` argument accepts `"react"`, `"vue"`, and `"svelte"`.
+ * The `target` argument accepts `"react"`, `"solid"`, `"vue"`, and `"svelte"`.
  * `mode` defaults to `"expression"` for backward compatibility.
  */
 export declare function renderFrameworkComponentCode(html: string, target: string, islands?: Array<JsFrameworkComponentIsland> | undefined | null, mode?: string | undefined | null): string

--- a/crates/ox_content_napi/src/framework_codegen.rs
+++ b/crates/ox_content_napi/src/framework_codegen.rs
@@ -36,7 +36,7 @@ fn props_to_map(value: serde_json::Value) -> FxHashMap<String, serde_json::Value
 
 /// Renders already-produced Markdown HTML into framework-native component code.
 ///
-/// The `target` argument accepts `"react"`, `"vue"`, and `"svelte"`.
+/// The `target` argument accepts `"react"`, `"solid"`, `"vue"`, and `"svelte"`.
 /// `mode` defaults to `"expression"` for backward compatibility.
 #[napi(js_name = "renderFrameworkComponentCode")]
 pub fn render_framework_component_code(

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -1841,7 +1841,7 @@ export declare function render(astJson: string): RenderResult
 /**
  * Renders already-produced Markdown HTML into framework-native component code.
  *
- * The `target` argument accepts `"react"`, `"vue"`, and `"svelte"`.
+ * The `target` argument accepts `"react"`, `"solid"`, `"vue"`, and `"svelte"`.
  * `mode` defaults to `"expression"` for backward compatibility.
  */
 export declare function renderFrameworkComponentCode(html: string, target: string, islands?: Array<JsFrameworkComponentIsland> | undefined | null, mode?: string | undefined | null): string

--- a/crates/ox_content_renderer/src/frameworks.rs
+++ b/crates/ox_content_renderer/src/frameworks.rs
@@ -30,6 +30,7 @@ pub struct FrameworkComponentIsland {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FrameworkCodegenTarget {
     React,
+    Solid,
     Svelte,
     Vue,
 }
@@ -38,6 +39,7 @@ impl FrameworkCodegenTarget {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::React => "react",
+            Self::Solid => "solid",
             Self::Svelte => "svelte",
             Self::Vue => "vue",
         }
@@ -56,6 +58,7 @@ impl FromStr for FrameworkCodegenTarget {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
             "react" => Ok(Self::React),
+            "solid" | "solid-js" | "solidjs" => Ok(Self::Solid),
             "svelte" => Ok(Self::Svelte),
             "vue" => Ok(Self::Vue),
             _ => Err(FrameworkCodegenError::UnsupportedTarget { target: String::from(value) }),
@@ -179,9 +182,9 @@ fn render_framework_expression(
     islands: &[FrameworkComponentIsland],
 ) -> Result<String, FrameworkCodegenError> {
     match target {
-        FrameworkCodegenTarget::React | FrameworkCodegenTarget::Vue => {
-            Ok(render_framework_component_code(html, target, islands))
-        }
+        FrameworkCodegenTarget::React
+        | FrameworkCodegenTarget::Solid
+        | FrameworkCodegenTarget::Vue => Ok(render_framework_component_code(html, target, islands)),
         FrameworkCodegenTarget::Svelte => Err(FrameworkCodegenError::UnsupportedModeForTarget {
             mode: FrameworkCodegenMode::Expression,
             target,
@@ -195,6 +198,7 @@ fn render_framework_render_function(
 ) -> Result<String, FrameworkCodegenError> {
     match target {
         FrameworkCodegenTarget::React => Ok(react::render_function_module(expression)),
+        FrameworkCodegenTarget::Solid => Ok(solid::render_function_module(expression)),
         FrameworkCodegenTarget::Vue => Ok(vue::render_function_module(expression)),
         FrameworkCodegenTarget::Svelte => Err(FrameworkCodegenError::UnsupportedModeForTarget {
             mode: FrameworkCodegenMode::RenderFunction,
@@ -213,6 +217,10 @@ fn render_framework_component(
             let expression = render_framework_component_code(html, target, islands);
             Ok(react::component_module(&expression))
         }
+        FrameworkCodegenTarget::Solid => {
+            let expression = render_framework_component_code(html, target, islands);
+            Ok(solid::component_module(&expression))
+        }
         FrameworkCodegenTarget::Vue => {
             let expression = render_framework_component_code(html, target, islands);
             Ok(vue::component_module(&expression))
@@ -224,6 +232,7 @@ fn render_framework_component(
 fn render_inner_html_component(html: &str, target: FrameworkCodegenTarget) -> String {
     match target {
         FrameworkCodegenTarget::React => react::inner_html_component_module(html),
+        FrameworkCodegenTarget::Solid => solid::inner_html_component_module(html),
         FrameworkCodegenTarget::Svelte => svelte::inner_html_component_module(html),
         FrameworkCodegenTarget::Vue => vue::inner_html_component_module(html),
     }

--- a/crates/ox_content_renderer/src/frameworks/render.rs
+++ b/crates/ox_content_renderer/src/frameworks/render.rs
@@ -1,6 +1,6 @@
 use super::{
     parser::{HtmlElement, HtmlNode},
-    react, shared, vue, FrameworkCodegenTarget, FrameworkComponentIsland,
+    react, shared, solid, vue, FrameworkCodegenTarget, FrameworkComponentIsland,
 };
 use smallvec::SmallVec;
 
@@ -17,6 +17,7 @@ impl FrameworkCodegen<'_> {
 
         match self.target {
             FrameworkCodegenTarget::React => react::render_root(&children),
+            FrameworkCodegenTarget::Solid => solid::render_root(&children),
             FrameworkCodegenTarget::Svelte => {
                 unreachable!("svelte component output does not use the VDOM renderer")
             }
@@ -51,6 +52,7 @@ impl FrameworkCodegen<'_> {
 
         match self.target {
             FrameworkCodegenTarget::React => react::render_element(element, &children),
+            FrameworkCodegenTarget::Solid => solid::render_element(element, &children),
             FrameworkCodegenTarget::Svelte => {
                 unreachable!("svelte component output does not use the VDOM renderer")
             }
@@ -61,6 +63,7 @@ impl FrameworkCodegen<'_> {
     fn render_island(&self, island: &FrameworkComponentIsland) -> String {
         match self.target {
             FrameworkCodegenTarget::React => react::render_island(island),
+            FrameworkCodegenTarget::Solid => solid::render_island(island),
             FrameworkCodegenTarget::Svelte => {
                 unreachable!("svelte component output does not use the VDOM renderer")
             }

--- a/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_solid_children_variadically.snap
+++ b/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_solid_children_variadically.snap
@@ -1,0 +1,9 @@
+---
+source: crates/ox_content_renderer/src/frameworks/tests.rs
+expression: "format!(\"single:\\n{single}\\n\\nmany:\\n{many}\")"
+---
+single:
+h('div', { class: 'ox-content' }, h("p", null, h("span", null, "one")))
+
+many:
+h('div', { class: 'ox-content' }, h("p", null, h("span", null, "one"), h("span", null, "two")))

--- a/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_solid_component_modes.snap
+++ b/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_solid_component_modes.snap
@@ -1,0 +1,28 @@
+---
+source: crates/ox_content_renderer/src/frameworks/tests.rs
+expression: "format!(\"component:\\n{component}\\n\\nrender_function:\\n{render_function}\\n\\ninner_html:\\n{inner_html}\")"
+---
+component:
+import h from 'solid-js/h';
+
+export default function MarkdownContent() {
+  return h('div', { class: 'ox-content' }, h("p", null, "Hello"));
+}
+
+
+render_function:
+import h from 'solid-js/h';
+
+export function renderMarkdownContent() {
+  return h('div', { class: 'ox-content' }, h("p", null, "Hello"));
+}
+
+
+inner_html:
+import h from 'solid-js/h';
+
+const rawHtml = "\x3Cp>Hello\x3C/p>";
+
+export default function MarkdownContent() {
+  return h('div', { class: 'ox-content', innerHTML: rawHtml });
+}

--- a/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_solid_hyperscript_code.snap
+++ b/crates/ox_content_renderer/src/frameworks/snapshots/ox_content_renderer__frameworks__tests__renders_solid_hyperscript_code.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ox_content_renderer/src/frameworks/tests.rs
+expression: code
+---
+h('div', { class: 'ox-content' }, h("label", { "class": "field", "for": "name" }, h("span", null, "Name"), h("input", { "disabled": true, "type": "text" })))

--- a/crates/ox_content_renderer/src/frameworks/solid.rs
+++ b/crates/ox_content_renderer/src/frameworks/solid.rs
@@ -1,1 +1,119 @@
 //! Solid framework rendering extension point.
+//!
+//! Solid has no virtual DOM and its JSX is compile-time only, so generated code
+//! cannot lean on a runtime element factory the way the React and Vue targets
+//! do. What it does ship is `solid-js/h`, the hyperscript entry point, which is
+//! the supported way to build Solid views without running the JSX compiler —
+//! that is what this module emits.
+
+use compact_str::CompactString;
+
+use super::{
+    parser::{HtmlAttribute, HtmlElement},
+    shared, FrameworkComponentIsland,
+};
+
+const IMPORT: &str = "import h from 'solid-js/h';\n\n";
+
+pub(super) fn render_root(children: &[String]) -> String {
+    let mut output = String::with_capacity(32 + children.iter().map(String::len).sum::<usize>());
+    output.push_str("h('div', { class: 'ox-content' }");
+    push_children(&mut output, children);
+    output.push(')');
+    output
+}
+
+pub(super) fn render_element(element: &HtmlElement, children: &[String]) -> String {
+    let props = render_props(&element.attributes);
+    let mut output = String::with_capacity(
+        8 + element.tag_name.len() + props.len() + children.iter().map(String::len).sum::<usize>(),
+    );
+    output.push_str("h(");
+    shared::push_js_string_literal(&mut output, &element.tag_name);
+    output.push_str(", ");
+    output.push_str(&props);
+    push_children(&mut output, children);
+    output.push(')');
+    output
+}
+
+pub(super) fn render_island(island: &FrameworkComponentIsland) -> String {
+    let props = shared::render_json_object_literal(&island.props);
+    let content_len = island.content.as_ref().map_or(0, |content| content.len() + 4);
+    let mut output = String::with_capacity(5 + island.name.len() + props.len() + content_len);
+    output.push_str("h(");
+    output.push_str(&island.name);
+    output.push_str(", ");
+    output.push_str(&props);
+    if let Some(content) = &island.content {
+        output.push_str(", ");
+        shared::push_js_string_literal(&mut output, content);
+    }
+    output.push(')');
+    output
+}
+
+pub(super) fn render_function_module(expression: &str) -> String {
+    let mut output = String::with_capacity(IMPORT.len() + 52 + expression.len());
+    output.push_str(IMPORT);
+    output.push_str("export function renderMarkdownContent() {\n  return ");
+    output.push_str(expression);
+    output.push_str(";\n}\n");
+    output
+}
+
+pub(super) fn component_module(expression: &str) -> String {
+    let mut output = String::with_capacity(IMPORT.len() + 58 + expression.len());
+    output.push_str(IMPORT);
+    output.push_str("export default function MarkdownContent() {\n  return ");
+    output.push_str(expression);
+    output.push_str(";\n}\n");
+    output
+}
+
+pub(super) fn inner_html_component_module(html: &str) -> String {
+    let mut output = String::with_capacity(IMPORT.len() + 124 + html.len());
+    output.push_str(IMPORT);
+    output.push_str("const rawHtml = ");
+    shared::push_raw_html_js_string_literal(&mut output, html);
+    output.push_str(";\n\n");
+    output.push_str("export default function MarkdownContent() {\n");
+    output.push_str("  return h('div', { class: 'ox-content', innerHTML: rawHtml });\n");
+    output.push_str("}\n");
+    output
+}
+
+/// Solid's hyperscript takes children variadically, like React's
+/// `createElement`, rather than Vue's single-array child slot.
+fn push_children(output: &mut String, children: &[String]) {
+    for child in children {
+        output.push_str(", ");
+        output.push_str(child);
+    }
+}
+
+fn render_props(attributes: &[HtmlAttribute]) -> String {
+    let mut output = String::with_capacity(attributes.len().saturating_mul(24).max(4));
+    let mut has_entries = false;
+    for attribute in attributes {
+        let prop_name = to_prop_name(&attribute.name);
+        if shared::should_skip_property(prop_name.as_str()) {
+            continue;
+        }
+        shared::push_object_entry_key(&mut output, &mut has_entries, prop_name.as_str());
+        shared::push_attribute_value(&mut output, attribute.value.as_deref());
+    }
+    shared::finish_object_literal(&mut output, has_entries);
+    output
+}
+
+/// Solid binds DOM attributes under their HTML names, so `className`/`htmlFor`
+/// are normalized back to `class`/`for` the same way the Vue target does.
+/// `style` is left as the original CSS string, which Solid accepts directly.
+fn to_prop_name(name: &str) -> CompactString {
+    match name {
+        "className" => CompactString::const_new("class"),
+        "htmlFor" => CompactString::const_new("for"),
+        _ => shared::to_data_or_aria_attribute_name(name),
+    }
+}

--- a/crates/ox_content_renderer/src/frameworks/tests.rs
+++ b/crates/ox_content_renderer/src/frameworks/tests.rs
@@ -257,3 +257,69 @@ fn rejects_svelte_render_function_mode() {
 fn escapes_svelte_expression_delimiters() {
     assert_eq!(escape_svelte_markup("<p>{count} and }</p>"), "<p>&#123;count&#125; and &#125;</p>");
 }
+
+#[test]
+fn renders_solid_hyperscript_code() {
+    let code = render_framework_component_code(
+        r#"<label className="field" htmlFor="name"><span>Name</span><input disabled type="text"></label>"#,
+        FrameworkCodegenTarget::Solid,
+        &[],
+    );
+
+    insta::assert_snapshot!(code);
+}
+
+#[test]
+fn renders_solid_children_variadically() {
+    // Unlike Vue's single-array child slot, `solid-js/h` takes children the way
+    // React's `createElement` does.
+    let single = render_framework_component_code(
+        "<p><span>one</span></p>",
+        FrameworkCodegenTarget::Solid,
+        &[],
+    );
+    let many = render_framework_component_code(
+        "<p><span>one</span><span>two</span></p>",
+        FrameworkCodegenTarget::Solid,
+        &[],
+    );
+
+    insta::assert_snapshot!(format!("single:\n{single}\n\nmany:\n{many}"));
+}
+
+#[test]
+fn renders_solid_component_modes() {
+    let component = render_framework_code(
+        "<p>Hello</p>",
+        FrameworkCodegenTarget::Solid,
+        FrameworkCodegenMode::Component,
+        &[],
+    )
+    .unwrap();
+    let render_function = render_framework_code(
+        "<p>Hello</p>",
+        FrameworkCodegenTarget::Solid,
+        FrameworkCodegenMode::RenderFunction,
+        &[],
+    )
+    .unwrap();
+    let inner_html = render_framework_code(
+        "<p>Hello</p>",
+        FrameworkCodegenTarget::Solid,
+        FrameworkCodegenMode::InnerHtml,
+        &[],
+    )
+    .unwrap();
+
+    insta::assert_snapshot!(format!(
+        "component:\n{component}\n\nrender_function:\n{render_function}\n\ninner_html:\n{inner_html}"
+    ));
+}
+
+#[test]
+fn parses_solid_target_aliases() {
+    for alias in ["solid", "solid-js", "solidjs"] {
+        assert_eq!(alias.parse::<FrameworkCodegenTarget>().unwrap(), FrameworkCodegenTarget::Solid);
+    }
+    assert_eq!(FrameworkCodegenTarget::Solid.as_str(), "solid");
+}

--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -76,6 +76,7 @@ lowest layer used by the docs site, package APIs, authoring tools, and checks.
 | `@ox-content/vite-plugin-vue`    | Vue component islands in Markdown                                                  | Base Vite plugin plus Vue runtime                |
 | `@ox-content/vite-plugin-react`  | React component islands in Markdown                                                | Base Vite plugin plus React runtime              |
 | `@ox-content/vite-plugin-svelte` | Svelte component islands in Markdown                                               | Base Vite plugin plus Svelte runtime             |
+| `@ox-content/vite-plugin-solid`  | Solid component islands in Markdown                                                | Base Vite plugin plus Solid runtime              |
 | `@ox-content/unplugin`           | Non-Vite bundlers such as Rollup, webpack, or esbuild                              | Universal plugin wrapper                         |
 | Editor integrations              | Completion, diagnostics, snippets, preview, i18n authoring                         | `ox-content-lsp` plus editor adapters            |
 
@@ -183,6 +184,7 @@ system while still publishing individual crates.
 | `@ox-content/vite-plugin-vue`    | Vue island runtime and transform integration                                     |
 | `@ox-content/vite-plugin-react`  | React island runtime and transform integration                                   |
 | `@ox-content/vite-plugin-svelte` | Svelte island runtime and transform integration                                  |
+| `@ox-content/vite-plugin-solid`  | Solid island runtime and transform integration                                   |
 | `@ox-content/islands`            | Framework-agnostic island registration and hydration primitives                  |
 | `@ox-content/unplugin`           | Universal bundler plugin wrapper                                                 |
 | `vscode-ox-content`              | VS Code extension that talks to the local LSP server                             |

--- a/docs/content/development-setup.md
+++ b/docs/content/development-setup.md
@@ -111,6 +111,7 @@ ox-content/
 │   ├── vite-plugin-ox-content-vue/   # @ox-content/vite-plugin-vue
 │   ├── vite-plugin-ox-content-react/ # @ox-content/vite-plugin-react
 │   ├── vite-plugin-ox-content-svelte/# @ox-content/vite-plugin-svelte
+│   ├── vite-plugin-ox-content-solid/ # @ox-content/vite-plugin-solid
 │   ├── unplugin-ox-content/          # @ox-content/unplugin
 │   └── vscode-ox-content/            # VS Code extension
 ├── editors/                # Editor integrations

--- a/docs/content/examples/index.md
+++ b/docs/content/examples/index.md
@@ -59,6 +59,25 @@ export default defineConfig({
 });
 ```
 
+### [Solid Integration](./integ-solid.md)
+
+Embed Solid components in Markdown using `@ox-content/vite-plugin-solid`.
+
+```ts
+import { oxContentSolid } from "@ox-content/vite-plugin-solid";
+
+export default defineConfig({
+  plugins: [
+    oxContentSolid({
+      components: "./src/components/*.tsx",
+    }),
+    // Solid's JSX is compile-time only, so this plugin runs after
+    // oxContentSolid() and needs the Markdown extensions.
+    solid({ extensions: [".md", ".markdown", ".mdx"] }),
+  ],
+});
+```
+
 ## Plugin Examples
 
 ### [Code Annotations](./code-annotations.md)

--- a/docs/content/examples/integ-solid.md
+++ b/docs/content/examples/integ-solid.md
@@ -1,0 +1,115 @@
+# Solid Integration Example
+
+Demonstrates embedding Solid components in Markdown.
+
+## Setup
+
+```bash
+cd examples/integ-solid
+npm install
+npm run dev
+```
+
+## Configuration
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import solid from "vite-plugin-solid";
+import { oxContentSolid } from "@ox-content/vite-plugin-solid";
+
+export default defineConfig({
+  plugins: [
+    oxContentSolid({
+      srcDir: "docs",
+      // Auto-discover all Solid components
+      components: "./src/components/*.tsx",
+    }),
+    solid({ extensions: [".md", ".markdown", ".mdx"] }),
+  ],
+});
+```
+
+Solid's JSX is compile-time only, so `oxContentSolid()` has to run first (it
+produces the JSX) and `solid()` has to be told about the Markdown extensions
+(it compiles the JSX). See
+[the package reference](../packages/vite-plugin-ox-content-solid.md#plugin-order-and-extensions).
+
+## Components
+
+### Counter
+
+```tsx
+import { createSignal } from "solid-js";
+
+export default function Counter(props: { start?: number }) {
+  const [count, setCount] = createSignal(props.start ?? 0);
+
+  return (
+    <div class="counter">
+      <button onClick={() => setCount(count() - 1)}>-</button>
+      <span>{count()}</span>
+      <button onClick={() => setCount(count() + 1)}>+</button>
+    </div>
+  );
+}
+```
+
+### Alert
+
+```tsx
+import type { JSX } from "solid-js";
+
+export default function Alert(props: {
+  type?: "info" | "success" | "warning";
+  title?: string;
+  children?: JSX.Element;
+}) {
+  return (
+    <div class={`alert alert-${props.type ?? "info"}`}>
+      {props.title ? <strong class="alert-title">{props.title}</strong> : null}
+      <div class="alert-body">{props.children}</div>
+    </div>
+  );
+}
+```
+
+## Usage in Markdown
+
+```markdown
+# My Documentation
+
+<Counter start={10} />
+
+<Alert type="warning">
+  Be careful with this feature!
+</Alert>
+```
+
+## Solid Notes
+
+- **Signals** — `createSignal` returns a getter/setter pair; read state by
+  calling the getter (`count()`), not by reading a value.
+- **Props stay reactive** — do not destructure `props`. Destructuring reads
+  every value once during setup and drops the reactivity.
+- **No virtual DOM** — components run once and updates are applied directly to
+  the DOM nodes that depend on the changed signal.
+
+## File Structure
+
+```
+integ-solid/
+├── docs/
+│   └── index.md
+├── src/
+│   ├── components/
+│   │   ├── Counter.tsx
+│   │   └── Alert.tsx
+│   ├── App.tsx
+│   ├── main.tsx
+│   └── styles.css
+├── index.html
+├── package.json
+├── tsconfig.json
+└── vite.config.ts
+```

--- a/docs/content/examples/integ-solid.md
+++ b/docs/content/examples/integ-solid.md
@@ -5,9 +5,9 @@ Demonstrates embedding Solid components in Markdown.
 ## Setup
 
 ```bash
-cd examples/integ-solid
-npm install
-npm run dev
+# The example depends on workspace packages, so install from the repository root
+corepack pnpm install
+corepack pnpm --filter ./examples/integ-solid dev
 ```
 
 ## Configuration
@@ -97,7 +97,7 @@ export default function Alert(props: {
 
 ## File Structure
 
-```
+```text
 integ-solid/
 ├── docs/
 │   └── index.md

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -95,6 +95,9 @@ vp install @ox-content/vite-plugin-react react react-dom @vitejs/plugin-react
 
 # Svelte
 vp install @ox-content/vite-plugin-svelte svelte @sveltejs/vite-plugin-svelte
+
+# Solid
+vp install @ox-content/vite-plugin-solid solid-js vite-plugin-solid
 ```
 
 Read more:
@@ -104,6 +107,7 @@ Read more:
 - [Vue integration](./packages/vite-plugin-ox-content-vue.md)
 - [React integration](./packages/vite-plugin-ox-content-react.md)
 - [Svelte integration](./packages/vite-plugin-ox-content-svelte.md)
+- [Solid integration](./packages/vite-plugin-ox-content-solid.md)
 - [Theming](./theming.md)
 - [Source docs example](./examples/gen-source-docs.md)
 

--- a/docs/content/mdx.md
+++ b/docs/content/mdx.md
@@ -43,9 +43,14 @@ export default defineConfig({
 });
 ```
 
-Vue and Svelte work the same way via `@ox-content/vite-plugin-vue`
-(`oxContentVue`) and `@ox-content/vite-plugin-svelte` (`oxContentSvelte`). When
-`components` is a glob, the component name is the PascalCased file name.
+Vue, Svelte, and Solid work the same way via `@ox-content/vite-plugin-vue`
+(`oxContentVue`), `@ox-content/vite-plugin-svelte` (`oxContentSvelte`), and
+`@ox-content/vite-plugin-solid` (`oxContentSolid`). When `components` is a glob,
+the component name is the PascalCased file name.
+
+The Solid integration additionally has to run before `vite-plugin-solid`, which
+must be given the Markdown extensions — see
+[its reference page](./packages/vite-plugin-ox-content-solid.md#plugin-order-and-extensions).
 
 ## Authoring components in Markdown
 
@@ -128,3 +133,4 @@ See [Theming](./theming.md) for using it to build a custom layout.
 - [React Integration](./packages/vite-plugin-ox-content-react.md)
 - [Vue Integration](./packages/vite-plugin-ox-content-vue.md)
 - [Svelte Integration](./packages/vite-plugin-ox-content-svelte.md)
+- [Solid Integration](./packages/vite-plugin-ox-content-solid.md)

--- a/docs/content/packages/vite-plugin-ox-content-solid.md
+++ b/docs/content/packages/vite-plugin-ox-content-solid.md
@@ -1,0 +1,176 @@
+# @ox-content/vite-plugin-solid
+
+Solid integration for Ox Content - embed Solid components in Markdown.
+
+## Installation
+
+```bash
+vp install @ox-content/vite-plugin-solid solid-js vite-plugin-solid
+```
+
+## Usage
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import solid from "vite-plugin-solid";
+import { oxContentSolid } from "@ox-content/vite-plugin-solid";
+
+export default defineConfig({
+  plugins: [
+    oxContentSolid({
+      srcDir: "docs",
+      // Auto-discover components with glob pattern
+      components: "./src/components/*.tsx",
+    }),
+    solid({ extensions: [".md", ".markdown", ".mdx"] }),
+  ],
+});
+```
+
+## Plugin Order and `extensions`
+
+Unlike the Vue, React, and Svelte integrations, this plugin has two setup rules
+that are not optional. Both follow from the same fact: **Solid's JSX is
+compile-time only.** There is no runtime element factory like React's
+`createElement` or Vue's `h` to fall back on, so Markdown is emitted as Solid
+JSX and `vite-plugin-solid` is what turns it into DOM or SSR instructions.
+
+1. `oxContentSolid()` must come **before** `solid()` in the `plugins` array.
+   Both plugins are `enforce: "pre"`, so array order decides which one sees the
+   Markdown file first. If `solid()` runs first, Babel tries to parse raw
+   Markdown as JSX.
+2. `solid()` must be given the Markdown extensions. By default it only looks at
+   `.jsx` and `.tsx` files, so the generated modules would be handed to the
+   browser as uncompiled JSX.
+
+Both mistakes are checked for you and reported with the fix — see
+[`verifySolidPlugin`](#verifysolidplugin).
+
+## Options
+
+### components
+
+- Type: `string | string[] | Record<string, string>`
+
+Components to register for use in Markdown. Supports:
+
+#### Glob Pattern (Recommended)
+
+```ts
+// Single pattern
+components: "./src/components/*.tsx";
+
+// Multiple patterns
+components: ["./src/components/*.tsx", "./src/ui/*.tsx"];
+```
+
+Component names are derived from file names in PascalCase:
+
+- `counter.tsx` → `Counter`
+- `my-button.tsx` → `MyButton`
+
+#### Explicit Map
+
+```ts
+components: {
+  Counter: './src/components/Counter.tsx',
+  Alert: './src/components/Alert.tsx',
+}
+```
+
+### verifySolidPlugin
+
+- Type: `boolean`
+- Default: `true`
+
+Fail fast on the two setup mistakes described above instead of letting them
+surface as an unrelated syntax error.
+
+The plugin check runs when the config resolves; the `extensions` check runs the
+first time a Markdown module comes out of the pipeline still uncompiled. Both
+throw a message naming the fix.
+
+Turn it off when Solid's JSX is compiled by something other than
+`vite-plugin-solid`.
+
+## Using Components in Markdown
+
+```markdown
+# My Page
+
+Here's an interactive counter:
+
+<Counter start={5} />
+
+And an alert:
+
+<Alert type="warning">
+  This is a warning message!
+</Alert>
+```
+
+## Example Component
+
+```tsx
+// src/components/Counter.tsx
+import { createSignal } from "solid-js";
+
+export default function Counter(props: { start?: number }) {
+  const [count, setCount] = createSignal(props.start ?? 0);
+
+  return (
+    <div class="counter">
+      <button onClick={() => setCount(count() - 1)}>-</button>
+      <span>{count()}</span>
+      <button onClick={() => setCount(count() + 1)}>+</button>
+    </div>
+  );
+}
+```
+
+Note that `props` is not destructured. Solid props are a reactive proxy, and
+destructuring them reads every value once at setup time, which is what breaks
+reactivity in components ported from React.
+
+## Virtual Modules
+
+- `virtual:ox-content-solid/components` - Registered components
+
+```ts
+import components from "virtual:ox-content-solid/components";
+```
+
+There is no `virtual:ox-content-solid/runtime` counterpart to the Svelte
+integration's: Solid mounts through `render` from `solid-js/web`, which the
+generated modules import directly.
+
+## Islands
+
+Markdown that uses a registered component is emitted with island markers and
+hydrated through `@ox-content/islands`, the same runtime the other framework
+integrations use. Each island is mounted with `render` from `solid-js/web` and
+disposed when the Markdown component unmounts.
+
+Markdown without any registered component skips the island runtime entirely and
+compiles to a single `innerHTML` binding.
+
+## HMR
+
+Components are hot-reloaded when modified. Markdown modules that use a changed
+component are invalidated alongside it.
+
+## Rust and N-API Codegen
+
+The Rust renderer can also emit Solid code directly from rendered Markdown HTML,
+without the Vite pipeline:
+
+```ts
+import { renderFrameworkComponentCode } from "@ox-content/napi";
+
+renderFrameworkComponentCode("<p>Hello</p>", "solid", [], "component");
+```
+
+That path targets `solid-js/h`, Solid's hyperscript entry point, because it has
+to produce code that runs without the JSX compiler. The Vite plugin emits JSX
+instead, which compiles to faster, finer-grained output.

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -122,6 +122,10 @@ export default defineConfig(({ mode }) => {
                     text: "Svelte Integration",
                     link: "/packages/vite-plugin-ox-content-svelte.md",
                   },
+                  {
+                    text: "Solid Integration",
+                    link: "/packages/vite-plugin-ox-content-solid.md",
+                  },
                   { text: "i18n Package", link: "/packages/i18n.md" },
                 ],
               },

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,7 @@ This directory contains runnable projects and small source examples.
 | [integ-vue](./integ-vue)       | Vue 3 + Vite    | Vue component islands in Markdown    |
 | [integ-react](./integ-react)   | React + Vite    | React component islands in Markdown  |
 | [integ-svelte](./integ-svelte) | Svelte 5 + Vite | Svelte component islands in Markdown |
+| [integ-solid](./integ-solid)   | Solid + Vite    | Solid component islands in Markdown  |
 
 ## Site and Tooling
 

--- a/examples/integ-solid/docs/index.md
+++ b/examples/integ-solid/docs/index.md
@@ -1,0 +1,52 @@
+---
+title: Solid Integration Example
+description: Embedding Solid components in Markdown
+---
+
+# Solid Integration Example
+
+Embed Solid components directly in Markdown using `@ox-content/vite-plugin-solid`.
+
+## Interactive Counter
+
+<Counter start={3} />
+
+Backed by Solid signals (`createSignal`) — no virtual DOM.
+
+## Alert Components
+
+<Alert type="info" title="Information">
+Powered by Solid's fine-grained reactivity.
+</Alert>
+
+<Alert type="success" title="Success">
+Components work seamlessly!
+</Alert>
+
+## Configuration
+
+```ts
+// vite.config.ts
+import solid from "vite-plugin-solid";
+import { oxContentSolid } from "@ox-content/vite-plugin-solid";
+
+export default defineConfig({
+  plugins: [
+    oxContentSolid({
+      components: {
+        Counter: "./src/components/Counter.tsx",
+        Alert: "./src/components/Alert.tsx",
+      },
+    }),
+    // Solid's JSX is compile-time only, so Markdown extensions must be listed
+    // here, and this plugin must come after oxContentSolid().
+    solid({ extensions: [".md", ".markdown", ".mdx"] }),
+  ],
+});
+```
+
+## Features
+
+- Solid signals and fine-grained reactivity
+- Hot Module Replacement
+- Island hydration through `@ox-content/islands`

--- a/examples/integ-solid/docs/index.md
+++ b/examples/integ-solid/docs/index.md
@@ -27,6 +27,7 @@ Components work seamlessly!
 
 ```ts
 // vite.config.ts
+import { defineConfig } from "vite-plus";
 import solid from "vite-plugin-solid";
 import { oxContentSolid } from "@ox-content/vite-plugin-solid";
 

--- a/examples/integ-solid/index.html
+++ b/examples/integ-solid/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ox Content + Solid Example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/integ-solid/package.json
+++ b/examples/integ-solid/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "ox-content-integ-solid-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vp dev",
+    "build": "vp build",
+    "preview": "vp preview"
+  },
+  "dependencies": {
+    "@ox-content/islands": "workspace:*",
+    "solid-js": "catalog:"
+  },
+  "devDependencies": {
+    "@ox-content/vite-plugin-solid": "workspace:*",
+    "vite": "catalog:",
+    "vite-plugin-solid": "catalog:",
+    "vite-plus": "catalog:"
+  }
+}

--- a/examples/integ-solid/src/App.tsx
+++ b/examples/integ-solid/src/App.tsx
@@ -1,0 +1,16 @@
+// Import Markdown document as a Solid component
+import IndexDoc from "../docs/index.md";
+
+export default function App() {
+  return (
+    <div class="app">
+      <header>
+        <h1>🦀 Ox Content + Solid</h1>
+        <p>Embed Solid components directly in Markdown</p>
+      </header>
+      <main>
+        <IndexDoc />
+      </main>
+    </div>
+  );
+}

--- a/examples/integ-solid/src/components/Alert.tsx
+++ b/examples/integ-solid/src/components/Alert.tsx
@@ -1,0 +1,14 @@
+import type { JSX } from "solid-js";
+
+export default function Alert(props: {
+  type?: "info" | "success" | "warning";
+  title?: string;
+  children?: JSX.Element;
+}) {
+  return (
+    <div class={`alert alert-${props.type ?? "info"}`}>
+      {props.title ? <strong class="alert-title">{props.title}</strong> : null}
+      <div class="alert-body">{props.children}</div>
+    </div>
+  );
+}

--- a/examples/integ-solid/src/components/Counter.tsx
+++ b/examples/integ-solid/src/components/Counter.tsx
@@ -1,0 +1,13 @@
+import { createSignal } from "solid-js";
+
+export default function Counter(props: { start?: number }) {
+  const [count, setCount] = createSignal(props.start ?? 0);
+
+  return (
+    <div class="counter">
+      <button onClick={() => setCount(count() - 1)}>-</button>
+      <span class="count">{count()}</span>
+      <button onClick={() => setCount(count() + 1)}>+</button>
+    </div>
+  );
+}

--- a/examples/integ-solid/src/main.tsx
+++ b/examples/integ-solid/src/main.tsx
@@ -1,0 +1,5 @@
+import { render } from "solid-js/web";
+import App from "./App";
+import "./styles.css";
+
+render(() => <App />, document.getElementById("app")!);

--- a/examples/integ-solid/src/styles.css
+++ b/examples/integ-solid/src/styles.css
@@ -112,7 +112,7 @@ main li {
   border: none;
   border-radius: 0.25rem;
   background: #ff6b35;
-  color: white;
+  color: #0f0f0f;
   cursor: pointer;
 }
 

--- a/examples/integ-solid/src/styles.css
+++ b/examples/integ-solid/src/styles.css
@@ -1,0 +1,143 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f0f0f;
+  color: #e5e5e5;
+  min-height: 100vh;
+}
+
+.app {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid #333;
+}
+
+header h1 {
+  color: #ff6b35;
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+}
+
+header p {
+  color: #888;
+  font-size: 1.1rem;
+}
+
+main {
+  line-height: 1.8;
+}
+
+main h1,
+main h2,
+main h3 {
+  color: #ff6b35;
+  margin: 2rem 0 1rem;
+}
+
+main h1 {
+  font-size: 2rem;
+}
+main h2 {
+  font-size: 1.5rem;
+}
+main h3 {
+  font-size: 1.25rem;
+}
+
+main p {
+  margin: 1rem 0;
+}
+
+main code {
+  background: #1a1a1a;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-family: "Fira Code", monospace;
+}
+
+main pre {
+  background: #1a1a1a;
+  padding: 1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  margin: 1rem 0;
+}
+
+main pre code {
+  background: transparent;
+  padding: 0;
+}
+
+main ul,
+main ol {
+  margin: 1rem 0;
+  padding-left: 2rem;
+}
+
+main li {
+  margin: 0.5rem 0;
+}
+
+.counter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border: 1px solid #333;
+  border-radius: 0.5rem;
+  background: #1a1a1a;
+}
+
+.counter .count {
+  min-width: 2rem;
+  text-align: center;
+  font-weight: 600;
+  color: #fff;
+}
+
+.counter button {
+  padding: 0.25rem 0.75rem;
+  border: none;
+  border-radius: 0.25rem;
+  background: #ff6b35;
+  color: white;
+  cursor: pointer;
+}
+
+.counter button:hover {
+  background: #e85d2c;
+}
+
+.alert {
+  margin: 1rem 0;
+  padding: 1rem;
+  border-radius: 8px;
+  border-left: 4px solid #ff6b35;
+  background: #1a1a1a;
+}
+
+.alert-success {
+  border-left-color: #3fb950;
+}
+
+.alert-warning {
+  border-left-color: #d29922;
+}
+
+.alert-title {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: #fff;
+}

--- a/examples/integ-solid/src/vite-env.d.ts
+++ b/examples/integ-solid/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+declare module "*.md" {
+  import type { Component } from "solid-js";
+
+  export const frontmatter: Record<string, unknown>;
+  const MarkdownContent: Component;
+  export default MarkdownContent;
+}

--- a/examples/integ-solid/src/vite-env.d.ts
+++ b/examples/integ-solid/src/vite-env.d.ts
@@ -7,3 +7,19 @@ declare module "*.md" {
   const MarkdownContent: Component;
   export default MarkdownContent;
 }
+
+declare module "*.markdown" {
+  import type { Component } from "solid-js";
+
+  export const frontmatter: Record<string, unknown>;
+  const MarkdownContent: Component;
+  export default MarkdownContent;
+}
+
+declare module "*.mdx" {
+  import type { Component } from "solid-js";
+
+  export const frontmatter: Record<string, unknown>;
+  const MarkdownContent: Component;
+  export default MarkdownContent;
+}

--- a/examples/integ-solid/tsconfig.json
+++ b/examples/integ-solid/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "paths": {
+      "@ox-content/vite-plugin-solid": ["../../npm/vite-plugin-ox-content-solid/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"]
+}

--- a/examples/integ-solid/vite.config.ts
+++ b/examples/integ-solid/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vite-plus";
+import solid from "vite-plugin-solid";
+import { oxContentSolid } from "@ox-content/vite-plugin-solid";
+
+export default defineConfig({
+  plugins: [
+    // Order matters: oxContentSolid() turns Markdown into Solid JSX, and
+    // vite-plugin-solid compiles that JSX. Both are `enforce: 'pre'`, so the
+    // array order is what decides which one sees the file first.
+    oxContentSolid({
+      srcDir: "docs",
+      // Auto-discover components using glob pattern
+      components: "./src/components/*.tsx",
+    }),
+    // Solid's JSX is compile-time only, so the Markdown extensions have to be
+    // listed here for the generated modules to be compiled at all.
+    solid({ extensions: [".md", ".markdown", ".mdx"] }),
+  ],
+});

--- a/npm/vite-plugin-ox-content-solid/package.json
+++ b/npm/vite-plugin-ox-content-solid/package.json
@@ -54,6 +54,7 @@
   },
   "peerDependencies": {
     "solid-js": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vite-plugin-solid": "catalog:"
   }
 }

--- a/npm/vite-plugin-ox-content-solid/package.json
+++ b/npm/vite-plugin-ox-content-solid/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@ox-content/vite-plugin-solid",
+  "version": "2.81.0",
+  "description": "Solid integration for Ox Content - Embed Solid components in Markdown",
+  "keywords": [
+    "markdown",
+    "ox-content",
+    "solid",
+    "solid-js",
+    "vite",
+    "vite-plugin"
+  ],
+  "license": "MIT",
+  "author": "ubugeeei",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ubugeeei-prod/ox-content.git",
+    "directory": "npm/vite-plugin-ox-content-solid"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.mts"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "vp pack",
+    "dev": "vp pack --watch",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@ox-content/islands": "workspace:*",
+    "@ox-content/vite-plugin": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "solid-js": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vite-plugin-solid": "catalog:",
+    "vite-plus": "catalog:"
+  },
+  "peerDependencies": {
+    "solid-js": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/npm/vite-plugin-ox-content-solid/src/__snapshots__/transform.test.ts.snap
+++ b/npm/vite-plugin-ox-content-solid/src/__snapshots__/transform.test.ts.snap
@@ -1,0 +1,78 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`transformMarkdownWithSolid > honors disabled built-in embeds from framework options 1`] = `
+"
+export const frontmatter = {};
+
+const rawHtml = "<p><GitHub repo=\\"ubugeeei-prod/ox-content\\"></GitHub></p>\\n";
+
+export default function MarkdownContent() {
+  return <div class="ox-content" innerHTML={rawHtml} />;
+}
+"
+`;
+
+exports[`transformMarkdownWithSolid > turns registered components into islands and leaves fenced tags literal 1`] = `
+"
+import { onCleanup, onMount } from 'solid-js';
+import { render } from 'solid-js/web';
+import { initIslands } from '@ox-content/islands';
+import Alert from '../src/components/Alert.tsx';
+
+export const frontmatter = {"title":"Solid Guide","draft":false};
+
+const rawHtml = "<h1 id=\\"solid-guide\\">Solid Guide</h1>\\n<div data-ox-island=\\"Alert\\" data-ox-props='{\\"tone\\":\\"info\\",\\"active\\":true}' data-ox-content='Read **docs**.'></div>\\n<pre><code class=\\"language-tsx\\">&lt;Alert tone=&quot;code&quot; /&gt;\\n</code></pre>\\n";
+const components = {
+  Alert,
+};
+
+function createSolidHydrate() {
+  return (element, props) => {
+    const componentName = element.dataset.oxIsland;
+    const Component = components[componentName];
+    if (!Component) return;
+
+    // Read the slot content before clearing: the island element still holds the
+    // markup the Markdown transform left behind.
+    const islandContent = element.dataset.oxContent || element.innerHTML;
+    element.innerHTML = '';
+
+    const dispose = render(
+      () =>
+        islandContent
+          ? <Component {...props}><div innerHTML={islandContent} /></Component>
+          : <Component {...props} />,
+      element,
+    );
+
+    return () => dispose();
+  };
+}
+
+export default function MarkdownContent() {
+  let container;
+
+  onMount(() => {
+    if (!container) return;
+    const controller = initIslands(createSolidHydrate(), {
+      selector: '.ox-content [data-ox-island]',
+    });
+    onCleanup(() => controller.destroy());
+  });
+
+  return <div class="ox-content" ref={container} innerHTML={rawHtml} />;
+}
+"
+`;
+
+exports[`transformMarkdownWithSolid > uses the static html path when no registered component is present 1`] = `
+"
+export const frontmatter = {};
+
+const rawHtml = "<h1 id=\\"plain\\">Plain</h1>\\n<Unknown />\\n";
+
+export default function MarkdownContent() {
+  return <div class="ox-content" innerHTML={rawHtml} />;
+}
+"
+`;

--- a/npm/vite-plugin-ox-content-solid/src/codegen.ts
+++ b/npm/vite-plugin-ox-content-solid/src/codegen.ts
@@ -1,0 +1,113 @@
+/**
+ * Generates the Solid module a Markdown file compiles to.
+ *
+ * The output is JSX on purpose. Solid has no runtime element factory to target
+ * — `vite-plugin-solid` compiles this into DOM or SSR instructions — so unlike
+ * the React and Vue integrations there is no factory-call form to emit.
+ */
+
+import * as path from "path";
+import type { ComponentIsland, ResolvedSolidOptions } from "./types";
+
+export function generateSolidModule(
+  content: string,
+  usedComponents: string[],
+  islands: ComponentIsland[],
+  frontmatter: Record<string, unknown>,
+  options: ResolvedSolidOptions & { root?: string },
+  id: string,
+): string {
+  const rawHtml = JSON.stringify(content);
+  const frontmatterLiteral = JSON.stringify(frontmatter);
+
+  // Markdown with no registered component skips the island runtime entirely and
+  // compiles to a single `innerHTML` binding — no imports needed, because Solid
+  // injects whatever its compiled output requires.
+  if (islands.length === 0) {
+    return `
+export const frontmatter = ${frontmatterLiteral};
+
+const rawHtml = ${rawHtml};
+
+export default function MarkdownContent() {
+  return <div class="ox-content" innerHTML={rawHtml} />;
+}
+`;
+  }
+
+  const imports = renderComponentImports(usedComponents, options, id);
+  const componentMap = usedComponents.map((name) => `  ${name},`).join("\n");
+
+  return `
+import { onCleanup, onMount } from 'solid-js';
+import { render } from 'solid-js/web';
+import { initIslands } from '@ox-content/islands';
+${imports}
+
+export const frontmatter = ${frontmatterLiteral};
+
+const rawHtml = ${rawHtml};
+const components = {
+${componentMap}
+};
+
+function createSolidHydrate() {
+  return (element, props) => {
+    const componentName = element.dataset.oxIsland;
+    const Component = components[componentName];
+    if (!Component) return;
+
+    // Read the slot content before clearing: the island element still holds the
+    // markup the Markdown transform left behind.
+    const islandContent = element.dataset.oxContent || element.innerHTML;
+    element.innerHTML = '';
+
+    const dispose = render(
+      () =>
+        islandContent
+          ? <Component {...props}><div innerHTML={islandContent} /></Component>
+          : <Component {...props} />,
+      element,
+    );
+
+    return () => dispose();
+  };
+}
+
+export default function MarkdownContent() {
+  let container;
+
+  onMount(() => {
+    if (!container) return;
+    const controller = initIslands(createSolidHydrate(), {
+      selector: '.ox-content [data-ox-island]',
+    });
+    onCleanup(() => controller.destroy());
+  });
+
+  return <div class="ox-content" ref={container} innerHTML={rawHtml} />;
+}
+`;
+}
+
+/** Rewrites registered component paths as imports relative to the Markdown file. */
+function renderComponentImports(
+  usedComponents: string[],
+  options: ResolvedSolidOptions & { root?: string },
+  id: string,
+): string {
+  const mdDir = path.dirname(id);
+  const root = options.root || process.cwd();
+
+  return usedComponents
+    .map((name) => {
+      const componentPath = options.components[name];
+      if (!componentPath) return "";
+      const absolutePath = path.resolve(root, componentPath.replace(/^\.\//, ""));
+      const relativePath = path.relative(mdDir, absolutePath).replace(/\\/g, "/");
+      const importPath = relativePath.startsWith(".") ? relativePath : "./" + relativePath;
+      return `import ${name} from '${importPath}';`;
+    })
+    .filter(Boolean)
+    .join("\n");
+}

--- a/npm/vite-plugin-ox-content-solid/src/components.test.ts
+++ b/npm/vite-plugin-ox-content-solid/src/components.test.ts
@@ -1,0 +1,36 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+import { resolveComponentsGlob } from "./components";
+
+describe("resolveComponentsGlob", () => {
+  let root = "";
+
+  beforeAll(async () => {
+    root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "ox-content-solid-glob-"));
+    await fs.promises.mkdir(path.join(root, "src/components/nested"), { recursive: true });
+    await fs.promises.writeFile(path.join(root, "src/components/alert.tsx"), "");
+    await fs.promises.writeFile(path.join(root, "src/components/nested/info-box.tsx"), "");
+    await fs.promises.writeFile(path.join(root, "src/components/notes.md"), "");
+  });
+
+  afterAll(async () => {
+    await fs.promises.rm(root, { recursive: true, force: true });
+  });
+
+  it("matches files in a single directory", async () => {
+    expect(await resolveComponentsGlob("./src/components/*.tsx", root)).toEqual({
+      Alert: "./src/components/alert.tsx",
+    });
+  });
+
+  it("keeps the extension filter for recursive patterns", async () => {
+    // `**/*.tsx` splits into more than two segments, so the suffix has to be
+    // read from the last one; otherwise every file (including notes.md) matches.
+    expect(await resolveComponentsGlob("./src/**/*.tsx", root)).toEqual({
+      Alert: "./src/components/alert.tsx",
+      InfoBox: "./src/components/nested/info-box.tsx",
+    });
+  });
+});

--- a/npm/vite-plugin-ox-content-solid/src/components.ts
+++ b/npm/vite-plugin-ox-content-solid/src/components.ts
@@ -42,7 +42,10 @@ async function globFiles(pattern: string, root: string): Promise<string[]> {
 
   const parts = pattern.split("*");
   const baseDir = path.resolve(root, parts[0]);
-  const ext = parts[1] || "";
+  // The suffix to match lives after the last `*`, so patterns that contain more
+  // than one wildcard (`**/*.tsx`) still filter on the file extension instead of
+  // matching every file under `baseDir`.
+  const ext = parts[parts.length - 1] || "";
 
   if (!fs.existsSync(baseDir)) {
     return files;

--- a/npm/vite-plugin-ox-content-solid/src/components.ts
+++ b/npm/vite-plugin-ox-content-solid/src/components.ts
@@ -1,0 +1,81 @@
+/**
+ * Resolves the `components` option into a name → path map, expanding glob
+ * patterns against the Vite project root.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import type { ComponentsMap, ComponentsOption } from "./types";
+
+export async function resolveComponentsGlob(
+  componentsOption: ComponentsOption,
+  root: string,
+): Promise<ComponentsMap> {
+  if (typeof componentsOption === "object" && !Array.isArray(componentsOption)) {
+    return componentsOption;
+  }
+
+  const patterns = Array.isArray(componentsOption) ? componentsOption : [componentsOption];
+  const result: ComponentsMap = {};
+
+  for (const pattern of patterns) {
+    for (const file of await globFiles(pattern, root)) {
+      const baseName = path.basename(file, path.extname(file));
+      const relativePath = "./" + path.relative(root, file).replace(/\\/g, "/");
+      result[toPascalCase(baseName)] = relativePath;
+    }
+  }
+
+  return result;
+}
+
+async function globFiles(pattern: string, root: string): Promise<string[]> {
+  const files: string[] = [];
+
+  if (!pattern.includes("*")) {
+    const fullPath = path.resolve(root, pattern);
+    if (fs.existsSync(fullPath)) {
+      files.push(fullPath);
+    }
+    return files;
+  }
+
+  const parts = pattern.split("*");
+  const baseDir = path.resolve(root, parts[0]);
+  const ext = parts[1] || "";
+
+  if (!fs.existsSync(baseDir)) {
+    return files;
+  }
+
+  if (pattern.includes("**")) {
+    await walkDir(baseDir, files, ext);
+  } else {
+    const entries = await fs.promises.readdir(baseDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isFile() && entry.name.endsWith(ext)) {
+        files.push(path.join(baseDir, entry.name));
+      }
+    }
+  }
+
+  return files;
+}
+
+async function walkDir(dir: string, files: string[], ext: string): Promise<void> {
+  const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      await walkDir(fullPath, files, ext);
+    } else if (entry.isFile() && entry.name.endsWith(ext)) {
+      files.push(fullPath);
+    }
+  }
+}
+
+function toPascalCase(str: string): string {
+  return str.replace(/[-_](\w)/g, (_, c) => c.toUpperCase()).replace(/^\w/, (c) => c.toUpperCase());
+}

--- a/npm/vite-plugin-ox-content-solid/src/environment.ts
+++ b/npm/vite-plugin-ox-content-solid/src/environment.ts
@@ -1,0 +1,32 @@
+import type { EnvironmentOptions } from "vite";
+import type { ResolvedSolidOptions } from "./types";
+
+export function createSolidMarkdownEnvironment(
+  mode: "ssr" | "client",
+  options: ResolvedSolidOptions,
+): EnvironmentOptions {
+  const isSSR = mode === "ssr";
+
+  return {
+    build: {
+      outDir: isSSR ? `${options.outDir}/.ox-content/ssr` : `${options.outDir}/.ox-content/client`,
+      ssr: isSSR,
+      rollupOptions: {
+        output: {
+          format: "esm",
+          entryFileNames: isSSR ? "[name].js" : "[name].[hash].js",
+        },
+      },
+      ...(isSSR && { target: "node18", minify: false }),
+    },
+    resolve: {
+      // `solid` must lead: Solid libraries ship their uncompiled JSX behind that
+      // condition, and the server/client split then comes from `node`/`browser`.
+      conditions: isSSR ? ["solid", "node", "import"] : ["solid", "browser", "import"],
+    },
+    optimizeDeps: {
+      include: isSSR ? [] : ["solid-js", "solid-js/web"],
+      exclude: ["@ox-content/vite-plugin", "@ox-content/vite-plugin-solid"],
+    },
+  };
+}

--- a/npm/vite-plugin-ox-content-solid/src/index.test.ts
+++ b/npm/vite-plugin-ox-content-solid/src/index.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { Plugin, ResolvedConfig } from "vite";
+import { oxContentSolid } from "./index";
+import type { SolidIntegrationOptions } from "./types";
+
+describe("oxContentSolid", () => {
+  it("returns the transform, verify, environment and hmr plugins", () => {
+    const names = pluginNames(oxContentSolid());
+
+    expect(names).toContain("ox-content:solid-transform");
+    expect(names).toContain("ox-content:solid-verify");
+    expect(names).toContain("ox-content:solid-environment");
+    expect(names).toContain("ox-content:solid-hmr");
+  });
+
+  it("accepts a config where vite-plugin-solid runs after it", async () => {
+    await expect(
+      resolveConfigWith({}, ["ox-content:solid-transform", "solid"]),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a config without vite-plugin-solid", async () => {
+    await expect(resolveConfigWith({}, ["ox-content:solid-transform"])).rejects.toThrow(
+      /vite-plugin-solid was not found/,
+    );
+  });
+
+  it("rejects a config where vite-plugin-solid runs first", async () => {
+    // Solid would receive raw Markdown instead of the generated JSX.
+    await expect(resolveConfigWith({}, ["solid", "ox-content:solid-transform"])).rejects.toThrow(
+      /runs before oxContentSolid\(\)/,
+    );
+  });
+
+  it("skips the check when verifySolidPlugin is disabled", async () => {
+    await expect(
+      resolveConfigWith({ verifySolidPlugin: false }, ["ox-content:solid-transform"]),
+    ).resolves.toBeUndefined();
+  });
+
+  it("reports an uncompiled module as a missing extensions entry", () => {
+    const verify = findPlugin(oxContentSolid(), "ox-content:solid-verify");
+    const errors: string[] = [];
+    const context = {
+      error(message: string) {
+        errors.push(message);
+        throw new Error(message);
+      },
+    };
+
+    const runTransform = (code: string, id: string) =>
+      (verify.transform as (this: unknown, code: string, id: string) => unknown).call(
+        context,
+        code,
+        id,
+      );
+
+    expect(() =>
+      runTransform('<div class="ox-content" innerHTML={rawHtml} />', "/docs/a.md"),
+    ).toThrow(/`extensions` option must list the Markdown extensions/);
+
+    // Compiled output and non-Markdown ids pass straight through.
+    expect(runTransform("_$template(`<div class=ox-content>`)", "/docs/a.md")).toBeNull();
+    expect(runTransform('<div class="ox-content" innerHTML={rawHtml} />', "/src/a.ts")).toBeNull();
+  });
+});
+
+function pluginNames(plugins: ReturnType<typeof oxContentSolid>): string[] {
+  return (plugins as Plugin[]).map((plugin) => plugin.name);
+}
+
+function findPlugin(plugins: ReturnType<typeof oxContentSolid>, name: string): Plugin {
+  const plugin = (plugins as Plugin[]).find((candidate) => candidate.name === name);
+  if (!plugin) throw new Error(`plugin ${name} not found`);
+  return plugin;
+}
+
+/**
+ * Drives `configResolved` on the transform plugin with a plugin list standing in
+ * for a resolved Vite config. Only the plugin names matter to the check.
+ */
+async function resolveConfigWith(
+  options: SolidIntegrationOptions,
+  pluginNames: string[],
+): Promise<void> {
+  const transform = findPlugin(oxContentSolid(options), "ox-content:solid-transform");
+  const config = {
+    root: "/repo",
+    plugins: pluginNames.map((name) => ({ name })),
+  } as unknown as ResolvedConfig;
+
+  const hook = transform.configResolved as (config: ResolvedConfig) => void | Promise<void>;
+  await hook.call(transform, config);
+}

--- a/npm/vite-plugin-ox-content-solid/src/index.ts
+++ b/npm/vite-plugin-ox-content-solid/src/index.ts
@@ -1,0 +1,224 @@
+/**
+ * Vite Plugin for Ox Content Solid Integration
+ *
+ * Uses Vite's Environment API to enable embedding Solid components in Markdown.
+ */
+
+import type { Plugin, PluginOption, ResolvedConfig } from "vite";
+import { oxContent } from "@ox-content/vite-plugin";
+import { resolveComponentsGlob } from "./components";
+import { createSolidMarkdownEnvironment } from "./environment";
+import { isMarkdownFilePath, resolveSolidOptions } from "./options";
+import { transformMarkdownWithSolid } from "./transform";
+import {
+  formatSolidPluginError,
+  TRANSFORM_PLUGIN_NAME,
+  UNCOMPILED_JSX_MARKER,
+  verifySolidPluginOrder,
+} from "./verify";
+import type { SolidIntegrationOptions } from "./types";
+
+export type {
+  SolidIntegrationOptions,
+  ResolvedSolidOptions,
+  ComponentsOption,
+  ComponentsMap,
+  BuiltinEmbedOptions,
+  GitHubEmbedOptions,
+  OpenGraphEmbedOptions,
+  ResolvedBuiltinEmbedOptions,
+  SolidTransformResult,
+  ComponentIsland,
+} from "./types";
+
+/**
+ * Creates the Ox Content Solid integration plugin.
+ *
+ * Unlike the React and Svelte integrations, this plugin must be listed **before**
+ * `vite-plugin-solid`, and that plugin must be told about the Markdown
+ * extensions. Markdown is turned into Solid JSX here, and Solid's JSX is
+ * compile-time only — `vite-plugin-solid` is what turns it into DOM or SSR
+ * instructions.
+ *
+ * @example
+ * ```ts
+ * // vite.config.ts
+ * import { defineConfig } from 'vite';
+ * import solid from 'vite-plugin-solid';
+ * import { oxContentSolid } from '@ox-content/vite-plugin-solid';
+ *
+ * export default defineConfig({
+ *   plugins: [
+ *     oxContentSolid({
+ *       srcDir: 'docs',
+ *       components: {
+ *         Counter: './src/components/Counter.tsx',
+ *       },
+ *     }),
+ *     solid({ extensions: ['.md', '.markdown', '.mdx'] }),
+ *   ],
+ * });
+ * ```
+ */
+export function oxContentSolid(options: SolidIntegrationOptions = {}): PluginOption[] {
+  const resolved = resolveSolidOptions(options);
+  let componentMap = new Map<string, string>();
+  let config: ResolvedConfig;
+
+  if (typeof options.components === "object" && !Array.isArray(options.components)) {
+    componentMap = new Map(Object.entries(options.components));
+  }
+
+  const solidTransformPlugin: Plugin = {
+    name: TRANSFORM_PLUGIN_NAME,
+    enforce: "pre",
+
+    async configResolved(resolvedConfig) {
+      config = resolvedConfig;
+
+      if (resolved.verifySolidPlugin) {
+        verifySolidPluginOrder(resolvedConfig);
+      }
+
+      const componentsOption = options.components;
+      if (componentsOption) {
+        const resolvedComponents = await resolveComponentsGlob(componentsOption, config.root);
+        componentMap = new Map(Object.entries(resolvedComponents));
+      }
+    },
+
+    async transform(code, id) {
+      if (!isMarkdownFilePath(id, resolved.extensions)) {
+        return null;
+      }
+
+      const result = await transformMarkdownWithSolid(code, id, {
+        ...resolved,
+        components: Object.fromEntries(componentMap),
+        root: config.root,
+      });
+
+      return {
+        code: result.code,
+        map: result.map,
+      };
+    },
+  };
+
+  // `post` so every `pre`/normal plugin — vite-plugin-solid included — has
+  // already had its turn at the module.
+  const solidVerifyPlugin: Plugin = {
+    name: "ox-content:solid-verify",
+    enforce: "post",
+
+    transform(code, id) {
+      if (!resolved.verifySolidPlugin) return null;
+      if (!isMarkdownFilePath(id, resolved.extensions)) return null;
+      if (!code.includes(UNCOMPILED_JSX_MARKER)) return null;
+
+      this.error(formatSolidPluginError("extensions"));
+    },
+  };
+
+  const solidEnvironmentPlugin: Plugin = {
+    name: "ox-content:solid-environment",
+
+    config() {
+      const envOptions = {
+        ...resolved,
+        components: Object.fromEntries(componentMap),
+      };
+      return {
+        environments: {
+          oxcontent_ssr: createSolidMarkdownEnvironment("ssr", envOptions),
+          oxcontent_client: createSolidMarkdownEnvironment("client", envOptions),
+        },
+      };
+    },
+
+    resolveId(id) {
+      if (id === "virtual:ox-content-solid/components") {
+        return "\0virtual:ox-content-solid/components";
+      }
+      return null;
+    },
+
+    load(id) {
+      if (id === "\0virtual:ox-content-solid/components") {
+        return generateComponentsModule(componentMap);
+      }
+      return null;
+    },
+
+    applyToEnvironment(environment) {
+      return ["oxcontent_ssr", "oxcontent_client", "client", "ssr"].includes(environment.name);
+    },
+  };
+
+  const solidHmrPlugin: Plugin = {
+    name: "ox-content:solid-hmr",
+    apply: "serve",
+
+    handleHotUpdate({ file, server, modules }) {
+      const isComponent = Array.from(componentMap.values()).some((path) =>
+        file.endsWith(path.replace(/^\.\//, "")),
+      );
+
+      if (isComponent) {
+        const mdModules = Array.from(server.moduleGraph.idToModuleMap.values()).filter(
+          (mod) => mod.file && isMarkdownFilePath(mod.file, resolved.extensions),
+        );
+
+        if (mdModules.length > 0) {
+          server.ws.send({
+            type: "custom",
+            event: "ox-content:solid-update",
+            data: { file },
+          });
+          return [...modules, ...mdModules];
+        }
+      }
+
+      return modules;
+    },
+  };
+
+  const basePlugins = oxContent(options).flatMap((plugin) =>
+    Array.isArray(plugin) ? plugin : [plugin],
+  ) as Plugin[];
+  const environmentPlugin = basePlugins.find((plugin) => plugin.name === "ox-content:environment");
+  const plugins: Plugin[] = [
+    solidTransformPlugin,
+    solidVerifyPlugin,
+    solidEnvironmentPlugin,
+    solidHmrPlugin,
+  ];
+
+  if (environmentPlugin) {
+    plugins.push(environmentPlugin);
+  }
+
+  return plugins;
+}
+
+function generateComponentsModule(componentMap: Map<string, string>): string {
+  const imports: string[] = [];
+  const exports: string[] = [];
+
+  componentMap.forEach((path, name) => {
+    imports.push(`import ${name} from '${path}';`);
+    exports.push(`  ${name},`);
+  });
+
+  return `
+${imports.join("\n")}
+
+export const components = {
+${exports.join("\n")}
+};
+
+export default components;
+`;
+}
+
+export { oxContent } from "@ox-content/vite-plugin";

--- a/npm/vite-plugin-ox-content-solid/src/markdown.ts
+++ b/npm/vite-plugin-ox-content-solid/src/markdown.ts
@@ -1,0 +1,216 @@
+/**
+ * Markdown-side scanning shared by the Solid transform: locating component
+ * tags, keeping fenced samples literal, and round-tripping islands through the
+ * rendered HTML as placeholder markers.
+ */
+
+import type { ComponentIsland, ComponentsMap } from "./types";
+
+const COMPONENT_REGEX = /<([A-Z][a-zA-Z0-9]*)\s*([^>]*?)\s*(?:\/>|>([\s\S]*?)<\/\1>)/g;
+const PROP_REGEX = /([a-zA-Z0-9-]+)(?:=(?:"([^"]*)"|'([^']*)'|{([^}]*)}|\[([^\]]*)\]))?/g;
+
+const ISLAND_MARKER_PREFIX = "OXCONTENT-ISLAND-";
+const ISLAND_MARKER_SUFFIX = "-PLACEHOLDER";
+
+interface Range {
+  start: number;
+  end: number;
+}
+
+export interface ScannedMarkdown {
+  /** Markdown with component tags replaced by island placeholder markers. */
+  content: string;
+  islands: ComponentIsland[];
+  usedComponents: string[];
+}
+
+/**
+ * Replaces every registered component tag with a placeholder marker that
+ * survives Markdown rendering, so the island can be re-attached to the produced
+ * HTML afterwards. Tags inside fenced code blocks are left as literal text.
+ */
+export function scanComponents(markdown: string, components: ComponentsMap): ScannedMarkdown {
+  const usedComponents: string[] = [];
+  const islands: ComponentIsland[] = [];
+  const fenceRanges = collectFenceRanges(markdown);
+
+  let islandIndex = 0;
+  let content = "";
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  COMPONENT_REGEX.lastIndex = 0;
+  while ((match = COMPONENT_REGEX.exec(markdown)) !== null) {
+    const [fullMatch, componentName, propsString, rawIslandContent] = match;
+    const matchStart = match.index;
+    const matchEnd = matchStart + fullMatch.length;
+
+    if (
+      !Object.prototype.hasOwnProperty.call(components, componentName) ||
+      isInRanges(matchStart, matchEnd, fenceRanges)
+    ) {
+      content += markdown.slice(lastIndex, matchEnd);
+      lastIndex = matchEnd;
+      continue;
+    }
+
+    if (!usedComponents.includes(componentName)) {
+      usedComponents.push(componentName);
+    }
+
+    const islandId = `ox-island-${islandIndex++}`;
+    islands.push({
+      name: componentName,
+      props: parseProps(propsString),
+      position: matchStart,
+      id: islandId,
+      content: typeof rawIslandContent === "string" ? rawIslandContent.trim() : undefined,
+    });
+
+    content += markdown.slice(lastIndex, matchStart) + createIslandMarker(islandId);
+    lastIndex = matchEnd;
+  }
+
+  content += markdown.slice(lastIndex);
+
+  return { content, islands, usedComponents };
+}
+
+/** Swaps the placeholder markers in rendered HTML for island mount points. */
+export function injectIslandMarkers(html: string, islands: ComponentIsland[]): string {
+  let output = html;
+
+  for (const island of islands) {
+    const marker = createIslandMarker(island.id);
+    const propsAttr =
+      Object.keys(island.props).length > 0
+        ? ` data-ox-props='${JSON.stringify(island.props).replace(/'/g, "&#39;")}'`
+        : "";
+    const contentAttr = island.content
+      ? ` data-ox-content='${island.content.replace(/'/g, "&#39;")}'`
+      : "";
+    const attrs = `data-ox-island="${island.name}"${propsAttr}${contentAttr}`;
+    output = output.replaceAll(`<p>${marker}</p>`, `<div ${attrs}></div>`);
+    output = output.replaceAll(marker, `<span ${attrs}></span>`);
+  }
+
+  return output;
+}
+
+export function extractFrontmatter(content: string): {
+  content: string;
+  frontmatter: Record<string, unknown>;
+} {
+  const frontmatterRegex = /^---\n([\s\S]*?)\n---\n/;
+  const match = frontmatterRegex.exec(content);
+
+  if (!match) {
+    return { content, frontmatter: {} };
+  }
+
+  const frontmatter: Record<string, unknown> = {};
+
+  for (const line of match[1].split("\n")) {
+    const colonIndex = line.indexOf(":");
+    if (colonIndex > 0) {
+      const key = line.slice(0, colonIndex).trim();
+      let value: unknown = line.slice(colonIndex + 1).trim();
+      try {
+        value = JSON.parse(value as string);
+      } catch {
+        if (
+          typeof value === "string" &&
+          ((value.startsWith('"') && value.endsWith('"')) ||
+            (value.startsWith("'") && value.endsWith("'")))
+        ) {
+          value = value.slice(1, -1);
+        }
+      }
+      frontmatter[key] = value;
+    }
+  }
+
+  return { content: content.slice(match[0].length), frontmatter };
+}
+
+function createIslandMarker(islandId: string): string {
+  return `${ISLAND_MARKER_PREFIX}${islandId}${ISLAND_MARKER_SUFFIX}`;
+}
+
+function collectFenceRanges(content: string): Range[] {
+  const ranges: Range[] = [];
+  let inFence = false;
+  let fenceChar = "";
+  let fenceLength = 0;
+  let fenceStart = 0;
+  let pos = 0;
+
+  while (pos < content.length) {
+    const lineEnd = content.indexOf("\n", pos);
+    const next = lineEnd === -1 ? content.length : lineEnd + 1;
+    const line = content.slice(pos, lineEnd === -1 ? content.length : lineEnd);
+    const fenceMatch = line.match(/^\s{0,3}([`~]{3,})/);
+
+    if (fenceMatch) {
+      const marker = fenceMatch[1];
+      if (!inFence) {
+        inFence = true;
+        fenceChar = marker[0];
+        fenceLength = marker.length;
+        fenceStart = pos;
+      } else if (marker[0] === fenceChar && marker.length >= fenceLength) {
+        inFence = false;
+        ranges.push({ start: fenceStart, end: next });
+        fenceChar = "";
+        fenceLength = 0;
+      }
+    }
+
+    pos = next;
+  }
+
+  if (inFence) {
+    ranges.push({ start: fenceStart, end: content.length });
+  }
+
+  return ranges;
+}
+
+function isInRanges(start: number, end: number, ranges: Range[]): boolean {
+  for (const range of ranges) {
+    if (start < range.end && end > range.start) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function parseProps(propsString: string): Record<string, unknown> {
+  const props: Record<string, unknown> = {};
+  if (!propsString) return props;
+
+  PROP_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = PROP_REGEX.exec(propsString)) !== null) {
+    const [, name, doubleQuoted, singleQuoted, braceValue, bracketValue] = match;
+    if (!name) continue;
+
+    if (doubleQuoted !== undefined) props[name] = doubleQuoted;
+    else if (singleQuoted !== undefined) props[name] = singleQuoted;
+    else if (braceValue !== undefined) {
+      try {
+        props[name] = JSON.parse(braceValue);
+      } catch {
+        props[name] = braceValue;
+      }
+    } else if (bracketValue !== undefined) {
+      try {
+        props[name] = JSON.parse(`[${bracketValue}]`);
+      } catch {
+        props[name] = bracketValue;
+      }
+    } else props[name] = true;
+  }
+
+  return props;
+}

--- a/npm/vite-plugin-ox-content-solid/src/options.ts
+++ b/npm/vite-plugin-ox-content-solid/src/options.ts
@@ -1,0 +1,69 @@
+import type { BuiltinEmbedOptions, ResolvedSolidOptions, SolidIntegrationOptions } from "./types";
+
+const DEFAULT_MARKDOWN_EXTENSIONS = [".md", ".markdown", ".mdx"] as const;
+
+export function resolveSolidOptions(
+  options: SolidIntegrationOptions,
+): Omit<ResolvedSolidOptions, "components"> {
+  return {
+    srcDir: options.srcDir ?? "docs",
+    outDir: options.outDir ?? "dist",
+    base: options.base ?? "/",
+    extensions: normalizeMarkdownExtensions(options.extensions),
+    gfm: options.gfm ?? true,
+    autolinks: options.autolinks ?? options.gfm ?? true,
+    frontmatter: options.frontmatter ?? true,
+    toc: options.toc ?? true,
+    tocMaxDepth: options.tocMaxDepth ?? 3,
+    codeAnnotations: resolveCodeAnnotationsOptions(options.codeAnnotations),
+    verifySolidPlugin: options.verifySolidPlugin ?? true,
+    embeds: resolveBuiltinEmbedOptions(options.embeds),
+  };
+}
+
+export function normalizeMarkdownExtensions(extensions?: readonly string[]): string[] {
+  const values = extensions?.length ? extensions : DEFAULT_MARKDOWN_EXTENSIONS;
+  return Array.from(
+    new Map(
+      values.map((extension) => {
+        const value = extension.startsWith(".") ? extension : `.${extension}`;
+        return [value.toLowerCase(), value] as const;
+      }),
+    ).values(),
+  );
+}
+
+export function isMarkdownFilePath(filePath: string, extensions: readonly string[]): boolean {
+  const pathname = filePath.split("?")[0].split("#")[0].toLowerCase();
+  return extensions.some((extension) => pathname.endsWith(extension.toLowerCase()));
+}
+
+function resolveCodeAnnotationsOptions(
+  options: SolidIntegrationOptions["codeAnnotations"],
+): ResolvedSolidOptions["codeAnnotations"] {
+  if (!options) {
+    return { enabled: false, metaKey: "annotate" };
+  }
+
+  if (options === true) {
+    return { enabled: true, metaKey: "annotate" };
+  }
+
+  return { enabled: true, metaKey: options.metaKey ?? "annotate" };
+}
+
+function resolveBuiltinEmbedOptions(
+  options: BuiltinEmbedOptions | false | undefined,
+): ResolvedSolidOptions["embeds"] {
+  if (options === false) return { github: false, openGraph: false };
+  return {
+    github: resolveSingleEmbedOptions(options?.github),
+    openGraph: resolveSingleEmbedOptions(options?.openGraph),
+  };
+}
+
+function resolveSingleEmbedOptions<T extends object>(options: boolean | T | undefined): T | false {
+  if (options === false) return false;
+  if (options === true || options === undefined) return {} as T;
+  return options;
+}

--- a/npm/vite-plugin-ox-content-solid/src/transform.test.ts
+++ b/npm/vite-plugin-ox-content-solid/src/transform.test.ts
@@ -62,6 +62,20 @@ describe("transformMarkdownWithSolid", () => {
     expect(result.code).not.toContain("createElement");
   });
 
+  it("keeps the frontmatter block in the document when frontmatter parsing is off", async () => {
+    const source = ["---", "title: Solid Guide", "---", "# Solid Guide"].join("\n");
+
+    const result = await transformMarkdownWithSolid(
+      source,
+      "/repo/docs/no-frontmatter.md",
+      createOptions({ frontmatter: false }),
+    );
+
+    expect(result.frontmatter).toEqual({});
+    expect(result.code).toContain("export const frontmatter = {};");
+    expect(result.code).toContain("title: Solid Guide");
+  });
+
   it("mounts islands through solid-js/web render", async () => {
     const result = await transformMarkdownWithSolid(
       '<Alert tone="info">Body</Alert>',

--- a/npm/vite-plugin-ox-content-solid/src/transform.test.ts
+++ b/npm/vite-plugin-ox-content-solid/src/transform.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vite-plus/test";
+import { transformMarkdownWithSolid } from "./transform";
+import type { ResolvedSolidOptions } from "./types";
+
+describe("transformMarkdownWithSolid", () => {
+  it("turns registered components into islands and leaves fenced tags literal", async () => {
+    const result = await transformMarkdownWithSolid(
+      [
+        "---",
+        "title: Solid Guide",
+        "draft: false",
+        "---",
+        "# Solid Guide",
+        "",
+        '<Alert tone="info" active>Read **docs**.</Alert>',
+        "",
+        "```tsx",
+        '<Alert tone="code" />',
+        "```",
+      ].join("\n"),
+      "/repo/docs/solid.md",
+      createOptions(),
+    );
+
+    expect(result.frontmatter).toEqual({ title: "Solid Guide", draft: false });
+    expect(result.usedComponents).toEqual(["Alert"]);
+    expect(result.code).toMatchSnapshot();
+  });
+
+  it("uses the static html path when no registered component is present", async () => {
+    const result = await transformMarkdownWithSolid(
+      "# Plain\n\n<Unknown />",
+      "/repo/docs/plain.md",
+      createOptions(),
+    );
+
+    expect(result.usedComponents).toEqual([]);
+    expect(result.code).toMatchSnapshot();
+  });
+
+  it("honors disabled built-in embeds from framework options", async () => {
+    const result = await transformMarkdownWithSolid(
+      '<GitHub repo="ubugeeei-prod/ox-content"></GitHub>',
+      "/repo/docs/embed.md",
+      createOptions({ embeds: { github: false, openGraph: false } }),
+    );
+
+    expect(result.code).toMatchSnapshot();
+  });
+
+  it("emits Solid JSX rather than a runtime element factory", async () => {
+    const result = await transformMarkdownWithSolid(
+      "# Static",
+      "/repo/docs/static.md",
+      createOptions(),
+    );
+
+    // Solid has no runtime JSX factory: the generated module stays JSX and is
+    // compiled by vite-plugin-solid. The `class` (not `className`) attribute is
+    // part of that contract.
+    expect(result.code).toContain('<div class="ox-content" innerHTML={rawHtml} />');
+    expect(result.code).not.toContain("createElement");
+  });
+
+  it("mounts islands through solid-js/web render", async () => {
+    const result = await transformMarkdownWithSolid(
+      '<Alert tone="info">Body</Alert>',
+      "/repo/docs/island.md",
+      createOptions(),
+    );
+
+    expect(result.code).toContain(`import { render } from 'solid-js/web';`);
+    expect(result.code).toContain(`import { onCleanup, onMount } from 'solid-js';`);
+    expect(result.code).toContain("initIslands(createSolidHydrate()");
+  });
+});
+
+function createOptions(overrides: Partial<ResolvedSolidOptions> = {}): ResolvedSolidOptions {
+  return {
+    srcDir: "docs",
+    outDir: "dist",
+    base: "/",
+    extensions: [".md", ".markdown", ".mdx"],
+    gfm: true,
+    autolinks: true,
+    frontmatter: true,
+    toc: true,
+    tocMaxDepth: 3,
+    codeAnnotations: { enabled: false, metaKey: "annotate" },
+    components: { Alert: "./src/components/Alert.tsx" },
+    verifySolidPlugin: true,
+    embeds: { github: false, openGraph: false },
+    root: "/repo",
+    ...overrides,
+  };
+}

--- a/npm/vite-plugin-ox-content-solid/src/transform.ts
+++ b/npm/vite-plugin-ox-content-solid/src/transform.ts
@@ -1,0 +1,92 @@
+import { transformMarkdown as baseTransformMarkdown } from "@ox-content/vite-plugin";
+import { generateSolidModule } from "./codegen";
+import { extractFrontmatter, injectIslandMarkers, scanComponents } from "./markdown";
+import type { ResolvedSolidOptions, SolidTransformResult } from "./types";
+
+export async function transformMarkdownWithSolid(
+  code: string,
+  id: string,
+  options: ResolvedSolidOptions,
+): Promise<SolidTransformResult> {
+  const { content: markdownContent, frontmatter } = extractFrontmatter(code);
+  const scanned = scanComponents(markdownContent, options.components);
+
+  const transformed = await baseTransformMarkdown(scanned.content, id, createBaseOptions(options));
+
+  const htmlWithIslands = injectIslandMarkers(transformed.html, scanned.islands);
+
+  return {
+    code: generateSolidModule(
+      htmlWithIslands,
+      scanned.usedComponents,
+      scanned.islands,
+      frontmatter,
+      options,
+      id,
+    ),
+    map: null,
+    usedComponents: scanned.usedComponents,
+    frontmatter,
+  };
+}
+
+/**
+ * Options handed to the core Markdown transform.
+ *
+ * The site-level features (SSG, search, OG images, highlighting) are turned off
+ * here: this path only produces the HTML that gets embedded in a Solid module,
+ * and the host app owns everything around it. Frontmatter is stripped before
+ * this point, so the core parser sees a body-only document.
+ */
+function createBaseOptions(
+  options: ResolvedSolidOptions,
+): Parameters<typeof baseTransformMarkdown>[2] {
+  return {
+    srcDir: options.srcDir,
+    outDir: options.outDir,
+    base: options.base,
+    extensions: options.extensions,
+    ssg: {
+      enabled: false,
+      extension: ".html",
+      clean: false,
+      bare: false,
+      generateOgImage: false,
+      lastUpdated: false,
+    },
+    gfm: options.gfm,
+    frontmatter: false,
+    toc: options.toc,
+    tocMaxDepth: options.tocMaxDepth,
+    codeAnnotations: options.codeAnnotations,
+    footnotes: true,
+    tables: true,
+    taskLists: true,
+    strikethrough: true,
+    autolinks: options.autolinks,
+    highlight: false,
+    highlightTheme: "github-dark",
+    highlightLangs: [],
+    mermaid: false,
+    ogImage: false,
+    ogImageOptions: {
+      vuePlugin: "vitejs",
+      width: 1200,
+      height: 630,
+      cache: true,
+      concurrency: 1,
+    },
+    transformers: [],
+    docs: false,
+    ogViewer: false,
+    search: {
+      enabled: false,
+      limit: 10,
+      prefix: true,
+      placeholder: "Search...",
+      hotkey: "k",
+    },
+    embeds: options.embeds,
+    i18n: false,
+  } as unknown as Parameters<typeof baseTransformMarkdown>[2];
+}

--- a/npm/vite-plugin-ox-content-solid/src/transform.ts
+++ b/npm/vite-plugin-ox-content-solid/src/transform.ts
@@ -8,7 +8,9 @@ export async function transformMarkdownWithSolid(
   id: string,
   options: ResolvedSolidOptions,
 ): Promise<SolidTransformResult> {
-  const { content: markdownContent, frontmatter } = extractFrontmatter(code);
+  const { content: markdownContent, frontmatter } = options.frontmatter
+    ? extractFrontmatter(code)
+    : { content: code, frontmatter: {} as Record<string, unknown> };
   const scanned = scanComponents(markdownContent, options.components);
 
   const transformed = await baseTransformMarkdown(scanned.content, id, createBaseOptions(options));
@@ -35,8 +37,9 @@ export async function transformMarkdownWithSolid(
  *
  * The site-level features (SSG, search, OG images, highlighting) are turned off
  * here: this path only produces the HTML that gets embedded in a Solid module,
- * and the host app owns everything around it. Frontmatter is stripped before
- * this point, so the core parser sees a body-only document.
+ * and the host app owns everything around it. Frontmatter is handled by this
+ * plugin (or left untouched when `frontmatter: false`), so the core parser never
+ * needs to look at it.
  */
 function createBaseOptions(
   options: ResolvedSolidOptions,

--- a/npm/vite-plugin-ox-content-solid/src/types.ts
+++ b/npm/vite-plugin-ox-content-solid/src/types.ts
@@ -1,0 +1,238 @@
+import type { OxContentOptions } from "@ox-content/vite-plugin";
+
+/**
+ * Code annotation options for the Solid integration.
+ *
+ * The Solid integration supports the same opt-in fence metadata as the core
+ * plugin, but only exposes the attribute key because rendering is handled by
+ * the Solid markdown transform.
+ */
+export interface CodeAnnotationsOptions {
+  /**
+   * Attribute name read from the code fence meta string.
+   *
+   * @default 'annotate'
+   */
+  metaKey?: string;
+}
+
+export interface ResolvedCodeAnnotationsOptions {
+  enabled: boolean;
+  metaKey: string;
+}
+
+/**
+ * Map from Markdown component names to import paths.
+ */
+export type ComponentsMap = Record<string, string>;
+
+/**
+ * Component registration options.
+ *
+ * Can be a map, a glob pattern, or an array of glob patterns.
+ * Globbed components are resolved relative to the Vite project root during
+ * `configResolved`.
+ */
+export type ComponentsOption = ComponentsMap | string | string[];
+
+/**
+ * Solid integration plugin options.
+ *
+ * This extends the core ox-content options with Solid component registration.
+ * Markdown files are transformed into Solid JSX modules while the core plugin
+ * still provides shared parsing, embeds, and environment setup.
+ *
+ * Solid has no runtime JSX factory, so the generated modules must still be
+ * compiled by `vite-plugin-solid`. See {@link SolidIntegrationOptions.verifySolidPlugin}.
+ */
+export interface SolidIntegrationOptions extends OxContentOptions {
+  /**
+   * Markdown-like file extensions to process.
+   *
+   * Values are normalized with a leading dot before matching file paths.
+   *
+   * @default ['.md', '.markdown', '.mdx']
+   */
+  extensions?: string[];
+
+  /**
+   * Components to register for use in Markdown.
+   *
+   * Can be a map of names to paths, a glob pattern, or an array of globs.
+   * When using glob patterns, component names are derived from file names.
+   *
+   * @default {}
+   *
+   * @example
+   * ```ts
+   * // Glob pattern (recommended)
+   * components: './src/components/*.tsx'
+   *
+   * // Explicit map
+   * components: { Counter: './src/components/Counter.tsx' }
+   * ```
+   */
+  components?: ComponentsOption;
+
+  /**
+   * Enable opt-in line annotations for fenced code blocks.
+   *
+   * Pass `true` to use the default `annotate` meta key, or an object to change it.
+   *
+   * @default false
+   */
+  codeAnnotations?: boolean | CodeAnnotationsOptions;
+
+  /**
+   * Fail fast when `vite-plugin-solid` cannot compile the generated modules.
+   *
+   * Markdown files are emitted as Solid JSX, and Solid's JSX has no runtime
+   * factory to fall back on: it only works after `babel-preset-solid` has
+   * compiled it. `vite-plugin-solid` only looks at `.jsx`/`.tsx` ids unless its
+   * own `extensions` option lists the Markdown extensions too, so a missing
+   * entry surfaces as an opaque syntax error in an unrelated file.
+   *
+   * With this enabled the plugin checks the resolved plugin list and throws a
+   * message naming the extensions that are missing. Turn it off when Solid JSX
+   * is compiled by something other than `vite-plugin-solid`.
+   *
+   * @default true
+   *
+   * @example
+   * ```ts
+   * plugins: [
+   *   solid({ extensions: ['.md', '.markdown', '.mdx'] }),
+   *   oxContentSolid({ srcDir: 'docs' }),
+   * ]
+   * ```
+   */
+  verifySolidPlugin?: boolean;
+
+  /**
+   * Built-in static embeds rendered during Markdown transformation.
+   *
+   * Set to `false` to disable all built-in embeds.
+   * Configure individual fetch-related options under `github` and `openGraph`.
+   *
+   * @default { github: true, openGraph: true }
+   */
+  embeds?: BuiltinEmbedOptions | false;
+}
+
+/**
+ * Fetch options for Solid GitHub embeds.
+ */
+export interface GitHubEmbedOptions {
+  /**
+   * GitHub API token used for higher rate limits and private repository access.
+   * @default ''
+   */
+  token?: string;
+
+  /**
+   * Cache fetched repository and source data in memory for the current process.
+   * @default true
+   */
+  cache?: boolean;
+
+  /**
+   * Cache TTL in milliseconds.
+   * @default 3600000
+   */
+  cacheTTL?: number;
+
+  /**
+   * Maximum source file size to inline in bytes.
+   * @default 200000
+   */
+  maxSourceBytes?: number;
+
+  /**
+   * Maximum source lines to inline when no line range is specified.
+   * @default 120
+   */
+  maxSourceLines?: number;
+}
+
+/**
+ * Fetch options for Solid Open Graph embeds.
+ */
+export interface OpenGraphEmbedOptions {
+  /**
+   * Request timeout in milliseconds.
+   * @default 10000
+   */
+  timeout?: number;
+
+  /**
+   * Cache fetched Open Graph metadata in memory for the current process.
+   * @default true
+   */
+  cache?: boolean;
+
+  /**
+   * Cache TTL in milliseconds.
+   * @default 3600000
+   */
+  cacheTTL?: number;
+
+  /**
+   * User agent sent with metadata fetch requests.
+   * @default 'ox-content-ogp-bot/1.0 (compatible; +https://github.com/ubugeeei-prod/ox-content)'
+   */
+  userAgent?: string;
+}
+
+/**
+ * Built-in embed options for the Solid integration.
+ */
+export interface BuiltinEmbedOptions {
+  /**
+   * Render `<GitHub repo="owner/name" />` repository cards.
+   * @default true
+   */
+  github?: boolean | GitHubEmbedOptions;
+
+  /**
+   * Render `<OgCard url="https://example.com" />` Open Graph link cards.
+   * @default true
+   */
+  openGraph?: boolean | OpenGraphEmbedOptions;
+}
+
+export interface ResolvedBuiltinEmbedOptions {
+  github: GitHubEmbedOptions | false;
+  openGraph: OpenGraphEmbedOptions | false;
+}
+
+export interface ResolvedSolidOptions {
+  srcDir: string;
+  outDir: string;
+  base: string;
+  extensions: string[];
+  gfm: boolean;
+  autolinks: boolean;
+  frontmatter: boolean;
+  toc: boolean;
+  tocMaxDepth: number;
+  codeAnnotations: ResolvedCodeAnnotationsOptions;
+  components: ComponentsMap;
+  verifySolidPlugin: boolean;
+  embeds: ResolvedBuiltinEmbedOptions;
+  root?: string;
+}
+
+export interface SolidTransformResult {
+  code: string;
+  map: null;
+  usedComponents: string[];
+  frontmatter: Record<string, unknown>;
+}
+
+export interface ComponentIsland {
+  name: string;
+  props: Record<string, unknown>;
+  position: number;
+  id: string;
+  content?: string;
+}

--- a/npm/vite-plugin-ox-content-solid/src/verify.ts
+++ b/npm/vite-plugin-ox-content-solid/src/verify.ts
@@ -1,0 +1,61 @@
+/**
+ * Guards against the two ways `vite-plugin-solid` can fail to compile the
+ * Markdown modules this plugin emits.
+ *
+ * Both are configuration mistakes with silent-until-cryptic failure modes, so
+ * each is checked as early as it can be observed: plugin presence and ordering
+ * are known once the config resolves, while the `extensions` option is held in
+ * the Solid plugin's closure and can only be inferred from whether the generated
+ * JSX actually got compiled.
+ */
+
+import type { ResolvedConfig } from "vite";
+
+export const TRANSFORM_PLUGIN_NAME = "ox-content:solid-transform";
+
+const SOLID_PLUGIN_NAME = "solid";
+
+/**
+ * Emitted by both generated module shapes. Solid's JSX has no runtime factory,
+ * so this attribute only survives into the final module when nothing compiled
+ * the JSX away — which is exactly the misconfiguration worth reporting.
+ */
+export const UNCOMPILED_JSX_MARKER = "innerHTML={rawHtml}";
+
+export function formatSolidPluginError(reason: "missing" | "ordering" | "extensions"): string {
+  const example = [
+    "  plugins: [",
+    "    oxContentSolid({ srcDir: 'docs' }),",
+    "    solid({ extensions: ['.md', '.markdown', '.mdx'] }),",
+    "  ]",
+  ].join("\n");
+
+  const detail = {
+    missing:
+      "vite-plugin-solid was not found in the Vite config. Markdown files are emitted as Solid JSX, which only runs after babel-preset-solid compiles it.",
+    ordering:
+      "vite-plugin-solid runs before oxContentSolid(), so it sees raw Markdown instead of the generated JSX. Both plugins are `enforce: 'pre'`, so their order follows the `plugins` array.",
+    extensions:
+      "vite-plugin-solid did not compile the generated Markdown module. Its `extensions` option must list the Markdown extensions; by default it only looks at .jsx/.tsx files.",
+  }[reason];
+
+  return `[ox-content:solid] ${detail}\n\n${example}\n`;
+}
+
+/**
+ * Throws when `vite-plugin-solid` is absent, or placed where it would see raw
+ * Markdown instead of the JSX this plugin generates.
+ */
+export function verifySolidPluginOrder(config: ResolvedConfig): void {
+  const names = config.plugins.map((plugin) => plugin.name);
+  const solidIndex = names.indexOf(SOLID_PLUGIN_NAME);
+
+  if (solidIndex === -1) {
+    throw new Error(formatSolidPluginError("missing"));
+  }
+
+  const transformIndex = names.indexOf(TRANSFORM_PLUGIN_NAME);
+  if (transformIndex !== -1 && solidIndex < transformIndex) {
+    throw new Error(formatSolidPluginError("ordering"));
+  }
+}

--- a/npm/vite-plugin-ox-content-solid/tsconfig.json
+++ b/npm/vite-plugin-ox-content-solid/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"],
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/npm/vite-plugin-ox-content-solid/vite.config.ts
+++ b/npm/vite-plugin-ox-content-solid/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite-plus";
+import { defineConfig as definePackConfig } from "vite-plus/pack";
+
+export default defineConfig({
+  fmt: {
+    ignorePatterns: ["dist/**"],
+  },
+  pack: definePackConfig({
+    entry: ["src/index.ts"],
+    format: ["esm", "cjs"],
+    dts: true,
+    clean: true,
+    hash: false,
+    deps: {
+      neverBundle: ["vite", "solid-js", "@ox-content/vite-plugin"],
+    },
+  }),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,7 +209,7 @@ importers:
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.8.1
-        version: 3.8.1(@emnapi/runtime@1.9.2)(@types/node@26.1.2)
+        version: 3.8.1(@emnapi/runtime@1.11.2)(@types/node@26.1.2)
 
   deploy: {}
 
@@ -4061,12 +4061,8 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
-
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -8422,7 +8418,7 @@ snapshots:
       '@napi-rs/canvas-win32-x64-msvc': 0.1.100
     optional: true
 
-  '@napi-rs/cli@3.8.1(@emnapi/runtime@1.9.2)(@types/node@26.1.2)':
+  '@napi-rs/cli@3.8.1(@emnapi/runtime@1.11.2)(@types/node@26.1.2)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@26.1.2)
       '@napi-rs/cross-toolchain': 1.0.3
@@ -8438,7 +8434,7 @@ snapshots:
       typanion: 3.14.0
       typescript: 6.0.3
     optionalDependencies:
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/runtime': 1.11.2
     transitivePeerDependencies:
       - '@napi-rs/cross-toolchain-arm64-target-aarch64'
       - '@napi-rs/cross-toolchain-arm64-target-armv7'
@@ -10295,13 +10291,9 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
-
-  brace-expansion@5.0.6:
-    dependencies:
-      balanced-match: 4.0.4
 
   brace-expansion@5.0.9:
     dependencies:
@@ -12138,7 +12130,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@10.2.6:
     dependencies:
@@ -12146,7 +12138,7 @@ snapshots:
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.4
 
   minimizer-webpack-plugin@5.6.1(esbuild@0.27.7)(webpack@5.109.2(esbuild@0.27.7)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,12 +36,18 @@ catalogs:
     react-dom:
       specifier: ^19.0.0
       version: 19.2.6
+    solid-js:
+      specifier: ^1.9.14
+      version: 1.9.14
     svelte:
       specifier: ^5.55.7
       version: 5.55.9
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
+    vite-plugin-solid:
+      specifier: ^2.11.14
+      version: 2.11.14
     vite-plus:
       specifier: 0.1.21
       version: 0.1.21
@@ -203,7 +209,7 @@ importers:
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.8.1
-        version: 3.8.1(@emnapi/runtime@1.11.2)(@types/node@26.1.2)
+        version: 3.8.1(@emnapi/runtime@1.9.2)(@types/node@26.1.2)
 
   deploy: {}
 
@@ -274,6 +280,28 @@ importers:
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.1.21
         version: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@26.1.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)'
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.1.21(@types/node@26.1.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(vite@8.0.14(@types/node@26.1.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(yaml@2.9.0)
+
+  examples/integ-solid:
+    dependencies:
+      '@ox-content/islands':
+        specifier: workspace:*
+        version: link:../../npm/ox-content-islands
+      solid-js:
+        specifier: 'catalog:'
+        version: 1.9.14
+    devDependencies:
+      '@ox-content/vite-plugin-solid':
+        specifier: workspace:*
+        version: link:../../npm/vite-plugin-ox-content-solid
+      vite:
+        specifier: npm:@voidzero-dev/vite-plus-core@0.1.21
+        version: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@26.1.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)'
+      vite-plugin-solid:
+        specifier: 'catalog:'
+        version: 2.11.14(@voidzero-dev/vite-plus-core@0.1.21(@types/node@26.1.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0))(solid-js@1.9.14)
       vite-plus:
         specifier: 'catalog:'
         version: 0.1.21(@types/node@26.1.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(vite@8.0.14(@types/node@26.1.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(yaml@2.9.0)
@@ -636,7 +664,7 @@ importers:
         version: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)'
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 0.1.21(@types/node@25.9.1)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)
       webpack:
         specifier: ^5.109.2
         version: 5.109.2(esbuild@0.27.7)
@@ -730,7 +758,7 @@ importers:
         version: 7.0.0-dev.20260523.1
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 0.1.21(@types/node@25.9.1)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -773,7 +801,38 @@ importers:
         version: 6.0.3
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 0.1.21(@types/node@25.9.1)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)
+
+  npm/vite-plugin-ox-content-solid:
+    dependencies:
+      '@ox-content/islands':
+        specifier: workspace:*
+        version: link:../ox-content-islands
+      '@ox-content/vite-plugin':
+        specifier: workspace:*
+        version: link:../vite-plugin-ox-content
+      vite:
+        specifier: npm:@voidzero-dev/vite-plus-core@0.1.21
+        version: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)'
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260523.1
+      solid-js:
+        specifier: 'catalog:'
+        version: 1.9.14
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite-plugin-solid:
+        specifier: 'catalog:'
+        version: 2.11.14(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0))(solid-js@1.9.14)
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.1.21(@types/node@25.9.1)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)
 
   npm/vite-plugin-ox-content-svelte:
     dependencies:
@@ -804,7 +863,7 @@ importers:
         version: 6.0.3
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 0.1.21(@types/node@25.9.1)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)
 
   npm/vite-plugin-ox-content-vue:
     dependencies:
@@ -832,7 +891,7 @@ importers:
         version: 6.0.3
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 0.1.21(@types/node@25.9.1)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)
       vue:
         specifier: 'catalog:'
         version: 3.5.34(typescript@6.0.3)
@@ -1018,6 +1077,10 @@ packages:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.18.6':
+    resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.28.6':
@@ -3158,6 +3221,18 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -3898,6 +3973,20 @@ packages:
       react-native-b4a: '*'
     peerDependenciesMeta:
       react-native-b4a:
+        optional: true
+
+  babel-plugin-jsx-dom-expressions@0.40.7:
+    resolution: {integrity: sha512-/O6JWUmjv03OI9lL2ry9bUjpD5S3PclM55RRJEyCdcFZ5W2SEA/59d+l2hNsk3gI6kiWRdRPdOtqZmsQzFN1pQ==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  babel-preset-solid@1.9.12:
+    resolution: {integrity: sha512-LLqnuKVDlKpyBlMPcH6qEvs/wmS9a+NczppxJ3ryS/c0O5IiSFOIBQi9GzyiGDSbcJpx4Gr87jyFTos1MyEuWg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      solid-js: ^1.9.12
+    peerDependenciesMeta:
+      solid-js:
         optional: true
 
   bail@2.0.2:
@@ -4923,6 +5012,9 @@ packages:
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
+  html-entities@2.3.3:
+    resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -5097,6 +5189,10 @@ packages:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
 
+  is-what@4.1.16:
+    resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
+    engines: {node: '>=12.13'}
+
   is-what@5.5.0:
     resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
     engines: {node: '>=18'}
@@ -5219,34 +5315,16 @@ packages:
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
-  lightningcss-android-arm64@1.32.0:
-    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [android]
-
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
 
-  lightningcss-darwin-arm64@1.32.0:
-    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
   lightningcss-darwin-arm64@1.33.0:
     resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
-    os: [darwin]
-
-  lightningcss-darwin-x64@1.32.0:
-    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.33.0:
@@ -5255,23 +5333,11 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-freebsd-x64@1.32.0:
-    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-
   lightningcss-freebsd-x64@1.33.0:
     resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
-
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm]
-    os: [linux]
 
   lightningcss-linux-arm-gnueabihf@1.33.0:
     resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
@@ -5279,20 +5345,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  lightningcss-linux-arm64-gnu@1.32.0:
-    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-
   lightningcss-linux-arm64-gnu@1.33.0:
     resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  lightningcss-linux-arm64-musl@1.32.0:
-    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -5303,20 +5357,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  lightningcss-linux-x64-gnu@1.32.0:
-    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-
-  lightningcss-linux-x64-musl@1.32.0:
-    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -5327,22 +5369,10 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  lightningcss-win32-arm64-msvc@1.32.0:
-    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [win32]
-
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
-    os: [win32]
-
-  lightningcss-win32-x64-msvc@1.32.0:
-    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.33.0:
@@ -5350,10 +5380,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
-
-  lightningcss@1.32.0:
-    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
-    engines: {node: '>= 12.0.0'}
 
   lightningcss@1.33.0:
     resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
@@ -5529,6 +5555,10 @@ packages:
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  merge-anything@5.1.7:
+    resolution: {integrity: sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==}
+    engines: {node: '>=12.13'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -6351,6 +6381,16 @@ packages:
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
+  seroval-plugins@1.5.6:
+    resolution: {integrity: sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.6:
+    resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
+    engines: {node: '>=10'}
+
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
@@ -6395,6 +6435,14 @@ packages:
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
+
+  solid-js@1.9.14:
+    resolution: {integrity: sha512-sAEXC0Kk0S1EDg+8ysEWJDbYhA3RRoEjwuySUGlKIemeo0I5YZfOyumNjNs9Sv3y2nmhD+0rW66ag2HsMuQiGQ==}
+
+  solid-refresh@0.6.3:
+    resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
+    peerDependencies:
+      solid-js: ^1.3
 
   sonic-boom@3.8.1:
     resolution: {integrity: sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==}
@@ -6803,6 +6851,16 @@ packages:
       vite: ^6.0.0 || ^7.0.0-0
     peerDependenciesMeta:
       '@nuxt/kit':
+        optional: true
+
+  vite-plugin-solid@2.11.14:
+    resolution: {integrity: sha512-7ZVBt8rpoyqmlwin2kRIUveaHoF6/kulY7gsnD+qFh4nS29V4OPAnw+ojoAspXIjObiL9o1xh9a/nTuYHm02Rw==}
+    peerDependencies:
+      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.0.0 || ^7.0.0
+      solid-js: ^1.7.2
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
+    peerDependenciesMeta:
+      '@testing-library/jest-dom':
         optional: true
 
   vite-plugin-vue-devtools@8.1.2:
@@ -7377,6 +7435,10 @@ snapshots:
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/helper-module-imports@7.18.6':
+    dependencies:
+      '@babel/types': 7.29.8
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
@@ -8360,7 +8422,7 @@ snapshots:
       '@napi-rs/canvas-win32-x64-msvc': 0.1.100
     optional: true
 
-  '@napi-rs/cli@3.8.1(@emnapi/runtime@1.11.2)(@types/node@26.1.2)':
+  '@napi-rs/cli@3.8.1(@emnapi/runtime@1.9.2)(@types/node@26.1.2)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@26.1.2)
       '@napi-rs/cross-toolchain': 1.0.3
@@ -8376,7 +8438,7 @@ snapshots:
       typanion: 3.14.0
       typescript: 6.0.3
     optionalDependencies:
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/runtime': 1.9.2
     transitivePeerDependencies:
       - '@napi-rs/cross-toolchain-arm64-target-aarch64'
       - '@napi-rs/cross-toolchain-arm64-target-armv7'
@@ -9166,6 +9228,27 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.8
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -9446,9 +9529,9 @@ snapshots:
     dependencies:
       '@oxc-project/runtime': 0.129.0
       '@oxc-project/types': 0.129.0
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.25
     optionalDependencies:
       '@types/node': 25.9.1
       esbuild: 0.27.7
@@ -9462,9 +9545,9 @@ snapshots:
     dependencies:
       '@oxc-project/runtime': 0.129.0
       '@oxc-project/types': 0.129.0
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.25
     optionalDependencies:
       '@types/node': 26.1.2
       esbuild: 0.27.7
@@ -9491,6 +9574,46 @@ snapshots:
 
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.21':
     optional: true
+
+  '@voidzero-dev/vite-plus-test@0.1.21(@types/node@25.9.1)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@voidzero-dev/vite-plus-core': 0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)
+      es-module-lexer: 1.7.0
+      obug: 2.1.1
+      pixelmatch: 7.2.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      vite: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)'
+      ws: 8.21.0
+    optionalDependencies:
+      '@types/node': 25.9.1
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@vitejs/devtools'
+      - bufferutil
+      - esbuild
+      - jiti
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - unrun
+      - utf-8-validate
+      - yaml
 
   '@voidzero-dev/vite-plus-test@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(yaml@2.9.0)':
     dependencies:
@@ -10105,6 +10228,22 @@ snapshots:
   axobject-query@4.1.0: {}
 
   b4a@1.8.1: {}
+
+  babel-plugin-jsx-dom-expressions@0.40.7(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/types': 7.29.8
+      html-entities: 2.3.3
+      parse5: 7.3.0
+
+  babel-preset-solid@1.9.12(@babel/core@7.29.0)(solid-js@1.9.14):
+    dependencies:
+      '@babel/core': 7.29.0
+      babel-plugin-jsx-dom-expressions: 0.40.7(@babel/core@7.29.0)
+    optionalDependencies:
+      solid-js: 1.9.14
 
   bail@2.0.2: {}
 
@@ -11184,6 +11323,8 @@ snapshots:
 
   hookable@5.5.3: {}
 
+  html-entities@2.3.3: {}
+
   html-escaper@2.0.2: {}
 
   html-escaper@3.0.3: {}
@@ -11313,6 +11454,8 @@ snapshots:
 
   is-unicode-supported@2.1.0: {}
 
+  is-what@4.1.16: {}
+
   is-what@5.5.0: {}
 
   is-wsl@3.1.1:
@@ -11410,87 +11553,38 @@ snapshots:
     dependencies:
       immediate: 3.0.6
 
-  lightningcss-android-arm64@1.32.0:
-    optional: true
-
   lightningcss-android-arm64@1.33.0:
-    optional: true
-
-  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-arm64@1.33.0:
     optional: true
 
-  lightningcss-darwin-x64@1.32.0:
-    optional: true
-
   lightningcss-darwin-x64@1.33.0:
-    optional: true
-
-  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-freebsd-x64@1.33.0:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    optional: true
-
   lightningcss-linux-arm-gnueabihf@1.33.0:
-    optional: true
-
-  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.32.0:
-    optional: true
-
   lightningcss-linux-arm64-musl@1.33.0:
-    optional: true
-
-  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
-  lightningcss-linux-x64-musl@1.32.0:
-    optional: true
-
   lightningcss-linux-x64-musl@1.33.0:
-    optional: true
-
-  lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
   lightningcss-win32-arm64-msvc@1.33.0:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.32.0:
-    optional: true
-
   lightningcss-win32-x64-msvc@1.33.0:
     optional: true
-
-  lightningcss@1.32.0:
-    dependencies:
-      detect-libc: 2.1.2
-    optionalDependencies:
-      lightningcss-android-arm64: 1.32.0
-      lightningcss-darwin-arm64: 1.32.0
-      lightningcss-darwin-x64: 1.32.0
-      lightningcss-freebsd-x64: 1.32.0
-      lightningcss-linux-arm-gnueabihf: 1.32.0
-      lightningcss-linux-arm64-gnu: 1.32.0
-      lightningcss-linux-arm64-musl: 1.32.0
-      lightningcss-linux-x64-gnu: 1.32.0
-      lightningcss-linux-x64-musl: 1.32.0
-      lightningcss-win32-arm64-msvc: 1.32.0
-      lightningcss-win32-x64-msvc: 1.32.0
 
   lightningcss@1.33.0:
     dependencies:
@@ -11782,6 +11876,10 @@ snapshots:
   mdn-data@2.27.1: {}
 
   mdurl@2.0.0: {}
+
+  merge-anything@5.1.7:
+    dependencies:
+      is-what: 4.1.16
 
   merge-stream@2.0.0: {}
 
@@ -12938,6 +13036,12 @@ snapshots:
     dependencies:
       randombytes: 2.1.0
 
+  seroval-plugins@1.5.6(seroval@1.5.6):
+    dependencies:
+      seroval: 1.5.6
+
+  seroval@1.5.6: {}
+
   setimmediate@1.0.5: {}
 
   shallow-clone@3.0.1:
@@ -13019,6 +13123,21 @@ snapshots:
   sisteransi@1.0.5: {}
 
   smol-toml@1.6.1: {}
+
+  solid-js@1.9.14:
+    dependencies:
+      csstype: 3.2.3
+      seroval: 1.5.6
+      seroval-plugins: 1.5.6(seroval@1.5.6)
+
+  solid-refresh@0.6.3(solid-js@1.9.14):
+    dependencies:
+      '@babel/generator': 7.29.1
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/types': 7.29.8
+      solid-js: 1.9.14
+    transitivePeerDependencies:
+      - supports-color
 
   sonic-boom@3.8.1:
     dependencies:
@@ -13460,6 +13579,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  vite-plugin-solid@2.11.14(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0))(solid-js@1.9.14):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@types/babel__core': 7.20.5
+      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@1.9.14)
+      merge-anything: 5.1.7
+      solid-js: 1.9.14
+      solid-refresh: 0.6.3(solid-js@1.9.14)
+      vite: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)'
+      vitefu: 1.1.3(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  vite-plugin-solid@2.11.14(@voidzero-dev/vite-plus-core@0.1.21(@types/node@26.1.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0))(solid-js@1.9.14):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@types/babel__core': 7.20.5
+      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@1.9.14)
+      merge-anything: 5.1.7
+      solid-js: 1.9.14
+      solid-refresh: 0.6.3(solid-js@1.9.14)
+      vite: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@26.1.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)'
+      vitefu: 1.1.3(@voidzero-dev/vite-plus-core@0.1.21(@types/node@26.1.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - supports-color
+
   vite-plugin-vue-devtools@8.1.2(@voidzero-dev/vite-plus-core@0.1.21(@types/node@26.1.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3)):
     dependencies:
       '@vue/devtools-core': 8.1.2(vue@3.5.34(typescript@6.0.3))
@@ -13488,6 +13633,54 @@ snapshots:
       vite: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@26.1.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)'
     transitivePeerDependencies:
       - supports-color
+
+  vite-plus@0.1.21(@types/node@25.9.1)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0):
+    dependencies:
+      '@oxc-project/types': 0.129.0
+      '@voidzero-dev/vite-plus-core': 0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)
+      '@voidzero-dev/vite-plus-test': 0.1.21(@types/node@25.9.1)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(yaml@2.9.0)
+      oxfmt: 0.48.0
+      oxlint: 1.63.0(oxlint-tsgolint@0.22.1)
+      oxlint-tsgolint: 0.22.1
+    optionalDependencies:
+      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.21
+      '@voidzero-dev/vite-plus-darwin-x64': 0.1.21
+      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.21
+      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.1.21
+      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.21
+      '@voidzero-dev/vite-plus-linux-x64-musl': 0.1.21
+      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.21
+      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.21
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - bufferutil
+      - esbuild
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - unrun
+      - utf-8-validate
+      - vite
+      - yaml
 
   vite-plus@0.1.21(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,8 +19,10 @@ catalog:
   esbuild: ^0.27.4
   react: ^19.0.0
   react-dom: ^19.0.0
+  solid-js: ^1.9.14
   svelte: ^5.55.7
   typescript: ^6.0.3
+  vite-plugin-solid: ^2.11.14
   vite: npm:@voidzero-dev/vite-plus-core@0.1.21
   vitest: npm:@voidzero-dev/vite-plus-test@0.1.21
   vue: ^3.5.34

--- a/scripts/package-dry-run.mjs
+++ b/scripts/package-dry-run.mjs
@@ -12,6 +12,7 @@ const packages = [
   "npm/unplugin-ox-content",
   "npm/vite-plugin-ox-content-vue",
   "npm/vite-plugin-ox-content-react",
+  "npm/vite-plugin-ox-content-solid",
   "npm/vite-plugin-ox-content-svelte",
 ];
 const packDir = mkdtempSync(join(tmpdir(), "ox-content-pack-"));

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -16,6 +16,7 @@ const NPM_PACKAGES = [
   "npm/unplugin-ox-content",
   "npm/vite-plugin-ox-content",
   "npm/vite-plugin-ox-content-react",
+  "npm/vite-plugin-ox-content-solid",
   "npm/vite-plugin-ox-content-svelte",
   "npm/vite-plugin-ox-content-vue",
   "npm/vscode-ox-content",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -138,11 +138,18 @@ export default defineConfig({
       }),
       "test:framework-integrations": noopTask([
         "test:framework-react",
+        "test:framework-solid",
         "test:framework-svelte",
         "test:framework-vue",
       ]),
       "test:framework-react": task(
         "vp exec --filter @ox-content/vite-plugin-react -- vp test src",
+        {
+          dependsOn: ["build:vite-plugin"],
+        },
+      ),
+      "test:framework-solid": task(
+        "vp exec --filter @ox-content/vite-plugin-solid -- vp test src",
         {
           dependsOn: ["build:vite-plugin"],
         },
@@ -234,6 +241,7 @@ export default defineConfig({
       playground: uncachedTask("vp run --filter ./examples/playground dev"),
       "integ-vue": uncachedTask("vp run --filter ./examples/integ-vue dev"),
       "integ-react": uncachedTask("vp run --filter ./examples/integ-react dev"),
+      "integ-solid": uncachedTask("vp run --filter ./examples/integ-solid dev"),
       "integ-svelte": uncachedTask("vp run --filter ./examples/integ-svelte dev"),
       "ssg-vite": uncachedTask("vp run --filter ./examples/ssg-vite dev"),
       "plugin-markdown-it": uncachedTask("vp run --filter ./examples/plugin-markdown-it start"),


### PR DESCRIPTION
Closes #540.

Adds `@ox-content/vite-plugin-solid`, mirroring the Vue, React, and Svelte integrations, plus a `Solid` target for the renderer's framework codegen.

## Why the two consumers emit different code

Solid's JSX is compile-time only — there is no runtime element factory like React's `createElement` or Vue's `h` — so the two code paths need different output shapes:

- **The Vite plugin emits Solid JSX** and lets `vite-plugin-solid` compile it. This is the arrangement solid-mdx uses, and it keeps the environment-sensitive `generate: 'dom' | 'ssr'` decision with the plugin that owns it rather than reimplementing babel-preset-solid configuration here.
- **The Rust/N-API `renderFrameworkComponentCode` path** has to produce code that runs without a compiler, so it targets `solid-js/h`, Solid's hyperscript entry point. `solid.rs` was already stubbed as an "extension point"; this fills it in.

## The two setup rules, and why they are checked

The JSX approach costs two rules the sibling integrations do not have:

1. `oxContentSolid()` must precede `solid()`. Both are `enforce: 'pre'`, so array order decides which plugin sees the Markdown first — with the wrong order babel parses raw Markdown as JSX.
2. `solid()` needs the Markdown extensions in its `extensions` option, or the generated modules reach the browser as uncompiled JSX.

Both otherwise fail as an opaque Babel syntax error in an unrelated file, so `verifySolidPlugin` (default on) checks ordering when the config resolves and detects uncompiled output in a `post` transform, reporting each with the fix.

## Verification

- 11 unit tests in the new package, including the misconfiguration guards
- `examples/integ-solid` builds and was driven in a browser: islands hydrate, the counter's signal updates on click, no console errors
- Renderer codegen snapshots for hyperscript output, variadic children, and all three module modes
- `cargo test --workspace --all-features`, `cargo clippy -- -D warnings`, `vp check`, and the React/Svelte/Vue integration suites all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Solid.js support for rendering Markdown, components, islands, and interactive content.
  * Introduced the `@ox-content/vite-plugin-solid` package for Vite projects.
  * Added component discovery, hydration, HMR, frontmatter, and Markdown extension support.
  * Added a complete Solid integration example with interactive Counter and Alert components.

* **Documentation**
  * Added setup guides, configuration references, examples, and architecture documentation for Solid integration.

* **Tests**
  * Added coverage for Solid rendering, transformations, plugin validation, and integration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->