### PR TITLE
feat(parser): make cjkEmphasis pair runs against CJK punctuation (#545)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Where the two Ox Content rows in the tables differ: `ox-content (native)` is the
 
 Extensions beyond CommonMark — GFM tables, task lists, strikethrough, footnotes, and the built-in embeds — are opt-out rather than opt-in, so a document that uses none of them renders exactly as the specification requires. [Markdown Baseline](https://ubugeeei-prod.github.io/ox-content/built-in/markdown/) lists each toggle.
 
-Ox Content does **not** extend CommonMark's emphasis rules for CJK text: `**` immediately inside CJK punctuation (`A**強調。**B`) is left as literal text, matching CommonMark and every other spec-conformant engine.
+One deliberate deviation is available opt-in. CommonMark's flanking rules leave `**` immediately inside CJK punctuation (`A**強調。**B`) as literal text, which bites CJK prose constantly because punctuation is set directly against the preceding word. Enabling [`cjkEmphasis`](https://ubugeeei-prod.github.io/ox-content/examples/cjk-emphasis/) makes those runs pair; halfwidth ASCII punctuation is untouched, so Latin documents parse identically. It is off by default so the shipped default stays spec-conformant.
 
 ## Development
 

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -1644,12 +1644,21 @@ export interface JsTransformOptions {
    */
   attributes?: JsAttrsOptions
   /**
-   * Opt-in CJK emphasis compatibility flag, accepted for parity with
-   * configurations that set it. It does not change parsing: emphasis between
-   * CJK characters (`これは**重要**です`) already works because CommonMark's
-   * delimiter rules allow it, and emphasis immediately inside CJK
-   * punctuation (`A**強調。**B`) stays literal either way, matching every
-   * spec-conformant engine.
+   * Recognize emphasis whose delimiters sit against East Asian punctuation.
+   *
+   * CommonMark's flanking rules let punctuation on the outside of a `*`/`_`
+   * run block it, and they read Unicode punctuation as a whole — so
+   * `A**強調。**B` stays literal text. CJK sets punctuation directly against
+   * the words it follows, which is why this bites there and rarely in Latin
+   * text. Enabling this classifies East Asian punctuation as an ordinary
+   * character for that decision only; halfwidth ASCII punctuation is
+   * untouched, so Latin documents parse identically.
+   *
+   * Emphasis merely adjacent to CJK *characters* (`これは**重要**です`)
+   * needs no option — CommonMark already allows it.
+   *
+   * Off by default because it is a deliberate deviation from the
+   * specification.
    *
    * Default: `false`.
    */

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -1648,12 +1648,21 @@ export interface JsTransformOptions {
    */
   attributes?: JsAttrsOptions
   /**
-   * Opt-in CJK emphasis compatibility flag, accepted for parity with
-   * configurations that set it. It does not change parsing: emphasis between
-   * CJK characters (`これは**重要**です`) already works because CommonMark's
-   * delimiter rules allow it, and emphasis immediately inside CJK
-   * punctuation (`A**強調。**B`) stays literal either way, matching every
-   * spec-conformant engine.
+   * Recognize emphasis whose delimiters sit against East Asian punctuation.
+   *
+   * CommonMark's flanking rules let punctuation on the outside of a `*`/`_`
+   * run block it, and they read Unicode punctuation as a whole — so
+   * `A**強調。**B` stays literal text. CJK sets punctuation directly against
+   * the words it follows, which is why this bites there and rarely in Latin
+   * text. Enabling this classifies East Asian punctuation as an ordinary
+   * character for that decision only; halfwidth ASCII punctuation is
+   * untouched, so Latin documents parse identically.
+   *
+   * Emphasis merely adjacent to CJK *characters* (`これは**重要**です`)
+   * needs no option — CommonMark already allows it.
+   *
+   * Off by default because it is a deliberate deviation from the
+   * specification.
    *
    * Default: `false`.
    */

--- a/crates/ox_content_napi/src/transform_bindings/transform_options.rs
+++ b/crates/ox_content_napi/src/transform_bindings/transform_options.rs
@@ -121,12 +121,21 @@ pub struct JsTransformOptions {
     /// Default: disabled.
     pub attributes: Option<JsAttrsOptions>,
 
-    /// Opt-in CJK emphasis compatibility flag, accepted for parity with
-    /// configurations that set it. It does not change parsing: emphasis between
-    /// CJK characters (`これは**重要**です`) already works because CommonMark's
-    /// delimiter rules allow it, and emphasis immediately inside CJK
-    /// punctuation (`A**強調。**B`) stays literal either way, matching every
-    /// spec-conformant engine.
+    /// Recognize emphasis whose delimiters sit against East Asian punctuation.
+    ///
+    /// CommonMark's flanking rules let punctuation on the outside of a `*`/`_`
+    /// run block it, and they read Unicode punctuation as a whole — so
+    /// `A**強調。**B` stays literal text. CJK sets punctuation directly against
+    /// the words it follows, which is why this bites there and rarely in Latin
+    /// text. Enabling this classifies East Asian punctuation as an ordinary
+    /// character for that decision only; halfwidth ASCII punctuation is
+    /// untouched, so Latin documents parse identically.
+    ///
+    /// Emphasis merely adjacent to CJK *characters* (`これは**重要**です`)
+    /// needs no option — CommonMark already allows it.
+    ///
+    /// Off by default because it is a deliberate deviation from the
+    /// specification.
     ///
     /// Default: `false`.
     pub cjk_emphasis: Option<bool>,

--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -68,6 +68,24 @@ pub struct ParserOptions {
     /// Default: `false`; [`ParserOptions::gfm`] sets this to `true`.
     pub autolinks: bool,
 
+    /// Recognize emphasis whose delimiters sit against East Asian punctuation.
+    ///
+    /// CommonMark decides whether a `*`/`_` run may open or close from the
+    /// characters on either side, and punctuation on the outside blocks the
+    /// run. The rule reads Unicode punctuation as a whole, so East Asian
+    /// punctuation blocks it too — and because CJK text sets punctuation
+    /// directly against the words it follows, `A**強調。**B` leaves the
+    /// delimiters as literal text. Latin text rarely hits this, since a space
+    /// usually separates the punctuation from the delimiter.
+    ///
+    /// With this enabled, East Asian punctuation is classified as an ordinary
+    /// character for flanking purposes only, which lets those runs pair. It is
+    /// off by default because it is a deliberate deviation: the parser renders
+    /// every CommonMark 0.31.2 example per spec with it off.
+    ///
+    /// Default: `false`.
+    pub cjk_emphasis: bool,
+
     /// Maximum nesting depth for block elements.
     ///
     /// Default: `0`; [`ParserOptions::gfm`] sets this to `100`.
@@ -85,6 +103,8 @@ impl ParserOptions {
             tables: true,
             strikethrough: true,
             autolinks: true,
+            // Not part of GFM: GitHub renders these runs per CommonMark too.
+            cjk_emphasis: false,
             max_nesting_depth: 100,
         }
     }

--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -124,7 +124,7 @@ impl<'a> Parser<'a> {
                 self.parse_strikethrough(content, offset, children, pos)?;
             }
             b'*' | b'_' => {
-                Self::push_delimiter_run(content, offset, children, delimiters, pos);
+                self.push_delimiter_run(content, offset, children, delimiters, pos);
             }
             b'`' => self.parse_inline_code(content, offset, children, pos),
             b'[' => self.parse_link(content, offset, children, pos)?,

--- a/crates/ox_content_parser/src/parser/inline/emphasis.rs
+++ b/crates/ox_content_parser/src/parser/inline/emphasis.rs
@@ -30,6 +30,7 @@ impl<'a> Parser<'a> {
     /// Records a `*`/`_` run: pushes its text node and the delimiter
     /// entry describing how it may participate in emphasis.
     pub(in crate::parser) fn push_delimiter_run(
+        &self,
         content: &'a str,
         offset: usize,
         children: &mut Vec<'a, Node<'a>>,
@@ -42,7 +43,8 @@ impl<'a> Parser<'a> {
 
         let prev_char = content[..*pos].chars().next_back();
         let next_char = content[*pos + run_len..].chars().next();
-        let (can_open, can_close) = classify_flanking(marker, prev_char, next_char);
+        let (can_open, can_close) =
+            classify_flanking(marker, prev_char, next_char, self.options.cjk_emphasis);
 
         Self::push_text(
             children,
@@ -222,11 +224,24 @@ fn trim_text_head(node: &mut Node<'_>, count: u32) {
 
 /// Flanking classification (CommonMark "Emphasis and strong emphasis").
 /// Sequence boundaries count as whitespace.
-fn classify_flanking(marker: u8, prev: Option<char>, next: Option<char>) -> (bool, bool) {
+///
+/// `cjk_emphasis` reclassifies East Asian punctuation as an ordinary character
+/// here and nowhere else; see [`ParserOptions::cjk_emphasis`].
+///
+/// [`ParserOptions::cjk_emphasis`]: crate::ParserOptions::cjk_emphasis
+fn classify_flanking(
+    marker: u8,
+    prev: Option<char>,
+    next: Option<char>,
+    cjk_emphasis: bool,
+) -> (bool, bool) {
+    let is_punct =
+        |ch: char| is_punctuation_like(ch) && !(cjk_emphasis && is_east_asian_punctuation(ch));
+
     let prev_ws = prev.is_none_or(char::is_whitespace);
     let next_ws = next.is_none_or(char::is_whitespace);
-    let prev_punct = prev.is_some_and(is_punctuation_like);
-    let next_punct = next.is_some_and(is_punctuation_like);
+    let prev_punct = prev.is_some_and(is_punct);
+    let next_punct = next.is_some_and(is_punct);
 
     let left_flanking = !next_ws && (!next_punct || prev_ws || prev_punct);
     let right_flanking = !prev_ws && (!prev_punct || next_ws || next_punct);
@@ -247,4 +262,33 @@ fn classify_flanking(marker: u8, prev: Option<char>, next: Option<char>) -> (boo
 fn is_punctuation_like(ch: char) -> bool {
     ch.is_ascii_punctuation()
         || (!ch.is_ascii() && !ch.is_alphanumeric() && !ch.is_whitespace() && !ch.is_control())
+}
+
+/// Punctuation that East Asian scripts set directly against the text, with no
+/// separating space — the reason CommonMark's flanking rules reject emphasis
+/// that Latin text would accept.
+///
+/// The ranges are the fullwidth and CJK-specific blocks only. Halfwidth ASCII
+/// punctuation is deliberately excluded even in CJK text: it is written the
+/// same way in every script, so reclassifying it would change how ordinary
+/// Latin documents parse.
+///
+/// U+3000 IDEOGRAPHIC SPACE falls inside the first range but is whitespace, and
+/// the flanking rules test whitespace before punctuation, so it is unaffected.
+fn is_east_asian_punctuation(ch: char) -> bool {
+    matches!(ch,
+        // CJK Symbols and Punctuation: 、。〈〉《》「」『』【】〜 and friends.
+        '\u{3000}'..='\u{303F}'
+        // Vertical forms and CJK Compatibility Forms: vertical/rotated variants.
+        | '\u{FE10}'..='\u{FE19}'
+        | '\u{FE30}'..='\u{FE4F}'
+        // Small Form Variants: small comma, small full stop, small brackets.
+        | '\u{FE50}'..='\u{FE6F}'
+        // Fullwidth ASCII punctuation, split around the fullwidth digits and
+        // letters, which stay alphanumeric.
+        | '\u{FF01}'..='\u{FF0F}'
+        | '\u{FF1A}'..='\u{FF20}'
+        | '\u{FF3B}'..='\u{FF40}'
+        | '\u{FF5B}'..='\u{FF65}'
+    )
 }

--- a/crates/ox_content_parser/tests/edge_cases/inline.rs
+++ b/crates/ox_content_parser/tests/edge_cases/inline.rs
@@ -162,3 +162,81 @@ fn hard_break_creates_break_node() {
         other => panic!("expected paragraph, got {other:?}"),
     }
 }
+
+/// Whether the paragraph's first inline is a `Strong` node.
+fn parses_as_strong(source: &str, cjk_emphasis: bool) -> bool {
+    let allocator = Allocator::new();
+    let options = ParserOptions { cjk_emphasis, ..ParserOptions::default() };
+    let doc = parse_with_options(&allocator, source, options);
+    match &doc.children[0] {
+        Node::Paragraph(paragraph) => {
+            paragraph.children.iter().any(|node| matches!(node, Node::Strong(_)))
+        }
+        other => panic!("expected paragraph, got {other:?}"),
+    }
+}
+
+#[test]
+fn cjk_emphasis_off_leaves_punctuation_adjacent_runs_literal() {
+    // CommonMark's flanking rules reject these, and the default profile follows
+    // the spec: the conformance suite depends on it.
+    for source in [
+        "A**強調。**B",
+        "A**。強調**B",
+        "A**強調、**B",
+        "A**強調！**B",
+        "A**強調）**B",
+        "中文**加粗，**测试",
+    ] {
+        assert!(!parses_as_strong(source, false), "{source} must stay literal by default");
+    }
+}
+
+#[test]
+fn cjk_emphasis_on_pairs_punctuation_adjacent_runs() {
+    for source in [
+        "A**強調。**B",
+        "A**。強調**B",
+        "A**強調、**B",
+        "A**強調！**B",
+        "A**強調）**B",
+        "中文**加粗，**测试",
+    ] {
+        assert!(parses_as_strong(source, true), "{source} must render as strong when enabled");
+    }
+}
+
+#[test]
+fn cjk_emphasis_leaves_ascii_punctuation_alone() {
+    // Only fullwidth and CJK-specific punctuation is reclassified. Halfwidth
+    // ASCII is written the same way in every script, so enabling the option
+    // must not change how a Latin document parses.
+    for source in ["a**bold.**c", "a**.bold**c", "a**bold!**c"] {
+        assert_eq!(
+            parses_as_strong(source, false),
+            parses_as_strong(source, true),
+            "{source} must parse the same either way"
+        );
+    }
+}
+
+#[test]
+fn cjk_emphasis_keeps_working_for_cases_commonmark_already_accepts() {
+    // Emphasis between CJK *characters* needs no help from the option; it must
+    // keep working with the option in either state.
+    for source in ["これは**重要**です。", "「**強調**」というもの", "（**注**）です"]
+    {
+        assert!(parses_as_strong(source, false), "{source} works per CommonMark");
+        assert!(parses_as_strong(source, true), "{source} must keep working when enabled");
+    }
+}
+
+#[test]
+fn cjk_emphasis_does_not_pair_across_whitespace() {
+    // The option relaxes punctuation, not the whitespace rule: a run with
+    // whitespace on its inner side still cannot open or close.
+    assert!(!parses_as_strong("A** 強調。 **B", true));
+    // Ideographic space is whitespace, and the flanking rules test that before
+    // punctuation, so it is unaffected by the reclassification.
+    assert!(!parses_as_strong("A**\u{3000}強調\u{3000}**B", true));
+}

--- a/crates/ox_content_transform/src/transformer/options.rs
+++ b/crates/ox_content_transform/src/transformer/options.rs
@@ -22,6 +22,9 @@ pub(super) fn transform_options_to_parser_options(opts: &TransformOptions) -> Pa
     if let Some(v) = opts.autolinks {
         options.autolinks = v;
     }
+    if let Some(v) = opts.cjk_emphasis {
+        options.cjk_emphasis = v;
+    }
 
     options
 }

--- a/docs/content/built-in/syntax-extensions.md
+++ b/docs/content/built-in/syntax-extensions.md
@@ -138,16 +138,8 @@ belong in code spans or fences.
 
 ## CJK Emphasis
 
-The native parser recognizes `**emphasis**` adjacent to CJK characters without
-requiring ASCII spaces. The `cjkEmphasis` option keeps that behavior explicit in
-the public API for compatibility contracts; it does not change parsing, because
-CommonMark's delimiter rules already allow this case:
-
-```ts
-oxContent({
-  cjkEmphasis: true,
-});
-```
+Emphasis adjacent to CJK characters needs no configuration — CommonMark's
+delimiter rules already allow it, and no ASCII spaces are required:
 
 ```md
 これは**重要**です。次の文でも*強調*できます。
@@ -157,11 +149,33 @@ Rendered:
 
 これは**重要**です。次の文でも*強調*できます。
 
-What CommonMark does **not** allow is `**` placed immediately inside CJK
-punctuation — `A**強調。**B` stays literal text. That follows from the
-specification's left/right-flanking delimiter rules, so it behaves the same in
-every spec-conformant engine, Ox Content included. See
-[CJK Emphasis](../examples/cjk-emphasis.md) for the full boundary.
+What plain CommonMark rejects is a delimiter run sitting directly against
+punctuation on its outer side. Its flanking rules read Unicode punctuation as a
+whole, so East Asian punctuation blocks a run just like ASCII punctuation does,
+and `A**強調。**B` stays literal text. Latin prose rarely hits this because a
+space usually separates the two; CJK sets punctuation against the preceding
+word, so it comes up constantly.
+
+`cjkEmphasis` classifies East Asian punctuation as an ordinary character for
+that decision only:
+
+```ts
+oxContent({
+  cjkEmphasis: true,
+});
+```
+
+```md
+A**強調。**B
+```
+
+renders as `A<strong>強調。</strong>B` with the option on, and as literal text
+with it off. Halfwidth ASCII punctuation is deliberately untouched, so a Latin
+document parses identically either way.
+
+This is a deliberate deviation from the specification, which is why it is
+opt-in. See [CJK Emphasis](../examples/cjk-emphasis.md) for the exact boundary
+and the reclassified character ranges.
 
 ## Related
 

--- a/docs/content/examples/cjk-emphasis.md
+++ b/docs/content/examples/cjk-emphasis.md
@@ -1,12 +1,37 @@
 ---
 title: CJK Emphasis
-description: Recognize emphasis adjacent to CJK text.
+description: Recognize emphasis adjacent to CJK text and CJK punctuation.
 ---
 
 # CJK Emphasis
 
-The native parser recognizes emphasis next to CJK characters without requiring
-ASCII spaces.
+Emphasis between CJK characters works out of the box — CommonMark's delimiter
+rules already allow it, and no ASCII spaces are needed:
+
+```md
+これは**重要**です。
+これは*強調*です。
+```
+
+## Emphasis Against CJK Punctuation
+
+What plain CommonMark rejects is a `*`/`_` run sitting directly against
+punctuation on its outer side. Its flanking rules read Unicode punctuation as a
+whole, so East Asian punctuation blocks a run the same way ASCII punctuation
+does:
+
+```md
+A**強調。**B
+中文**加粗，**测试
+```
+
+Both render as literal text in any spec-conformant engine. Latin prose rarely
+runs into it because a space usually separates the punctuation from the
+delimiter, but CJK sets punctuation directly against the words it follows, so it
+comes up constantly.
+
+`cjkEmphasis` classifies East Asian punctuation as an ordinary character for
+that decision, which lets those runs pair:
 
 ```ts
 import { oxContent } from "@ox-content/vite-plugin";
@@ -20,37 +45,23 @@ export default {
 };
 ```
 
-```md
-これは**重要**です。
-これは*強調*です。
-```
+| Source                 | Default      | `cjkEmphasis: true`      |
+| ---------------------- | ------------ | ------------------------ |
+| `これは**重要**です。` | **重要**     | **重要**                 |
+| `A**強調。**B`         | literal text | **強調。**               |
+| `中文**加粗，**测试`   | literal text | **加粗，**               |
+| `a**bold.**c`          | literal text | literal text (unchanged) |
 
-The option is explicit for compatibility, while the parser keeps the fast common
-inline path. It does not change parsing: the cases above are handled with or
-without it, because CommonMark's delimiter rules already allow emphasis between
-CJK characters.
+Only the fullwidth and CJK-specific punctuation blocks are reclassified —
+`U+3000`–`U+303F`, the vertical and compatibility forms, and fullwidth ASCII.
+Halfwidth ASCII punctuation is written the same way in every script, so
+enabling the option never changes how a Latin document parses.
 
-## What Is Not Covered
+The option relaxes the punctuation rule only. Whitespace still blocks a run, so
+`A** 強調。 **B` stays literal either way.
 
-CommonMark does not recognize `**` placed immediately **inside CJK
-punctuation**:
+## Conformance
 
-```md
-A**強調。**B
-A**、強調**B
-```
-
-Both render as literal text rather than bold. This is a property of the
-specification's left/right-flanking delimiter rules, so it affects every
-spec-conformant engine — `markdown-it` in `commonmark` mode, `micromark`,
-`pulldown-cmark`, and Ox Content all behave the same way here.
-
-Ox Content does not currently deviate from the specification for this case. If
-you need it, keep the punctuation outside the emphasis:
-
-```md
-A**強調**。B
-```
-
-See [CommonMark Conformance](../performance.md#commonmark-conformance) for where
-Ox Content does and does not follow the specification.
+This is a deliberate deviation from the specification, which is why it is
+opt-in: with the option off the parser renders every CommonMark 0.31.2 example
+per spec. See [CommonMark Conformance](../performance.md#commonmark-conformance).

--- a/docs/content/examples/cjk-emphasis.md
+++ b/docs/content/examples/cjk-emphasis.md
@@ -52,8 +52,10 @@ export default {
 | `中文**加粗，**测试`   | literal text | **加粗，**               |
 | `a**bold.**c`          | literal text | literal text (unchanged) |
 
-Only the fullwidth and CJK-specific punctuation blocks are reclassified —
-`U+3000`–`U+303F`, the vertical and compatibility forms, and fullwidth ASCII.
+Only the fullwidth and CJK-specific punctuation blocks are reclassified:
+`U+3000`–`U+303F`, the vertical and compatibility forms (`U+FE10`–`U+FE19`,
+`U+FE30`–`U+FE4F`), the small form variants (`U+FE50`–`U+FE6F`), and fullwidth
+ASCII (`U+FF01`–`U+FF65`, skipping the fullwidth digits and letters).
 Halfwidth ASCII punctuation is written the same way in every script, so
 enabling the option never changes how a Latin document parses.
 

--- a/docs/content/performance.md
+++ b/docs/content/performance.md
@@ -211,14 +211,17 @@ node benchmarks/commonmark-conformance/run.mjs --json benchmarks/commonmark-conf
 
 CommonMark's emphasis rules do not recognize `**` placed immediately inside CJK
 punctuation, so `A**強調。**B` renders as literal text rather than bold. This
-affects every spec-conformant engine, Ox Content included — it is a property of
-the specification's left/right-flanking delimiter rules, not an implementation
-gap.
+affects every spec-conformant engine — it is a property of the specification's
+left/right-flanking delimiter rules, not an implementation gap. Emphasis that
+merely sits next to CJK _characters_ — `これは**重要**です。` — is allowed by
+the specification and works everywhere.
 
-Ox Content does not currently deviate from the specification here. Emphasis that
-merely sits next to CJK _characters_ — `これは**重要**です。` — works in Ox
-Content and in CommonMark generally; only the punctuation-adjacent form is
-affected.
+Ox Content ships an opt-in deviation for it. `cjkEmphasis` classifies East Asian
+punctuation as an ordinary character when deciding whether a delimiter run may
+open or close, which lets those runs pair; halfwidth ASCII punctuation is left
+alone, so Latin documents parse identically. It is off by default, which is what
+keeps the 652/652 figure above true of the shipped default. See
+[CJK Emphasis](./examples/cjk-emphasis.md).
 
 ## Bundle Size
 


### PR DESCRIPTION
Closes #545 — the last of its three proposed improvements.

The first two landed in #547. This one could not, because the issue's claim was not true: it asks to document that this framework *already* recognizes `**` placed immediately outside CJK punctuation. It did not. `A**強調。**B` stayed literal, exactly as in `markdown-it` (commonmark preset), `micromark`, and `pulldown-cmark`.

Worse, `cjkEmphasis` was a **documented no-op**. It was plumbed from the N-API bindings into `ox_content_transform` and stopped there — `ox_content_parser` never read it — while its doc comment claimed "the parser is already CJK-friendly". #547 corrected the docs; this PR gives the option an implementation instead.

## The gap

CommonMark decides whether a `*`/`_` run may open or close from the characters beside it, and punctuation on the outer side blocks the run. The rule reads Unicode punctuation as a whole, so East Asian punctuation blocks it too. Latin prose rarely notices, because a space usually separates the punctuation from the delimiter. CJK sets punctuation directly against the preceding word, so it comes up constantly.

| Source | Default | `cjkEmphasis: true` |
| --- | --- | --- |
| `これは**重要**です。` | **重要** | **重要** |
| `A**強調。**B` | literal text | **強調。** |
| `中文**加粗，**测试` | literal text | **加粗，** |
| `a**bold.**c` | literal text | literal text (unchanged) |

## Scope

Deliberately narrow, since this is a deviation from the specification:

- **Only fullwidth and CJK-specific punctuation is reclassified** (`U+3000`–`U+303F`, vertical/compatibility forms, fullwidth ASCII). Halfwidth ASCII punctuation is written the same way in every script, so reclassifying it would change how ordinary Latin documents parse — there is a test asserting the two settings agree on ASCII input.
- **Only the punctuation rule is relaxed.** Whitespace still blocks a run. `U+3000` IDEOGRAPHIC SPACE sits inside the first reclassified range but is whitespace, and flanking tests whitespace first, so it is unaffected — also covered by a test.
- **Off by default**, and not part of the GFM profile (GitHub renders these runs per CommonMark too).

## Conformance is unchanged

The default profile still renders all 652 CommonMark 0.31.2 examples per spec. `spec_commonmark` and `spec_gfm` pass unchanged, and re-running the conformance sweep produces a byte-identical `results.json` — the published `CommonMark` column still reads 652/652 for `ox-content (native)`.

## Verification

Five new parser tests (option off / option on / ASCII untouched / already-working cases still work / whitespace still blocks), the full `cargo test --workspace --all-features`, `cargo clippy -- -D warnings`, `vp check`, `vp fmt --check`, the 181 core TS tests, and a docs build. Behaviour also checked end-to-end through `@ox-content/napi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `cjkEmphasis` setting for emphasis across East Asian punctuation boundaries.
  * The setting is disabled by default, preserving standard CommonMark behavior.
  * ASCII punctuation handling, whitespace rules, and existing CJK-adjacent emphasis remain unchanged.

* **Documentation**
  * Updated configuration guidance, syntax references, examples, and performance notes with supported punctuation ranges, examples, and default behavior.
  * Clarified that enabling the option intentionally provides compatibility behavior beyond the CommonMark specification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->