### PR TITLE
chore(deps): override nanoid and js-yaml to patched versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,8 @@ overrides:
   vitest: npm:@voidzero-dev/vite-plus-test@0.1.21
   brace-expansion@2: 2.1.4
   brace-expansion@5: 5.0.9
+  nanoid@3: 3.3.18
+  js-yaml@4: 4.3.1
 
 packageExtensionsChecksum: sha256-heIAjU0i7QlZhLUF1Lt9/jyzqfYnUFeqzDkoi7f10vo=
 
@@ -253,7 +255,7 @@ importers:
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.8.1
-        version: 3.8.1(@emnapi/runtime@1.11.2)(@types/node@26.1.2)
+        version: 3.8.1(@emnapi/runtime@1.9.2)(@types/node@26.1.2)
 
   deploy: {}
 
@@ -5295,14 +5297,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
-
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
-    hasBin: true
-
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
@@ -5802,13 +5796,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7028,7 +7017,7 @@ packages:
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
-      js-yaml: ^4.0.0 || ^5.0.0
+      js-yaml: 4.3.1
       json5: ^2.2.3
       toml: ^3.0.0 || ^4.0.0
       webpack: ^5.101.0
@@ -7303,7 +7292,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       picomatch: 4.0.4
       retext-smartypants: 6.2.0
       shiki: 4.1.0
@@ -7321,7 +7310,7 @@ snapshots:
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       hast-util-to-text: 4.0.2
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
       rehype-stringify: 10.0.1
@@ -8462,7 +8451,7 @@ snapshots:
       '@napi-rs/canvas-win32-x64-msvc': 0.1.100
     optional: true
 
-  '@napi-rs/cli@3.8.1(@emnapi/runtime@1.11.2)(@types/node@26.1.2)':
+  '@napi-rs/cli@3.8.1(@emnapi/runtime@1.9.2)(@types/node@26.1.2)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@26.1.2)
       '@napi-rs/cross-toolchain': 1.0.3
@@ -8478,7 +8467,7 @@ snapshots:
       typanion: 3.14.0
       typescript: 6.0.3
     optionalDependencies:
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/runtime': 1.9.2
     transitivePeerDependencies:
       - '@napi-rs/cross-toolchain-arm64-target-aarch64'
       - '@napi-rs/cross-toolchain-arm64-target-armv7'
@@ -10190,7 +10179,7 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       jsonc-parser: 3.3.1
       magic-string: 0.30.21
       magicast: 0.5.3
@@ -11540,14 +11529,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
-
-  js-yaml@4.2.0:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
@@ -12221,7 +12202,7 @@ snapshots:
       glob: 10.5.0
       he: 1.2.0
       is-path-inside: 3.0.3
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       log-symbols: 4.1.0
       minimatch: 9.0.9
       ms: 2.1.3
@@ -12251,9 +12232,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.12: {}
-
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   neo-async@2.6.2: {}
 
@@ -12583,13 +12562,13 @@ snapshots:
 
   postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,6 +42,10 @@ overrides:
   # GHSA-rgw5-rvv9-x895: ReDoS in brace-expansion, patched in 2.1.4 and 5.0.9.
   brace-expansion@2: "2.1.4"
   brace-expansion@5: "5.0.9"
+  # GHSA-28wg-ghj8-5hjv, GHSA-2v37-7h3g-55p8: nanoid, patched in 3.3.17.
+  nanoid@3: "3.3.18"
+  # GHSA-5p4m-2wfm-xmqj: js-yaml, patched in 4.3.1.
+  js-yaml@4: "4.3.1"
 peerDependencyRules:
   allowAny:
     - vite


### PR DESCRIPTION
The `Dependency policy` job is failing on every open PR because three newly published npm advisories now match packages in `pnpm-lock.yaml`: `GHSA-28wg-ghj8-5hjv` and `GHSA-2v37-7h3g-55p8` (nanoid `<3.3.16` / `<3.3.17`, pulled in twice via postcss) and `GHSA-5p4m-2wfm-xmqj` (js-yaml `>=4.0.0 <4.3.1`). This is not caused by any of the dependabot PRs, it is advisory data that landed after the last green run on `main`, so all four PRs stay blocked until it is resolved here.

Rather than allowlisting them in `config/dependency-policy.json`, this pins the transitives to patched releases using the existing `overrides` block in `pnpm-workspace.yaml`, matching how `brace-expansion` was handled:

```yaml
overrides:
  vite: "catalog:"
  vitest: "catalog:"
  # GHSA-rgw5-rvv9-x895: ReDoS in brace-expansion, patched in 2.1.4 and 5.0.9.
  brace-expansion@2: "2.1.4"
  brace-expansion@5: "5.0.9"
  # GHSA-28wg-ghj8-5hjv, GHSA-2v37-7h3g-55p8: nanoid, patched in 3.3.17.
  nanoid@3: "3.3.18"
  # GHSA-5p4m-2wfm-xmqj: js-yaml, patched in 4.3.1.
  js-yaml@4: "4.3.1"
```

The lockfile collapses `nanoid` 3.3.12/3.3.16 into 3.3.18 and `js-yaml` 4.1.1/4.2.0 into 4.3.1, which also retires the `GHSA-52cp-r559-cp3m` js-yaml allowlist entry in practice. `node scripts/check-npm-advisories.mjs` now reports no unapproved advisories at high+ severity.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated bundled security fixes for `nanoid` and `js-yaml` by pinning them to patched versions.
  * Documented the related security advisories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->