### PR TITLE
bench: measure the Polonius Alpha borrow checker

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,7 +1,7 @@
 # Benchmarks
 
 Two flavors of performance measurement live in this tree, plus a correctness
-sweep that the published tables depend on:
+sweep that the published tables depend on and a one-off compiler experiment:
 
 - **JS comparison sweep** in `bundle-size/` — runs Ox Content alongside
   `@tanstack/markdown`, `markdown-it-ts`, `markdown-it`, `marked`, `md4w`,
@@ -15,6 +15,11 @@ sweep that the published tables depend on:
   engine in the speed tables against the vendored CommonMark 0.31.2 spec, so a
   faster engine that skips spec behavior is visible as such. Trigger via
   `node benchmarks/commonmark-conformance/run.mjs`.
+- **Polonius borrow-checker comparison** in `polonius-borrowck/` — measures what
+  the next-generation borrow checker costs this workspace to compile, and lists
+  the borrow-checker workarounds it would let us delete once it stabilizes. This
+  one measures the compiler, not Ox Content, so it feeds no published table.
+  Trigger via `node benchmarks/polonius-borrowck/run.mjs`.
 
 ## CommonMark conformance sweep
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -19,7 +19,8 @@ sweep that the published tables depend on and a one-off compiler experiment:
   the next-generation borrow checker costs this workspace to compile, and lists
   the borrow-checker workarounds it would let us delete once it stabilizes. This
   one measures the compiler, not Ox Content, so it feeds no published table.
-  Trigger via `node benchmarks/polonius-borrowck/run.mjs`.
+  Trigger via
+  `node benchmarks/polonius-borrowck/run.mjs --toolchain nightly-2026-08-09`.
 
 ## CommonMark conformance sweep
 

--- a/benchmarks/polonius-borrowck/README.md
+++ b/benchmarks/polonius-borrowck/README.md
@@ -1,0 +1,152 @@
+# Polonius Alpha borrow checker
+
+[Polonius Alpha][blog] is the next iteration of the borrow checker. It became
+the default on nightly in `nightly-2026-08-06`, and stabilization is planned
+before the end of 2026 — so it will arrive on stable whether or not this
+workspace is ready for it. This directory answers two questions ahead of time:
+what it costs to compile, and what it lets us delete.
+
+Run it with:
+
+```bash
+node benchmarks/polonius-borrowck/run.mjs --iterations 4 --json results.json
+```
+
+The harness needs a nightly toolchain and a POSIX `/usr/bin/time`. It never
+mutates the workspace beyond touching crate roots to force a re-check, and it
+builds into throwaway target directories, so it will not disturb an existing
+`target/`.
+
+## What was measured
+
+One toolchain, one flag difference: `-Zpolonius=off` selects today's stable NLL
+borrow checker, `-Zpolonius=next` selects Polonius Alpha. Everything else — the
+compiler build, the dependency graph, the machine — is held constant, so the
+delta is attributable to the borrow checker alone.
+
+Two phases, because they answer different questions:
+
+- **`clean`** — a full `cargo check --workspace` from an empty target directory,
+  dependencies included. This is the number a developer feels.
+- **`borrowck`** — each of the 26 workspace crates re-checked on its own with
+  `-Ztime-passes`, reporting the `MIR_borrow_checking` pass in isolation. If a
+  borrow-checker change shows up anywhere, it shows up here.
+
+Two measurement details are load-bearing, and both were mistakes first:
+
+- **CPU time, not wall clock, for the `clean` phase.** Wall clock on a laptop
+  drifts with temperature by more than the effect being measured — an early run
+  of this benchmark produced a "+11%" and a "−1.6%" from the same pair of
+  configurations on the same machine an hour apart. CPU time (user + sys, over
+  the whole `cargo` + `rustc` tree) is far steadier, and even it should be read
+  as an upper bound on the noise rather than a precise figure.
+- **One crate per `rustc` invocation for the `borrowck` phase.** Cargo replays
+  the cached stderr of units it does not rebuild. If dependencies are built with
+  `-Ztime-passes`, their timing lines reappear on every later run and get
+  counted against whichever crate was being checked, which inflated an early
+  measurement of this pass by roughly 7×. Passing the flag through
+  `cargo rustc -p <crate> -- -Ztime-passes` means no dependency ever emits a
+  timing line at all.
+
+## Results
+
+`rustc 1.99.0-nightly (969b803cb 2026-08-09)`, Apple M2 Max (12 cores, 96 GB),
+macOS 26.5.1, 4 iterations per configuration in ABBA order.
+
+| Measurement                                     |           NLL | Polonius Alpha |     Delta |
+| ----------------------------------------------- | ------------: | -------------: | --------: |
+| `MIR_borrow_checking`, 26 crates, min per crate |        1.50 s |         1.62 s | **+8.0%** |
+| Clean workspace check, CPU time                 | 108.3 s ± 8.5 |  111.0 s ± 6.1 |     +2.4% |
+| Clean workspace check, wall clock               |  17.7 s ± 1.8 |   17.3 s ± 1.4 |     −1.9% |
+
+The borrow-checking pass itself is consistently slower, and consistently in one
+direction: 21 of 26 crates regressed, 5 were unchanged, none improved. The
+largest movers are the crates with the most borrow-heavy control flow.
+
+| Crate               |     NLL | Polonius Alpha |  Delta |
+| ------------------- | ------: | -------------: | -----: |
+| `ox_content_docs`   | 0.373 s |        0.411 s | +10.2% |
+| `ox_content_ssg`    | 0.166 s |        0.187 s | +12.7% |
+| `ox_content_napi`   | 0.250 s |        0.262 s |  +4.8% |
+| `ox_content_parser` | 0.091 s |        0.101 s | +11.0% |
+| `ox_content_lsp`    | 0.184 s |        0.194 s |  +5.4% |
+
+That 8% lands on a pass that is a small fraction of a compile. In absolute terms
+it is 0.12 s spread across the whole workspace, which is why it does not survive
+into the `clean` numbers: at workspace scale the difference sits inside the
+run-to-run spread, and repeated rounds put it between +0.7% and +2.4% CPU with
+wall clock unable to distinguish the two at all. This is comfortably inside the
+"relatively few and minimal" regressions the release announcement describes, and
+nowhere near the 2–3× worst case it reports for borrow-heavy crates.
+
+**Nothing in the workspace fails to compile under Polonius Alpha**, with no new
+warnings — checked across all 26 crates.
+
+## Borrow-checker workarounds this would let us delete
+
+Polonius Alpha accepts code NLL rejects, so some existing code is shaped around
+a restriction that is going away. Each candidate below was verified by actually
+rewriting it and compiling the result both ways — `-Zpolonius=off` rejects it,
+`-Zpolonius=next` accepts it.
+
+All three are the same shape: a function that takes `&'a mut` a cache and
+returns a borrow out of it. The natural spelling — look up, return the hit,
+otherwise insert and return — is [NLL problem case #3][case3]. NLL rejects it
+because the borrow taken for the early return is held across the later `insert`,
+even on the path where the early return did not happen.
+
+- **`normalized_entries_for_module`** —
+  [`crates/ox_content_docs/src/graph/docs.rs:76`](../../crates/ox_content_docs/src/graph/docs.rs#L76).
+  Guards with `contains_key`, then repeats the lookup as `get(...).expect(...)`,
+  costing a second hash of every path on every cache hit. Self-documenting: the
+  comment above it already says the shape exists to "keep the returned borrow
+  simple".
+- **`get_transformed_file`** —
+  [`crates/ox_content_napi/src/collection_bindings.rs:207`](../../crates/ox_content_napi/src/collection_bindings.rs#L207).
+  The same double lookup. Its `expect("transformed file should be cached")`
+  documents an invariant that exists only because the borrow could not be held
+  across the insert.
+- **`get_prepared_file`** —
+  [`crates/ox_content_napi/src/collection_bindings.rs:181`](../../crates/ox_content_napi/src/collection_bindings.rs#L181).
+  Sidesteps the problem by returning an owned `PreparedFile` rather than a
+  borrow, which costs two clones of the struct per call. This is the most
+  valuable of the three to fix, since returning `&'a PreparedFile` removes real
+  copying rather than one hash lookup.
+
+### Why these are not fixed in this PR
+
+Applying them would break the build for everyone. The workspace declares
+`rust-version = "1.83.0"` and CI pins stable; `-Zpolonius=next` is nightly-only
+until stabilization lands. Each rewrite above compiles _only_ under Polonius,
+so committing it would take the crate from "builds on stable" to "builds on
+nightly with a `-Z` flag". They are recorded here so the work is already scoped
+when Polonius reaches stable, and so nobody re-derives the same three sites.
+
+Two further candidates were investigated and rejected, which is worth recording
+so they are not re-examined:
+
+- `ox_content_ssg/src/assets/chunk.rs:35` `get_or_create` stores an index rather
+  than holding a borrow, but the simplified form compiles under NLL too — the
+  `Vec` it indexes is load-bearing for deterministic output order, not a
+  borrow-checker concession.
+- The block scope around `module_entries` in
+  `ox_content_docs/src/graph/entrypoint_docs.rs:82` also compiles without the
+  braces under NLL. It is stylistic.
+
+Disjoint-field borrow accommodations elsewhere in the tree (for example the
+`&self.doc_extractor` / `&mut self.docs` split in `graph/builder.rs`) are a
+different limitation — view types — which Polonius Alpha does not address.
+
+## If Polonius Alpha causes trouble
+
+It can be turned off without leaving nightly:
+
+```bash
+RUSTFLAGS=-Zpolonius=off cargo build
+```
+
+Regressions and unsoundness go to the [tracking issue][tracking].
+
+[blog]: https://blog.rust-lang.org/2026/08/04/enabling-polonius-alpha-on-nightly/
+[case3]: https://rust-lang.github.io/rfcs/2094-nll.html#problem-case-3-conditional-control-flow-across-functions
+[tracking]: https://github.com/rust-lang/rust/issues/160456

--- a/benchmarks/polonius-borrowck/README.md
+++ b/benchmarks/polonius-borrowck/README.md
@@ -2,15 +2,19 @@
 
 [Polonius Alpha][blog] is the next iteration of the borrow checker. It became
 the default on nightly in `nightly-2026-08-06`, and stabilization is planned
-before the end of 2026 — so it will arrive on stable whether or not this
-workspace is ready for it. This directory answers two questions ahead of time:
-what it costs to compile, and what it lets us delete.
+before the end of 2026, so it is expected to arrive on stable whether or not
+this workspace is ready for it. This directory answers two questions ahead of
+time: what it costs to compile, and what it lets us delete.
 
 Run it with:
 
 ```bash
-node benchmarks/polonius-borrowck/run.mjs --iterations 4 --json results.json
+node benchmarks/polonius-borrowck/run.mjs \
+  --toolchain nightly-2026-08-09 --iterations 4 --json results.json
 ```
+
+`--toolchain` pins the compiler the results below were collected with; it
+defaults to `nightly`, which measures whatever nightly is current instead.
 
 The harness needs a nightly toolchain and a POSIX `/usr/bin/time`. It never
 mutates the workspace beyond touching crate roots to force a re-check, and it
@@ -29,8 +33,10 @@ Two phases, because they answer different questions:
 - **`clean`** — a full `cargo check --workspace` from an empty target directory,
   dependencies included. This is the number a developer feels.
 - **`borrowck`** — each of the 26 workspace crates re-checked on its own with
-  `-Ztime-passes`, reporting the `MIR_borrow_checking` pass in isolation. If a
-  borrow-checker change shows up anywhere, it shows up here.
+  `-Ztime-passes`, reporting the `MIR_borrow_checking` pass in isolation. One
+  target per crate (its lib, or its bins when it has no lib), so this is where a
+  borrow-checker change has to show up for library and binary code; examples,
+  tests, and benches are not checked.
 
 Two measurement details are load-bearing, and both were mistakes first:
 
@@ -75,9 +81,12 @@ That 8% lands on a pass that is a small fraction of a compile. In absolute terms
 it is 0.12 s spread across the whole workspace, which is why it does not survive
 into the `clean` numbers: at workspace scale the difference sits inside the
 run-to-run spread, and repeated rounds put it between +0.7% and +2.4% CPU with
-wall clock unable to distinguish the two at all. This is comfortably inside the
-"relatively few and minimal" regressions the release announcement describes, and
-nowhere near the 2–3× worst case it reports for borrow-heavy crates.
+wall clock unable to distinguish the two at all. The "relatively few and
+minimal" regressions the release announcement describes are a statement about
+magnitude, and by that measure these qualify: the regression is broad here (21
+of 26 crates), but every crate moves by a fraction of a second, the workspace
+total is unchanged, and nothing comes near the 2–3× worst case the announcement
+reports for borrow-heavy crates.
 
 **Nothing in the workspace fails to compile under Polonius Alpha**, with no new
 warnings — checked across all 26 crates.

--- a/benchmarks/polonius-borrowck/run.mjs
+++ b/benchmarks/polonius-borrowck/run.mjs
@@ -18,8 +18,9 @@
  *     so it can only show that the effect is small, not how large it is.
  *
  *   - `borrowck`: each workspace crate re-checked on its own with
- *     `-Ztime-passes`, reporting the `MIR_borrow_checking` pass alone. This is
- *     where a borrow-checker change has to show up if it shows up anywhere, and
+ *     `-Ztime-passes`, reporting the `MIR_borrow_checking` pass alone. One
+ *     target per crate (lib, or bins when there is no lib), so this is where a
+ *     borrow-checker change has to show up for library and binary code, and
  *     isolating it keeps the signal from drowning in dependency compile time.
  *     Per-crate minimum across repetitions, which is robust to scheduler noise.
  *
@@ -54,6 +55,11 @@ const argValue = (flag) => {
 const iterations = Number(argValue("--iterations") ?? 4);
 const toolchain = argValue("--toolchain") ?? "nightly";
 const jsonPath = argValue("--json");
+
+if (!Number.isSafeInteger(iterations) || iterations < 1) {
+  console.error("--iterations must be a positive integer");
+  process.exit(1);
+}
 
 const targetDirs = new Map(
   CONFIGS.map((config) => [config.name, mkdtempSync(join(tmpdir(), `polonius-${config.name}-`))]),
@@ -101,10 +107,17 @@ function cargo(cargoArgs, { rustflags, targetDir }) {
  */
 function passTotal(stderr, pass) {
   let total = 0;
+  let found = false;
   for (const line of stderr.split("\n")) {
     const timed = /^time:\s+([0-9.]+);.*\t(\S+)$/.exec(line.trimEnd());
-    if (timed && timed[2] === pass) total += Number(timed[1]);
+    if (timed && timed[2] === pass) {
+      found = true;
+      total += Number(timed[1]);
+    }
   }
+  // A missing pass means the crate was replayed from cache or `-Ztime-passes`
+  // changed shape; either way a silent 0 would be recorded as a real timing.
+  if (!found) throw new Error(`no ${pass} timing in the run output`);
   return total;
 }
 

--- a/benchmarks/polonius-borrowck/run.mjs
+++ b/benchmarks/polonius-borrowck/run.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+
+/**
+ * Polonius Alpha vs NLL borrow-checker build-time benchmark.
+ *
+ * Since nightly-2026-08-06 the Polonius Alpha borrow checker is the default on
+ * nightly, with stabilization planned before the end of 2026. This measures
+ * what that switch costs this workspace: one nightly toolchain checks every
+ * crate twice, once with `-Zpolonius=off` (today's stable NLL checker) and once
+ * with `-Zpolonius=next` (Polonius Alpha), so the flag is the only variable.
+ *
+ * Two phases, because they answer different questions:
+ *
+ *   - `clean`: full `cargo check --workspace` from an empty target directory,
+ *     dependencies included. This is the number a developer feels. CPU time
+ *     (user + sys) is the headline metric — wall clock on a laptop has a
+ *     standard deviation several times larger than the effect being measured,
+ *     so it can only show that the effect is small, not how large it is.
+ *
+ *   - `borrowck`: each workspace crate re-checked on its own with
+ *     `-Ztime-passes`, reporting the `MIR_borrow_checking` pass alone. This is
+ *     where a borrow-checker change has to show up if it shows up anywhere, and
+ *     isolating it keeps the signal from drowning in dependency compile time.
+ *     Per-crate minimum across repetitions, which is robust to scheduler noise.
+ *
+ * Each config gets its own `CARGO_TARGET_DIR` so alternating `RUSTFLAGS` does
+ * not invalidate dependency fingerprints, and `clean` runs alternate in ABBA
+ * order to cancel thermal drift. `CARGO_INCREMENTAL=0` keeps cargo from
+ * replaying cached output instead of recompiling.
+ *
+ * Usage:
+ *   node benchmarks/polonius-borrowck/run.mjs
+ *   node benchmarks/polonius-borrowck/run.mjs --iterations 4 --json results.json
+ */
+
+import { spawnSync } from "node:child_process";
+import { globSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+const CONFIGS = [
+  { name: "nll", rustflags: "-Zpolonius=off" },
+  { name: "polonius", rustflags: "-Zpolonius=next" },
+];
+
+const args = process.argv.slice(2);
+const argValue = (flag) => {
+  const index = args.indexOf(flag);
+  return index === -1 ? undefined : args[index + 1];
+};
+const iterations = Number(argValue("--iterations") ?? 4);
+const toolchain = argValue("--toolchain") ?? "nightly";
+const jsonPath = argValue("--json");
+
+const targetDirs = new Map(
+  CONFIGS.map((config) => [config.name, mkdtempSync(join(tmpdir(), `polonius-${config.name}-`))]),
+);
+
+/**
+ * `cargo check` under `/usr/bin/time -p`, which reports the CPU consumed by the
+ * whole `cargo` + `rustc` process tree. Node's `spawnSync` exposes no rusage,
+ * and summing rustc's self-reported passes would miss cargo itself, so the
+ * external timer is what makes the CPU metric trustworthy.
+ */
+function cargo(cargoArgs, { rustflags, targetDir }) {
+  const started = process.hrtime.bigint();
+  const result = spawnSync("/usr/bin/time", ["-p", "cargo", `+${toolchain}`, ...cargoArgs], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      RUSTFLAGS: rustflags,
+      CARGO_TARGET_DIR: targetDir,
+      CARGO_INCREMENTAL: "0",
+    },
+    encoding: "utf8",
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  const stderr = result.stderr ?? "";
+  const seconds = (name) =>
+    Number(new RegExp(`^${name}\\s+([0-9.]+)$`, "m").exec(stderr)?.[1] ?? 0);
+  return {
+    wall: Number(process.hrtime.bigint() - started) / 1e9,
+    cpu: seconds("user") + seconds("sys"),
+    stderr,
+    status: result.status ?? -1,
+  };
+}
+
+/**
+ * Sums one `-Ztime-passes` pass in a run's output.
+ *
+ * Only ever called on a single-crate `cargo rustc` run, which is what makes the
+ * number trustworthy: cargo replays the cached stderr of already-built units,
+ * so if dependencies had been built with `-Ztime-passes` their timing lines
+ * would reappear on every later run and be counted as the crate under test.
+ * Passing the flag through `cargo rustc --` applies it to this crate alone, so
+ * no dependency ever emits a timing line to begin with.
+ */
+function passTotal(stderr, pass) {
+  let total = 0;
+  for (const line of stderr.split("\n")) {
+    const timed = /^time:\s+([0-9.]+);.*\t(\S+)$/.exec(line.trimEnd());
+    if (timed && timed[2] === pass) total += Number(timed[1]);
+  }
+  return total;
+}
+
+const samples = [];
+const borrowck = new Map(CONFIGS.map((config) => [config.name, new Map()]));
+
+const rustcVersion = spawnSync("rustc", [`+${toolchain}`, "--version"], {
+  encoding: "utf8",
+}).stdout?.trim();
+if (!rustcVersion) {
+  console.error(`toolchain "${toolchain}" is missing (rustup toolchain install ${toolchain})`);
+  process.exit(1);
+}
+console.log(`${rustcVersion}\n${iterations} iterations per config, ABBA order\n`);
+
+try {
+  for (let iteration = 1; iteration <= iterations; iteration += 1) {
+    const order = iteration % 2 === 1 ? CONFIGS : [...CONFIGS].reverse();
+    for (const config of order) {
+      const targetDir = targetDirs.get(config.name);
+      rmSync(targetDir, { recursive: true, force: true });
+      const run = cargo(["check", "--workspace"], { rustflags: config.rustflags, targetDir });
+      if (run.status !== 0) {
+        console.error(
+          run.stderr
+            .split("\n")
+            .filter((l) => l.startsWith("error"))
+            .join("\n"),
+        );
+        throw new Error(`${config.name} clean check failed (exit ${run.status})`);
+      }
+      samples.push({ iteration, config: config.name, phase: "clean", ...pick(run) });
+      console.log(
+        `clean     ${config.name.padEnd(8)} #${iteration}  ${run.cpu.toFixed(1)}s CPU  ${run.wall.toFixed(1)}s wall`,
+      );
+    }
+  }
+
+  // Dependencies are already primed in each config's target dir by the loop
+  // above (without `-Ztime-passes`, see passTotal), so each crate is measured
+  // alone: touch its root, re-check just that crate, read its own pass timing.
+  // `cargo rustc` refuses to forward flags to more than one target, so each
+  // crate is pinned to a single one: its lib when it has one, its bins
+  // otherwise (six crates here ship both a lib and a CLI binary).
+  const crateRoots = globSync("crates/*/src/{lib,main}.rs", { cwd: ROOT })
+    .map((path) => ({ crate: path.split("/")[1], file: join(ROOT, path), path }))
+    .filter(({ crate, path }, _, all) => {
+      const isLib = path.endsWith("lib.rs");
+      return isLib || !all.some((other) => other.crate === crate && other.path.endsWith("lib.rs"));
+    })
+    .map((entry) => ({ ...entry, target: entry.path.endsWith("lib.rs") ? "--lib" : "--bins" }));
+  for (let rep = 1; rep <= iterations; rep += 1) {
+    for (const config of CONFIGS) {
+      const best = borrowck.get(config.name);
+      for (const { crate, file, target } of crateRoots) {
+        const now = new Date();
+        utimesSync(file, now, now);
+        const run = cargo(
+          ["rustc", "-p", crate, "--profile", "check", target, "--", "-Ztime-passes"],
+          { rustflags: config.rustflags, targetDir: targetDirs.get(config.name) },
+        );
+        if (run.status !== 0) throw new Error(`${config.name} borrowck run failed for ${crate}`);
+        const seconds = passTotal(run.stderr, "MIR_borrow_checking");
+        best.set(crate, Math.min(best.get(crate) ?? Infinity, seconds));
+      }
+      console.log(
+        `borrowck  ${config.name.padEnd(8)} #${rep}  ${sum(best).toFixed(2)}s (best-so-far)`,
+      );
+    }
+  }
+} finally {
+  for (const dir of targetDirs.values()) rmSync(dir, { recursive: true, force: true });
+}
+
+function pick({ wall, cpu, status }) {
+  return { wall, cpu, status };
+}
+function sum(map) {
+  return [...map.values()].reduce((a, b) => a + b, 0);
+}
+function mean(values) {
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+console.log("");
+const summary = {};
+for (const metric of ["cpu", "wall"]) {
+  const means = {};
+  for (const config of CONFIGS) {
+    const values = samples.filter((s) => s.config === config.name).map((s) => s[metric]);
+    means[config.name] = mean(values);
+    const sd = Math.sqrt(mean(values.map((v) => (v - means[config.name]) ** 2)));
+    console.log(
+      `clean ${metric.padEnd(4)}  ${config.name.padEnd(8)} mean ${means[config.name].toFixed(1)}s ± ${sd.toFixed(1)}s`,
+    );
+  }
+  const delta = means.polonius - means.nll;
+  summary[`clean_${metric}`] = { ...means, delta, percent: (delta / means.nll) * 100 };
+  console.log(
+    `clean ${metric.padEnd(4)}  delta    ${delta > 0 ? "+" : ""}${delta.toFixed(1)}s (${((delta / means.nll) * 100).toFixed(1)}%)\n`,
+  );
+}
+
+const borrowckTotals = Object.fromEntries(
+  CONFIGS.map((config) => [config.name, sum(borrowck.get(config.name))]),
+);
+const borrowckDelta = borrowckTotals.polonius - borrowckTotals.nll;
+summary.borrowck = {
+  ...borrowckTotals,
+  delta: borrowckDelta,
+  percent: (borrowckDelta / borrowckTotals.nll) * 100,
+};
+console.log(
+  `MIR_borrow_checking (workspace crates, min per crate)  nll ${borrowckTotals.nll.toFixed(2)}s  ` +
+    `polonius ${borrowckTotals.polonius.toFixed(2)}s  ` +
+    `delta ${borrowckDelta > 0 ? "+" : ""}${borrowckDelta.toFixed(2)}s ` +
+    `(${((borrowckDelta / borrowckTotals.nll) * 100).toFixed(1)}%)`,
+);
+
+if (jsonPath) {
+  const perCrate = Object.fromEntries(
+    CONFIGS.map((config) => [config.name, Object.fromEntries(borrowck.get(config.name))]),
+  );
+  writeFileSync(
+    jsonPath,
+    `${JSON.stringify({ rustcVersion, summary, samples, perCrate }, null, 2)}\n`,
+  );
+  console.log(`\nwrote ${jsonPath}`);
+}

--- a/benchmarks/polonius-borrowck/run.mjs
+++ b/benchmarks/polonius-borrowck/run.mjs
@@ -25,9 +25,9 @@
  *     Per-crate minimum across repetitions, which is robust to scheduler noise.
  *
  * Each config gets its own `CARGO_TARGET_DIR` so alternating `RUSTFLAGS` does
- * not invalidate dependency fingerprints, and `clean` runs alternate in ABBA
- * order to cancel thermal drift. `CARGO_INCREMENTAL=0` keeps cargo from
- * replaying cached output instead of recompiling.
+ * not invalidate dependency fingerprints, and both phases alternate config
+ * order per repetition (ABBA) to cancel thermal drift. `CARGO_INCREMENTAL=0`
+ * keeps cargo from replaying cached output instead of recompiling.
  *
  * Usage:
  *   node benchmarks/polonius-borrowck/run.mjs
@@ -170,7 +170,8 @@ try {
     })
     .map((entry) => ({ ...entry, target: entry.path.endsWith("lib.rs") ? "--lib" : "--bins" }));
   for (let rep = 1; rep <= iterations; rep += 1) {
-    for (const config of CONFIGS) {
+    const order = rep % 2 === 1 ? CONFIGS : [...CONFIGS].reverse();
+    for (const config of order) {
       const best = borrowck.get(config.name);
       for (const { crate, file, target } of crateRoots) {
         const now = new Date();


### PR DESCRIPTION
## Why

[Polonius Alpha][blog] became the default borrow checker on nightly in
`nightly-2026-08-06`, and stabilization is planned before the end of 2026. It
reaches this workspace whether or not we prepare for it, so this measures the
cost ahead of time and writes down what it would let us delete.

## What this adds

`benchmarks/polonius-borrowck/` — a harness that pins one nightly toolchain and
varies only `-Zpolonius` (`off` = today's stable NLL checker, `next` = Polonius
Alpha), plus a README recording the results.

```bash
node benchmarks/polonius-borrowck/run.mjs --iterations 4 --json results.json
```

**No Rust code changes.** The diff is one new benchmark directory and an index
entry in `benchmarks/README.md`.

## Results

`rustc 1.99.0-nightly (969b803cb 2026-08-09)`, Apple M2 Max, 4 iterations per
configuration in ABBA order.

| Measurement | NLL | Polonius Alpha | Delta |
| --- | ---: | ---: | ---: |
| `MIR_borrow_checking`, 26 crates | 1.50 s | 1.62 s | **+8.0%** |
| Clean workspace check, CPU time | 108.3 s ± 8.5 | 111.0 s ± 6.1 | +2.4% |
| Clean workspace check, wall clock | 17.7 s ± 1.8 | 17.3 s ± 1.4 | −1.9% |

The whole workspace checks clean under Polonius Alpha with **no new warnings**.
Borrow checking itself is consistently slower — 21 of 26 crates regressed, 5
unchanged, none improved — but 8% of that pass is 0.12 s across the entire
workspace, which does not survive into a full check: the difference sits inside
the run-to-run spread, and wall clock cannot distinguish the two at all. That is
well inside the "relatively few and minimal" regressions the announcement
describes, and nowhere near the 2–3× worst case it reports.

## Two measurement traps, both hit before getting this right

Worth flagging for anyone who reruns this:

- **Wall clock is useless here.** It drifts with machine temperature by more
  than the effect being measured — an early round produced "+11%" and "−1.6%"
  from the same pair of configurations an hour apart. CPU time is the headline
  metric, and even it should be read as an upper bound.
- **Cargo replays cached stderr.** Building dependencies with `-Ztime-passes`
  makes their timing lines reappear on every later run, attributed to whichever
  crate was being checked. That inflated this pass by roughly 7× until each
  crate got its own `cargo rustc -p <crate> -- -Ztime-passes` invocation.

## Borrow-checker workarounds it would let us delete — found, but deliberately not applied

Three sites exist only to work around [NLL problem case #3][case3] (return a
borrow from a cache, then insert on the miss path). Each was verified by
rewriting it and compiling both ways: `-Zpolonius=off` rejects it with E0502,
`-Zpolonius=next` accepts it.

- `normalized_entries_for_module` (`ox_content_docs/src/graph/docs.rs:76`) —
  double hash lookup on every cache hit. Its comment already admits the shape
  exists to "keep the returned borrow simple".
- `get_transformed_file` (`ox_content_napi/src/collection_bindings.rs:207`) —
  same double lookup, plus an `expect` for an invariant that exists only because
  of it.
- `get_prepared_file` (`ox_content_napi/src/collection_bindings.rs:181`) —
  returns an owned `PreparedFile` instead of a borrow, costing two clones per
  call. The most valuable of the three to fix.

**They are not fixed in this PR, on purpose.** Every rewrite compiles *only*
under `-Zpolonius=next`, and this workspace declares `rust-version = "1.83.0"`
with CI pinned to stable — applying them would move the crates off stable
Rust today. They are recorded so the work is already scoped when Polonius
stabilizes, and so nobody re-derives the same three sites.

Two further candidates were investigated and **rejected**, also recorded so they
are not re-examined: `get_or_create` in `ox_content_ssg/src/assets/chunk.rs:35`
and the block scope in `ox_content_docs/src/graph/entrypoint_docs.rs:82` both
compile fine under NLL. Disjoint-field borrow accommodations elsewhere (e.g.
`graph/builder.rs`) are the view-types limitation, which Polonius Alpha does not
address.

[blog]: https://blog.rust-lang.org/2026/08/04/enabling-polonius-alpha-on-nightly/
[case3]: https://rust-lang.github.io/rfcs/2094-nll.html#problem-case-3-conditional-control-flow-across-functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a benchmark for comparing nightly Rust’s NLL and Polonius Alpha borrow checkers.
  * Added configurable iterations, timing measurements, workspace compatibility checks, cleanup, failure reporting, and optional JSON results.
  * Added aggregate comparisons to highlight borrow-checking performance differences.

* **Documentation**
  * Documented benchmark setup, execution, measurement methodology, results, compatibility, potential workarounds, stabilization constraints, and fallback options.
  * Updated benchmark guidance to cover correctness and compiler experiments alongside performance measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->