### PR TITLE
perf: win back the md4x benchmark on small documents

### DIFF
--- a/benchmarks/bundle-size/package.json
+++ b/benchmarks/bundle-size/package.json
@@ -18,7 +18,7 @@
     "markdown-it-ts": "^1.0.10",
     "marked": "^18.0.9",
     "md4w": "^0.2.7",
-    "md4x": "^0.0.25",
+    "md4x": "^0.0.29",
     "micromark": "^4.0.1",
     "remark-html": "^16.0.1",
     "remark-parse": "^11.0.0",

--- a/benchmarks/commonmark-conformance/package.json
+++ b/benchmarks/commonmark-conformance/package.json
@@ -14,7 +14,7 @@
     "markdown-it-ts": "^1.0.10",
     "marked": "^18.0.9",
     "md4w": "^0.2.7",
-    "md4x": "^0.0.25",
+    "md4x": "^0.0.29",
     "micromark": "^4.0.1",
     "remark-html": "^16.0.1",
     "remark-parse": "^11.0.0",

--- a/benchmarks/commonmark-conformance/results.json
+++ b/benchmarks/commonmark-conformance/results.json
@@ -42,6 +42,10 @@
       "passed": 649,
       "total": 652
     },
+    "md4x (napi)": {
+      "passed": 649,
+      "total": 652
+    },
     "satteri": {
       "passed": 645,
       "total": 652
@@ -50,19 +54,15 @@
       "passed": 609,
       "total": 652
     },
-    "md4x (napi)": {
-      "passed": 603,
-      "total": 652
-    },
     "md4w (md4c)": {
       "passed": 598,
       "total": 652
     },
-    "@mizchi/markdown": {
-      "passed": 299,
+    "@tanstack/markdown": {
+      "passed": 309,
       "total": 652
     },
-    "@tanstack/markdown": {
+    "@mizchi/markdown": {
       "passed": 299,
       "total": 652
     }

--- a/crates/ox_content_allocator/src/lib.rs
+++ b/crates/ox_content_allocator/src/lib.rs
@@ -33,7 +33,7 @@ impl Allocator {
 
     /// Creates a new allocator pre-sized for parsing a Markdown source of
     /// the given length. The capacity is a heuristic (`source_len * 8`
-    /// bytes, with a 4 KB floor) that covers the typical AST footprint
+    /// bytes, with a 16 KB floor) that covers the typical AST footprint
     /// for real-world Markdown without growing through bumpalo's
     /// chunk-doubling path — on a fresh [`Self::new`], that path accounts
     /// for ~10 global allocations on a 64 KB document.
@@ -43,15 +43,36 @@ impl Allocator {
     /// arena chunk for the whole parse + render pipeline.
     #[must_use]
     pub fn for_source_len(source_len: usize) -> Self {
+        Self::with_capacity(Self::capacity_for_source_len(source_len))
+    }
+
+    /// Returns the arena capacity [`Self::for_source_len`] would pick for a
+    /// source of `source_len` bytes.
+    ///
+    /// Exposed for callers that reuse one arena across documents and need to
+    /// decide whether the retained chunk is still big enough for the next one.
+    #[must_use]
+    pub const fn capacity_for_source_len(source_len: usize) -> usize {
         // The 8× factor is empirical: across the bundled corpora
         // (rust-book / vite / vue / typescript-handbook) the AST + render
         // output combined comes in between 5× and 7× of the source
         // length. 8× errs slightly on the over-allocation side so the
         // first chunk almost always suffices.
         const BYTES_PER_INPUT_BYTE: usize = 8;
-        const MIN_CAPACITY: usize = 4 * 1024;
-        let capacity = source_len.saturating_mul(BYTES_PER_INPUT_BYTE).max(MIN_CAPACITY);
-        Self::with_capacity(capacity)
+        // Small documents break the ratio: a 500-byte document still builds a
+        // full block/inline tree, whose fixed per-node overhead lands nowhere
+        // near 8× the source. Measured against the md4x bench fixture (494
+        // bytes) the parse needs ~16 KB, so a 4 KB floor bought two extra
+        // chunk-growth allocations on precisely the small inputs where
+        // per-call cost dominates. 16 KB is one page-cluster of slack and
+        // covers everything under ~2 KB of Markdown in a single chunk.
+        const MIN_CAPACITY: usize = 16 * 1024;
+        let capacity = source_len.saturating_mul(BYTES_PER_INPUT_BYTE);
+        if capacity < MIN_CAPACITY {
+            MIN_CAPACITY
+        } else {
+            capacity
+        }
     }
 
     /// Returns the underlying bump allocator.

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -17,6 +17,8 @@ mod lint;
 mod mermaid_bindings;
 mod og_image_bindings;
 mod parse_bindings;
+mod parser_options;
+mod render_scratch;
 mod search_bindings;
 mod ssg_bindings;
 mod ssg_page_types;
@@ -44,21 +46,12 @@ pub use lint::*;
 pub use mermaid_bindings::*;
 pub use og_image_bindings::*;
 pub use parse_bindings::*;
+pub use parser_options::JsParserOptions;
 pub use search_bindings::*;
 pub use ssg_bindings::*;
 pub use ssg_page_types::*;
 pub use ssg_theme_types::*;
 pub use transform_bindings::*;
-
-use ox_content_allocator::Allocator;
-
-pub(crate) fn create_allocator_for_source(source: &str) -> Allocator {
-    // NAPI parse/render calls know the full Markdown string length before
-    // parsing. Use the shared source-length heuristic so synchronous native
-    // calls start with one appropriately sized bump chunk instead of growing
-    // from `Bump::new()` while JavaScript is blocked.
-    Allocator::for_source_len(source.len())
-}
 
 #[cfg(test)]
 mod tests;

--- a/crates/ox_content_napi/src/parse_bindings.rs
+++ b/crates/ox_content_napi/src/parse_bindings.rs
@@ -3,11 +3,11 @@ use std::collections::HashMap;
 use napi::bindgen_prelude::*;
 use napi::Task;
 use napi_derive::napi;
-use ox_content_mdast::{mdast, mdast_raw, transfer::TransferPayloadKind};
-use ox_content_parser::{Parser, ParserOptions};
-use ox_content_renderer::HtmlRenderer;
+use ox_content_mdast::transfer::TransferPayloadKind;
+use ox_content_parser::ParserOptions;
 
-use crate::create_allocator_for_source;
+use crate::parser_options::JsParserOptions;
+use crate::render_scratch;
 
 /// Parse result containing the AST as JSON.
 #[napi(object)]
@@ -102,90 +102,16 @@ pub struct JsSourceOptions {
     pub frontmatter: Option<bool>,
 }
 
-/// Parser options for JavaScript.
-///
-/// When `gfm` is `true`, omitted extension flags inherit the GFM profile.
-#[napi(object)]
-#[derive(Default, Clone)]
-pub struct JsParserOptions {
-    /// Enable the GFM convenience profile.
-    ///
-    /// Default: `false`.
-    pub gfm: Option<bool>,
-
-    /// Enable footnote references and definitions.
-    ///
-    /// Default: `false`, or `true` when `gfm` is `true`.
-    pub footnotes: Option<bool>,
-
-    /// Enable GFM task-list item markers.
-    ///
-    /// Default: `false`, or `true` when `gfm` is `true`.
-    pub task_lists: Option<bool>,
-
-    /// Enable GFM pipe tables.
-    ///
-    /// Default: `false`, or `true` when `gfm` is `true`.
-    pub tables: Option<bool>,
-
-    /// Enable GFM strikethrough spans.
-    ///
-    /// Default: `false`, or `true` when `gfm` is `true`.
-    pub strikethrough: Option<bool>,
-
-    /// Enable GFM autolinks.
-    ///
-    /// Default: `false`, or `true` when `gfm` is `true`.
-    pub autolinks: Option<bool>,
-}
-
-impl From<JsParserOptions> for ParserOptions {
-    fn from(opts: JsParserOptions) -> Self {
-        let mut options =
-            if opts.gfm.unwrap_or(false) { ParserOptions::gfm() } else { ParserOptions::default() };
-
-        if let Some(v) = opts.footnotes {
-            options.footnotes = v;
-        }
-        if let Some(v) = opts.task_lists {
-            options.task_lists = v;
-        }
-        if let Some(v) = opts.tables {
-            options.tables = v;
-        }
-        if let Some(v) = opts.strikethrough {
-            options.strikethrough = v;
-        }
-        if let Some(v) = opts.autolinks {
-            options.autolinks = v;
-        }
-
-        options
-    }
-}
-
-fn transfer_buffer_to_uint8(
-    buffer: ox_content_mdast::transfer::Result<Vec<u8>>,
-) -> Result<Uint8Array> {
-    buffer.map(Uint8Array::new).map_err(|error| Error::from_reason(error.to_string()))
-}
-
 /// Parses Markdown source into an AST.
 ///
 /// Returns the AST as a JSON string for compatibility-oriented JavaScript consumers.
 #[napi]
 pub fn parse(source: String, options: Option<JsParserOptions>) -> ParseResult {
-    let allocator = create_allocator_for_source(&source);
     let parser_options = options.map(ParserOptions::from).unwrap_or_default();
-    let parser = Parser::with_options(&allocator, &source, parser_options);
 
-    let result = parser.parse();
-    match result {
-        Ok(doc) => {
-            let ast = mdast::to_mdast_json(&doc);
-            ParseResult { ast, errors: vec![] }
-        }
-        Err(e) => ParseResult { ast: String::new(), errors: vec![e.to_string()] },
+    match render_scratch::parse_to_mdast_json(&source, parser_options) {
+        Ok(ast) => ParseResult { ast, errors: vec![] },
+        Err(error) => ParseResult { ast: String::new(), errors: vec![error] },
     }
 }
 
@@ -212,14 +138,12 @@ pub fn parse_transfer_raw(
     match payload_kind {
         TransferPayloadKind::Mdast => {
             // Raw mdast transfer serializes immediately after parsing, so it
-            // has the same arena shape as `parse`/`parseAndRender`; pre-sizing
-            // keeps large transfer requests from paying bumpalo chunk growth.
-            let allocator = create_allocator_for_source(&source);
+            // has the same arena shape as `parse`/`parseAndRender` and shares
+            // the same reused arena.
             let parser_options = options.map(ParserOptions::from).unwrap_or_default();
-            let parser = Parser::with_options(&allocator, &source, parser_options);
-            let document =
-                parser.parse().map_err(|error| napi::Error::from_reason(error.to_string()))?;
-            transfer_buffer_to_uint8(mdast_raw::to_mdast_raw(&document))
+            render_scratch::parse_to_mdast_raw(&source, parser_options)
+                .map(Uint8Array::new)
+                .map_err(napi::Error::from_reason)
         }
         TransferPayloadKind::MarkdownItTokens => Err(napi::Error::from_reason(
             "markdown-it token transfer is not implemented yet; mdast is the current baseline",
@@ -233,18 +157,11 @@ pub fn parse_transfer_raw(
 /// Parses Markdown and renders to HTML.
 #[napi]
 pub fn parse_and_render(source: String, options: Option<JsParserOptions>) -> RenderResult {
-    let allocator = create_allocator_for_source(&source);
     let parser_options = options.map(ParserOptions::from).unwrap_or_default();
-    let parser = Parser::with_options(&allocator, &source, parser_options);
 
-    let result = parser.parse();
-    match result {
-        Ok(doc) => {
-            let mut renderer = HtmlRenderer::new();
-            let html = renderer.render(&doc);
-            RenderResult { html, errors: vec![] }
-        }
-        Err(e) => RenderResult { html: String::new(), errors: vec![e.to_string()] },
+    match render_scratch::parse_and_render_html(&source, parser_options) {
+        Ok(html) => RenderResult { html, errors: vec![] },
+        Err(error) => RenderResult { html: String::new(), errors: vec![error] },
     }
 }
 
@@ -280,16 +197,10 @@ impl Task for ParseAndRenderTask {
     type JsValue = RenderResult;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        let allocator = create_allocator_for_source(&self.source);
-        let parser = Parser::with_options(&allocator, &self.source, self.options.clone());
-
-        let result = match parser.parse() {
-            Ok(doc) => {
-                let mut renderer = HtmlRenderer::new();
-                let html = renderer.render(&doc);
-                RenderResult { html, errors: vec![] }
-            }
-            Err(e) => RenderResult { html: String::new(), errors: vec![e.to_string()] },
+        let result = match render_scratch::parse_and_render_html(&self.source, self.options.clone())
+        {
+            Ok(html) => RenderResult { html, errors: vec![] },
+            Err(error) => RenderResult { html: String::new(), errors: vec![error] },
         };
         Ok(result)
     }

--- a/crates/ox_content_napi/src/parser_options.rs
+++ b/crates/ox_content_napi/src/parser_options.rs
@@ -1,0 +1,144 @@
+//! Parser options as seen from JavaScript, plus a hand-written reader for them.
+//!
+//! Every Markdown entry point takes this object, so how fast it crosses the
+//! boundary sets the floor for a `parseAndRender` call on a short document. The
+//! derived reader spends four Node-API calls per field, one of which allocates a
+//! fresh JavaScript string for the property name — six fields of that measured
+//! at roughly as much as parsing a 500-byte document. [`FromNapiValue`] is
+//! therefore written by hand below; the struct keeps `#[napi(object)]` so the
+//! generated TypeScript declaration and the JavaScript-facing conversion stay
+//! exactly as they were.
+
+// Reading a property off a JavaScript value is raw Node-API: `FromNapiValue` is
+// an unsafe trait and `napi_sys` is a C ABI. The unsafety is confined to this
+// module, which holds nothing but the options type and its reader.
+#![allow(unsafe_code)]
+
+use std::ffi::CStr;
+use std::ptr;
+
+use napi::bindgen_prelude::{FromNapiValue, ValidateNapiValue};
+use napi::sys;
+use napi_derive::napi;
+use ox_content_parser::ParserOptions;
+
+/// Parser options for JavaScript.
+///
+/// When `gfm` is `true`, omitted extension flags inherit the GFM profile.
+#[napi(object, object_from_js = false)]
+#[derive(Default, Clone)]
+pub struct JsParserOptions {
+    /// Enable the GFM convenience profile.
+    ///
+    /// Default: `false`.
+    pub gfm: Option<bool>,
+
+    /// Enable footnote references and definitions.
+    ///
+    /// Default: `false`, or `true` when `gfm` is `true`.
+    pub footnotes: Option<bool>,
+
+    /// Enable GFM task-list item markers.
+    ///
+    /// Default: `false`, or `true` when `gfm` is `true`.
+    pub task_lists: Option<bool>,
+
+    /// Enable GFM pipe tables.
+    ///
+    /// Default: `false`, or `true` when `gfm` is `true`.
+    pub tables: Option<bool>,
+
+    /// Enable GFM strikethrough spans.
+    ///
+    /// Default: `false`, or `true` when `gfm` is `true`.
+    pub strikethrough: Option<bool>,
+
+    /// Enable GFM autolinks.
+    ///
+    /// Default: `false`, or `true` when `gfm` is `true`.
+    pub autolinks: Option<bool>,
+}
+
+impl From<JsParserOptions> for ParserOptions {
+    fn from(opts: JsParserOptions) -> Self {
+        let mut options =
+            if opts.gfm.unwrap_or(false) { ParserOptions::gfm() } else { ParserOptions::default() };
+
+        if let Some(v) = opts.footnotes {
+            options.footnotes = v;
+        }
+        if let Some(v) = opts.task_lists {
+            options.task_lists = v;
+        }
+        if let Some(v) = opts.tables {
+            options.tables = v;
+        }
+        if let Some(v) = opts.strikethrough {
+            options.strikethrough = v;
+        }
+        if let Some(v) = opts.autolinks {
+            options.autolinks = v;
+        }
+
+        options
+    }
+}
+
+/// Reads one optional boolean property from a JavaScript object.
+///
+/// `napi_get_named_property` takes the key as a C string and lets Node
+/// internalize it, which skips the `napi_create_string_utf8` the derived reader
+/// pays per field. An absent property arrives as `undefined` and reads as
+/// `None`; any other non-boolean value is a type error, exactly as before.
+///
+/// # Safety
+///
+/// `env` must be the environment of the running call, and `object` a live
+/// handle to a JavaScript object in it.
+unsafe fn read_flag(
+    env: sys::napi_env,
+    object: sys::napi_value,
+    key: &CStr,
+) -> napi::Result<Option<bool>> {
+    let mut value = ptr::null_mut();
+    napi::check_status!(
+        unsafe { sys::napi_get_named_property(env, object, key.as_ptr(), &raw mut value) },
+        "Failed to read parser option `{}`",
+        key.to_string_lossy()
+    )?;
+
+    let mut value_type = sys::ValueType::napi_undefined;
+    napi::check_status!(
+        unsafe { sys::napi_typeof(env, value, &raw mut value_type) },
+        "Failed to read parser option `{}`",
+        key.to_string_lossy()
+    )?;
+    if matches!(value_type, sys::ValueType::napi_undefined | sys::ValueType::napi_null) {
+        return Ok(None);
+    }
+
+    let mut flag = false;
+    napi::check_status!(
+        unsafe { sys::napi_get_value_bool(env, value, &raw mut flag) },
+        "Parser option `{}` must be a boolean",
+        key.to_string_lossy()
+    )?;
+    Ok(Some(flag))
+}
+
+impl FromNapiValue for JsParserOptions {
+    unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
+        Ok(Self {
+            gfm: unsafe { read_flag(env, napi_val, c"gfm") }?,
+            footnotes: unsafe { read_flag(env, napi_val, c"footnotes") }?,
+            task_lists: unsafe { read_flag(env, napi_val, c"taskLists") }?,
+            tables: unsafe { read_flag(env, napi_val, c"tables") }?,
+            strikethrough: unsafe { read_flag(env, napi_val, c"strikethrough") }?,
+            autolinks: unsafe { read_flag(env, napi_val, c"autolinks") }?,
+        })
+    }
+}
+
+/// Uses the default object check from [`ValidateNapiValue`], matching what the
+/// derived implementation installed before the reader was written by hand.
+impl ValidateNapiValue for JsParserOptions {}

--- a/crates/ox_content_napi/src/render_scratch.rs
+++ b/crates/ox_content_napi/src/render_scratch.rs
@@ -1,0 +1,100 @@
+//! Thread-local scratch state for the synchronous parse/render entry points.
+//!
+//! A `parseAndRender` call on a small document spends a surprising share of its
+//! time in setup rather than in Markdown work: building a fresh arena,
+//! constructing an [`HtmlRenderer`] (whose options own six heap strings), and
+//! growing an output buffer up from zero. Those costs are per call, so they hurt
+//! exactly where a throughput table hides them — short documents, which is what
+//! a per-request or per-file caller actually feeds us.
+//!
+//! Both pieces are reusable by design: bumpalo can [`Allocator::reset`] back to
+//! the start of its largest chunk, and `HtmlRenderer` already documents that
+//! reusing an instance avoids hot-path allocations. Keeping one of each per
+//! thread turns that setup into a pointer reset after the first call.
+//!
+//! Reuse is safe here because every helper below returns owned data (a `String`,
+//! a `Vec<u8>`): nothing that borrows the arena survives the call to observe the
+//! next reset. The state is thread-local, so Node worker threads and the async
+//! task pool each get their own and never share one.
+
+use std::cell::RefCell;
+
+use ox_content_allocator::Allocator;
+use ox_content_mdast::{mdast, mdast_raw};
+use ox_content_parser::{Parser, ParserOptions};
+use ox_content_renderer::HtmlRenderer;
+
+/// Largest arena capacity carried over to the next call.
+///
+/// `reset` keeps the arena's largest chunk, which is what makes reuse free —
+/// but it also pins that chunk for the lifetime of the thread. One oversized
+/// document should not leave a permanently oversized arena behind, so anything
+/// past this bound is dropped and re-sized for the next source.
+const MAX_RETAINED_ARENA_BYTES: usize = 1 << 20;
+
+struct Scratch {
+    allocator: Allocator,
+    renderer: HtmlRenderer,
+}
+
+thread_local! {
+    static SCRATCH: RefCell<Scratch> = RefCell::new(Scratch {
+        allocator: Allocator::new(),
+        renderer: HtmlRenderer::new(),
+    });
+}
+
+impl Scratch {
+    /// Readies the arena for a source of `source_len` bytes.
+    ///
+    /// The retained chunk is kept when it is both large enough for this source
+    /// and not oversized; otherwise the arena is replaced with one sized for
+    /// the source, which is the same capacity a non-reusing caller would have
+    /// picked.
+    fn prepare(&mut self, source_len: usize) {
+        let retained = self.allocator.allocated_bytes();
+        if retained < Allocator::capacity_for_source_len(source_len)
+            || retained > MAX_RETAINED_ARENA_BYTES
+        {
+            self.allocator = Allocator::for_source_len(source_len);
+            return;
+        }
+        self.allocator.reset();
+    }
+}
+
+/// Parses `source` and renders it to HTML with a reused arena and renderer.
+pub fn parse_and_render_html(source: &str, options: ParserOptions) -> Result<String, String> {
+    SCRATCH.with_borrow_mut(|scratch| {
+        scratch.prepare(source.len());
+        // Split the borrow so the parsed document (which borrows the arena) and
+        // the renderer can be live at the same time.
+        let Scratch { allocator, renderer } = scratch;
+        match Parser::with_options(allocator, source, options).parse() {
+            Ok(document) => Ok(renderer.render_borrowed(&document).to_owned()),
+            Err(error) => Err(error.to_string()),
+        }
+    })
+}
+
+/// Parses `source` into mdast JSON with a reused arena.
+pub fn parse_to_mdast_json(source: &str, options: ParserOptions) -> Result<String, String> {
+    SCRATCH.with_borrow_mut(|scratch| {
+        scratch.prepare(source.len());
+        match Parser::with_options(&scratch.allocator, source, options).parse() {
+            Ok(document) => Ok(mdast::to_mdast_json(&document)),
+            Err(error) => Err(error.to_string()),
+        }
+    })
+}
+
+/// Parses `source` into a raw mdast transfer buffer with a reused arena.
+pub fn parse_to_mdast_raw(source: &str, options: ParserOptions) -> Result<Vec<u8>, String> {
+    SCRATCH.with_borrow_mut(|scratch| {
+        scratch.prepare(source.len());
+        match Parser::with_options(&scratch.allocator, source, options).parse() {
+            Ok(document) => mdast_raw::to_mdast_raw(&document).map_err(|error| error.to_string()),
+            Err(error) => Err(error.to_string()),
+        }
+    })
+}

--- a/crates/ox_content_napi/src/tests.rs
+++ b/crates/ox_content_napi/src/tests.rs
@@ -51,4 +51,5 @@ mod docs_markdown_types_and_modules;
 mod docs_nav_output;
 mod entry_points;
 mod frontmatter;
+mod render_scratch;
 mod runtime_features;

--- a/crates/ox_content_napi/src/tests/render_scratch.rs
+++ b/crates/ox_content_napi/src/tests/render_scratch.rs
@@ -1,0 +1,76 @@
+//! The parse/render entry points share one arena and one renderer per thread,
+//! so a call must not be able to see anything the previous call left behind.
+//! These cover the state that reuse could leak: the arena, the renderer's output
+//! buffer, its heading-id counter, and the arena-sizing decision.
+
+use ox_content_parser::ParserOptions;
+
+use crate::render_scratch::{parse_and_render_html, parse_to_mdast_json};
+
+fn render(source: &str) -> String {
+    parse_and_render_html(source, ParserOptions::gfm()).expect("render should succeed")
+}
+
+#[test]
+fn consecutive_renders_do_not_leak_into_each_other() {
+    let first = render("# First\n\nOne paragraph.\n");
+    let second = render("# Second\n");
+    let third = render("# First\n\nOne paragraph.\n");
+
+    assert!(first.contains("First"), "unexpected first render: {first}");
+    assert!(!second.contains("First"), "second render kept the first document: {second}");
+    assert!(!second.contains("paragraph"), "second render kept the first document: {second}");
+    assert_eq!(first, third, "the same source rendered differently the second time");
+}
+
+#[test]
+fn heading_ids_restart_for_each_document() {
+    // Duplicate slugs get a `-1`, `-2`, … suffix within one document. A renderer
+    // that carried its counter across calls would number the second document's
+    // first `## Dup` as a duplicate of the first document's.
+    let first = render("## Dup\n\n## Dup\n");
+    assert!(first.contains("id=\"dup\""), "missing base id: {first}");
+    assert!(first.contains("id=\"dup-1\""), "missing deduplicated id: {first}");
+
+    let second = render("## Dup\n");
+    assert!(second.contains("id=\"dup\""), "heading id did not restart: {second}");
+    assert!(!second.contains("dup-1"), "heading id counter leaked across documents: {second}");
+}
+
+#[test]
+fn a_large_document_does_not_corrupt_the_next_small_one() {
+    // The large source both grows the arena past the retained bound and forces
+    // the next call to decide between resetting and re-sizing it.
+    let large = "# Heading\n\nParagraph with **bold** text.\n".repeat(4000);
+    let large_html = render(&large);
+    assert!(large_html.len() > large.len(), "large render looks truncated");
+
+    let small = render("Just a sentence.\n");
+    assert_eq!(small, "<p>Just a sentence.</p>\n");
+}
+
+#[test]
+fn options_are_not_carried_over_between_calls() {
+    let table = "| a | b |\n| - | - |\n| 1 | 2 |\n";
+
+    let with_gfm = render(table);
+    assert!(with_gfm.contains("<table>"), "GFM tables should render: {with_gfm}");
+
+    let without_gfm =
+        parse_and_render_html(table, ParserOptions::default()).expect("render should succeed");
+    assert!(!without_gfm.contains("<table>"), "table parsed without GFM enabled: {without_gfm}");
+}
+
+#[test]
+fn the_ast_entry_point_shares_the_arena_safely() {
+    // `parse` and `parseAndRender` reset the same arena, so interleaving them is
+    // the case where a stale borrow would surface.
+    let ast = parse_to_mdast_json("# Title\n", ParserOptions::gfm()).expect("parse should succeed");
+    let html = render("# Other\n");
+    let ast_again =
+        parse_to_mdast_json("# Title\n", ParserOptions::gfm()).expect("parse should succeed");
+
+    assert!(ast.contains("Title"), "unexpected ast: {ast}");
+    assert!(html.contains("Other"), "unexpected html: {html}");
+    assert_eq!(ast, ast_again, "the same source parsed differently after an interleaved render");
+}

--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -130,18 +130,24 @@ pub struct Parser<'a> {
     /// Link reference definitions collected by the root parser's
     /// pre-pass, shared with sub-parsers (block quote and list item
     /// contents) so references resolve document-wide.
-    definitions: std::rc::Rc<reference::ReferenceMap<'a>>,
+    ///
+    /// `None` and an empty map mean the same thing to every reader; the
+    /// distinction exists so that documents without definitions — the
+    /// overwhelming majority, and the ones where per-call cost is most
+    /// visible — never pay for the `Rc` allocation at all. The same applies
+    /// to the two collections below.
+    definitions: Option<std::rc::Rc<reference::ReferenceMap<'a>>>,
 
     /// Footnote labels defined anywhere in the document, collected by the
     /// same kind of pre-pass as `definitions` so an inline `[^x]` can tell
     /// whether a definition exists before reaching it.
-    footnote_labels: std::rc::Rc<footnote::FootnoteLabels>,
+    footnote_labels: Option<std::rc::Rc<footnote::FootnoteLabels>>,
 
     /// Byte offsets (in `source`) of lines that entered this sub-source
     /// via lazy continuation. Such lines are paragraph text by
     /// construction and must not be reinterpreted as setext underlines
     /// during the re-parse.
-    lazy_lines: std::rc::Rc<rustc_hash::FxHashSet<u32>>,
+    lazy_lines: Option<std::rc::Rc<rustc_hash::FxHashSet<u32>>>,
 }
 
 impl<'a> Parser<'a> {
@@ -160,9 +166,9 @@ impl<'a> Parser<'a> {
             options,
             position: 0,
             nesting_depth: 0,
-            definitions: std::rc::Rc::new(reference::ReferenceMap::default()),
-            footnote_labels: std::rc::Rc::default(),
-            lazy_lines: std::rc::Rc::default(),
+            definitions: None,
+            footnote_labels: None,
+            lazy_lines: None,
         };
         // A single fused pre-pass collects both the reference definitions
         // and the footnote labels (see `prepass.rs`).
@@ -188,9 +194,11 @@ impl<'a> Parser<'a> {
             options: self.options.clone(),
             position: 0,
             nesting_depth: 0,
-            definitions: std::rc::Rc::clone(&self.definitions),
-            footnote_labels: std::rc::Rc::clone(&self.footnote_labels),
-            lazy_lines: std::rc::Rc::new(lazy_lines),
+            definitions: self.definitions.clone(),
+            footnote_labels: self.footnote_labels.clone(),
+            // Most sub-sources are entered without any lazy continuation
+            // line, and every block quote and list item builds one of these.
+            lazy_lines: (!lazy_lines.is_empty()).then(|| std::rc::Rc::new(lazy_lines)),
         }
     }
 

--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -226,7 +226,11 @@ impl<'a> Parser<'a> {
     fn setext_underline_depth(&self, line_start: usize, first_non_ws: usize) -> Option<u8> {
         // A lazily-continued line is paragraph text by construction and
         // can never underline the paragraph it continues.
-        if self.lazy_lines.contains(&(line_start as u32)) {
+        if self
+            .lazy_lines
+            .as_ref()
+            .is_some_and(|lazy_lines| lazy_lines.contains(&(line_start as u32)))
+        {
             return None;
         }
         let bytes = self.source.as_bytes();

--- a/crates/ox_content_parser/src/parser/footnote.rs
+++ b/crates/ox_content_parser/src/parser/footnote.rs
@@ -175,8 +175,9 @@ impl<'a> Parser<'a> {
 
     /// Whether a definition exists for `label` (already normalized-able).
     pub(super) fn has_footnote_label(&self, label: &str) -> bool {
-        !self.footnote_labels.is_empty()
-            && self.footnote_labels.contains(&normalize_footnote_label(label))
+        self.footnote_labels
+            .as_ref()
+            .is_some_and(|labels| labels.contains(&normalize_footnote_label(label)))
     }
 
     /// Emits a [`FootnoteReference`] for `[^label]` at `pos`. Returns

--- a/crates/ox_content_parser/src/parser/inline/gfm_autolink.rs
+++ b/crates/ox_content_parser/src/parser/inline/gfm_autolink.rs
@@ -6,6 +6,8 @@
 //! interfere with emphasis pairing, and recurses into emphasis-like
 //! containers while never descending into existing links.
 
+use std::sync::LazyLock;
+
 use memchr::memmem;
 use ox_content_allocator::Vec;
 use ox_content_ast::{Link, Node, Span, Text};
@@ -119,33 +121,54 @@ impl<'a> Parser<'a> {
     }
 }
 
+/// Searchers for the multi-byte autolink needles, built once for the process.
+///
+/// The one-shot `memmem::find` rebuilds its SIMD prefilter on every call, and
+/// this scan runs over every text node of every document — on short prose
+/// nodes that setup cost dominated the search itself.
+static URL_FINDERS: LazyLock<[memmem::Finder<'static>; 4]> =
+    LazyLock::new(|| ["www.", "http://", "https://", "ftp://"].map(memmem::Finder::new));
+
 /// Finds the earliest valid autolink candidate in `value`.
 fn find_candidate(value: &str) -> Option<Candidate> {
+    let bytes = value.as_bytes();
     let mut best: Option<Candidate> = None;
-    for (needle, _href, is_email) in [
-        ("www.", "http://", false),
-        ("http://", "", false),
-        ("https://", "", false),
-        ("ftp://", "", false),
-        ("@", "mailto:", true),
-    ] {
+
+    // `www.` is the only needle that contains neither `:` nor `@`, so one
+    // `memchr2` decides whether the three scheme scans and the email scan can
+    // match at all. Ordinary prose — nearly every text node in a document —
+    // answers no and skips four scans.
+    let has_scheme_or_email = memchr::memchr2(b':', b'@', bytes).is_some();
+
+    for finder in URL_FINDERS.iter().take(if has_scheme_or_email { 4 } else { 1 }) {
+        let needle_len = finder.needle().len();
         let mut from = 0;
-        while let Some(offset) = memmem::find(&value.as_bytes()[from..], needle.as_bytes()) {
+        while let Some(offset) = finder.find(&bytes[from..]) {
             let at = from + offset;
-            let candidate = if is_email {
-                validate_email(value, at)
-            } else {
-                validate_url(value, at, needle.len())
-            };
-            if let Some(candidate) = candidate {
+            if let Some(candidate) = validate_url(value, at, needle_len) {
                 if best.as_ref().is_none_or(|current| candidate.start < current.start) {
                     best = Some(candidate);
                 }
                 break;
             }
-            from = at + needle.len();
+            from = at + needle_len;
         }
     }
+
+    if has_scheme_or_email {
+        let mut from = 0;
+        while let Some(offset) = memchr::memchr(b'@', &bytes[from..]) {
+            let at = from + offset;
+            if let Some(candidate) = validate_email(value, at) {
+                if best.as_ref().is_none_or(|current| candidate.start < current.start) {
+                    best = Some(candidate);
+                }
+                break;
+            }
+            from = at + 1;
+        }
+    }
+
     best
 }
 

--- a/crates/ox_content_parser/src/parser/prepass.rs
+++ b/crates/ox_content_parser/src/parser/prepass.rs
@@ -29,7 +29,13 @@ impl<'a> Parser<'a> {
     /// Runs the fused pre-pass for a root parser. Returns the
     /// document-wide reference map and footnote label set that are shared
     /// with sub-parsers.
-    pub(super) fn build_prepass(&self) -> (Rc<ReferenceMap<'a>>, Rc<FootnoteLabels>) {
+    ///
+    /// Either collection comes back as `None` when it stayed empty, so the
+    /// common document — no link reference definitions, no footnotes — never
+    /// allocates an `Rc` for a map nothing will read.
+    pub(super) fn build_prepass(
+        &self,
+    ) -> (Option<Rc<ReferenceMap<'a>>>, Option<Rc<FootnoteLabels>>) {
         profile_span!("parser::build_prepass");
         // Cheap bails. Both collectors need a `[` somewhere, and both a
         // literal `]:`: a reference definition's label must be closed by
@@ -41,7 +47,7 @@ impl<'a> Parser<'a> {
         if !self.source.contains('[')
             || memchr::memmem::find(self.source.as_bytes(), b"]:").is_none()
         {
-            return (Rc::new(ReferenceMap::default()), Rc::new(FootnoteLabels::default()));
+            return (None, None);
         }
         let collect_footnotes = self.options.footnotes && self.source.contains("[^");
 
@@ -166,7 +172,10 @@ impl<'a> Parser<'a> {
             pos = line_end + 1;
         }
 
-        (Rc::new(definitions), Rc::new(labels))
+        (
+            (!definitions.is_empty()).then(|| Rc::new(definitions)),
+            (!labels.is_empty()).then(|| Rc::new(labels)),
+        )
     }
 }
 

--- a/crates/ox_content_parser/src/parser/reference.rs
+++ b/crates/ox_content_parser/src/parser/reference.rs
@@ -67,10 +67,11 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn lookup_reference(&self, raw_label: &str) -> Option<&ReferenceDef<'a>> {
-        if self.definitions.is_empty() {
+        let definitions = self.definitions.as_ref()?;
+        if definitions.is_empty() {
             return None;
         }
-        self.definitions.get(&Self::normalize_reference_label(raw_label))
+        definitions.get(&Self::normalize_reference_label(raw_label))
     }
 
     /// Parses a single definition at the start of `text`. `text` must not

--- a/crates/ox_content_renderer/src/html/renderer.rs
+++ b/crates/ox_content_renderer/src/html/renderer.rs
@@ -103,6 +103,26 @@ impl HtmlRenderer {
     /// Renders a document to HTML string.
     #[must_use]
     pub fn render(&mut self, document: &Document<'_>) -> String {
+        self.render_into_output(document);
+        std::mem::take(&mut self.output)
+    }
+
+    /// Renders a document and returns a borrow of the renderer's own output
+    /// buffer instead of handing the buffer away.
+    ///
+    /// [`Self::render`] moves the buffer out, so a reused renderer starts the
+    /// next document from zero capacity and pays for the growth again. Callers
+    /// that copy the HTML somewhere else anyway (the NAPI boundary copies it
+    /// into a JavaScript string) should prefer this: the buffer stays warm and
+    /// steady-state rendering stops allocating for output entirely. The borrow
+    /// lasts until the next render call.
+    #[must_use]
+    pub fn render_borrowed(&mut self, document: &Document<'_>) -> &str {
+        self.render_into_output(document);
+        &self.output
+    }
+
+    fn render_into_output(&mut self, document: &Document<'_>) {
         crate::profile_span!("renderer::render");
         self.output.clear();
         // Renderer setup is intentionally split into a cheap structural scan
@@ -142,7 +162,6 @@ impl HtmlRenderer {
             self.output.reserve(estimated_len - self.output.capacity());
         }
         self.render_document(document);
-        std::mem::take(&mut self.output)
     }
 
     pub(in crate::html::renderer) fn render_document(&mut self, document: &Document<'_>) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: ^0.2.7
         version: 0.2.7
       md4x:
-        specifier: ^0.0.25
-        version: 0.0.25
+        specifier: ^0.0.29
+        version: 0.0.29
       micromark:
         specifier: ^4.0.1
         version: 4.0.2
@@ -233,8 +233,8 @@ importers:
         specifier: ^0.2.7
         version: 0.2.7
       md4x:
-        specifier: ^0.0.25
-        version: 0.0.25
+        specifier: ^0.0.29
+        version: 0.0.29
       micromark:
         specifier: ^4.0.1
         version: 4.0.2
@@ -967,7 +967,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10))(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
       vscode-languageclient:
         specifier: ^10.1.0
         version: 10.1.0
@@ -5967,8 +5967,8 @@ packages:
   md4w@0.2.7:
     resolution: {integrity: sha512-lFM7vwk3d4MzkV2mija7aPkK6OjKXZDQsH2beX+e2cvccBoqc6RraheMtAO0Wcr/gjj5L+WS5zhb+06AmuGZrg==}
 
-  md4x@0.0.25:
-    resolution: {integrity: sha512-GrexawUhrKcwl7o2hkgs7Ut0PqI/meOCevmaRB1ueKo2y1Fh2nIl8e6KKawYGm9eXJP3u6BzVs4rzZOc2+w3hA==}
+  md4x@0.0.29:
+    resolution: {integrity: sha512-I4gPatCcXSkeI2BgsTwt6rv0dGSu6DpiIiO8bhdmL1xEKVbg6riLxoKzUmQxe3tLVNDcFtzE2smPqZlLkJJXsw==}
     hasBin: true
 
   mdast-util-definitions@6.0.0:
@@ -10285,12 +10285,12 @@ snapshots:
       vite: '@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)'
       vue: 3.5.41(typescript@7.0.2)
 
-  '@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.3(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)
-      vitest: 4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
+      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))
+      vitest: 4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10))(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -10301,15 +10301,15 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.3(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
-      vitest: 4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
+      '@vitest/browser': 4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))
+      vitest: 4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10))(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))':
     dependencies:
       '@blazediff/core': 1.9.1
       '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
@@ -10318,7 +10318,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10))(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -10326,7 +10326,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser@4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))':
     dependencies:
       '@blazediff/core': 1.9.1
       '@vitest/mocker': 4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
@@ -10335,7 +10335,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10))(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -12445,7 +12445,7 @@ snapshots:
 
   md4w@0.2.7: {}
 
-  md4x@0.0.25: {}
+  md4x@0.0.29: {}
 
   mdast-util-definitions@6.0.0:
     dependencies:
@@ -14349,8 +14349,8 @@ snapshots:
     dependencies:
       '@oxc-project/types': 0.142.0
       '@oxlint/plugins': 1.73.0
-      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))
+      '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
@@ -14362,7 +14362,7 @@ snapshots:
       oxfmt: 0.61.0(svelte@5.56.8)(vite-plus@0.2.8(@types/node@26.1.2)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(jiti@1.21.7)(svelte@5.56.8)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
       oxlint: 1.76.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.8(@types/node@26.1.2)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(jiti@1.21.7)(svelte@5.56.8)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
       oxlint-tsgolint: 7.0.2001
-      vitest: 4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.8
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.8
@@ -14407,7 +14407,7 @@ snapshots:
     dependencies:
       '@oxc-project/types': 0.142.0
       '@oxlint/plugins': 1.73.0
-      '@vitest/browser': 4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))
       '@vitest/browser-preview': 4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
@@ -14420,7 +14420,7 @@ snapshots:
       oxfmt: 0.61.0(svelte@5.56.8)(vite-plus@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(svelte@5.56.8)(terser@5.49.0)(typescript@7.0.2)(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(yaml@2.9.0))
       oxlint: 1.76.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(svelte@5.56.8)(terser@5.49.0)(typescript@7.0.2)(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(yaml@2.9.0))
       oxlint-tsgolint: 7.0.2001
-      vitest: 4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10))(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.8
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.8
@@ -14537,7 +14537,7 @@ snapshots:
       - unrun
       - yaml
 
-  vitest@4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
@@ -14561,11 +14561,11 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.2
-      '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-preview': 4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@26.1.2)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10))(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.0.14(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))


### PR DESCRIPTION
## Summary

md4x 0.0.27 replaced its C core with a Zig port, and [pi0's release post](https://x.com/_pi0_/status/2088192068514406777) benchmarked it against ox-content on md4x's own harness. ox-content lost. Reproducing that benchmark locally (md4x 0.0.29, same fixture, same call shape) confirmed it: **md4x was 1.24× faster**.

It was not a throughput problem. Splitting the call cost against an empty document showed where it actually went:

| | md4x | ox-content (before) |
| --- | ---: | ---: |
| fixed cost per call | 57 ns | 750 ns |
| Markdown work (494-byte doc) | 3636 ns | 3817 ns |

Almost the whole gap was setup that does not scale with the input, plus one hot scan in the parser. This PR fixes both. On the same harness ox-content is now **1.10–1.15× faster than md4x**, and it leads md4x's own summary table:

```
ox-content (renderToHtml)      3.52 µs/iter
md4x.napi  (renderToHtml)      4.04 µs/iter   ← 1.15x slower
md4w                           5.57 µs
md4x.wasm                      6.13 µs
satteri                        9.28 µs
markdown-it                   16.43 µs
```

## What changed

**`perf(parser)`: autolink candidate scan.** `find_candidate` ran five one-shot `memmem::find` calls per text node. That API rebuilds its SIMD prefilter every call, and on short prose nodes the setup cost dominated the search — this was the largest single share of parse time on a small document. The four multi-byte searchers are now built once, and the three scheme scans plus the email scan sit behind one `memchr2` for `:` and `@` (`www.` is the only needle containing neither, so prose skips four scans). The candidate selected for any given text node is unchanged.

**`perf(parser)`: shared document maps.** A root parser allocated five `Rc`s — two of them discarded as soon as the pre-pass returned its own — and every block quote and list item allocated another for a lazy-continuation set that is almost always empty. All three are now `Option<Rc<_>>`; `None` reads the same as empty to every consumer.

**`perf(napi)`: fixed per-call cost.**
- The arena and the `HtmlRenderer` are now reused per thread instead of rebuilt per call. `HtmlRenderer`'s default options own six heap strings, and `render` handed its output buffer away, so a fresh renderer per call meant nine allocations plus buffer regrowth every time. New `render_borrowed` renders into the renderer's own buffer, which stays warm.
- The arena floor moves from 4 KB to 16 KB. A 500-byte document still builds a full block and inline tree and needs ~16 KB, so the old floor cost two chunk-growth allocations on exactly the inputs where per-call cost dominates.
- `JsParserOptions` gets a hand-written `FromNapiValue`. The derived reader spends four Node-API calls per field, one of which allocates a JavaScript string for the property name; six fields of that measured at roughly as much as parsing the document. `napi_get_named_property` takes the key as a C string and lets Node internalize it.

**`bench`:** md4x `^0.0.25` → `^0.0.29` in both the speed sweep and the conformance sweep, so the two tables keep describing the same engine.

## Results

494-byte document (md4x's `medium` fixture), minimum of 40 rounds × 3000 iterations:

| | before | after |
| --- | ---: | ---: |
| `parseAndRender(doc, {gfm:true})` | 4567 ns | 3351 ns |
| fixed cost (`parseAndRender("")`) | 388 ns | 159 ns |
| options object conversion | 362 ns | 286 ns |
| heap allocations per call | 28 | 11 |
| **vs md4x 0.0.29** | **1.24× slower** | **1.11× faster** |

Larger inputs are unaffected or better — 48.7 KB parse+render `@ox-content/napi` 5186 ops/s vs md4x 3588; ~1 MB 251 vs 164.

## Credit where it is due

The Zig port did not only make md4x faster. Its CommonMark conformance went from **92.5% to 99.5%** (603/652 → 649/652), which is now recorded in `results.json` — md4x ties `@ox-content/napi` exactly on the spec suite. The speed tables should be read with that in mind: this is no longer a case of a faster engine skipping spec behavior.

(`@tanstack/markdown` also moves 45.9% → 47.4% in `results.json`, from the `0.0.13` bump that already landed on main.)

## Not addressed

md4x's harness also benchmarks an AST row as `JSON.parse(oxContent.parse(input, opts).ast)`. That shape loses (12.8 µs vs md4x's 9.3 µs) because of the JSON round trip. `parseMdastRaw`, the buffer-transfer path meant for this, does the same work in 5.56 µs — 1.67× faster than md4x's `parseAST`. Making `parse` itself cheaper is a separate change.

## Verification

- `cargo test --workspace` — 951 passed, 0 failed (CommonMark 0.31.2 and GFM spec suites included)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Conformance sweep re-run: `ox-content (native)` 100.0% and `@ox-content/napi` 99.5%, both unchanged by this PR
- Generated `index.js` and `index.d.ts` are byte-identical, so the published TypeScript surface does not move
- Renderer/arena reuse is the risky part, so it has dedicated tests: consecutive renders, heading-id counter reset, a large document followed by a small one, differing options per call, and `parse` interleaved with `parseAndRender`

README and docs speed tables are regenerated by the benchmark-docs workflow on its own runner, so they are untouched here; the md4x speed and conformance columns will pick up 0.0.29 on the next CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added JavaScript-facing parser options for GFM features, including footnotes, tables, task lists, strikethrough, and autolinks.
  - Improved HTML and AST rendering for synchronous and asynchronous workflows.

- **Bug Fixes**
  - Prevented content, heading IDs, and parser settings from leaking between rendering calls.
  - Improved reliability when rendering large documents followed by smaller ones.

- **Performance**
  - Reduced repeated allocations during parsing and rendering.
  - Improved autolink candidate scanning for faster Markdown processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->