### PR TITLE
perf(parser): gate and deduplicate the GFM autolink post-pass (fixes nested <a> in link text)

### DIFF
--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -183,7 +183,7 @@ impl<'a> Parser<'a> {
                 };
                 self.position = heading_end;
                 let content = self.source[start..content_end].trim();
-                let children = self.parse_inline(content, start)?;
+                let children = self.parse_inline_block(content, start)?;
                 return Ok(Some(Node::Heading(Heading {
                     depth,
                     children,
@@ -213,7 +213,7 @@ impl<'a> Parser<'a> {
         let span = Span::new(start as u32, content_end as u32);
 
         // Parse inline content
-        let children = self.parse_inline(content, start)?;
+        let children = self.parse_inline_block(content, start)?;
 
         Ok(Some(Node::Paragraph(Paragraph { children, span })))
     }

--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -22,6 +22,28 @@ pub(in crate::parser) use self::link_target::{
 };
 
 impl<'a> Parser<'a> {
+    /// Parses the inline content of a block-level construct (paragraph,
+    /// heading, table cell, list item paragraph) and runs the block-scoped
+    /// post-passes on the result — today, the GFM autolink rewrite.
+    ///
+    /// Nested inline contexts (link text, image alt, strikethrough
+    /// interiors) call [`Self::parse_inline`] directly instead: the
+    /// autolink pass itself recurses through emphasis-like containers, so
+    /// running it per nested sequence both re-scanned the same nodes and —
+    /// for link text, which GFM excludes from autolinking — manufactured
+    /// nested `<a>` elements.
+    pub(super) fn parse_inline_block(
+        &self,
+        content: &'a str,
+        offset: usize,
+    ) -> ParseResult<Vec<'a, Node<'a>>> {
+        let mut children = self.parse_inline(content, offset)?;
+        if self.options.autolinks && gfm_autolink::may_contain_autolink(content) {
+            self.apply_gfm_autolinks(&mut children);
+        }
+        Ok(children)
+    }
+
     pub(super) fn parse_inline(
         &self,
         content: &'a str,
@@ -54,9 +76,6 @@ impl<'a> Parser<'a> {
 
         if !delimiters.is_empty() {
             self.process_emphasis(&mut children, &mut delimiters);
-        }
-        if self.options.autolinks {
-            self.apply_gfm_autolinks(&mut children);
         }
         Ok(children)
     }

--- a/crates/ox_content_parser/src/parser/inline/gfm_autolink.rs
+++ b/crates/ox_content_parser/src/parser/inline/gfm_autolink.rs
@@ -129,6 +129,21 @@ impl<'a> Parser<'a> {
 static URL_FINDERS: LazyLock<[memmem::Finder<'static>; 4]> =
     LazyLock::new(|| ["www.", "http://", "https://", "ftp://"].map(memmem::Finder::new));
 
+/// Cheap pre-flight over a block's raw inline content: can the autolink
+/// pass possibly rewrite anything here?
+///
+/// Every candidate needs a `:` (scheme), `@` (email), or `www.` — and those
+/// needle bytes are never inline-special, so if they appear in the parsed
+/// text nodes they appear verbatim in `content` too. The one indirection is
+/// entities: `&colon;`/`&commat;` decode into candidate bytes that the raw
+/// source spells with `&`, so `&` also keeps the pass on. Ordinary prose —
+/// almost every block in a document — fails all four probes and skips the
+/// node-tree walk (and its text-coalescing rewrites) entirely.
+pub(super) fn may_contain_autolink(content: &str) -> bool {
+    let bytes = content.as_bytes();
+    memchr::memchr3(b':', b'@', b'&', bytes).is_some() || URL_FINDERS[0].find(bytes).is_some()
+}
+
 /// Finds the earliest valid autolink candidate in `value`.
 fn find_candidate(value: &str) -> Option<Candidate> {
     let bytes = value.as_bytes();

--- a/crates/ox_content_parser/src/parser/leaf.rs
+++ b/crates/ox_content_parser/src/parser/leaf.rs
@@ -127,7 +127,7 @@ impl<'a> Parser<'a> {
 
         // Parse inline content
         let children = if !content.is_empty() {
-            self.parse_inline(content, content_start)?
+            self.parse_inline_block(content, content_start)?
         } else {
             self.allocator.new_vec()
         };

--- a/crates/ox_content_parser/src/parser/list/item_source.rs
+++ b/crates/ox_content_parser/src/parser/list/item_source.rs
@@ -86,7 +86,7 @@ impl<'a> Parser<'a> {
             return Ok(children);
         }
 
-        let paragraph_children = self.parse_inline(inline, content_offset)?;
+        let paragraph_children = self.parse_inline_block(inline, content_offset)?;
         children.push(Node::Paragraph(Paragraph {
             children: paragraph_children,
             span: Span::new(content_offset as u32, item_end as u32),

--- a/crates/ox_content_parser/src/parser/table.rs
+++ b/crates/ox_content_parser/src/parser/table.rs
@@ -111,7 +111,7 @@ impl<'a> Parser<'a> {
         let mut cells: Vec<'a, TableCell<'a>> = self.allocator.new_vec();
         for cell_content in Self::table_row_cells(line).take(column_count) {
             let cell_content = self.unescape_table_pipes(cell_content);
-            let cell_children = self.parse_inline(cell_content, 0)?;
+            let cell_children = self.parse_inline_block(cell_content, 0)?;
             cells.push(TableCell { children: cell_children, span: Span::new(0, 0) });
         }
         while cells.len() < column_count {

--- a/crates/ox_content_parser/tests/edge_cases/inline.rs
+++ b/crates/ox_content_parser/tests/edge_cases/inline.rs
@@ -135,16 +135,67 @@ fn backslash_before_non_punctuation_stays_literal() {
 }
 
 #[test]
+fn gfm_autolink_does_not_fire_inside_link_text() {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(
+        &allocator,
+        "[visit www.example.com](https://real.example)",
+        ParserOptions::gfm(),
+    );
+
+    match &doc.children[0] {
+        Node::Paragraph(paragraph) => match &paragraph.children[0] {
+            Node::Link(link) => {
+                assert_eq!(link.url, "https://real.example");
+                // GFM excludes link text from the autolink extension; a
+                // nested Link here would render as invalid nested <a> tags.
+                assert!(
+                    link.children.iter().all(|child| matches!(child, Node::Text(_))),
+                    "link text must stay plain text, got {:?}",
+                    link.children
+                );
+            }
+            other => panic!("expected link, got {other:?}"),
+        },
+        other => panic!("expected paragraph, got {other:?}"),
+    }
+}
+
+#[test]
+fn gfm_autolink_still_fires_inside_strikethrough() {
+    let allocator = Allocator::new();
+    let doc = parse_with_options(&allocator, "~~see www.example.com~~", ParserOptions::gfm());
+
+    match &doc.children[0] {
+        Node::Paragraph(paragraph) => match &paragraph.children[0] {
+            Node::Delete(delete) => {
+                let link_count =
+                    delete.children.iter().filter(|child| matches!(child, Node::Link(_))).count();
+                // The root-level pass recurses into emphasis-like
+                // containers, so the bare URL still links exactly once.
+                assert_eq!(link_count, 1, "expected one autolink, got {:?}", delete.children);
+            }
+            other => panic!("expected strikethrough, got {other:?}"),
+        },
+        other => panic!("expected paragraph, got {other:?}"),
+    }
+}
+
+#[test]
 fn unmatched_strikethrough_remains_text() {
     let allocator = Allocator::new();
     let doc = parse_with_options(&allocator, "~~open", ParserOptions::gfm());
 
     match &doc.children[0] {
         Node::Paragraph(paragraph) => {
+            // The unmatched marker stays literal text. It remains a separate
+            // node from the following prose: the GFM autolink post-pass is
+            // the only thing that coalesces adjacent text nodes, and it only
+            // runs when the block contains a candidate byte (`:`, `@`, `&`,
+            // or `www.`) — plain prose keeps the parser's raw segmentation.
             assert!(matches!(&paragraph.children[0], Node::Text(_)));
-            // GFM post-processing coalesces adjacent text nodes, so the
-            // unmatched marker merges with the following prose.
-            assert_eq!(first_text(&paragraph.children[0]), Some("~~open"));
+            assert_eq!(first_text(&paragraph.children[0]), Some("~~"));
+            assert_eq!(first_text(&paragraph.children[1]), Some("open"));
         }
         other => panic!("expected paragraph, got {other:?}"),
     }

--- a/crates/ox_content_parser/tests/snapshots/parser/inline_strikethrough_unmatched.snap
+++ b/crates/ox_content_parser/tests/snapshots/parser/inline_strikethrough_unmatched.snap
@@ -4,4 +4,5 @@ description: "~~open\n"
 ---
 Document [0..7]
   Paragraph [0..7]
-    Text "~~open" [0..6]
+    Text "~~" [0..2]
+    Text "open" [2..6]


### PR DESCRIPTION
## Summary

Profiling with the updated tracer (#562) showed `parser::apply_gfm_autolinks` at **12–26% of total parse time** — and with *more hits than `parse_inline` itself* (179,940 vs 150,270 on a 1.2 MB corpus): the pass ran once per nested inline sequence *and* recursed into the same containers from the root, re-coalescing and re-scanning nodes it had already processed. It also walked blocks that could not possibly contain a candidate.

### Changes
- **Root-only**: the pass now runs from block-level inline contexts only (`parse_inline_block`: paragraphs, headings, table cells, list-item paragraphs). Its own recursion covers emphasis/strong/delete interiors exactly once.
- **Candidate gate**: a pre-flight over the block's raw content (`memchr3` for `:`/`@`/`&` + a `www.` finder) skips the node walk entirely for ordinary prose. `&` stays in the probe because entities (`&colon;`, `&commat;`) can decode into candidate bytes.

### Bug fix (behavior change)
Running the pass inside link-text parses autolinked bare URLs **inside link text**, which GFM excludes — producing nested `<a>` elements:

```text
IN : [visit www.example.com](https://real.example)
OLD: <p><a href="https://real.example" …>visit <a href="http://www.example.com" …>www.example.com</a></a></p>
NEW: link text stays plain text (matches cmark-gfm)
```

Regression tests cover the fix and the still-autolinked strikethrough interior.

### Numbers (profile CLI, min of 40–150 iters, alternating A/B ×4, GFM)
| corpus | before | after | Δ |
|---|---|---|---|
| rust-book concat (1.2 MB) | 3.31 ms | 2.80 ms | **-15%** |
| TS handbook Reference.md (64 KB) | 128 µs | 106 µs | **-17%** |
| vue component-basics.md (24 KB) | 40 µs | 36 µs | **-10%** |

### Notes
- AST shape: adjacent text nodes in candidate-free blocks are no longer coalesced (the merge was a side effect of the unconditional pass). One parser snapshot updated; rendered HTML is byte-identical except the nested-`<a>` fix.
- `cargo test` green across parser/renderer/mdast/napi; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789541250&installation_model_id=422833&pr_number=563&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F563&signature=a8dffa4b9b491685ed41167d53db3f6a580445dc2b306eb9d46f95429cb23ac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->