### PR TITLE
perf(wasm): re-enable wasm-opt with the post-MVP feature set (-7% module size)

### DIFF
--- a/crates/ox_content_wasm/Cargo.toml
+++ b/crates/ox_content_wasm/Cargo.toml
@@ -34,4 +34,20 @@ js-sys = "0.3"
 wasm-bindgen-test = "0.3"
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = false
+# Size pass over the published module: 363 KB -> 336 KB (-7%). wasm-opt used
+# to be disabled because wasm-pack's bundled binaryen (v117) rejects the
+# module during input validation — current rustc emits post-MVP features
+# (tail calls among them) that binaryen only accepts when told so
+# explicitly. The --enable-* list below is exactly that told-so set; a bare
+# ["-Oz"] fails with "error validating input", so keep the flags in sync if
+# a toolchain bump starts emitting another feature.
+wasm-opt = [
+  "-Oz",
+  "--enable-tail-call",
+  "--enable-bulk-memory",
+  "--enable-nontrapping-float-to-int",
+  "--enable-sign-ext",
+  "--enable-mutable-globals",
+  "--enable-reference-types",
+  "--enable-multivalue",
+]


### PR DESCRIPTION
## Summary

Part of the size sweep. `wasm-opt = false` turned out to be a workaround, not a choice: wasm-pack's bundled binaryen (v117) fails **input validation** on modules produced by current rustc, which emits post-MVP features — tail calls among them — that binaryen only accepts when enabled explicitly. A bare `["-Oz"]` dies with `error validating input`.

Passing the feature-enable set alongside `-Oz` makes the bundled binary work again, so the existing CI publish flow (`cargo install wasm-pack` → `vp run build:wasm`) needs no changes.

## Numbers

| artifact | before | after | Δ |
|---|---|---|---|
| `ox_content_wasm_bg.wasm` raw | 362,565 B | 335,927 B | **-7.4%** |
| gzip -9 | 145,601 B | 143,571 B | -1.4% |

(A modern binaryen v130 with `--all-features` only saves ~4 KB more, so staying on the wasm-pack-bundled one is the right trade.)

## Verification
- `wasm-pack build --target web` exits 0 with no validator errors
- Optimized module loaded in Node and exercised through `parseAndRender` with GFM input (headings, tables, strikethrough, autolinks) — output correct
- Note: while testing I found a real `WasmParserOptions` bug — `gfm = true` gets its sub-features immediately overwritten by the individual field defaults. Separate fix PR incoming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789542168&installation_model_id=422833&pr_number=566&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F566&signature=234bba9525cfb904d43fef2e0103944b193ddd31fd9eede8ab8f90be6422075b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->