### PR TITLE
fix(wasm): stop the gfm option from disabling its own sub-features

### DIFF
--- a/crates/ox_content_wasm/src/lib.rs
+++ b/crates/ox_content_wasm/src/lib.rs
@@ -35,11 +35,14 @@ pub struct TransformResult {
 #[derive(Default)]
 pub struct WasmParserOptions {
     gfm: bool,
-    footnotes: bool,
-    task_lists: bool,
-    tables: bool,
-    strikethrough: bool,
-    autolinks: bool,
+    // The extension flags are tri-state: `None` means "not set from JS",
+    // which lets the `gfm` profile supply its own defaults instead of the
+    // field defaults silently overwriting them (see the `From` impl).
+    footnotes: Option<bool>,
+    task_lists: Option<bool>,
+    tables: Option<bool>,
+    strikethrough: Option<bool>,
+    autolinks: Option<bool>,
     toc_max_depth: u8,
     autolink_urls: bool,
     autolink_patterns: Vec<String>,
@@ -57,11 +60,11 @@ impl WasmParserOptions {
     pub fn new() -> Self {
         Self {
             gfm: false,
-            footnotes: false,
-            task_lists: false,
-            tables: false,
-            strikethrough: false,
-            autolinks: false,
+            footnotes: None,
+            task_lists: None,
+            tables: None,
+            strikethrough: None,
+            autolinks: None,
             toc_max_depth: 3,
             autolink_urls: true,
             autolink_patterns: vec!["http://".to_string(), "https://".to_string()],
@@ -79,42 +82,42 @@ impl WasmParserOptions {
 
     /// Enables footnote references and definitions.
     ///
-    /// Default: `false`.
+    /// Default: unset — follows the `gfm` profile (`false` without it).
     #[wasm_bindgen(setter)]
     pub fn set_footnotes(&mut self, value: bool) {
-        self.footnotes = value;
+        self.footnotes = Some(value);
     }
 
     /// Enables GFM task-list item markers such as `- [x]`.
     ///
-    /// Default: `false`.
+    /// Default: unset — follows the `gfm` profile (`false` without it).
     #[wasm_bindgen(setter = taskLists)]
     pub fn set_task_lists(&mut self, value: bool) {
-        self.task_lists = value;
+        self.task_lists = Some(value);
     }
 
     /// Enables GFM pipe tables.
     ///
-    /// Default: `false`.
+    /// Default: unset — follows the `gfm` profile (`false` without it).
     #[wasm_bindgen(setter)]
     pub fn set_tables(&mut self, value: bool) {
-        self.tables = value;
+        self.tables = Some(value);
     }
 
     /// Enables GFM strikethrough spans.
     ///
-    /// Default: `false`.
+    /// Default: unset — follows the `gfm` profile (`false` without it).
     #[wasm_bindgen(setter)]
     pub fn set_strikethrough(&mut self, value: bool) {
-        self.strikethrough = value;
+        self.strikethrough = Some(value);
     }
 
     /// Enables GFM autolinks in the parser.
     ///
-    /// Default: `false`.
+    /// Default: unset — follows the `gfm` profile (`false` without it).
     #[wasm_bindgen(setter)]
     pub fn set_autolinks(&mut self, value: bool) {
-        self.autolinks = value;
+        self.autolinks = Some(value);
     }
 
     /// Sets the maximum heading depth included in inline TOCs.
@@ -157,11 +160,25 @@ impl From<&WasmParserOptions> for ParserOptions {
     fn from(opts: &WasmParserOptions) -> Self {
         let mut options = if opts.gfm { ParserOptions::gfm() } else { ParserOptions::default() };
 
-        options.footnotes = opts.footnotes;
-        options.task_lists = opts.task_lists;
-        options.tables = opts.tables;
-        options.strikethrough = opts.strikethrough;
-        options.autolinks = opts.autolinks;
+        // Only apply flags JS actually set. Overwriting unconditionally
+        // meant `gfm = true` had its sub-features (tables, strikethrough,
+        // autolinks, footnotes, task lists) immediately reset to the field
+        // defaults, disabling the profile it had just enabled.
+        if let Some(footnotes) = opts.footnotes {
+            options.footnotes = footnotes;
+        }
+        if let Some(task_lists) = opts.task_lists {
+            options.task_lists = task_lists;
+        }
+        if let Some(tables) = opts.tables {
+            options.tables = tables;
+        }
+        if let Some(strikethrough) = opts.strikethrough {
+            options.strikethrough = strikethrough;
+        }
+        if let Some(autolinks) = opts.autolinks {
+            options.autolinks = autolinks;
+        }
 
         options
     }


### PR DESCRIPTION
## Summary

Found while smoke-testing the wasm module for #566: `WasmParserOptions.gfm = true` builds `ParserOptions::gfm()` — and then unconditionally overwrites `footnotes` / `taskLists` / `tables` / `strikethrough` / `autolinks` with the plain field defaults (all `false`). The profile it just enabled was immediately disabled again, so wasm callers got `gfm: true` with every GFM extension off unless they also set each flag by hand.

The extension flags are now tri-state internally (`None` = not set from JS): the `gfm` profile supplies defaults, and only explicitly-set flags override them. JS-facing API is unchanged (same setters, same types).

## Verified against the built wasm-pack module in Node

| input | before | after |
|---|---|---|
| `gfm = true` alone | no tables, no `<del>`, no autolinks | tables + strikethrough + autolinks work |
| `gfm = true, tables = false` | — | tables disabled (explicit override wins) |
| `new WasmParserOptions()` | all extensions off | unchanged |

`cargo check --target wasm32-unknown-unknown`, crate tests, fmt all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789542269&installation_model_id=422833&pr_number=567&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F567&signature=268a9510bc10f6958c83582096ca8786e59a6e15cb34062006c81606af3ca3c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->