### PR TITLE
perf(renderer): gate the URL-autolink scan on a required byte (-23% render on prose)

### DIFF
--- a/crates/ox_content_renderer/src/html/autolink.rs
+++ b/crates/ox_content_renderer/src/html/autolink.rs
@@ -91,8 +91,9 @@ impl FirstByteIndex {
         let qualifies = |byte: u8| {
             !byte.is_ascii_alphabetic() && patterns.iter().all(|pat| pat.as_bytes().contains(&byte))
         };
-        let gate = [b':', b'/', b'@', b'.']
-            .into_iter()
+        let gate = b":/@."
+            .iter()
+            .copied()
             .find(|&byte| qualifies(byte))
             .or_else(|| gate_candidates.iter().copied().find(|&byte| qualifies(byte)));
 

--- a/crates/ox_content_renderer/src/html/autolink.rs
+++ b/crates/ox_content_renderer/src/html/autolink.rs
@@ -24,6 +24,14 @@ pub(super) struct FirstByteIndex {
     /// on a frequent first byte — `h` matches "the", "here", … — are
     /// rejected with one comparison instead of full prefix checks.
     second: [u8; 256],
+    /// A byte every pattern contains, when one exists. Since a match always
+    /// begins with a full pattern verbatim (prefix compare is
+    /// case-insensitive, so only caseless bytes qualify), a text node
+    /// without this byte cannot contain a match at all — one `memchr` proves
+    /// it. The default patterns (`http://`, `https://`) gate on `:`, which
+    /// is far rarer in prose than their first byte `h`; most text nodes
+    /// skip the candidate walk entirely.
+    gate: Option<u8>,
 }
 
 /// Sentinel in `FirstByteIndex::second`: no single second byte filters
@@ -73,7 +81,29 @@ impl FirstByteIndex {
         if needle_len > needles.len() {
             overflow = true;
         }
-        Self { table, needles, needle_len, overflow, second }
+
+        // Pick the gate byte: preferred candidates first (roughly ordered by
+        // rarity in prose), then any other caseless byte the first pattern
+        // holds. Alphabetic bytes never qualify — the prefix compare is
+        // case-insensitive, so a letter's presence proves nothing about the
+        // other case.
+        let gate_candidates = patterns.first().map_or(&[][..], |pat| pat.as_bytes());
+        let qualifies = |byte: u8| {
+            !byte.is_ascii_alphabetic() && patterns.iter().all(|pat| pat.as_bytes().contains(&byte))
+        };
+        let gate = [b':', b'/', b'@', b'.']
+            .into_iter()
+            .find(|&byte| qualifies(byte))
+            .or_else(|| gate_candidates.iter().copied().find(|&byte| qualifies(byte)));
+
+        Self { table, needles, needle_len, overflow, second, gate }
+    }
+
+    /// The byte that must appear in a haystack for any pattern to match, if
+    /// the pattern set has one. See the field docs.
+    #[inline]
+    pub(super) fn gate_byte(&self) -> Option<u8> {
+        self.gate
     }
 
     /// True when the byte after a first-byte hit rules the candidate out

--- a/crates/ox_content_renderer/src/html/renderer/write.rs
+++ b/crates/ox_content_renderer/src/html/renderer/write.rs
@@ -47,6 +47,16 @@ impl HtmlRenderer {
             write_escaped_into(&mut self.output, s);
             return;
         };
+        // A match must contain the index's gate byte (`:` for the default
+        // `http://`/`https://` patterns), so one memchr over the node proves
+        // "nothing can match here" for almost every prose node — skipping
+        // the candidate walk with its per-first-byte boundary checks.
+        if let Some(gate) = index.gate_byte() {
+            if memchr::memchr(gate, bytes).is_none() {
+                write_escaped_into(&mut self.output, s);
+                return;
+            }
+        }
         // Borrow the relevant fields disjointly so the URL scan (which only
         // reads `options`/`autolink_index`) and the output writes can coexist.
         let patterns = &self.options.autolink_patterns;


### PR DESCRIPTION
## Summary

Round 2, following the #562 profiling data on the post-#563/#565 main. The detail trace showed `write_text_with_autolinks` + `autolink_scan` at ~a third of render time on prose: the candidate walk runs over every text node, and its first-byte probe (`h`/`H` for the default patterns) stops at ~6% of English prose bytes just to reject them.

**Observation**: a match always begins with a full pattern verbatim, so any byte contained in *every* pattern must be present in the node for any match to exist. The index now derives such a **gate byte** at build time — `:` for the default `http://`+`https://` set. One `memchr` against the gate sends the overwhelming majority of nodes straight to plain escaping without entering the candidate walk.

Details:
- Gate selection prefers rare punctuation (`:` > `/` > `@` > `.`), falls back to any caseless byte common to all patterns, and never picks an alphabetic byte (prefix comparison is case-insensitive, so a letter's presence proves nothing about the other case).
- Pattern sets with no qualifying common byte skip the gate and behave exactly as before.

## Numbers (profile CLI, min of 40–150 iters, alternating A/B ×3, GFM)

| corpus | before | after | Δ |
|---|---|---|---|
| rust-book concat (1.2 MB), render | 1.44 ms | 1.11 ms | **-23%** |
| TS handbook Reference.md (64 KB), render | 65 µs | 57 µs | **-12%** |

## Verification
- `cargo test -p ox_content_renderer` (incl. the autolink suite) — green; fmt/clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789543549&installation_model_id=422833&pr_number=568&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F568&signature=b0d4346bca7c7ca2ce5003961b734eb7072515c1aa8111167cd8c8254389eb60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved text rendering efficiency by quickly identifying content that cannot contain autolinks.
  * Added faster handling for plain text without potential autolink patterns while preserving existing escaping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->