### PR TITLE
bench: add a wasm arena — @ox-content/wasm vs md4x (wasm)

### DIFF
--- a/benchmarks/bundle-size/parse-benchmark.mjs
+++ b/benchmarks/bundle-size/parse-benchmark.mjs
@@ -186,10 +186,7 @@ function readOptionValue(args, index, optionName) {
  * @returns {number}
  */
 function readPositiveIntegerOption(args, index, optionName) {
-  return parsePositiveInteger(
-    readOptionValue(args, index, optionName),
-    optionName,
-  );
+  return parsePositiveInteger(readOptionValue(args, index, optionName), optionName);
 }
 
 /**
@@ -212,10 +209,7 @@ function readInlineOptionValue(arg, optionName) {
  * @returns {number}
  */
 function readPositiveIntegerInlineOption(arg, optionName) {
-  return parsePositiveInteger(
-    readInlineOptionValue(arg, optionName),
-    optionName,
-  );
+  return parsePositiveInteger(readInlineOptionValue(arg, optionName), optionName);
 }
 
 function parsePositiveInteger(value, optionName) {
@@ -334,9 +328,7 @@ function printTable(title, results) {
     const name = result.name.padEnd(nameWidth);
     const opsPerSec = result.opsPerSec.toFixed(0).padStart(opsWidth);
     const avgMs = (result.avgMs.toFixed(2) + "ms").padStart(avgWidth);
-    const throughput = (result.throughputMBs.toFixed(2) + " MB/s").padStart(
-      throughputWidth,
-    );
+    const throughput = (result.throughputMBs.toFixed(2) + " MB/s").padStart(throughputWidth);
     const ratio = (fastest / result.opsPerSec).toFixed(2) + "x";
     console.log(
       `| ${name} | ${opsPerSec} | ${avgMs} | ${throughput} | ${ratio.padStart(ratioWidth)} |`,
@@ -354,14 +346,10 @@ function loadBunMarkdownBenchmarks() {
     return null;
   }
 
-  const run = spawnSync(
-    "bun",
-    [BUN_BENCHMARK_SCRIPT, "--runs", String(options.runs)],
-    {
-      cwd: __dirname,
-      encoding: "utf8",
-    },
-  );
+  const run = spawnSync("bun", [BUN_BENCHMARK_SCRIPT, "--runs", String(options.runs)], {
+    cwd: __dirname,
+    encoding: "utf8",
+  });
 
   if (run.status !== 0) {
     const details = run.stderr.trim() || run.stdout.trim();
@@ -411,13 +399,7 @@ function loadNativeCompetitorBenchmarks() {
 
   const build = spawnSync(
     "cargo",
-    [
-      "build",
-      "--release",
-      "--quiet",
-      "--manifest-path",
-      NATIVE_COMPETITORS_MANIFEST,
-    ],
+    ["build", "--release", "--quiet", "--manifest-path", NATIVE_COMPETITORS_MANIFEST],
     {
       cwd: __dirname,
       encoding: "utf8",
@@ -430,14 +412,10 @@ function loadNativeCompetitorBenchmarks() {
     return null;
   }
 
-  const run = spawnSync(
-    NATIVE_COMPETITORS_BINARY,
-    ["--runs", String(options.runs)],
-    {
-      cwd: __dirname,
-      encoding: "utf8",
-    },
-  );
+  const run = spawnSync(NATIVE_COMPETITORS_BINARY, ["--runs", String(options.runs)], {
+    cwd: __dirname,
+    encoding: "utf8",
+  });
 
   if (run.status !== 0) {
     const details = (run.stderr ?? "").trim() || (run.stdout ?? "").trim();
@@ -448,9 +426,7 @@ function loadNativeCompetitorBenchmarks() {
   try {
     return JSON.parse(run.stdout);
   } catch (error) {
-    console.warn(
-      `Failed to parse native competitor benchmark output: ${String(error)}`,
-    );
+    console.warn(`Failed to parse native competitor benchmark output: ${String(error)}`);
     return null;
   }
 }
@@ -475,8 +451,7 @@ async function runBenchmarks() {
   const { Lexer: MarkedLexer } = await import("marked");
   const MarkdownIt = (await import("markdown-it")).default;
   const { init: initMd4w, mdToHtml, mdToJSON } = await import("md4w");
-  const { parseAST: md4xParseAST, renderToHtml: md4xRenderToHtml } =
-    await import("md4x/napi");
+  const { parseAST: md4xParseAST, renderToHtml: md4xRenderToHtml } = await import("md4x/napi");
   const { micromark } = await import("micromark");
   const { unified } = await import("unified");
   const remarkParse = (await import("remark-parse")).default;
@@ -510,10 +485,7 @@ async function runBenchmarks() {
 
   let oxWasmRender = null;
   try {
-    const pkgDir = new URL(
-      "../../crates/ox_content_wasm/pkg/",
-      import.meta.url,
-    );
+    const pkgDir = new URL("../../crates/ox_content_wasm/pkg/", import.meta.url);
     const oxWasm = await import(new URL("ox_content_wasm.js", pkgDir).href);
     const wasmBytes = readFileSync(new URL("ox_content_wasm_bg.wasm", pkgDir));
     await oxWasm.default({ module_or_path: wasmBytes });
@@ -527,9 +499,7 @@ async function runBenchmarks() {
     console.log("Using @ox-content/wasm (crates/ox_content_wasm/pkg)\n");
   } catch {
     oxWasmRender = null;
-    console.log(
-      "@ox-content/wasm pkg not built (vp run build:wasm), skipping\n",
-    );
+    console.log("@ox-content/wasm pkg not built (vp run build:wasm), skipping\n");
   }
 
   // @mizchi/markdown (markdown.mbt) is a MoonBit-authored Markdown compiler
@@ -540,9 +510,7 @@ async function runBenchmarks() {
     mizchi = await import("@mizchi/markdown");
     console.log("Using @mizchi/markdown\n");
   } catch {
-    console.log(
-      "@mizchi/markdown not available, skipping mizchi comparisons\n",
-    );
+    console.log("@mizchi/markdown not available, skipping mizchi comparisons\n");
   }
 
   // TanStack Markdown exposes separate parser and HTML renderer entry points.
@@ -557,9 +525,7 @@ async function runBenchmarks() {
     tanstackMarkdown = { parseMarkdown, renderHtml };
     console.log("Using @tanstack/markdown\n");
   } catch {
-    console.log(
-      "@tanstack/markdown not available, skipping TanStack Markdown comparisons\n",
-    );
+    console.log("@tanstack/markdown not available, skipping TanStack Markdown comparisons\n");
   }
 
   // markdown-it-ts is a TypeScript rewrite with the familiar markdown-it
@@ -570,9 +536,7 @@ async function runBenchmarks() {
     MarkdownItTs = (await import("markdown-it-ts")).default;
     console.log("Using markdown-it-ts\n");
   } catch {
-    console.log(
-      "markdown-it-ts not available, skipping markdown-it-ts comparisons\n",
-    );
+    console.log("markdown-it-ts not available, skipping markdown-it-ts comparisons\n");
   }
 
   // @astrojs/markdown-remark is the Markdown renderer Astro uses internally
@@ -581,14 +545,11 @@ async function runBenchmarks() {
   // others so an older checkout without the dependency skips it.
   let astroProcessor = null;
   try {
-    const { createMarkdownProcessor } =
-      await import("@astrojs/markdown-remark");
+    const { createMarkdownProcessor } = await import("@astrojs/markdown-remark");
     astroProcessor = await createMarkdownProcessor({});
     console.log("Using @astrojs/markdown-remark (Astro)\n");
   } catch {
-    console.log(
-      "@astrojs/markdown-remark not available, skipping Astro comparisons\n",
-    );
+    console.log("@astrojs/markdown-remark not available, skipping Astro comparisons\n");
   }
 
   // Try to import NAPI
@@ -610,9 +571,7 @@ async function runBenchmarks() {
 
   const nativeCompetitors = loadNativeCompetitorBenchmarks();
   if (nativeCompetitors) {
-    console.log(
-      "Using native Rust competitors (pulldown-cmark, Grok Build markdown)\n",
-    );
+    console.log("Using native Rust competitors (pulldown-cmark, Grok Build markdown)\n");
   } else {
     console.log("native competitors not available, skipping\n");
   }
@@ -758,26 +717,14 @@ async function runBenchmarks() {
     console.log(`\n## ${sizeName.toUpperCase()} (${sizeKB} KB)`);
 
     const iterations =
-      sizeName === "huge"
-        ? 5
-        : sizeName === "large"
-          ? 20
-          : sizeName === "medium"
-            ? 50
-            : 100;
+      sizeName === "huge" ? 5 : sizeName === "large" ? 20 : sizeName === "medium" ? 50 : 100;
     const suites = {};
 
     // Parse only benchmark
     const parseResults = [];
     for (const parser of parsers) {
       try {
-        const result = benchmark(
-          parser.name,
-          parser.fn,
-          content,
-          iterations,
-          options.runs,
-        );
+        const result = benchmark(parser.name, parser.fn, content, iterations, options.runs);
         parseResults.push(result);
       } catch {
         parseResults.push({ name: parser.name, error: true });
@@ -795,13 +742,7 @@ async function runBenchmarks() {
     const renderResults = [];
     for (const renderer of renderers) {
       try {
-        const result = benchmark(
-          renderer.name,
-          renderer.fn,
-          content,
-          iterations,
-          options.runs,
-        );
+        const result = benchmark(renderer.name, renderer.fn, content, iterations, options.runs);
         renderResults.push(result);
       } catch {
         renderResults.push({ name: renderer.name, error: true });
@@ -820,19 +761,11 @@ async function runBenchmarks() {
 
     // Async benchmark (only for the large and ~1 MB cases, where offloading
     // to a worker thread can actually pay for its overhead)
-    if (
-      asyncRenderers.length > 0 &&
-      (sizeName === "large" || sizeName === "huge")
-    ) {
+    if (asyncRenderers.length > 0 && (sizeName === "large" || sizeName === "huge")) {
       const asyncResults = [];
       for (const renderer of asyncRenderers) {
         try {
-          const result = await benchmarkAsync(
-            renderer.name,
-            renderer.fn,
-            content,
-            iterations,
-          );
+          const result = await benchmarkAsync(renderer.name, renderer.fn, content, iterations);
           asyncResults.push(result);
         } catch {
           asyncResults.push({ name: renderer.name, error: true });

--- a/benchmarks/bundle-size/parse-benchmark.mjs
+++ b/benchmarks/bundle-size/parse-benchmark.mjs
@@ -4,7 +4,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { cpus, totalmem } from "node:os";
 import { performance } from "node:perf_hooks";
 import { dirname, join, resolve } from "node:path";
@@ -186,7 +186,10 @@ function readOptionValue(args, index, optionName) {
  * @returns {number}
  */
 function readPositiveIntegerOption(args, index, optionName) {
-  return parsePositiveInteger(readOptionValue(args, index, optionName), optionName);
+  return parsePositiveInteger(
+    readOptionValue(args, index, optionName),
+    optionName,
+  );
 }
 
 /**
@@ -209,7 +212,10 @@ function readInlineOptionValue(arg, optionName) {
  * @returns {number}
  */
 function readPositiveIntegerInlineOption(arg, optionName) {
-  return parsePositiveInteger(readInlineOptionValue(arg, optionName), optionName);
+  return parsePositiveInteger(
+    readInlineOptionValue(arg, optionName),
+    optionName,
+  );
 }
 
 function parsePositiveInteger(value, optionName) {
@@ -328,7 +334,9 @@ function printTable(title, results) {
     const name = result.name.padEnd(nameWidth);
     const opsPerSec = result.opsPerSec.toFixed(0).padStart(opsWidth);
     const avgMs = (result.avgMs.toFixed(2) + "ms").padStart(avgWidth);
-    const throughput = (result.throughputMBs.toFixed(2) + " MB/s").padStart(throughputWidth);
+    const throughput = (result.throughputMBs.toFixed(2) + " MB/s").padStart(
+      throughputWidth,
+    );
     const ratio = (fastest / result.opsPerSec).toFixed(2) + "x";
     console.log(
       `| ${name} | ${opsPerSec} | ${avgMs} | ${throughput} | ${ratio.padStart(ratioWidth)} |`,
@@ -346,10 +354,14 @@ function loadBunMarkdownBenchmarks() {
     return null;
   }
 
-  const run = spawnSync("bun", [BUN_BENCHMARK_SCRIPT, "--runs", String(options.runs)], {
-    cwd: __dirname,
-    encoding: "utf8",
-  });
+  const run = spawnSync(
+    "bun",
+    [BUN_BENCHMARK_SCRIPT, "--runs", String(options.runs)],
+    {
+      cwd: __dirname,
+      encoding: "utf8",
+    },
+  );
 
   if (run.status !== 0) {
     const details = run.stderr.trim() || run.stdout.trim();
@@ -399,7 +411,13 @@ function loadNativeCompetitorBenchmarks() {
 
   const build = spawnSync(
     "cargo",
-    ["build", "--release", "--quiet", "--manifest-path", NATIVE_COMPETITORS_MANIFEST],
+    [
+      "build",
+      "--release",
+      "--quiet",
+      "--manifest-path",
+      NATIVE_COMPETITORS_MANIFEST,
+    ],
     {
       cwd: __dirname,
       encoding: "utf8",
@@ -412,10 +430,14 @@ function loadNativeCompetitorBenchmarks() {
     return null;
   }
 
-  const run = spawnSync(NATIVE_COMPETITORS_BINARY, ["--runs", String(options.runs)], {
-    cwd: __dirname,
-    encoding: "utf8",
-  });
+  const run = spawnSync(
+    NATIVE_COMPETITORS_BINARY,
+    ["--runs", String(options.runs)],
+    {
+      cwd: __dirname,
+      encoding: "utf8",
+    },
+  );
 
   if (run.status !== 0) {
     const details = (run.stderr ?? "").trim() || (run.stdout ?? "").trim();
@@ -426,7 +448,9 @@ function loadNativeCompetitorBenchmarks() {
   try {
     return JSON.parse(run.stdout);
   } catch (error) {
-    console.warn(`Failed to parse native competitor benchmark output: ${String(error)}`);
+    console.warn(
+      `Failed to parse native competitor benchmark output: ${String(error)}`,
+    );
     return null;
   }
 }
@@ -451,7 +475,8 @@ async function runBenchmarks() {
   const { Lexer: MarkedLexer } = await import("marked");
   const MarkdownIt = (await import("markdown-it")).default;
   const { init: initMd4w, mdToHtml, mdToJSON } = await import("md4w");
-  const { parseAST: md4xParseAST, renderToHtml: md4xRenderToHtml } = await import("md4x/napi");
+  const { parseAST: md4xParseAST, renderToHtml: md4xRenderToHtml } =
+    await import("md4x/napi");
   const { micromark } = await import("micromark");
   const { unified } = await import("unified");
   const remarkParse = (await import("remark-parse")).default;
@@ -469,6 +494,44 @@ async function runBenchmarks() {
     console.log("satteri not available, skipping satteri comparisons\n");
   }
 
+  // Wasm arena. md4x ships a wasm build alongside its NAPI one; ours is the
+  // wasm-pack output under crates/ox_content_wasm/pkg, which is generated
+  // (`vp run build:wasm`) rather than checked in — load both defensively so
+  // the benchmark still runs on a checkout without the artifacts.
+  let md4xWasm = null;
+  try {
+    md4xWasm = await import("md4x/wasm");
+    await md4xWasm.init();
+    console.log("Using md4x/wasm\n");
+  } catch {
+    md4xWasm = null;
+    console.log("md4x/wasm not available, skipping\n");
+  }
+
+  let oxWasmRender = null;
+  try {
+    const pkgDir = new URL(
+      "../../crates/ox_content_wasm/pkg/",
+      import.meta.url,
+    );
+    const oxWasm = await import(new URL("ox_content_wasm.js", pkgDir).href);
+    const wasmBytes = readFileSync(new URL("ox_content_wasm_bg.wasm", pkgDir));
+    await oxWasm.default({ module_or_path: wasmBytes });
+    // serde-wasm-bindgen returns a Map by default; probe once so the hot
+    // benchmark closure does no shape checks.
+    const probe = oxWasm.parseAndRender("# probe");
+    oxWasmRender =
+      probe instanceof Map
+        ? (input) => oxWasm.parseAndRender(input).get("html")
+        : (input) => oxWasm.parseAndRender(input).html;
+    console.log("Using @ox-content/wasm (crates/ox_content_wasm/pkg)\n");
+  } catch {
+    oxWasmRender = null;
+    console.log(
+      "@ox-content/wasm pkg not built (vp run build:wasm), skipping\n",
+    );
+  }
+
   // @mizchi/markdown (markdown.mbt) is a MoonBit-authored Markdown compiler
   // shipped as a pure-JS build. Loaded defensively like satteri so an older
   // checkout without the dependency skips it rather than crashing.
@@ -477,7 +540,9 @@ async function runBenchmarks() {
     mizchi = await import("@mizchi/markdown");
     console.log("Using @mizchi/markdown\n");
   } catch {
-    console.log("@mizchi/markdown not available, skipping mizchi comparisons\n");
+    console.log(
+      "@mizchi/markdown not available, skipping mizchi comparisons\n",
+    );
   }
 
   // TanStack Markdown exposes separate parser and HTML renderer entry points.
@@ -492,7 +557,9 @@ async function runBenchmarks() {
     tanstackMarkdown = { parseMarkdown, renderHtml };
     console.log("Using @tanstack/markdown\n");
   } catch {
-    console.log("@tanstack/markdown not available, skipping TanStack Markdown comparisons\n");
+    console.log(
+      "@tanstack/markdown not available, skipping TanStack Markdown comparisons\n",
+    );
   }
 
   // markdown-it-ts is a TypeScript rewrite with the familiar markdown-it
@@ -503,7 +570,9 @@ async function runBenchmarks() {
     MarkdownItTs = (await import("markdown-it-ts")).default;
     console.log("Using markdown-it-ts\n");
   } catch {
-    console.log("markdown-it-ts not available, skipping markdown-it-ts comparisons\n");
+    console.log(
+      "markdown-it-ts not available, skipping markdown-it-ts comparisons\n",
+    );
   }
 
   // @astrojs/markdown-remark is the Markdown renderer Astro uses internally
@@ -512,11 +581,14 @@ async function runBenchmarks() {
   // others so an older checkout without the dependency skips it.
   let astroProcessor = null;
   try {
-    const { createMarkdownProcessor } = await import("@astrojs/markdown-remark");
+    const { createMarkdownProcessor } =
+      await import("@astrojs/markdown-remark");
     astroProcessor = await createMarkdownProcessor({});
     console.log("Using @astrojs/markdown-remark (Astro)\n");
   } catch {
-    console.log("@astrojs/markdown-remark not available, skipping Astro comparisons\n");
+    console.log(
+      "@astrojs/markdown-remark not available, skipping Astro comparisons\n",
+    );
   }
 
   // Try to import NAPI
@@ -538,7 +610,9 @@ async function runBenchmarks() {
 
   const nativeCompetitors = loadNativeCompetitorBenchmarks();
   if (nativeCompetitors) {
-    console.log("Using native Rust competitors (pulldown-cmark, Grok Build markdown)\n");
+    console.log(
+      "Using native Rust competitors (pulldown-cmark, Grok Build markdown)\n",
+    );
   } else {
     console.log("native competitors not available, skipping\n");
   }
@@ -566,12 +640,25 @@ async function runBenchmarks() {
     { name: "remark", fn: (input) => remarkParseProcessor.parse(input) },
   );
 
+  if (md4xWasm) {
+    parsers.push({
+      name: "md4x (wasm)",
+      fn: (input) => md4xWasm.parseAST(input),
+    });
+  }
+
   if (satteri) {
-    parsers.push({ name: "satteri", fn: (input) => satteri.markdownToMdast(input) });
+    parsers.push({
+      name: "satteri",
+      fn: (input) => satteri.markdownToMdast(input),
+    });
   }
 
   if (mizchi) {
-    parsers.push({ name: "@mizchi/markdown", fn: (input) => mizchi.parse(input) });
+    parsers.push({
+      name: "@mizchi/markdown",
+      fn: (input) => mizchi.parse(input),
+    });
   }
 
   if (tanstackMarkdown) {
@@ -610,12 +697,29 @@ async function runBenchmarks() {
     },
   );
 
+  if (oxWasmRender) {
+    renderers.push({ name: "@ox-content/wasm", fn: oxWasmRender });
+  }
+
+  if (md4xWasm) {
+    renderers.push({
+      name: "md4x (wasm)",
+      fn: (input) => md4xWasm.renderToHtml(input),
+    });
+  }
+
   if (satteri) {
-    renderers.push({ name: "satteri", fn: (input) => satteri.markdownToHtml(input) });
+    renderers.push({
+      name: "satteri",
+      fn: (input) => satteri.markdownToHtml(input),
+    });
   }
 
   if (mizchi) {
-    renderers.push({ name: "@mizchi/markdown", fn: (input) => mizchi.toHtml(input) });
+    renderers.push({
+      name: "@mizchi/markdown",
+      fn: (input) => mizchi.toHtml(input),
+    });
   }
 
   if (tanstackMarkdown) {
@@ -654,14 +758,26 @@ async function runBenchmarks() {
     console.log(`\n## ${sizeName.toUpperCase()} (${sizeKB} KB)`);
 
     const iterations =
-      sizeName === "huge" ? 5 : sizeName === "large" ? 20 : sizeName === "medium" ? 50 : 100;
+      sizeName === "huge"
+        ? 5
+        : sizeName === "large"
+          ? 20
+          : sizeName === "medium"
+            ? 50
+            : 100;
     const suites = {};
 
     // Parse only benchmark
     const parseResults = [];
     for (const parser of parsers) {
       try {
-        const result = benchmark(parser.name, parser.fn, content, iterations, options.runs);
+        const result = benchmark(
+          parser.name,
+          parser.fn,
+          content,
+          iterations,
+          options.runs,
+        );
         parseResults.push(result);
       } catch {
         parseResults.push({ name: parser.name, error: true });
@@ -679,7 +795,13 @@ async function runBenchmarks() {
     const renderResults = [];
     for (const renderer of renderers) {
       try {
-        const result = benchmark(renderer.name, renderer.fn, content, iterations, options.runs);
+        const result = benchmark(
+          renderer.name,
+          renderer.fn,
+          content,
+          iterations,
+          options.runs,
+        );
         renderResults.push(result);
       } catch {
         renderResults.push({ name: renderer.name, error: true });
@@ -698,11 +820,19 @@ async function runBenchmarks() {
 
     // Async benchmark (only for the large and ~1 MB cases, where offloading
     // to a worker thread can actually pay for its overhead)
-    if (asyncRenderers.length > 0 && (sizeName === "large" || sizeName === "huge")) {
+    if (
+      asyncRenderers.length > 0 &&
+      (sizeName === "large" || sizeName === "huge")
+    ) {
       const asyncResults = [];
       for (const renderer of asyncRenderers) {
         try {
-          const result = await benchmarkAsync(renderer.name, renderer.fn, content, iterations);
+          const result = await benchmarkAsync(
+            renderer.name,
+            renderer.fn,
+            content,
+            iterations,
+          );
           asyncResults.push(result);
         } catch {
           asyncResults.push({ name: renderer.name, error: true });

--- a/benchmarks/commonmark-conformance/engines.mjs
+++ b/benchmarks/commonmark-conformance/engines.mjs
@@ -28,15 +28,9 @@ async function optional(name, load) {
 export async function collectJsRenderers() {
   const renderers = [];
 
-  const napi = await optional(
-    "@ox-content/napi",
-    () => import("@ox-content/napi"),
-  );
+  const napi = await optional("@ox-content/napi", () => import("@ox-content/napi"));
   if (napi) {
-    renderers.push([
-      "@ox-content/napi",
-      (input) => napi.parseAndRender(input).html,
-    ]);
+    renderers.push(["@ox-content/napi", (input) => napi.parseAndRender(input).html]);
   }
 
   // marked exposes no CommonMark preset; scored as it ships.
@@ -48,17 +42,13 @@ export async function collectJsRenderers() {
   const md4w = await optional("md4w", () => import("md4w"));
   if (md4w) {
     await md4w.init();
-    renderers.push([
-      "md4w (md4c)",
-      (input) => md4w.mdToHtml(input, { parseFlags: 0 }),
-    ]);
+    renderers.push(["md4w (md4c)", (input) => md4w.mdToHtml(input, { parseFlags: 0 })]);
   }
 
   // md4x wraps the same engine but exposes no flag to turn its GFM extensions
   // off, so it is scored with them on.
   const md4x = await optional("md4x", () => import("md4x/napi"));
-  if (md4x)
-    renderers.push(["md4x (napi)", (input) => md4x.renderToHtml(input)]);
+  if (md4x) renderers.push(["md4x (napi)", (input) => md4x.renderToHtml(input)]);
 
   // Same engine again through its wasm build, so the two runtimes' scores
   // can be compared directly (and against @ox-content/wasm below).
@@ -67,18 +57,14 @@ export async function collectJsRenderers() {
     await mod.init();
     return mod;
   });
-  if (md4xWasm)
-    renderers.push(["md4x (wasm)", (input) => md4xWasm.renderToHtml(input)]);
+  if (md4xWasm) renderers.push(["md4x (wasm)", (input) => md4xWasm.renderToHtml(input)]);
 
   // Our wasm-pack output is generated (`vp run build:wasm`), not checked in;
   // score it when the pkg exists so the wasm runtime gets conformance
   // coverage too.
   const oxWasm = await optional("@ox-content/wasm", async () => {
     const { readFileSync } = await import("node:fs");
-    const pkgDir = new URL(
-      "../../crates/ox_content_wasm/pkg/",
-      import.meta.url,
-    );
+    const pkgDir = new URL("../../crates/ox_content_wasm/pkg/", import.meta.url);
     const mod = await import(new URL("ox_content_wasm.js", pkgDir).href);
     await mod.default({
       module_or_path: readFileSync(new URL("ox_content_wasm_bg.wasm", pkgDir)),
@@ -135,21 +121,15 @@ export async function collectJsRenderers() {
     const remarkHtml = (await import("remark-html")).default;
     return unified().use(remarkParse).use(remarkHtml, { sanitize: false });
   });
-  if (remark)
-    renderers.push(["remark", (input) => String(remark.processSync(input))]);
+  if (remark) renderers.push(["remark", (input) => String(remark.processSync(input))]);
 
   // satteri returns `{ html, frontmatter }` rather than a string.
   const satteri = await optional("satteri", () => import("satteri"));
-  if (satteri)
-    renderers.push(["satteri", (input) => satteri.markdownToHtml(input).html]);
+  if (satteri) renderers.push(["satteri", (input) => satteri.markdownToHtml(input).html]);
 
   // @mizchi/markdown exposes no CommonMark mode; scored as it ships.
-  const mizchi = await optional(
-    "@mizchi/markdown",
-    () => import("@mizchi/markdown"),
-  );
-  if (mizchi)
-    renderers.push(["@mizchi/markdown", (input) => mizchi.toHtml(input)]);
+  const mizchi = await optional("@mizchi/markdown", () => import("@mizchi/markdown"));
+  if (mizchi) renderers.push(["@mizchi/markdown", (input) => mizchi.toHtml(input)]);
 
   // @tanstack/markdown exposes no CommonMark mode; scored as it ships.
   const tanstack = await optional("@tanstack/markdown", async () => {

--- a/benchmarks/commonmark-conformance/engines.mjs
+++ b/benchmarks/commonmark-conformance/engines.mjs
@@ -28,9 +28,15 @@ async function optional(name, load) {
 export async function collectJsRenderers() {
   const renderers = [];
 
-  const napi = await optional("@ox-content/napi", () => import("@ox-content/napi"));
+  const napi = await optional(
+    "@ox-content/napi",
+    () => import("@ox-content/napi"),
+  );
   if (napi) {
-    renderers.push(["@ox-content/napi", (input) => napi.parseAndRender(input).html]);
+    renderers.push([
+      "@ox-content/napi",
+      (input) => napi.parseAndRender(input).html,
+    ]);
   }
 
   // marked exposes no CommonMark preset; scored as it ships.
@@ -42,13 +48,51 @@ export async function collectJsRenderers() {
   const md4w = await optional("md4w", () => import("md4w"));
   if (md4w) {
     await md4w.init();
-    renderers.push(["md4w (md4c)", (input) => md4w.mdToHtml(input, { parseFlags: 0 })]);
+    renderers.push([
+      "md4w (md4c)",
+      (input) => md4w.mdToHtml(input, { parseFlags: 0 }),
+    ]);
   }
 
   // md4x wraps the same engine but exposes no flag to turn its GFM extensions
   // off, so it is scored with them on.
   const md4x = await optional("md4x", () => import("md4x/napi"));
-  if (md4x) renderers.push(["md4x (napi)", (input) => md4x.renderToHtml(input)]);
+  if (md4x)
+    renderers.push(["md4x (napi)", (input) => md4x.renderToHtml(input)]);
+
+  // Same engine again through its wasm build, so the two runtimes' scores
+  // can be compared directly (and against @ox-content/wasm below).
+  const md4xWasm = await optional("md4x (wasm)", async () => {
+    const mod = await import("md4x/wasm");
+    await mod.init();
+    return mod;
+  });
+  if (md4xWasm)
+    renderers.push(["md4x (wasm)", (input) => md4xWasm.renderToHtml(input)]);
+
+  // Our wasm-pack output is generated (`vp run build:wasm`), not checked in;
+  // score it when the pkg exists so the wasm runtime gets conformance
+  // coverage too.
+  const oxWasm = await optional("@ox-content/wasm", async () => {
+    const { readFileSync } = await import("node:fs");
+    const pkgDir = new URL(
+      "../../crates/ox_content_wasm/pkg/",
+      import.meta.url,
+    );
+    const mod = await import(new URL("ox_content_wasm.js", pkgDir).href);
+    await mod.default({
+      module_or_path: readFileSync(new URL("ox_content_wasm_bg.wasm", pkgDir)),
+    });
+    return mod;
+  });
+  if (oxWasm) {
+    const probe = oxWasm.parseAndRender("# probe");
+    const render =
+      probe instanceof Map
+        ? (input) => oxWasm.parseAndRender(input).get("html")
+        : (input) => oxWasm.parseAndRender(input).html;
+    renderers.push(["@ox-content/wasm", render]);
+  }
 
   // markdown-it's default preset is not its CommonMark mode; the 'commonmark'
   // preset is what its own docs point at for spec compliance.
@@ -77,7 +121,10 @@ export async function collectJsRenderers() {
     renderers.push([
       "micromark",
       (input) =>
-        micromark.micromark(input, { allowDangerousHtml: true, allowDangerousProtocol: true }),
+        micromark.micromark(input, {
+          allowDangerousHtml: true,
+          allowDangerousProtocol: true,
+        }),
     ]);
   }
 
@@ -88,15 +135,21 @@ export async function collectJsRenderers() {
     const remarkHtml = (await import("remark-html")).default;
     return unified().use(remarkParse).use(remarkHtml, { sanitize: false });
   });
-  if (remark) renderers.push(["remark", (input) => String(remark.processSync(input))]);
+  if (remark)
+    renderers.push(["remark", (input) => String(remark.processSync(input))]);
 
   // satteri returns `{ html, frontmatter }` rather than a string.
   const satteri = await optional("satteri", () => import("satteri"));
-  if (satteri) renderers.push(["satteri", (input) => satteri.markdownToHtml(input).html]);
+  if (satteri)
+    renderers.push(["satteri", (input) => satteri.markdownToHtml(input).html]);
 
   // @mizchi/markdown exposes no CommonMark mode; scored as it ships.
-  const mizchi = await optional("@mizchi/markdown", () => import("@mizchi/markdown"));
-  if (mizchi) renderers.push(["@mizchi/markdown", (input) => mizchi.toHtml(input)]);
+  const mizchi = await optional(
+    "@mizchi/markdown",
+    () => import("@mizchi/markdown"),
+  );
+  if (mizchi)
+    renderers.push(["@mizchi/markdown", (input) => mizchi.toHtml(input)]);
 
   // @tanstack/markdown exposes no CommonMark mode; scored as it ships.
   const tanstack = await optional("@tanstack/markdown", async () => {


### PR DESCRIPTION
## Summary

Per request: md4x also ships a **wasm** build, so the comparison now covers that runtime too. Both harnesses load the wasm variants defensively and skip the rows cleanly when artifacts are absent (CI checkouts without a wasm build keep working; the PR regression gate only targets the napi rows and is unaffected).

- `parse-benchmark.mjs`: `md4x (wasm)` rows in parse + render arenas, `@ox-content/wasm` in render (the wasm package has no parse-only export); ours loads from the generated `crates/ox_content_wasm/pkg` (`vp run build:wasm`).
- `commonmark-conformance/engines.mjs`: both wasm engines scored alongside their napi builds.

## Results on this machine (M5 Pro, parse+render)

| corpus | @ox-content/wasm | md4x (wasm) | Δ |
|---|---|---|---|
| conformance | **652/652** | 649/652 | — |
| medium (24 KB) | 86 MB/s | 73 MB/s | **+18%** |
| large (117 KB) | 157 MB/s | 93 MB/s | **+69%** |
| huge (1 MB) | 181 MB/s | 53 MB/s | **3.4×** |
| small (1.5 KB) | 33 MB/s | 51 MB/s | md4x wins |

The small-doc loss is our per-call boundary cost (serde-wasm-bindgen `Map` return, options plumbing) dominating tiny inputs — the same shape #560 fixed on the napi side. That's the obvious follow-up optimization; I'll take it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789544409&installation_model_id=422833&pr_number=569&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F569&signature=fd8cbf31e9e8a353751602ca13c509ecfa9a1cf7354e65285057bdc466245819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->