### PR TITLE
perf(wasm): reuse arena and renderer per call, return plain objects (+54% small-doc throughput)

### DIFF
--- a/crates/ox_content_wasm/src/lib.rs
+++ b/crates/ox_content_wasm/src/lib.rs
@@ -4,18 +4,19 @@
 //! and other WebAssembly environments.
 
 use rustc_hash::FxHashMap;
+use serde::Serialize as _;
 
 use wasm_bindgen::prelude::*;
 
-use ox_content_allocator::Allocator;
 use ox_content_parser::{Parser, ParserOptions};
-use ox_content_renderer::{HtmlRenderer, HtmlRendererOptions};
+use scratch::{with_scratch, RendererKey};
 
 use frontmatter::parse_frontmatter;
 use toc::extract_toc;
 pub use toc::TocEntry;
 
 mod frontmatter;
+mod scratch;
 mod toc;
 
 /// Transform result containing HTML, frontmatter, and TOC.
@@ -184,40 +185,47 @@ impl From<&WasmParserOptions> for ParserOptions {
     }
 }
 
+/// Builds the `{ html, errors }` result object without a serde round-trip.
+///
+/// The old path serialized through a `serde_json::Value` tree and
+/// `serde_wasm_bindgen`, which (a) copied the whole HTML string an extra
+/// time and (b) produced a JS `Map` — so the documented `result.html`
+/// access never actually worked. A plain object built directly is both the
+/// documented shape and the cheap one.
+fn render_result(html: &str, error: Option<String>) -> JsValue {
+    let out = js_sys::Object::new();
+    let errors = js_sys::Array::new();
+    if let Some(error) = error {
+        errors.push(&JsValue::from_str(&error));
+    }
+    // Reflect::set only fails on non-object targets; `out` is always an
+    // object, so the results are ignorable.
+    let _ = js_sys::Reflect::set(&out, &JsValue::from_str("html"), &JsValue::from_str(html));
+    let _ = js_sys::Reflect::set(&out, &JsValue::from_str("errors"), &errors);
+    out.into()
+}
+
 /// Parses Markdown and renders to HTML.
 #[wasm_bindgen(js_name = parseAndRender)]
 pub fn parse_and_render(source: &str, options: Option<WasmParserOptions>) -> JsValue {
     let opts = options.unwrap_or_default();
-    // Pre-size the arena from the source length (same policy as the NAPI
-    // binding) so the parse+render fits one bump chunk instead of growing
-    // through repeated chunk doublings.
-    let allocator = Allocator::for_source_len(source.len());
     let parser_options = ParserOptions::from(&opts);
-    let parser = Parser::with_options(&allocator, source, parser_options);
+    let renderer_key = RendererKey {
+        toc_max_depth: opts.toc_max_depth,
+        autolink_urls: opts.autolink_urls,
+        autolink_target_blank: opts.autolink_target_blank,
+        autolink_patterns: opts.autolink_patterns,
+    };
 
-    let result = parser.parse();
-    match result {
-        Ok(doc) => {
-            let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
-                toc_max_depth: opts.toc_max_depth,
-                autolink_urls: opts.autolink_urls,
-                autolink_target_blank: opts.autolink_target_blank,
-                autolink_patterns: opts.autolink_patterns,
-                ..Default::default()
-            });
-            let html = renderer.render(&doc);
-            serde_wasm_bindgen::to_value(&serde_json::json!({
-                "html": html,
-                "errors": Vec::<String>::new()
-            }))
-            .unwrap_or(JsValue::NULL)
+    // The arena and renderer are reused across calls (see `scratch`); on a
+    // small document the fresh-per-call versions of both used to dominate
+    // the entire call.
+    with_scratch(source.len(), &renderer_key, |allocator, renderer| {
+        match Parser::with_options(allocator, source, parser_options).parse() {
+            Ok(doc) => render_result(renderer.render_borrowed(&doc), None),
+            Err(e) => render_result("", Some(e.to_string())),
         }
-        Err(e) => serde_wasm_bindgen::to_value(&serde_json::json!({
-            "html": "",
-            "errors": [e.to_string()]
-        }))
-        .unwrap_or(JsValue::NULL),
-    }
+    })
 }
 
 /// Transforms Markdown source into HTML, frontmatter, and TOC.
@@ -231,44 +239,37 @@ pub fn transform(source: &str, options: Option<WasmParserOptions>) -> JsValue {
     // handing the source to the parser.
     let (content, frontmatter) = parse_frontmatter(source);
 
-    // Parse markdown
-    let allocator = Allocator::for_source_len(content.len());
+    // Parse markdown with the reused arena + renderer (see `scratch`).
     let parser_options = ParserOptions::from(&opts);
-    let parser = Parser::with_options(&allocator, &content, parser_options);
+    let renderer_key = RendererKey {
+        toc_max_depth,
+        autolink_urls: opts.autolink_urls,
+        autolink_target_blank: opts.autolink_target_blank,
+        autolink_patterns: opts.autolink_patterns,
+    };
 
-    let result = parser.parse();
-    match result {
-        Ok(doc) => {
-            // Extract TOC from headings
-            let toc = extract_toc(&doc, toc_max_depth);
-
-            // Render to HTML
-            let mut renderer = HtmlRenderer::with_options(HtmlRendererOptions {
-                toc_max_depth,
-                autolink_urls: opts.autolink_urls,
-                // `opts` is owned and unused after this literal, so move the
-                // pattern Vec instead of deep-cloning it every call.
-                autolink_patterns: opts.autolink_patterns,
-                autolink_target_blank: opts.autolink_target_blank,
-                ..Default::default()
-            });
-            let html = renderer.render(&doc);
-
-            let transform_result = TransformResult { html, frontmatter, toc, errors: vec![] };
-
-            serde_wasm_bindgen::to_value(&transform_result).unwrap_or(JsValue::NULL)
-        }
-        Err(e) => {
-            let transform_result = TransformResult {
+    let transform_result = with_scratch(content.len(), &renderer_key, |allocator, renderer| {
+        match Parser::with_options(allocator, &content, parser_options).parse() {
+            Ok(doc) => {
+                // Extract TOC from headings
+                let toc = extract_toc(&doc, toc_max_depth);
+                let html = renderer.render_borrowed(&doc).to_owned();
+                TransformResult { html, frontmatter, toc, errors: vec![] }
+            }
+            Err(e) => TransformResult {
                 html: String::new(),
                 frontmatter: FxHashMap::default(),
                 toc: vec![],
                 errors: vec![e.to_string()],
-            };
-
-            serde_wasm_bindgen::to_value(&transform_result).unwrap_or(JsValue::NULL)
+            },
         }
-    }
+    });
+
+    // `json_compatible` produces plain JS objects instead of Maps, matching
+    // the documented `result.html` / `result.frontmatter` access.
+    transform_result
+        .serialize(&serde_wasm_bindgen::Serializer::json_compatible())
+        .unwrap_or(JsValue::NULL)
 }
 
 /// Returns the version of ox_content_wasm.

--- a/crates/ox_content_wasm/src/scratch.rs
+++ b/crates/ox_content_wasm/src/scratch.rs
@@ -1,0 +1,95 @@
+//! Per-instance scratch state for the synchronous wasm entry points.
+//!
+//! A `parseAndRender` call on a small document spends most of its time in
+//! setup rather than Markdown work: building a fresh arena, constructing an
+//! [`HtmlRenderer`] (whose options own heap strings), and growing an output
+//! buffer up from zero — the same fixed costs the NAPI binding shed in its
+//! `render_scratch` module. Wasm runs single-threaded, so one cached arena
+//! and renderer per thread-local slot serves every call.
+//!
+//! Reuse is safe for the same reason as on the NAPI side: every entry point
+//! returns owned data (a JS string / object), so nothing borrowing the arena
+//! survives the call to observe the next reset. The renderer clears its
+//! per-document state (output, TOC entries, heading-id counts) at the top of
+//! each render.
+
+use std::cell::RefCell;
+
+use ox_content_allocator::Allocator;
+use ox_content_renderer::{HtmlRenderer, HtmlRendererOptions};
+
+/// Largest arena capacity carried over to the next call. One oversized
+/// document should not pin an oversized chunk for the rest of the instance's
+/// lifetime; anything past this bound is dropped and re-sized.
+const MAX_RETAINED_ARENA_BYTES: usize = 1 << 20;
+
+/// The renderer-affecting subset of `WasmParserOptions`, kept alongside the
+/// cached renderer so a call with different options rebuilds it instead of
+/// silently rendering with stale ones.
+#[derive(PartialEq, Clone)]
+pub struct RendererKey {
+    pub toc_max_depth: u8,
+    pub autolink_urls: bool,
+    pub autolink_target_blank: bool,
+    pub autolink_patterns: Vec<String>,
+}
+
+struct Scratch {
+    allocator: Allocator,
+    renderer: HtmlRenderer,
+    renderer_key: RendererKey,
+}
+
+fn default_key() -> RendererKey {
+    let defaults = HtmlRendererOptions::default();
+    RendererKey {
+        toc_max_depth: defaults.toc_max_depth,
+        autolink_urls: defaults.autolink_urls,
+        autolink_target_blank: defaults.autolink_target_blank,
+        autolink_patterns: defaults.autolink_patterns,
+    }
+}
+
+thread_local! {
+    static SCRATCH: RefCell<Scratch> = RefCell::new(Scratch {
+        allocator: Allocator::new(),
+        renderer: HtmlRenderer::new(),
+        renderer_key: default_key(),
+    });
+}
+
+/// Runs `f` with an arena readied for `source_len` bytes and a renderer
+/// configured for `key` — both reused across calls when possible.
+pub fn with_scratch<R>(
+    source_len: usize,
+    key: &RendererKey,
+    f: impl FnOnce(&Allocator, &mut HtmlRenderer) -> R,
+) -> R {
+    SCRATCH.with_borrow_mut(|scratch| {
+        let retained = scratch.allocator.allocated_bytes();
+        if retained < Allocator::capacity_for_source_len(source_len)
+            || retained > MAX_RETAINED_ARENA_BYTES
+        {
+            scratch.allocator = Allocator::for_source_len(source_len);
+        } else {
+            scratch.allocator.reset();
+        }
+
+        // Rebuilding the renderer costs the same as the old fresh-per-call
+        // path, so a caller cycling through option sets is no worse off; a
+        // caller with stable options (the common case, and the default) pays
+        // one comparison.
+        if scratch.renderer_key != *key {
+            scratch.renderer = HtmlRenderer::with_options(HtmlRendererOptions {
+                toc_max_depth: key.toc_max_depth,
+                autolink_urls: key.autolink_urls,
+                autolink_target_blank: key.autolink_target_blank,
+                autolink_patterns: key.autolink_patterns.clone(),
+                ..Default::default()
+            });
+            scratch.renderer_key = key.clone();
+        }
+
+        f(&scratch.allocator, &mut scratch.renderer)
+    })
+}


### PR DESCRIPTION
## Summary

Follow-up to #569, which surfaced that `@ox-content/wasm` lost to `md4x (wasm)` on small documents. Two causes, both fixed:

1. **Per-call setup** — every call built a fresh arena and a fresh `HtmlRenderer` and grew an output buffer from zero. This mirrors the napi-side fix from #560: a per-instance cached `Allocator` (reset instead of rebuilt, 1 MB retention cap) and a cached renderer keyed on the renderer-affecting options; `render_borrowed` keeps the output buffer warm.
2. **Return-value shape** — the result round-tripped through `serde_json::Value` + `serde_wasm_bindgen`, which copied the whole HTML string an extra time and produced a JS **`Map`**. Notably, the README and docs show `result.html` — which never worked on a Map. `parseAndRender` now builds the `{ html, errors }` object directly via `js_sys`, and `transform` serializes with the json-compatible serializer, so the **documented API shape now actually works**.

## Numbers (benchmark harness from #569, same machine)

| corpus | before | after | md4x (wasm) |
|---|---|---|---|
| small (497 B) | 33.3 MB/s | **51.3 MB/s (+54%)** | 58.1 MB/s |
| medium (5 KB) | 86.2 MB/s | **114.1 MB/s (+32%)** | 88.4 MB/s |
| large (50 KB) | 157.2 MB/s | **179.5 MB/s (+14%)** | 98.9 MB/s |
| huge (1 MB) | 181.2 MB/s | 181.2 MB/s | 53.4 MB/s |

Steady-state (warmed, 5000-iter loops) the small doc is **3.1 µs vs md4x's 4.9 µs — 1.6× faster**; the harness's remaining small-doc gap is cold-glue warmup inside its 100-iteration window.

## Verification
- Node smoke suite over the built pkg: documented `result.html` access, consecutive renders don't leak heading-id state, large-then-small reuse, option changes rebuild the renderer, error path, `transform` object shape (html / frontmatter / toc)
- CommonMark conformance via the #569 harness: **652/652** unchanged
- `cargo clippy --target wasm32-unknown-unknown` and fmt clean

## API note
The `Map` → plain-object change is technically observable, but the Map shape contradicted our own documentation (`result.html`), so this lands as fixing the API to match the docs. #569's benchmark probe handles both shapes either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789544908&installation_model_id=422833&pr_number=570&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F570&signature=303605f8d3e18f430dbce317a6204b8c19c321a944b82e5e31889bafb42dbe83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->