### PR TITLE
ci(publish-editors): retry marketplace publishes through transient outages

### DIFF
--- a/.github/workflows/publish-editors.yml
+++ b/.github/workflows/publish-editors.yml
@@ -129,20 +129,7 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
           PUBLISH_FROM_DISPATCH: ${{ inputs.publish }}
-        run: |
-          set -euo pipefail
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] \
-            && [ "${PUBLISH_FROM_DISPATCH}" != "true" ]; then
-            echo "Packaging-only dispatch; skipping VS Code Marketplace publish."
-            exit 0
-          fi
-          if [ -z "${VSCE_PAT:-}" ]; then
-            echo "::warning::VSCE_PAT is not configured; skipping Marketplace publish."
-            exit 0
-          fi
-          for vsix in dist/vscode/*.vsix; do
-            vp exec -- pnpm dlx @vscode/vsce publish --skip-duplicate --packagePath "$vsix"
-          done
+        run: node scripts/publish-editor-extensions.ts vscode-marketplace
 
   publish-open-vsx:
     name: Publish Open VSX
@@ -172,20 +159,7 @@ jobs:
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
           PUBLISH_FROM_DISPATCH: ${{ inputs.publish }}
-        run: |
-          set -euo pipefail
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] \
-            && [ "${PUBLISH_FROM_DISPATCH}" != "true" ]; then
-            echo "Packaging-only dispatch; skipping Open VSX publish."
-            exit 0
-          fi
-          if [ -z "${OVSX_PAT:-}" ]; then
-            echo "::warning::OVSX_PAT is not configured; skipping Open VSX publish."
-            exit 0
-          fi
-          for vsix in dist/vscode/*.vsix; do
-            vp exec -- pnpm dlx ovsx publish "$vsix" -p "$OVSX_PAT"
-          done
+        run: node scripts/publish-editor-extensions.ts open-vsx
 
   zed-extension:
     name: Validate Zed extension

--- a/scripts/publish-editor-extensions.ts
+++ b/scripts/publish-editor-extensions.ts
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
+type Registry = {
+  label: string;
+  tokenEnv: string;
+  args: (vsix: string, token: string) => string[];
+};
+
+// Marketplace outages surface as a hard failure on the very first VSIX (Azure
+// DevOps returns TF10216), which would otherwise leave a release with only
+// some platforms published. Both publishers run with --skip-duplicate, so a
+// retry after an attempt that actually landed is skipped rather than failing.
+const maxAttempts = 6;
+const initialDelayMs = 30_000;
+const maxDelayMs = 300_000;
+const vsixDir = "dist/vscode";
+
+const registries: Record<string, Registry> = {
+  "vscode-marketplace": {
+    label: "VS Code Marketplace",
+    tokenEnv: "VSCE_PAT",
+    args: (vsix) => [
+      "exec",
+      "--",
+      "pnpm",
+      "dlx",
+      "@vscode/vsce",
+      "publish",
+      "--skip-duplicate",
+      "--packagePath",
+      vsix,
+    ],
+  },
+  "open-vsx": {
+    label: "Open VSX",
+    tokenEnv: "OVSX_PAT",
+    args: (vsix, token) => [
+      "exec",
+      "--",
+      "pnpm",
+      "dlx",
+      "ovsx",
+      "publish",
+      vsix,
+      "--skip-duplicate",
+      "-p",
+      token,
+    ],
+  },
+};
+
+const registry = registries[process.argv[2] ?? ""];
+if (!registry) {
+  console.error(`Usage: publish-editor-extensions.ts <${Object.keys(registries).join("|")}>`);
+  process.exit(2);
+}
+
+// A packaging-only workflow_dispatch builds the VSIXs without shipping them.
+if (
+  process.env.GITHUB_EVENT_NAME === "workflow_dispatch" &&
+  process.env.PUBLISH_FROM_DISPATCH !== "true"
+) {
+  console.log(`Packaging-only dispatch; skipping ${registry.label} publish.`);
+  process.exit(0);
+}
+
+const token = process.env[registry.tokenEnv];
+if (!token) {
+  console.log(
+    `::warning::${registry.tokenEnv} is not configured; skipping ${registry.label} publish.`,
+  );
+  process.exit(0);
+}
+
+const packages = listVsixPackages();
+console.log(
+  `Publishing ${packages.length} package(s) to ${registry.label}: ${packages
+    .map((vsix) => vsix.slice(vsixDir.length + 1))
+    .join(", ")}`,
+);
+
+for (const vsix of packages) {
+  await publishWithRetry(registry, vsix, token);
+}
+
+function listVsixPackages(): string[] {
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(vsixDir);
+  } catch (error) {
+    console.error(`::error::Cannot read ${vsixDir}: ${(error as Error).message}`);
+    process.exit(1);
+  }
+
+  const found = entries
+    .filter((name) => name.endsWith(".vsix"))
+    .sort()
+    .map((name) => join(vsixDir, name));
+
+  if (found.length === 0) {
+    console.error(`::error::No .vsix packages found in ${vsixDir}`);
+    process.exit(1);
+  }
+
+  return found;
+}
+
+async function publishWithRetry(target: Registry, vsix: string, pat: string): Promise<void> {
+  let delay = initialDelayMs;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const result = spawnSync("vp", target.args(vsix, pat), { stdio: "inherit" });
+
+    if (result.status === 0) {
+      return;
+    }
+
+    const reason = result.error
+      ? result.error.message
+      : `exit code ${result.status ?? `signal ${result.signal}`}`;
+
+    if (attempt === maxAttempts) {
+      console.error(
+        `::error::${target.label} publish of ${vsix} failed after ${maxAttempts} attempts (${reason})`,
+      );
+      process.exit(1);
+    }
+
+    console.log(
+      `::warning::${target.label} publish of ${vsix} failed (${reason}); attempt ${attempt}/${maxAttempts}, retrying in ${delay / 1000}s`,
+    );
+    await sleep(delay);
+    delay = Math.min(delay * 2, maxDelayMs);
+  }
+}


### PR DESCRIPTION
## Problem

The `v2.83.0` release run failed in **Publish VS Code Marketplace**:

```
Publishing 'ubugeeei.vscode-ox-content (darwin-arm64) v2.83.0'...
##[error]TF10216: Azure DevOps services are currently unavailable. Try again later.
```

This was an Azure DevOps incident — the status API reported `Other services` (which covers the Marketplace) degraded across every geography. Manual re-runs all hit the same `TF10216`.

Two things made a transient outage worse than it needed to be:

- Under `set -euo pipefail`, the first failing VSIX aborted the whole `for` loop, so **none** of the platform packages got published — not just the one that hit the error.
- There was no retry, so the only recovery was a human re-running the job and guessing when the upstream service was back.

## Change

Move both publish steps out of inline YAML into `scripts/publish-editor-extensions.ts`, alongside the other release tooling. Each `run:` is now a single invocation:

```yaml
run: node scripts/publish-editor-extensions.ts vscode-marketplace
```

Node runs the TypeScript directly via type stripping — no build step, matching how CI already runs `node scripts/check-file-lines.ts`.

The script wraps each publish in a bounded exponential backoff: 6 attempts, 30s doubling to a 300s cap, ~12 minutes of total tolerance. Exhausting the attempts still fails the step, so a real breakage is not silently swallowed.

Retrying is only safe if the publish is idempotent:

- `vsce` already passed `--skip-duplicate`.
- `ovsx` did **not** — added here. Without it a retry after an attempt that actually landed would fail as a duplicate, converting a recoverable blip into a hard failure.

## Verification

Ran the script under Node 24 against a stub `vp` on `PATH`, with the backoff constants shrunk so the suite is fast:

| case | result |
| --- | --- |
| no failures | both VSIXs published, `rc=0` |
| fails 3× then succeeds | retries, publishes, `rc=0` |
| always fails | 5 warnings + `::error::`, `rc=1` |
| backoff growth | 30s → 60s → 120s → capped at 300s |
| packaging-only `workflow_dispatch` | skipped, `rc=0` |
| `workflow_dispatch` with `publish=true` | publishes, `rc=0` |
| PAT unset | `::warning::`, skipped, `rc=0` |
| `dist/vscode` empty | `::error::`, `rc=1` |
| `dist/vscode` missing | `::error::` with ENOENT, `rc=1` |
| unknown / missing registry argument | usage, `rc=2` |

Emitted command lines match what the YAML ran before, aside from the added `--skip-duplicate`:

```
vp exec -- pnpm dlx @vscode/vsce publish --skip-duplicate --packagePath dist/vscode/…​.vsix
vp exec -- pnpm dlx ovsx publish dist/vscode/…​.vsix --skip-duplicate -p ***
```

`vp check` (format + lint) is clean. `tsc -p scripts/tsconfig.json` reports only the repo-wide `@types/node` baseline that `release.ts`, `check-file-lines.ts`, and `build-wasm-package.ts` already emit — no new diagnostics.

Note this does not change the outcome of the `v2.83.0` publish, which still needs a re-run once the upstream incident clears.