### PR TITLE
perf(renderer): key the heading-id map by CompactString (-43% allocations)

### DIFF
--- a/crates/ox_content_renderer/src/html/renderer.rs
+++ b/crates/ox_content_renderer/src/html/renderer.rs
@@ -14,6 +14,7 @@ mod links;
 mod visit;
 mod write;
 
+use compact_str::CompactString;
 use ox_content_ast::{Document, Node};
 use rustc_hash::FxHashMap;
 
@@ -32,7 +33,12 @@ use crate::render::{RenderResult, Renderer};
 pub struct HtmlRenderer {
     options: HtmlRendererOptions,
     output: String,
-    heading_id_counts: FxHashMap<String, usize>,
+    /// Keyed by `CompactString` rather than `String`: heading slugs are
+    /// short (median 22 bytes on the bundled corpora), so the majority sit
+    /// inside `CompactString`'s 24-byte inline capacity and cost no heap
+    /// allocation at all. This map is the renderer's single largest
+    /// allocation source — one insert per unique heading.
+    heading_id_counts: FxHashMap<CompactString, usize>,
     /// How many times each footnote identifier has been referenced so
     /// far in this render, so repeated references can be given unique
     /// `fnref-` ids. Cleared per `render()` like the heading id map.
@@ -52,9 +58,9 @@ pub struct HtmlRenderer {
     /// `String` allocation per heading — `slugify_heading` previously
     /// allocated one `text` String per call.
     heading_text_scratch: String,
-    /// Reusable scratch buffer for the slugified id. The final id String
-    /// that ends up in `heading_id_counts` is cloned out of here on
-    /// vacant inserts; the buffer itself stays around across renders.
+    /// Reusable scratch buffer for the slugified id. The final id that
+    /// ends up in `heading_id_counts` is copied out of here on vacant
+    /// inserts; the buffer itself stays around across renders.
     heading_slug_scratch: String,
     /// Suppresses URL auto-linking while we're already inside an `<a>` so
     /// the builtin can't nest anchors. Tracked manually rather than via

--- a/crates/ox_content_renderer/src/html/renderer/write.rs
+++ b/crates/ox_content_renderer/src/html/renderer/write.rs
@@ -6,6 +6,7 @@
 
 use std::fmt::{Display, Write as _};
 
+use compact_str::CompactString;
 use ox_content_ast::{Heading, Node};
 
 use super::super::autolink::find_autolink_match;
@@ -220,7 +221,9 @@ impl HtmlRenderer {
         }
 
         self.output.push_str(&self.heading_slug_scratch);
-        let key = self.heading_slug_scratch.clone();
+        // `CompactString::from(&str)` stores slugs up to 24 bytes inline, so
+        // the common heading pays no allocation for its map key at all.
+        let key = CompactString::from(self.heading_slug_scratch.as_str());
         self.heading_id_counts.insert(key, 1);
     }
 }


### PR DESCRIPTION
## What

`write_heading_id` clones its slug scratch buffer into `heading_id_counts` on every unique heading. Profiling the parse+render pipeline shows that one clone is the renderer's single largest allocation source — on the bundled TypeScript-handbook corpus it is **1628 of the pipeline's 1704 allocations per iteration** (95%).

Heading slugs are short. Measured over the same corpus (1777 headings):

| slug length | share |
| --- | --- |
| ≤ 16 bytes | 34.5% |
| 17–24 bytes | 22.6% |
| > 24 bytes | 42.9% |

median 22, mean 24.9. `CompactString` stores up to 24 bytes inline, so the majority of heading keys stop touching the heap at all.

## Result

Allocation count per pipeline iteration (`ox-content-profile pipeline --gfm`):

| corpus | before | after | change |
| --- | --- | --- | --- |
| typescript-handbook | 1704 | 974 | **−42.8%** |
| rust-book | 708 | 490 | **−30.8%** |
| vue-docs | 811 | 621 | **−23.4%** |

**Wall-clock is unchanged on native.** Interleaved A/B (two pinned binaries, alternating, six rounds of 150 iterations + 20 warmup) on typescript-handbook:

| build | best min | mean of mins |
| --- | --- | --- |
| `main` | 6.51 ms | 6.550 ms |
| this branch | 6.47 ms | 6.542 ms |

That 0.1% is inside the noise floor of this machine (load average ~4.7 during measurement), and rust-book / vue-docs behave the same way. I am **not** claiming a throughput win — this lands for the reduced allocator pressure, which matters most where allocation is comparatively expensive (WASM linear memory, the NAPI path) and as groundwork for further allocation work on this path.

An earlier criterion run against a stale baseline reported swings of −11% to +24% across corpora; that was machine noise from concurrent builds, not signal, which is why the numbers above come from interleaved same-session runs comparing minima.

## Verification

- `cargo test --workspace`: 950 passed, 0 failed.
- `cargo clippy -p ox_content_renderer --all-targets`: clean.
- Behaviour is unchanged — `CompactString` has the same `Hash`/`Eq` semantics as `String` for the same bytes, so duplicate-heading suffixing is untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789558802&installation_model_id=422833&pr_number=572&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F572&signature=381a072b082b8e85f2b41dccc9ed2ce42f67c31d4c5cf48a637049813f81703e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->