### PR TITLE
perf(renderer): scan for escapes with SWAR word tests (+40-67% on the routine)

### DIFF
--- a/crates/ox_content_renderer/src/html/escape.rs
+++ b/crates/ox_content_renderer/src/html/escape.rs
@@ -1,14 +1,14 @@
 //! Allocation-aware escaping helpers for text and URL attributes.
 //!
-//! These routines are on the renderer's hottest path. They use static byte lookup
-//! tables so long runs of safe text can be copied in chunks while only the bytes that
-//! affect HTML parsing are replaced.
+//! These routines are on the renderer's hottest path — escaping accounts for
+//! roughly a seventh of a full parse+render pipeline on the bundled corpora.
+//! They scan for the handful of bytes that must be replaced using SWAR
+//! (SIMD-within-a-register) word tests, so long runs of safe text are proven
+//! clean eight bytes at a time and then copied with one `push_str`.
 
-// Per-byte HTML-escape mapping. `ESCAPE_FLAG[b] == 1` and
-// `ESCAPE_TABLE[b]` is the replacement string when `b` must be escaped;
-// otherwise the flag is 0 and the entry is `""`. Splitting flag/string
-// lets the inner scan use a plain integer OR over 8-byte chunks (which
-// LLVM vectorizes) instead of branching on a string comparison.
+// Replacement strings for the bytes that must be escaped. `ESCAPE_FLAG[b]`
+// answers "does byte `b` need replacing" for the scalar tail; the hot loop
+// uses the SWAR word tests below instead of per-byte lookups.
 static ESCAPE_TABLE: [&str; 256] = {
     let mut table: [&str; 256] = [""; 256];
     table[b'&' as usize] = "&amp;";
@@ -49,69 +49,102 @@ static URL_ESCAPE_FLAG: [u8; 256] = {
     t
 };
 
+const ONES: u64 = 0x0101_0101_0101_0101;
+const HIGH: u64 = 0x8080_8080_8080_8080;
+
+const fn splat(byte: u8) -> u64 {
+    (byte as u64) * ONES
+}
+
+/// Sets `0x80` in every byte lane of `word` that is zero.
+///
+/// The classic bit-twiddling zero test. It can also light up a lane holding
+/// `0x01` when a lower lane borrowed into it, which is why every caller below
+/// only ever consumes the *lowest* set bit: a spurious lane can only sit
+/// above a genuine zero lane that produced the borrow, so the lowest set bit
+/// is always a true match.
 #[inline]
-pub(super) fn write_escaped_into(out: &mut String, s: &str) {
-    crate::profile_span_detail!("renderer::escape_text");
-    // The invariant for this routine is: bytes in `s[start..i]` have not yet
-    // been copied, and every byte before `start` has already been emitted in
-    // escaped form. Safe runs are copied with one `push_str`; only bytes that
-    // require replacement are handled individually. `reserve(s.len())` covers
-    // the no-escape case exactly and reduces growth even when replacements make
-    // the final output longer.
+const fn has_zero(word: u64) -> u64 {
+    word.wrapping_sub(ONES) & !word & HIGH
+}
+
+/// Nonzero iff `word` holds any of `&`, `<`, `>`, `"`, `'`.
+///
+/// Five needles fold into three zero tests: `&`(0x26)/`'`(0x27) differ only in
+/// bit 0 and `<`(0x3C)/`>`(0x3E) only in bit 1, so forcing that bit on maps
+/// each pair onto a single value. `y | 0x01 == 0x27` holds for exactly
+/// {0x26, 0x27} and `y | 0x02 == 0x3E` for exactly {0x3C, 0x3E}, so the fold
+/// admits no bytes beyond the five.
+#[inline]
+const fn escape_mask(word: u64) -> u64 {
+    has_zero((word | splat(0x01)) ^ splat(b'\''))
+        | has_zero((word | splat(0x02)) ^ splat(b'>'))
+        | has_zero(word ^ splat(b'"'))
+}
+
+/// Nonzero iff `word` holds any of `&`, `<`, `>`, `"`, ` `.
+///
+/// Same fold: `<`/`>` share bit 1, and so do ` `(0x20)/`"`(0x22), leaving `&`
+/// on its own.
+#[inline]
+const fn url_escape_mask(word: u64) -> u64 {
+    has_zero((word | splat(0x02)) ^ splat(b'>'))
+        | has_zero((word | splat(0x02)) ^ splat(b'"'))
+        | has_zero(word ^ splat(b'&'))
+}
+
+/// Byte offset of the lowest flagged lane in a nonzero mask.
+#[inline]
+const fn first_flagged_lane(mask: u64) -> usize {
+    (mask.trailing_zeros() / 8) as usize
+}
+
+/// Shared scan/copy loop for both escapers.
+///
+/// `mask_of` proves a whole 8-byte word clean in one test; when a word is
+/// dirty its mask names the exact byte, so the scalar walk never re-examines
+/// bytes the word test already cleared. `flags`/`table` drive the tail and the
+/// replacement itself.
+#[inline]
+fn escape_into(
+    out: &mut String,
+    s: &str,
+    mask_of: impl Fn(u64) -> u64,
+    flags: &[u8; 256],
+    table: &[&'static str; 256],
+) {
+    // The invariant: bytes in `s[start..i]` have not been copied yet, and
+    // everything before `start` has already been emitted in escaped form.
     let bytes = s.as_bytes();
     let mut start = 0usize;
     let mut i = 0usize;
-    out.reserve(s.len());
 
-    // 8-byte chunk fast-skip: the OR over 8 lookups vectorizes well and
-    // dominates the inner loop on long no-escape runs (most plain text). A
-    // nonzero mask only says "at least one byte in this chunk needs the slow
-    // path"; the scalar loop below still finds the exact byte to replace.
-    while i + 8 <= bytes.len() {
-        let chunk = &bytes[i..i + 8];
-        let mask = ESCAPE_FLAG[chunk[0] as usize]
-            | ESCAPE_FLAG[chunk[1] as usize]
-            | ESCAPE_FLAG[chunk[2] as usize]
-            | ESCAPE_FLAG[chunk[3] as usize]
-            | ESCAPE_FLAG[chunk[4] as usize]
-            | ESCAPE_FLAG[chunk[5] as usize]
-            | ESCAPE_FLAG[chunk[6] as usize]
-            | ESCAPE_FLAG[chunk[7] as usize];
-        if mask == 0 {
-            i += 8;
-            continue;
-        }
-        break;
-    }
-
-    while i < bytes.len() {
-        let b = bytes[i];
-        if ESCAPE_FLAG[b as usize] != 0 {
-            if start < i {
-                out.push_str(&s[start..i]);
+    loop {
+        while i + 8 <= bytes.len() {
+            // `unwrap` is unreachable: the slice is exactly 8 bytes wide.
+            let word = u64::from_le_bytes(bytes[i..i + 8].try_into().unwrap());
+            let mask = mask_of(word);
+            if mask == 0 {
+                i += 8;
+                continue;
             }
-            out.push_str(ESCAPE_TABLE[b as usize]);
+            i += first_flagged_lane(mask);
+            break;
+        }
+        // Tail (and the byte the mask pointed at): at most seven bytes of
+        // scalar work per dirty word.
+        while i < bytes.len() && flags[bytes[i] as usize] == 0 {
             i += 1;
-            start = i;
-            while i + 8 <= bytes.len() {
-                let chunk = &bytes[i..i + 8];
-                let mask = ESCAPE_FLAG[chunk[0] as usize]
-                    | ESCAPE_FLAG[chunk[1] as usize]
-                    | ESCAPE_FLAG[chunk[2] as usize]
-                    | ESCAPE_FLAG[chunk[3] as usize]
-                    | ESCAPE_FLAG[chunk[4] as usize]
-                    | ESCAPE_FLAG[chunk[5] as usize]
-                    | ESCAPE_FLAG[chunk[6] as usize]
-                    | ESCAPE_FLAG[chunk[7] as usize];
-                if mask == 0 {
-                    i += 8;
-                    continue;
-                }
-                break;
-            }
-            continue;
         }
+        if i >= bytes.len() {
+            break;
+        }
+        if start < i {
+            out.push_str(&s[start..i]);
+        }
+        out.push_str(table[bytes[i] as usize]);
         i += 1;
+        start = i;
     }
 
     if start < bytes.len() {
@@ -119,64 +152,121 @@ pub(super) fn write_escaped_into(out: &mut String, s: &str) {
     }
 }
 
+#[inline]
+pub(super) fn write_escaped_into(out: &mut String, s: &str) {
+    crate::profile_span_detail!("renderer::escape_text");
+    // `reserve(s.len())` covers the no-escape case exactly and reduces growth
+    // even when replacements make the final output longer.
+    out.reserve(s.len());
+    escape_into(out, s, escape_mask, &ESCAPE_FLAG, &ESCAPE_TABLE);
+}
+
 pub(super) fn write_url_escaped_into(out: &mut String, s: &str) {
     crate::profile_span_detail!("renderer::escape_url");
-    // Same chunked scanner as `write_escaped_into`, but with URL attribute
-    // semantics. Ampersand remains HTML-escaped because the result is written
-    // inside an HTML attribute, while spaces and tag delimiters are percent
-    // encoded to keep the URL value itself stable.
-    let bytes = s.as_bytes();
-    let mut start = 0usize;
-    let mut i = 0usize;
+    // Same scanner as `write_escaped_into`, but with URL attribute semantics.
+    // Ampersand stays HTML-escaped because the result is written inside an
+    // HTML attribute, while spaces and tag delimiters are percent encoded to
+    // keep the URL value itself stable.
+    escape_into(out, s, url_escape_mask, &URL_ESCAPE_FLAG, &URL_ESCAPE_TABLE);
+}
 
-    while i + 8 <= bytes.len() {
-        let chunk = &bytes[i..i + 8];
-        let mask = URL_ESCAPE_FLAG[chunk[0] as usize]
-            | URL_ESCAPE_FLAG[chunk[1] as usize]
-            | URL_ESCAPE_FLAG[chunk[2] as usize]
-            | URL_ESCAPE_FLAG[chunk[3] as usize]
-            | URL_ESCAPE_FLAG[chunk[4] as usize]
-            | URL_ESCAPE_FLAG[chunk[5] as usize]
-            | URL_ESCAPE_FLAG[chunk[6] as usize]
-            | URL_ESCAPE_FLAG[chunk[7] as usize];
-        if mask == 0 {
-            i += 8;
-            continue;
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Straightforward byte-at-a-time escaper the SWAR scanner must match.
+    ///
+    /// Every escaped byte is ASCII, so copying the rest through verbatim at
+    /// the byte level keeps multi-byte sequences intact.
+    fn reference(s: &str, flags: &[u8; 256], table: &[&'static str; 256]) -> String {
+        let mut out: Vec<u8> = Vec::new();
+        for byte in s.bytes() {
+            if flags[byte as usize] != 0 {
+                out.extend_from_slice(table[byte as usize].as_bytes());
+            } else {
+                out.push(byte);
+            }
         }
-        break;
+        String::from_utf8(out).expect("escaping only rewrites ASCII bytes")
     }
 
-    while i < bytes.len() {
-        let b = bytes[i];
-        if URL_ESCAPE_FLAG[b as usize] != 0 {
-            if start < i {
-                out.push_str(&s[start..i]);
-            }
-            out.push_str(URL_ESCAPE_TABLE[b as usize]);
-            i += 1;
-            start = i;
-            while i + 8 <= bytes.len() {
-                let chunk = &bytes[i..i + 8];
-                let mask = URL_ESCAPE_FLAG[chunk[0] as usize]
-                    | URL_ESCAPE_FLAG[chunk[1] as usize]
-                    | URL_ESCAPE_FLAG[chunk[2] as usize]
-                    | URL_ESCAPE_FLAG[chunk[3] as usize]
-                    | URL_ESCAPE_FLAG[chunk[4] as usize]
-                    | URL_ESCAPE_FLAG[chunk[5] as usize]
-                    | URL_ESCAPE_FLAG[chunk[6] as usize]
-                    | URL_ESCAPE_FLAG[chunk[7] as usize];
-                if mask == 0 {
-                    i += 8;
-                    continue;
+    fn check(s: &str) {
+        let mut text = String::new();
+        write_escaped_into(&mut text, s);
+        assert_eq!(text, reference(s, &ESCAPE_FLAG, &ESCAPE_TABLE), "text escape: {s:?}");
+
+        let mut url = String::new();
+        write_url_escaped_into(&mut url, s);
+        assert_eq!(url, reference(s, &URL_ESCAPE_FLAG, &URL_ESCAPE_TABLE), "url escape: {s:?}");
+    }
+
+    #[test]
+    fn matches_reference_on_fixtures() {
+        for case in [
+            "",
+            "a",
+            "&",
+            "<>",
+            "plain ascii text with no escapes at all",
+            "&<>\"'",
+            "a&b<c>d\"e'f",
+            "exactly-8b",
+            "seven77",
+            "&&&&&&&&&&&&&&&&",
+            "trailing escape &",
+            "& leading escape",
+            // The folded masks admit no extra bytes, but these neighbours are
+            // the ones a sloppy fold would leak: 0x21 0x23 0x25 0x3D 0x3F.
+            "!#%=?",
+            "!#%=? &<>\"' !#%=?",
+        ] {
+            check(case);
+        }
+    }
+
+    #[test]
+    fn matches_reference_on_borrow_propagation_shapes() {
+        // `has_zero` can flag a 0x01 lane that borrowed from a real match
+        // below it. These interleavings put such bytes directly after a match
+        // inside the same word, which is where a wrong lane index would show.
+        for filler in ["!", "#", "%", "=", "?", "\x01", "\x00"] {
+            for needle in ["&", "<", ">", "\"", "'", " "] {
+                for lead in 0..9 {
+                    let mut s = "x".repeat(lead);
+                    s.push_str(needle);
+                    for _ in 0..8 {
+                        s.push_str(filler);
+                    }
+                    s.push_str(needle);
+                    check(&s);
                 }
-                break;
             }
-            continue;
         }
-        i += 1;
     }
 
-    if start < bytes.len() {
-        out.push_str(&s[start..]);
+    #[test]
+    fn matches_reference_on_pseudorandom_bytes() {
+        // xorshift over the printable-plus-needles range; deterministic so a
+        // failure is reproducible.
+        let mut state = 0x2545_F491_4F6C_DD1Du64;
+        let alphabet: Vec<u8> =
+            (0x20u8..0x7f).chain(*b"&<>\"' ").collect();
+        for len in 0..200 {
+            let mut s = String::with_capacity(len);
+            for _ in 0..len {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                s.push(alphabet[(state % alphabet.len() as u64) as usize] as char);
+            }
+            check(&s);
+        }
+    }
+
+    #[test]
+    fn matches_reference_on_multibyte_utf8() {
+        check("日本語のテキスト");
+        check("emoji 🎉 and <tags> mixed");
+        check("café & naïve — \"quoted\"");
     }
 }

--- a/crates/ox_content_renderer/src/html/escape.rs
+++ b/crates/ox_content_renderer/src/html/escape.rs
@@ -249,8 +249,7 @@ mod tests {
         // xorshift over the printable-plus-needles range; deterministic so a
         // failure is reproducible.
         let mut state = 0x2545_F491_4F6C_DD1Du64;
-        let alphabet: Vec<u8> =
-            (0x20u8..0x7f).chain(*b"&<>\"' ").collect();
+        let alphabet: Vec<u8> = (0x20u8..0x7f).chain(*b"&<>\"' ").collect();
         for len in 0..200 {
             let mut s = String::with_capacity(len);
             for _ in 0..len {


### PR DESCRIPTION
## Why here

Profiling the parse+render pipeline (`ox-content-profile pipeline --gfm`) puts ~14.8% of the run in `visit_paragraph`'s self time, which is where inline text rendering lands. Timing the escape routine in isolation on the same corpus confirms it: **1.91 MB in 0.94 ms of a 6.5 ms pipeline**.

The scanner proved an 8-byte chunk clean by ORing eight `ESCAPE_FLAG` lookups — one load per byte — and when a chunk was dirty it `break`s and lets a scalar loop re-find the offending byte the chunk test had just located.

## Change

Replace the lookups with SWAR zero tests over a `u64`.

Five needles fold into three tests: `&`(0x26)/`'`(0x27) differ only in bit 0, and `<`(0x3C)/`>`(0x3E) only in bit 1. Forcing that bit on maps each pair onto one value, and the fold admits nothing extra — `y | 0x01 == 0x27` holds for exactly {0x26, 0x27}, `y | 0x02 == 0x3E` for exactly {0x3C, 0x3E}. The URL escaper folds the same way (` `/`"` share bit 1).

A dirty word's mask then names the offending lane via `trailing_zeros() / 8`, so the scalar walk never re-examines bytes the word test already cleared. Both escapers now share one scanner.

## Result

Isolated routine, the same algorithms compiled standalone and fed paragraph-sized chunks of each corpus:

| corpus | before | after | change |
| --- | --- | --- | --- |
| typescript-handbook | 1.89 GB/s | 3.16 GB/s | **+67%** |
| rust-book | 3.78 GB/s | 6.08 GB/s | **+61%** |
| vue-docs | 2.39 GB/s | 3.35 GB/s | **+40%** |

End-to-end pipeline — two pinned binaries run alternating, eight rounds of 300 iterations each, comparing minima (this machine carries background load, so minima are the robust statistic):

| corpus | `main` | this branch | change |
| --- | --- | --- | --- |
| typescript-handbook | 6.76 ms | 6.57 ms | **−2.81%** |
| vue-docs | 3.59 ms | 3.49 ms | **−2.79%** |
| rust-book | 4.45 ms | 4.38 ms | **−1.57%** |

An intermediate `#[inline(always)]` build measured a little better (−4.7% / −3.7% / −1.8%) but trips `clippy::inline_always`, which this workspace warns on and uses nowhere else, so the shipped version uses plain `#[inline]`.

I also tried 16- and 32-byte unrolled variants; they win on rust-book but lose on typescript-handbook, so the 8-byte scanner is the one that improves every corpus.

## Correctness

Output is byte-identical — verified over all three corpora (4.15 MB) while developing, and pinned by tests here.

The one subtlety worth stating: `has_zero` can light up a lane holding `0x01` when a lower lane borrowed into it. That is safe because such a lane can only sit **above** a genuine zero lane (the borrow has to come from somewhere), so the lowest set bit is always a true match — and the lowest set bit is the only thing any caller reads. New tests pin this against a byte-at-a-time reference implementation over:

- fixtures, including the bytes a sloppy fold would leak (`!` `#` `%` `=` `?`)
- borrow-propagation shapes: every needle followed by eight filler bytes (including `0x00`/`0x01`) at every alignment
- 200 pseudorandom strings from a deterministic xorshift
- multi-byte UTF-8

`cargo test --workspace`: 954 passed, 0 failed. `cargo clippy -p ox_content_renderer --all-targets`: clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789559812&installation_model_id=422833&pr_number=573&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F573&signature=dc22222f3304569716f55412a7e505ed242ac23f8d7f2fd855f6ddb3404775bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved text and URL escaping efficiency, especially for larger content.
  * Reduced processing overhead while preserving existing escaping behavior.

* **Bug Fixes**
  * Improved handling of multibyte UTF-8 text and URL content.
  * Confirmed escaping results remain consistent across a broad range of inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->