### PR TITLE
perf(parser): walk short inline runs before the chunked scan (+8-16% on the routine)

### DIFF
--- a/crates/ox_content_parser/src/parser/inline/scan.rs
+++ b/crates/ox_content_parser/src/parser/inline/scan.rs
@@ -23,16 +23,39 @@ static INLINE_SPECIAL: [u8; 256] = {
     t
 };
 
+/// How far `next_inline_special` walks byte-at-a-time before switching to the
+/// chunked scan. Eight is the only length measured that never regressed:
+/// longer prefixes bought a little more on code-dense corpora and lost
+/// 12-16% on prose-dense ones.
+const SHORT_RUN_PREFIX: usize = 8;
+
 #[inline]
 pub(super) fn next_inline_special(bytes: &[u8], from: usize) -> usize {
     profile_span_detail!("parser::inline_scan");
+    let end = bytes.len();
+
+    // Text runs are strongly bimodal on the bundled corpora: 53-64% of them
+    // end within eight bytes while holding under 5% of the bytes, and 44-52%
+    // of the bytes sit in runs of 64 or more. Walking that short prefix one
+    // byte at a time means the common run never pays the chunked scan's eight
+    // lookups and seven ORs to find a marker two bytes in, while long runs —
+    // where the bytes actually are — still reach the wide scan below.
+    let quick = if from + SHORT_RUN_PREFIX < end { from + SHORT_RUN_PREFIX } else { end };
+    let mut i = from;
+    while i < quick && INLINE_SPECIAL[bytes[i] as usize] == 0 {
+        i += 1;
+    }
+    if i < quick {
+        return i;
+    }
+    if i == end {
+        return end;
+    }
+
     // Skip eight bytes at a time while the OR of their marker flags is zero.
     // This is not a semantic parser: it only proves that none of those bytes
     // can start inline syntax, so returning the first flagged byte preserves
     // the exact same marker positions as the previous per-byte loop.
-    let mut i = from;
-    let end = bytes.len();
-
     while i + 8 <= end {
         let chunk = &bytes[i..i + 8];
         let mask = INLINE_SPECIAL[chunk[0] as usize]
@@ -52,4 +75,65 @@ pub(super) fn next_inline_special(bytes: &[u8], from: usize) -> usize {
         i += 1;
     }
     i
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The definition the chunked scan has to agree with.
+    fn reference(bytes: &[u8], from: usize) -> usize {
+        let mut i = from;
+        while i < bytes.len() && INLINE_SPECIAL[bytes[i] as usize] == 0 {
+            i += 1;
+        }
+        i
+    }
+
+    #[test]
+    fn matches_reference_around_the_prefix_boundary() {
+        // A marker at every offset, in inputs long and short enough to exercise
+        // the short-run prefix, the prefix/chunk handoff, and the scalar tail.
+        for len in 0..40usize {
+            for marker_at in 0..len {
+                let mut buffer = [b'x'; 40];
+                buffer[marker_at] = b'*';
+                let bytes = &buffer[..len];
+                for from in 0..=len {
+                    assert_eq!(
+                        next_inline_special(bytes, from),
+                        reference(bytes, from),
+                        "len {len}, marker at {marker_at}, from {from}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn matches_reference_with_no_marker() {
+        let buffer = [b'x'; 40];
+        for len in 0..=buffer.len() {
+            let bytes = &buffer[..len];
+            for from in 0..=len {
+                assert_eq!(next_inline_special(bytes, from), reference(bytes, from));
+            }
+        }
+    }
+
+    #[test]
+    fn matches_reference_on_every_marker_byte() {
+        for marker in *b"*_`[!~\\<\n&" {
+            for lead in 0..20usize {
+                let mut buffer = [b'x'; 40];
+                buffer[lead] = marker;
+                let bytes = &buffer[..lead + 8];
+                assert_eq!(
+                    next_inline_special(bytes, 0),
+                    reference(bytes, 0),
+                    "marker {marker:?} at {lead}"
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Why

`next_inline_special` is the text-run scanner behind `parse_inline`, which the profiler puts at ~20% of the pipeline. Measuring the run lengths it actually sees explains where its time goes — the distribution is strongly bimodal:

| run length | share of runs | share of bytes |
| --- | --- | --- |
| < 8 bytes | **53–64%** | 4.4–4.9% |
| 8–15 | 10–12% | 6.6–7.9% |
| 16–63 | 19–24% | 26–43% |
| ≥ 64 | 6–13% | **44–52%** |

So most *calls* end within a couple of bytes, while most *bytes* live in long runs. The chunked scan paid eight lookups and seven ORs to prove a word clean — and then a scalar rescan to locate the byte — even when the marker was two bytes in, which is what the majority of calls do.

## Change

Walk the first eight bytes one at a time, then hand the rest to the existing chunked scan. Short runs stop paying chunk setup; long runs still get the wide scan.

## Result

Isolated routine, driven exactly the way `parse_inline` drives it (including the soft-break fold loop), best of 12 interleaved rounds:

| corpus | before | after | best | median |
| --- | --- | --- | --- | --- |
| typescript-handbook | 1.67 GB/s | 1.88 GB/s | **+12.6%** | +10.9% |
| rust-book | 2.29 GB/s | 2.47 GB/s | **+7.9%** | +11.5% |
| vue-docs | 2.73 GB/s | 2.77 GB/s | +1.5% | **+16.0%** |

**End-to-end the effect is small and close to this machine's noise floor.** 16 interleaved rounds of 300 iterations:

| corpus | best | median |
| --- | --- | --- |
| typescript-handbook | −0.64% | −0.31% |
| rust-book | −0.24% | −0.46% |
| vue-docs | −0.90% | 0.00% |

Six of six statistics land on the improvement side, which is what you would predict from a ~12% faster scanner inside a stage that is ~20% of the pipeline — but I am not claiming a measurable pipeline win, and none of those numbers clears the noise on its own.

## Choosing the prefix length

Eight is the only length that never regressed. Best-of-6-rounds, relative to `main`:

| prefix | ts-handbook | rust-book | vue-docs |
| --- | --- | --- | --- |
| **8** | **+13.3%** | **+12.8%** | **+0.0%** |
| 12 | +14.5% | +11.0% | −12.5% |
| 16 | +15.1% | +7.8% | −12.5% |
| 24 | +11.4% | +1.8% | −16.5% |
| 32 | +15.1% | +3.2% | −15.0% |
| 48 | +15.1% | +0.5% | −16.1% |

Longer prefixes buy a little more on code-dense corpora and give it back on prose-dense ones.

## Also tried and rejected

- **Folding plain soft line breaks into the scanner** so it would not re-enter once per line. `\n` is 45–51% of all stops and 21–33% of them are plain soft breaks, so this removes a third of the work — and it is slower on every corpus. The extra branch in the hot loop costs more than the saved re-entries.
- **A positional mask (`trailing_zeros`) to skip the scalar rescan.** A wash on ts-handbook, −13% on vue-docs.
- **Dropping the chunked scan entirely.** +28% on ts-handbook, −3% and −10% on the others.
- **SWAR word tests**, the trick that worked for [#573](https://github.com/ubugeeei-prod/ox-content/pull/573). It does not transfer: ten needles fold to only eight zero-tests (`\n`/`*` share a bit, `[`/`_` share a bit), which is ~32 ops per word against the table scan's ~15.

## Correctness

No behaviour change — the scanner returns the same marker positions. Verified in the harness (identical run counts and offset checksums over 4.2 MB of corpus) and pinned by new unit tests against a byte-at-a-time reference: a marker at every offset for every input length 0–39 scanned from every start position, inputs with no marker at all, and every one of the ten marker bytes at every offset across the prefix/chunk handoff.

`cargo test --workspace`: 957 passed, 0 failed. `cargo fmt --check` and `cargo clippy -p ox_content_parser --all-targets`: clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789564416&installation_model_id=422833&pr_number=575&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F575&signature=b380d908d69a928422a446d790c273cbdeaed70c7650db72cc72bf070038e3c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved scanning efficiency for short inline content runs while preserving marker detection behavior.

* **Tests**
  * Added coverage across boundary lengths, marker positions, inputs without markers, and all supported marker bytes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->