### PR TITLE
perf(parser): scan pre-pass lines with SWAR instead of memchr (-10% on the pass)

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -19,6 +19,7 @@ mod inline;
 mod inline_helpers;
 mod inline_html;
 mod leaf;
+mod line_scan;
 mod list;
 mod list_item;
 mod prepass;

--- a/crates/ox_content_parser/src/parser/line_scan.rs
+++ b/crates/ox_content_parser/src/parser/line_scan.rs
@@ -1,0 +1,140 @@
+//! Newline scanning for the document pre-pass.
+//!
+//! The pre-pass walks every line of the document — blanks and one-word lines
+//! included — so it asks "where does this line end" tens of thousands of times
+//! against very short spans. At that length a `memchr` call spends most of its
+//! time on per-call setup rather than on scanning: measured on the bundled
+//! corpora, walking lines is ~90% of the pre-pass, and a SWAR
+//! (SIMD-within-a-register) word test beats `memchr` there by a third.
+//!
+//! That advantage is specific to this access pattern. Block parsing walks the
+//! long prose lines of a paragraph, where `memchr`'s wider SIMD step overtakes
+//! an eight-byte word test — converting those call sites measured 4-11% slower,
+//! so they deliberately keep using `memchr`.
+
+const ONES: u64 = 0x0101_0101_0101_0101;
+const HIGH: u64 = 0x8080_8080_8080_8080;
+const NEWLINES: u64 = (b'\n' as u64) * ONES;
+
+/// Sets `0x80` in every byte lane of `word` that is zero.
+///
+/// A lane holding `0x01` can also light up when a lower lane borrowed into it,
+/// so callers must only consume the *lowest* set bit: a spurious lane can only
+/// sit above a genuine zero lane, which means the lowest set bit is always a
+/// true match.
+#[inline]
+const fn has_zero(word: u64) -> u64 {
+    word.wrapping_sub(ONES) & !word & HIGH
+}
+
+/// Byte offset of the newline ending the line that starts at `from`, or
+/// `bytes.len()` when the last line is unterminated.
+#[inline]
+pub(in crate::parser) fn line_end(bytes: &[u8], from: usize) -> usize {
+    let end = bytes.len();
+    let mut i = from;
+
+    while i + 8 <= end {
+        // `unwrap` is unreachable: the slice is exactly 8 bytes wide.
+        let word = u64::from_le_bytes(bytes[i..i + 8].try_into().unwrap());
+        let mask = has_zero(word ^ NEWLINES);
+        if mask != 0 {
+            return i + (mask.trailing_zeros() / 8) as usize;
+        }
+        i += 8;
+    }
+
+    while i < end && bytes[i] != b'\n' {
+        i += 1;
+    }
+    i
+}
+
+/// Byte offset of the next line's start — just past the newline, or `bytes.len()`
+/// at end of input.
+#[inline]
+pub(in crate::parser) fn next_line_start(bytes: &[u8], from: usize) -> usize {
+    let end = line_end(bytes, from);
+    if end < bytes.len() {
+        end + 1
+    } else {
+        end
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_memchr_at_every_offset() {
+        // Newlines at every position across the word boundary and the tail, so
+        // both the SWAR lane index and the scalar remainder get exercised.
+        for len in 0..40usize {
+            for newline_at in 0..len {
+                let mut buffer = [b'x'; 40];
+                buffer[newline_at] = b'\n';
+                let bytes = &buffer[..len];
+                for from in 0..=len {
+                    let expected =
+                        memchr::memchr(b'\n', &bytes[from..]).map_or(len, |off| from + off);
+                    assert_eq!(
+                        line_end(bytes, from),
+                        expected,
+                        "len {len}, newline at {newline_at}, from {from}"
+                    );
+                    let expected_start = if expected < len { expected + 1 } else { expected };
+                    assert_eq!(next_line_start(bytes, from), expected_start);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn matches_memchr_with_no_newline() {
+        let buffer = [b'x'; 40];
+        for len in 0..=buffer.len() {
+            let bytes = &buffer[..len];
+            for from in 0..=len {
+                assert_eq!(line_end(bytes, from), len);
+                assert_eq!(next_line_start(bytes, from), len);
+            }
+        }
+    }
+
+    #[test]
+    fn matches_memchr_on_borrow_propagation_shapes() {
+        // `0x0B` is the byte whose lane holds `0x01` after the newline xor, so
+        // it is the one that can light up spuriously behind a real newline.
+        for filler in [0x0Bu8, 0x00, 0x01, b'x'] {
+            for lead in 0..12usize {
+                let mut buffer = [filler; 40];
+                buffer[lead] = b'\n';
+                let bytes = &buffer[..];
+                let expected = memchr::memchr(b'\n', bytes).unwrap_or(bytes.len());
+                assert_eq!(line_end(bytes, 0), expected, "filler {filler:#x}, newline at {lead}");
+            }
+        }
+    }
+
+    #[test]
+    fn matches_memchr_on_multiline_walk() {
+        let source = "alpha\nbeta\n\ngamma delta epsilon\n\tindented\nlast line without newline";
+        let bytes = source.as_bytes();
+        // Walk both scanners in lockstep so a divergence fails on the line it
+        // happens, rather than as a mismatch between two collected lists.
+        let mut pos = 0;
+        let mut expected_pos = 0;
+        let mut lines = 0;
+        while expected_pos < bytes.len() {
+            let expected = memchr::memchr(b'\n', &bytes[expected_pos..])
+                .map_or(bytes.len(), |off| expected_pos + off);
+            assert_eq!(line_end(bytes, pos), expected, "line {lines}");
+            pos = next_line_start(bytes, pos);
+            expected_pos = if expected < bytes.len() { expected + 1 } else { expected };
+            assert_eq!(pos, expected_pos, "line {lines}");
+            lines += 1;
+        }
+        assert_eq!(lines, 6);
+    }
+}

--- a/crates/ox_content_parser/src/parser/prepass.rs
+++ b/crates/ox_content_parser/src/parser/prepass.rs
@@ -17,6 +17,7 @@
 use std::rc::Rc;
 
 use super::footnote::{normalize_footnote_label, parse_footnote_opener, FootnoteLabels};
+use super::line_scan::{line_end as scan_line_end, next_line_start};
 use super::reference::{
     closes_paragraph_context, fence_open, is_fence_close, strip_quote_markers, ReferenceDef,
     ReferenceMap,
@@ -99,7 +100,7 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            let line_end = memchr::memchr(b'\n', &bytes[pos..]).map_or(bytes.len(), |o| pos + o);
+            let line_end = scan_line_end(bytes, pos);
             let line = &self.source[pos..line_end];
 
             // Footnote side first: the reference side `continue`s out of
@@ -153,8 +154,7 @@ impl<'a> Parser<'a> {
                     if collect_footnotes {
                         let mut foot_pos = line_end + 1;
                         while foot_pos < next_pos {
-                            let foot_line_end = memchr::memchr(b'\n', &bytes[foot_pos..])
-                                .map_or(bytes.len(), |o| foot_pos + o);
+                            let foot_line_end = scan_line_end(bytes, foot_pos);
                             footnote_scan_line(
                                 &self.source[foot_pos..foot_line_end],
                                 bytes[foot_pos],
@@ -203,10 +203,4 @@ fn footnote_scan_line(
             labels.insert(normalize_footnote_label(label));
         }
     }
-}
-
-/// Byte offset of the next line's start (just past the newline, or EOF).
-#[inline]
-fn next_line_start(bytes: &[u8], pos: usize) -> usize {
-    memchr::memchr(b'\n', &bytes[pos..]).map_or(bytes.len(), |off| pos + off + 1)
 }


### PR DESCRIPTION
## Finding

I ablated `build_prepass` down to a bare line walk — every classification branch removed, nothing but "find the next newline and advance" — and measured the span:

| variant | build_prepass self (120 iters) |
| --- | --- |
| baseline | 80.13 ms |
| **pure line walk, no classification at all** | **72.41 ms** |

**Walking lines is ~90% of the pre-pass.** The reference-definition and footnote-label collection it exists to do is under 10% of its cost.

That walk is one `memchr` per line, and the pre-pass visits *every* line of the document — blanks and one-word lines included, ~37 bytes on average. At that length a memchr call spends most of its time on per-call setup rather than scanning: 41 cycles per line to find a newline 37 bytes ahead. A SWAR zero-test over a `u64` has no setup to amortize.

Swapping just the walk in the same ablation: **72.41 ms → 47.56 ms (−34%)**.

## Result

The real pass keeps its classification work, so it lands short of that ceiling:

| | before | after | change |
| --- | --- | --- | --- |
| `build_prepass` self, best of 3 | 79.18 ms | 71.19 ms | **−10.1%** |

End-to-end, two pinned binaries alternating, 14 rounds of 300 iterations:

| corpus | best | median |
| --- | --- | --- |
| typescript-handbook | **−1.90%** | −1.25% |
| vue-docs | −1.45% | −1.15% |
| rust-book | −0.47% | −1.15% |

Six of six statistics improve.

## Why this is scoped to the pre-pass

The same newline scan appears in `cursor.rs`, `block.rs`, `leaf.rs`, `html.rs` and `footnote.rs`. I converted all of them first — and it measured **worse**:

| span | main | all sites converted |
| --- | --- | --- |
| `parse_paragraph` | 60.65 ms | 67.11 ms (**+10.7%**) |
| `parse_block` | 55.96 ms | 58.16 ms (**+3.9%**) |

Block parsing walks the long prose lines of a paragraph, where memchr's wider SIMD step overtakes an eight-byte word test. The win here is specific to the pre-pass's short-line access pattern, so those call sites keep `memchr` and this PR touches only `prepass.rs`.

A hybrid — four SWAR words, then delegate to memchr — was tried to get both. It gave back the pre-pass win (69.8 → 85.1 ms) without fixing the block paths, so it is not here either.

(One of those conversions, `consume_line`, also had me scanning each line twice; fixing that did not change the verdict, and the whole conversion is reverted regardless.)

## Correctness

`line_end` / `next_line_start` return exactly what the `memchr` expressions they replace returned. `has_zero` can flag a `0x01` lane that borrowed from a real newline below it — safe for the same reason as [#573](https://github.com/ubugeeei-prod/ox-content/pull/573): a spurious lane can only sit *above* a genuine zero lane, so the lowest set bit is always a true match, and that is the only bit read.

New tests check the helpers against `memchr` directly: a newline at every position for every length 0–39 scanned from every start offset, inputs with no newline, borrow-propagation shapes (filler `0x0B` is the byte that goes to `0x01` after the newline xor), and a lockstep multi-line walk.

`cargo test --workspace`: 961 passed, 0 failed. `cargo fmt --check` and `cargo clippy -p ox_content_parser --all-targets`: clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789566048&installation_model_id=422833&pr_number=576&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F576&signature=6222dbee7f8238c2419851cb7c2818eb1321d23714ef02b9f6587f989f1d6130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->