### PR TITLE
perf(parser): reserve inline children from the content length (-4% parse)

### DIFF
--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -50,7 +50,24 @@ impl<'a> Parser<'a> {
         offset: usize,
     ) -> ParseResult<Vec<'a, Node<'a>>> {
         profile_span!("parser::parse_inline");
-        let mut children = self.allocator.new_vec();
+        // Reserve the child vector from the content length instead of
+        // growing into it. A bump-allocated `Vec` cannot extend the block
+        // it already owns — bumpalo hands back a fresh region and copies —
+        // so every doubling step memcpies the nodes so far and abandons the
+        // old block inside the arena. Nodes are 80 bytes, so a paragraph
+        // that ends up with nine children paid three copies and left
+        // 4 + 8 = 12 dead slots behind.
+        //
+        // Measured over the bundled corpora, the node count tracks the
+        // content length closely: the 90th percentile sits near one node
+        // per 20 bytes across every length bucket. Reserving that up front
+        // covers the overwhelming majority of blocks in one allocation and
+        // still ends up using ~3% *less* arena than growing did, because
+        // the abandoned intermediate blocks disappear. The floor keeps the
+        // shortest spans (table cells, link text) at bumpalo's own minimum,
+        // and the ceiling stops one long paragraph from reserving a
+        // kilobyte it will not fill.
+        let mut children = self.allocator.new_vec_with_capacity((content.len() / 20).clamp(4, 12));
         let mut delimiters = self.allocator.new_vec();
         let mut pos = 0;
         let bytes = content.as_bytes();


### PR DESCRIPTION
## What

`parse_inline` built its child vector by growing into it. A bump-allocated `Vec` cannot extend the block it already owns — bumpalo hands back a fresh region and memcpies — so a paragraph that ends up with nine 80-byte nodes paid three copies and abandoned `4 + 8 = 12` dead slots inside the arena on the way there.

This reserves the vector up front from the content length.

## Why that size

Node counts track the content length closely. Instrumenting every `parse_inline` call over the bundled corpora (108k samples) puts the 90th percentile near one node per 20 bytes, and it holds across every length bucket:

| content len | p50 | p90 | p99 |
| --- | --- | --- | --- |
| 0-31 | 1 | 3 | 5 |
| 64-95 | 1 | 5 | 9 |
| 128-159 | 3 | 7 | 11 |
| 224-255 | 5 | 11 | 17 |
| 320-351 | 7 | 15 | 25 |

Reserving `len / 20`, floored at 4 and capped at 12, covers the block in one allocation almost always. Modelling every call's allocation sequence against the measured counts, it also leaves the arena *smaller* than growing did — the abandoned intermediates outweigh the slack:

| strategy | arena node slots |
| --- | --- |
| growth from 4 (today) | 916000 |
| `len / 20` clamped 4..12 | 889824 (**-2.9%**) |

## Numbers

Parse, best of two runs of 60 iterations over `benchmarks/corpus`:

| corpus | before | after | |
| --- | --- | --- | --- |
| rust-book | 3.033 ms | 2.882 ms | **-5.0%** |
| typescript-handbook | 4.058 ms | 3.864 ms | **-4.8%** |
| vite-docs | 1.324 ms | 1.272 ms | **-3.9%** |
| vue-docs | 2.327 ms | 2.240 ms | **-3.7%** |

Parse + render:

| corpus | before | after | |
| --- | --- | --- | --- |
| rust-book | 4.540 ms | 4.391 ms | **-3.3%** |
| typescript-handbook | 6.488 ms | 6.201 ms | **-4.4%** |
| vite-docs | 1.966 ms | 1.906 ms | **-3.1%** |
| vue-docs | 3.566 ms | 3.470 ms | **-2.7%** |

## Alternatives tried

- A flat reserve of 8 is another ~0.2% faster but grows the arena 24% past today's, so the length-derived form wins on both axes.
- The `delimiters` vector deliberately keeps growing from empty: most inline content has no emphasis run at all, and reserving for it regressed every corpus.

## Verification

`cargo test --workspace` passes (including the CommonMark conformance suite), `cargo clippy -p ox_content_parser --all-targets -- -D warnings` and `cargo fmt -p ox_content_parser -- --check` are clean. No behavior change — the reservation only affects how the vector is allocated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789573542&installation_model_id=422833&pr_number=577&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F577&signature=9c38d7ac724b1235b694a4ccf47b84b8ea5429ef7f832d0e7bdfbd2202cdddb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->