### PR TITLE
refactor(parser): move the inline reserve heuristic beside push_text

### DIFF
--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -50,24 +50,8 @@ impl<'a> Parser<'a> {
         offset: usize,
     ) -> ParseResult<Vec<'a, Node<'a>>> {
         profile_span!("parser::parse_inline");
-        // Reserve the child vector from the content length instead of
-        // growing into it. A bump-allocated `Vec` cannot extend the block
-        // it already owns — bumpalo hands back a fresh region and copies —
-        // so every doubling step memcpies the nodes so far and abandons the
-        // old block inside the arena. Nodes are 80 bytes, so a paragraph
-        // that ends up with nine children paid three copies and left
-        // 4 + 8 = 12 dead slots behind.
-        //
-        // Measured over the bundled corpora, the node count tracks the
-        // content length closely: the 90th percentile sits near one node
-        // per 20 bytes across every length bucket. Reserving that up front
-        // covers the overwhelming majority of blocks in one allocation and
-        // still ends up using ~3% *less* arena than growing did, because
-        // the abandoned intermediate blocks disappear. The floor keeps the
-        // shortest spans (table cells, link text) at bumpalo's own minimum,
-        // and the ceiling stops one long paragraph from reserving a
-        // kilobyte it will not fill.
-        let mut children = self.allocator.new_vec_with_capacity((content.len() / 20).clamp(4, 12));
+        let mut children =
+            self.allocator.new_vec_with_capacity(Self::inline_children_capacity(content.len()));
         let mut delimiters = self.allocator.new_vec();
         let mut pos = 0;
         let bytes = content.as_bytes();

--- a/crates/ox_content_parser/src/parser/inline_helpers.rs
+++ b/crates/ox_content_parser/src/parser/inline_helpers.rs
@@ -213,6 +213,22 @@ impl<'a> Parser<'a> {
         Ok(out.into_bump_str())
     }
 
+    /// Child slots to reserve for `content_len` bytes of inline content.
+    ///
+    /// A bump-allocated `Vec` cannot extend the block it owns — bumpalo
+    /// hands back a fresh region and memcpies — so growing copies every
+    /// node so far at each doubling step and abandons the old block in the
+    /// arena. Measured over the bundled corpora the node count tracks the
+    /// content length closely (p90 ≈ one node per 20 bytes in every length
+    /// bucket), so reserving that covers most blocks in one allocation and
+    /// still uses ~3% *less* arena than growing did. The floor keeps short
+    /// spans at bumpalo's own minimum; the ceiling stops a long paragraph
+    /// from reserving a kilobyte it will not fill.
+    pub(super) fn inline_children_capacity(content_len: usize) -> usize {
+        const BYTES_PER_NODE: usize = 20;
+        (content_len / BYTES_PER_NODE).clamp(4, 12)
+    }
+
     pub(super) fn push_text(
         children: &mut Vec<'a, Node<'a>>,
         value: &'a str,


### PR DESCRIPTION
Follow-up to #577.

That PR landed the reserve as an inline expression with its rationale as a 17-line comment, which pushed `crates/ox_content_parser/src/parser/inline.rs` from 348 to 365 lines and broke the 350-line source cap — the `Changed source files` check is currently red on `main`.

The heuristic is a property of the child vector, so it belongs next to `push_text` in `inline_helpers.rs` as a named function carrying the same reasoning as a doc comment.

| file | before | after |
| --- | --- | --- |
| `inline.rs` | 365 | 349 |
| `inline_helpers.rs` | 323 | 339 |

No behavior change: `inline_children_capacity` computes exactly what the inline expression did, and parse timings are unchanged within run-to-run noise. `node scripts/check-file-lines.ts` is clean, as are `cargo test -p ox_content_parser -p ox_content_renderer`, clippy and rustfmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789574626&installation_model_id=422833&pr_number=578&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F578&signature=538e56c99d96513f845561fbe035011b7309d60e64d0eb731a514141e2d8dc44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->