### PR TITLE
perf(parser): reject autolink candidates on `://` instead of `:` (-4% parse)

### DIFF
--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -27,19 +27,20 @@ impl<'a> Parser<'a> {
     /// post-passes on the result — today, the GFM autolink rewrite.
     ///
     /// Nested inline contexts (link text, image alt, strikethrough
-    /// interiors) call [`Self::parse_inline`] directly instead: the
-    /// autolink pass itself recurses through emphasis-like containers, so
-    /// running it per nested sequence both re-scanned the same nodes and —
-    /// for link text, which GFM excludes from autolinking — manufactured
-    /// nested `<a>` elements.
+    /// interiors) call [`Self::parse_inline`] directly instead: the autolink
+    /// pass itself recurses through emphasis-like containers, so running it
+    /// per nested sequence both re-scanned the same nodes and — for link
+    /// text, which GFM excludes from autolinking — made nested `<a>`s.
     pub(super) fn parse_inline_block(
         &self,
         content: &'a str,
         offset: usize,
     ) -> ParseResult<Vec<'a, Node<'a>>> {
         let mut children = self.parse_inline(content, offset)?;
-        if self.options.autolinks && gfm_autolink::may_contain_autolink(content) {
-            self.apply_gfm_autolinks(&mut children);
+        let scan =
+            self.options.autolinks.then(|| gfm_autolink::may_contain_autolink(content)).flatten();
+        if let Some(scan) = scan {
+            self.apply_gfm_autolinks(&mut children, scan);
         }
         Ok(children)
     }

--- a/crates/ox_content_parser/src/parser/inline/gfm_autolink.rs
+++ b/crates/ox_content_parser/src/parser/inline/gfm_autolink.rs
@@ -6,24 +6,43 @@
 //! interfere with emphasis pairing, and recurses into emphasis-like
 //! containers while never descending into existing links.
 
-use std::sync::LazyLock;
-
-use memchr::memmem;
 use ox_content_allocator::Vec;
 use ox_content_ast::{Link, Node, Span, Text};
+
+mod scan;
+
+use self::scan::find_candidate;
+pub(super) use self::scan::may_contain_autolink;
 
 use crate::parser::Parser;
 #[allow(unused_imports)]
 use crate::{profile_span, profile_span_detail};
 
-struct Candidate {
-    start: usize,
-    end: usize,
-    href_prefix: &'static str,
+pub(super) struct Candidate {
+    pub(super) start: usize,
+    pub(super) end: usize,
+    pub(super) href_prefix: &'static str,
+}
+
+/// What the block-level pre-flight proved about a block's raw content, so
+/// the per-node scan does not re-derive it.
+///
+/// `www.` is the only needle with no `:` and no `@` in it, which makes it
+/// the only reason a node has to pay for a substring search when the cheap
+/// `memchr2` comes back empty. Whether a block can hold one is a property
+/// of its raw source, so [`may_contain_autolink`] answers it once for the
+/// whole block instead of once per text node.
+#[derive(Clone, Copy)]
+pub(in crate::parser::inline) struct AutolinkScan {
+    pub(super) may_have_www: bool,
 }
 
 impl<'a> Parser<'a> {
-    pub(in crate::parser) fn apply_gfm_autolinks(&self, children: &mut Vec<'a, Node<'a>>) {
+    pub(in crate::parser::inline) fn apply_gfm_autolinks(
+        &self,
+        children: &mut Vec<'a, Node<'a>>,
+        scan: AutolinkScan,
+    ) {
         profile_span!("parser::apply_gfm_autolinks");
         // Entity, escape, and unpaired-delimiter handling fragment plain
         // prose into adjacent text nodes; autolinks must see the joined
@@ -32,12 +51,12 @@ impl<'a> Parser<'a> {
         let mut i = 0;
         while i < children.len() {
             match &mut children[i] {
-                Node::Emphasis(node) => self.apply_gfm_autolinks(&mut node.children),
-                Node::Strong(node) => self.apply_gfm_autolinks(&mut node.children),
-                Node::Delete(node) => self.apply_gfm_autolinks(&mut node.children),
+                Node::Emphasis(node) => self.apply_gfm_autolinks(&mut node.children, scan),
+                Node::Strong(node) => self.apply_gfm_autolinks(&mut node.children, scan),
+                Node::Delete(node) => self.apply_gfm_autolinks(&mut node.children, scan),
                 Node::Text(text) => {
                     let value = text.value;
-                    if let Some(candidate) = find_candidate(value) {
+                    if let Some(candidate) = find_candidate(value, scan) {
                         let span_start = text.span.start;
                         let link_value = &value[candidate.start..candidate.end];
                         let url: &'a str = if candidate.href_prefix.is_empty() {
@@ -120,190 +139,4 @@ impl<'a> Parser<'a> {
             i += 1;
         }
     }
-}
-
-/// Searchers for the multi-byte autolink needles, built once for the process.
-///
-/// The one-shot `memmem::find` rebuilds its SIMD prefilter on every call, and
-/// this scan runs over every text node of every document — on short prose
-/// nodes that setup cost dominated the search itself.
-static URL_FINDERS: LazyLock<[memmem::Finder<'static>; 4]> =
-    LazyLock::new(|| ["www.", "http://", "https://", "ftp://"].map(memmem::Finder::new));
-
-/// Cheap pre-flight over a block's raw inline content: can the autolink
-/// pass possibly rewrite anything here?
-///
-/// Every candidate needs a `:` (scheme), `@` (email), or `www.` — and those
-/// needle bytes are never inline-special, so if they appear in the parsed
-/// text nodes they appear verbatim in `content` too. The one indirection is
-/// entities: `&colon;`/`&commat;` decode into candidate bytes that the raw
-/// source spells with `&`, so `&` also keeps the pass on. Ordinary prose —
-/// almost every block in a document — fails all four probes and skips the
-/// node-tree walk (and its text-coalescing rewrites) entirely.
-pub(super) fn may_contain_autolink(content: &str) -> bool {
-    let bytes = content.as_bytes();
-    memchr::memchr3(b':', b'@', b'&', bytes).is_some() || URL_FINDERS[0].find(bytes).is_some()
-}
-
-/// Finds the earliest valid autolink candidate in `value`.
-fn find_candidate(value: &str) -> Option<Candidate> {
-    profile_span_detail!("parser::gfm_autolink_scan");
-    let bytes = value.as_bytes();
-    let mut best: Option<Candidate> = None;
-
-    // `www.` is the only needle that contains neither `:` nor `@`, so one
-    // `memchr2` decides whether the three scheme scans and the email scan can
-    // match at all. Ordinary prose — nearly every text node in a document —
-    // answers no and skips four scans.
-    let has_scheme_or_email = memchr::memchr2(b':', b'@', bytes).is_some();
-
-    for finder in URL_FINDERS.iter().take(if has_scheme_or_email { 4 } else { 1 }) {
-        let needle_len = finder.needle().len();
-        let mut from = 0;
-        while let Some(offset) = finder.find(&bytes[from..]) {
-            let at = from + offset;
-            if let Some(candidate) = validate_url(value, at, needle_len) {
-                if best.as_ref().is_none_or(|current| candidate.start < current.start) {
-                    best = Some(candidate);
-                }
-                break;
-            }
-            from = at + needle_len;
-        }
-    }
-
-    if has_scheme_or_email {
-        let mut from = 0;
-        while let Some(offset) = memchr::memchr(b'@', &bytes[from..]) {
-            let at = from + offset;
-            if let Some(candidate) = validate_email(value, at) {
-                if best.as_ref().is_none_or(|current| candidate.start < current.start) {
-                    best = Some(candidate);
-                }
-                break;
-            }
-            from = at + 1;
-        }
-    }
-
-    best
-}
-
-/// Start-of-text, whitespace, or `*`, `_`, `~`, `(` may precede an
-/// autolink.
-fn valid_boundary(value: &str, start: usize) -> bool {
-    value[..start]
-        .chars()
-        .next_back()
-        .is_none_or(|ch| ch.is_whitespace() || matches!(ch, '*' | '_' | '~' | '('))
-}
-
-fn validate_url(value: &str, start: usize, prefix_len: usize) -> Option<Candidate> {
-    if !valid_boundary(value, start) {
-        return None;
-    }
-    let bytes = value.as_bytes();
-    // Validate the domain: alphanumerics, `-`, `_`, `.`; at least one
-    // dot; no underscore in the last two segments.
-    let domain_start = start + prefix_len;
-    let mut domain_end = domain_start;
-    while domain_end < bytes.len()
-        && (bytes[domain_end].is_ascii_alphanumeric()
-            || matches!(bytes[domain_end], b'-' | b'_' | b'.'))
-    {
-        domain_end += 1;
-    }
-    // Trailing dots belong to the surrounding sentence, not the domain.
-    let domain = value[domain_start..domain_end].trim_end_matches('.');
-    if domain.split('.').count() < 2
-        || domain.rsplit('.').take(2).any(|segment| segment.is_empty() || segment.contains('_'))
-    {
-        return None;
-    }
-
-    // The link runs to whitespace or `<`, then trailing punctuation is
-    // trimmed (unbalanced `)` and entity-like `&x;` suffixes included).
-    let mut end = domain_end;
-    while end < bytes.len() && !bytes[end].is_ascii_whitespace() && bytes[end] != b'<' {
-        end += 1;
-    }
-    let end = trim_trailing_punctuation(value, start, end);
-    (end > domain_start).then_some(Candidate {
-        start,
-        end,
-        href_prefix: if prefix_len == 4 { "http://" } else { "" },
-    })
-}
-
-fn trim_trailing_punctuation(value: &str, start: usize, mut end: usize) -> usize {
-    let bytes = value.as_bytes();
-    loop {
-        if end <= start {
-            return end;
-        }
-        match bytes[end - 1] {
-            b'?' | b'!' | b'.' | b',' | b':' | b'*' | b'_' | b'~' | b'\'' | b'"' => end -= 1,
-            b')' => {
-                let opens = value[start..end].bytes().filter(|&b| b == b'(').count();
-                let closes = value[start..end].bytes().filter(|&b| b == b')').count();
-                if closes > opens {
-                    end -= 1;
-                } else {
-                    return end;
-                }
-            }
-            b';' => {
-                // Strip an entity-like `&name;` suffix entirely.
-                let entity_start = value[start..end - 1].rfind('&').map(|found| start + found);
-                match entity_start {
-                    Some(amp)
-                        if value[amp + 1..end - 1]
-                            .bytes()
-                            .all(|byte| byte.is_ascii_alphanumeric())
-                            && amp + 1 < end - 1 =>
-                    {
-                        end = amp;
-                    }
-                    _ => end -= 1,
-                }
-            }
-            _ => return end,
-        }
-    }
-}
-
-fn validate_email(value: &str, at: usize) -> Option<Candidate> {
-    let bytes = value.as_bytes();
-    // Local part: alphanumerics plus `.`, `-`, `_`, `+`.
-    let mut start = at;
-    while start > 0 {
-        let byte = bytes[start - 1];
-        if byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_' | b'+') {
-            start -= 1;
-        } else {
-            break;
-        }
-    }
-    if start == at || !valid_boundary(value, start) {
-        return None;
-    }
-
-    // Domain: alphanumerics plus `.`, `-`, `_`, with at least one dot;
-    // trailing dots are trimmed; a trailing `-` or `_` invalidates.
-    let mut end = at + 1;
-    while end < bytes.len()
-        && (bytes[end].is_ascii_alphanumeric() || matches!(bytes[end], b'.' | b'-' | b'_'))
-    {
-        end += 1;
-    }
-    while end > at + 1 && bytes[end - 1] == b'.' {
-        end -= 1;
-    }
-    if end <= at + 1 || matches!(bytes[end - 1], b'-' | b'_') {
-        return None;
-    }
-    if !value[at + 1..end].contains('.') {
-        return None;
-    }
-    Some(Candidate { start, end, href_prefix: "mailto:" })
 }

--- a/crates/ox_content_parser/src/parser/inline/gfm_autolink/scan.rs
+++ b/crates/ox_content_parser/src/parser/inline/gfm_autolink/scan.rs
@@ -1,0 +1,243 @@
+//! Needle searches for the GFM autolink post-pass.
+//!
+//! Everything here is a pure scan over one string: the block-level
+//! pre-flight that decides whether the post-pass runs at all, and the
+//! per-text-node search for the earliest valid candidate.
+
+use std::sync::LazyLock;
+
+use memchr::memmem;
+
+use super::{AutolinkScan, Candidate};
+
+/// Searchers for the multi-byte autolink needles, built once for the process.
+///
+/// The one-shot `memmem::find` rebuilds its SIMD prefilter on every call, and
+/// this scan runs over every text node of every document — on short prose
+/// nodes that setup cost dominated the search itself.
+static WWW_FINDER: LazyLock<memmem::Finder<'static>> =
+    LazyLock::new(|| memmem::Finder::new("www."));
+
+/// The three schemes share one needle: `http://`, `https://` and `ftp://`
+/// all end in `://` and differ only in the name in front. One pass for
+/// `://` therefore finds every scheme candidate, in position order, in
+/// place of three separate whole-node substring scans.
+static SCHEME_FINDER: LazyLock<memmem::Finder<'static>> =
+    LazyLock::new(|| memmem::Finder::new("://"));
+
+/// Scheme names accepted in front of `://`, longest first so `https://`
+/// is not mistaken for a `ttp`-suffixed shorter name.
+const SCHEMES: [&str; 3] = ["https", "http", "ftp"];
+
+/// Cheap pre-flight over a block's raw inline content: can the autolink
+/// pass possibly rewrite anything here, and if so does it need the `www.`
+/// search at all?
+///
+/// Every candidate needs `://` (scheme), `@` (email), or `www.` — and none
+/// of those bytes are inline-special, so if they appear in the parsed text
+/// nodes they appear verbatim in `content` too. The one indirection is
+/// entities: `&colon;`/`&commat;`/`&#119;` decode into candidate bytes that
+/// the raw source spells with `&`, so `&` both keeps the pass on and forces
+/// the `www.` search back on.
+///
+/// The probes are ordered by how cheaply they reject. `@` and `&` fall out
+/// of one vectorized byte scan, and asking for the whole `://` rather than
+/// a bare `:` is what makes the gate bite: prose is full of `Note:` and
+/// `1:1`, and every one of those used to drag a block through the node-tree
+/// walk, the text coalescing, and a per-node substring search.
+pub(in crate::parser::inline) fn may_contain_autolink(content: &str) -> Option<AutolinkScan> {
+    let bytes = content.as_bytes();
+    if memchr::memchr2(b'@', b'&', bytes).is_some() {
+        // An `&` may expand to anything, so the `www.` search stays on.
+        return Some(AutolinkScan { may_have_www: true });
+    }
+    if WWW_FINDER.find(bytes).is_some() {
+        return Some(AutolinkScan { may_have_www: true });
+    }
+    SCHEME_FINDER.find(bytes).map(|_| AutolinkScan { may_have_www: false })
+}
+
+/// Finds the earliest valid autolink candidate in `value`.
+pub(super) fn find_candidate(value: &str, scan: AutolinkScan) -> Option<Candidate> {
+    crate::profile_span_detail!("parser::gfm_autolink_scan");
+    let bytes = value.as_bytes();
+    let mut best: Option<Candidate> = None;
+
+    // One `memchr2` decides whether the scheme and email scans can match at
+    // all. Together with the block's `www.` verdict it means the ordinary
+    // prose node — the overwhelming majority — leaves this function after a
+    // single vectorized byte scan, with no substring searcher touched.
+    let has_scheme_or_email = memchr::memchr2(b':', b'@', bytes).is_some();
+    if !has_scheme_or_email && !scan.may_have_www {
+        return None;
+    }
+
+    if has_scheme_or_email {
+        let mut from = 0;
+        while let Some(offset) = SCHEME_FINDER.find(&bytes[from..]) {
+            let at = from + offset;
+            if let Some(prefix_len) = scheme_prefix_len(bytes, at) {
+                // `at + 3 - prefix_len` steps back over the scheme name to
+                // the first byte of the candidate.
+                if let Some(candidate) = validate_url(value, at + 3 - prefix_len, prefix_len) {
+                    best = Some(candidate);
+                    break;
+                }
+            }
+            from = at + 3;
+        }
+
+        let mut from = 0;
+        while let Some(offset) = memchr::memchr(b'@', &bytes[from..]) {
+            let at = from + offset;
+            if let Some(candidate) = validate_email(value, at) {
+                if best.as_ref().is_none_or(|current| candidate.start < current.start) {
+                    best = Some(candidate);
+                }
+                break;
+            }
+            from = at + 1;
+        }
+    }
+
+    if scan.may_have_www {
+        let mut from = 0;
+        while let Some(offset) = WWW_FINDER.find(&bytes[from..]) {
+            let at = from + offset;
+            if let Some(candidate) = validate_url(value, at, 4) {
+                if best.as_ref().is_none_or(|current| candidate.start < current.start) {
+                    best = Some(candidate);
+                }
+                break;
+            }
+            from = at + 4;
+        }
+    }
+
+    best
+}
+
+/// Length of the whole `scheme://` prefix ending at the `://` that starts
+/// at `at`, or `None` when the bytes in front are not a known scheme.
+fn scheme_prefix_len(bytes: &[u8], at: usize) -> Option<usize> {
+    SCHEMES.iter().find(|name| bytes[..at].ends_with(name.as_bytes())).map(|name| name.len() + 3)
+}
+
+/// Start-of-text, whitespace, or `*`, `_`, `~`, `(` may precede an
+/// autolink.
+fn valid_boundary(value: &str, start: usize) -> bool {
+    value[..start]
+        .chars()
+        .next_back()
+        .is_none_or(|ch| ch.is_whitespace() || matches!(ch, '*' | '_' | '~' | '('))
+}
+
+fn validate_url(value: &str, start: usize, prefix_len: usize) -> Option<Candidate> {
+    if !valid_boundary(value, start) {
+        return None;
+    }
+    let bytes = value.as_bytes();
+    // Validate the domain: alphanumerics, `-`, `_`, `.`; at least one
+    // dot; no underscore in the last two segments.
+    let domain_start = start + prefix_len;
+    let mut domain_end = domain_start;
+    while domain_end < bytes.len()
+        && (bytes[domain_end].is_ascii_alphanumeric()
+            || matches!(bytes[domain_end], b'-' | b'_' | b'.'))
+    {
+        domain_end += 1;
+    }
+    // Trailing dots belong to the surrounding sentence, not the domain.
+    let domain = value[domain_start..domain_end].trim_end_matches('.');
+    if domain.split('.').count() < 2
+        || domain.rsplit('.').take(2).any(|segment| segment.is_empty() || segment.contains('_'))
+    {
+        return None;
+    }
+
+    // The link runs to whitespace or `<`, then trailing punctuation is
+    // trimmed (unbalanced `)` and entity-like `&x;` suffixes included).
+    let mut end = domain_end;
+    while end < bytes.len() && !bytes[end].is_ascii_whitespace() && bytes[end] != b'<' {
+        end += 1;
+    }
+    let end = trim_trailing_punctuation(value, start, end);
+    (end > domain_start).then_some(Candidate {
+        start,
+        end,
+        href_prefix: if prefix_len == 4 { "http://" } else { "" },
+    })
+}
+
+fn trim_trailing_punctuation(value: &str, start: usize, mut end: usize) -> usize {
+    let bytes = value.as_bytes();
+    loop {
+        if end <= start {
+            return end;
+        }
+        match bytes[end - 1] {
+            b'?' | b'!' | b'.' | b',' | b':' | b'*' | b'_' | b'~' | b'\'' | b'"' => end -= 1,
+            b')' => {
+                let opens = value[start..end].bytes().filter(|&b| b == b'(').count();
+                let closes = value[start..end].bytes().filter(|&b| b == b')').count();
+                if closes > opens {
+                    end -= 1;
+                } else {
+                    return end;
+                }
+            }
+            b';' => {
+                // Strip an entity-like `&name;` suffix entirely.
+                let entity_start = value[start..end - 1].rfind('&').map(|found| start + found);
+                match entity_start {
+                    Some(amp)
+                        if value[amp + 1..end - 1]
+                            .bytes()
+                            .all(|byte| byte.is_ascii_alphanumeric())
+                            && amp + 1 < end - 1 =>
+                    {
+                        end = amp;
+                    }
+                    _ => end -= 1,
+                }
+            }
+            _ => return end,
+        }
+    }
+}
+
+fn validate_email(value: &str, at: usize) -> Option<Candidate> {
+    let bytes = value.as_bytes();
+    // Local part: alphanumerics plus `.`, `-`, `_`, `+`.
+    let mut start = at;
+    while start > 0 {
+        let byte = bytes[start - 1];
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_' | b'+') {
+            start -= 1;
+        } else {
+            break;
+        }
+    }
+    if start == at || !valid_boundary(value, start) {
+        return None;
+    }
+
+    // Domain: alphanumerics plus `.`, `-`, `_`, with at least one dot;
+    // trailing dots are trimmed; a trailing `-` or `_` invalidates.
+    let mut end = at + 1;
+    while end < bytes.len()
+        && (bytes[end].is_ascii_alphanumeric() || matches!(bytes[end], b'.' | b'-' | b'_'))
+    {
+        end += 1;
+    }
+    while end > at + 1 && bytes[end - 1] == b'.' {
+        end -= 1;
+    }
+    if end <= at + 1 || matches!(bytes[end - 1], b'-' | b'_') {
+        return None;
+    }
+    if !value[at + 1..end].contains('.') {
+        return None;
+    }
+    Some(Candidate { start, end, href_prefix: "mailto:" })
+}


### PR DESCRIPTION
## What

The GFM autolink post-pass costs **10-14% of a parse** on the bundled corpora — ablating it entirely takes rust-book from 2.88 ms to 2.51 ms. Almost none of that is spent rewriting anything; it is the cost of deciding there is nothing to rewrite. Two things were paying for that decision.

**The block-level gate asked for a bare `:`.** Documentation prose is full of `Note:`, `1:1` and `see Chapter 3:`, so the gate passed constantly and dragged the block through the whole node-tree walk, the text coalescing, and a per-node substring search. But a scheme candidate needs the whole `://`, and asking for that is the same one-pass `memmem` — it just rejects far more. The gate now probes `@`/`&` with one `memchr2`, then `www.`, then `://`, ordered by how cheaply each rejects.

**Per text node, `find_candidate` ran up to six whole-node scans**: one `memchr2`, four `memmem` searchers, and an `@` walk.

- `http://`, `https://` and `ftp://` all end in `://` and differ only in the name in front, so one pass for `://` finds every scheme candidate in position order and the name is recovered by looking back from the match — three searchers become one.
- `www.` is the only needle a node can hold without a `:` or `@` in it, so whether it is worth searching for is a property of the *block*, not the node. The gate now hands that verdict down, and ordinary prose leaves `find_candidate` after a single vectorized byte scan with no substring searcher touched.

## Numbers

Parse, best of 60 iterations over `benchmarks/corpus`:

| corpus | before | after | |
| --- | --- | --- | --- |
| rust-book | 2.884 ms | 2.718 ms | **-5.8%** |
| typescript-handbook | 3.882 ms | 3.757 ms | **-3.2%** |
| vite-docs | 1.272 ms | 1.226 ms | **-3.6%** |
| vue-docs | 2.234 ms | 2.150 ms | **-3.8%** |

Parse + render:

| corpus | before | after | |
| --- | --- | --- | --- |
| rust-book | 4.131 ms | 3.963 ms | **-4.1%** |
| typescript-handbook | 5.938 ms | 5.828 ms | **-1.9%** |
| vite-docs | 1.839 ms | 1.778 ms | **-3.3%** |
| vue-docs | 3.347 ms | 3.258 ms | **-2.7%** |

## Correctness

Both gates stay conservative supersets. `:`, `@` and `.` are never inline-special, so a needle that survives into a text node was spelled verbatim in the block's raw source; the one indirection is entities, which `&` covers by keeping the pass — and the `www.` search — on. Scheme names are matched longest-first so `https://` is not read as a `ttp`-suffixed shorter name, and the candidate start is recovered as `at + 3 - prefix_len`, exactly the offset the per-scheme searchers used to report.

`cargo test --workspace` passes, including the CommonMark conformance suite and the GFM autolink tests. Clippy and rustfmt are clean.

## Note

The scans move to a `gfm_autolink/scan.rs` submodule to keep both files inside the 350-line source cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789575421&installation_model_id=422833&pr_number=579&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F579&signature=ef776baf782ce2fc5f97e60895cfdfea6f936eb9bb5e241f33dc2a46b1bbe0e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of GFM autolinks, including URLs, `www.` addresses, and email links.
  - More accurately handles link boundaries and trailing punctuation.
  - Preserves correct autolink behavior within emphasized, strongly emphasized, and deleted text.

- **Performance**
  - Streamlined autolink detection by scanning content once before processing links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->