### PR TITLE
perf(parser): skip fenced-code interiors in the pre-pass (-3% parse)

### DIFF
--- a/crates/ox_content_parser/src/parser/prepass.rs
+++ b/crates/ox_content_parser/src/parser/prepass.rs
@@ -15,6 +15,9 @@
 //! definition chunk the reference side skips over.
 
 use std::rc::Rc;
+use std::sync::LazyLock;
+
+use memchr::{memmem, memrchr};
 
 use super::footnote::{normalize_footnote_label, parse_footnote_opener, FootnoteLabels};
 use super::line_scan::{line_end as scan_line_end, next_line_start};
@@ -25,6 +28,29 @@ use super::reference::{
 use super::Parser;
 #[allow(unused_imports)]
 use crate::{profile_span, profile_span_detail};
+
+/// Three-byte fence-run searchers, built once for the process.
+///
+/// A closing fence line holds at least three of its fence byte in a row, so
+/// the needle is a necessary condition for one — enough to skip straight to
+/// the first line that could possibly close an open fence. The one-shot
+/// `memmem::find` would rebuild its SIMD prefilter for every fence in the
+/// document.
+static BACKTICK_RUN: LazyLock<memmem::Finder<'static>> =
+    LazyLock::new(|| memmem::Finder::new("```"));
+static TILDE_RUN: LazyLock<memmem::Finder<'static>> = LazyLock::new(|| memmem::Finder::new("~~~"));
+
+/// Start of the first line at or after `from` holding a run of three
+/// `fence_byte`s, or `None` when the rest of the source holds none.
+fn next_fence_run_line(bytes: &[u8], from: usize, fence_byte: u8) -> Option<usize> {
+    // `from` is one past a newline, which is one past the end when the last
+    // line of the document is unterminated.
+    let from = from.min(bytes.len());
+    let finder = if fence_byte == b'`' { &*BACKTICK_RUN } else { &*TILDE_RUN };
+    let at = from + finder.find(&bytes[from..])?;
+    // `from` is a line start, so the match's line starts at or after it.
+    Some(memrchr(b'\n', &bytes[from..at]).map_or(from, |off| from + off + 1))
+}
 
 impl<'a> Parser<'a> {
     /// Runs the fused pre-pass for a root parser. Returns the
@@ -115,8 +141,31 @@ impl<'a> Parser<'a> {
             if let Some((fence_byte, fence_len)) = def_fence {
                 if is_fence_close(trimmed, fence_byte, fence_len) {
                     def_fence = None;
+                    pos = line_end + 1;
+                    continue;
                 }
-                pos = line_end + 1;
+                // Nothing inside a fence is collected and `paragraph_open`
+                // is frozen while one is open, so the only line left worth
+                // stopping on is the one that closes it — and that needs
+                // three fence bytes in a row. Skip straight to it instead of
+                // walking the block's contents line by line.
+                //
+                // The footnote collector is the exception: it tracks its own
+                // fence on the raw line and looks for `[^` openers, so when
+                // it is running every line still has to be visited. Only
+                // 1-2 files in 100 across the bundled corpora contain a
+                // `[^` at all, so the skip still applies to almost every
+                // real document.
+                if collect_footnotes {
+                    pos = line_end + 1;
+                    continue;
+                }
+                match next_fence_run_line(bytes, line_end + 1, fence_byte) {
+                    Some(next) => pos = next,
+                    // An unterminated fence swallows the rest of the
+                    // document, so there is nothing left to collect.
+                    None => break,
+                }
                 continue;
             }
             if let Some(open) = fence_open(trimmed) {


### PR DESCRIPTION
## What

The pre-pass walks every line of the document, code blocks included, even though nothing inside a fence is collectible: definitions and footnote labels are only read outside fences, and `paragraph_open` is frozen while one is open. The only line left worth stopping on is the one that closes it — and a closing fence line holds at least three of its fence byte in a row, so one `memmem` search jumps straight to the first candidate.

Fenced lines are 6% of rust-book but **30% of vite-docs and 40-43% of vue-docs and typescript-handbook**, so the skipped span is substantial on code-heavy documentation.

## The footnote exception

The footnote collector tracks its own fence on the raw line and looks for `[^` openers, so while it runs every line still has to be visited. That gate is `options.footnotes && source.contains("[^")`, and **only 1-2 files in 100** across the bundled corpora contain a `[^` at all — the skip still applies to almost every real document.

The concatenated benchmark corpora are the unlucky shape: three of the four pick up a `[^` from a single file, which turns the collector on for the whole 1.9 MB. Only vue-docs shows the win there.

## Numbers

Parse, best of two runs of 60 iterations over `benchmarks/corpus`:

| corpus | before | after | |
| --- | --- | --- | --- |
| vue-docs | 2.134 ms | 2.061 ms | **-3.4%** |
| rust-book | 2.685 ms | 2.675 ms | footnote collector on |
| typescript-handbook | 3.687 ms | 3.693 ms | footnote collector on |
| vite-docs | 1.216 ms | 1.217 ms | footnote collector on |

Parsing each file separately, which is how the engine is actually used and where the collector is off for 99% of documents:

| corpus | before | after | |
| --- | --- | --- | --- |
| rust-book | 2.759 ms | 2.709 ms | **-1.8%** |
| vue-docs | 1.877 ms | 1.856 ms | **-1.1%** |
| typescript-handbook | 3.298 ms | 3.271 ms | **-0.8%** |

## Alternatives tried and rejected

- **Extending the skip to footnote runs** by also searching for `[^` and the other fence byte made the walk **quadratic** — a needle that has run out rescans the whole remaining document on every fence, taking typescript-handbook from 3.7 ms to **47 ms**.
- **Adding monotonic cursors** to fix that worked, but still cost rust-book 2%: a document with few fenced lines pays the extra searches without saving a walk.

## Correctness

The three-byte run is a *necessary* condition for a closing fence, never a sufficient one — the jump only relocates the cursor, and the existing `is_fence_close` check still decides. A match found mid-line lands the cursor on that line's start, which then fails the check and jumps again, so the cursor always advances. An unterminated fence swallows the rest of the document, so a `None` result ends the walk.

The stress suite caught a real bug in the first draft (`line_end + 1` is one past the end on an unterminated final line); the offset is now clamped. `cargo test --workspace` passes, clippy and rustfmt are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789605934&installation_model_id=422833&pr_number=583&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F583&signature=157724f1c9c05834fad8c8103bf5bac15ecdb92351bd8b5298f9906973c910b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of fenced content during document parsing.
  * Unterminated fences now stop reference scanning correctly.
  * Fence detection is more efficient while preserving footnote scanning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->