### PR TITLE
perf(parser): fuse the code-span newline probe into the closer scan (-3% parse)

### DIFF
--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -8,6 +8,7 @@ use crate::error::ParseResult;
 use crate::{profile_span, profile_span_detail};
 
 mod autolink;
+mod code_span;
 mod emphasis;
 mod entity;
 mod gfm_autolink;
@@ -283,68 +284,5 @@ impl<'a> Parser<'a> {
         Self::push_text(children, &content[*pos..*pos + 2], offset + *pos, offset + *pos + 2);
         *pos += 2;
         Ok(())
-    }
-
-    fn parse_inline_code(
-        &self,
-        content: &'a str,
-        offset: usize,
-        children: &mut Vec<'a, Node<'a>>,
-        pos: &mut usize,
-    ) {
-        profile_span_detail!("parser::inline_code_span");
-        let bytes = content.as_bytes();
-        let open_len = Self::marker_run_len(bytes, *pos, b'`');
-        let code_start = *pos + open_len;
-
-        // The closer is the next backtick run of exactly the opener's
-        // length (CommonMark "Code spans"). memchr jumps between runs.
-        let mut cursor = code_start;
-        while cursor < bytes.len() {
-            let Some(off) = memchr(b'`', &bytes[cursor..]) else {
-                break;
-            };
-            cursor += off;
-            let run = Self::marker_run_len(bytes, cursor, b'`');
-            if run == open_len {
-                let span = Span::new((offset + *pos) as u32, (offset + cursor + run) as u32);
-                children.push(Node::InlineCode(ox_content_ast::InlineCode {
-                    value: self.normalize_code_span(&content[code_start..cursor]),
-                    span,
-                }));
-                *pos = cursor + run;
-                return;
-            }
-            cursor += run;
-        }
-
-        // No closer: the opening run is literal text.
-        Self::push_text(children, &content[*pos..code_start], offset + *pos, offset + code_start);
-        *pos = code_start;
-    }
-
-    /// Applies the code span content rules: line endings become spaces,
-    /// and one leading plus one trailing space is dropped when the content
-    /// starts and ends with a space without being all spaces.
-    fn normalize_code_span(&self, raw: &'a str) -> &'a str {
-        let value: &'a str = if raw.contains('\n') {
-            let mut converted = self.allocator.new_string();
-            for ch in raw.chars() {
-                converted.push(if ch == '\n' { ' ' } else { ch });
-            }
-            converted.into_bump_str()
-        } else {
-            raw
-        };
-
-        let stripped = value.starts_with(' ')
-            && value.ends_with(' ')
-            && value.len() >= 2
-            && value.bytes().any(|byte| byte != b' ');
-        if stripped {
-            &value[1..value.len() - 1]
-        } else {
-            value
-        }
     }
 }

--- a/crates/ox_content_parser/src/parser/inline/code_span.rs
+++ b/crates/ox_content_parser/src/parser/inline/code_span.rs
@@ -1,0 +1,91 @@
+//! Inline code spans (CommonMark "Code spans").
+//!
+//! The opener is a run of backticks; the closer is the next run of exactly
+//! the same length. Everything in between is literal, so this is one of the
+//! few inline constructs that can be skipped over in bulk rather than
+//! walked byte by byte.
+
+use memchr::memchr2;
+use ox_content_allocator::Vec;
+use ox_content_ast::{Node, Span};
+
+use super::super::Parser;
+#[allow(unused_imports)]
+use crate::profile_span_detail;
+
+impl<'a> Parser<'a> {
+    pub(super) fn parse_inline_code(
+        &self,
+        content: &'a str,
+        offset: usize,
+        children: &mut Vec<'a, Node<'a>>,
+        pos: &mut usize,
+    ) {
+        profile_span_detail!("parser::inline_code_span");
+        let bytes = content.as_bytes();
+        let open_len = Self::marker_run_len(bytes, *pos, b'`');
+        let code_start = *pos + open_len;
+
+        // The closer is the next backtick run of exactly the opener's
+        // length (CommonMark "Code spans"). memchr jumps between runs, and
+        // searching for the newline in the same pass answers the question
+        // `normalize_code_span` would otherwise re-scan the whole span for.
+        let mut cursor = code_start;
+        let mut has_newline = false;
+        while cursor < bytes.len() {
+            let Some(off) = memchr2(b'`', b'\n', &bytes[cursor..]) else {
+                break;
+            };
+            cursor += off;
+            if bytes[cursor] == b'\n' {
+                has_newline = true;
+                cursor += 1;
+                continue;
+            }
+            let run = Self::marker_run_len(bytes, cursor, b'`');
+            if run == open_len {
+                let span = Span::new((offset + *pos) as u32, (offset + cursor + run) as u32);
+                children.push(Node::InlineCode(ox_content_ast::InlineCode {
+                    value: self.normalize_code_span(&content[code_start..cursor], has_newline),
+                    span,
+                }));
+                *pos = cursor + run;
+                return;
+            }
+            cursor += run;
+        }
+
+        // No closer: the opening run is literal text.
+        Self::push_text(children, &content[*pos..code_start], offset + *pos, offset + code_start);
+        *pos = code_start;
+    }
+
+    /// Applies the code span content rules: line endings become spaces,
+    /// and one leading plus one trailing space is dropped when the content
+    /// starts and ends with a space without being all spaces.
+    ///
+    /// `has_newline` comes from the closer scan, which already walked these
+    /// bytes; re-deriving it here cost 1-3% of a parse because almost every
+    /// code span is single-line and paid a whole extra scan to prove it.
+    fn normalize_code_span(&self, raw: &'a str, has_newline: bool) -> &'a str {
+        let value: &'a str = if has_newline {
+            let mut converted = self.allocator.new_string();
+            for ch in raw.chars() {
+                converted.push(if ch == '\n' { ' ' } else { ch });
+            }
+            converted.into_bump_str()
+        } else {
+            raw
+        };
+
+        let stripped = value.starts_with(' ')
+            && value.ends_with(' ')
+            && value.len() >= 2
+            && value.bytes().any(|byte| byte != b' ');
+        if stripped {
+            &value[1..value.len() - 1]
+        } else {
+            value
+        }
+    }
+}


### PR DESCRIPTION
## What

A code span's content rules turn line endings into spaces, so `normalize_code_span` asked `raw.contains('\n')` — a second full scan of bytes the closer search had *just walked*. Almost every inline code span is single-line, so almost every one paid a whole extra scan to prove it had nothing to normalize.

Ablating that one call (replacing the condition with `false`) was worth **1.3-2.9% of a parse**, which is what set the ceiling for this change.

The closer search now uses `memchr2(b'`', b'\n')` and carries the answer out with it. Newlines inside a span are rare, so the extra loop iterations cost nothing measurable, and `memchr2` is no slower than `memchr` per call.

## Numbers

Parse, best of 60 iterations over `benchmarks/corpus`:

| corpus | before | after | |
| --- | --- | --- | --- |
| rust-book | 2.699 ms | 2.615 ms | **-3.1%** |
| typescript-handbook | 3.688 ms | 3.629 ms | **-1.6%** |
| vite-docs | 1.216 ms | 1.201 ms | **-1.2%** |
| vue-docs | 2.131 ms | 2.108 ms | **-1.1%** |

Parse + render:

| corpus | before | after | |
| --- | --- | --- | --- |
| typescript-handbook | 5.679 ms | 5.601 ms | **-1.4%** |
| vite-docs | 1.742 ms | 1.722 ms | **-1.1%** |
| vue-docs | 3.206 ms | 3.187 ms | **-0.6%** |
| rust-book | 3.860 ms | 3.849 ms | **-0.3%** |

## Note

`has_newline` covers exactly `content[code_start..cursor]` — the same range `normalize_code_span` receives — because that is the span the closer loop walks. An unterminated opener never reaches `normalize_code_span` at all.

`parse_inline_code` and `normalize_code_span` move to an `inline/code_span.rs` submodule to keep `inline.rs` inside the 350-line source cap (362 → 288).

`cargo test --workspace` passes, clippy and rustfmt are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789606275&installation_model_id=422833&pr_number=584&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F584&signature=d417979d45b791054022d3c588ab3819a8bd7c5e0bb0604bd973dee1af27025f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline code formatting with CommonMark-compatible backtick parsing.
  * Preserved inline code content while normalizing newlines and surrounding spaces.
  * Unterminated code spans are now treated as regular text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->