### PR TITLE
perf(parser): stop re-probing for a table on every table row (-13% on the span)

### DIFF
--- a/crates/ox_content_parser/src/parser/cursor.rs
+++ b/crates/ox_content_parser/src/parser/cursor.rs
@@ -111,6 +111,30 @@ impl<'a> Parser<'a> {
     /// paragraph loop consume the line without a second scan over the same
     /// bytes.
     pub(super) fn probe_line(&self, line_start: usize, trimmed_start: usize) -> BlockProbe {
+        self.probe_line_inner(line_start, trimmed_start, self.options.tables)
+    }
+
+    /// [`Self::probe_line`] without the table check.
+    ///
+    /// A table's own body rows are the one place the check is pure waste:
+    /// consecutive rows always belong to the same table, yet every one of
+    /// them re-ran the two-line header/delimiter probe — peeking both lines,
+    /// counting the header's cells, and validating a delimiter row that is
+    /// really the next data row — only to answer "no".
+    pub(super) fn probe_line_without_table(
+        &self,
+        line_start: usize,
+        trimmed_start: usize,
+    ) -> BlockProbe {
+        self.probe_line_inner(line_start, trimmed_start, false)
+    }
+
+    fn probe_line_inner(
+        &self,
+        line_start: usize,
+        trimmed_start: usize,
+        check_tables: bool,
+    ) -> BlockProbe {
         profile_span_detail!("parser::line_starts_block");
         let bytes = self.source.as_bytes();
 
@@ -148,7 +172,7 @@ impl<'a> Parser<'a> {
         if starts_block {
             return BlockProbe { starts_block: true, line_end: None };
         }
-        if !self.options.tables {
+        if !check_tables {
             return BlockProbe { starts_block: false, line_end: None };
         }
         match memchr2(b'|', b'\n', &bytes[line_start..]) {

--- a/crates/ox_content_parser/src/parser/table.rs
+++ b/crates/ox_content_parser/src/parser/table.rs
@@ -84,9 +84,10 @@ impl<'a> Parser<'a> {
 
             // A blank line or another block-level construct terminates the
             // table. Ordinary lines remain data rows even without a pipe.
-            if self.first_non_whitespace_in_line(self.position).is_none()
-                || self.line_starts_block()
-            {
+            let Some(trimmed_start) = self.first_non_whitespace_in_line(self.position) else {
+                break;
+            };
+            if self.probe_line_without_table(self.position, trimmed_start).starts_block {
                 break;
             }
 


### PR DESCRIPTION
## What

`parse_table`'s body loop asked `line_starts_block()` for each row, and that ends with the table check: peek two lines, count the header row's cells, then validate the line after it as a delimiter row. Inside a table the answer is always no — the "delimiter row" it validates is really the next data row — but the work runs in full first. A four-row table paid three of these.

Consecutive rows always belong to the same table, so the body loop now uses a probe with the table check switched off. It also reuses the first-non-whitespace offset it had already computed instead of making the probe walk the indent again.

## Numbers

Measured on the benchmark harness's own sample document (the one the JS and native competitor rows use), repeated 100×, 200 iterations:

| | before | after | |
| --- | --- | --- | --- |
| `parser::parse_table` self | 11.34 ms | 9.88 ms | **-12.9%** |
| pipeline p50 | 632.25 µs | 602.04 µs | **-4.8%** |

The prose corpora under `benchmarks/corpus` are flat — they contain few tables — so this is a win specific to table-dense content, which is exactly what the tracked benchmark sample is.

## Behaviour

This also settles a latent question in the parser's favour. The old code would end the table and start a new one if two consecutive *body* rows happened to look like a header/delimiter pair. GFM says the delimiter row is only ever the second line of a table and every later line is data, so the new behaviour is the spec's.

The whole workspace suite passes, including the CommonMark and GFM conformance baselines — unchanged, not regenerated. Clippy and rustfmt are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789607174&installation_model_id=422833&pr_number=585&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F585&signature=accffb9d5782e81a2e605dd0900a609c0ffcd4b5bcaa326c053ce15a67bf6ea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->