### PR TITLE
perf(renderer): gate URL autolinking on `://` instead of `:` (-7% render)

### DIFF
--- a/crates/ox_content_renderer/src/html/autolink.rs
+++ b/crates/ox_content_renderer/src/html/autolink.rs
@@ -32,6 +32,14 @@ pub(super) struct FirstByteIndex {
     /// is far rarer in prose than their first byte `h`; most text nodes
     /// skip the candidate walk entirely.
     gate: Option<u8>,
+    /// Bytes that must follow `gate` for a match to be possible, when every
+    /// pattern agrees on them. The gate byte alone is a weak filter: `:` is
+    /// everywhere in prose (`Note:`, `1:1`, `Listing 3-2:`) and each hit used
+    /// to drag the node through the full candidate walk. The default
+    /// patterns both continue `//` after their `:`, so requiring `://`
+    /// rejects all of those with a two-byte compare.
+    gate_tail: [u8; 2],
+    gate_tail_len: usize,
 }
 
 /// Sentinel in `FirstByteIndex::second`: no single second byte filters
@@ -97,14 +105,63 @@ impl FirstByteIndex {
             .find(|&byte| qualifies(byte))
             .or_else(|| gate_candidates.iter().copied().find(|&byte| qualifies(byte)));
 
-        Self { table, needles, needle_len, overflow, second, gate }
+        // Extend the gate with the bytes that follow it in every pattern.
+        // Only caseless bytes qualify, for the same reason the gate byte
+        // itself must be caseless: the prefix compare is case-insensitive,
+        // so a letter's presence proves nothing about the other case.
+        let mut gate_tail = [0u8; 2];
+        let mut gate_tail_len = 0usize;
+        if let Some(gate_byte) = gate {
+            if let Some(first) = patterns.first() {
+                let first = first.as_bytes();
+                if let Some(at) = memchr::memchr(gate_byte, first) {
+                    let mut len = 0usize;
+                    while len < gate_tail.len()
+                        && at + 1 + len < first.len()
+                        && !first[at + 1 + len].is_ascii_alphabetic()
+                    {
+                        len += 1;
+                    }
+                    // Shrink until every pattern holds the whole needle; a
+                    // pattern set that disagrees falls back to the bare byte.
+                    while len > 0 {
+                        let needle = &first[at..=at + len];
+                        if patterns
+                            .iter()
+                            .all(|pat| memchr::memmem::find(pat.as_bytes(), needle).is_some())
+                        {
+                            gate_tail[..len].copy_from_slice(&first[at + 1..=at + len]);
+                            gate_tail_len = len;
+                            break;
+                        }
+                        len -= 1;
+                    }
+                }
+            }
+        }
+
+        Self { table, needles, needle_len, overflow, second, gate, gate_tail, gate_tail_len }
     }
 
-    /// The byte that must appear in a haystack for any pattern to match, if
-    /// the pattern set has one. See the field docs.
-    #[inline]
-    pub(super) fn gate_byte(&self) -> Option<u8> {
-        self.gate
+    /// Whether `haystack` can hold a pattern match at all.
+    ///
+    /// One `memchr` for the gate byte, then a compare against the bytes that
+    /// must follow it. With no gate byte configured this is vacuously true,
+    /// and with no tail it degrades to exactly the old single-byte probe.
+    pub(super) fn may_match(&self, haystack: &[u8]) -> bool {
+        let Some(gate) = self.gate else {
+            return true;
+        };
+        let tail = &self.gate_tail[..self.gate_tail_len];
+        let mut from = 0;
+        while let Some(off) = memchr::memchr(gate, &haystack[from..]) {
+            let at = from + off;
+            if haystack[at + 1..].starts_with(tail) {
+                return true;
+            }
+            from = at + 1;
+        }
+        false
     }
 
     /// True when the byte after a first-byte hit rules the candidate out

--- a/crates/ox_content_renderer/src/html/renderer/write.rs
+++ b/crates/ox_content_renderer/src/html/renderer/write.rs
@@ -48,15 +48,14 @@ impl HtmlRenderer {
             write_escaped_into(&mut self.output, s);
             return;
         };
-        // A match must contain the index's gate byte (`:` for the default
-        // `http://`/`https://` patterns), so one memchr over the node proves
-        // "nothing can match here" for almost every prose node — skipping
-        // the candidate walk with its per-first-byte boundary checks.
-        if let Some(gate) = index.gate_byte() {
-            if memchr::memchr(gate, bytes).is_none() {
-                write_escaped_into(&mut self.output, s);
-                return;
-            }
+        // A match must contain the index's gate needle (`://` for the
+        // default `http://`/`https://` patterns), so one memchr plus a short
+        // compare proves "nothing can match here" for almost every prose
+        // node — skipping the candidate walk with its per-first-byte
+        // boundary checks.
+        if !index.may_match(bytes) {
+            write_escaped_into(&mut self.output, s);
+            return;
         }
         // Borrow the relevant fields disjointly so the URL scan (which only
         // reads `options`/`autolink_index`) and the output writes can coexist.


### PR DESCRIPTION
## What

`write_text_with_autolinks` runs for **every text node** the renderer emits, and its cheap rejection was a single `memchr` for the pattern set's gate byte — `:` for the default `http://`/`https://`. Prose is full of colons: `Note:`, `1:1`, `Listing 3-2:`. Each one got past the gate and dragged the node through the candidate walk with its per-first-byte boundary checks.

Ablating the whole post-gate path measured it at **3-15% of a render**, so the gate was leaking a lot.

Both default patterns continue `//` after their `:`, so the gate now carries the bytes that follow it in *every* pattern and rejects on `://`. That is still one `memchr`, plus a two-byte compare at each hit — and the hits it now rejects are exactly the prose colons.

## Numbers

Render, best of two interleaved runs of 60 iterations. Both binaries were built up front and alternated, so the measurement is immune to the machine drifting between builds — an earlier build-then-measure pass reported this same change as a 25% *regression* purely from thermal drift.

| corpus | before | after | |
| --- | --- | --- | --- |
| rust-book | 1.157 ms | 1.065 ms | **-7.5%** |
| vite-docs | 0.479 ms | 0.444 ms | **-7.3%** |
| vue-docs | 1.022 ms | 0.972 ms | **-4.4%** |
| typescript-handbook | 1.978 ms | 1.913 ms | **-3.6%** |

Parse + render:

| corpus | before | after | |
| --- | --- | --- | --- |
| rust-book | 3.819 ms | 3.747 ms | **-1.9%** |
| vue-docs | 3.157 ms | 3.099 ms | **-1.8%** |
| vite-docs | 1.744 ms | 1.723 ms | **-1.2%** |
| typescript-handbook | 5.680 ms | 5.654 ms | **-0.5%** |

## Correctness

The tail is **derived, not hardcoded**: it grows from the first pattern's bytes after the gate byte and shrinks until every pattern contains the whole needle. A set that disagrees (`["http://", "mailto:"]`) falls back to the bare byte and behaves exactly as before, and an empty tail makes `may_match` identical to the old probe.

Alphabetic bytes are excluded for the same reason the gate byte excludes them — the prefix compare is case-insensitive, so a letter proves nothing about the other case.

Rendering the whole rust-book corpus produces **byte-for-byte identical output**. `cargo test --workspace` passes, clippy and rustfmt are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789607849&installation_model_id=422833&pr_number=586&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F586&signature=86fac04a83cb9482667a987b703caa9ece682a75c1e4d5bd53b08599d3419d05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->