### PR TITLE
perf(parser): classify inline markers with a SIMD nibble lookup (-9% parse)

### DIFF
--- a/crates/ox_content_parser/src/parser/inline/scan.rs
+++ b/crates/ox_content_parser/src/parser/inline/scan.rs
@@ -1,13 +1,28 @@
+//! Scanning for the next byte that can begin an inline construct.
+//!
+//! This is the parser's hottest loop: it classifies every byte of every
+//! block's inline content. Ten markers is too many for the `memchr` family
+//! and too scattered for a SWAR fold, so the portable path is a 256-entry
+//! flag table read eight bytes at a time — one load per byte.
+//!
+//! Both SIMD paths replace that with a nibble-pair classifier that needs no
+//! per-byte load at all, and they run the *same* classifier: aarch64 uses
+//! `vqtbl1q_u8` and x86-64 `pshufb`, which are the same 16-entry table
+//! lookup. Every path is checked against the flag table by the differential
+//! tests below, for all 256 byte values at every offset.
+
 #[allow(unused_imports)]
 use crate::profile_span_detail;
 
 /// Lookup table: `INLINE_SPECIAL[b] == 1` iff the byte can begin an inline
 /// construct handled by `parse_inline_special`.
 ///
-/// The table deliberately stores flags instead of enum variants. The scan in
-/// `next_inline_special` ORs eight table entries at a time, which gives LLVM a
-/// simple branch-free loop for long runs of normal text. The actual parser
-/// decision still happens only after a candidate byte is found.
+/// This is the definition the vectorized paths must agree with, and the
+/// scan every target without one falls back to. The table deliberately
+/// stores flags instead of enum variants: the scalar scan ORs eight entries
+/// at a time, which gives LLVM a branch-free loop for long runs of normal
+/// text. The actual parser decision still happens only after a candidate
+/// byte is found.
 static INLINE_SPECIAL: [u8; 256] = {
     let mut t = [0u8; 256];
     t[b'*' as usize] = 1;
@@ -29,8 +44,126 @@ static INLINE_SPECIAL: [u8; 256] = {
 /// 12-16% on prose-dense ones.
 const SHORT_RUN_PREFIX: usize = 8;
 
+/// Nibble-pair classifier tables for the vectorized paths.
+///
+/// A byte is special iff `LOW[b & 0x0F] & HIGH[b >> 4]` is nonzero. The ten
+/// markers fall into six (high nibble, low-nibble set) groups — `\n`;
+/// `!`/`&`/`*`; `<`; `[`/`\`/`_`; `` ` ``; `~` — and each group owns one
+/// bit, so the AND is exact: it admits no byte outside the set, and every
+/// byte >= 0x80 maps to a zero high-nibble entry.
+///
+/// A 16-entry table is what a vector shuffle can hold, which is the whole
+/// point: `vqtbl1q_u8` / `pshufb` look up all sixteen lanes in one
+/// instruction, where the flag table needs sixteen loads.
+const LOW_NIBBLE: [u8; 16] =
+    [0x10, 0x02, 0, 0, 0, 0, 0x02, 0, 0, 0, 0x03, 0x08, 0x0C, 0, 0x20, 0x08];
+const HIGH_NIBBLE: [u8; 16] = [0x01, 0, 0x02, 0x04, 0, 0x08, 0x10, 0x20, 0, 0, 0, 0, 0, 0, 0, 0];
+
+#[cfg(target_arch = "aarch64")]
+#[allow(unsafe_code)]
+#[inline]
+fn next_special_neon(bytes: &[u8], from: usize) -> usize {
+    use std::arch::aarch64::*;
+    let end = bytes.len();
+    let mut i = from;
+    unsafe {
+        let low = vld1q_u8(LOW_NIBBLE.as_ptr());
+        let high = vld1q_u8(HIGH_NIBBLE.as_ptr());
+        let nibble = vdupq_n_u8(0x0F);
+        while i + 16 <= end {
+            let v = vld1q_u8(bytes.as_ptr().add(i));
+            let lo = vqtbl1q_u8(low, vandq_u8(v, nibble));
+            let hi = vqtbl1q_u8(high, vshrq_n_u8(v, 4));
+            // `vtstq_u8` turns the per-lane AND into the all-ones/all-zeros
+            // form the nibble-narrowing mask extraction needs.
+            let m = vtstq_u8(lo, hi);
+            let narrow = vshrn_n_u16(vreinterpretq_u16_u8(m), 4);
+            let mask = vget_lane_u64(vreinterpret_u64_u8(narrow), 0);
+            if mask != 0 {
+                return i + (mask.trailing_zeros() / 4) as usize;
+            }
+            i += 16;
+        }
+    }
+    while i < end && INLINE_SPECIAL[bytes[i] as usize] == 0 {
+        i += 1;
+    }
+    i
+}
+
+/// SSSE3 sibling of [`next_special_neon`]. `pshufb` is the same 16-entry
+/// table lookup `vqtbl1q_u8` performs, so both paths run the identical
+/// classifier and are covered by the same differential tests.
+///
+/// # Safety
+///
+/// The caller must have verified SSSE3 support. Every load is bounded by
+/// the `i + 16 <= end` guard.
+#[cfg(target_arch = "x86_64")]
+#[allow(unsafe_code)]
+#[target_feature(enable = "ssse3")]
+unsafe fn next_special_ssse3(bytes: &[u8], from: usize) -> usize {
+    use std::arch::x86_64::*;
+    let end = bytes.len();
+    let mut i = from;
+    unsafe {
+        let low = _mm_loadu_si128(LOW_NIBBLE.as_ptr().cast());
+        let high = _mm_loadu_si128(HIGH_NIBBLE.as_ptr().cast());
+        let nibble = _mm_set1_epi8(0x0F);
+        while i + 16 <= end {
+            let v = _mm_loadu_si128(bytes.as_ptr().add(i).cast());
+            // `_mm_srli_epi16` shifts 16-bit lanes, so the neighbouring
+            // byte's low bits ride along; masking leaves the high nibble.
+            let lo = _mm_shuffle_epi8(low, _mm_and_si128(v, nibble));
+            let hi = _mm_shuffle_epi8(high, _mm_and_si128(_mm_srli_epi16(v, 4), nibble));
+            let m = _mm_and_si128(lo, hi);
+            // `movemask` of "lane is zero" sets a bit per *clean* byte, so
+            // the complement's lowest set bit is the first marker.
+            // `movemask` fills only the low 16 bits, so the cast is exact
+            // and the complement below stays inside them.
+            let clean = _mm_movemask_epi8(_mm_cmpeq_epi8(m, _mm_setzero_si128()));
+            let flagged = !clean & 0xFFFF;
+            if flagged != 0 {
+                return i + flagged.trailing_zeros() as usize;
+            }
+            i += 16;
+        }
+    }
+    next_inline_special_scalar(bytes, i)
+}
+
+#[cfg(target_arch = "aarch64")]
 #[inline]
 pub(super) fn next_inline_special(bytes: &[u8], from: usize) -> usize {
+    next_special_neon(bytes, from)
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+pub(super) fn next_inline_special(bytes: &[u8], from: usize) -> usize {
+    // SSSE3 is not in the x86-64 baseline, so it is detected rather than
+    // assumed. `is_x86_feature_detected!` caches its answer in an atomic,
+    // and a machine without it keeps the scalar scan unchanged.
+    if std::arch::is_x86_feature_detected!("ssse3") {
+        // SAFETY: guarded by the detection above.
+        #[allow(unsafe_code)]
+        unsafe {
+            next_special_ssse3(bytes, from)
+        }
+    } else {
+        next_inline_special_scalar(bytes, from)
+    }
+}
+
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+#[inline]
+pub(super) fn next_inline_special(bytes: &[u8], from: usize) -> usize {
+    next_inline_special_scalar(bytes, from)
+}
+
+#[cfg_attr(target_arch = "aarch64", allow(dead_code))]
+#[inline]
+fn next_inline_special_scalar(bytes: &[u8], from: usize) -> usize {
     profile_span_detail!("parser::inline_scan");
     let end = bytes.len();
 
@@ -117,6 +250,32 @@ mod tests {
             let bytes = &buffer[..len];
             for from in 0..=len {
                 assert_eq!(next_inline_special(bytes, from), reference(bytes, from));
+            }
+        }
+    }
+
+    #[test]
+    fn matches_reference_for_every_byte_value_at_every_offset() {
+        // The vectorized classifiers decide from nibble pairs rather than a
+        // 256-entry table, so a wrong entry would admit or drop a byte the
+        // flag table disagrees with. Check all 256 values, at every offset
+        // of a buffer long enough to cross the 16-byte step and land in the
+        // scalar tail.
+        for value in 0..=255u8 {
+            for at in 0..40usize {
+                let mut buffer = [b'x'; 40];
+                buffer[at] = value;
+                let bytes = &buffer[..];
+                assert_eq!(
+                    next_inline_special(bytes, 0),
+                    reference(bytes, 0),
+                    "byte {value:#04x} at {at}"
+                );
+                assert_eq!(
+                    next_inline_special_scalar(bytes, 0),
+                    reference(bytes, 0),
+                    "scalar: byte {value:#04x} at {at}"
+                );
             }
         }
     }


### PR DESCRIPTION
> **This is the workspace's first `unsafe`.** `unsafe_code = "warn"` plus CI at `-D warnings` means it needs an explicit `#[allow(unsafe_code)]`, so please treat the scope and the testing below as the substance of the review, not the numbers.

## What

`next_inline_special` is the parser's hottest loop — it classifies every byte of every block's inline content, and ablating it showed the scan alone accounts for roughly a quarter of a parse. Ten markers is too many for the `memchr` family and too scattered for a SWAR fold, so the portable path reads a 256-entry flag table: **one load per byte**.

The ten markers fall into six (high nibble, low-nibble set) groups — `\n`; `!`/`&`/`*`; `<`; `[`/`\`/`_`; `` ` ``; `~` — so giving each group a bit makes `LOW[b & 0x0F] & HIGH[b >> 4]` an *exact* test. Both tables are 16 entries, which is exactly what a vector shuffle holds: `vqtbl1q_u8` on aarch64 and `pshufb` on x86-64 look up all sixteen lanes in **one instruction** where the flag table needs sixteen loads.

## Numbers

Parse, best of three interleaved runs of 60 iterations, aarch64 (both binaries built up front and alternated):

| corpus | before | after | |
| --- | --- | --- | --- |
| rust-book | 2.610 ms | 2.372 ms | **-9.1%** |
| typescript-handbook | 3.605 ms | 3.375 ms | **-6.4%** |
| vite-docs | 1.171 ms | 1.116 ms | **-4.7%** |
| vue-docs | 2.029 ms | 1.942 ms | **-4.3%** |

Parse + render:

| corpus | before | after | |
| --- | --- | --- | --- |
| rust-book | 3.729 ms | 3.530 ms | **-5.3%** |
| typescript-handbook | 5.637 ms | 5.420 ms | **-3.8%** |
| vite-docs | 1.687 ms | 1.632 ms | **-3.3%** |
| vue-docs | 3.095 ms | 3.034 ms | **-2.0%** |

x86-64, same harness under Rosetta — the translation overhead is in both columns, so a native run should do at least this well:

| corpus | before | after | |
| --- | --- | --- | --- |
| rust-book | 3.515 ms | 3.355 ms | **-5.3%** |
| typescript-handbook | 4.805 ms | 4.594 ms | **-4.9%** |
| vite-docs | 1.541 ms | 1.501 ms | **-3.7%** |
| vue-docs | 2.659 ms | 2.616 ms | **-1.9%** |

## Scope of the `unsafe`

- Each path is **ten lines of intrinsics**. The only pointer arithmetic is the load, bounded by the `i + 16 <= end` loop guard.
- The flag table stays as **the definition** and as the fallback for every target without a path.
- SSSE3 is not in the x86-64 baseline, so it is **detected at runtime** rather than assumed; a machine without it keeps today's scan byte for byte.
- No lifetime, aliasing, or initialization reasoning is involved — the shuffles are pure register operations over a loaded vector.

## Testing

- A new differential test checks **all 256 byte values at every offset** of a buffer long enough to cross the vector step and land in the scalar tail, against the flag table — and asserts the scalar path separately, so neither can drift.
- It runs on **both architectures**: `cargo test -p ox_content_parser` and `cargo test -p ox_content_parser --target x86_64-apple-darwin` (the x86 path executes for real under Rosetta, which implements SSSE3).
- `cargo test --workspace` passes, including the CommonMark and GFM conformance baselines — unchanged, not regenerated.
- Rendering all four corpora produces **byte-for-byte identical HTML** (5,750,889 bytes).
- Clippy at `-D warnings` and rustfmt are clean on both targets.

## Safe alternatives tried first

Writing the same nibble classifier in safe Rust and hoping LLVM would emit the shuffle made it **10% slower** — it kept the two array indexings as loads. Earlier attempts on this scan (varying the short-run prefix, 16-byte scalar chunks, `iter().position()`) all landed within noise; the portable path is at a local optimum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789611442&installation_model_id=422833&pr_number=587&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F587&signature=c9a1bb9cfa032b5e0ed1d4cdcb6510c14ff9ac0bdd8fa455ff2baa5fddd97bd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved inline content scanning performance on supported modern devices.
  - Added optimized processing for common hardware platforms while preserving compatibility with other systems.

- **Reliability**
  - Improved consistency of inline parsing across different byte patterns and input positions.
  - Expanded validation to help ensure equivalent results across supported execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->