### PR TITLE
fix(build): make build:npm reach the nested theme packages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -108,7 +108,10 @@ export default defineConfig({
       "build:napi": task("vp run --filter ./crates/ox_content_napi build", {
         dependsOn: ["build:rust"],
       }),
-      "build:npm": task("vp run --filter './npm/*' build", {
+      // `./npm/**` (not `./npm/*`): the theme presets live one level deeper at
+      // npm/theme/* and npm/theme-color/*, and publish.yml packs them straight
+      // from this task's output — a single-star filter would ship them dist-less.
+      "build:npm": task("vp run --filter './npm/**' build", {
         dependsOn: ["build:napi"],
       }),
       "build:docs": task("vp run --filter ./docs build", {


### PR DESCRIPTION
## Problem

`build:npm` filters with `./npm/*`, which only matches direct children of `npm/`. The 72 theme preset packages merged in #589 live one level deeper (`npm/theme/*`, `npm/theme-color/*`), so the task never builds them. `publish.yml` packs those directories right after running `build:npm`, meaning the next `v*` tag push would have published every theme package **without its `dist/`** (the `files` allowlist would silently produce manifest-only tarballs).

## Fix

Widen the filter to `./npm/**`.

Verified locally by deleting a theme's `dist/` and running the task command:

- `vp run --filter './npm/*' build` → 8 tasks, nested `dist/` **not** rebuilt
- `vp run --filter './npm/**' build` → 80 tasks, nested `dist/` rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789886300&installation_model_id=422833&pr_number=590&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F590&signature=63180efa702e829223af0ebeea811a22db1ce5941f10c4a598751b9f284a73f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package builds to include nested npm theme packages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->