### PR TITLE
fix(clippy): satisfy the two lints Rust 1.98 turned on

### DIFF
--- a/crates/ox_content_component_resolver/src/lib.rs
+++ b/crates/ox_content_component_resolver/src/lib.rs
@@ -136,7 +136,11 @@ impl Resolver {
     /// The scaffold returns `Ok(Self)` without actually spawning the
     /// process so the rest of the workspace can integrate the public
     /// types ahead of the real implementation landing.
-    #[allow(clippy::unused_async)] // The follow-up PR replaces the body with real async work.
+    #[allow(clippy::unused_async)]
+    // The follow-up PR replaces the body with real async work.
+    // Same story for the 1.98 split-off lint; unknown_lints keeps older local
+    // toolchains (which predate it) from tripping over the name.
+    #[allow(unknown_lints, clippy::unused_async_trait_impl)]
     pub async fn spawn(config: ResolverConfig) -> Result<Self, Error> {
         if !config.tsgo_path.exists() {
             return Err(Error::TsgoMissing(config.tsgo_path));
@@ -155,7 +159,11 @@ impl Resolver {
     ///    React.FC `<Props>`)
     /// 4. enumerate prop members, looking up their type strings,
     ///    optionality, JSDoc, and declaration locations
-    #[allow(clippy::unused_async)] // The follow-up PR replaces the body with real async work.
+    #[allow(clippy::unused_async)]
+    // The follow-up PR replaces the body with real async work.
+    // Same story for the 1.98 split-off lint; unknown_lints keeps older local
+    // toolchains (which predate it) from tripping over the name.
+    #[allow(unknown_lints, clippy::unused_async_trait_impl)]
     pub async fn resolve_component_props(
         &self,
         component_file: &Path,

--- a/crates/ox_content_lsp/src/backend.rs
+++ b/crates/ox_content_lsp/src/backend.rs
@@ -52,7 +52,7 @@ impl Backend {
     }
 
     pub(super) async fn open_document(&self, uri: &Url, text: String) {
-        if uri.to_file_path().ok().is_some_and(|path| i18n::is_i18n_source_path(&path)) {
+        if uri.to_file_path().is_ok_and(|path| i18n::is_i18n_source_path(&path)) {
             self.i18n_state.add_open_uri(uri.clone()).await;
         }
         self.on_change(uri, text).await;

--- a/crates/ox_content_lsp/src/backend/handlers.rs
+++ b/crates/ox_content_lsp/src/backend/handlers.rs
@@ -196,8 +196,7 @@ impl LanguageServer for Backend {
     }
 
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
-        if params.text_document.uri.to_file_path().ok().is_some_and(|path| !is_markdown_path(&path))
-        {
+        if params.text_document.uri.to_file_path().is_ok_and(|path| !is_markdown_path(&path)) {
             return Ok(None);
         }
         let mut actions = insert_actions(&params.text_document.uri, params.range.start);

--- a/crates/ox_content_lsp/src/config.rs
+++ b/crates/ox_content_lsp/src/config.rs
@@ -115,8 +115,7 @@ impl ResolvedConfig {
             config.textlint.enabled.unwrap_or(false)
         } else {
             env::var("OX_CONTENT_TEXTLINT_ENABLED")
-                .ok()
-                .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes"))
+                .is_ok_and(|value| matches!(value.as_str(), "1" | "true" | "yes"))
         };
         let textlint_command = init
             .textlint_command
@@ -160,8 +159,7 @@ impl ResolvedConfig {
             config.spacing.auto_fix_on_save.unwrap_or(false)
         } else {
             env::var("OX_CONTENT_SPACING_AUTO_FIX_ON_SAVE")
-                .ok()
-                .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes"))
+                .is_ok_and(|value| matches!(value.as_str(), "1" | "true" | "yes"))
         };
 
         Self {


### PR DESCRIPTION
CI's Clippy job runs `dtolnay/rust-toolchain@stable`, which picked up Rust 1.98.0 (released 2026-08-18). Two of its lint changes turned main red (first failing run: [32454643385](https://github.com/ubugeeei-prod/ox-content/actions/runs/32454643385)):

1. **`clippy::unused_async_trait_impl`** split off from `unused_async` ([rust-clippy#16244](https://github.com/rust-lang/rust-clippy/pull/16244)), so the existing `#[allow(clippy::unused_async)]` on the component resolver's scaffold methods no longer suppresses it. This PR allows the new name as well, paired with `unknown_lints` so toolchains predating 1.98 don't warn about the unknown lint.
2. **`clippy::manual_is_variant_and`** (pedantic) now also matches `.ok().is_some_and(..)` on `Result`s. Applied its suggested `is_ok_and` rewrite at the four LSP call sites — a genuine simplification, so no allow.

Verified locally with both toolchains:
- `cargo clippy --workspace --all-targets -- -D warnings` clean under **1.98.0** (reproduces CI failure before the fix) and **1.97.1**
- `cargo test -p ox_content_lsp -p ox_content_component_resolver` all green

Note: PR #590's Clippy check fails with the same root cause — it should go green once this lands and it rebases/merges with main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789887164&installation_model_id=422833&pr_number=591&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F591&signature=b06659f7fae69b6a8ca2f0883686794222f9908a319c67463831ed8ba3f1cb75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal validation and configuration checks.
  * Preserved existing behavior for document handling, code actions, and textlint and spacing auto-fix settings.
  * Maintained compatibility with older toolchains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->