### PR TITLE
perf(parser): fast-path plain inline text

### DIFF
--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -52,11 +52,28 @@ impl<'a> Parser<'a> {
         offset: usize,
     ) -> ParseResult<Vec<'a, Node<'a>>> {
         profile_span!("parser::parse_inline");
+        let bytes = content.as_bytes();
+        let first_special = next_inline_special(bytes, 0);
+
+        // Plain text is both the most common inline shape and exactly one AST
+        // node. Reserving the general four-node floor here wasted three
+        // full Node slots for every prose block and plain table cell. The
+        // scan is required by the normal loop anyway, so use its no-marker
+        // result to build the exact one-slot representation and return.
+        if first_special == content.len() {
+            if content.is_empty() {
+                return Ok(self.allocator.new_vec());
+            }
+            let mut children = self.allocator.new_vec_with_capacity(1);
+            Self::push_text(&mut children, content, offset, offset + content.len());
+            return Ok(children);
+        }
+
         let mut children =
             self.allocator.new_vec_with_capacity(Self::inline_children_capacity(content.len()));
         let mut delimiters = self.allocator.new_vec();
         let mut pos = 0;
-        let bytes = content.as_bytes();
+        let mut first_scan = Some(first_special);
 
         while pos < content.len() {
             let start = pos;
@@ -65,7 +82,7 @@ impl<'a> Parser<'a> {
             // one Text node. This keeps the parser on bulk byte scans for
             // prose and only enters the slower match when a real marker byte
             // has been reached.
-            pos = next_inline_special(bytes, pos);
+            pos = first_scan.take().unwrap_or_else(|| next_inline_special(bytes, pos));
 
             // Fold soft line breaks into the running text node. A newline
             // with non-whitespace on both sides is a soft break with nothing

--- a/crates/ox_content_parser/src/parser/tests.rs
+++ b/crates/ox_content_parser/src/parser/tests.rs
@@ -77,6 +77,21 @@ fn test_parse_paragraph() {
 }
 
 #[test]
+fn plain_text_paragraph_reserves_one_inline_node() {
+    let allocator = Allocator::new();
+    let doc = Parser::new(&allocator, "One plain text node").parse().unwrap();
+    let Node::Paragraph(paragraph) = &doc.children[0] else {
+        panic!("expected paragraph");
+    };
+
+    assert_eq!(paragraph.children.len(), 1);
+    assert_eq!(paragraph.children.capacity(), 1);
+    assert!(
+        matches!(&paragraph.children[0], Node::Text(text) if text.value == "One plain text node")
+    );
+}
+
+#[test]
 fn test_parse_thematic_break() {
     let allocator = Allocator::new();
     let doc = Parser::new(&allocator, "---").parse().unwrap();


### PR DESCRIPTION
## Summary
- detect marker-free inline content using the scan the parser already performs
- allocate exactly one AST slot and return the Text node directly for plain content
- reuse the first scan result on the marker-rich path
- pin the one-slot representation with a regression test

## Performance
Rust 1.98 Criterion, same checkout and target history:

| case | before | after | change |
| --- | ---: | ---: | ---: |
| simple parse | 629.63 ns | 540.47 ns | -14.9% |
| large parse | 3.4858 us | 3.2075 us | -11.1% |

The detailed README pipeline profile also moved from 213.21 us to 193.79 us p50 (-9.1%), with throughput from 81.53 MB/s to 89.70 MB/s (+10.0%). Global bump-allocation chunk counts and bytes were unchanged, so this PR makes no claim of reducing allocator chunk acquisition.

## Risk
Low. Public AST shape and rendered output are unchanged. Empty input still produces no inline nodes; marker-rich content stays on the existing parser path; GFM autolinking and Unicode remain covered by the all-feature and workspace suites.

## Validation
- cargo +1.98.0 fmt --all -- --check
- CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo +1.98.0 clippy --workspace --all-targets -- -D warnings
- CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo +1.98.0 test --workspace
- cargo +1.98.0 test -p ox_content_parser --all-features
- cargo +1.98.0 bench -p ox_content_parser --bench parser
- cargo +1.98.0 run --release -p ox_content_profile_cli -- pipeline --gfm --detail --iters 100 --warmup 20 README.md

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789893725&installation_model_id=422833&pr_number=595&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F595&signature=4bf97354c75946eb2ec66fe1bcb6ac50c296e7fd2ba211044acfc2afc746e82b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of plain-text paragraphs to preserve complete text content and produce the expected inline structure.
  * Improved processing for empty and plain-text content.

* **Performance**
  * Reduced unnecessary scanning and allocations when parsing inline content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->