### PR TITLE
perf(parser): reuse parsed list siblings

### DIFF
--- a/crates/ox_content_parser/benches/parser.rs
+++ b/crates/ox_content_parser/benches/parser.rs
@@ -132,6 +132,40 @@ Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aen
 This document serves as a comprehensive test case for the markdown parser, covering various markdown features and edge cases.
 "#;
 
+const LONG_LIST: &str = r"- item 01
+- item 02
+- item 03
+- item 04
+- item 05
+- item 06
+- item 07
+- item 08
+- item 09
+- item 10
+- item 11
+- item 12
+- item 13
+- item 14
+- item 15
+- item 16
+- item 17
+- item 18
+- item 19
+- item 20
+- item 21
+- item 22
+- item 23
+- item 24
+- item 25
+- item 26
+- item 27
+- item 28
+- item 29
+- item 30
+- item 31
+- item 32
+";
+
 fn bench_parse_simple(c: &mut Criterion) {
     let mut group = c.benchmark_group("parse_simple");
     group.throughput(Throughput::Bytes(SIMPLE_MD.len() as u64));
@@ -162,5 +196,23 @@ fn bench_parse_large(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_parse_simple, bench_parse_large);
+fn bench_parse_lists(c: &mut Criterion) {
+    let single_item = "- one\n";
+    let mut group = c.benchmark_group("parse_lists");
+
+    for (name, source) in [("single_item", single_item), ("long_list", LONG_LIST)] {
+        group.throughput(Throughput::Bytes(source.len() as u64));
+        group.bench_with_input(name, source, |b, source| {
+            b.iter(|| {
+                let allocator = Allocator::new();
+                let parser = Parser::new(&allocator, black_box(source));
+                let _ = parser.parse();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_parse_simple, bench_parse_large, bench_parse_lists);
 criterion_main!(benches);

--- a/crates/ox_content_parser/src/parser/list.rs
+++ b/crates/ox_content_parser/src/parser/list.rs
@@ -22,42 +22,14 @@ impl<'a> Parser<'a> {
         let ordered = first_item.ordered;
         let marker = first_item.marker;
         let list_start = first_item.start;
+        let mut item = first_item;
 
         let mut children: Vec<'a, ListItem<'a>> = self.allocator.new_vec();
         let mut list_spread = false;
 
         loop {
-            if self.is_at_end() {
-                break;
-            }
-
             let line_start = self.position;
-            self.skip_whitespace();
-            if self.peek() == Some('\n') || self.is_at_end() {
-                self.position = line_start; // Backtrack to handle end of block
-                break;
-            }
-            self.position = line_start;
-
-            // A sibling marker may sit between the baseline and three
-            // columns past it; anything else at this level ends the list.
-            let sibling_indent = self.calc_indentation(line_start);
-            if sibling_indent < baseline_indent || sibling_indent > baseline_indent + 3 {
-                break;
-            }
             let line = self.line_at(line_start);
-            // A thematic break takes precedence over a sibling marker
-            // (`* * *` between items splits the list around an <hr>).
-            if Self::try_parse_thematic_break_line(line) {
-                break;
-            }
-            let Some(item) = self.parse_list_item_line_from_line(line_start, line) else {
-                break;
-            };
-            if item.ordered != ordered || item.marker != marker {
-                // A different marker starts a new list at the block level.
-                break;
-            }
 
             // Consume the marker line.
             self.position += line.len();
@@ -67,12 +39,16 @@ impl<'a> Parser<'a> {
             }
 
             let mut lazy_lines = rustc_hash::FxHashSet::default();
-            let (gap_spread, item_end, item_source) = self.consume_item_continuation(
-                &item,
-                baseline_indent,
-                consumed_newline,
-                &mut lazy_lines,
-            );
+            let (gap_spread, item_end, item_source, next_item) = if self.is_at_end() {
+                (false, self.position, None, None)
+            } else {
+                self.consume_item_continuation(
+                    &item,
+                    baseline_indent,
+                    consumed_newline,
+                    &mut lazy_lines,
+                )
+            };
 
             let mut content_spread = false;
             let item_children = if item_source.is_none()
@@ -103,7 +79,23 @@ impl<'a> Parser<'a> {
                 children: item_children,
                 span: Span::new(line_start as u32, item_end as u32),
             };
+            // The first push keeps one-item lists at bumpalo's exact minimum.
+            // Once a second sibling is known to exist, skip the otherwise
+            // inevitable two-slot allocation and its copy; four slots cover
+            // the common short list without penalizing the single-item case.
+            if children.len() == 1 {
+                children.reserve(3);
+            }
             children.push(list_item);
+
+            let Some(next_item) = next_item else {
+                break;
+            };
+            if next_item.ordered != ordered || next_item.marker != marker {
+                // A different marker starts a new list at the block level.
+                break;
+            }
+            item = next_item;
         }
 
         let span = Span::new(start as u32, self.position as u32);
@@ -120,20 +112,22 @@ impl<'a> Parser<'a> {
     /// (paragraphs, nested blocks — the item sub-parser sorts them out),
     /// interior blank lines, and lazy paragraph continuation. Returns
     /// whether the item/list turned loose, the item end position, and the
-    /// dedented source when block re-parsing is needed.
+    /// dedented source when block re-parsing is needed. A parsed sibling is
+    /// carried back to the caller so its marker is not scanned twice.
     fn consume_item_continuation(
         &mut self,
         item: &ParsedListItem<'a>,
         baseline_indent: usize,
         consumed_newline: bool,
         lazy_lines: &mut rustc_hash::FxHashSet<u32>,
-    ) -> (bool, usize, Option<ox_content_allocator::String<'a>>) {
+    ) -> (bool, usize, Option<ox_content_allocator::String<'a>>, Option<ParsedListItem<'a>>) {
         profile_span_detail!("parser::list_item_continuation");
         let content_indent = item.content_indent;
         let item_is_empty = item.content.trim().is_empty();
         let mut item_source = None;
         let mut item_end = self.position;
         let mut gap_spread = false;
+        let mut next_item = None;
         // Lazy paragraph continuation is only valid while the item's last
         // consumed line kept a paragraph open (not right after blanks).
         let mut after_blank = false;
@@ -182,16 +176,17 @@ impl<'a> Parser<'a> {
                     continue;
                 }
 
-                if next_indent >= baseline_indent
-                    && next_indent <= baseline_indent + 3
-                    && self.parse_list_item_line(lookahead).as_ref().is_some_and(|next| {
-                        next.ordered == item.ordered && next.marker == item.marker
-                    })
-                {
-                    // Blank line between siblings: the list is loose.
-                    self.position = lookahead;
-                    gap_spread = true;
-                    break;
+                if next_indent >= baseline_indent && next_indent <= baseline_indent + 3 {
+                    if let Some(sibling) = self
+                        .parse_list_item_line(lookahead)
+                        .filter(|next| next.ordered == item.ordered && next.marker == item.marker)
+                    {
+                        // Blank line between siblings: the list is loose.
+                        self.position = lookahead;
+                        gap_spread = true;
+                        next_item = Some(sibling);
+                        break;
+                    }
                 }
 
                 break;
@@ -214,12 +209,16 @@ impl<'a> Parser<'a> {
 
             // A list marker (indented at most three columns past the
             // baseline — deeper "markers" are just text) ends this item.
-            if current_indent <= baseline_indent + 3
-                && self
-                    .parse_list_item_line_from_line(continuation_start, continuation_line)
-                    .is_some()
+            if current_indent >= baseline_indent
+                && current_indent <= baseline_indent + 3
+                && !Self::try_parse_thematic_break_line(continuation_line)
             {
-                break;
+                if let Some(sibling) =
+                    self.parse_list_item_line_from_line(continuation_start, continuation_line)
+                {
+                    next_item = Some(sibling);
+                    break;
+                }
             }
 
             // A block start interrupts the item; anything else lazily
@@ -243,7 +242,7 @@ impl<'a> Parser<'a> {
             item_end = self.position;
         }
 
-        (gap_spread, item_end, item_source)
+        (gap_spread, item_end, item_source, next_item)
     }
 }
 

--- a/crates/ox_content_parser/src/parser/tests.rs
+++ b/crates/ox_content_parser/src/parser/tests.rs
@@ -212,6 +212,45 @@ fn test_parse_unordered_list() {
 }
 
 #[test]
+fn multi_item_list_skips_the_two_slot_growth_step() {
+    let single_allocator = Allocator::new();
+    let single = Parser::new(&single_allocator, "- one").parse().unwrap();
+    let Node::List(single_list) = &single.children[0] else {
+        panic!("expected single-item list");
+    };
+    assert_eq!(single_list.children.capacity(), 1);
+
+    let pair_allocator = Allocator::new();
+    let pair = Parser::new(&pair_allocator, "- one\n- two").parse().unwrap();
+    let Node::List(pair_list) = &pair.children[0] else {
+        panic!("expected two-item list");
+    };
+    assert_eq!(pair_list.children.capacity(), 4);
+}
+
+#[test]
+fn outdented_marker_starts_a_new_list() {
+    let allocator = Allocator::new();
+    let doc = Parser::new(&allocator, "  - indented\n- outdented").parse().unwrap();
+
+    assert_eq!(doc.children.len(), 2);
+    assert!(doc
+        .children
+        .iter()
+        .all(|node| { matches!(node, Node::List(list) if list.children.len() == 1) }));
+}
+
+#[test]
+fn thematic_break_after_list_stays_a_block_boundary() {
+    let allocator = Allocator::new();
+    let doc = Parser::new(&allocator, "- item\n* * *").parse().unwrap();
+
+    assert_eq!(doc.children.len(), 2);
+    assert!(matches!(&doc.children[0], Node::List(list) if list.children.len() == 1));
+    assert!(matches!(&doc.children[1], Node::ThematicBreak(_)));
+}
+
+#[test]
 fn test_parse_ordered_list() {
     let allocator = Allocator::new();
     let list_md = "1. First\n2. Second\n3. Third";


### PR DESCRIPTION
## Summary

- carry the already parsed sibling marker out of list-item continuation instead of scanning every marker again in the outer loop
- bypass continuation scanning for a list item that ends at EOF and skip the two-slot Vec growth step once a second item is present
- add focused Criterion cases plus regressions for capacity growth, outdented markers, and thematic-break boundaries

## Performance

Criterion against a saved clean-main baseline, Rust 1.98.0:

- single-item list: 11.3% lower parse time, p = 0.00
- 32-item list: 8.0% lower parse time, p = 0.00

Both cases were rerun after the final implementation and reported Performance has improved.

## Validation

- cargo +1.98.0 fmt --all -- --check
- CARGO_INCREMENTAL=0 cargo +1.98.0 clippy --workspace --all-targets --all-features -- -D warnings
- CARGO_INCREMENTAL=0 cargo +1.98.0 test --workspace --all-features
- cargo +1.98.0 test -p ox_content_parser --all-features
- cargo +1.98.0 bench -p ox_content_parser --bench parser -- --baseline before-list-growth parse_lists

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789898233&installation_model_id=422833&pr_number=596&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F596&signature=f9901fdb3ed239a674ac870b5909a91fd8f3a53656a938a4816d7789a184f3a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown list parsing for continuation lines, nested indentation, blank lines, and thematic breaks.
  * Correctly separates list items when indentation changes.
  * Prevented list content from being incorrectly absorbed across thematic-break boundaries.

* **Performance**
  * Improved parsing efficiency for lists, especially longer lists.

* **Tests**
  * Added regression coverage for list boundary and capacity-handling scenarios.
  * Added benchmarks for parsing short and long Markdown lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->