### PR TITLE
perf(parser): reuse first list dispatch result

### DIFF
--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -38,7 +38,8 @@ impl<'a> Parser<'a> {
         // other block construct can begin on such a line. (This runs at
         // block level only — an indented line after an open paragraph is
         // lazy continuation, handled by `parse_paragraph`.)
-        if self.line_indent_width(start, trimmed_start) >= 4 {
+        let line_indent = self.line_indent_width(start, trimmed_start);
+        if line_indent >= 4 {
             return self.parse_indented_code(start);
         }
 
@@ -65,8 +66,10 @@ impl<'a> Parser<'a> {
                 if Self::try_parse_thematic_break_line(line) {
                     return self.parse_thematic_break(start);
                 }
-                if Self::try_parse_list_line(trimmed) {
-                    return self.parse_list(start);
+                if let Some(first_item) =
+                    self.parse_list_item_line_from_trimmed(start, line, trimmed)
+                {
+                    return self.parse_list(start, line_indent, first_item, line.len());
                 }
             }
             b'_' if Self::try_parse_thematic_break_line(self.line_at(start)) => {
@@ -96,8 +99,10 @@ impl<'a> Parser<'a> {
             b'+' | b'0'..=b'9' => {
                 let line = self.line_at(start);
                 let trimmed = &line[trimmed_start - start..];
-                if Self::try_parse_list_line(trimmed) {
-                    return self.parse_list(start);
+                if let Some(first_item) =
+                    self.parse_list_item_line_from_trimmed(start, line, trimmed)
+                {
+                    return self.parse_list(start, line_indent, first_item, line.len());
                 }
             }
             _ => {}

--- a/crates/ox_content_parser/src/parser/list.rs
+++ b/crates/ox_content_parser/src/parser/list.rs
@@ -10,15 +10,17 @@ use crate::{profile_span, profile_span_detail};
 mod item_source;
 
 impl<'a> Parser<'a> {
-    pub(super) fn parse_list(&mut self, start: usize) -> ParseResult<Option<Node<'a>>> {
+    pub(super) fn parse_list(
+        &mut self,
+        start: usize,
+        baseline_indent: usize,
+        first_item: ParsedListItem<'a>,
+        first_line_len: usize,
+    ) -> ParseResult<Option<Node<'a>>> {
         profile_span!("parser::parse_list");
-        let baseline_indent = self.calc_indentation(start);
 
-        // Determine list type from the first line (already verified by try_parse_list)
-        let first_line_start = self.position;
-        let Some(first_item) = self.parse_list_item_line(first_line_start) else {
-            return Ok(None);
-        };
+        // Block dispatch has already parsed the first marker to distinguish a
+        // real list from marker-shaped paragraph text. Reuse that result.
         let ordered = first_item.ordered;
         let marker = first_item.marker;
         let list_start = first_item.start;
@@ -26,13 +28,14 @@ impl<'a> Parser<'a> {
 
         let mut children: Vec<'a, ListItem<'a>> = self.allocator.new_vec();
         let mut list_spread = false;
+        let mut first_line_len = Some(first_line_len);
 
         loop {
             let line_start = self.position;
-            let line = self.line_at(line_start);
+            let line_len = first_line_len.take().unwrap_or_else(|| self.line_at(line_start).len());
 
             // Consume the marker line.
-            self.position += line.len();
+            self.position += line_len;
             let consumed_newline = self.peek() == Some('\n');
             if consumed_newline {
                 self.advance();

--- a/crates/ox_content_parser/src/parser/list.rs
+++ b/crates/ox_content_parser/src/parser/list.rs
@@ -212,14 +212,21 @@ impl<'a> Parser<'a> {
 
             // A list marker (indented at most three columns past the
             // baseline — deeper "markers" are just text) ends this item.
-            if current_indent >= baseline_indent
-                && current_indent <= baseline_indent + 3
-                && !Self::try_parse_thematic_break_line(continuation_line)
-            {
+            if current_indent >= baseline_indent && current_indent <= baseline_indent + 3 {
                 if let Some(sibling) =
                     self.parse_list_item_line_from_line(continuation_start, continuation_line)
                 {
-                    next_item = Some(sibling);
+                    // A thematic break can overlap list syntax only when an
+                    // unordered item's content starts with the same `-` or
+                    // `*` marker. All ordinary item text skips the full-line
+                    // marker scan that previously ran before every sibling.
+                    let could_be_thematic = !sibling.ordered
+                        && matches!(sibling.marker, b'-' | b'*')
+                        && sibling.content.as_bytes().first() == Some(&sibling.marker);
+                    if !could_be_thematic || !Self::try_parse_thematic_break_line(continuation_line)
+                    {
+                        next_item = Some(sibling);
+                    }
                     break;
                 }
             }

--- a/crates/ox_content_parser/src/parser/list_item.rs
+++ b/crates/ox_content_parser/src/parser/list_item.rs
@@ -103,8 +103,17 @@ impl<'a> Parser<'a> {
         line_start: usize,
         line: &'a str,
     ) -> Option<ParsedListItem<'a>> {
-        profile_span_detail!("parser::list_item_line");
         let trimmed = line.trim_start();
+        self.parse_list_item_line_from_trimmed(line_start, line, trimmed)
+    }
+
+    pub(super) fn parse_list_item_line_from_trimmed(
+        &self,
+        line_start: usize,
+        line: &'a str,
+        trimmed: &'a str,
+    ) -> Option<ParsedListItem<'a>> {
+        profile_span_detail!("parser::list_item_line");
         let trimmed_offset = line_start + (line.len() - trimmed.len());
         let bytes = trimmed.as_bytes();
 

--- a/crates/ox_content_parser/src/parser/tests.rs
+++ b/crates/ox_content_parser/src/parser/tests.rs
@@ -257,12 +257,14 @@ fn outdented_marker_starts_a_new_list() {
 
 #[test]
 fn thematic_break_after_list_stays_a_block_boundary() {
-    let allocator = Allocator::new();
-    let doc = Parser::new(&allocator, "- item\n* * *").parse().unwrap();
+    for source in ["- item\n* * *", "- item\n- - -", "* item\n*  *  *"] {
+        let allocator = Allocator::new();
+        let doc = Parser::new(&allocator, source).parse().unwrap();
 
-    assert_eq!(doc.children.len(), 2);
-    assert!(matches!(&doc.children[0], Node::List(list) if list.children.len() == 1));
-    assert!(matches!(&doc.children[1], Node::ThematicBreak(_)));
+        assert_eq!(doc.children.len(), 2, "source: {source:?}");
+        assert!(matches!(&doc.children[0], Node::List(list) if list.children.len() == 1));
+        assert!(matches!(&doc.children[1], Node::ThematicBreak(_)));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- carry the block dispatcher's already-computed indentation into list parsing
- reuse the fully parsed first list marker instead of recognizing and parsing it twice
- reuse the first line length and already-trimmed slice instead of scanning them again

## Performance

Fixed-iteration A/B measurements used process user CPU time because unrelated Playwright workloads made wall time unstable:

- 50,000,000 single-item parses: 4.095 s -> 3.550 s mean user CPU time (**-13.3%**)
- 3,000,000 32-item parses: 4.615 s -> 4.555 s mean user CPU time (**-1.3%**)

The larger corpus sees the expected smaller percentage because this slice removes work once per list, not once per sibling.

## Validation

- `cargo fmt --all -- --check`
- `cargo +1.98.0 clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo +1.98.0 test --workspace --all-features`
- parent PR #596: all checks green, including its benchmark rerun

## Stack

This PR is intentionally based on #596 because it optimizes the first-item handoff into the sibling-reuse loop introduced there. Keeping it stacked makes this diff independently reviewable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789901765&installation_model_id=422833&pr_number=599&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F599&signature=f53eed6b4a56971553ef003a2fafc8aca34c6fea127ecc919ee85ffbeb7829e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->