### PR TITLE
perf(parser): gate sibling thematic scans

### DIFF
--- a/crates/ox_content_parser/src/parser/list.rs
+++ b/crates/ox_content_parser/src/parser/list.rs
@@ -212,14 +212,21 @@ impl<'a> Parser<'a> {
 
             // A list marker (indented at most three columns past the
             // baseline — deeper "markers" are just text) ends this item.
-            if current_indent >= baseline_indent
-                && current_indent <= baseline_indent + 3
-                && !Self::try_parse_thematic_break_line(continuation_line)
-            {
+            if current_indent >= baseline_indent && current_indent <= baseline_indent + 3 {
                 if let Some(sibling) =
                     self.parse_list_item_line_from_line(continuation_start, continuation_line)
                 {
-                    next_item = Some(sibling);
+                    // A thematic break can overlap list syntax only when an
+                    // unordered item's content starts with the same `-` or
+                    // `*` marker. All ordinary item text skips the full-line
+                    // marker scan that previously ran before every sibling.
+                    let could_be_thematic = !sibling.ordered
+                        && matches!(sibling.marker, b'-' | b'*')
+                        && sibling.content.as_bytes().first() == Some(&sibling.marker);
+                    if !could_be_thematic || !Self::try_parse_thematic_break_line(continuation_line)
+                    {
+                        next_item = Some(sibling);
+                    }
                     break;
                 }
             }

--- a/crates/ox_content_parser/src/parser/tests.rs
+++ b/crates/ox_content_parser/src/parser/tests.rs
@@ -242,12 +242,14 @@ fn outdented_marker_starts_a_new_list() {
 
 #[test]
 fn thematic_break_after_list_stays_a_block_boundary() {
-    let allocator = Allocator::new();
-    let doc = Parser::new(&allocator, "- item\n* * *").parse().unwrap();
+    for source in ["- item\n* * *", "- item\n- - -", "* item\n*  *  *"] {
+        let allocator = Allocator::new();
+        let doc = Parser::new(&allocator, source).parse().unwrap();
 
-    assert_eq!(doc.children.len(), 2);
-    assert!(matches!(&doc.children[0], Node::List(list) if list.children.len() == 1));
-    assert!(matches!(&doc.children[1], Node::ThematicBreak(_)));
+        assert_eq!(doc.children.len(), 2, "source: {source:?}");
+        assert!(matches!(&doc.children[0], Node::List(list) if list.children.len() == 1));
+        assert!(matches!(&doc.children[1], Node::ThematicBreak(_)));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- parse a possible sibling before paying for a full thematic-break scan
- run that scan only for unordered `-` / `*` items whose content can actually complete a thematic break
- extend the precedence regression across same-marker, different-marker, and extra-spacing cases

## Performance

Fixed-iteration A/B measurements used process user CPU time to isolate the benchmark from unrelated machine load:

- 3,000,000 parses of a 32-item list: 4.360 s -> 3.965 s mean user CPU time (**-9.1%**)
- 50,000,000 single-item parses: 4.220 s -> 4.220 s (**neutral**)

The result matches the intended scope: sibling-heavy lists improve while single-item lists do not move.

## Validation

- `cargo fmt --all -- --check`
- `cargo +1.98.0 clippy -p ox_content_parser --all-targets --all-features -- -D warnings`
- `cargo +1.98.0 test -p ox_content_parser --all-features`

## Stack

This PR is intentionally based on #599 so the sibling scan change stays independently reviewable from the first-item handoff optimization.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789902444&installation_model_id=422833&pr_number=600&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F600&signature=361c89527cc2887761fc987e763f471e97026eac6f426f9e2727620c6cbd8cfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->