### PR TITLE
fix(renderer): stop rewriting other origins' .md URLs

### DIFF
--- a/crates/ox_content_renderer/src/html/renderer/links.rs
+++ b/crates/ox_content_renderer/src/html/renderer/links.rs
@@ -105,27 +105,29 @@ impl HtmlRenderer {
     /// Converts a Markdown URL to an `.html` URL for SSG output.
     pub(in crate::html::renderer) fn convert_md_url(&self, url: &str) -> Option<String> {
         crate::profile_span_detail!("renderer::convert_md_url");
-        // Split URL into path and fragment
-        let (path, fragment) = match url.split_once('#') {
-            Some((p, f)) => (p, Some(f)),
-            None => (url, None),
-        };
+        // A URL is not a filesystem path. Split the query and fragment off
+        // before looking at the extension so `./guide.md?plain=1` is still
+        // recognized as Markdown, and so whatever follows the path is carried
+        // through the rewrite untouched.
+        let suffix_start = url.find(['?', '#']).unwrap_or(url.len());
+        let (path, suffix) = url.split_at(suffix_start);
 
-        let markdown_extension =
-            std::path::Path::new(path).extension().and_then(|ext| ext.to_str()).filter(|ext| {
-                ext.eq_ignore_ascii_case("md")
-                    || ext.eq_ignore_ascii_case("mdx")
-                    || ext.eq_ignore_ascii_case("markdown")
-            });
-
-        let markdown_extension = markdown_extension?;
+        let markdown_extension_len = markdown_extension_len(path)?;
 
         if !self.options.convert_md_links {
             return None;
         }
 
+        // Another origin's `.md` is not a page this build generates, so there
+        // is no `index.html` route to point it at. Leaving it alone also keeps
+        // it recognizable as external further down `render_link`, which is
+        // what adds `target="_blank" rel="noopener noreferrer"`.
+        if is_non_local_url(path) {
+            return None;
+        }
+
         // Remove the Markdown extension, including the leading dot.
-        let path_without_ext = &path[..path.len() - markdown_extension.len() - 1];
+        let path_without_ext = &path[..path.len() - markdown_extension_len - 1];
 
         // Check if the source file is an index file
         // index.md stays at the directory level, so relative paths work differently
@@ -223,11 +225,8 @@ impl HtmlRenderer {
             }
         };
 
-        // Reattach fragment if present
-        Some(match fragment {
-            Some(f) => append_fragment(converted, f),
-            None => converted,
-        })
+        // Reattach the query and/or fragment if there was one.
+        Some(if suffix.is_empty() { converted } else { append_suffix(converted, suffix) })
     }
 
     /// Checks if the source file is an index file (index.md).
@@ -255,9 +254,63 @@ fn join3(a: &str, b: &str, c: &str) -> String {
     out
 }
 
-fn append_fragment(mut converted: String, fragment: &str) -> String {
-    converted.reserve(1 + fragment.len());
-    converted.push('#');
-    converted.push_str(fragment);
+fn append_suffix(mut converted: String, suffix: &str) -> String {
+    converted.reserve(suffix.len());
+    converted.push_str(suffix);
     converted
+}
+
+/// Returns the length of the trailing Markdown extension of `path`, if it has
+/// one.
+///
+/// This deliberately does not go through `std::path::Path`: a URL only ever
+/// separates segments with `/`, and on Windows `Path` would also split on `\`
+/// and read a drive letter, so the same href would convert differently
+/// depending on the build host.
+fn markdown_extension_len(path: &str) -> Option<usize> {
+    let file_name = match path.rfind('/') {
+        Some(slash) => &path[slash + 1..],
+        None => path,
+    };
+    let dot = file_name.rfind('.')?;
+    // A leading dot names a hidden file rather than an extension, matching
+    // what `Path::extension` reports for `.md`.
+    if dot == 0 {
+        return None;
+    }
+
+    let extension = &file_name[dot + 1..];
+    (extension.eq_ignore_ascii_case("md")
+        || extension.eq_ignore_ascii_case("mdx")
+        || extension.eq_ignore_ascii_case("markdown"))
+    .then_some(extension.len())
+}
+
+/// Reports whether `path` addresses another origin, either through a URI
+/// scheme (`https:`, `mailto:`) or as a protocol-relative URL (`//cdn.test`).
+///
+/// `path` must already have had its query and fragment removed, so a `:` or
+/// `//` appearing only in those parts cannot be mistaken for a scheme.
+fn is_non_local_url(path: &str) -> bool {
+    if path.starts_with("//") {
+        return true;
+    }
+
+    let mut chars = path.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_alphabetic() {
+        return false;
+    }
+
+    for ch in chars {
+        if ch == ':' {
+            return true;
+        }
+        if !(ch.is_ascii_alphanumeric() || matches!(ch, '+' | '.' | '-')) {
+            return false;
+        }
+    }
+    false
 }

--- a/crates/ox_content_renderer/tests/edge_links.rs
+++ b/crates/ox_content_renderer/tests/edge_links.rs
@@ -88,3 +88,47 @@ fn xhtml_images_self_close() {
 
     insta::assert_snapshot!(html);
 }
+
+#[test]
+fn markdown_urls_on_another_origin_are_left_alone() {
+    // A `.md` on another origin is not a page this build generates, so there
+    // is no `index.html` route to rewrite it to. It must stay verbatim — and
+    // stay recognizable as external, so it still gets the security attributes.
+    let html = render(
+        concat!(
+            "[abs](https://ex.com/docs/guide.md)\n\n",
+            "[proto](//cdn.example/docs/x.md)\n\n",
+            "[mail](mailto:a@b.com/x.md)\n\n",
+            "[upper](https://ex.com/docs/GUIDE.MD)\n\n",
+            "![alt](https://ex.com/d/g.md)\n\n",
+            "<a href=\"https://ex.com/docs/guide.md\">raw</a>\n",
+        ),
+        ParserOptions::default(),
+        HtmlRendererOptions {
+            convert_md_links: true,
+            base_url: "/".to_string(),
+            source_path: "content/blog/post.md".to_string(),
+            ..Default::default()
+        },
+    );
+
+    insta::assert_snapshot!(html);
+}
+
+#[test]
+fn local_markdown_urls_convert_around_query_and_fragment() {
+    // The extension lives in the path, not in the query string, so a local
+    // link still routes to its generated page and carries its suffix along.
+    let html = render(
+        "[q](./other.md?tab=2) [both](./other.md?tab=2#anchor) [frag](./other.md#anchor)",
+        ParserOptions::default(),
+        HtmlRendererOptions {
+            convert_md_links: true,
+            base_url: "/".to_string(),
+            source_path: "api/index.md".to_string(),
+            ..Default::default()
+        },
+    );
+
+    insta::assert_snapshot!(html);
+}

--- a/crates/ox_content_renderer/tests/snapshots/edge_links__local_markdown_urls_convert_around_query_and_fragment.snap
+++ b/crates/ox_content_renderer/tests/snapshots/edge_links__local_markdown_urls_convert_around_query_and_fragment.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ox_content_renderer/tests/edge_links.rs
+expression: html
+---
+<p><a href="./other/index.html?tab=2">q</a> <a href="./other/index.html?tab=2#anchor">both</a> <a href="./other/index.html#anchor">frag</a></p>

--- a/crates/ox_content_renderer/tests/snapshots/edge_links__markdown_urls_on_another_origin_are_left_alone.snap
+++ b/crates/ox_content_renderer/tests/snapshots/edge_links__markdown_urls_on_another_origin_are_left_alone.snap
@@ -1,0 +1,10 @@
+---
+source: crates/ox_content_renderer/tests/edge_links.rs
+expression: html
+---
+<p><a href="https://ex.com/docs/guide.md" target="_blank" rel="noopener noreferrer">abs</a></p>
+<p><a href="//cdn.example/docs/x.md">proto</a></p>
+<p><a href="mailto:a@b.com/x.md">mail</a></p>
+<p><a href="https://ex.com/docs/GUIDE.MD" target="_blank" rel="noopener noreferrer">upper</a></p>
+<p><img src="https://ex.com/d/g.md" alt="alt"></p>
+<p><a href="https://ex.com/docs/guide.md">raw</a></p>


### PR DESCRIPTION
Fixes #598

## Summary

`convert_md_url` read the extension with `std::path::Path` and then dispatched purely on the **shape** of the path (`/`, `./`, `../`, else). An absolute URL matches none of those, so it fell through to the plain-relative branch:

| input | before | after |
| --- | --- | --- |
| `[x](https://ex.com/docs/guide.md)` | `../https://ex.com/docs/guide/index.html` | unchanged |
| `[x](//cdn.example/docs/x.md)` | `//cdn.example/docs/x/index.html` | unchanged |
| `[x](mailto:a@b.com/x.md)` | `../mailto:a@b.com/x/index.html` | unchanged |
| `[x](https://ex.com/docs/GUIDE.MD)` | `../https://ex.com/docs/GUIDE/index.html` | unchanged |
| `![alt](https://ex.com/d/g.md)` | `<img src="../https://ex.com/d/g/index.html">` | unchanged |

`render_link` checks for an external URL *after* the rewrite, so the mangled href also silently lost `target="_blank" rel="noopener noreferrer"`. That is restored.

Since v2.77.0 (`0d12fc0`) `rewrite_html_root_urls` routes raw HTML `href`/`src` through the same helper, so raw anchors, images and scripts were affected too.

## Changes

- **Guard on non-local URLs.** After the (cheap) extension filter, bail out for a URI scheme or a protocol-relative `//` prefix. Another origin's `.md` is not a page this build generates, so there is no `index.html` route to point it at. This matches `ox_content_ssg/src/routes/sidebar.rs` (`has_uri_scheme`), `ox_content_ssg/src/routes/manual.rs` (`is_external_href`) and `ox_content_link_checker`, which already classify the same string as external.
- **Stop treating a URL as a filesystem path.** Split the query and fragment off before looking at the extension, the way `apply_base_to_root_absolute_url` already does. Two consequences:
  - `./other.md?tab=2` is now recognized as Markdown and converts to `./other/index.html?tab=2`; it was previously left alone because `Path::extension()` returned `md?tab=2`.
  - The scheme guard cannot be fooled by a `:` or `//` that appears only in the query or fragment.
- **Drop `std::path::Path` from the extension check.** A URL only separates segments with `/`; on Windows `Path` also splits on `\` and reads a drive letter, so the same href could convert differently depending on the build host. The replacement keeps `Path::extension()`'s hidden-file rule (a leading `.` is not an extension) and the existing case-insensitive `md` / `mdx` / `markdown` match.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- Two new regression tests in `crates/ox_content_renderer/tests/edge_links.rs` covering every input from the issue table (Markdown links, images and raw HTML anchors) plus query/fragment round-tripping. No existing snapshot changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790004895&installation_model_id=422833&pr_number=603&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F603&signature=84aeb4d27564dbb52d61ecf547c73950561df9d7b51acd20ddcc4175579c3376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->