### PR TITLE
fix(vite-plugin): generate OG images in bare mode

### DIFF
--- a/docs/content/built-in/site-generation.md
+++ b/docs/content/built-in/site-generation.md
@@ -96,6 +96,10 @@ generated image looks like this:
 | `cache`          | `true`   | Skip re-rendering unchanged pages.                    |
 | `concurrency`    | `1`      | Parallel image renders.                               |
 
+Under `bare`, the images are still generated, but nothing references them —
+bare output has no `<head>` for the `<meta>` tags, so inject them from your own
+shell. Each page's image lands next to its HTML, under the page's own route.
+
 During dev, `/__og-viewer` previews every page's Open Graph metadata and
 image (the `ogViewer` option, on by default):
 

--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -11,7 +11,9 @@ import {
   getUrlPath,
   resolveNavigationGroups,
   resolveSsgOptions,
+  shouldGenerateOgImages,
 } from "./ssg";
+import type { ResolvedOptions } from "./types";
 
 describe("resolveSsgOptions", () => {
   it("disables git timestamps by default", () => {
@@ -20,6 +22,46 @@ describe("resolveSsgOptions", () => {
 
   it("enables git timestamps when requested", () => {
     expect(resolveSsgOptions({ lastUpdated: true }).lastUpdated).toBe(true);
+  });
+});
+
+describe("shouldGenerateOgImages", () => {
+  const optionsWith = (
+    ogImage: boolean,
+    ssg: { bare: boolean; generateOgImage: boolean },
+  ): ResolvedOptions =>
+    ({
+      ogImage,
+      ssg: { ...resolveSsgOptions(true), ...ssg },
+    }) as unknown as ResolvedOptions;
+
+  it("stays off when neither switch is set", () => {
+    expect(
+      shouldGenerateOgImages(optionsWith(false, { bare: false, generateOgImage: false })),
+    ).toBe(false);
+  });
+
+  it("follows the top-level ogImage switch", () => {
+    expect(shouldGenerateOgImages(optionsWith(true, { bare: false, generateOgImage: false }))).toBe(
+      true,
+    );
+  });
+
+  it("follows ssg.generateOgImage", () => {
+    expect(shouldGenerateOgImages(optionsWith(false, { bare: false, generateOgImage: true }))).toBe(
+      true,
+    );
+  });
+
+  it("still generates images in bare mode", () => {
+    // Bare mode brings its own shell, which is exactly when per-page OG
+    // images are wanted; only the `<meta>` injection is the consumer's job.
+    expect(shouldGenerateOgImages(optionsWith(false, { bare: true, generateOgImage: true }))).toBe(
+      true,
+    );
+    expect(shouldGenerateOgImages(optionsWith(true, { bare: true, generateOgImage: false }))).toBe(
+      true,
+    );
   });
 });
 

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -588,9 +588,22 @@ async function createBuildSsgContext(
     base,
     navItems,
     siteName: await resolveSiteName(root, ssgOptions),
-    shouldGenerateOgImages: (options.ogImage || ssgOptions.generateOgImage) && !ssgOptions.bare,
+    shouldGenerateOgImages: shouldGenerateOgImages(options),
     napi: ssgOptions.lastUpdated ? await importNapiModule() : undefined,
   };
+}
+
+/**
+ * Whether this build emits one Open Graph image per page.
+ *
+ * `ssg.bare` deliberately does not turn this off. Bare mode only drops the
+ * generated page shell, and bringing your own shell is exactly the case where
+ * per-page OG images are still wanted — the images are written to the output
+ * tree and the consumer injects the `<meta>` tags itself. Nothing in the bare
+ * HTML references them, because bare output has no `<head>` to put them in.
+ */
+export function shouldGenerateOgImages(options: ResolvedOptions): boolean {
+  return options.ogImage || options.ssg.generateOgImage;
 }
 
 async function resolveSiteName(root: string, ssgOptions: ResolvedSsgOptions): Promise<string> {

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -223,6 +223,10 @@ export interface SsgOptions {
    * each page's metadata. Configure rendering details with the top-level
    * `ogImageOptions` option.
    *
+   * Under `bare`, the images are still written but nothing references them,
+   * because bare output has no `<head>` to put the `<meta>` tags in — inject
+   * them from your own shell.
+   *
    * @default false
    */
   generateOgImage?: boolean;


### PR DESCRIPTION
Fixes #602

## Summary

`shouldGenerateOgImages` was:

```js
(options.ogImage || ssgOptions.generateOgImage) && !ssgOptions.bare
```

so setting both `ssg.bare` and `ssg.generateOgImage` produced no images and no warning — `collectOgImageEntry()` and `generateOgImageAssets()` both returned early on the flag.

Bare mode only drops the generated page shell. Bringing your own shell is exactly the case where per-page OG images are still wanted, so the images are now written either way, and injecting the `<meta>` tags stays the consumer's job — bare output has no `<head>` to put them in.

Route paths already resolve `ogImagePath` / `ogImageUrl` independently of `bare` (`resolveSsgRoutePaths` never looks at it), so nothing else in the pipeline changes. Non-bare builds are unaffected: they still reference the generated image from the page metadata.

## Changes

- Drop the `bare` term from the predicate and move it into a named `shouldGenerateOgImages()`, so the rule is testable without standing up a full build.
- Document the combination on `SsgOptions.generateOgImage` and in `docs/content/built-in/site-generation.md`, since "images written but nothing references them" is worth stating explicitly.

## Validation

- `vp test src` — 199 passing, including four new cases covering both switches and the bare combination.
- `vp run typecheck`, `vp check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790005796&installation_model_id=422833&pr_number=605&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F605&signature=5be956abed2daae66aecb4e3bc621c290ef772adfb777a0802e15b281e93e122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->