### PR TITLE
perf(ast): stop walking the arena AST to drop it

### DIFF
--- a/crates/ox_content_allocator/src/lib.rs
+++ b/crates/ox_content_allocator/src/lib.rs
@@ -135,7 +135,93 @@ impl Deref for Allocator {
 pub type Box<'a, T> = bumpalo::boxed::Box<'a, T>;
 
 /// A vector allocated in an arena.
-pub type Vec<'a, T> = bumpalo::collections::Vec<'a, T>;
+///
+/// Unlike [`bumpalo::collections::Vec`], this deliberately does **not** run its
+/// elements' destructors. Everything it holds lives in the same arena, so the
+/// `Bump` reclaims all of it at once; dropping the root of a parsed AST
+/// normally would still walk every node in the tree to run empty drop glue,
+/// which measured ~4% of a parse-and-render over the bundled corpora.
+///
+/// **Every element type must own nothing outside the arena.** Nothing here can
+/// enforce that generically — a `needs_drop::<T>()` assertion in a generic
+/// constructor is never forced — so each crate that stores a type in one of
+/// these asserts it concretely instead. See `ox_content_ast`'s
+/// `AST_IS_ARENA_ONLY` for the AST's.
+#[repr(transparent)]
+pub struct Vec<'a, T>(std::mem::ManuallyDrop<bumpalo::collections::Vec<'a, T>>);
+
+impl<'a, T> Vec<'a, T> {
+    /// Constructs a new, empty vector in `bump`.
+    pub fn new_in(bump: &'a Bump) -> Self {
+        Self(std::mem::ManuallyDrop::new(bumpalo::collections::Vec::new_in(bump)))
+    }
+
+    /// Constructs a new, empty vector in `bump` with room for `capacity`
+    /// elements.
+    pub fn with_capacity_in(capacity: usize, bump: &'a Bump) -> Self {
+        Self(std::mem::ManuallyDrop::new(bumpalo::collections::Vec::with_capacity_in(
+            capacity, bump,
+        )))
+    }
+
+    /// Returns the elements as an arena slice, consuming the vector.
+    pub fn into_bump_slice(self) -> &'a [T] {
+        std::mem::ManuallyDrop::into_inner(self.0).into_bump_slice()
+    }
+}
+
+impl<'a, T> std::ops::Deref for Vec<'a, T> {
+    type Target = bumpalo::collections::Vec<'a, T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> std::ops::DerefMut for Vec<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for Vec<'_, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T: PartialEq> PartialEq for Vec<'_, T> {
+    fn eq(&self, other: &Self) -> bool {
+        **self == **other
+    }
+}
+
+impl<'a, T> IntoIterator for Vec<'a, T> {
+    type Item = T;
+    type IntoIter = bumpalo::collections::vec::IntoIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        std::mem::ManuallyDrop::into_inner(self.0).into_iter()
+    }
+}
+
+impl<'v, T> IntoIterator for &'v Vec<'_, T> {
+    type Item = &'v T;
+    type IntoIter = std::slice::Iter<'v, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'v, T> IntoIterator for &'v mut Vec<'_, T> {
+    type Item = &'v mut T;
+    type IntoIter = std::slice::IterMut<'v, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
 
 /// A string allocated in an arena.
 pub type String<'a> = bumpalo::collections::String<'a>;

--- a/crates/ox_content_ast/src/ast.rs
+++ b/crates/ox_content_ast/src/ast.rs
@@ -7,21 +7,6 @@ use ox_content_allocator::Vec;
 
 use crate::Span;
 
-/// The AST must own nothing outside the arena.
-///
-/// [`ox_content_allocator::Vec`] never runs its elements' destructors, so a
-/// field that owned heap memory — a `std::string::String`, a `Box`, an `Rc` —
-/// would leak it on every parse instead of being reclaimed with the `Bump`.
-/// Every field below is either `Copy` or another arena vector, which is what
-/// makes that safe, and this is where that stops being a convention: adding a
-/// heap-owning field to any node makes `Node` need dropping and fails the
-/// build here.
-const AST_IS_ARENA_ONLY: () = {
-    assert!(!std::mem::needs_drop::<Node<'static>>());
-    assert!(!std::mem::needs_drop::<Document<'static>>());
-};
-const _: () = AST_IS_ARENA_ONLY;
-
 /// Root node of a Markdown document.
 #[derive(Debug)]
 pub struct Document<'a> {

--- a/crates/ox_content_ast/src/ast.rs
+++ b/crates/ox_content_ast/src/ast.rs
@@ -7,6 +7,21 @@ use ox_content_allocator::Vec;
 
 use crate::Span;
 
+/// The AST must own nothing outside the arena.
+///
+/// [`ox_content_allocator::Vec`] never runs its elements' destructors, so a
+/// field that owned heap memory — a `std::string::String`, a `Box`, an `Rc` —
+/// would leak it on every parse instead of being reclaimed with the `Bump`.
+/// Every field below is either `Copy` or another arena vector, which is what
+/// makes that safe, and this is where that stops being a convention: adding a
+/// heap-owning field to any node makes `Node` need dropping and fails the
+/// build here.
+const AST_IS_ARENA_ONLY: () = {
+    assert!(!std::mem::needs_drop::<Node<'static>>());
+    assert!(!std::mem::needs_drop::<Document<'static>>());
+};
+const _: () = AST_IS_ARENA_ONLY;
+
 /// Root node of a Markdown document.
 #[derive(Debug)]
 pub struct Document<'a> {

--- a/crates/ox_content_ast/src/lib.rs
+++ b/crates/ox_content_ast/src/lib.rs
@@ -13,3 +13,20 @@ mod visit;
 pub use ast::*;
 pub use span::*;
 pub use visit::*;
+
+/// The AST must own nothing outside the arena.
+///
+/// [`ox_content_allocator::Vec`] never runs its elements' destructors, which
+/// is what keeps dropping a parsed document from walking the whole tree. A
+/// field that owned heap memory — a `std::string::String`, a `Box`, an `Rc` —
+/// would therefore leak it on every parse instead of being reclaimed with the
+/// `Bump`. Every field in [`Node`] is either `Copy` or another arena vector,
+/// and this is where that stops being a convention: giving any node a
+/// heap-owning field makes `Node` need dropping and fails the build here.
+///
+/// The check has to name concrete types. Written generically inside
+/// `Vec::new_in` it is simply never forced, so it would pass while leaking.
+const _AST_IS_ARENA_ONLY: () = {
+    assert!(!std::mem::needs_drop::<Node<'static>>());
+    assert!(!std::mem::needs_drop::<Document<'static>>());
+};


### PR DESCRIPTION
## Summary

Dropping a parsed `Document` walked every node in the tree to run drop glue that does nothing. `bumpalo::collections::Vec` runs its elements' destructors, and every AST node holds one or more of them, so the drop recursed the whole tree — even though the `Bump` reclaims all of that memory in one go.

The sampling profile put `core::ptr::drop_in_place<ox_content_ast::Node>` at ~4% of self time, and `std::mem::forget`ing the document confirmed it independently before any code changed.

## Why it is safe

Every field in `crates/ox_content_ast/src/ast.rs` is either `Copy` — `Span`, `bool`, `u8`, `&'a str`, `Option<&'a str>`, `Option<u32>`, `Option<bool>` — or another arena vector. Nothing in the tree owns memory outside the arena, so none of those destructors has anything to do.

## Changes

- **`ox_content_allocator::Vec` becomes a `#[repr(transparent)]` newtype** over `ManuallyDrop<bumpalo::collections::Vec>`. Because the newtype has no `Drop`, `Node` stops needing drop at all — the recursion disappears rather than being skipped at the root, which also covers the intermediate vectors sub-parsers build.
- **No caller changed.** `Deref`/`DerefMut` cover every borrowing method, and `IntoIterator` for owned/`&`/`&mut` covers the rest. `into_bump_slice` is forwarded explicitly because `Deref` cannot carry a by-value method. The whole workspace compiles untouched — that was the check on whether this newtype is a drop-in.
- **The invariant is now compiler-checked.** `_AST_IS_ARENA_ONLY` in `ox_content_ast/src/lib.rs` asserts `!needs_drop::<Node>()` and `!needs_drop::<Document>()`, so adding a `String`, `Box` or `Rc` field to any node fails the build with that assertion instead of leaking on every parse. Verified by adding such a field and watching it fail.

  The assertion has to be concrete. The same check written generically inside `Vec::new_in` — as an inline `const {}` block, inside a nested `const fn`, and as a read associated `const` — never fires; a deliberate `Vec<'_, String>` compiled clean under all three. That is why it lives in `ox_content_ast` against the real types. It sits in `lib.rs` rather than `ast.rs` only because `ast.rs` was 347 of the repo's 350 allowed lines.

## Measurements

Prebuilt binaries run alternately (never rebuilt between halves), min of five runs each, `ox-content-profile --gfm --iters 80 --warmup 15`:

| corpus | parse | pipeline |
| --- | --- | --- |
| typescript-handbook | **-4.7%** | -3.6% |
| rust-book | **-3.8%** | -2.0% |
| vue-docs | **-4.1%** | -2.0% |
| vite-docs | **-4.7%** | -2.7% |

The pipeline number is smaller because rendering does not drop anything.

## Validation

- `cargo test --workspace --all-features` — all green, including the CommonMark and GFM conformance suites
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- Rendered output byte-identical on all four corpora, with and without `--gfm`

## One thing to flag

`ox_content_allocator::Vec` goes from a type alias to a newtype. Source-compatible for everything in this workspace and for anything that only *uses* an AST (the `Deref` impls make reads and pushes transparent), but a published consumer that names `bumpalo::collections::Vec<'a, Node<'a>>` explicitly — or constructs AST nodes with one — would need to switch to `ox_content_allocator::Vec`. Worth deciding whether that warrants a major bump rather than the usual minor.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790008400&installation_model_id=422833&pr_number=606&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F606&signature=99b6f5d35fe04c637819e91ee33d09f21ab8a46666913c5d2055f30d0bbae8be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory cleanup behavior for arena-allocated content and AST data.
  * Added safeguards ensuring stored content does not unexpectedly release external resources.

* **Documentation**
  * Clarified ownership requirements for arena-allocated AST nodes.
  * Added validation for safe cleanup behavior of long-lived AST and document values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->