### PR TITLE
perf(renderer): copy short escape runs without memmove

### DIFF
--- a/crates/ox_content_renderer/src/html/escape.rs
+++ b/crates/ox_content_renderer/src/html/escape.rs
@@ -166,6 +166,51 @@ fn first_flagged(
     i
 }
 
+/// Appends `src` to `out`, copying short runs inline instead of handing them
+/// to `memmove`.
+///
+/// Half of the byte runs this module copies are under 16 bytes long — text
+/// nodes are short, and every escape replacement is 5 bytes or fewer. At that
+/// size libc's `memmove` spends most of its time picking a strategy, and
+/// `push_str` cannot avoid it: any length the compiler cannot see lowers to a
+/// `memcpy` call. Two overlapping loads and stores cover every run up to 16
+/// bytes with no length-dependent branching inside the copy.
+#[allow(unsafe_code)]
+#[inline]
+fn push_run(out: &mut String, src: &str) {
+    let len = src.len();
+    if len > 16 {
+        out.push_str(src);
+        return;
+    }
+    out.reserve(len);
+
+    // SAFETY: `reserve` above guarantees `len` spare bytes past the current
+    // length, and every write below lands inside `[0, len)` of that spare
+    // region, so `set_len` covers exactly the bytes written. `src` is a `&str`
+    // appended at the end of `out`, which is a char boundary, so the result
+    // stays valid UTF-8. The two pointers cannot overlap: `out` is borrowed
+    // uniquely, so no live `&str` can alias its buffer.
+    unsafe {
+        let vec = out.as_mut_vec();
+        let at = vec.len();
+        let dst = vec.as_mut_ptr().add(at);
+        let src = src.as_ptr();
+        if len >= 8 {
+            std::ptr::copy_nonoverlapping(src, dst, 8);
+            std::ptr::copy_nonoverlapping(src.add(len - 8), dst.add(len - 8), 8);
+        } else if len >= 4 {
+            std::ptr::copy_nonoverlapping(src, dst, 4);
+            std::ptr::copy_nonoverlapping(src.add(len - 4), dst.add(len - 4), 4);
+        } else if len > 0 {
+            *dst = *src;
+            *dst.add(len / 2) = *src.add(len / 2);
+            *dst.add(len - 1) = *src.add(len - 1);
+        }
+        vec.set_len(at + len);
+    }
+}
+
 /// Shared scan/copy loop for both escapers.
 ///
 /// `mask_of` proves a whole 8-byte word clean in one test; when a word is
@@ -191,14 +236,14 @@ fn escape_into(
             break;
         }
         if start < i {
-            out.push_str(&s[start..i]);
+            push_run(out, &s[start..i]);
         }
-        out.push_str(table[bytes[i] as usize]);
+        push_run(out, table[bytes[i] as usize]);
         start = i + 1;
     }
 
     if start < bytes.len() {
-        out.push_str(&s[start..]);
+        push_run(out, &s[start..]);
     }
 }
 

--- a/crates/ox_content_renderer/src/html/escape/tests.rs
+++ b/crates/ox_content_renderer/src/html/escape/tests.rs
@@ -136,3 +136,34 @@ fn matches_reference_on_multibyte_utf8() {
     check("emoji 🎉 and <tags> mixed");
     check("café & naïve — \"quoted\"");
 }
+
+#[test]
+fn matches_reference_across_the_short_run_copy_boundaries() {
+    // `push_run` copies runs of 16 bytes or fewer with overlapping loads
+    // instead of `memmove`, switching strategy at 1, 4, 8 and 16 bytes. A
+    // run is the gap between two escapes, so bracketing a plain run of
+    // every length puts each of those boundaries through the mid-loop copy,
+    // the leading copy and the trailing copy in turn.
+    for len in 0..=40usize {
+        let run = "x".repeat(len);
+        check(&run);
+        check(&format!("&{run}"));
+        check(&format!("{run}&"));
+        check(&format!("&{run}&"));
+        check(&format!("<{run}>{run}\""));
+    }
+}
+
+#[test]
+fn short_run_copy_keeps_multibyte_sequences_intact() {
+    // The overlapping copy is byte-oriented, so anything that split a
+    // multi-byte sequence would surface as invalid UTF-8 rather than a
+    // wrong escape. Sweep lengths that straddle every branch boundary.
+    for filler in ["é", "→", "🙂", "日本語"] {
+        for count in 0..=12usize {
+            let run = filler.repeat(count);
+            check(&run);
+            check(&format!("&{run}<"));
+        }
+    }
+}


### PR DESCRIPTION
## Where this came from

Sampling a parse+render of the bundled corpora puts `_platform_memmove` at **10.4% of self time**, and walking the call graph shows **two thirds of it reached from `escape_into`**.

That is not a scanning problem. The scan/copy loop is already the right shape — the SWAR/SIMD classifier proves long runs clean and each run is emitted with a single `push_str`. It is a **size** problem. Histogramming what the renderer actually escapes on typescript-handbook:

```
n=33835  total_bytes=1650904  mean=48
      0-7:  10513 (31.1%)
     8-15:   5908 (17.5%)
    16-31:   5432 (16.1%)
    32-63:   4589 (13.6%)
   64-127:   3788 (11.2%)
  128-255:   2598 ( 7.7%)
 256-1023:    985 ( 2.9%)
    1024+:     22 ( 0.1%)
```

**Half of all copies are under 16 bytes**, and every escape replacement (`&amp;`, `&lt;`, …) is 5 bytes or fewer on top of that. At those sizes libc's `memmove` spends most of its time choosing a strategy, and `push_str` cannot skip it — any length the compiler cannot see lowers to a `memcpy` call.

## The change

`push_run` copies runs of 16 bytes or fewer with two overlapping loads and stores, which needs no length-dependent branching inside the copy itself, and hands anything longer straight back to `push_str`. Both the run between escapes and the replacement text go through it.

This follows the shape already used for the SIMD classifiers in this crate: scoped `#[allow(unsafe_code)]`, the portable path kept as the fallback rather than deleted, and a differential test suite that has to agree with a byte-at-a-time reference.

## Measurements

Both binaries built first, then run alternately — and on **process user CPU time**, because wall clock cannot resolve a delta this size on this machine (it reported a 3% swing on unrelated code that user CPU showed as flat). Min of six runs each, profiler-free example binary:

| corpus | parse+render |
| --- | --- |
| typescript-handbook | **-4.4%** |
| vue-docs | **-3.4%** |
| vite-docs | **-2.4%** |
| rust-book | **-2.0%** |

Since the change is renderer-only, the render-relative win is roughly double. **Parse alone is unchanged**, which is the sanity check that nothing leaked into the other half.

## Correctness

- Rendered output **byte-identical** across all four corpora, with and without `--gfm`.
- The existing differential suite already covers every byte value at every offset. Two new cases sweep the run lengths that select each copy strategy: 0–40 plain bytes bracketed by escapes so the leading, mid-loop and trailing copies each see every length, plus multi-byte UTF-8 across the same boundaries.
- **The new tests were mutation-checked** against two deliberately broken copies — a dropped tail store in the `>= 8` branch, and a wrong last byte in the `< 4` branch. Each fails 10 tests, so the sweep has teeth rather than just passing.

## Safety note

`push_run` reserves `len` bytes, writes only inside `[0, len)` of the spare region, then `set_len`s exactly what it wrote. The appended bytes come from a `&str` and land at the end of `out`, which is a char boundary, so the result stays valid UTF-8. The two pointers cannot overlap: `out` is borrowed uniquely, so no live `&str` can alias its buffer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790013175&installation_model_id=422833&pr_number=610&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F610&signature=3c5ac7300f52d8d43010e23552078bf3045da884fd6248cecccfe5d8a49c4a01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved HTML escaping efficiency for short text segments.
  - Preserved correct handling of escaped content and multibyte UTF-8 characters.

- **Tests**
  - Added coverage for varied text lengths, escape placement, boundary conditions, and UTF-8 sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->