### PR TITLE
fix(og-image): stop inlining package imports into .ts templates

### DIFF
--- a/npm/vite-plugin-ox-content/src/og-image.test.ts
+++ b/npm/vite-plugin-ox-content/src/og-image.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vite-plus/test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { rolldown } from "rolldown";
+import { isBareSpecifier, tsTemplateBundleOptions } from "./og-image";
+
+describe("isBareSpecifier", () => {
+  it("treats package specifiers as resolvable at runtime", () => {
+    for (const id of [
+      "@ox-content/vite-plugin",
+      "@ox-content/vite-plugin/jsx-runtime",
+      "react",
+      "react-dom/server",
+      "lodash-es",
+    ]) {
+      expect(isBareSpecifier(id), id).toBe(true);
+    }
+  });
+
+  it("keeps the template's own files in the bundle", () => {
+    for (const id of [
+      "./card",
+      "../shared/card.ts",
+      ".",
+      "/abs/card.ts",
+      "C:\\project\\card.ts",
+      "C:/project/card.ts",
+      "\0virtual:module",
+    ]) {
+      expect(isBareSpecifier(id), id).toBe(false);
+    }
+  });
+});
+
+describe("tsTemplateBundleOptions", () => {
+  it("leaves a resolvable package import external instead of inlining it", async () => {
+    // Regression: the `.ts` bundle had no `external` at all, so importing the
+    // plugin's own helpers pulled the whole plugin — chokidar, fsevents and
+    // all — into the template bundle and the build failed outright.
+    //
+    // The fixture ships its own `node_modules` so the specifier really does
+    // resolve. Pointing at a package the fixture cannot see would leave the
+    // import external either way and prove nothing.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-og-template-"));
+    try {
+      const pkg = path.join(dir, "node_modules", "fake-runtime");
+      await fs.mkdir(pkg, { recursive: true });
+      await fs.writeFile(
+        path.join(pkg, "package.json"),
+        JSON.stringify({ name: "fake-runtime", version: "1.0.0", main: "index.js" }),
+      );
+      await fs.writeFile(
+        path.join(pkg, "index.js"),
+        'export const renderToString = (node) => node.__html + "/*INLINED-RUNTIME*/";\n',
+      );
+      await fs.writeFile(
+        path.join(dir, "card.ts"),
+        "export const card = (title: string) => `<h1>${title}</h1>`;\n",
+      );
+      await fs.writeFile(
+        path.join(dir, "template.ts"),
+        [
+          'import { renderToString } from "fake-runtime";',
+          'import { card } from "./card";',
+          "export default (props: { title: string }) =>",
+          "  renderToString({ __html: card(props.title) });",
+          "",
+        ].join("\n"),
+      );
+
+      const bundle = await rolldown(tsTemplateBundleOptions(path.join(dir, "template.ts")));
+      const { output } = await bundle.generate({ format: "esm" });
+      await bundle.close();
+      const code = output.map((chunk) => ("code" in chunk ? chunk.code : "")).join("\n");
+
+      expect(code).toContain('from "fake-runtime"');
+      expect(code).not.toContain("INLINED-RUNTIME");
+      // The template's own modules still travel with it.
+      expect(code).toContain("<h1>");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/npm/vite-plugin-ox-content/src/og-image/index.ts
+++ b/npm/vite-plugin-ox-content/src/og-image/index.ts
@@ -102,6 +102,51 @@ async function resolveTemplate(
 }
 
 /**
+ * Matches this package and every subpath it exports.
+ *
+ * A template's natural runtime is whatever renders it, and for the
+ * framework-less kinds that is this package: `renderToString`, `raw`, `when`
+ * and `each` live at its root, and the JSX runtime under `./jsx-runtime`.
+ * Inlining them instead drags the entire plugin — chokidar, fsevents and all
+ * — into the template bundle, which is what made importing it fail outright.
+ */
+const OX_CONTENT_PACKAGE = /^@ox-content\/vite-plugin(\/.*)?$/;
+
+/**
+ * Whether `id` is a bare specifier, and so resolvable at runtime rather than
+ * something the template bundle has to inline.
+ *
+ * Template bundles are written to `<root>/.cache/og-images/` and imported
+ * from there, so Node resolves anything left external against the project's
+ * own `node_modules`. Relative and absolute imports still bundle, which is
+ * what a template actually needs — its own components travel with it.
+ */
+export function isBareSpecifier(id: string): boolean {
+  if (id.startsWith(".") || id.startsWith("/") || id.startsWith("\0")) {
+    return false;
+  }
+  // Windows drive letters and rolldown's virtual-module prefixes.
+  return !/^[a-zA-Z]:[\\/]/.test(id);
+}
+
+/**
+ * Rolldown input options for a `.ts` template bundle.
+ *
+ * A `.ts` template is the framework-less kind, so it has no single runtime to
+ * externalize the way the `.vue`, `.svelte` and `.tsx` paths do — anything
+ * from `node_modules` is better resolved at import time than inlined. Nothing
+ * on this path has a compiler plugin, so nothing here needed bundling to be
+ * loadable in the first place.
+ */
+export function tsTemplateBundleOptions(templatePath: string) {
+  return {
+    input: templatePath,
+    platform: "node" as const,
+    external: (id: string) => isBareSpecifier(id),
+  };
+}
+
+/**
  * Resolves a plain TypeScript template (existing behavior).
  */
 async function resolveTsTemplate(
@@ -116,10 +161,7 @@ async function resolveTsTemplate(
 
   const outfile = path.join(cacheDir, "_template.mjs");
 
-  const bundle = await rolldown({
-    input: templatePath,
-    platform: "node",
-  });
+  const bundle = await rolldown(tsTemplateBundleOptions(templatePath));
   await bundle.write({
     file: outfile,
     format: "esm",
@@ -162,7 +204,7 @@ async function resolveVueTemplate(
   const bundle = await rolldown({
     input: templatePath,
     platform: "node",
-    external: ["vue", "vue/server-renderer"],
+    external: ["vue", "vue/server-renderer", OX_CONTENT_PACKAGE],
     plugins,
   });
   await bundle.write({
@@ -312,7 +354,13 @@ async function resolveSvelteTemplate(
   const bundle = await rolldown({
     input: templatePath,
     platform: "node",
-    external: ["svelte", "svelte/server", "svelte/internal", "svelte/internal/server"],
+    external: [
+      "svelte",
+      "svelte/server",
+      "svelte/internal",
+      "svelte/internal/server",
+      OX_CONTENT_PACKAGE,
+    ],
     plugins: [createSvelteCompilerPlugin()],
   });
   await bundle.write({
@@ -397,6 +445,7 @@ async function resolveReactTemplate(
       "react/jsx-dev-runtime",
       "react-dom",
       "react-dom/server",
+      OX_CONTENT_PACKAGE,
     ],
     transform: {
       jsx: "react-jsx",


### PR DESCRIPTION
Fixes #608

## Summary

`resolveTsTemplate` bundled with **no `external` at all**, so a `.ts` OG template that imported anything from `@ox-content/vite-plugin` pulled the entire plugin into its bundle — chokidar, fsevents and all — and the build died:

```
[UNLOADABLE_DEPENDENCY] Could not load .../fsevents/fsevents.node
```

That matters because `.ts` is the one template kind not tied to a framework, which makes it the natural home for the built-in JSX runtime. But the helpers that runtime exists to be used with — `renderToString`, `raw`, `when`, `each` — all live at the package root, so none of them could be imported at all. The workaround was to hand-build `{ __html }` nodes and reimplement published helpers.

## Changes

- **`.ts` templates externalize every bare specifier.** The bundle is written to `<root>/.cache/og-images/` and imported from there, so Node resolves those against the project's own `node_modules`. Relative and absolute imports still bundle, which is what a template actually needs — its own components travel with it. Nothing on this path has a compiler plugin, so nothing here needed bundling to be loadable in the first place.
- **`.vue` / `.svelte` / `.tsx` keep their runtime allowlists** rather than switching to the same blanket rule: those paths run compiler plugins, and externalizing everything would stop a `.vue` or `.svelte` file inside a node_modules package from ever being compiled. They gain `@ox-content/vite-plugin` and its subpaths alongside their existing entries, so a framework template can reach the same helpers.

## On the test

The fixture **ships its own `node_modules`** so the import really resolves. That detail is the whole test: the first version pointed at `@ox-content/vite-plugin` from a temp dir outside the project, where it does not resolve — so rolldown left it external either way and the test passed against the unfixed code too. With a resolvable package, removing the `external` option fails it.

## Validation

- `vp test src` — 208 passing, 3 new
- `tsgo --noEmit`, `vp check`, `node scripts/check-file-lines.ts`

## Not included

#608 also notes that `.tsx`/`.jsx` templates always go through React's runtime, so a framework-less JSX template still cannot be used for OG images even with these imports working. That needs a separate render path and a way to select it — a feature rather than this fix — and it is the same gap flagged in #601.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790013800&installation_model_id=422833&pr_number=611&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F611&signature=528efa661fb7d848a33cbbc3683db5ab5614916a48594a1d8d621e669c1e3dfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Open Graph image generation from TypeScript, Vue, Svelte, and React templates.
  * External package dependencies are now preserved correctly, reducing bundling conflicts and runtime errors.
  * Improved handling of relative, absolute, platform-specific, and virtual module paths.

* **Tests**
  * Added coverage for module path detection and template bundling scenarios, including temporary project fixtures and dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->