### PR TITLE
feat(ssg): complete bare mode and let ssg.render take a theme component

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -178,6 +178,9 @@ export declare function generateSearchModuleFromOptions(options: JsSearchRuntime
 /** Generates a bare SSG HTML page without navigation or styles. */
 export declare function generateSsgBareHtml(content: string, title: string): string
 
+/** Generates a bare SSG HTML page carrying head metadata and injected markup. */
+export declare function generateSsgBarePage(page: JsSsgBarePage): string
+
 /** Generates SSG HTML page with navigation and search. */
 export declare function generateSsgHtml(pageData: JsSsgPageData, navGroups: Array<JsSsgNavGroup>, config: JsSsgConfig): string
 
@@ -1248,6 +1251,37 @@ export interface JsSourceOrigin {
   line: number
   /** 1-based column number. */
   column: number
+}
+
+/**
+ * Head metadata and injected markup for a bare SSG page.
+ *
+ * Every field is optional. A value with none of them set renders the same
+ * document bare mode emitted before any of this existed.
+ */
+export interface JsSsgBarePage {
+  /** Page title. */
+  title: string
+  /** Rendered page body. */
+  content: string
+  /** `lang` attribute. Defaults to `en`. */
+  lang?: string
+  /** `dir` attribute. Omitted when absent. */
+  dir?: string
+  /** Page description for `description` and the OG/Twitter variants. */
+  description?: string
+  /** Absolute page URL for `<link rel="canonical">` and `og:url`. */
+  canonicalUrl?: string
+  /** Site name for `og:site_name`. */
+  siteName?: string
+  /** Image URL for `og:image` and `twitter:image`. */
+  ogImage?: string
+  /** Raw markup appended to `<head>`. */
+  head?: string
+  /** Raw markup inserted directly after `<body>`. */
+  bodyStart?: string
+  /** Raw markup inserted directly before `</body>`. */
+  bodyEnd?: string
 }
 
 /** SSG configuration. */

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -209,6 +209,7 @@ module.exports.collectSearchMarkdownFiles = binding.collectSearchMarkdownFiles;
 module.exports.normalizeVitePressFrontmatter = binding.normalizeVitePressFrontmatter;
 module.exports.generateSsgHtml = binding.generateSsgHtml;
 module.exports.generateSsgBareHtml = binding.generateSsgBareHtml;
+module.exports.generateSsgBarePage = binding.generateSsgBarePage;
 module.exports.getGitLastUpdated = binding.getGitLastUpdated;
 module.exports.resolveSsgRoutePaths = binding.resolveSsgRoutePaths;
 module.exports.getSsgOutputPath = binding.getSsgOutputPath;

--- a/crates/ox_content_napi/src/ssg_bindings.rs
+++ b/crates/ox_content_napi/src/ssg_bindings.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use napi_derive::napi;
 
 use crate::{
-    JsSsgConfig, JsSsgExternalizedAssets, JsSsgGeneratedHtmlPage, JsSsgNavGroup,
+    JsSsgBarePage, JsSsgConfig, JsSsgExternalizedAssets, JsSsgGeneratedHtmlPage, JsSsgNavGroup,
     JsSsgNavigationGroup, JsSsgPageData, JsSsgRoutePaths, JsSsgSidebarItem,
 };
 
@@ -216,6 +216,24 @@ pub fn generate_ssg_html(
 #[napi(js_name = "generateSsgBareHtml")]
 pub fn generate_ssg_bare_html(content: String, title: String) -> String {
     ox_content_ssg::generate_bare_html(&content, &title)
+}
+
+/// Generates a bare SSG HTML page carrying head metadata and injected markup.
+#[napi(js_name = "generateSsgBarePage")]
+pub fn generate_ssg_bare_page(page: JsSsgBarePage) -> String {
+    ox_content_ssg::generate_bare_page(&ox_content_ssg::BarePageData {
+        title: &page.title,
+        content: &page.content,
+        lang: page.lang.as_deref().unwrap_or_default(),
+        dir: page.dir.as_deref().unwrap_or_default(),
+        description: page.description.as_deref(),
+        canonical_url: page.canonical_url.as_deref(),
+        site_name: page.site_name.as_deref(),
+        og_image: page.og_image.as_deref(),
+        head: page.head.as_deref().unwrap_or_default(),
+        body_start: page.body_start.as_deref().unwrap_or_default(),
+        body_end: page.body_end.as_deref().unwrap_or_default(),
+    })
 }
 
 /// Extracts shared CSS and JavaScript assets from generated SSG pages.

--- a/crates/ox_content_napi/src/ssg_page_types.rs
+++ b/crates/ox_content_napi/src/ssg_page_types.rs
@@ -29,6 +29,36 @@ pub struct JsSsgNavGroup {
     pub sticky_collapsed: Option<bool>,
 }
 
+/// Head metadata and injected markup for a bare SSG page.
+///
+/// Every field is optional. A value with none of them set renders the same
+/// document bare mode emitted before any of this existed.
+#[napi(object)]
+pub struct JsSsgBarePage {
+    /// Page title.
+    pub title: String,
+    /// Rendered page body.
+    pub content: String,
+    /// `lang` attribute. Defaults to `en`.
+    pub lang: Option<String>,
+    /// `dir` attribute. Omitted when absent.
+    pub dir: Option<String>,
+    /// Page description for `description` and the OG/Twitter variants.
+    pub description: Option<String>,
+    /// Absolute page URL for `<link rel="canonical">` and `og:url`.
+    pub canonical_url: Option<String>,
+    /// Site name for `og:site_name`.
+    pub site_name: Option<String>,
+    /// Image URL for `og:image` and `twitter:image`.
+    pub og_image: Option<String>,
+    /// Raw markup appended to `<head>`.
+    pub head: Option<String>,
+    /// Raw markup inserted directly after `<body>`.
+    pub body_start: Option<String>,
+    /// Raw markup inserted directly before `</body>`.
+    pub body_end: Option<String>,
+}
+
 /// Resolved SSG output and public route paths.
 #[napi(object)]
 pub struct JsSsgRoutePaths {

--- a/crates/ox_content_napi/src/tests/runtime_features.rs
+++ b/crates/ox_content_napi/src/tests/runtime_features.rs
@@ -53,6 +53,7 @@ fn javascript_wrapper_and_declarations_cover_expected_exports() {
         "generateSearchModule",
         "generateSearchModuleFromOptions",
         "generateSsgBareHtml",
+        "generateSsgBarePage",
         "generateSsgHtml",
         "getGitLastUpdated",
         "getSearchDocumentScopes",

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -182,6 +182,9 @@ export declare function generateSearchModuleFromOptions(options: JsSearchRuntime
 /** Generates a bare SSG HTML page without navigation or styles. */
 export declare function generateSsgBareHtml(content: string, title: string): string
 
+/** Generates a bare SSG HTML page carrying head metadata and injected markup. */
+export declare function generateSsgBarePage(page: JsSsgBarePage): string
+
 /** Generates SSG HTML page with navigation and search. */
 export declare function generateSsgHtml(pageData: JsSsgPageData, navGroups: Array<JsSsgNavGroup>, config: JsSsgConfig): string
 
@@ -1252,6 +1255,37 @@ export interface JsSourceOrigin {
   line: number
   /** 1-based column number. */
   column: number
+}
+
+/**
+ * Head metadata and injected markup for a bare SSG page.
+ *
+ * Every field is optional. A value with none of them set renders the same
+ * document bare mode emitted before any of this existed.
+ */
+export interface JsSsgBarePage {
+  /** Page title. */
+  title: string
+  /** Rendered page body. */
+  content: string
+  /** `lang` attribute. Defaults to `en`. */
+  lang?: string
+  /** `dir` attribute. Omitted when absent. */
+  dir?: string
+  /** Page description for `description` and the OG/Twitter variants. */
+  description?: string
+  /** Absolute page URL for `<link rel="canonical">` and `og:url`. */
+  canonicalUrl?: string
+  /** Site name for `og:site_name`. */
+  siteName?: string
+  /** Image URL for `og:image` and `twitter:image`. */
+  ogImage?: string
+  /** Raw markup appended to `<head>`. */
+  head?: string
+  /** Raw markup inserted directly after `<body>`. */
+  bodyStart?: string
+  /** Raw markup inserted directly before `</body>`. */
+  bodyEnd?: string
 }
 
 /** SSG configuration. */

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
@@ -35,6 +35,7 @@ generateOgImageSvg
 generateSearchModule
 generateSearchModuleFromOptions
 generateSsgBareHtml
+generateSsgBarePage
 generateSsgHtml
 getGitLastUpdated
 getSearchDocumentScopes

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
@@ -213,6 +213,7 @@ module.exports.collectSearchMarkdownFiles = binding.collectSearchMarkdownFiles;
 module.exports.normalizeVitePressFrontmatter = binding.normalizeVitePressFrontmatter;
 module.exports.generateSsgHtml = binding.generateSsgHtml;
 module.exports.generateSsgBareHtml = binding.generateSsgBareHtml;
+module.exports.generateSsgBarePage = binding.generateSsgBarePage;
 module.exports.getGitLastUpdated = binding.getGitLastUpdated;
 module.exports.resolveSsgRoutePaths = binding.resolveSsgRoutePaths;
 module.exports.getSsgOutputPath = binding.getSsgOutputPath;

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
@@ -213,6 +213,7 @@ module.exports.collectSearchMarkdownFiles = binding.collectSearchMarkdownFiles;
 module.exports.normalizeVitePressFrontmatter = binding.normalizeVitePressFrontmatter;
 module.exports.generateSsgHtml = binding.generateSsgHtml;
 module.exports.generateSsgBareHtml = binding.generateSsgBareHtml;
+module.exports.generateSsgBarePage = binding.generateSsgBarePage;
 module.exports.getGitLastUpdated = binding.getGitLastUpdated;
 module.exports.resolveSsgRoutePaths = binding.resolveSsgRoutePaths;
 module.exports.getSsgOutputPath = binding.getSsgOutputPath;

--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -16,7 +16,7 @@ pub use page::{
     EntryPageConfig, FeatureConfig, HeroAction, HeroConfig, HeroImage, HeroNoticeConfig,
     LocaleInfo, NavGroup, NavItem, PageData, SsgConfig, TocEntry,
 };
-pub use render::{generate_bare_html, generate_html};
+pub use render::{BarePageData, generate_bare_html, generate_bare_page, generate_html};
 pub use theme::{
     SocialLink, SocialLinks, ThemeColors, ThemeConfig, ThemeEmbed, ThemeEntryPage, ThemeFonts,
     ThemeFooter, ThemeHeader, ThemeLayout,
@@ -135,8 +135,18 @@ struct PageTemplate<'a> {
 #[derive(Template)]
 #[template(path = "bare_page.html")]
 struct BarePageTemplate<'a> {
+    lang: &'a str,
+    dir: &'a str,
     title: &'a str,
     content: &'a str,
+    has_metadata: bool,
+    description: Option<&'a str>,
+    canonical_url: Option<&'a str>,
+    site_name: Option<&'a str>,
+    og_image: Option<&'a str>,
+    head: &'a str,
+    body_start: &'a str,
+    body_end: &'a str,
 }
 
 /// CSS styles for SSG pages.

--- a/crates/ox_content_ssg/src/html/render.rs
+++ b/crates/ox_content_ssg/src/html/render.rs
@@ -215,9 +215,70 @@ pub fn generate_html(page_data: &PageData, nav_groups: &[NavGroup], config: &Ssg
     template.render().unwrap_or_default()
 }
 
+/// Everything the bare template can put around a rendered page body.
+///
+/// Bare mode leaves the shell to the consumer, but the metadata below is
+/// already computed for the themed page and is not something a consumer can
+/// recover afterwards — the generated OG image in particular is only
+/// discoverable by guessing at the output directory. Every field is optional,
+/// and a `BarePageData` carrying none of them renders exactly the document
+/// bare mode emitted before: no `<meta>` beyond charset and viewport, which
+/// keeps the no-JS size baseline honest.
+#[derive(Default)]
+pub struct BarePageData<'a> {
+    /// Page title, used for `<title>` and the OG/Twitter title.
+    pub title: &'a str,
+    /// Rendered page body.
+    pub content: &'a str,
+    /// `lang` attribute. Defaults to `en` when empty.
+    pub lang: &'a str,
+    /// `dir` attribute. Omitted entirely when empty.
+    pub dir: &'a str,
+    /// Page description, used for `description` and the OG/Twitter variants.
+    pub description: Option<&'a str>,
+    /// Absolute page URL, used for `<link rel="canonical">` and `og:url`.
+    pub canonical_url: Option<&'a str>,
+    /// Site name for `og:site_name`.
+    pub site_name: Option<&'a str>,
+    /// Image URL for `og:image` and `twitter:image`.
+    pub og_image: Option<&'a str>,
+    /// Raw markup appended to `<head>`.
+    pub head: &'a str,
+    /// Raw markup inserted directly after `<body>`.
+    pub body_start: &'a str,
+    /// Raw markup inserted directly before `</body>`.
+    pub body_end: &'a str,
+}
+
 /// Generates a bare HTML page for SSG.
 ///
 /// This page intentionally omits navigation, styles, and scripts.
 pub fn generate_bare_html(content: &str, title: &str) -> String {
-    BarePageTemplate { title, content }.render().unwrap_or_default()
+    generate_bare_page(&BarePageData { title, content, ..BarePageData::default() })
+}
+
+/// Generates a bare HTML page with whatever head metadata and injected markup
+/// the caller has.
+pub fn generate_bare_page(data: &BarePageData<'_>) -> String {
+    let has_metadata = data.description.is_some()
+        || data.canonical_url.is_some()
+        || data.site_name.is_some()
+        || data.og_image.is_some();
+
+    BarePageTemplate {
+        lang: if data.lang.is_empty() { "en" } else { data.lang },
+        dir: data.dir,
+        title: data.title,
+        content: data.content,
+        has_metadata,
+        description: data.description,
+        canonical_url: data.canonical_url,
+        site_name: data.site_name,
+        og_image: data.og_image,
+        head: data.head,
+        body_start: data.body_start,
+        body_end: data.body_end,
+    }
+    .render()
+    .unwrap_or_default()
 }

--- a/crates/ox_content_ssg/src/html/tests/rendering.rs
+++ b/crates/ox_content_ssg/src/html/tests/rendering.rs
@@ -53,6 +53,61 @@ fn test_generate_bare_html() {
 }
 
 #[test]
+fn test_generate_bare_page_without_metadata_matches_the_old_bare_output() {
+    // Bare mode is also the no-JS size baseline in the benchmark tables, so a
+    // page with nothing configured must not grow a single tag.
+    let data =
+        BarePageData { title: "Test Page", content: "<h1>Hello</h1>", ..BarePageData::default() };
+
+    assert_eq!(generate_bare_page(&data), generate_bare_html("<h1>Hello</h1>", "Test Page"));
+}
+
+#[test]
+fn test_generate_bare_page_emits_head_metadata() {
+    let data = BarePageData {
+        title: "Guide",
+        content: "<p>body</p>",
+        lang: "ja",
+        dir: "ltr",
+        description: Some("How it works"),
+        canonical_url: Some("https://example.com/guide/"),
+        site_name: Some("Docs"),
+        og_image: Some("https://example.com/guide/og-image.png"),
+        ..BarePageData::default()
+    };
+
+    insta::assert_snapshot!(super::snapshot_text(&generate_bare_page(&data)));
+}
+
+#[test]
+fn test_generate_bare_page_injects_consumer_markup() {
+    let data = BarePageData {
+        title: "Guide",
+        content: "<p>body</p>",
+        head: "<link rel=\"stylesheet\" href=\"/assets/site.css\">",
+        body_start: "<header>site</header>",
+        body_end: "<footer>end</footer>",
+        ..BarePageData::default()
+    };
+
+    insta::assert_snapshot!(super::snapshot_text(&generate_bare_page(&data)));
+}
+
+#[test]
+fn test_generate_bare_page_escapes_metadata_but_keeps_injected_markup_raw() {
+    let data = BarePageData {
+        title: "Guide",
+        content: "<p>body</p>",
+        description: Some("a \"quoted\" & <angled> value"),
+        site_name: Some("Docs & More"),
+        head: "<meta name=\"raw\" content=\"kept\">",
+        ..BarePageData::default()
+    };
+
+    insta::assert_snapshot!(super::snapshot_text(&generate_bare_page(&data)));
+}
+
+#[test]
 fn test_generate_bare_html_escapes_title_but_keeps_content_raw() {
     let html = generate_bare_html("<h1>Raw & ready</h1>", "<script>alert(1)</script>");
     insta::assert_snapshot!(super::snapshot_text(&html));

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_bare_page_emits_head_metadata.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_bare_page_emits_head_metadata.snap
@@ -1,0 +1,27 @@
+---
+source: crates/ox_content_ssg/src/html/tests/rendering.rs
+expression: "super::snapshot_text(&generate_bare_page(&data))"
+---
+<!DOCTYPE html>
+<html lang="ja" dir="ltr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Guide</title>
+  <meta name="description" content="How it works">
+  <meta property="og:description" content="How it works">
+  <meta name="twitter:description" content="How it works">
+  <link rel="canonical" href="https://example.com/guide/">
+  <meta property="og:url" content="https://example.com/guide/">
+  <meta property="og:site_name" content="Docs">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Guide">
+  <meta property="og:image" content="https://example.com/guide/og-image.png">
+  <meta name="twitter:image" content="https://example.com/guide/og-image.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Guide">
+</head>
+<body>
+<p>body</p>
+</body>
+</html>

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_bare_page_escapes_metadata_but_keeps_injected_markup_raw.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_bare_page_escapes_metadata_but_keeps_injected_markup_raw.snap
@@ -1,0 +1,24 @@
+---
+source: crates/ox_content_ssg/src/html/tests/rendering.rs
+expression: "super::snapshot_text(&generate_bare_page(&data))"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Guide</title>
+  <meta name="description" content="a &#34;quoted&#34; &#38; &#60;angled&#62; value">
+  <meta property="og:description" content="a &#34;quoted&#34; &#38; &#60;angled&#62; value">
+  <meta name="twitter:description" content="a &#34;quoted&#34; &#38; &#60;angled&#62; value">
+  <meta property="og:site_name" content="Docs &#38; More">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Guide">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Guide">
+<meta name="raw" content="kept">
+</head>
+<body>
+<p>body</p>
+</body>
+</html>

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_bare_page_injects_consumer_markup.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_bare_page_injects_consumer_markup.snap
@@ -1,0 +1,18 @@
+---
+source: crates/ox_content_ssg/src/html/tests/rendering.rs
+expression: "super::snapshot_text(&generate_bare_page(&data))"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Guide</title>
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+<header>site</header>
+<p>body</p>
+<footer>end</footer>
+</body>
+</html>

--- a/crates/ox_content_ssg/src/lib.rs
+++ b/crates/ox_content_ssg/src/lib.rs
@@ -60,10 +60,10 @@ pub use assets::{
     ExternalizedAssets, GeneratedHtmlPage, SharedAsset, externalize_shared_page_assets,
 };
 pub use html::{
-    EntryPageConfig, FeatureConfig, HeroAction, HeroConfig, HeroImage, HeroNoticeConfig,
-    LocaleInfo, NavGroup, NavItem, PageData, SocialLink, SocialLinks, SsgConfig, ThemeColors,
-    ThemeConfig, ThemeEmbed, ThemeEntryPage, ThemeFonts, ThemeFooter, ThemeHeader, ThemeLayout,
-    TocEntry, generate_bare_html, generate_html,
+    BarePageData, EntryPageConfig, FeatureConfig, HeroAction, HeroConfig, HeroImage,
+    HeroNoticeConfig, LocaleInfo, NavGroup, NavItem, PageData, SocialLink, SocialLinks, SsgConfig,
+    ThemeColors, ThemeConfig, ThemeEmbed, ThemeEntryPage, ThemeFonts, ThemeFooter, ThemeHeader,
+    ThemeLayout, TocEntry, generate_bare_html, generate_bare_page, generate_html,
 };
 pub use routes::{
     ManualNavigationGroup, ManualNavigationItem, RoutePaths, SidebarItem, build_nav_items,

--- a/crates/ox_content_ssg/templates/bare_page.html
+++ b/crates/ox_content_ssg/templates/bare_page.html
@@ -1,11 +1,42 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ lang }}"{% if !dir.is_empty() %} dir="{{ dir }}"{% endif %}>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ title }}</title>
+{%- if has_metadata %}
+{%- if let Some(desc) = description %}
+  <meta name="description" content="{{ desc }}">
+  <meta property="og:description" content="{{ desc }}">
+  <meta name="twitter:description" content="{{ desc }}">
+{%- endif %}
+{%- if let Some(url) = canonical_url %}
+  <link rel="canonical" href="{{ url }}">
+  <meta property="og:url" content="{{ url }}">
+{%- endif %}
+{%- if let Some(name) = site_name %}
+  <meta property="og:site_name" content="{{ name }}">
+{%- endif %}
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="{{ title }}">
+{%- if let Some(img) = og_image %}
+  <meta property="og:image" content="{{ img }}">
+  <meta name="twitter:image" content="{{ img }}">
+{%- endif %}
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ title }}">
+{%- endif %}
+{%- if !head.is_empty() %}
+{{ head|safe }}
+{%- endif %}
 </head>
 <body>
+{%- if !body_start.is_empty() %}
+{{ body_start|safe }}
+{%- endif %}
 {{ content|safe }}
+{%- if !body_end.is_empty() %}
+{{ body_end|safe }}
+{%- endif %}
 </body>
 </html>

--- a/docs/content/built-in/site-generation.md
+++ b/docs/content/built-in/site-generation.md
@@ -58,6 +58,10 @@ export default defineConfig({
 | `extension`       | `".html"`      | Generated page extension.                            |
 | `clean`           | `false`        | Remove generated output before writing.              |
 | `bare`            | `false`        | Emit unthemed HTML without navigation.               |
+| `lang`            | `"en"`         | `lang` attribute on `<html>` (bare mode).            |
+| `head`            | —              | Raw markup appended to `<head>` (bare mode).         |
+| `bodyStart`       | —              | Raw markup after `<body>` (bare mode).               |
+| `bodyEnd`         | —              | Raw markup before `</body>` (bare mode).             |
 | `siteName`        | —              | Suffix for `<title>` and OG site name.               |
 | `siteUrl`         | —              | Origin used for absolute OG URLs.                    |
 | `ogImage`         | —              | Static fallback OG image URL.                        |
@@ -68,6 +72,36 @@ export default defineConfig({
 
 Theming — colors, fonts, header, footer, sidebar, custom CSS — is a topic of
 its own: see [Theming](../theming.md).
+
+## Bare Mode
+
+`bare: true` emits the rendered Markdown body without the navigation, layout
+shell or theme styles. It is what you want when the project brings its own
+design system, or when you are measuring the no-JavaScript baseline.
+
+Bare pages still carry the head metadata the plugin already computes — the
+description, `og:*` and `twitter:*` tags, the canonical link, and the generated
+OG image. That metadata only appears when there is something to say: a page
+with no description, no `siteUrl` and no OG image renders exactly the minimal
+document bare mode has always emitted, so the size baseline stays honest.
+
+Everything else is yours to inject:
+
+```ts
+oxContent({
+  ssg: {
+    bare: true,
+    lang: "ja",
+    siteUrl: "https://example.com",
+    head: '<link rel="stylesheet" href="/assets/site.css">',
+    bodyStart: "<header>…</header><main>",
+    bodyEnd: "</main><footer>…</footer>",
+  },
+});
+```
+
+`siteUrl` is what turns on `<link rel="canonical">` and the absolute `og:url`;
+without it those tags are omitted rather than guessed.
 
 ## OG Images
 
@@ -96,9 +130,10 @@ generated image looks like this:
 | `cache`          | `true`   | Skip re-rendering unchanged pages.                    |
 | `concurrency`    | `1`      | Parallel image renders.                               |
 
-Under `bare`, the images are still generated, but nothing references them —
-bare output has no `<head>` for the `<meta>` tags, so inject them from your own
-shell. Each page's image lands next to its HTML, under the page's own route.
+Under `bare`, the images are generated **and referenced**: bare pages carry the
+same `og:image` / `twitter:image` tags the themed pages get. `buildSsg()` also
+returns an `ogImages` map of source path to image URL, so a post-processing
+step does not have to go looking for `og-image.png` in the output tree.
 
 During dev, `/__og-viewer` previews every page's Open Graph metadata and
 image (the `ogViewer` option, on by default):

--- a/docs/content/built-in/site-generation.md
+++ b/docs/content/built-in/site-generation.md
@@ -58,6 +58,7 @@ export default defineConfig({
 | `extension`       | `".html"`      | Generated page extension.                            |
 | `clean`           | `false`        | Remove generated output before writing.              |
 | `bare`            | `false`        | Emit unthemed HTML without navigation.               |
+| `render`          | —              | JSX component that owns the whole document.          |
 | `lang`            | `"en"`         | `lang` attribute on `<html>` (bare mode).            |
 | `head`            | —              | Raw markup appended to `<head>` (bare mode).         |
 | `bodyStart`       | —              | Raw markup after `<body>` (bare mode).               |
@@ -72,6 +73,42 @@ export default defineConfig({
 
 Theming — colors, fonts, header, footer, sidebar, custom CSS — is a topic of
 its own: see [Theming](../theming.md).
+
+## Custom Theme Component
+
+`ssg.render` hands the whole document to a JSX component. The component owns
+everything from `<html>` down, so `theme`, `bare` and the head metadata options
+do not apply — nothing is injected that you did not write.
+
+```tsx
+import { createTheme, usePageProps, useSiteConfig } from "@ox-content/vite-plugin";
+
+function DefaultLayout({ children }) {
+  const page = usePageProps();
+  const site = useSiteConfig();
+  return (
+    <html lang="ja">
+      <head>
+        <title>{`${page.title} | ${site.name}`}</title>
+        <link rel="stylesheet" href="/assets/site.css" />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}
+
+oxContent({
+  ssg: { render: createTheme({ layouts: { default: DefaultLayout } }) },
+});
+```
+
+`createTheme()` picks the layout named by each page's `layout` frontmatter,
+falling back to `default`. Inside a layout, `usePageProps()` gives the current
+page and `useSiteConfig()` gives the site-wide config including navigation and
+every other page.
+
+This uses the built-in JSX runtime, so configure `jsxImportSource` as described
+in [MDX and JSX](../mdx.md#static-jsx-in-themes).
 
 ## Bare Mode
 

--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -25,6 +25,11 @@ describe("resolveSsgOptions", () => {
     expect(resolveSsgOptions({ lastUpdated: true }).lastUpdated).toBe(true);
   });
 
+  it("carries a theme component through", () => {
+    const component = () => ({ __html: "<html></html>" });
+    expect(resolveSsgOptions({ render: component }).render).toBe(component);
+  });
+
   it("carries the bare-mode shell options through", () => {
     const resolved = resolveSsgOptions({
       bare: true,

--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -5,6 +5,7 @@ import {
   buildThemeNavItems,
   formatTitle,
   generateBareHtmlPage,
+  generateBarePage,
   getHref,
   getOutputPath,
   getPageLocale,
@@ -22,6 +23,67 @@ describe("resolveSsgOptions", () => {
 
   it("enables git timestamps when requested", () => {
     expect(resolveSsgOptions({ lastUpdated: true }).lastUpdated).toBe(true);
+  });
+
+  it("carries the bare-mode shell options through", () => {
+    const resolved = resolveSsgOptions({
+      bare: true,
+      lang: "ja",
+      head: '<link rel="stylesheet" href="/site.css">',
+      bodyStart: "<header>site</header>",
+      bodyEnd: "<footer>end</footer>",
+    });
+
+    expect(resolved.lang).toBe("ja");
+    expect(resolved.head).toBe('<link rel="stylesheet" href="/site.css">');
+    expect(resolved.bodyStart).toBe("<header>site</header>");
+    expect(resolved.bodyEnd).toBe("<footer>end</footer>");
+  });
+});
+
+describe("generateBarePage", () => {
+  it("renders exactly the old bare output when nothing is configured", () => {
+    // Bare mode doubles as the no-JS size baseline in the benchmark tables,
+    // so an unconfigured page must not grow a single tag.
+    expect(generateBarePage({ title: "Test Page", content: "<h1>Hello</h1>" })).toBe(
+      generateBareHtmlPage("<h1>Hello</h1>", "Test Page"),
+    );
+  });
+
+  it("emits the head metadata the themed page already computes", () => {
+    const html = generateBarePage({
+      title: "Guide",
+      content: "<p>body</p>",
+      lang: "ja",
+      description: "How it works",
+      canonicalUrl: "https://example.com/guide/",
+      siteName: "Docs",
+      ogImage: "https://example.com/guide/og-image.png",
+    });
+
+    expect(html).toContain('<html lang="ja">');
+    expect(html).toContain('<meta name="description" content="How it works">');
+    expect(html).toContain('<link rel="canonical" href="https://example.com/guide/">');
+    expect(html).toContain('<meta property="og:url" content="https://example.com/guide/">');
+    expect(html).toContain('<meta property="og:site_name" content="Docs">');
+    expect(html).toContain(
+      '<meta property="og:image" content="https://example.com/guide/og-image.png">',
+    );
+    expect(html).toContain('<meta name="twitter:card" content="summary_large_image">');
+  });
+
+  it("injects consumer markup into head and around the body", () => {
+    const html = generateBarePage({
+      title: "Guide",
+      content: "<p>body</p>",
+      head: '<link rel="stylesheet" href="/assets/site.css">',
+      bodyStart: "<header>site</header>",
+      bodyEnd: "<footer>end</footer>",
+    });
+
+    expect(html).toContain('<link rel="stylesheet" href="/assets/site.css">');
+    expect(html.indexOf("<header>site</header>")).toBeLessThan(html.indexOf("<p>body</p>"));
+    expect(html.indexOf("<footer>end</footer>")).toBeGreaterThan(html.indexOf("<p>body</p>"));
   });
 });
 

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -111,6 +111,10 @@ export function resolveSsgOptions(ssg: SsgOptions | boolean | undefined): Resolv
     extension: ssg.extension ?? ".html",
     clean: ssg.clean ?? false,
     bare: ssg.bare ?? false,
+    lang: ssg.lang,
+    head: ssg.head,
+    bodyStart: ssg.bodyStart,
+    bodyEnd: ssg.bodyEnd,
     siteName: ssg.siteName,
     ogImage: ssg.ogImage,
     generateOgImage: ssg.generateOgImage ?? false,
@@ -136,6 +140,34 @@ export function extractTitle(content: string, frontmatter: Record<string, unknow
  */
 export function generateBareHtmlPage(content: string, title: string): string {
   return importNapiModuleSync().generateSsgBareHtml(content, title);
+}
+
+/**
+ * Generates a bare HTML page carrying head metadata and injected markup.
+ *
+ * Bare mode leaves the shell to the consumer, but the metadata here is
+ * already computed for the themed page and cannot be recovered afterwards —
+ * the generated OG image in particular was only discoverable by guessing at
+ * the output directory. A page with none of it set renders exactly what bare
+ * mode emitted before, which keeps the no-JS size baseline honest.
+ */
+export function generateBarePage(page: SsgBarePage): string {
+  return importNapiModuleSync().generateSsgBarePage(page);
+}
+
+/** Head metadata and injected markup for a bare page. */
+export interface SsgBarePage {
+  title: string;
+  content: string;
+  lang?: string;
+  dir?: string;
+  description?: string;
+  canonicalUrl?: string;
+  siteName?: string;
+  ogImage?: string;
+  head?: string;
+  bodyStart?: string;
+  bodyEnd?: string;
 }
 
 /** NAPI-facing nav group shape produced from a [`NavGroup`]. */
@@ -520,16 +552,29 @@ interface CollectedPageResults {
   errors: string[];
 }
 
+/** Result of an SSG build. */
+export interface SsgBuildResult {
+  /** Every file written, HTML pages and generated OG images alike. */
+  files: string[];
+  /** Per-page failures that did not abort the build. */
+  errors: string[];
+  /**
+   * Generated OG image URL per source file, keyed by absolute input path.
+   *
+   * Bare mode renders these into the page itself, but a consumer
+   * post-processing the output had no way to find them short of probing the
+   * output directory for `og-image.png`.
+   */
+  ogImages: Record<string, string>;
+}
+
 /**
  * Builds all markdown files to static HTML.
  */
-export async function buildSsg(
-  options: ResolvedOptions,
-  root: string,
-): Promise<{ files: string[]; errors: string[] }> {
+export async function buildSsg(options: ResolvedOptions, root: string): Promise<SsgBuildResult> {
   const ssgOptions = options.ssg;
   if (!ssgOptions.enabled) {
-    return { files: [], errors: [] };
+    return { files: [], errors: [], ogImages: {} };
   }
 
   const srcDir = path.resolve(root, options.srcDir);
@@ -549,7 +594,11 @@ export async function buildSsg(
   const generatedPages = await generateHtmlPages(context, collected.pageResults, collected, errors);
   await writeGeneratedPages(generatedPages, context, generatedFiles);
 
-  return { files: generatedFiles, errors };
+  return {
+    files: generatedFiles,
+    errors,
+    ogImages: Object.fromEntries(collected.ogImageUrlMap),
+  };
 }
 
 async function cleanOutputDirectory(ssgOptions: ResolvedSsgOptions, outDir: string): Promise<void> {
@@ -833,15 +882,29 @@ async function renderSsgPage(
   pageResult: PageProcessResult,
   ogImageUrlMap: Map<string, string>,
 ): Promise<string> {
-  if (context.ssgOptions.bare) {
-    return generateBareHtmlPage(pageResult.transformedHtml, pageResult.title);
-  }
-
-  const pageData = createSsgPageData(pageResult);
   const pageOgImage =
     context.shouldGenerateOgImages && ogImageUrlMap.has(pageResult.inputPath)
       ? ogImageUrlMap.get(pageResult.inputPath)
       : context.ssgOptions.ogImage;
+
+  if (context.ssgOptions.bare) {
+    return generateBarePage({
+      title: pageResult.title,
+      content: pageResult.transformedHtml,
+      lang:
+        context.ssgOptions.lang ??
+        getPageLocale(pageResult.routePaths.urlPath, context.options.i18n),
+      description: pageResult.description,
+      canonicalUrl: canonicalPageUrl(context, pageResult.routePaths.urlPath),
+      siteName: context.ssgOptions.siteName,
+      ogImage: pageOgImage,
+      head: context.ssgOptions.head,
+      bodyStart: context.ssgOptions.bodyStart,
+      bodyEnd: context.ssgOptions.bodyEnd,
+    });
+  }
+
+  const pageData = createSsgPageData(pageResult);
 
   return generateHtmlPage(
     pageData,
@@ -853,6 +916,23 @@ async function renderSsgPage(
     getPageLocale(pageData.path, context.options.i18n),
     context.options.i18n ? context.options.i18n.locales : undefined,
   );
+}
+
+/**
+ * Absolute URL of a page, or `undefined` when `ssg.siteUrl` is not set.
+ *
+ * Built the same way `get_og_image_url` builds the image URL next to it, so
+ * the canonical link and `og:image` always agree about where the page lives.
+ */
+function canonicalPageUrl(context: BuildSsgContext, urlPath: string): string | undefined {
+  const siteUrl = context.ssgOptions.siteUrl?.replace(/\/+$/, "");
+  if (!siteUrl) {
+    return undefined;
+  }
+  if (urlPath === "/" || urlPath === "") {
+    return `${siteUrl}${context.base}`;
+  }
+  return `${siteUrl}${context.base}${urlPath}/`;
 }
 
 function createSsgPageData(pageResult: PageProcessResult): SsgPageData {

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -26,6 +26,8 @@ import type {
 import { resolveTheme, themeToNapi } from "./theme";
 import type { ResolvedThemeConfig, SidebarItem } from "./theme";
 import { normalizeVitePressFrontmatter } from "./vitepress";
+import { renderPage } from "./theme-renderer";
+import type { PageData as ThemePageData } from "./theme-renderer";
 
 /**
  * Navigation item for SSG.
@@ -111,6 +113,7 @@ export function resolveSsgOptions(ssg: SsgOptions | boolean | undefined): Resolv
     extension: ssg.extension ?? ".html",
     clean: ssg.clean ?? false,
     bare: ssg.bare ?? false,
+    render: ssg.render,
     lang: ssg.lang,
     head: ssg.head,
     bodyStart: ssg.bodyStart,
@@ -866,7 +869,7 @@ async function generateHtmlPages(
       generatedPages.push({
         inputPath: pageResult.inputPath,
         outputPath: pageResult.routePaths.outputPath,
-        html: await renderSsgPage(context, pageResult, collected.ogImageUrlMap),
+        html: await renderSsgPage(context, pageResult, collected, pageResults),
       });
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);
@@ -880,12 +883,26 @@ async function generateHtmlPages(
 async function renderSsgPage(
   context: BuildSsgContext,
   pageResult: PageProcessResult,
-  ogImageUrlMap: Map<string, string>,
+  collected: CollectedPageResults,
+  allPageResults: PageProcessResult[],
 ): Promise<string> {
+  const { ogImageUrlMap } = collected;
   const pageOgImage =
     context.shouldGenerateOgImages && ogImageUrlMap.has(pageResult.inputPath)
       ? ogImageUrlMap.get(pageResult.inputPath)
       : context.ssgOptions.ogImage;
+
+  // A theme component owns the whole document, so it comes before both the
+  // bare shell and the built-in renderer.
+  if (context.ssgOptions.render) {
+    return renderPage(toThemePageData(pageResult), {
+      theme: context.ssgOptions.render,
+      siteName: context.siteName,
+      base: context.base,
+      nav: context.navItems,
+      pages: allPageResults.map(toThemePageData),
+    });
+  }
 
   if (context.ssgOptions.bare) {
     return generateBarePage({
@@ -916,6 +933,22 @@ async function renderSsgPage(
     getPageLocale(pageData.path, context.options.i18n),
     context.options.i18n ? context.options.i18n.locales : undefined,
   );
+}
+
+/** Maps an internal page result onto the theme renderer's page shape. */
+function toThemePageData(pageResult: PageProcessResult): ThemePageData {
+  return {
+    title: pageResult.title,
+    description: pageResult.description,
+    html: pageResult.transformedHtml,
+    toc: pageResult.toc,
+    lastUpdated: pageResult.lastUpdated,
+    path: pageResult.inputPath,
+    url: pageResult.routePaths.href,
+    frontmatter: pageResult.frontmatter,
+    layout:
+      typeof pageResult.frontmatter.layout === "string" ? pageResult.frontmatter.layout : undefined,
+  };
 }
 
 /**

--- a/npm/vite-plugin-ox-content/src/theme-renderer.test.ts
+++ b/npm/vite-plugin-ox-content/src/theme-renderer.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createTheme, renderPage, type PageData } from "./theme-renderer";
+import { usePageProps, useSiteConfig } from "./page-context";
+import { jsx, raw } from "./jsx-html";
+
+const page: PageData = {
+  title: "Guide",
+  description: "How it works",
+  html: "<p>body</p>",
+  toc: [],
+  path: "content/guide.md",
+  url: "/guide/index.html",
+  frontmatter: {},
+};
+
+describe("renderPage", () => {
+  it("lets the component own the whole document", () => {
+    const Theme = ({ children }: { children: { __html: string } }) => {
+      const current = usePageProps();
+      const site = useSiteConfig();
+      return jsx("html", {
+        lang: "ja",
+        children: [
+          jsx("head", { children: jsx("title", { children: `${current.title} | ${site.name}` }) }),
+          jsx("body", { children }),
+        ],
+      });
+    };
+
+    const html = renderPage(page, {
+      theme: Theme,
+      siteName: "Docs",
+      base: "/",
+      nav: [],
+      pages: [page],
+    });
+
+    expect(html.startsWith("<!DOCTYPE html>")).toBe(true);
+    expect(html).toContain('<html lang="ja">');
+    expect(html).toContain("<title>Guide | Docs</title>");
+    expect(html).toContain("<p>body</p>");
+    // No theme stylesheet, no runtime scripts — the component decides.
+    expect(html).not.toContain("ox-content-core.js");
+    expect(html).not.toContain("--octc-");
+  });
+
+  it("picks the layout named by the page's frontmatter", () => {
+    const theme = createTheme({
+      layouts: {
+        default: ({ children }) => jsx("main", { children }),
+        entry: ({ children }) => jsx("section", { class: "entry", children }),
+      },
+    });
+
+    const entryPage: PageData = { ...page, layout: "entry" };
+    const html = renderPage(entryPage, {
+      theme,
+      siteName: "Docs",
+      base: "/",
+      nav: [],
+      pages: [entryPage],
+    });
+
+    expect(html).toContain('<section class="entry">');
+    expect(html).not.toContain("<main>");
+  });
+});
+
+describe("raw", () => {
+  it("passes page html through without escaping", () => {
+    expect(raw("<em>x</em>").__html).toBe("<em>x</em>");
+  });
+});

--- a/npm/vite-plugin-ox-content/src/theme-renderer.ts
+++ b/npm/vite-plugin-ox-content/src/theme-renderer.ts
@@ -10,6 +10,7 @@ import {
   setRenderContext,
   clearRenderContext,
   generateFrontmatterTypes,
+  usePageProps,
   type RenderContext,
   type PageProps,
   type SiteConfig,
@@ -271,8 +272,10 @@ export function createTheme(config: {
   const { layouts, defaultLayout = "default" } = config;
 
   return function ThemeWithLayouts({ children }: ThemeProps): JSXNode {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { usePageProps } = require("./page-context");
+    // `page-context` is already imported statically above, so there is no
+    // cycle to dodge here. The lazy `require` this replaces threw
+    // "Cannot find module" outright once the package shipped as ESM, which
+    // is what made `createTheme` unusable.
     const page = usePageProps();
 
     // Get layout from frontmatter or use default

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -217,6 +217,43 @@ export interface SsgOptions {
   ogImage?: string;
 
   /**
+   * `lang` attribute for the generated `<html>` element.
+   *
+   * Bare mode uses this verbatim; themed pages derive it from `i18n` instead.
+   *
+   * @default "en"
+   */
+  lang?: string;
+
+  /**
+   * Raw markup appended to `<head>`.
+   *
+   * Bare mode only — themed pages own their head. Use it for the stylesheet
+   * your own build emits, or any tag the plugin does not generate.
+   *
+   * @default undefined
+   */
+  head?: string;
+
+  /**
+   * Raw markup inserted directly after `<body>`.
+   *
+   * Bare mode only. Use it for a site header that wraps the rendered page.
+   *
+   * @default undefined
+   */
+  bodyStart?: string;
+
+  /**
+   * Raw markup inserted directly before `</body>`.
+   *
+   * Bare mode only. Use it for a site footer, or scripts you inject yourself.
+   *
+   * @default undefined
+   */
+  bodyEnd?: string;
+
+  /**
    * Generate one Open Graph image per page.
    *
    * Generated images are written alongside the SSG output and referenced from
@@ -289,6 +326,10 @@ export interface ResolvedSsgOptions {
   extension: string;
   clean: boolean;
   bare: boolean;
+  lang?: string;
+  head?: string;
+  bodyStart?: string;
+  bodyEnd?: string;
   siteName?: string;
   ogImage?: string;
   generateOgImage: boolean;

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -5,6 +5,7 @@
 import type { LanguageRegistration, ThemeRegistration } from "shiki";
 import type { ThemeConfig, ResolvedThemeConfig } from "./theme";
 import type { GitHubOptions, OgpOptions, TwitterEmbedOptions } from "./plugins";
+import type { ThemeComponent } from "./theme-renderer";
 
 // =============================================================================
 // Entry Page Types (VitePress-like)
@@ -217,6 +218,23 @@ export interface SsgOptions {
   ogImage?: string;
 
   /**
+   * Render each page with a JSX theme component instead of the built-in
+   * renderer.
+   *
+   * The component owns the whole document, so `theme`, `bare` and the head
+   * metadata options do not apply — everything from `<html>` down is yours.
+   * Compose one per layout with `createTheme()`, and read the current page
+   * through `usePageProps()` / `useSiteConfig()`.
+   *
+   * ```ts
+   * ssg: { render: createTheme({ layouts: { default: DefaultLayout } }) }
+   * ```
+   *
+   * @default undefined
+   */
+  render?: ThemeComponent;
+
+  /**
    * `lang` attribute for the generated `<html>` element.
    *
    * Bare mode uses this verbatim; themed pages derive it from `i18n` instead.
@@ -326,6 +344,7 @@ export interface ResolvedSsgOptions {
   extension: string;
   clean: boolean;
   bare: boolean;
+  render?: ThemeComponent;
   lang?: string;
   head?: string;
   bodyStart?: string;


### PR DESCRIPTION
Refs #609 — both directions the issue offered, since you asked for both. Two commits, reviewable separately.

## 1. Bare mode carries the metadata it already computes

Bare mode emitted a body and a `<title>` and nothing else, so a consumer wrapping the output rebuilt by hand everything the themed page already gets — including the metadata for the OG images the same build had just rendered. The issue reports that as ~180 lines of `closeBundle` string-replacement, most of it not project-specific.

Bare pages now carry `description`, `og:*`, `twitter:*` and `<link rel="canonical">`, honor a `lang`, and take raw markup for the parts that genuinely are the consumer's:

```ts
ssg: {
  bare: true,
  lang: "ja",
  siteUrl: "https://example.com",
  head: '<link rel="stylesheet" href="/assets/site.css">',
  bodyStart: "<header>…</header><main>",
  bodyEnd: "</main><footer>…</footer>",
}
```

**The metadata only appears when there is something to say.** A page with no description, no `siteUrl` and no OG image renders byte-for-byte what bare mode emitted before — asserted directly against `generate_bare_html`, not just eyeballed. That matters because `ox-content (bare)` is the no-JS baseline in the benchmark tables (20.6 KB), and it must not quietly grow tags.

`ssg.siteUrl` was accepted but unused in bare mode. It is now what turns on the canonical link and the absolute `og:url`, built the same way `get_og_image_url` builds the image URL beside it so the two always agree about where the page lives. Without it those tags are omitted rather than guessed.

`buildSsg()` also returns an `ogImages` map of source path to image URL — the other half of the complaint, since the generated image was previously discoverable only by probing the output tree for `og-image.png`.

`generate_bare_html(content, title)` keeps working and delegates, so no crates.io consumer has to move.

## 2. `ssg.render` takes a theme component

`ThemeComponent`, `createTheme`, `renderPage` and `DefaultTheme` were all exported and documented but unreachable: `SsgOptions.theme` only accepts a `ThemeConfig`, and SSG pages render in Rust.

`ssg.render` hands the component the whole document. It takes precedence over both the bare shell and the built-in renderer, so `theme`, `bare` and the head metadata options do not apply — nothing is injected that the consumer did not write. That is exactly the case bare mode could not serve: a zero-JS page with its own token system, where the default theme's `ox-content-core.js`, `--octc-*` stylesheet and page structure are all unwanted.

### A bug the test found

`createTheme` reached for `require("./page-context")` **inside an ESM module**, so every layout it built threw `Cannot find module` on the first render. That is presumably why the component API had gone unused rather than merely unreachable. `page-context` is already imported statically at the top of the same file, so there was no cycle to dodge — it is now a plain call.

## Validation

- `cargo test --workspace --all-features`, `cargo clippy -D warnings`, `cargo fmt --all -- --check`
- `vp test src` — 213 passing, 12 new across Rust and TS
- `tsgo --noEmit`, `vp check`, `node scripts/check-file-lines.ts`
- The napi wrapper snapshots are regenerated, not hand-edited; the only diff is the new `generateSsgBarePage` export.

## Note on the option name

The issue floated `ssg.theme: createTheme(…)` or a dedicated `ssg.render`. I went with `ssg.render` because `ssg.theme` already means "a `ThemeConfig` of colors/fonts/header/footer fed to the Rust renderer", and overloading it would make the two meanings hard to tell apart at a glance. Happy to rename if you'd rather have the single option.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790014912&installation_model_id=422833&pr_number=612&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F612&signature=7f4048b806edfe76bd75a0907772510d83982aafaeefdb175780d3ef872d5e4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->