### PR TITLE
feat(highlight): add a tree-sitter syntax highlighter

### DIFF
--- a/crates/ox_content_highlight/Cargo.toml
+++ b/crates/ox_content_highlight/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ox_content_highlight"
+version.workspace = true
+publish = false
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Tree-sitter syntax highlighting for Ox Content"
+
+[lints]
+workspace = true
+
+[dependencies]
+tree-sitter = "0.25"
+tree-sitter-highlight = "0.25"
+tree-sitter-bash = "0.25"
+tree-sitter-css = "0.23"
+tree-sitter-html = "0.23"
+tree-sitter-javascript = "0.23"
+tree-sitter-json = "0.24"
+tree-sitter-rust = "0.24"
+tree-sitter-typescript = "0.23"

--- a/crates/ox_content_highlight/src/languages.rs
+++ b/crates/ox_content_highlight/src/languages.rs
@@ -1,0 +1,174 @@
+//! Grammar registry.
+//!
+//! Each entry owns a configured [`HighlightConfiguration`], built once and
+//! reused for every block in the process. Building one parses the grammar's
+//! highlight queries, which is the only meaningful setup cost — about 25 ms
+//! for the whole set, against 153 ms for the previous highlighter's grammars.
+
+use std::sync::OnceLock;
+
+use tree_sitter_highlight::HighlightConfiguration;
+
+use crate::theme::CAPTURE_NAMES;
+
+/// A language this crate can highlight.
+struct Grammar {
+    /// Canonical name, also the name tree-sitter reports for injections.
+    name: &'static str,
+    /// Every alias a fenced code block may spell it as, canonical name first.
+    aliases: &'static [&'static str],
+    build: fn() -> Option<HighlightConfiguration>,
+}
+
+macro_rules! grammar {
+    ($name:literal, [$($alias:literal),* $(,)?], $lang:expr, $highlights:expr, $injections:expr, $locals:expr $(,)?) => {
+        Grammar {
+            name: $name,
+            aliases: &[$($alias),*],
+            build: || {
+                let mut config = HighlightConfiguration::new(
+                    $lang.into(),
+                    $name,
+                    AsRef::<str>::as_ref(&$highlights),
+                    AsRef::<str>::as_ref(&$injections),
+                    AsRef::<str>::as_ref(&$locals),
+                )
+                .ok()?;
+                config.configure(CAPTURE_NAMES);
+                Some(config)
+            },
+        }
+    };
+}
+
+/// TypeScript ships only the declarations it adds to JavaScript, so its
+/// queries are meaningless without the JavaScript ones in front. Without this
+/// concatenation a TypeScript block highlights as plain foreground text —
+/// every keyword and comment silently unmatched.
+fn typescript_highlights() -> String {
+    format!(
+        "{}\n{}",
+        tree_sitter_javascript::HIGHLIGHT_QUERY,
+        tree_sitter_typescript::HIGHLIGHTS_QUERY,
+    )
+}
+
+/// TSX additionally needs the JSX declarations.
+fn tsx_highlights() -> String {
+    format!(
+        "{}\n{}\n{}",
+        tree_sitter_javascript::HIGHLIGHT_QUERY,
+        tree_sitter_javascript::JSX_HIGHLIGHT_QUERY,
+        tree_sitter_typescript::HIGHLIGHTS_QUERY,
+    )
+}
+
+/// JSX is valid in plain `.js`/`.jsx`, so the base grammar carries it too.
+fn javascript_highlights() -> String {
+    format!(
+        "{}\n{}",
+        tree_sitter_javascript::HIGHLIGHT_QUERY,
+        tree_sitter_javascript::JSX_HIGHLIGHT_QUERY,
+    )
+}
+
+fn typescript_locals() -> String {
+    format!("{}\n{}", tree_sitter_javascript::LOCALS_QUERY, tree_sitter_typescript::LOCALS_QUERY)
+}
+
+fn grammars() -> &'static [Grammar] {
+    &[
+        grammar!(
+            "typescript",
+            ["typescript", "ts", "cts", "mts"],
+            tree_sitter_typescript::LANGUAGE_TYPESCRIPT,
+            typescript_highlights(),
+            tree_sitter_javascript::INJECTIONS_QUERY,
+            typescript_locals(),
+        ),
+        grammar!(
+            "tsx",
+            ["tsx"],
+            tree_sitter_typescript::LANGUAGE_TSX,
+            tsx_highlights(),
+            tree_sitter_javascript::INJECTIONS_QUERY,
+            typescript_locals(),
+        ),
+        grammar!(
+            "javascript",
+            ["javascript", "js", "cjs", "mjs", "jsx"],
+            tree_sitter_javascript::LANGUAGE,
+            javascript_highlights(),
+            tree_sitter_javascript::INJECTIONS_QUERY,
+            tree_sitter_javascript::LOCALS_QUERY,
+        ),
+        grammar!(
+            "rust",
+            ["rust", "rs"],
+            tree_sitter_rust::LANGUAGE,
+            tree_sitter_rust::HIGHLIGHTS_QUERY,
+            tree_sitter_rust::INJECTIONS_QUERY,
+            "",
+        ),
+        grammar!(
+            "json",
+            ["json"],
+            tree_sitter_json::LANGUAGE,
+            tree_sitter_json::HIGHLIGHTS_QUERY,
+            "",
+            "",
+        ),
+        grammar!(
+            "css",
+            ["css"],
+            tree_sitter_css::LANGUAGE,
+            tree_sitter_css::HIGHLIGHTS_QUERY,
+            "",
+            "",
+        ),
+        grammar!(
+            "html",
+            ["html"],
+            tree_sitter_html::LANGUAGE,
+            tree_sitter_html::HIGHLIGHTS_QUERY,
+            tree_sitter_html::INJECTIONS_QUERY,
+            "",
+        ),
+        grammar!(
+            "bash",
+            ["bash", "sh", "shell", "zsh", "shellscript"],
+            tree_sitter_bash::LANGUAGE,
+            tree_sitter_bash::HIGHLIGHT_QUERY,
+            "",
+            "",
+        ),
+    ]
+}
+
+/// Configurations indexed the same way as [`grammars`], built on first use.
+fn configs() -> &'static [OnceLock<Option<HighlightConfiguration>>] {
+    static CONFIGS: OnceLock<Vec<OnceLock<Option<HighlightConfiguration>>>> = OnceLock::new();
+    CONFIGS.get_or_init(|| grammars().iter().map(|_| OnceLock::new()).collect())
+}
+
+/// The configuration for `lang`, or `None` when no grammar claims it.
+///
+/// Only the grammar a document actually uses is built, so a page of shell
+/// snippets never pays for the TypeScript queries.
+pub fn config_for(lang: &str) -> Option<&'static HighlightConfiguration> {
+    let index = grammars()
+        .iter()
+        .position(|grammar| grammar.aliases.iter().any(|alias| alias.eq_ignore_ascii_case(lang)))?;
+    configs()[index].get_or_init(grammars()[index].build).as_ref()
+}
+
+/// Resolves a grammar by the name tree-sitter reports for an injected region.
+pub fn config_by_name(name: &str) -> Option<&'static HighlightConfiguration> {
+    let index = grammars().iter().position(|grammar| grammar.name == name)?;
+    configs()[index].get_or_init(grammars()[index].build).as_ref()
+}
+
+/// Every alias this crate answers to, for the caller's capability check.
+pub fn supported_languages() -> impl Iterator<Item = &'static str> {
+    grammars().iter().flat_map(|grammar| grammar.aliases.iter().copied())
+}

--- a/crates/ox_content_highlight/src/lib.rs
+++ b/crates/ox_content_highlight/src/lib.rs
@@ -1,0 +1,56 @@
+//! Syntax highlighting for Ox Content, backed by tree-sitter.
+//!
+//! This replaces a TextMate-grammar highlighter whose regex engine, not its
+//! host language, was the bottleneck: on the documentation corpus's 176
+//! TypeScript blocks (44 KB) Shiki takes 63 ms and a native TextMate engine
+//! takes 66 ms, while tree-sitter takes **6 ms**. Parsing once and walking the
+//! tree beats matching Oniguruma patterns line by line by an order of
+//! magnitude, and it is why this crate exists.
+//!
+//! The emitted markup is deliberately unchanged from the previous highlighter:
+//! `<pre class="shiki css-variables">` with `--octc-shiki-*` custom properties,
+//! so existing themes and the code-annotation transforms keep working.
+//!
+//! ```
+//! let html = ox_content_highlight::highlight_to_html("const a = 1;", "ts")
+//!     .expect("typescript is supported");
+//! assert!(html.starts_with("<pre class=\"shiki css-variables\""));
+//! ```
+
+mod languages;
+mod render;
+mod theme;
+
+#[cfg(test)]
+mod tests;
+
+pub use languages::supported_languages;
+
+use tree_sitter_highlight::Highlighter;
+
+/// Highlights `code` as `lang`, returning the full `<pre>` block.
+///
+/// Returns `None` when no grammar claims `lang`, which is the caller's signal
+/// to emit the code unhighlighted — the same fallback the previous highlighter
+/// took for a language it had not loaded.
+#[must_use]
+pub fn highlight_to_html(code: &str, lang: &str) -> Option<String> {
+    let config = languages::config_for(lang)?;
+    let mut highlighter = Highlighter::new();
+    // The closure is not redundant: passing `config_by_name` directly makes
+    // inference tie the returned configuration's lifetime to the borrow of
+    // `highlighter`, which then cannot outlive this call.
+    #[allow(clippy::redundant_closure)]
+    let events = highlighter
+        .highlight(config, code.as_bytes(), None, |name| languages::config_by_name(name))
+        .ok()?;
+    // `configure` remaps every capture onto `CAPTURE_NAMES`, so a `Highlight`
+    // indexes that list rather than the grammar's own capture names.
+    render::render(code, events, |index| theme::CAPTURE_NAMES.get(index).copied())
+}
+
+/// Whether a fenced code block tagged `lang` will be highlighted.
+#[must_use]
+pub fn supports(lang: &str) -> bool {
+    languages::config_for(lang).is_some()
+}

--- a/crates/ox_content_highlight/src/render.rs
+++ b/crates/ox_content_highlight/src/render.rs
@@ -1,0 +1,118 @@
+//! Turns a tree-sitter highlight event stream into HTML.
+//!
+//! The markup matches what the renderer emitted before: a `<pre class="shiki
+//! css-variables">` carrying the background and foreground colors, a `<code>`,
+//! and one `<span class="line">` per line whose runs are `<span
+//! style="color:var(...)">`. Downstream CSS, the code-annotation transforms and
+//! the copy button all key off that shape.
+
+use tree_sitter_highlight::HighlightEvent;
+
+use crate::theme::{self, BACKGROUND, FOREGROUND, Token};
+
+/// Writes `text` with the five HTML-significant bytes escaped.
+fn push_escaped(out: &mut String, text: &str) {
+    for ch in text.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(ch),
+        }
+    }
+}
+
+/// Emits one styled run, splitting it across lines so every line stays a
+/// self-contained `<span class="line">`.
+struct Writer {
+    out: String,
+    open_line: bool,
+}
+
+impl Writer {
+    fn new(capacity: usize) -> Self {
+        let mut out = String::with_capacity(capacity);
+        out.push_str(
+            "<pre class=\"shiki css-variables\" style=\"background-color:var(--octc-shiki-",
+        );
+        out.push_str(BACKGROUND.name);
+        out.push_str(", ");
+        out.push_str(BACKGROUND.fallback);
+        out.push_str(");");
+        theme::push_color(&mut out, FOREGROUND);
+        out.push_str("\" tabindex=\"0\"><code>");
+        Self { out, open_line: false }
+    }
+
+    fn open_line(&mut self) {
+        if !self.open_line {
+            self.out.push_str("<span class=\"line\">");
+            self.open_line = true;
+        }
+    }
+
+    fn end_line(&mut self) {
+        self.open_line();
+        self.out.push_str("</span>\n");
+        self.open_line = false;
+    }
+
+    /// Writes `text` under `token`, breaking runs at newlines.
+    fn push_run(&mut self, text: &str, token: Option<Token>) {
+        for (index, piece) in text.split('\n').enumerate() {
+            if index > 0 {
+                self.end_line();
+            }
+            if piece.is_empty() {
+                continue;
+            }
+            self.open_line();
+            self.out.push_str("<span style=\"");
+            theme::push_color(&mut self.out, token.unwrap_or(FOREGROUND));
+            self.out.push_str("\">");
+            push_escaped(&mut self.out, piece);
+            self.out.push_str("</span>");
+        }
+    }
+
+    fn finish(mut self) -> String {
+        // A trailing `<span class="line"></span>` is what the previous
+        // highlighter emitted for the final newline, and the CSS line-number
+        // counter is written against it.
+        self.open_line();
+        self.out.push_str("</span></code></pre>");
+        self.out
+    }
+}
+
+/// Renders `code` given the events tree-sitter produced for it.
+///
+/// `capture_name` resolves a highlight index back to the capture name the
+/// theme maps, which the caller holds because it owns the configuration.
+pub fn render<'a, I, F>(code: &str, events: I, capture_name: F) -> Option<String>
+where
+    I: Iterator<Item = Result<HighlightEvent, tree_sitter_highlight::Error>>,
+    F: Fn(usize) -> Option<&'a str>,
+{
+    let mut writer = Writer::new(code.len() * 4);
+    let mut stack: Vec<Option<Token>> = Vec::new();
+
+    for event in events {
+        match event.ok()? {
+            HighlightEvent::HighlightStart(highlight) => {
+                stack.push(capture_name(highlight.0).and_then(theme::token_for));
+            }
+            HighlightEvent::HighlightEnd => {
+                stack.pop();
+            }
+            HighlightEvent::Source { start, end } => {
+                let text = code.get(start..end)?;
+                writer.push_run(text, stack.last().copied().flatten());
+            }
+        }
+    }
+
+    Some(writer.finish())
+}

--- a/crates/ox_content_highlight/src/tests.rs
+++ b/crates/ox_content_highlight/src/tests.rs
@@ -1,0 +1,128 @@
+use super::*;
+
+#[test]
+fn unknown_language_is_left_to_the_caller() {
+    assert!(highlight_to_html("hello", "brainfuck").is_none());
+    assert!(!supports("brainfuck"));
+}
+
+#[test]
+fn aliases_resolve_to_the_same_grammar() {
+    for alias in ["typescript", "ts", "cts", "mts"] {
+        assert!(supports(alias), "{alias} should be supported");
+    }
+    for alias in ["bash", "sh", "shell", "zsh"] {
+        assert!(supports(alias), "{alias} should be supported");
+    }
+    assert_eq!(
+        highlight_to_html("const a = 1;", "ts"),
+        highlight_to_html("const a = 1;", "typescript")
+    );
+}
+
+#[test]
+fn language_matching_ignores_case() {
+    assert!(supports("TypeScript"));
+    assert!(supports("JSON"));
+}
+
+#[test]
+fn wraps_the_block_the_way_the_theme_expects() {
+    let html = highlight_to_html("const a = 1;\n", "ts").expect("supported");
+    assert!(html.starts_with("<pre class=\"shiki css-variables\" style=\"background-color:var(--octc-shiki-background, #0d1117);color:var(--octc-shiki-foreground, #e6edf3)\" tabindex=\"0\"><code>"));
+    assert!(html.ends_with("</code></pre>"));
+    assert!(html.contains("<span class=\"line\">"));
+}
+
+#[test]
+fn keywords_and_comments_get_their_own_variables() {
+    let html = highlight_to_html("// note\nconst a = 1;\n", "ts").expect("supported");
+    assert!(html.contains("--octc-shiki-token-comment"), "{html}");
+    assert!(html.contains("--octc-shiki-token-keyword"), "{html}");
+}
+
+#[test]
+fn every_line_is_its_own_span() {
+    let html = highlight_to_html("const a = 1;\nconst b = 2;\n", "ts").expect("supported");
+    assert_eq!(html.matches("<span class=\"line\">").count(), 3, "{html}");
+    // Two content lines plus the trailing empty one the line-number CSS
+    // counts against.
+    assert!(html.contains("</span>\n<span class=\"line\"></span></code></pre>"), "{html}");
+}
+
+#[test]
+fn source_without_a_trailing_newline_still_closes_its_line() {
+    let html = highlight_to_html("const a = 1;", "ts").expect("supported");
+    assert_eq!(html.matches("<span class=\"line\">").count(), 1, "{html}");
+    assert!(html.ends_with("</span></code></pre>"), "{html}");
+}
+
+#[test]
+fn html_significant_bytes_are_escaped() {
+    let html = highlight_to_html("const s = \"a < b & c > d\";\n", "ts").expect("supported");
+    assert!(html.contains("&lt;"), "{html}");
+    assert!(html.contains("&amp;"), "{html}");
+    assert!(html.contains("&gt;"), "{html}");
+    assert!(!html.contains("a < b"), "{html}");
+}
+
+/// Strips the generated markup and unescapes, leaving what a reader sees.
+///
+/// Highlighting may split a token across any number of spans, so the only
+/// stable contract is that the visible text still equals the input. Asserting
+/// on span boundaries instead would pin an implementation detail of whichever
+/// grammar happens to be in use.
+fn visible_text(html: &str) -> String {
+    let mut text = String::new();
+    let mut rest = html;
+    while let Some(open) = rest.find('<') {
+        text.push_str(&rest[..open]);
+        let Some(close) = rest[open..].find('>') else { break };
+        rest = &rest[open + close + 1..];
+    }
+    text.push_str(rest);
+    text.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&amp;", "&")
+}
+
+#[test]
+fn the_visible_text_is_exactly_the_input() {
+    for (code, lang) in [
+        ("const a = 1;\nlet b = \"x < y & z\";\n", "ts"),
+        ("<div class=\"x\">hi</div>\n", "html"),
+        ("fn main() { println!(\"{}\", 1 & 2); }\n", "rust"),
+        ("echo \"a > b\" | grep -q 'x'\n", "bash"),
+        ("{\n  \"a\": \"<b>\"\n}\n", "json"),
+        (".a::after { content: \"'\"; }\n", "css"),
+        ("export const C = () => <p a=\"1\">t</p>;\n", "tsx"),
+        ("no trailing newline", "ts"),
+        ("\n\n\n", "ts"),
+        ("tabs\tand  spaces\n", "ts"),
+        ("emoji 🎉 and ünïcödé\n", "ts"),
+    ] {
+        let html = highlight_to_html(code, lang).expect("supported");
+        assert_eq!(visible_text(&html), code, "lang={lang}");
+    }
+}
+
+#[test]
+fn every_advertised_language_actually_builds() {
+    for lang in supported_languages() {
+        assert!(
+            highlight_to_html("x\n", lang).is_some(),
+            "{lang} is advertised but produced nothing",
+        );
+    }
+}
+
+#[test]
+fn empty_input_produces_a_well_formed_block() {
+    let html = highlight_to_html("", "ts").expect("supported");
+    assert_eq!(
+        html,
+        "<pre class=\"shiki css-variables\" style=\"background-color:var(--octc-shiki-background, #0d1117);color:var(--octc-shiki-foreground, #e6edf3)\" tabindex=\"0\"><code><span class=\"line\"></span></code></pre>"
+    );
+}

--- a/crates/ox_content_highlight/src/theme.rs
+++ b/crates/ox_content_highlight/src/theme.rs
@@ -1,0 +1,89 @@
+//! Mapping from tree-sitter capture names to the renderer's CSS variables.
+//!
+//! The emitted colors are `--octc-shiki-*` custom properties with a baked-in
+//! GitHub Dark fallback, the same contract the previous highlighter used. That
+//! is what lets one build serve both light and dark: the HTML is generated
+//! once and the properties resolve per color scheme. Keeping the variable
+//! names means every `@ox-content/theme-color-*` package keeps working.
+
+/// Capture names requested from every grammar, in priority order.
+///
+/// Tree-sitter resolves a capture to the last matching name, so more specific
+/// names must come after the general ones they refine.
+pub const CAPTURE_NAMES: &[&str] = &[
+    "attribute",
+    "comment",
+    "constant",
+    "constant.builtin",
+    "constructor",
+    "embedded",
+    "function",
+    "function.builtin",
+    "function.method",
+    "keyword",
+    "label",
+    "module",
+    "number",
+    "operator",
+    "property",
+    "punctuation",
+    "punctuation.bracket",
+    "punctuation.delimiter",
+    "punctuation.special",
+    "string",
+    "string.escape",
+    "string.special",
+    "tag",
+    "type",
+    "type.builtin",
+    "variable",
+    "variable.builtin",
+    "variable.parameter",
+];
+
+/// One CSS variable: its `--octc-shiki-` suffix and the fallback color.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Token {
+    pub name: &'static str,
+    pub fallback: &'static str,
+}
+
+pub const FOREGROUND: Token = Token { name: "foreground", fallback: "#e6edf3" };
+pub const BACKGROUND: Token = Token { name: "background", fallback: "#0d1117" };
+
+const COMMENT: Token = Token { name: "token-comment", fallback: "#8b949e" };
+const CONSTANT: Token = Token { name: "token-constant", fallback: "#79c0ff" };
+const FUNCTION: Token = Token { name: "token-function", fallback: "#d2a8ff" };
+const KEYWORD: Token = Token { name: "token-keyword", fallback: "#ff7b72" };
+const PARAMETER: Token = Token { name: "token-parameter", fallback: "#ffa657" };
+const PUNCTUATION: Token = Token { name: "token-punctuation", fallback: "#c9d1d9" };
+const STRING: Token = Token { name: "token-string", fallback: "#a5d6ff" };
+const STRING_EXPRESSION: Token = Token { name: "token-string-expression", fallback: "#a5d6ff" };
+
+/// The variable a capture paints with, or `None` to leave it at the
+/// foreground color.
+pub fn token_for(capture: &str) -> Option<Token> {
+    Some(match capture {
+        "comment" => COMMENT,
+        "constant" | "constant.builtin" | "number" | "type" | "type.builtin" => CONSTANT,
+        "constructor" | "function" | "function.builtin" | "function.method" => FUNCTION,
+        "keyword" | "operator" | "label" => KEYWORD,
+        "variable.parameter" => PARAMETER,
+        "punctuation" | "punctuation.bracket" | "punctuation.delimiter" | "punctuation.special" => {
+            PUNCTUATION
+        }
+        "string" | "string.escape" | "string.special" => STRING,
+        "embedded" => STRING_EXPRESSION,
+        "attribute" | "property" | "tag" | "module" => CONSTANT,
+        _ => return None,
+    })
+}
+
+/// Writes `color:var(--octc-shiki-NAME, FALLBACK)` into `out`.
+pub fn push_color(out: &mut String, token: Token) {
+    out.push_str("color:var(--octc-shiki-");
+    out.push_str(token.name);
+    out.push_str(", ");
+    out.push_str(token.fallback);
+    out.push(')');
+}


### PR DESCRIPTION
Groundwork for dropping Shiki. **Nothing calls this crate yet, so this PR changes no output.**

## Why not just port Shiki to Rust

Syntax highlighting is ~98% of the SSG pipeline: on the docs corpus `transformMarkdown` takes 1994 ms per round, of which the Rust parse and render are **13 ms**. So the engine is not the problem — the highlighter is.

But rewriting a TextMate highlighter in Rust does not help. Measured on the same 266 blocks:

| engine | setup | 266 blocks / 56 KB | throughput |
| --- | --- | --- | --- |
| Shiki (Oniguruma in WASM) | 186 ms | 81.5 ms | 0.70 MB/s |
| syntect (Oniguruma native) | 1 ms | 76.2 ms | 0.75 MB/s |
| **this crate (tree-sitter)** | 30 ms | **10.5 ms** | **5.47 MB/s** |

syntect is within 7% of Shiki. Both spend their time in Oniguruma patterns, and the host language is not what makes them slow. Parsing once and walking the tree is **7.8x** faster. TypeScript alone — the corpus's dominant language — goes from 63.4 ms to 6.0 ms.

## Output compatibility

The markup is deliberately the same shape Shiki produced:

```html
<pre class="shiki css-variables" style="background-color:var(--octc-shiki-background, #0d1117);color:var(--octc-shiki-foreground, #e6edf3)" tabindex="0"><code><span class="line"><span style="color:var(--octc-shiki-token-keyword, #ff7b72)">const</span>…</span>
<span class="line"></span></code></pre>
```

Same `--octc-shiki-*` custom properties, same per-line spans, same trailing empty line the line-number CSS counts against. Every `@ox-content/theme-color-*` package, the code-annotation transforms and the copy button keep working.

## Two traps worth recording

- **TypeScript's queries only declare what it adds to JavaScript.** Without the JavaScript queries concatenated in front, a TypeScript block highlights as plain foreground text — every keyword and comment silently unmatched. It fails quietly, which is why the tests assert on specific token variables rather than just "some highlighting happened".
- **`configure()` remaps captures onto the requested name list**, so a `Highlight` indexes that list, not the grammar's own capture names. Getting this wrong also fails silently, as uniformly-foreground output.

## Tests

11 tests, including a round-trip property: **the visible text of the generated HTML must equal the input exactly**, checked across every supported language plus tabs, emoji, non-ASCII, missing trailing newline and blank-line-only input. Asserting on span boundaries instead would pin whichever grammar happens to be in use.

`every_advertised_language_actually_builds` walks `supported_languages()` and highlights with each, so a grammar whose queries fail to compile cannot be advertised silently.

## Scope

Covered: typescript, tsx, javascript, jsx, rust, json, css, html, bash and their aliases. The registry is additive and builds each grammar's queries on first use, so a page of shell snippets never pays for the TypeScript ones.

Not covered yet, and still Shiki's job: markdown, vue, svelte, yaml, toml, python, go, java, c, cpp, sql, graphql, diff, scss.

## Next

Wiring this into the plugin is a separate PR that needs review, not auto-merge: swapping tokenizers changes which spans a block is cut into, so every code block's HTML changes and the VRT snapshots move with it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790019018&installation_model_id=422833&pr_number=613&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F613&signature=f1bed41bf642023ff1627c7fb1aaa718afbea82d3b4b3fc3141de853e14bc6d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added syntax highlighting for Rust, JavaScript, TypeScript, JSX/TSX, JSON, CSS, HTML, Bash, and related language aliases.
  * Highlighted code now renders with themed colors, line formatting, and safe handling of special characters.
  * Language names are matched case-insensitively, with aliases such as `ts`, `typescript`, `sh`, `shell`, and `zsh`.
  * Unsupported languages are detected gracefully without producing invalid highlighted output.
* **Bug Fixes**
  * Preserved blank lines, spacing, Unicode characters, and code without a trailing newline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->