### PR TITLE
perf(highlight): render plain-text blocks natively

### DIFF
--- a/crates/ox_content_highlight/src/languages.rs
+++ b/crates/ox_content_highlight/src/languages.rs
@@ -215,7 +215,18 @@ pub fn config_by_name(name: &str) -> Option<&'static HighlightConfiguration> {
     configs()[index].get_or_init(grammars()[index].build).as_ref()
 }
 
+/// Names for "this block has no syntax", rendered without tokenizing.
+pub const PLAIN_LANGUAGES: &[&str] = &["text", "plaintext", "txt", "plain"];
+
+/// Whether `lang` names a block that should render without tokenizing.
+pub fn is_plain(lang: &str) -> bool {
+    PLAIN_LANGUAGES.iter().any(|name| name.eq_ignore_ascii_case(lang))
+}
+
 /// Every alias this crate answers to, for the caller's capability check.
 pub fn supported_languages() -> impl Iterator<Item = &'static str> {
-    grammars().iter().flat_map(|grammar| grammar.aliases.iter().copied())
+    grammars()
+        .iter()
+        .flat_map(|grammar| grammar.aliases.iter().copied())
+        .chain(PLAIN_LANGUAGES.iter().copied())
 }

--- a/crates/ox_content_highlight/src/lib.rs
+++ b/crates/ox_content_highlight/src/lib.rs
@@ -35,6 +35,9 @@ use tree_sitter_highlight::Highlighter;
 /// took for a language it had not loaded.
 #[must_use]
 pub fn highlight_to_html(code: &str, lang: &str) -> Option<String> {
+    if languages::is_plain(lang) {
+        return Some(render::render_plain(code));
+    }
     let config = languages::config_for(lang)?;
     let mut highlighter = Highlighter::new();
     // The closure is not redundant: passing `config_by_name` directly makes
@@ -52,5 +55,5 @@ pub fn highlight_to_html(code: &str, lang: &str) -> Option<String> {
 /// Whether a fenced code block tagged `lang` will be highlighted.
 #[must_use]
 pub fn supports(lang: &str) -> bool {
-    languages::config_for(lang).is_some()
+    languages::is_plain(lang) || languages::config_for(lang).is_some()
 }

--- a/crates/ox_content_highlight/src/render.rs
+++ b/crates/ox_content_highlight/src/render.rs
@@ -87,6 +87,19 @@ impl Writer {
     }
 }
 
+/// Renders `code` with no tokenization, every line at the foreground color.
+///
+/// A `text` block has nothing to highlight, but it still has to come out in
+/// the same `<pre>` the other blocks do — the copy button, line numbers and
+/// annotation transforms all key off that markup. Handling it here rather than
+/// declining it is also what lets a page of prose and plain-text snippets
+/// avoid constructing the fallback highlighter at all.
+pub fn render_plain(code: &str) -> String {
+    let mut writer = Writer::new(code.len() * 2);
+    writer.push_run(code, None);
+    writer.finish()
+}
+
 /// Renders `code` given the events tree-sitter produced for it.
 ///
 /// `capture_name` resolves a highlight index back to the capture name the

--- a/crates/ox_content_highlight/src/tests.rs
+++ b/crates/ox_content_highlight/src/tests.rs
@@ -125,6 +125,31 @@ fn every_advertised_language_actually_builds() {
 }
 
 #[test]
+fn plain_text_renders_without_tokenizing() {
+    // `text` is the third most common fence tag in the documentation corpus.
+    // Declining it would send those pages to the fallback highlighter purely
+    // to render prose, which is the cost this avoids.
+    for lang in ["text", "plaintext", "txt", "plain", "TEXT"] {
+        assert!(supports(lang), "{lang} should be supported");
+    }
+
+    let html = highlight_to_html("a < b\nline two\n", "text").expect("supported");
+    assert!(html.starts_with("<pre class=\"shiki css-variables\""), "{html}");
+    assert!(html.contains("&lt;"), "{html}");
+    // Nothing is tokenized, so no token variable may appear.
+    assert!(!html.contains("--octc-shiki-token-"), "{html}");
+    assert_eq!(html.matches("<span class=\"line\">").count(), 3, "{html}");
+}
+
+#[test]
+fn plain_text_keeps_the_input_verbatim() {
+    for code in ["a < b & c > d\n", "\ttabbed\n\n", "🎉 ünï\n", "no newline"] {
+        let html = highlight_to_html(code, "text").expect("supported");
+        assert_eq!(visible_text(&html), code);
+    }
+}
+
+#[test]
 fn empty_input_produces_a_well_formed_block() {
     let html = highlight_to_html("", "ts").expect("supported");
     assert_eq!(


### PR DESCRIPTION
`text` is the **third most common fence tag** in the documentation corpus — 54 blocks, behind only `ts` (153) and `bash` (70). Declining it sent those pages to Shiki purely to render prose, and constructing Shiki parses two dozen TextMate grammars.

A `text` block has nothing to tokenize, but it still has to come out in the same `<pre>` every other block does — the copy button, line numbers and the annotation transforms all key off that markup. So this renders it rather than declining it.

## Measured

Documentation corpus, on top of #616:

| | before | after |
| --- | --- | --- |
| cold | 1297 ms | 1189 ms |
| warm | 446 ms | 428 ms |

Against the original Shiki baseline: **1687 → 1189 ms cold (-30%)** and **564 → 428 ms warm (-24%)**.

## Output

`text` blocks now carry a foreground-colored span per line rather than Shiki's bare `<span>`, keeping the markup uniform with every other block this engine emits. The color is the one the `<pre>` already sets, so nothing renders differently.

## Tests

Two new cases: `text`/`plaintext`/`txt`/`plain` are all claimed and produce no token variables at all, and the round-trip property (visible text equals input) holds for tabs, emoji, blank lines and a missing trailing newline.

`cargo test --workspace --all-features`, `clippy -D warnings`, `vp test src` (220), `tsgo --noEmit` all green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790020087&installation_model_id=422833&pr_number=617&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F617&signature=39319bf440a7f3e4f2381d2a98f06b3fda092d7516e5b08a09057418458cb136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->