### PR TITLE
bench(native): add ferromark to the competitor rows

### DIFF
--- a/benchmarks/native-competitors/Cargo.lock
+++ b/benchmarks/native-competitors/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,10 +43,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
+name = "ferromark"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+checksum = "f26bc33597a3dede0e3c54e0a8ca200c7e94a6ecc69b4d4092896937ee1fa5dd"
+dependencies = [
+ "html-escape",
+ "memchr",
+ "rustc-hash",
+ "smallvec",
+ "unicode-ident",
+]
 
 [[package]]
 name = "getopts"
@@ -67,42 +65,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "html-escape"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9356095b4b41197bba32173600e1582792cda618f65d12f68e2e77d273413c5"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "logos"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
-dependencies = [
- "logos-derive",
-]
-
-[[package]]
-name = "logos-codegen"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
-dependencies = [
- "fnv",
- "proc-macro2",
- "quote",
- "regex-automata",
- "regex-syntax",
- "syn",
-]
-
-[[package]]
-name = "logos-derive"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
-dependencies = [
- "logos-codegen",
-]
 
 [[package]]
 name = "memchr"
@@ -114,6 +86,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 name = "ox-content-native-competitors"
 version = "0.0.0"
 dependencies = [
+ "ferromark",
  "ox_content_allocator",
  "ox_content_parser",
  "ox_content_renderer",
@@ -124,24 +97,23 @@ dependencies = [
 
 [[package]]
 name = "ox_content_allocator"
-version = "2.81.0"
+version = "2.89.0"
 dependencies = [
  "bumpalo",
 ]
 
 [[package]]
 name = "ox_content_ast"
-version = "2.81.0"
+version = "2.89.0"
 dependencies = [
  "ox_content_allocator",
 ]
 
 [[package]]
 name = "ox_content_parser"
-version = "2.81.0"
+version = "2.89.0"
 dependencies = [
  "compact_str",
- "logos",
  "memchr",
  "ox_content_allocator",
  "ox_content_ast",
@@ -151,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "ox_content_renderer"
-version = "2.81.0"
+version = "2.89.0"
 dependencies = [
  "compact_str",
  "memchr",
@@ -198,23 +170,6 @@ checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-hash"

--- a/benchmarks/native-competitors/Cargo.toml
+++ b/benchmarks/native-competitors/Cargo.toml
@@ -19,6 +19,9 @@ pulldown-cmark = { version = "0.13.4", default-features = false, features = ["ht
 # Grok Build's markdown stack (Apache-2.0, not published on crates.io): a lean
 # wrapper whose only dependency is pulldown-cmark. Pinned by rev so competitor
 # numbers stay reproducible.
+# Single-pass Markdown-to-HTML compiler. It has no parse-only step — its
+# `parse` returns rendered HTML — so it appears in the render rows only.
+ferromark = "0.7"
 xai-grok-markdown-core = { git = "https://github.com/xai-org/grok-build", rev = "98c3b2438aa922fbbe6178a5c0a4c48f85edc8ce" }
 # The engine under test, referenced by path so the base and head benchmark
 # checkouts each measure their own core. These rows show the boundary-free

--- a/benchmarks/native-competitors/src/conformance.rs
+++ b/benchmarks/native-competitors/src/conformance.rs
@@ -113,6 +113,11 @@ fn render_grok(markdown: &str) -> String {
 /// A panicking engine scores the example as a failure instead of aborting:
 /// refusing to parse an input the spec defines is a conformance result, not a
 /// harness error.
+/// ferromark compiles straight to HTML in one pass.
+fn render_ferromark(markdown: &str) -> String {
+    ferromark::to_html(markdown)
+}
+
 pub fn run(spec_path: &str) -> Result<String, String> {
     let text = std::fs::read_to_string(spec_path)
         .map_err(|error| format!("failed to read {spec_path}: {error}"))?;
@@ -121,8 +126,9 @@ pub fn run(spec_path: &str) -> Result<String, String> {
     let expected: Vec<String> =
         examples.iter().map(|example| normalize_html(&example.html)).collect();
 
-    let engines: [Engine; 3] = [
+    let engines: [Engine; 4] = [
         ("ox-content (native)", render_ox_content),
+        ("ferromark", render_ferromark),
         ("pulldown-cmark", render_pulldown),
         ("xai-grok-markdown-core (Grok Build)", render_grok),
     ];
@@ -224,7 +230,7 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
         let results = value["results"].as_array().expect("results array");
 
-        assert_eq!(results.len(), 3);
+        assert_eq!(results.len(), 4);
         for result in results {
             let passed = result["passed"].as_u64().expect("passed count");
             let total = result["total"].as_u64().expect("total count");

--- a/benchmarks/native-competitors/src/main.rs
+++ b/benchmarks/native-competitors/src/main.rs
@@ -158,6 +158,14 @@ fn ox_content_render_html(input: &str) -> usize {
     renderer.render(&document).len()
 }
 
+/// ferromark compiles straight to HTML — its `parse` returns rendered HTML
+/// too, so it has no parse-only step to time and appears in the render rows
+/// only. Timing its `parse` against the other engines' parse rows would be
+/// comparing a full compile to a tree build.
+fn render_ferromark_html(input: &str) -> String {
+    ferromark::to_html(input)
+}
+
 fn run_benchmarks(sizes: &[(&'static str, usize, u32)], runs: u32) -> SuiteResults {
     let mut parse = Vec::new();
     let mut render = Vec::new();
@@ -197,6 +205,15 @@ fn run_benchmarks(sizes: &[(&'static str, usize, u32)], runs: u32) -> SuiteResul
                     "ox-content (native)",
                     || {
                         black_box(ox_content_render_html(&content));
+                    },
+                    iterations,
+                    runs,
+                    bytes,
+                ),
+                bench(
+                    "ferromark",
+                    || {
+                        black_box(render_ferromark_html(&content).len());
                     },
                     iterations,
                     runs,
@@ -284,7 +301,10 @@ mod tests {
             ]
         );
         let render_names: Vec<_> = render_rows.iter().map(|row| row["name"].as_str()).collect();
-        assert_eq!(render_names, [Some("ox-content (native)"), Some("pulldown-cmark + push_html")]);
+        assert_eq!(
+            render_names,
+            [Some("ox-content (native)"), Some("ferromark"), Some("pulldown-cmark + push_html")]
+        );
 
         for row in parse_rows.iter().chain(render_rows) {
             for field in ["opsPerSec", "avgMs", "throughputMBs"] {


### PR DESCRIPTION
ferromark bills itself as an *ultra-high-performance Markdown-to-HTML compiler with a native Rust core*, so it belongs next to pulldown-cmark in the boundary-free rows.

## Result: ox-content wins at every size

`--runs 3`, render rows (ops/sec):

| size | ox-content | ferromark | pulldown-cmark | ox/ferromark |
| --- | --- | --- | --- | --- |
| small | 368,947 | 183,052 | 229,052 | **2.02x** |
| medium | 45,631 | 26,120 | 28,154 | **1.75x** |
| large | 5,998 | 3,447 | 3,721 | **1.74x** |
| huge | 275 | 152 | 132 | **1.81x** |

And on the vendored CommonMark 0.31.2 spec:

| engine | passed |
| --- | --- |
| ox-content (native) | **652/652 — 100%** |
| ferromark | 579/652 — 88.8% |
| pulldown-cmark | 652/652 — 100% |
| xai-grok-markdown-core | 652/652 — 100% |

That conformance column is exactly why it exists: a faster engine that skips spec behavior should not read as a straight win. Here ferromark is neither faster nor complete.

## Render rows only, deliberately

ferromark's `parse` returns rendered HTML — it is a single-pass compiler with no tree to build. Putting it in the parse rows would compare a full compile against the other engines' tree construction, which would flatter it at small sizes and mean nothing.

## Tests

Both pinned engine lists are **updated rather than loosened** — the JSON row-shape assertion and the conformance engine count. Adding an engine should keep having to be deliberate; they caught this change, which is what they are for.

`cargo test` (19), `clippy -D warnings`, `fmt --check` all green in the standalone competitor workspace.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790020622&installation_model_id=422833&pr_number=618&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F618&signature=56779b1ab4b13a48825529b3be46d37e4bd1f33c4c0bd23155e48fb054ca0706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->