### PR TITLE
perf(highlight): highlight a page's code without an HTML round trip

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -212,6 +212,15 @@ export declare function getSsgUrlPath(inputPath: string, srcDir: string): string
  */
 export declare function highlightCodeBlock(code: string, lang: string): string | null
 
+/**
+ * Highlights every code block in a rendered document in one call.
+ *
+ * The alternative is walking the page through an HTML parser and serializer
+ * to find the blocks and splice results back, which on the documentation
+ * corpus costs an order of magnitude more than the highlighting itself.
+ */
+export declare function highlightHtmlCodeBlocks(html: string): JsHighlightedDocument
+
 /** Result of i18n checking. */
 export interface I18NCheckResult {
   /** All diagnostics. */
@@ -847,6 +856,17 @@ export interface JsHeroNotice {
   title?: string
   /** Notice paragraphs. */
   body?: Array<string>
+}
+
+/** Result of highlighting every code block in a rendered document. */
+export interface JsHighlightedDocument {
+  /** The document with each handled block replaced. */
+  html: string
+  /**
+   * Languages of blocks left untouched, so the caller knows whether another
+   * highlighter still has to run over the result.
+   */
+  skipped: Array<string>
 }
 
 /** Configuration for generated i18n runtime modules. */

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -210,6 +210,7 @@ module.exports.normalizeVitePressFrontmatter = binding.normalizeVitePressFrontma
 module.exports.generateSsgHtml = binding.generateSsgHtml;
 module.exports.generateSsgBareHtml = binding.generateSsgBareHtml;
 module.exports.highlightCodeBlock = binding.highlightCodeBlock;
+module.exports.highlightHtmlCodeBlocks = binding.highlightHtmlCodeBlocks;
 module.exports.supportsHighlightLanguage = binding.supportsHighlightLanguage;
 module.exports.nativeHighlightLanguages = binding.nativeHighlightLanguages;
 module.exports.generateSsgBarePage = binding.generateSsgBarePage;

--- a/crates/ox_content_napi/src/highlight_bindings.rs
+++ b/crates/ox_content_napi/src/highlight_bindings.rs
@@ -24,3 +24,28 @@ pub fn supports_highlight_language(lang: String) -> bool {
 pub fn native_highlight_languages() -> Vec<String> {
     ox_content_highlight::supported_languages().map(ToOwned::to_owned).collect()
 }
+
+/// Result of highlighting every code block in a rendered document.
+#[napi(object)]
+pub struct JsHighlightedDocument {
+    /// The document with each handled block replaced.
+    pub html: String,
+    /// Languages of blocks left untouched, so the caller knows whether another
+    /// highlighter still has to run over the result.
+    pub skipped: Vec<String>,
+}
+
+/// Highlights every code block in a rendered document in one call.
+///
+/// The alternative is walking the page through an HTML parser and serializer
+/// to find the blocks and splice results back, which on the documentation
+/// corpus costs an order of magnitude more than the highlighting itself.
+#[napi(js_name = "highlightHtmlCodeBlocks")]
+pub fn highlight_html_code_blocks(html: String) -> JsHighlightedDocument {
+    let result = ox_content_transform::highlight::highlight_code_blocks(
+        &html,
+        ox_content_highlight::supports,
+        ox_content_highlight::highlight_to_html,
+    );
+    JsHighlightedDocument { html: result.html, skipped: result.skipped }
+}

--- a/crates/ox_content_napi/src/tests/runtime_features.rs
+++ b/crates/ox_content_napi/src/tests/runtime_features.rs
@@ -55,6 +55,7 @@ fn javascript_wrapper_and_declarations_cover_expected_exports() {
         "generateSsgBareHtml",
         "generateSsgBarePage",
         "highlightCodeBlock",
+        "highlightHtmlCodeBlocks",
         "nativeHighlightLanguages",
         "supportsHighlightLanguage",
         "generateSsgHtml",

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -216,6 +216,15 @@ export declare function getSsgUrlPath(inputPath: string, srcDir: string): string
  */
 export declare function highlightCodeBlock(code: string, lang: string): string | null
 
+/**
+ * Highlights every code block in a rendered document in one call.
+ *
+ * The alternative is walking the page through an HTML parser and serializer
+ * to find the blocks and splice results back, which on the documentation
+ * corpus costs an order of magnitude more than the highlighting itself.
+ */
+export declare function highlightHtmlCodeBlocks(html: string): JsHighlightedDocument
+
 /** Result of i18n checking. */
 export interface I18NCheckResult {
   /** All diagnostics. */
@@ -851,6 +860,17 @@ export interface JsHeroNotice {
   title?: string
   /** Notice paragraphs. */
   body?: Array<string>
+}
+
+/** Result of highlighting every code block in a rendered document. */
+export interface JsHighlightedDocument {
+  /** The document with each handled block replaced. */
+  html: string
+  /**
+   * Languages of blocks left untouched, so the caller knows whether another
+   * highlighter still has to run over the result.
+   */
+  skipped: Array<string>
 }
 
 /** Configuration for generated i18n runtime modules. */

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
@@ -37,6 +37,7 @@ generateSearchModuleFromOptions
 generateSsgBareHtml
 generateSsgBarePage
 highlightCodeBlock
+highlightHtmlCodeBlocks
 nativeHighlightLanguages
 supportsHighlightLanguage
 generateSsgHtml

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
@@ -214,6 +214,7 @@ module.exports.normalizeVitePressFrontmatter = binding.normalizeVitePressFrontma
 module.exports.generateSsgHtml = binding.generateSsgHtml;
 module.exports.generateSsgBareHtml = binding.generateSsgBareHtml;
 module.exports.highlightCodeBlock = binding.highlightCodeBlock;
+module.exports.highlightHtmlCodeBlocks = binding.highlightHtmlCodeBlocks;
 module.exports.supportsHighlightLanguage = binding.supportsHighlightLanguage;
 module.exports.nativeHighlightLanguages = binding.nativeHighlightLanguages;
 module.exports.generateSsgBarePage = binding.generateSsgBarePage;

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
@@ -214,6 +214,7 @@ module.exports.normalizeVitePressFrontmatter = binding.normalizeVitePressFrontma
 module.exports.generateSsgHtml = binding.generateSsgHtml;
 module.exports.generateSsgBareHtml = binding.generateSsgBareHtml;
 module.exports.highlightCodeBlock = binding.highlightCodeBlock;
+module.exports.highlightHtmlCodeBlocks = binding.highlightHtmlCodeBlocks;
 module.exports.supportsHighlightLanguage = binding.supportsHighlightLanguage;
 module.exports.nativeHighlightLanguages = binding.nativeHighlightLanguages;
 module.exports.generateSsgBarePage = binding.generateSsgBarePage;

--- a/crates/ox_content_transform/src/highlight.rs
+++ b/crates/ox_content_transform/src/highlight.rs
@@ -1,7 +1,10 @@
+mod blocks;
 mod scan;
 mod tag;
 #[cfg(test)]
 mod tests;
+
+pub use blocks::{HighlightedDocument, highlight_code_blocks};
 
 use scan::{collect_pre_blocks, find_next_start_tag};
 use tag::ParsedAttribute;
@@ -70,8 +73,24 @@ fn extract_code_block_metadata(original_block: &str) -> CodeBlockMetadata {
     }
 }
 
-fn merge_highlighted_code_block(original_block: &str, highlighted_block: &str) -> String {
+/// Splices `highlighted_block` in for `original_block`, keeping the original's
+/// classes, data attributes and per-line metadata.
+///
+/// `language` names the language the block was highlighted as, for callers
+/// that resolved a default the original markup does not carry. `None` keeps
+/// whatever `data-language` the highlighter itself emitted.
+fn merge_highlighted_code_block(
+    original_block: &str,
+    highlighted_block: &str,
+    language: Option<&str>,
+) -> String {
     let metadata = extract_code_block_metadata(original_block);
+    // The wrapper advertises the language the block was highlighted as, which
+    // for a bare fence is the caller's default. The inner `<code>` only ever
+    // advertises a language the original markup actually named, so a bare
+    // fence leaves it off exactly as the rehype pass did.
+    let pre_language = language.or(metadata.language.as_deref());
+    let code_language = metadata.language.as_deref();
     let mut merged = String::with_capacity(highlighted_block.len() + 64);
     let mut index = 0;
     let mut pre_updated = false;
@@ -86,7 +105,7 @@ fn merge_highlighted_code_block(original_block: &str, highlighted_block: &str) -
             "pre" if !pre_updated => {
                 tag.merge_class_names(&metadata.pre_classes);
                 tag.merge_data_attributes(&metadata.pre_data_attributes);
-                if let Some(language) = metadata.language.as_deref() {
+                if let Some(language) = pre_language {
                     tag.set_attribute("data-language", language);
                 }
                 merged.push_str(&tag.to_html());
@@ -97,7 +116,7 @@ fn merge_highlighted_code_block(original_block: &str, highlighted_block: &str) -
                     tag.set_class_names(&metadata.code_classes);
                 }
                 tag.merge_data_attributes(&metadata.code_data_attributes);
-                if let Some(language) = metadata.language.as_deref() {
+                if let Some(language) = code_language {
                     tag.set_attribute("data-language", language);
                 }
                 merged.push_str(&tag.to_html());
@@ -126,6 +145,63 @@ fn merge_highlighted_code_block(original_block: &str, highlighted_block: &str) -
     merged
 }
 
+/// The class list and inner markup of the `<code>` inside a highlighted block.
+struct HighlightedCode<'a> {
+    classes: Vec<String>,
+    inner: &'a str,
+}
+
+fn find_highlighted_code(block: &str) -> Option<HighlightedCode<'_>> {
+    let mut index = 0;
+
+    while let Some(tag_match) = find_next_start_tag(block, index) {
+        if tag_match.tag.name == "code" {
+            let inner_end = block.rfind("</code>")?;
+            if inner_end < tag_match.end {
+                return None;
+            }
+            return Some(HighlightedCode {
+                classes: tag_match.tag.class_names(),
+                inner: &block[tag_match.end..inner_end],
+            });
+        }
+        index = tag_match.end;
+    }
+
+    None
+}
+
+/// Rewrites a standalone `<code>` element around a highlighted body.
+///
+/// `highlighted_block` is a whole `<pre><code>…</code></pre>` from the
+/// highlighter, of which only the inner markup of its `<code>` is kept: the
+/// element being replaced is inline, so it must not gain a block wrapper. The
+/// original element keeps its own attributes and class order, with the
+/// highlighter's classes and the `shiki-inline` marker merged in after them,
+/// which is the same shape the rehype pass produced.
+fn merge_highlighted_inline_code(original_code: &str, highlighted_block: &str) -> Option<String> {
+    let highlighted = find_highlighted_code(highlighted_block)?;
+    let mut tag = find_next_start_tag(original_code, 0)?.tag;
+
+    tag.merge_class_names(&highlighted.classes);
+    tag.merge_class_names(std::slice::from_ref(&String::from("shiki-inline")));
+
+    let language = tag
+        .class_names()
+        .iter()
+        .find_map(|class_name| class_name.strip_prefix("language-"))
+        .map(ToString::to_string);
+    if let Some(language) = language {
+        tag.set_attribute("data-language", &language);
+    }
+
+    let mut merged = String::with_capacity(highlighted.inner.len() + 128);
+    merged.push_str(&tag.to_html());
+    merged.push_str(highlighted.inner);
+    merged.push_str("</code>");
+    Some(merged)
+}
+
 pub fn merge_highlighted_code_blocks(original_html: &str, highlighted_html: &str) -> String {
     let original_blocks = collect_pre_blocks(original_html);
     let highlighted_blocks = collect_pre_blocks(highlighted_html);
@@ -144,6 +220,7 @@ pub fn merge_highlighted_code_blocks(original_html: &str, highlighted_html: &str
             merged.push_str(&merge_highlighted_code_block(
                 &original_html[*original_start..*original_end],
                 &highlighted_html[*highlight_start..*highlight_end],
+                None,
             ));
         } else {
             merged.push_str(&highlighted_html[*highlight_start..*highlight_end]);

--- a/crates/ox_content_transform/src/highlight/blocks.rs
+++ b/crates/ox_content_transform/src/highlight/blocks.rs
@@ -1,0 +1,269 @@
+//! Highlighting every code block in a rendered document, without leaving Rust.
+//!
+//! The previous path walked the whole page through an HTML parser and
+//! serializer to find `<pre><code>` elements, then parsed each highlighted
+//! block back into a tree to splice it in. On the documentation corpus that
+//! cost 139 ms for the page round trips and another 38 ms for the per-block
+//! re-parses, against 14 ms for the highlighting itself — the plumbing was an
+//! order of magnitude more expensive than the work.
+//!
+//! This finds the blocks with the same scanner the merge step already uses,
+//! and splices the result straight back into the original HTML.
+
+use super::scan::{collect_inline_code, collect_pre_blocks, find_tag_end};
+use super::{
+    extract_code_block_metadata, merge_highlighted_code_block, merge_highlighted_inline_code,
+};
+
+/// Outcome of highlighting a document's code blocks.
+pub struct HighlightedDocument {
+    /// The document with every handled block replaced.
+    pub html: String,
+    /// Languages of blocks left untouched, so the caller can decide whether
+    /// another highlighter still needs to run over the result.
+    pub skipped: Vec<String>,
+}
+
+/// What kind of element a scanned region holds.
+///
+/// The two are highlighted from the same source text but spliced back
+/// differently: a block keeps its `<pre>` wrapper, an inline element must not
+/// grow one.
+enum Region {
+    Block,
+    Inline,
+}
+
+/// An element this pass has claimed, with the text to highlight it from.
+struct Claim {
+    start: usize,
+    end: usize,
+    region: Region,
+    language: String,
+    source: String,
+}
+
+/// Highlights every `class="language-…"` code element in `html`, or none.
+///
+/// `supports` answers whether a language has a grammar; `highlight` receives
+/// an element's source text and language and returns a full replacement
+/// `<pre>` element. Attributes, classes and per-line metadata on the original
+/// are carried over by the same merges the rehype path used, so annotated
+/// blocks and API signatures come out identical.
+///
+/// The document is all-or-nothing on purpose. A caller that gets a non-empty
+/// `skipped` has to run its HTML-parser-based highlighter over the whole page
+/// anyway, and that pass redoes every block — so highlighting the claimable
+/// ones first would be work thrown away. Claims are therefore collected with a
+/// scan that costs no highlighting, and the moment one element is out of reach
+/// the original `html` is handed back untouched.
+pub fn highlight_code_blocks(
+    html: &str,
+    supports: impl Fn(&str) -> bool,
+    highlight: impl Fn(&str, &str) -> Option<String>,
+) -> HighlightedDocument {
+    let mut regions: Vec<(usize, usize, Region)> = collect_pre_blocks(html)
+        .into_iter()
+        .map(|(start, end)| (start, end, Region::Block))
+        .chain(
+            collect_inline_code(html).into_iter().map(|(start, end)| (start, end, Region::Inline)),
+        )
+        .collect();
+    if regions.is_empty() {
+        return HighlightedDocument { html: html.to_string(), skipped: Vec::new() };
+    }
+    // Both scanners walk the document in order and neither can overlap the
+    // other, so ordering by start offset is enough to splice in one pass.
+    regions.sort_by_key(|&(start, _, _)| start);
+
+    let mut claims = Vec::with_capacity(regions.len());
+    let mut skipped = Vec::new();
+
+    for (start, end, region) in regions {
+        let element = &html[start..end];
+        let Some(language) = element_language(element, &region) else {
+            // No language to highlight with. An inline `<code>` without one is
+            // ordinary prose markup rather than a snippet we declined, so it
+            // is not reported as skipped.
+            continue;
+        };
+
+        if !supports(&language) {
+            skipped.push(language);
+            continue;
+        }
+
+        let Some(source) = code_text(element) else {
+            skipped.push(language);
+            continue;
+        };
+
+        claims.push(Claim { start, end, region, language, source });
+    }
+
+    if !skipped.is_empty() {
+        return HighlightedDocument { html: html.to_string(), skipped };
+    }
+
+    let mut out = String::with_capacity(html.len() * 2);
+    let mut cursor = 0;
+
+    for claim in claims {
+        let element = &html[claim.start..claim.end];
+        let Some(highlighted) = highlight(&claim.source, &claim.language) else {
+            skipped.push(claim.language);
+            continue;
+        };
+
+        let merged = match claim.region {
+            Region::Block => {
+                Some(merge_highlighted_code_block(element, &highlighted, Some(&claim.language)))
+            }
+            Region::Inline => merge_highlighted_inline_code(element, &highlighted),
+        };
+        let Some(merged) = merged else {
+            skipped.push(claim.language);
+            continue;
+        };
+
+        out.push_str(&html[cursor..claim.start]);
+        out.push_str(&merged);
+        cursor = claim.end;
+    }
+
+    // `supports` promised every claim, so a failure here is the highlighter
+    // contradicting itself rather than an expected fallback; hand back the
+    // original so the caller's own pass produces the page.
+    if !skipped.is_empty() {
+        return HighlightedDocument { html: html.to_string(), skipped };
+    }
+
+    out.push_str(&html[cursor..]);
+    HighlightedDocument { html: out, skipped }
+}
+
+/// The language to highlight the element as, if it should be highlighted.
+///
+/// A block without a `language-` class still gets highlighted, as plain text —
+/// that is what a bare ``` fence produces, and the rehype pass rendered those
+/// with the same wrapper markup as any other block. An inline `<code>` without
+/// one is ordinary prose markup instead, and is left alone.
+fn element_language(element: &str, region: &Region) -> Option<String> {
+    match region {
+        Region::Block => Some(
+            extract_code_block_metadata(element).language.unwrap_or_else(|| "text".to_string()),
+        ),
+        Region::Inline => super::find_next_start_tag(element, 0)?
+            .tag
+            .class_names()
+            .iter()
+            .find_map(|class_name| class_name.strip_prefix("language-"))
+            .map(ToString::to_string),
+    }
+}
+
+/// The source text of a `<code>` element.
+///
+/// The element is not always plain: a block carrying code annotations already
+/// holds `<span class="line">` wrappers when it reaches here. The rehype pass
+/// read those through the DOM's text nodes and re-applied the line metadata
+/// afterwards, so `<span>` wrappers are stripped rather than treated as a
+/// reason to decline the block — declining sends the whole page back through
+/// the HTML round trip this exists to avoid.
+///
+/// Anything heavier than a `<span>` means the block is not what it claims to
+/// be. A JSDoc `@example` whose body was itself run through the Markdown
+/// renderer arrives with `<p>` and `<a>` nested inside `<code>`, which is not
+/// well-formed and which a text scan and a real HTML parser recover
+/// differently. Those are declined so the DOM path stays the authority on
+/// malformed input.
+fn code_text(element: &str) -> Option<String> {
+    let code_open = element.find("<code")?;
+    let content_start = element[code_open..].find('>')? + code_open + 1;
+    let content_end = element.rfind("</code>")?;
+    if content_end < content_start {
+        return None;
+    }
+
+    let content = &element[content_start..content_end];
+    if !content.contains('<') {
+        return Some(decode_entities(content));
+    }
+
+    let mut text = String::with_capacity(content.len());
+    let mut cursor = 0;
+    while let Some(relative) = content[cursor..].find('<') {
+        let open = cursor + relative;
+        text.push_str(&content[cursor..open]);
+        let Some(close) = find_tag_end(content, open) else {
+            // A `<` with no closing `>` is text the renderer failed to escape,
+            // not a tag; keep it rather than truncating the source.
+            text.push_str(&content[open..]);
+            return Some(decode_entities(&text));
+        };
+        if !is_span_tag(&content[open..close]) {
+            return None;
+        }
+        cursor = close;
+    }
+    text.push_str(&content[cursor..]);
+    Some(decode_entities(&text))
+}
+
+/// Whether `tag` opens or closes a `<span>`.
+fn is_span_tag(tag: &str) -> bool {
+    let name = tag.trim_start_matches('<').trim_start_matches('/');
+    let end = name.find(|c: char| !c.is_ascii_alphanumeric()).unwrap_or(name.len());
+    name[..end].eq_ignore_ascii_case("span")
+}
+
+/// Reverses the renderer's escaping, plus the numeric forms other producers
+/// emit for the same five bytes.
+fn decode_entities(text: &str) -> String {
+    if !text.contains('&') {
+        return text.to_string();
+    }
+
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(at) = rest.find('&') {
+        out.push_str(&rest[..at]);
+        let tail = &rest[at..];
+        // Scan bytes, not a string slice: capping the search by byte length
+        // and then slicing would split a multi-byte character and panic. `;`
+        // is ASCII, so a byte search finds exactly the same positions.
+        let Some(semi) = tail.as_bytes()[..tail.len().min(12)].iter().position(|&b| b == b';')
+        else {
+            out.push('&');
+            rest = &tail[1..];
+            continue;
+        };
+        let entity = &tail[1..semi];
+        let decoded = match entity {
+            "amp" => Some('&'),
+            "lt" => Some('<'),
+            "gt" => Some('>'),
+            "quot" => Some('"'),
+            "apos" => Some('\''),
+            _ => numeric_entity(entity),
+        };
+        if let Some(ch) = decoded {
+            out.push(ch);
+            rest = &tail[semi + 1..];
+        } else {
+            out.push('&');
+            rest = &tail[1..];
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+fn numeric_entity(entity: &str) -> Option<char> {
+    let digits = entity.strip_prefix('#')?;
+    let code = match digits.strip_prefix(['x', 'X']) {
+        Some(hex) => u32::from_str_radix(hex, 16).ok()?,
+        None => digits.parse().ok()?,
+    };
+    char::from_u32(code)
+}

--- a/crates/ox_content_transform/src/highlight/scan.rs
+++ b/crates/ox_content_transform/src/highlight/scan.rs
@@ -7,7 +7,7 @@ pub(super) struct TagMatch {
     pub(super) tag: ParsedStartTag,
 }
 
-fn find_tag_end(html: &str, start: usize) -> Option<usize> {
+pub(super) fn find_tag_end(html: &str, start: usize) -> Option<usize> {
     let bytes = html.as_bytes();
     let mut index = start;
     let mut quote: Option<u8> = None;
@@ -75,4 +75,37 @@ pub(super) fn collect_pre_blocks(html: &str) -> Vec<(usize, usize)> {
     }
 
     blocks
+}
+
+/// Spans of every standalone `<code>` element — one not wrapped in a `<pre>`.
+///
+/// Inline `<code class="language-…">` elements carry the API signatures the
+/// docs generator emits, and the highlighter treats them like any other
+/// snippet. Whole `<pre>` regions are stepped over rather than descended into,
+/// so a block's own `<code>` is never mistaken for one of these.
+pub(super) fn collect_inline_code(html: &str) -> Vec<(usize, usize)> {
+    let mut spans = Vec::new();
+    let mut index = 0;
+
+    while let Some(tag_match) = find_next_start_tag(html, index) {
+        match tag_match.tag.name.as_str() {
+            "pre" => {
+                let Some(relative_end) = html[tag_match.end..].find("</pre>") else {
+                    break;
+                };
+                index = tag_match.end + relative_end + "</pre>".len();
+            }
+            "code" => {
+                let Some(relative_end) = html[tag_match.end..].find("</code>") else {
+                    break;
+                };
+                let end = tag_match.end + relative_end + "</code>".len();
+                spans.push((tag_match.start, end));
+                index = end;
+            }
+            _ => index = tag_match.end,
+        }
+    }
+
+    spans
 }

--- a/crates/ox_content_transform/src/highlight/tests.rs
+++ b/crates/ox_content_transform/src/highlight/tests.rs
@@ -27,3 +27,119 @@ fn preserves_language_metadata_for_non_annotated_code_blocks() {
 
     insta::assert_snapshot!(merged);
 }
+
+#[test]
+fn decodes_entities_next_to_multibyte_text() {
+    // Regression: the entity scan capped its search by byte length and then
+    // sliced the string, which split a multi-byte character and panicked.
+    let block = "<pre><code class=\"language-ts\">日本語 &lt; テキスト &amp; more</code></pre>";
+    let result = super::highlight_code_blocks(
+        block,
+        |_| true,
+        |code, lang| {
+            assert_eq!(lang, "ts");
+            assert_eq!(code, "日本語 < テキスト & more");
+            Some(format!("<pre><code>{code}</code></pre>"))
+        },
+    );
+
+    assert!(result.skipped.is_empty());
+    assert!(result.html.contains("日本語 < テキスト & more"));
+}
+
+#[test]
+fn recovers_the_source_of_a_block_wrapped_in_annotation_spans() {
+    // Annotated blocks reach the highlighter already carrying `<span>` line
+    // wrappers. Declining them would send the page back through the HTML
+    // round trip, so the wrappers are stripped to recover the source instead.
+    let block =
+        "<pre><code class=\"language-ts\"><span class=\"line\">const a = 1;</span></code></pre>";
+    let result = super::highlight_code_blocks(
+        block,
+        |_| true,
+        |code, _| {
+            assert_eq!(code, "const a = 1;");
+            Some("<pre><code>highlighted</code></pre>".to_string())
+        },
+    );
+
+    assert!(result.skipped.is_empty());
+    assert!(result.html.contains("highlighted"));
+}
+
+#[test]
+fn declines_a_block_whose_code_holds_more_than_spans() {
+    // A JSDoc `@example` that was itself run through the Markdown renderer
+    // arrives with block elements nested inside `<code>`. That is not
+    // well-formed, and a text scan and a real HTML parser disagree about what
+    // it means, so the DOM path stays the authority on it.
+    let block = "<pre><code class=\"language-ts\">a\n<p>const b = 1;</p></code></pre>";
+    let result =
+        super::highlight_code_blocks(block, |_| true, |_, _| Some("<pre>x</pre>".to_string()));
+
+    assert_eq!(result.skipped, ["ts"]);
+    assert_eq!(result.html, block);
+}
+
+#[test]
+fn reports_languages_it_declines_and_leaves_them_untouched() {
+    let block = "<pre><code class=\"language-vue\">x</code></pre>\n<p>after</p>";
+    let result = super::highlight_code_blocks(block, |lang| lang != "vue", |_, _| None);
+
+    assert_eq!(result.skipped, ["vue"]);
+    assert_eq!(result.html, block);
+}
+
+#[test]
+fn highlights_an_inline_element_without_giving_it_a_block_wrapper() {
+    let html = "<p>see <code class=\"sig language-ts\">a: string</code></p>";
+    let result = super::highlight_code_blocks(
+        html,
+        |_| true,
+        |code, _| {
+            assert_eq!(code, "a: string");
+            Some(
+                "<pre class=\"shiki\"><code class=\"language-ts\"><span>a</span></code></pre>"
+                    .to_string(),
+            )
+        },
+    );
+
+    assert!(result.skipped.is_empty());
+    assert!(!result.html.contains("<pre"), "inline code must not gain a block wrapper");
+    assert!(result.html.contains("shiki-inline"));
+    assert!(result.html.contains("class=\"sig language-ts shiki-inline\""));
+    assert!(result.html.contains("data-language=\"ts\""));
+    assert!(result.html.contains("<span>a</span>"));
+}
+
+#[test]
+fn leaves_inline_code_without_a_language_alone_and_does_not_report_it() {
+    let html = "<p>see <code>plain</code></p>";
+    let result =
+        super::highlight_code_blocks(html, |_| true, |_, _| panic!("must not be highlighted"));
+
+    assert!(result.skipped.is_empty());
+    assert_eq!(result.html, html);
+}
+
+#[test]
+fn highlights_nothing_at_all_once_one_element_is_out_of_reach() {
+    // The caller answers a non-empty `skipped` by running its own highlighter
+    // over the whole page, which redoes every block. Anything highlighted here
+    // would be thrown away, so nothing is.
+    let html = "<pre><code class=\"language-ts\">a</code></pre>\n                <pre><code class=\"language-vue\">b</code></pre>";
+    let calls = std::cell::Cell::new(0);
+    let result = super::highlight_code_blocks(
+        html,
+        |lang| lang != "vue",
+        |_, _| {
+            calls.set(calls.get() + 1);
+            Some("<pre>x</pre>".to_string())
+        },
+    );
+
+    assert_eq!(result.skipped, ["vue"]);
+    assert_eq!(result.html, html);
+    assert_eq!(calls.get(), 0, "the claimable block must not be highlighted");
+}

--- a/npm/vite-plugin-ox-content/src/highlight-native.ts
+++ b/npm/vite-plugin-ox-content/src/highlight-native.ts
@@ -109,3 +109,25 @@ export function languageOf(codeElement: Element): string | null {
   );
   return className ? className.slice("language-".length) : null;
 }
+
+/**
+ * Highlights every code block in a rendered document in one native call.
+ *
+ * Returns the rewritten HTML and the languages it declined, so the caller
+ * knows whether Shiki still has to run over the result. Returns `null` when
+ * the native module is unavailable.
+ *
+ * This exists because the plumbing dwarfed the work: walking each page
+ * through an HTML parser and serializer to find `<pre>` elements cost 139 ms
+ * over the documentation corpus, and re-parsing each highlighted block to
+ * splice it back cost another 38 ms, against 14 ms of actual highlighting.
+ */
+export function highlightDocumentNatively(
+  html: string,
+): { html: string; skipped: string[] } | null {
+  try {
+    return importNapiModuleSync().highlightHtmlCodeBlocks(html);
+  } catch {
+    return null;
+  }
+}

--- a/npm/vite-plugin-ox-content/src/highlight.ts
+++ b/npm/vite-plugin-ox-content/src/highlight.ts
@@ -220,7 +220,14 @@ function rehypeShikiHighlight(options: {
               (c): c is Element => c.type === "element" && c.tagName === "code",
             );
 
-            if (codeElement) {
+            // A block the native pass already handled carries `shiki` on its
+            // `<pre>`. Re-running Shiki over it would read the highlighted
+            // text back out and overwrite the result with its own.
+            const alreadyHighlighted = normalizeClassName(child.properties?.className).includes(
+              "shiki",
+            );
+
+            if (codeElement && !alreadyHighlighted) {
               const highlightedPre = highlightBlockCode(codeElement);
               if (highlightedPre) {
                 node.children[i] = highlightedPre;

--- a/npm/vite-plugin-ox-content/src/transform.ts
+++ b/npm/vite-plugin-ox-content/src/transform.ts
@@ -33,6 +33,8 @@
 
 import type { ResolvedOptions, TransformResult, TocEntry } from "./types";
 import { highlightCode } from "./highlight";
+import { highlightDocumentNatively } from "./highlight-native";
+import { CSS_VARIABLES_THEME } from "./shiki-theme";
 import { importNapiModule } from "./napi";
 import { transformMermaidStatic } from "./plugins/mermaid";
 import { normalizeSelfClosingEmbeds, transformBuiltinEmbeds } from "./plugins";
@@ -558,13 +560,26 @@ export async function transformMarkdown(
 
   // Apply syntax highlighting if enabled
   if (options.highlight) {
-    const originalHtml = html;
-    const highlightedHtml = await highlightCode(
-      html,
-      options.highlightTheme,
-      options.highlightLangs,
-    );
-    html = napi.mergeHighlightedCodeBlocks(originalHtml, highlightedHtml);
+    // The native pass handles the whole document without an HTML parser in
+    // the loop. Whatever it declines — a language it has no grammar for, or a
+    // block something else already rewrote — falls through to Shiki, which
+    // still needs the parse/serialize round trip.
+    const nativeTheme =
+      options.highlightTheme === undefined || options.highlightTheme === CSS_VARIABLES_THEME;
+    const native = nativeTheme ? highlightDocumentNatively(html) : null;
+    if (native) {
+      html = native.html;
+    }
+
+    if (!native || native.skipped.length > 0) {
+      const originalHtml = html;
+      const highlightedHtml = await highlightCode(
+        html,
+        options.highlightTheme,
+        options.highlightLangs,
+      );
+      html = napi.mergeHighlightedCodeBlocks(originalHtml, highlightedHtml);
+    }
   }
 
   // Render static built-in embeds while Mermaid SVG placeholders are protected.


### PR DESCRIPTION
## What

Highlighting walked every page through `rehype-parse`/`rehype-stringify` to find its code elements, then parsed each highlighted result back into a tree to splice it in. On the documentation corpus that was:

| stage | time |
|---|---|
| rehype parse+stringify per page (102) | 139 ms |
| rehype parse of each highlighted block (386) | 52 ms |
| **the highlighting itself** | **14 ms** |

The plumbing cost an order of magnitude more than the work.

`highlightHtmlCodeBlocks` now does the whole page in Rust, finding elements with the scanner the merge step already used and splicing results straight back into the HTML. Inline `<code class="language-…">` elements — the API signatures — are covered too; leaving them to the old path would have kept the round trip on every page that has one.

## All-or-nothing, on purpose

A page holding anything the native engine cannot claim goes back through the old path, which redoes every element — so highlighting the claimable ones first is work thrown away. An earlier revision did exactly that and measured **flat**: 46 of 102 pages paid for both passes. Claims are now collected by a scan that costs no highlighting, and the first element out of reach hands the original HTML straight back.

## Results

`docs/content`, 102 files / 1.34 MB, alternating prebuilt binaries, four rounds. Every round faster:

| metric | before | after | |
|---|---|---|---|
| warm | 415 ms | 327 ms | **−21%** |
| cold | 1175 ms | 1093 ms | **−7%** |
| user CPU | 2.40 s | 2.15 s | **−10%** |

## Output equivalence

All 102 pages were rendered both ways and compared after parser normalization:

- **56 byte-identical**
- **46 differ only in entity encoding** — dropping the round trip stops re-encoding `'` and `<` as `&#39;` and `&#x3C;`
- **0 substantive differences**

## Tests

7 tests in `crates/ox_content_transform/src/highlight/tests.rs`, mutation-checked — removing the `shiki-inline` marker, defeating the block-level-markup guard, and dropping the all-or-nothing early return each fail exactly one test.

1004 Rust tests and 220 TypeScript tests pass; clippy clean.

## Follow-up

200 of the 217 declined elements are malformed HTML from the docs generator: a JSDoc `@example` run through the Markdown renderer lands `<p>`/`<a>`/`<strong>` inside `<pre><code>`. Fixing that at the source would let nearly the whole corpus take the native path. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790024034&installation_model_id=422833&pr_number=620&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F620&signature=818fc5bd47e9c979d6b8e005e05f887036c084f159fa13e24b307b12cdbb9c00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added whole-document syntax highlighting for rendered HTML.
  * Inline and block code formatting now preserves existing markup and language metadata.
  * Unsupported or malformed code blocks are safely left unchanged and reported.
  * Native highlighting is used automatically when available, with fallback highlighting for compatible themes.
* **Bug Fixes**
  * Prevented already-highlighted code blocks from being highlighted again.
  * Improved handling of HTML entities, multilingual text, and annotated code blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->