### PR TITLE
perf(highlight): read through the links inside a member type

### DIFF
--- a/crates/ox_content_transform/src/highlight/blocks.rs
+++ b/crates/ox_content_transform/src/highlight/blocks.rs
@@ -164,12 +164,13 @@ fn element_language(element: &str, region: &Region) -> Option<String> {
 
 /// The source text of a `<code>` element.
 ///
-/// The element is not always plain: a block carrying code annotations already
-/// holds `<span class="line">` wrappers when it reaches here. The rehype pass
-/// read those through the DOM's text nodes and re-applied the line metadata
-/// afterwards, so `<span>` wrappers are stripped rather than treated as a
-/// reason to decline the block — declining sends the whole page back through
-/// the HTML round trip this exists to avoid.
+/// The element is not always plain: a block carrying code annotations arrives
+/// wrapped in `<span class="line">`, and a member type arrives with an `<a>`
+/// around the type name it cross-references. The rehype pass read both through
+/// the DOM's text nodes — dropping the wrappers, and for a block re-applying
+/// the line metadata afterwards — so those are stripped here too rather than
+/// treated as a reason to decline the element. Declining sends the whole page
+/// back through the HTML round trip this exists to avoid.
 ///
 /// Anything heavier than a `<span>` means the block is not what it claims to
 /// be. A JSDoc `@example` whose body was itself run through the Markdown
@@ -201,7 +202,7 @@ fn code_text(element: &str) -> Option<String> {
             text.push_str(&content[open..]);
             return Some(decode_entities(&text));
         };
-        if !is_span_tag(&content[open..close]) {
+        if !is_text_wrapper(&content[open..close]) {
             return None;
         }
         cursor = close;
@@ -210,11 +211,18 @@ fn code_text(element: &str) -> Option<String> {
     Some(decode_entities(&text))
 }
 
-/// Whether `tag` opens or closes a `<span>`.
-fn is_span_tag(tag: &str) -> bool {
+/// Elements that may wrap part of a code element's text.
+///
+/// `span` comes from code annotations; `a` is the type cross-reference the
+/// docs generator puts inside a member type. Both wrap text and nothing else,
+/// so dropping them recovers exactly the source the DOM walk read.
+const TEXT_WRAPPERS: [&str; 2] = ["span", "a"];
+
+/// Whether `tag` opens or closes one of [`TEXT_WRAPPERS`].
+fn is_text_wrapper(tag: &str) -> bool {
     let name = tag.trim_start_matches('<').trim_start_matches('/');
     let end = name.find(|c: char| !c.is_ascii_alphanumeric()).unwrap_or(name.len());
-    name[..end].eq_ignore_ascii_case("span")
+    TEXT_WRAPPERS.iter().any(|wrapper| name[..end].eq_ignore_ascii_case(wrapper))
 }
 
 /// Reverses the renderer's escaping, plus the numeric forms other producers

--- a/crates/ox_content_transform/src/highlight/tests.rs
+++ b/crates/ox_content_transform/src/highlight/tests.rs
@@ -68,7 +68,27 @@ fn recovers_the_source_of_a_block_wrapped_in_annotation_spans() {
 }
 
 #[test]
-fn declines_a_block_whose_code_holds_more_than_spans() {
+fn recovers_the_source_of_a_member_type_that_cross_references_another() {
+    // The docs generator links a type name to its definition from inside the
+    // member type. The rehype pass read straight through the link, so the
+    // highlighted text must come out the same way.
+    let html =
+        "<p><code class=\"mt language-ts\"><a href=\"./x.html\">NavGroup</a>[] | null</code></p>";
+    let result = super::highlight_code_blocks(
+        html,
+        |_| true,
+        |code, _| {
+            assert_eq!(code, "NavGroup[] | null");
+            Some("<pre><code><span>t</span></code></pre>".to_string())
+        },
+    );
+
+    assert!(result.skipped.is_empty());
+    assert!(result.html.contains("shiki-inline"));
+}
+
+#[test]
+fn declines_a_block_whose_code_holds_more_than_text_wrappers() {
     // A JSDoc `@example` that was itself run through the Markdown renderer
     // arrives with block elements nested inside `<code>`. That is not
     // well-formed, and a text scan and a real HTML parser disagree about what


### PR DESCRIPTION
## What

The docs generator writes a type cross-reference as a link inside the member type it belongs to:

```html
<code class="ox-api-entry__member-type language-typescript"><a href="../page-context/index.html#navgroup">NavGroup</a>[] | null</code>
```

The native document pass (#620) declined any element holding a tag other than a `<span>`, and since the pass is all-or-nothing, each of these sent its **whole page** back through the HTML parser. They were **134 of the 140 elements** the pass turned down on the documentation corpus — the single biggest thing keeping pages on the slow path.

An `<a>` wraps text and nothing else, so dropping it recovers exactly the source the DOM walk read. Elements heavier than a text wrapper are still declined — those are the malformed ones (a JSDoc `@example` run through the Markdown renderer), where a text scan and a real HTML parser disagree about what the markup means.

## This does not change what the link does

Highlighting has always replaced the element's children with the highlighted markup, so the `<a>` was already discarded on both paths. On the corpus, **711 member types are highlighted and 0 keep their link** — every type cross-reference in the generated API docs is already unclickable. Restoring them is a deliberate design change, filed as #622.

## Results

`docs/content`, 102 files / 1.34 MB, alternating prebuilt binaries, four rounds. Every round faster:

| metric | before | after | |
|---|---|---|---|
| warm | 271 ms | 186 ms | **−31%** (4.9 → 7.2 MB/s) |
| cold | 917 ms | 804 ms | **−12%** |
| user CPU | 1.86 s | 1.58 s | **−15%** |

## Output equivalence

All 102 pages rendered both ways and compared after parser normalization:

- **95 byte-identical**
- **7 encoding-only** — those pages no longer take the round trip that re-encodes `'` and `<` as `&#39;` and `&#x3C;`
- **0 substantive differences**

## Tests

One added test, mutation-checked: dropping `"a"` from the wrapper list fails it and nothing else. 1007 Rust tests and 220 TypeScript tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790024704&installation_model_id=422833&pr_number=623&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F623&signature=2317eba5fcf46d0f8aed6c0926c352f33de035d3c2e9a03d773dfbea47ae02ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code highlighting for annotated and cross-referenced content.
  * Linked member types inside inline code now correctly display as plain source text while retaining code formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->