### PR TITLE
perf(highlight): highlight a repeated snippet once per page

### DIFF
--- a/crates/ox_content_transform/src/highlight/blocks.rs
+++ b/crates/ox_content_transform/src/highlight/blocks.rs
@@ -10,6 +10,8 @@
 //! This finds the blocks with the same scanner the merge step already uses,
 //! and splices the result straight back into the original HTML.
 
+use rustc_hash::FxHashMap;
+
 use super::scan::{collect_inline_code, collect_pre_blocks, find_tag_end};
 use super::{
     extract_code_block_metadata, merge_highlighted_code_block, merge_highlighted_inline_code,
@@ -105,24 +107,51 @@ pub fn highlight_code_blocks(
         return HighlightedDocument { html: html.to_string(), skipped };
     }
 
+    // A page repeats its short snippets heavily — `string` and `boolean` alone
+    // account for hundreds of member types across the corpus, and 31% of a
+    // page's elements are a source it already holds. Highlighting is keyed by
+    // nothing but the text and the language, so each distinct pair is parsed
+    // once and the result reused. The merge still runs per element, which is
+    // what carries each one's own classes and line metadata.
+    let mut rendered: Vec<String> = Vec::with_capacity(claims.len());
+    let mut rendered_at: FxHashMap<(&str, &str), usize> = FxHashMap::default();
+    let mut slots = Vec::with_capacity(claims.len());
+
+    for claim in &claims {
+        let key = (claim.language.as_str(), claim.source.as_str());
+        if let Some(&at) = rendered_at.get(&key) {
+            slots.push(at);
+            continue;
+        }
+        let Some(highlighted) = highlight(&claim.source, &claim.language) else {
+            // `supports` promised every claim, so a failure here is the
+            // highlighter contradicting itself rather than an expected
+            // fallback; hand back the original so the caller's own pass
+            // produces the page.
+            return HighlightedDocument {
+                html: html.to_string(),
+                skipped: vec![claim.language.clone()],
+            };
+        };
+        slots.push(rendered.len());
+        rendered_at.insert(key, rendered.len());
+        rendered.push(highlighted);
+    }
+
     let mut out = String::with_capacity(html.len() * 2);
     let mut cursor = 0;
 
-    for claim in claims {
+    for (claim, at) in claims.iter().zip(slots) {
         let element = &html[claim.start..claim.end];
-        let Some(highlighted) = highlight(&claim.source, &claim.language) else {
-            skipped.push(claim.language);
-            continue;
-        };
-
+        let highlighted = &rendered[at];
         let merged = match claim.region {
             Region::Block => {
-                Some(merge_highlighted_code_block(element, &highlighted, Some(&claim.language)))
+                Some(merge_highlighted_code_block(element, highlighted, Some(&claim.language)))
             }
-            Region::Inline => merge_highlighted_inline_code(element, &highlighted),
+            Region::Inline => merge_highlighted_inline_code(element, highlighted),
         };
         let Some(merged) = merged else {
-            skipped.push(claim.language);
+            skipped.push(claim.language.clone());
             continue;
         };
 
@@ -131,9 +160,10 @@ pub fn highlight_code_blocks(
         cursor = claim.end;
     }
 
-    // `supports` promised every claim, so a failure here is the highlighter
-    // contradicting itself rather than an expected fallback; hand back the
-    // original so the caller's own pass produces the page.
+    // A merge only fails on markup the claim scan said was well formed, so
+    // this is the module contradicting itself rather than an expected
+    // fallback; hand back the original and let the caller's pass produce the
+    // page.
     if !skipped.is_empty() {
         return HighlightedDocument { html: html.to_string(), skipped };
     }

--- a/crates/ox_content_transform/src/highlight/tests.rs
+++ b/crates/ox_content_transform/src/highlight/tests.rs
@@ -144,6 +144,45 @@ fn leaves_inline_code_without_a_language_alone_and_does_not_report_it() {
 }
 
 #[test]
+fn highlights_a_repeated_snippet_once_and_reuses_it() {
+    // API pages are mostly member types, and the same handful of type names
+    // recurs on every entry.
+    let html = "<p><code class=\"language-ts\">string</code> \
+                <code class=\"language-ts\">string</code> \
+                <code class=\"language-ts\">boolean</code></p>";
+    let calls = std::cell::Cell::new(0);
+    let result = super::highlight_code_blocks(
+        html,
+        |_| true,
+        |code, _| {
+            calls.set(calls.get() + 1);
+            Some(format!("<pre><code><span>{code}</span></code></pre>"))
+        },
+    );
+
+    assert!(result.skipped.is_empty());
+    assert_eq!(calls.get(), 2, "the repeated snippet must be highlighted once");
+    assert_eq!(result.html.matches("<span>string</span>").count(), 2);
+    assert_eq!(result.html.matches("<span>boolean</span>").count(), 1);
+}
+
+#[test]
+fn keeps_each_element_of_a_repeated_snippet_on_its_own_classes() {
+    // The highlight is shared but the merge is not: each element keeps the
+    // classes it arrived with.
+    let html = "<p><code class=\"first language-ts\">string</code> \
+                <code class=\"second language-ts\">string</code></p>";
+    let result = super::highlight_code_blocks(
+        html,
+        |_| true,
+        |_, _| Some("<pre><code><span>t</span></code></pre>".to_string()),
+    );
+
+    assert!(result.html.contains("class=\"first language-ts shiki-inline\""));
+    assert!(result.html.contains("class=\"second language-ts shiki-inline\""));
+}
+
+#[test]
 fn highlights_nothing_at_all_once_one_element_is_out_of_reach() {
     // The caller answers a non-empty `skipped` by running its own highlighter
     // over the whole page, which redoes every block. Anything highlighted here


### PR DESCRIPTION
## What

An API page is mostly member types, and the same handful of type names recurs on every entry. Across the documentation corpus:

| snippet | occurrences |
|---|---|
| `string` | 251 |
| `boolean` | 142 |
| `number` | 48 |
| `false` | 45 |

**31% of a page's code elements hold a source that page has already highlighted** (48% across the whole corpus).

Highlighting is keyed by nothing but the text and the language, so each distinct pair is now parsed once and the result reused. The merge still runs per element — that is what carries each element's own classes, data attributes and line metadata, so two elements sharing a highlight still come out with the markup they arrived with.

## Results

`docs/content`, 102 files / 1.34 MB, alternating prebuilt binaries. This is a modest win, and I want to be straight about its size — but it is a consistent one, with the newer half faster in **every** round of both measurements:

| measurement | before | after | |
|---|---|---|---|
| warm page loop (6 rounds) | 188.5 ms | 181.8 ms | **−3.6%** |
| the pass in isolation (3 rounds) | 77.8 ms | 74.9 ms | **−3.8%** |

Process user CPU is flat, but it is not the right metric here: `/usr/bin/time` covers the whole benchmark process, which is dominated by the cold pass and Shiki module loading, so a change worth ~3 ms of a 76 ms pass cannot show up in it.

## Output equivalence

All 102 pages are **byte-identical** — not merely equivalent.

## Tests

Two added tests, both mutation-checked:

- defeating the cache (always re-highlight) fails the call-count assertion
- sharing the *merged* result instead of merging per element fails the per-element class assertion

1009 Rust tests and 220 TypeScript tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790025071&installation_model_id=422833&pr_number=624&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F624&signature=7a594eee563ddaf69b9e7abb41c108898316d65e50d8d0ff0d3b0d6edfe10d42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->