### PR TITLE
perf(highlight): highlight one exotic block without surrendering the page

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -35,6 +35,17 @@ export declare class IncrementalMarkdownRenderer {
 }
 
 /**
+ * Splices the caller's highlighting back over the blocks
+ * `highlightHtmlCodeBlocks` left pending.
+ *
+ * `replacements` lines up with the `pending` list it returned: entry `i` is a
+ * full `<pre>` element for pending block `i`, or an empty string to leave that
+ * block as it is. This keeps a page that needs one exotic grammar off the
+ * HTML round trip, instead of surrendering the whole document for it.
+ */
+export declare function applyPendingHighlights(html: string, replacements: Array<string>): string
+
+/**
  * Builds a Markdown collection manifest directly from files on the Rust side.
  *
  * File discovery, pattern filtering, frontmatter preparation, route metadata,
@@ -863,10 +874,17 @@ export interface JsHighlightedDocument {
   /** The document with each handled block replaced. */
   html: string
   /**
-   * Languages of blocks left untouched, so the caller knows whether another
-   * highlighter still has to run over the result.
+   * Languages of elements the native pass could not read, which means the
+   * caller's own highlighter has to produce the whole page. Non-empty
+   * leaves `html` untouched and `pending` empty.
    */
   skipped: Array<string>
+  /**
+   * Well-formed blocks whose language has no native grammar, in document
+   * order. Highlight each one and hand the results to
+   * `applyPendingHighlights`; they are still in `html`, unchanged.
+   */
+  pending: Array<JsPendingBlock>
 }
 
 /** Configuration for generated i18n runtime modules. */
@@ -1070,6 +1088,14 @@ export interface JsParserOptions {
    * Default: `false`, or `true` when `gfm` is `true`.
    */
   autolinks?: boolean
+}
+
+/** A block the native pass left for the caller's highlighter. */
+export interface JsPendingBlock {
+  /** The `language-…` class the block carries. */
+  language: string
+  /** The block's source text, already unescaped. */
+  source: string
 }
 
 /** Options for [`super::transform_pm_embeds`]. */

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -210,6 +210,7 @@ module.exports.normalizeVitePressFrontmatter = binding.normalizeVitePressFrontma
 module.exports.generateSsgHtml = binding.generateSsgHtml;
 module.exports.generateSsgBareHtml = binding.generateSsgBareHtml;
 module.exports.highlightCodeBlock = binding.highlightCodeBlock;
+module.exports.applyPendingHighlights = binding.applyPendingHighlights;
 module.exports.highlightHtmlCodeBlocks = binding.highlightHtmlCodeBlocks;
 module.exports.supportsHighlightLanguage = binding.supportsHighlightLanguage;
 module.exports.nativeHighlightLanguages = binding.nativeHighlightLanguages;

--- a/crates/ox_content_napi/src/highlight_bindings.rs
+++ b/crates/ox_content_napi/src/highlight_bindings.rs
@@ -30,9 +30,23 @@ pub fn native_highlight_languages() -> Vec<String> {
 pub struct JsHighlightedDocument {
     /// The document with each handled block replaced.
     pub html: String,
-    /// Languages of blocks left untouched, so the caller knows whether another
-    /// highlighter still has to run over the result.
+    /// Languages of elements the native pass could not read, which means the
+    /// caller's own highlighter has to produce the whole page. Non-empty
+    /// leaves `html` untouched and `pending` empty.
     pub skipped: Vec<String>,
+    /// Well-formed blocks whose language has no native grammar, in document
+    /// order. Highlight each one and hand the results to
+    /// `applyPendingHighlights`; they are still in `html`, unchanged.
+    pub pending: Vec<JsPendingBlock>,
+}
+
+/// A block the native pass left for the caller's highlighter.
+#[napi(object)]
+pub struct JsPendingBlock {
+    /// The `language-…` class the block carries.
+    pub language: String,
+    /// The block's source text, already unescaped.
+    pub source: String,
 }
 
 /// Highlights every code block in a rendered document in one call.
@@ -47,5 +61,29 @@ pub fn highlight_html_code_blocks(html: String) -> JsHighlightedDocument {
         ox_content_highlight::supports,
         ox_content_highlight::highlight_to_html,
     );
-    JsHighlightedDocument { html: result.html, skipped: result.skipped }
+    JsHighlightedDocument {
+        html: result.html,
+        skipped: result.skipped,
+        pending: result
+            .pending
+            .into_iter()
+            .map(|block| JsPendingBlock { language: block.language, source: block.source })
+            .collect(),
+    }
+}
+
+/// Splices the caller's highlighting back over the blocks
+/// `highlightHtmlCodeBlocks` left pending.
+///
+/// `replacements` lines up with the `pending` list it returned: entry `i` is a
+/// full `<pre>` element for pending block `i`, or an empty string to leave that
+/// block as it is. This keeps a page that needs one exotic grammar off the
+/// HTML round trip, instead of surrendering the whole document for it.
+#[napi(js_name = "applyPendingHighlights")]
+pub fn apply_pending_highlights(html: String, replacements: Vec<String>) -> String {
+    ox_content_transform::highlight::apply_pending_highlights(
+        &html,
+        &replacements,
+        ox_content_highlight::supports,
+    )
 }

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -39,6 +39,17 @@ export declare class IncrementalMarkdownRenderer {
 }
 
 /**
+ * Splices the caller's highlighting back over the blocks
+ * `highlightHtmlCodeBlocks` left pending.
+ *
+ * `replacements` lines up with the `pending` list it returned: entry `i` is a
+ * full `<pre>` element for pending block `i`, or an empty string to leave that
+ * block as it is. This keeps a page that needs one exotic grammar off the
+ * HTML round trip, instead of surrendering the whole document for it.
+ */
+export declare function applyPendingHighlights(html: string, replacements: Array<string>): string
+
+/**
  * Builds a Markdown collection manifest directly from files on the Rust side.
  *
  * File discovery, pattern filtering, frontmatter preparation, route metadata,
@@ -867,10 +878,17 @@ export interface JsHighlightedDocument {
   /** The document with each handled block replaced. */
   html: string
   /**
-   * Languages of blocks left untouched, so the caller knows whether another
-   * highlighter still has to run over the result.
+   * Languages of elements the native pass could not read, which means the
+   * caller's own highlighter has to produce the whole page. Non-empty
+   * leaves `html` untouched and `pending` empty.
    */
   skipped: Array<string>
+  /**
+   * Well-formed blocks whose language has no native grammar, in document
+   * order. Highlight each one and hand the results to
+   * `applyPendingHighlights`; they are still in `html`, unchanged.
+   */
+  pending: Array<JsPendingBlock>
 }
 
 /** Configuration for generated i18n runtime modules. */
@@ -1074,6 +1092,14 @@ export interface JsParserOptions {
    * Default: `false`, or `true` when `gfm` is `true`.
    */
   autolinks?: boolean
+}
+
+/** A block the native pass left for the caller's highlighter. */
+export interface JsPendingBlock {
+  /** The `language-…` class the block carries. */
+  language: string
+  /** The block's source text, already unescaped. */
+  source: string
 }
 
 /** Options for [`super::transform_pm_embeds`]. */

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
@@ -214,6 +214,7 @@ module.exports.normalizeVitePressFrontmatter = binding.normalizeVitePressFrontma
 module.exports.generateSsgHtml = binding.generateSsgHtml;
 module.exports.generateSsgBareHtml = binding.generateSsgBareHtml;
 module.exports.highlightCodeBlock = binding.highlightCodeBlock;
+module.exports.applyPendingHighlights = binding.applyPendingHighlights;
 module.exports.highlightHtmlCodeBlocks = binding.highlightHtmlCodeBlocks;
 module.exports.supportsHighlightLanguage = binding.supportsHighlightLanguage;
 module.exports.nativeHighlightLanguages = binding.nativeHighlightLanguages;

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
@@ -214,6 +214,7 @@ module.exports.normalizeVitePressFrontmatter = binding.normalizeVitePressFrontma
 module.exports.generateSsgHtml = binding.generateSsgHtml;
 module.exports.generateSsgBareHtml = binding.generateSsgBareHtml;
 module.exports.highlightCodeBlock = binding.highlightCodeBlock;
+module.exports.applyPendingHighlights = binding.applyPendingHighlights;
 module.exports.highlightHtmlCodeBlocks = binding.highlightHtmlCodeBlocks;
 module.exports.supportsHighlightLanguage = binding.supportsHighlightLanguage;
 module.exports.nativeHighlightLanguages = binding.nativeHighlightLanguages;

--- a/crates/ox_content_transform/src/highlight.rs
+++ b/crates/ox_content_transform/src/highlight.rs
@@ -3,8 +3,11 @@ mod scan;
 mod tag;
 #[cfg(test)]
 mod tests;
+mod text;
 
-pub use blocks::{HighlightedDocument, highlight_code_blocks};
+pub use blocks::{
+    HighlightedDocument, PendingBlock, apply_pending_highlights, highlight_code_blocks,
+};
 
 use scan::{collect_pre_blocks, find_next_start_tag};
 use tag::ParsedAttribute;

--- a/crates/ox_content_transform/src/highlight/blocks.rs
+++ b/crates/ox_content_transform/src/highlight/blocks.rs
@@ -12,7 +12,8 @@
 
 use rustc_hash::FxHashMap;
 
-use super::scan::{collect_inline_code, collect_pre_blocks, find_tag_end};
+use super::scan::{collect_inline_code, collect_pre_blocks};
+use super::text::code_text;
 use super::{
     extract_code_block_metadata, merge_highlighted_code_block, merge_highlighted_inline_code,
 };
@@ -21,9 +22,23 @@ use super::{
 pub struct HighlightedDocument {
     /// The document with every handled block replaced.
     pub html: String,
-    /// Languages of blocks left untouched, so the caller can decide whether
-    /// another highlighter still needs to run over the result.
+    /// Languages of elements this pass could not read at all, which means the
+    /// caller's HTML-parser-based highlighter has to produce the whole page.
+    /// Non-empty leaves `html` untouched and `pending` empty.
     pub skipped: Vec<String>,
+    /// Well-formed elements whose language has no grammar here, in document
+    /// order. The caller highlights each one however it likes and hands the
+    /// results back to [`apply_pending_highlights`]; the elements are still
+    /// in `html`, unchanged.
+    pub pending: Vec<PendingBlock>,
+}
+
+/// An element left for the caller's highlighter.
+pub struct PendingBlock {
+    /// The `language-…` class the element carries.
+    pub language: String,
+    /// The element's source text, already unescaped.
+    pub source: String,
 }
 
 /// What kind of element a scanned region holds.
@@ -53,12 +68,15 @@ struct Claim {
 /// are carried over by the same merges the rehype path used, so annotated
 /// blocks and API signatures come out identical.
 ///
-/// The document is all-or-nothing on purpose. A caller that gets a non-empty
-/// `skipped` has to run its HTML-parser-based highlighter over the whole page
-/// anyway, and that pass redoes every block — so highlighting the claimable
-/// ones first would be work thrown away. Claims are therefore collected with a
-/// scan that costs no highlighting, and the moment one element is out of reach
-/// the original `html` is handed back untouched.
+/// An element whose language has no grammar here is *pending* rather than
+/// fatal: it is well formed, so the caller can highlight that one element on
+/// its own and splice the result back with [`apply_pending_highlights`],
+/// without an HTML parser ever seeing the page. Only an element this pass
+/// cannot read — markup where a text scan and a real parser would disagree —
+/// is `skipped`, and that does surrender the whole document, because the
+/// caller's pass will redo every element anyway and highlighting them first
+/// would be work thrown away. Claims are collected by a scan that costs no
+/// highlighting, so surrendering is cheap.
 pub fn highlight_code_blocks(
     html: &str,
     supports: impl Fn(&str) -> bool,
@@ -72,7 +90,11 @@ pub fn highlight_code_blocks(
         )
         .collect();
     if regions.is_empty() {
-        return HighlightedDocument { html: html.to_string(), skipped: Vec::new() };
+        return HighlightedDocument {
+            html: html.to_string(),
+            skipped: Vec::new(),
+            pending: Vec::new(),
+        };
     }
     // Both scanners walk the document in order and neither can overlap the
     // other, so ordering by start offset is enough to splice in one pass.
@@ -80,6 +102,7 @@ pub fn highlight_code_blocks(
 
     let mut claims = Vec::with_capacity(regions.len());
     let mut skipped = Vec::new();
+    let mut pending = Vec::new();
 
     for (start, end, region) in regions {
         let element = &html[start..end];
@@ -90,21 +113,20 @@ pub fn highlight_code_blocks(
             continue;
         };
 
-        if !supports(&language) {
-            skipped.push(language);
-            continue;
-        }
-
         let Some(source) = code_text(element) else {
             skipped.push(language);
             continue;
         };
 
-        claims.push(Claim { start, end, region, language, source });
+        if supports(&language) {
+            claims.push(Claim { start, end, region, language, source });
+        } else {
+            pending.push(PendingBlock { language, source });
+        }
     }
 
     if !skipped.is_empty() {
-        return HighlightedDocument { html: html.to_string(), skipped };
+        return HighlightedDocument { html: html.to_string(), skipped, pending: Vec::new() };
     }
 
     // A page repeats its short snippets heavily — `string` and `boolean` alone
@@ -131,6 +153,7 @@ pub fn highlight_code_blocks(
             return HighlightedDocument {
                 html: html.to_string(),
                 skipped: vec![claim.language.clone()],
+                pending: Vec::new(),
             };
         };
         slots.push(rendered.len());
@@ -165,11 +188,85 @@ pub fn highlight_code_blocks(
     // fallback; hand back the original and let the caller's pass produce the
     // page.
     if !skipped.is_empty() {
-        return HighlightedDocument { html: html.to_string(), skipped };
+        return HighlightedDocument { html: html.to_string(), skipped, pending: Vec::new() };
     }
 
     out.push_str(&html[cursor..]);
-    HighlightedDocument { html: out, skipped }
+    HighlightedDocument { html: out, skipped, pending }
+}
+
+/// Splices the caller's highlighting back over the elements
+/// [`highlight_code_blocks`] left pending.
+///
+/// `replacements` lines up with the `pending` list it returned: entry `i` is a
+/// full `<pre>` element for pending block `i`, or an empty string to leave
+/// that one as it is. `supports` must answer as it did then, since it is what
+/// tells the two scans apart — an element it claims was already highlighted
+/// and is not touched again.
+pub fn apply_pending_highlights(
+    html: &str,
+    replacements: &[String],
+    supports: impl Fn(&str) -> bool,
+) -> String {
+    if replacements.is_empty() {
+        return html.to_string();
+    }
+
+    let mut regions: Vec<(usize, usize, Region)> = collect_pre_blocks(html)
+        .into_iter()
+        .map(|(start, end)| (start, end, Region::Block))
+        .chain(
+            collect_inline_code(html).into_iter().map(|(start, end)| (start, end, Region::Inline)),
+        )
+        .collect();
+    regions.sort_by_key(|&(start, _, _)| start);
+
+    let mut out = String::with_capacity(html.len() * 2);
+    let mut cursor = 0;
+    let mut next = 0;
+
+    for (start, end, region) in regions {
+        if next >= replacements.len() {
+            break;
+        }
+        let element = &html[start..end];
+        let Some(language) = element_language(element, &region) else {
+            continue;
+        };
+        if supports(&language) || code_text(element).is_none() {
+            continue;
+        }
+
+        let replacement = replacements[next].as_str();
+        next += 1;
+
+        // An empty replacement means the caller's highlighter had no grammar
+        // for this block either. A block still picks up the `data-language`
+        // the merge writes — the tree walk reached the same state by leaving
+        // the element in place and merging the original metadata back over it
+        // — while an inline element is left exactly as it arrived, because
+        // that merge only ever ran over `<pre>` blocks.
+        let merged = match (&region, replacement.is_empty()) {
+            (Region::Block, true) => {
+                Some(merge_highlighted_code_block(element, element, Some(&language)))
+            }
+            (Region::Block, false) => {
+                Some(merge_highlighted_code_block(element, replacement, Some(&language)))
+            }
+            (Region::Inline, true) => None,
+            (Region::Inline, false) => merge_highlighted_inline_code(element, replacement),
+        };
+        let Some(merged) = merged else {
+            continue;
+        };
+
+        out.push_str(&html[cursor..start]);
+        out.push_str(&merged);
+        cursor = end;
+    }
+
+    out.push_str(&html[cursor..]);
+    out
 }
 
 /// The language to highlight the element as, if it should be highlighted.
@@ -190,118 +287,4 @@ fn element_language(element: &str, region: &Region) -> Option<String> {
             .find_map(|class_name| class_name.strip_prefix("language-"))
             .map(ToString::to_string),
     }
-}
-
-/// The source text of a `<code>` element.
-///
-/// The element is not always plain: a block carrying code annotations arrives
-/// wrapped in `<span class="line">`, and a member type arrives with an `<a>`
-/// around the type name it cross-references. The rehype pass read both through
-/// the DOM's text nodes — dropping the wrappers, and for a block re-applying
-/// the line metadata afterwards — so those are stripped here too rather than
-/// treated as a reason to decline the element. Declining sends the whole page
-/// back through the HTML round trip this exists to avoid.
-///
-/// Anything heavier than a `<span>` means the block is not what it claims to
-/// be. A JSDoc `@example` whose body was itself run through the Markdown
-/// renderer arrives with `<p>` and `<a>` nested inside `<code>`, which is not
-/// well-formed and which a text scan and a real HTML parser recover
-/// differently. Those are declined so the DOM path stays the authority on
-/// malformed input.
-fn code_text(element: &str) -> Option<String> {
-    let code_open = element.find("<code")?;
-    let content_start = element[code_open..].find('>')? + code_open + 1;
-    let content_end = element.rfind("</code>")?;
-    if content_end < content_start {
-        return None;
-    }
-
-    let content = &element[content_start..content_end];
-    if !content.contains('<') {
-        return Some(decode_entities(content));
-    }
-
-    let mut text = String::with_capacity(content.len());
-    let mut cursor = 0;
-    while let Some(relative) = content[cursor..].find('<') {
-        let open = cursor + relative;
-        text.push_str(&content[cursor..open]);
-        let Some(close) = find_tag_end(content, open) else {
-            // A `<` with no closing `>` is text the renderer failed to escape,
-            // not a tag; keep it rather than truncating the source.
-            text.push_str(&content[open..]);
-            return Some(decode_entities(&text));
-        };
-        if !is_text_wrapper(&content[open..close]) {
-            return None;
-        }
-        cursor = close;
-    }
-    text.push_str(&content[cursor..]);
-    Some(decode_entities(&text))
-}
-
-/// Elements that may wrap part of a code element's text.
-///
-/// `span` comes from code annotations; `a` is the type cross-reference the
-/// docs generator puts inside a member type. Both wrap text and nothing else,
-/// so dropping them recovers exactly the source the DOM walk read.
-const TEXT_WRAPPERS: [&str; 2] = ["span", "a"];
-
-/// Whether `tag` opens or closes one of [`TEXT_WRAPPERS`].
-fn is_text_wrapper(tag: &str) -> bool {
-    let name = tag.trim_start_matches('<').trim_start_matches('/');
-    let end = name.find(|c: char| !c.is_ascii_alphanumeric()).unwrap_or(name.len());
-    TEXT_WRAPPERS.iter().any(|wrapper| name[..end].eq_ignore_ascii_case(wrapper))
-}
-
-/// Reverses the renderer's escaping, plus the numeric forms other producers
-/// emit for the same five bytes.
-fn decode_entities(text: &str) -> String {
-    if !text.contains('&') {
-        return text.to_string();
-    }
-
-    let mut out = String::with_capacity(text.len());
-    let mut rest = text;
-    while let Some(at) = rest.find('&') {
-        out.push_str(&rest[..at]);
-        let tail = &rest[at..];
-        // Scan bytes, not a string slice: capping the search by byte length
-        // and then slicing would split a multi-byte character and panic. `;`
-        // is ASCII, so a byte search finds exactly the same positions.
-        let Some(semi) = tail.as_bytes()[..tail.len().min(12)].iter().position(|&b| b == b';')
-        else {
-            out.push('&');
-            rest = &tail[1..];
-            continue;
-        };
-        let entity = &tail[1..semi];
-        let decoded = match entity {
-            "amp" => Some('&'),
-            "lt" => Some('<'),
-            "gt" => Some('>'),
-            "quot" => Some('"'),
-            "apos" => Some('\''),
-            _ => numeric_entity(entity),
-        };
-        if let Some(ch) = decoded {
-            out.push(ch);
-            rest = &tail[semi + 1..];
-        } else {
-            out.push('&');
-            rest = &tail[1..];
-        }
-    }
-    out.push_str(rest);
-    out
-}
-
-fn numeric_entity(entity: &str) -> Option<char> {
-    let digits = entity.strip_prefix('#')?;
-    let code = match digits.strip_prefix(['x', 'X']) {
-        Some(hex) => u32::from_str_radix(hex, 16).ok()?,
-        None => digits.parse().ok()?,
-    };
-    char::from_u32(code)
 }

--- a/crates/ox_content_transform/src/highlight/tests.rs
+++ b/crates/ox_content_transform/src/highlight/tests.rs
@@ -102,12 +102,70 @@ fn declines_a_block_whose_code_holds_more_than_text_wrappers() {
 }
 
 #[test]
-fn reports_languages_it_declines_and_leaves_them_untouched() {
-    let block = "<pre><code class=\"language-vue\">x</code></pre>\n<p>after</p>";
-    let result = super::highlight_code_blocks(block, |lang| lang != "vue", |_, _| None);
+fn hands_an_unsupported_language_to_the_caller_instead_of_surrendering() {
+    // The block is well formed, so only it needs another highlighter — the
+    // rest of the page is still done here.
+    let html = "<pre><code class=\"language-vue\">x</code></pre>\n\
+                <pre><code class=\"language-ts\">y</code></pre>";
+    let result = super::highlight_code_blocks(
+        html,
+        |lang| lang != "vue",
+        |_, _| Some("<pre><code>done</code></pre>".to_string()),
+    );
 
-    assert_eq!(result.skipped, ["vue"]);
-    assert_eq!(result.html, block);
+    assert!(result.skipped.is_empty(), "a well-formed block must not surrender the page");
+    assert_eq!(result.pending.len(), 1);
+    assert_eq!(result.pending[0].language, "vue");
+    assert_eq!(result.pending[0].source, "x");
+    assert!(result.html.contains("done"), "the supported block is still highlighted");
+    assert!(result.html.contains("language-vue"), "the pending block is left in place");
+}
+
+#[test]
+fn splices_the_callers_highlighting_back_over_a_pending_block() {
+    let html = "<pre><code class=\"language-vue\">x</code></pre>";
+    let merged = super::apply_pending_highlights(
+        html,
+        &["<pre class=\"shiki\"><code><span>x</span></code></pre>".to_string()],
+        |lang| lang != "vue",
+    );
+
+    assert!(merged.contains("shiki"));
+    assert!(merged.contains("<span>x</span>"));
+    assert!(merged.contains("data-language=\"vue\""));
+}
+
+#[test]
+fn leaves_the_blocks_it_already_highlighted_out_of_the_second_pass() {
+    // The two scans are lined up by `supports` alone: the first pass highlights
+    // what it claims and lists the rest, and the second must walk to the same
+    // elements in the same order. Touching a claimed one would consume a
+    // replacement meant for a later block and shift every one after it.
+    let html = "<pre class=\"shiki\"><code class=\"language-ts\"><span>done</span></code></pre>\n\
+                <pre><code class=\"language-vue\">x</code></pre>";
+    let merged = super::apply_pending_highlights(
+        html,
+        &["<pre class=\"shiki\"><code><span>vue</span></code></pre>".to_string()],
+        |lang| lang != "vue",
+    );
+
+    assert!(merged.contains("<span>done</span>"), "the claimed block must be untouched");
+    assert_eq!(merged.matches("<span>done</span>").count(), 1);
+    assert!(merged.contains("<span>vue</span>"), "the pending block must be replaced");
+}
+
+#[test]
+fn gives_a_pending_block_its_language_even_when_nothing_could_highlight_it() {
+    // An empty replacement is "no grammar for this either". The tree walk
+    // reached the same state by leaving the element alone and merging the
+    // original metadata back over it, which is where `data-language` came
+    // from, so a block still picks that up.
+    let html = "<pre><code class=\"language-mermaid\">flowchart LR</code></pre>";
+    let merged = super::apply_pending_highlights(html, &[String::new()], |lang| lang != "mermaid");
+
+    assert!(merged.contains("<pre data-language=\"mermaid\">"));
+    assert!(merged.contains("flowchart LR"));
+    assert!(!merged.contains("shiki"));
 }
 
 #[test]
@@ -186,19 +244,20 @@ fn keeps_each_element_of_a_repeated_snippet_on_its_own_classes() {
 fn highlights_nothing_at_all_once_one_element_is_out_of_reach() {
     // The caller answers a non-empty `skipped` by running its own highlighter
     // over the whole page, which redoes every block. Anything highlighted here
-    // would be thrown away, so nothing is.
-    let html = "<pre><code class=\"language-ts\">a</code></pre>\n                <pre><code class=\"language-vue\">b</code></pre>";
+    // would be thrown away, so nothing is. Only markup this pass cannot read
+    // does that — an unsupported language comes back as pending instead.
+    let html = "<pre><code class=\"language-ts\">a</code></pre>\n                <pre><code class=\"language-ts\">b\n<p>c</p></code></pre>";
     let calls = std::cell::Cell::new(0);
     let result = super::highlight_code_blocks(
         html,
-        |lang| lang != "vue",
+        |_| true,
         |_, _| {
             calls.set(calls.get() + 1);
             Some("<pre>x</pre>".to_string())
         },
     );
 
-    assert_eq!(result.skipped, ["vue"]);
+    assert_eq!(result.skipped, ["ts"]);
     assert_eq!(result.html, html);
     assert_eq!(calls.get(), 0, "the claimable block must not be highlighted");
 }

--- a/crates/ox_content_transform/src/highlight/text.rs
+++ b/crates/ox_content_transform/src/highlight/text.rs
@@ -1,0 +1,121 @@
+//! Recovering a code element's source text from the markup around it.
+//!
+//! The rehype pass read a code element through the DOM's text nodes. This is
+//! the same reading done over the raw HTML, which is what lets a page be
+//! highlighted without an HTML parser in the loop.
+
+use super::scan::find_tag_end;
+
+/// The source text of a `<code>` element.
+///
+/// The element is not always plain: a block carrying code annotations arrives
+/// wrapped in `<span class="line">`, and a member type arrives with an `<a>`
+/// around the type name it cross-references. The rehype pass read both through
+/// the DOM's text nodes — dropping the wrappers, and for a block re-applying
+/// the line metadata afterwards — so those are stripped here too rather than
+/// treated as a reason to decline the element. Declining sends the whole page
+/// back through the HTML round trip this exists to avoid.
+///
+/// Anything heavier than a `<span>` means the block is not what it claims to
+/// be. A JSDoc `@example` whose body was itself run through the Markdown
+/// renderer arrives with `<p>` and `<a>` nested inside `<code>`, which is not
+/// well-formed and which a text scan and a real HTML parser recover
+/// differently. Those are declined so the DOM path stays the authority on
+/// malformed input.
+pub(super) fn code_text(element: &str) -> Option<String> {
+    let code_open = element.find("<code")?;
+    let content_start = element[code_open..].find('>')? + code_open + 1;
+    let content_end = element.rfind("</code>")?;
+    if content_end < content_start {
+        return None;
+    }
+
+    let content = &element[content_start..content_end];
+    if !content.contains('<') {
+        return Some(decode_entities(content));
+    }
+
+    let mut text = String::with_capacity(content.len());
+    let mut cursor = 0;
+    while let Some(relative) = content[cursor..].find('<') {
+        let open = cursor + relative;
+        text.push_str(&content[cursor..open]);
+        let Some(close) = find_tag_end(content, open) else {
+            // A `<` with no closing `>` is text the renderer failed to escape,
+            // not a tag; keep it rather than truncating the source.
+            text.push_str(&content[open..]);
+            return Some(decode_entities(&text));
+        };
+        if !is_text_wrapper(&content[open..close]) {
+            return None;
+        }
+        cursor = close;
+    }
+    text.push_str(&content[cursor..]);
+    Some(decode_entities(&text))
+}
+
+/// Elements that may wrap part of a code element's text.
+///
+/// `span` comes from code annotations; `a` is the type cross-reference the
+/// docs generator puts inside a member type. Both wrap text and nothing else,
+/// so dropping them recovers exactly the source the DOM walk read.
+const TEXT_WRAPPERS: [&str; 2] = ["span", "a"];
+
+/// Whether `tag` opens or closes one of [`TEXT_WRAPPERS`].
+fn is_text_wrapper(tag: &str) -> bool {
+    let name = tag.trim_start_matches('<').trim_start_matches('/');
+    let end = name.find(|c: char| !c.is_ascii_alphanumeric()).unwrap_or(name.len());
+    TEXT_WRAPPERS.iter().any(|wrapper| name[..end].eq_ignore_ascii_case(wrapper))
+}
+
+/// Reverses the renderer's escaping, plus the numeric forms other producers
+/// emit for the same five bytes.
+fn decode_entities(text: &str) -> String {
+    if !text.contains('&') {
+        return text.to_string();
+    }
+
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(at) = rest.find('&') {
+        out.push_str(&rest[..at]);
+        let tail = &rest[at..];
+        // Scan bytes, not a string slice: capping the search by byte length
+        // and then slicing would split a multi-byte character and panic. `;`
+        // is ASCII, so a byte search finds exactly the same positions.
+        let Some(semi) = tail.as_bytes()[..tail.len().min(12)].iter().position(|&b| b == b';')
+        else {
+            out.push('&');
+            rest = &tail[1..];
+            continue;
+        };
+        let entity = &tail[1..semi];
+        let decoded = match entity {
+            "amp" => Some('&'),
+            "lt" => Some('<'),
+            "gt" => Some('>'),
+            "quot" => Some('"'),
+            "apos" => Some('\''),
+            _ => numeric_entity(entity),
+        };
+        if let Some(ch) = decoded {
+            out.push(ch);
+            rest = &tail[semi + 1..];
+        } else {
+            out.push('&');
+            rest = &tail[1..];
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+fn numeric_entity(entity: &str) -> Option<char> {
+    let digits = entity.strip_prefix('#')?;
+    let code = match digits.strip_prefix(['x', 'X']) {
+        Some(hex) => u32::from_str_radix(hex, 16).ok()?,
+        None => digits.parse().ok()?,
+    };
+    char::from_u32(code)
+}

--- a/npm/vite-plugin-ox-content/src/highlight-native.ts
+++ b/npm/vite-plugin-ox-content/src/highlight-native.ts
@@ -122,12 +122,44 @@ export function languageOf(codeElement: Element): string | null {
  * over the documentation corpus, and re-parsing each highlighted block to
  * splice it back cost another 38 ms, against 14 ms of actual highlighting.
  */
-export function highlightDocumentNatively(
-  html: string,
-): { html: string; skipped: string[] } | null {
+export function highlightDocumentNatively(html: string): NativeDocument | null {
   try {
     return importNapiModuleSync().highlightHtmlCodeBlocks(html);
   } catch {
     return null;
+  }
+}
+
+/** A block the native pass left for another highlighter. */
+export interface PendingBlock {
+  language: string;
+  source: string;
+}
+
+/** What {@link highlightDocumentNatively} produced for a page. */
+export interface NativeDocument {
+  html: string;
+  /**
+   * Languages of elements the native pass could not read. Non-empty means the
+   * page has to be produced by the HTML-parser-based highlighter instead.
+   */
+  skipped: string[];
+  /** Well-formed blocks whose language has no native grammar, in order. */
+  pending: PendingBlock[];
+}
+
+/**
+ * Splices `replacements` back over the blocks the native pass left pending.
+ *
+ * Entry `i` is the highlighted `<pre>` for pending block `i`, or an empty
+ * string to leave that block alone. This keeps a page that needs one exotic
+ * grammar — a Vue SFC, a Mermaid diagram — off the HTML round trip, rather
+ * than surrendering the whole document for it.
+ */
+export function applyPendingHighlights(html: string, replacements: string[]): string {
+  try {
+    return importNapiModuleSync().applyPendingHighlights(html, replacements);
+  } catch {
+    return html;
   }
 }

--- a/npm/vite-plugin-ox-content/src/highlight.ts
+++ b/npm/vite-plugin-ox-content/src/highlight.ts
@@ -265,3 +265,40 @@ export async function highlightCode(
 
   return String(result);
 }
+
+/**
+ * Highlight the blocks the native pass left pending, in order.
+ *
+ * Entry `i` of the result is the `<pre>` for block `i`, or an empty string
+ * when Shiki has no grammar for it either — in which case the block is left
+ * exactly as it arrived, the same outcome the tree walk reached by keeping the
+ * original element.
+ *
+ * This is the whole point of the pending list: a page whose only unsupported
+ * block is a Mermaid diagram used to be handed to the tree walk in full, which
+ * re-highlighted every one of its other blocks and paid for a parse and a
+ * serialize of the page to do it.
+ */
+export async function highlightPendingBlocks(
+  blocks: readonly { language: string; source: string }[],
+  theme: string | ThemeRegistration = CSS_VARIABLES_THEME,
+  langs: LanguageRegistration[] = [],
+): Promise<string[]> {
+  if (blocks.length === 0) {
+    return [];
+  }
+
+  const { themeName } = normalizeThemeInput(theme);
+  const highlighter = await getHighlighter(theme, langs);
+
+  return blocks.map((block) => {
+    try {
+      return highlighter.codeToHtml(block.source, {
+        lang: block.language as never,
+        theme: themeName as BundledTheme,
+      });
+    } catch {
+      return "";
+    }
+  });
+}

--- a/npm/vite-plugin-ox-content/src/transform.ts
+++ b/npm/vite-plugin-ox-content/src/transform.ts
@@ -32,8 +32,8 @@
  */
 
 import type { ResolvedOptions, TransformResult, TocEntry } from "./types";
-import { highlightCode } from "./highlight";
-import { highlightDocumentNatively } from "./highlight-native";
+import { highlightCode, highlightPendingBlocks } from "./highlight";
+import { applyPendingHighlights, highlightDocumentNatively } from "./highlight-native";
 import { CSS_VARIABLES_THEME } from "./shiki-theme";
 import { importNapiModule } from "./napi";
 import { transformMermaidStatic } from "./plugins/mermaid";
@@ -561,17 +561,27 @@ export async function transformMarkdown(
   // Apply syntax highlighting if enabled
   if (options.highlight) {
     // The native pass handles the whole document without an HTML parser in
-    // the loop. Whatever it declines — a language it has no grammar for, or a
-    // block something else already rewrote — falls through to Shiki, which
-    // still needs the parse/serialize round trip.
+    // the loop. A block whose language it has no grammar for comes back as
+    // `pending`: Shiki highlights that block alone and the result is spliced
+    // straight back, so one Mermaid diagram no longer costs the page a parse
+    // and a serialize. Only markup the pass cannot read at all — where a text
+    // scan and a real HTML parser would disagree — surrenders the document to
+    // the tree walk.
     const nativeTheme =
       options.highlightTheme === undefined || options.highlightTheme === CSS_VARIABLES_THEME;
     const native = nativeTheme ? highlightDocumentNatively(html) : null;
-    if (native) {
-      html = native.html;
-    }
 
-    if (!native || native.skipped.length > 0) {
+    if (native && native.skipped.length === 0) {
+      html = native.html;
+      if (native.pending.length > 0) {
+        const replacements = await highlightPendingBlocks(
+          native.pending,
+          options.highlightTheme,
+          options.highlightLangs,
+        );
+        html = applyPendingHighlights(html, replacements);
+      }
+    } else {
       const originalHtml = html;
       const highlightedHtml = await highlightCode(
         html,


### PR DESCRIPTION
## What

The native pass was all-or-nothing: a page holding a single block whose language has no grammar here — a Mermaid diagram, a Vue SFC — handed the **whole document** to the tree walk, which re-highlighted every one of its other blocks and paid for a parse and a serialize of the page to do it.

On the documentation corpus that was 15 of 102 pages, and they were expensive:

| | pages | ms | per page |
|---|---|---|---|
| native (whole page) | 87 | 89 ms | 1.03 ms |
| falls back to the tree walk | 15 | 81 ms | **5.38 ms** |

**5.2x.** And the fallback's own breakdown showed the same shape as #620: of 76 ms, only ~12 ms was Shiki actually highlighting the exotic blocks — the rest was the page round trip, the per-block re-parses, and re-highlighting the 94 blocks the native pass had already done.

## What changed

Such a block is well formed, so nothing about it needs an HTML parser. The pass now reports it as **pending** — its language and its source text — and highlights the rest of the page as usual. The caller highlights those blocks alone and `applyPendingHighlights` splices the results back. On the corpus that is **17 blocks of five languages**, instead of 111 blocks and 15 page round trips.

Only markup the pass *cannot read* still surrenders the document — a JSDoc `@example` run through the Markdown renderer, where a text scan and a real parser disagree about where the block ends (#621). That is five pages.

A pending block whose language the caller cannot highlight either comes back as an empty replacement and keeps the `data-language` the merge writes, which is exactly the state the tree walk left it in.

## Results

`docs/content`, 102 files / 1.34 MB, alternating prebuilt binaries, eight rounds:

| metric | before | after | |
|---|---|---|---|
| warm | 184 ms | 161 ms | **−12.5%** (7.2 → 8.3 MB/s) |
| cold | 805 ms | 773 ms | **−4%** |
| user CPU | 1.57 s | 1.46 s | **−7.3%** — lower in every round |

## Output equivalence

All 102 pages rendered both ways and compared after parser normalization:

- **92 byte-identical**
- **10 encoding-only** — those pages no longer take the round trip that re-encodes `'` and `<`
- **0 substantive differences**

## Tests

Four added tests covering the pending path, all mutation-checked. The last one exists because a mutation survived the first round: letting `applyPendingHighlights` touch an already-claimed element passed everything, even though it would consume a replacement meant for a later block and shift every one after it. That invariant now has a test.

1011 Rust tests and 220 TypeScript tests pass; clippy clean. `blocks.rs` crossed the 350-line limit, so the text recovery moved to its own `text.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790025839&installation_model_id=422833&pr_number=625&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F625&signature=6040d7c5c7fb049033b05e6f326bb692ad5576713988bf220fbfdb1ebae887d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->