### PR TITLE
fix(docs): stop truncating generated examples at their first blank line

### DIFF
--- a/crates/ox_content_docs/src/markdown/markdown_html/inline.rs
+++ b/crates/ox_content_docs/src/markdown/markdown_html/inline.rs
@@ -97,9 +97,37 @@ pub(super) fn render_code_block_html(code: &str, language: &str) -> String {
     out.push_str("<pre><code class=\"language-");
     out.push_str(language);
     out.push_str("\">");
-    out.push_str(&code);
+    push_code_without_blank_lines(&mut out, &code);
     out.push_str("</code></pre>");
     out.into_string()
+}
+
+/// Appends `code`, writing any newline that would leave a blank source line as
+/// `&#10;` instead.
+///
+/// This block is emitted inside a `<div>`, which makes it part of a CommonMark
+/// HTML block, and one of those ends at the first blank line. Everything after
+/// that line is then parsed as Markdown — inside what is meant to be a code
+/// example — which silently drops the blank lines from every example that has
+/// one, and puts the rest of the block at the mercy of Markdown's own rules.
+/// Writing all but the last newline of a run as a character reference renders
+/// exactly the same line breaks while leaving the parser no blank line to end
+/// the block on.
+fn push_code_without_blank_lines(out: &mut StringBuilder, code: &str) {
+    let mut rest = code;
+
+    while let Some(at) = rest.find("\n\n") {
+        out.push_str(&rest[..at]);
+        let tail = &rest[at..];
+        let newlines = tail.len() - tail.trim_start_matches('\n').len();
+        for _ in 1..newlines {
+            out.push_str("&#10;");
+        }
+        out.push_char('\n');
+        rest = &tail[newlines..];
+    }
+
+    out.push_str(rest);
 }
 
 pub(super) fn render_highlighted_inline_code_html(

--- a/crates/ox_content_docs/src/markdown/tests/examples_and_sources.rs
+++ b/crates/ox_content_docs/src/markdown/tests/examples_and_sources.rs
@@ -90,3 +90,27 @@ fn entries_without_file_omit_source_link() {
         // The external symbol emits no source link and leaks no path.
     }
 }
+
+#[test]
+fn html_example_keeps_a_blank_line_out_of_the_markdown_source() {
+    // A `<pre>` here sits inside a `<div>`, so it is part of a CommonMark HTML
+    // block — and one of those ends at the first blank line, after which the
+    // rest of the example is parsed as Markdown. Encoding the blank line keeps
+    // the block whole, and the reader still sees the break.
+    let mut entry = test_entry("ArgSchema", "interface", "/repo/src/a.ts", "Schema.");
+    entry.examples = vec!["const a = 1;\n\nconst b = 2;".to_string()];
+    let out = generate_markdown(&lifecycle_module(entry), &html_typedoc_options());
+    let page = out
+        .values()
+        .find(|page| page.contains("const a = 1;"))
+        .expect("a page carrying the example");
+
+    assert!(
+        page.contains("const a = 1;&#10;\nconst b = 2;"),
+        "the blank line must survive as a character reference, got:\n{page}",
+    );
+    assert!(
+        !page.contains("const a = 1;\n\n"),
+        "no blank line may be left inside the HTML block, got:\n{page}",
+    );
+}

--- a/docs/content/api/docs.md
+++ b/docs/content/api/docs.md
@@ -74,8 +74,7 @@
 <h4>Examples</h4>
 <div class="ox-api-entry__example">
 <div class="ox-api-entry__example-heading">Example 1</div>
-<pre><code class="language-typescript">import { extractDocs, generateMarkdown, writeDocs } from &#39;./docs&#39;;
-
+<pre><code class="language-typescript">import { extractDocs, generateMarkdown, writeDocs } from &#39;./docs&#39;;&#10;
 const docsOptions = {
 enabled: true,
 src: [&#39;./src&#39;],
@@ -84,8 +83,7 @@ include: [&#39;**\/\*.ts&#39;],
 exclude: [&#39;**\/*.test.ts&#39;],
 groupBy: &#39;file&#39;,
 githubUrl: &#39;https://github.com/user/project&#39;,
-};
-
+};&#10;
 const extracted = await extractDocs([&#39;./src&#39;], docsOptions);
 const markdown = generateMarkdown(extracted, docsOptions);
 await writeDocs(markdown, &#39;./docs/api&#39;, extracted, docsOptions);</code></pre>
@@ -172,8 +170,7 @@ await writeDocs(markdown, &#39;./docs/api&#39;, extracted, docsOptions);</code><
     groupBy: &#39;file&#39;,
     generateNav: true,
   }
-);
-
+);&#10;
 // Returns:
 // [
 // {

--- a/docs/content/api/jsx-runtime.md
+++ b/docs/content/api/jsx-runtime.md
@@ -239,8 +239,7 @@
     &quot;jsx&quot;: &quot;react-jsx&quot;,
     &quot;jsxImportSource&quot;: &quot;@ox-content/vite-plugin&quot;
   }
-}
-
+}&#10;
 // MyComponent.tsx
 export function Hero({ title }: { title: string }) {
 return (
@@ -613,8 +612,7 @@ return (
     &quot;jsx&quot;: &quot;react-jsx&quot;,
     &quot;jsxImportSource&quot;: &quot;@ox-content/vite-plugin&quot;
   }
-}
-
+}&#10;
 // MyComponent.tsx
 export function Hero({ title }: { title: string }) {
 return (

--- a/docs/content/api/page-context.md
+++ b/docs/content/api/page-context.md
@@ -326,8 +326,7 @@
 <div class="ox-api-entry__example">
 <div class="ox-api-entry__example-heading">Example 1</div>
 <pre><code class="language-tsx">// theme/Layout.tsx
-import { usePageProps, PageProps } from &#39;@ox-content/vite-plugin&#39;;
-
+import { usePageProps, PageProps } from &#39;@ox-content/vite-plugin&#39;;&#10;
 export function Layout({ children }: { children: JSX.Element }) {
 const page = usePageProps&lt;MyPageProps&gt;();
 return (

--- a/docs/content/api/theme-renderer.md
+++ b/docs/content/api/theme-renderer.md
@@ -103,8 +103,7 @@
 <div class="ox-api-entry__example-heading">Example 1</div>
 <pre><code class="language-tsx">import { createTheme } from &#39;@ox-content/vite-plugin&#39;;
 import { DefaultLayout } from &#39;./layouts/Default&#39;;
-import { EntryLayout } from &#39;./layouts/Entry&#39;;
-
+import { EntryLayout } from &#39;./layouts/Entry&#39;;&#10;
 export default createTheme({
 layouts: {
 default: DefaultLayout,

--- a/docs/content/api/transform.md
+++ b/docs/content/api/transform.md
@@ -540,14 +540,12 @@
 <h4>Examples</h4>
 <div class="ox-api-entry__example">
 <div class="ox-api-entry__example-heading">Example 1</div>
-<pre><code class="language-typescript">import { transformMarkdown } from &#39;./transform&#39;;
-
+<pre><code class="language-typescript">import { transformMarkdown } from &#39;./transform&#39;;&#10;
 const content = await transformMarkdown(
 &#39;# Hello\n\nWorld&#39;,
 &#39;path/to/file.md&#39;,
 resolvedOptions
-);
-
+);&#10;
 console.log(content.html); // &#39;&lt;h1&gt;Hello&lt;/h1&gt;&lt;p&gt;World&lt;/p&gt;&#39;
 console.log(content.toc); // [{ depth: 1, text: &#39;Hello&#39;, slug: &#39;hello&#39;, children: [] }]</code></pre>
 


### PR DESCRIPTION
Closes #621.

## The bug

A generated API example is emitted as `<pre>` inside a `<div>`, which makes it part of a CommonMark **HTML block** — and one of those ends at the first blank line. Everything after that line is parsed as Markdown instead, so an example containing a blank line loses the rest of its body from the code block, and what does survive is at the mercy of Markdown's own rules.

`transform.ts`'s example currently renders as:

```
import { transformMarkdown } from './transform';
const content = await transformMarkdown(
'# Hello\n\nWorld',
'path/to/file.md',
resolvedOptions
);
```

Both `console.log` lines are gone. It should be:

```
import { transformMarkdown } from './transform';

const content = await transformMarkdown(
'# Hello\n\nWorld',
'path/to/file.md',
resolvedOptions
);

console.log(content.html); // '<h1>Hello</h1><p>World</p>'
console.log(content.toc);  // [{ depth: 1, text: 'Hello', slug: 'hello', children: [] }]
```

And `docs.ts`'s example loses the `**` from `include: ['**/*.ts']` — Markdown reads the two globs' asterisks as a pair of emphasis delimiters and renders `<strong>` instead.

## The fix

Writing all but the last newline of a run as `&#10;` renders exactly the same line breaks while leaving the parser no blank line to end the block on. Five generated pages change, and the checked-in Markdown is updated to match what the generator now produces for them.

## Why the diff is only five files

Regenerating the whole corpus touches ~4,100 lines, because the checked-in API docs are stale relative to their sources and three modules have no page at all. Only **7** of those lines are this fix. The rest is drift and belongs in its own change, so this PR carries just the blank-line correction — filed separately.

## Side effect: the last pages come off the slow path

These were also the only pages whose highlighting still needed an HTML parser. A truncated block arrives with `<p>` nested inside `<code>`, which is not well-formed, and the native pass cannot read markup where a text scan and a real parser would disagree. With them fixed, **all 102 pages** take the native path — 15 did not before #625, and 5 did not after it.

| metric | before | after | |
|---|---|---|---|
| warm | 162 ms | 123 ms | **−24%** (8.2 → 10.9 MB/s) |
| cold | 764 ms | 711 ms | **−7%** |
| user CPU | 1.43 s | 1.30 s | **−9%** |

Four alternated rounds warm, three cold; the fixed corpus was faster in every one.

## Tests

One added test, mutation-checked: emitting the newlines verbatim again fails it. 1013 Rust tests and 220 TypeScript tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)