### PR TITLE
perf(highlight): load only the grammars a page's pending blocks name

### DIFF
--- a/npm/vite-plugin-ox-content/src/highlight-pending.ts
+++ b/npm/vite-plugin-ox-content/src/highlight-pending.ts
@@ -1,0 +1,122 @@
+/**
+ * Highlighting the blocks the native pass could not claim.
+ *
+ * These arrive already named — the native pass reports each one's language —
+ * which lets this load exactly the grammars a page needs instead of the whole
+ * bundled set, and splice each result back without an HTML parser.
+ */
+
+import {
+  createHighlighter,
+  type BundledLanguage,
+  type BundledTheme,
+  type Highlighter,
+  type LanguageRegistration,
+  type ThemeRegistration,
+} from "shiki";
+import { BUILTIN_LANGS, normalizeThemeInput } from "./highlight";
+import { CSS_VARIABLES_THEME } from "./shiki-theme";
+
+/**
+ * A highlighter that starts with no grammars and gains them on demand.
+ *
+ * `getHighlighter` loads all two dozen `BUILTIN_LANGS` up front, because the
+ * tree walk it serves discovers a page's languages only while rewriting it.
+ * The pending list does not have that problem — it names every language it
+ * needs — and paying for two dozen TextMate grammars to highlight one Vue
+ * block is most of what a page with an exotic block costs.
+ */
+const lazyHighlighterCache = new Map<string, Promise<Highlighter>>();
+const loadedLangs = new WeakMap<Highlighter, Set<string>>();
+
+async function getLazyHighlighter(
+  theme: string | ThemeRegistration,
+  customLangs: LanguageRegistration[],
+  wanted: readonly string[],
+): Promise<Highlighter> {
+  const { themeInput } = normalizeThemeInput(theme);
+  const cacheKey = JSON.stringify({ theme: themeInput, langs: customLangs });
+
+  let highlighterPromise = lazyHighlighterCache.get(cacheKey);
+  if (!highlighterPromise) {
+    highlighterPromise = createHighlighter({
+      themes: [themeInput as BundledTheme | ThemeRegistration],
+      langs: customLangs,
+    });
+    lazyHighlighterCache.set(cacheKey, highlighterPromise);
+  }
+  const highlighter = await highlighterPromise;
+
+  // Only grammars `getHighlighter` would have loaded are loaded here, so a
+  // language neither of them carries stays unhighlighted either way. Adding
+  // one would change how a page renders, which is not this function's call to
+  // make.
+  let loaded = loadedLangs.get(highlighter);
+  if (!loaded) {
+    loaded = new Set();
+    loadedLangs.set(highlighter, loaded);
+  }
+  const missing = [
+    ...new Set(
+      wanted.filter(
+        (lang) => !loaded.has(lang) && (BUILTIN_LANGS as readonly string[]).includes(lang),
+      ),
+    ),
+  ];
+  if (missing.length > 0) {
+    await Promise.all(
+      missing.map(async (lang) => {
+        try {
+          await highlighter.loadLanguage(lang as BundledLanguage);
+          loaded.add(lang);
+        } catch {
+          // Leave it unloaded; `codeToHtml` then declines the block, which is
+          // what the tree walk did for a grammar it could not resolve.
+        }
+      }),
+    );
+  }
+
+  return highlighter;
+}
+
+/**
+ * Highlight the blocks the native pass left pending, in order.
+ *
+ * Entry `i` of the result is the `<pre>` for block `i`, or an empty string
+ * when Shiki has no grammar for it either — in which case the block is left
+ * exactly as it arrived, the same outcome the tree walk reached by keeping the
+ * original element.
+ *
+ * This is the whole point of the pending list: a page whose only unsupported
+ * block is a Mermaid diagram used to be handed to the tree walk in full, which
+ * re-highlighted every one of its other blocks and paid for a parse and a
+ * serialize of the page to do it.
+ */
+export async function highlightPendingBlocks(
+  blocks: readonly { language: string; source: string }[],
+  theme: string | ThemeRegistration = CSS_VARIABLES_THEME,
+  langs: LanguageRegistration[] = [],
+): Promise<string[]> {
+  if (blocks.length === 0) {
+    return [];
+  }
+
+  const { themeName } = normalizeThemeInput(theme);
+  const highlighter = await getLazyHighlighter(
+    theme,
+    langs,
+    blocks.map((block) => block.language),
+  );
+
+  return blocks.map((block) => {
+    try {
+      return highlighter.codeToHtml(block.source, {
+        lang: block.language as never,
+        theme: themeName as BundledTheme,
+      });
+    } catch {
+      return "";
+    }
+  });
+}

--- a/npm/vite-plugin-ox-content/src/highlight.ts
+++ b/npm/vite-plugin-ox-content/src/highlight.ts
@@ -9,6 +9,7 @@ import type { Root, Element } from "hast";
 import {
   createHighlighter,
   type Highlighter,
+  type BundledLanguage,
   type BundledTheme,
   type LanguageRegistration,
   type ThemeRegistration,
@@ -26,7 +27,7 @@ import { CSS_VARIABLES_THEME, resolveHighlightTheme } from "./shiki-theme";
 const rehypeParse = interopDefault(rehypeParsePlugin);
 const rehypeStringify = interopDefault(rehypeStringifyPlugin);
 
-const BUILTIN_LANGS = [
+export const BUILTIN_LANGS = [
   "javascript",
   "typescript",
   "jsx",
@@ -80,7 +81,7 @@ async function getHighlighter(
   return highlighterPromise;
 }
 
-function normalizeThemeInput(input: string | ThemeRegistration): {
+export function normalizeThemeInput(input: string | ThemeRegistration): {
   themeInput: string | ThemeRegistration;
   themeName: string;
 } {
@@ -264,41 +265,4 @@ export async function highlightCode(
     .process(html);
 
   return String(result);
-}
-
-/**
- * Highlight the blocks the native pass left pending, in order.
- *
- * Entry `i` of the result is the `<pre>` for block `i`, or an empty string
- * when Shiki has no grammar for it either — in which case the block is left
- * exactly as it arrived, the same outcome the tree walk reached by keeping the
- * original element.
- *
- * This is the whole point of the pending list: a page whose only unsupported
- * block is a Mermaid diagram used to be handed to the tree walk in full, which
- * re-highlighted every one of its other blocks and paid for a parse and a
- * serialize of the page to do it.
- */
-export async function highlightPendingBlocks(
-  blocks: readonly { language: string; source: string }[],
-  theme: string | ThemeRegistration = CSS_VARIABLES_THEME,
-  langs: LanguageRegistration[] = [],
-): Promise<string[]> {
-  if (blocks.length === 0) {
-    return [];
-  }
-
-  const { themeName } = normalizeThemeInput(theme);
-  const highlighter = await getHighlighter(theme, langs);
-
-  return blocks.map((block) => {
-    try {
-      return highlighter.codeToHtml(block.source, {
-        lang: block.language as never,
-        theme: themeName as BundledTheme,
-      });
-    } catch {
-      return "";
-    }
-  });
 }

--- a/npm/vite-plugin-ox-content/src/transform.ts
+++ b/npm/vite-plugin-ox-content/src/transform.ts
@@ -32,7 +32,8 @@
  */
 
 import type { ResolvedOptions, TransformResult, TocEntry } from "./types";
-import { highlightCode, highlightPendingBlocks } from "./highlight";
+import { highlightCode } from "./highlight";
+import { highlightPendingBlocks } from "./highlight-pending";
 import { applyPendingHighlights, highlightDocumentNatively } from "./highlight-native";
 import { CSS_VARIABLES_THEME } from "./shiki-theme";
 import { importNapiModule } from "./napi";


### PR DESCRIPTION
## What

Highlighting a page's leftovers went through the same highlighter the tree walk uses, which loads all two dozen `BUILTIN_LANGS` up front. The tree walk *needs* that — it discovers a page's languages while rewriting it, so it cannot say in advance what to load.

The pending list (#625) has no such problem: the native pass reports each block's language. So on the documentation corpus, two dozen TextMate grammars were being parsed through Oniguruma so that **seventeen blocks of five languages** could be highlighted.

Those blocks now get a highlighter that starts empty and loads what they name.

## Output is unchanged, deliberately

Only grammars `BUILTIN_LANGS` already carried are loaded. `loadLanguage` would happily resolve `mermaid` and `jsonc` — which the bundled set does *not* include — and those blocks would quietly gain colours they do not have today. That is a rendering change, and not this function's call to make.

**This was measured and rejected once before**, because it changed output: Markdown's highlighting depended on which other grammars happened to be loaded. Markdown has been highlighted natively since #619, so Shiki never sees it now, and the restriction above covers the rest. All 102 pages come out **byte-identical**.

## Results

`docs/content`, 102 files / 1.34 MB, alternating prebuilt binaries, seven rounds. Every round faster:

| metric | before | after | |
|---|---|---|---|
| cold | 720 ms | 578 ms | **−20%** (1.9 → 2.3 MB/s) |
| user CPU | 1.30 s | 1.10 s | **−15%** |
| warm | 123 ms | 123 ms | unchanged |

Warm being flat is the expected result, not a disappointment: this is setup that happened once per process.

## Note

`highlight.ts` crossed the 350-line limit, so the pending path moved to `highlight-pending.ts`.

220 TypeScript tests and 1013 Rust tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790026601&installation_model_id=422833&pr_number=628&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F628&signature=d576915bb5c7833e81ae12d41e54fe6ce4af721e7950aabe23304fbbc64a6f11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->