### PR TITLE
perf(highlight): spread a page's distinct snippets across threads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,9 @@ regex = "1.11"
 unicode-normalization = "0.1"
 memchr = "2.7"
 
+# Parallelism
+rayon = "1.10"
+
 # Hashing
 rustc-hash = "2"
 phf = { version = "0.14", features = ["macros"] }

--- a/crates/ox_content_transform/Cargo.toml
+++ b/crates/ox_content_transform/Cargo.toml
@@ -22,6 +22,7 @@ ox_content_ast = { workspace = true }
 ox_content_mdast = { workspace = true }
 ox_content_parser = { workspace = true }
 ox_content_renderer = { workspace = true }
+rayon = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/ox_content_transform/src/highlight/blocks.rs
+++ b/crates/ox_content_transform/src/highlight/blocks.rs
@@ -10,6 +10,7 @@
 //! This finds the blocks with the same scanner the merge step already uses,
 //! and splices the result straight back into the original HTML.
 
+use rayon::prelude::*;
 use rustc_hash::FxHashMap;
 
 use super::scan::{collect_inline_code, collect_pre_blocks};
@@ -51,6 +52,16 @@ enum Region {
     Inline,
 }
 
+/// How much distinct source a page needs before its highlighting is spread
+/// across threads.
+///
+/// Counted in bytes rather than snippets because that is what the work is:
+/// a page of thirty one-word member types is a fraction of the parsing of one
+/// long code sample. Below this a page's whole highlight pass is shorter than
+/// the hand-off costs, which keeps small pages — and the tests — on a plain
+/// sequential walk.
+pub(super) const PARALLEL_SOURCE_BYTES: usize = 4096;
+
 /// An element this pass has claimed, with the text to highlight it from.
 struct Claim {
     start: usize,
@@ -80,7 +91,7 @@ struct Claim {
 pub fn highlight_code_blocks(
     html: &str,
     supports: impl Fn(&str) -> bool,
-    highlight: impl Fn(&str, &str) -> Option<String>,
+    highlight: impl Fn(&str, &str) -> Option<String> + Sync,
 ) -> HighlightedDocument {
     let mut regions: Vec<(usize, usize, Region)> = collect_pre_blocks(html)
         .into_iter()
@@ -135,31 +146,41 @@ pub fn highlight_code_blocks(
     // nothing but the text and the language, so each distinct pair is parsed
     // once and the result reused. The merge still runs per element, which is
     // what carries each one's own classes and line metadata.
-    let mut rendered: Vec<String> = Vec::with_capacity(claims.len());
-    let mut rendered_at: FxHashMap<(&str, &str), usize> = FxHashMap::default();
+    let mut work: Vec<(&str, &str)> = Vec::with_capacity(claims.len());
+    let mut work_at: FxHashMap<(&str, &str), usize> = FxHashMap::default();
     let mut slots = Vec::with_capacity(claims.len());
 
     for claim in &claims {
         let key = (claim.language.as_str(), claim.source.as_str());
-        if let Some(&at) = rendered_at.get(&key) {
-            slots.push(at);
-            continue;
-        }
-        let Some(highlighted) = highlight(&claim.source, &claim.language) else {
-            // `supports` promised every claim, so a failure here is the
-            // highlighter contradicting itself rather than an expected
-            // fallback; hand back the original so the caller's own pass
-            // produces the page.
-            return HighlightedDocument {
-                html: html.to_string(),
-                skipped: vec![claim.language.clone()],
-                pending: Vec::new(),
-            };
-        };
-        slots.push(rendered.len());
-        rendered_at.insert(key, rendered.len());
-        rendered.push(highlighted);
+        let at = *work_at.entry(key).or_insert_with(|| {
+            work.push(key);
+            work.len() - 1
+        });
+        slots.push(at);
     }
+
+    // Each snippet is parsed and walked on its own — nothing is shared between
+    // them but the grammar tables, which are immutable once built — so the
+    // distinct list is pure independent work. Below the threshold a page does
+    // not have enough of it to pay for handing work to other threads.
+    let bytes: usize = work.iter().map(|(_, source)| source.len()).sum();
+    let rendered: Vec<Option<String>> = if bytes >= PARALLEL_SOURCE_BYTES {
+        work.par_iter().map(|&(language, source)| highlight(source, language)).collect()
+    } else {
+        work.iter().map(|&(language, source)| highlight(source, language)).collect()
+    };
+
+    // `supports` promised every claim, so a failure here is the highlighter
+    // contradicting itself rather than an expected fallback; hand back the
+    // original so the caller's own pass produces the page.
+    if let Some(at) = rendered.iter().position(Option::is_none) {
+        return HighlightedDocument {
+            html: html.to_string(),
+            skipped: vec![work[at].0.to_string()],
+            pending: Vec::new(),
+        };
+    }
+    let rendered: Vec<String> = rendered.into_iter().flatten().collect();
 
     let mut out = String::with_capacity(html.len() * 2);
     let mut cursor = 0;

--- a/crates/ox_content_transform/src/highlight/tests.rs
+++ b/crates/ox_content_transform/src/highlight/tests.rs
@@ -208,18 +208,22 @@ fn highlights_a_repeated_snippet_once_and_reuses_it() {
     let html = "<p><code class=\"language-ts\">string</code> \
                 <code class=\"language-ts\">string</code> \
                 <code class=\"language-ts\">boolean</code></p>";
-    let calls = std::cell::Cell::new(0);
+    let calls = std::sync::atomic::AtomicUsize::new(0);
     let result = super::highlight_code_blocks(
         html,
         |_| true,
         |code, _| {
-            calls.set(calls.get() + 1);
+            calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             Some(format!("<pre><code><span>{code}</span></code></pre>"))
         },
     );
 
     assert!(result.skipped.is_empty());
-    assert_eq!(calls.get(), 2, "the repeated snippet must be highlighted once");
+    assert_eq!(
+        calls.load(std::sync::atomic::Ordering::Relaxed),
+        2,
+        "the repeated snippet must be highlighted once"
+    );
     assert_eq!(result.html.matches("<span>string</span>").count(), 2);
     assert_eq!(result.html.matches("<span>boolean</span>").count(), 1);
 }
@@ -247,17 +251,80 @@ fn highlights_nothing_at_all_once_one_element_is_out_of_reach() {
     // would be thrown away, so nothing is. Only markup this pass cannot read
     // does that — an unsupported language comes back as pending instead.
     let html = "<pre><code class=\"language-ts\">a</code></pre>\n                <pre><code class=\"language-ts\">b\n<p>c</p></code></pre>";
-    let calls = std::cell::Cell::new(0);
+    let calls = std::sync::atomic::AtomicUsize::new(0);
     let result = super::highlight_code_blocks(
         html,
         |_| true,
         |_, _| {
-            calls.set(calls.get() + 1);
+            calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             Some("<pre>x</pre>".to_string())
         },
     );
 
     assert_eq!(result.skipped, ["ts"]);
     assert_eq!(result.html, html);
-    assert_eq!(calls.get(), 0, "the claimable block must not be highlighted");
+    assert_eq!(
+        calls.load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "the claimable block must not be highlighted"
+    );
+}
+
+#[test]
+fn names_the_language_of_the_snippet_the_highlighter_gave_up_on() {
+    // `supports` promised both languages, so a `None` here is the highlighter
+    // contradicting itself. The page goes back untouched for the caller to
+    // redo — and `skipped` names the language that actually failed, not
+    // whichever one happened to be claimed first.
+    let html = "<pre><code class=\"language-ts\">a</code></pre>\n\
+                <pre><code class=\"language-rs\">b</code></pre>";
+    let result = super::highlight_code_blocks(
+        html,
+        |_| true,
+        |_, language| {
+            (language != "rs").then(|| "<pre><code><span>t</span></code></pre>".to_string())
+        },
+    );
+
+    assert_eq!(result.skipped, ["rs"]);
+    assert_eq!(result.html, html);
+    assert!(result.pending.is_empty());
+}
+
+#[test]
+fn spreading_a_page_across_threads_keeps_each_result_on_its_own_element() {
+    // Enough distinct source to cross `PARALLEL_SOURCE_BYTES`, so this walks
+    // the threaded path. Every snippet highlights to a marker built from its
+    // own text, which the elements must carry back in the order they appeared:
+    // a page whose highlights landed on the wrong blocks is the failure that
+    // parallelising this could plausibly introduce.
+    let sources: Vec<String> =
+        (0..64).map(|i| format!("let v{i:03} = {};", "a".repeat(60))).collect();
+    assert!(
+        sources.iter().map(String::len).sum::<usize>() >= super::blocks::PARALLEL_SOURCE_BYTES,
+        "the fixture must be big enough to take the threaded path"
+    );
+
+    let mut html = String::new();
+    for source in &sources {
+        html.push_str("<pre><code class=\"language-ts\">");
+        html.push_str(source);
+        html.push_str("</code></pre>\n");
+    }
+
+    let result = super::highlight_code_blocks(
+        &html,
+        |_| true,
+        |code, _| Some(format!("<pre><code><span>{code}</span></code></pre>")),
+    );
+
+    assert!(result.skipped.is_empty());
+    let mut last = 0;
+    for source in &sources {
+        let marker = format!("<span>{source}</span>");
+        assert_eq!(result.html.matches(&marker).count(), 1, "{source} must appear once");
+        let at = result.html.find(&marker).expect("every snippet must reach the page");
+        assert!(at > last, "{source} landed out of order");
+        last = at;
+    }
 }


### PR DESCRIPTION
Once a page's repeated snippets collapse to a distinct list, that list is pure independent work: each entry is parsed and walked on its own, and the only state the entries share is the grammar tables, which are built behind a `OnceLock` and immutable thereafter. Nothing about it has to happen in sequence — so it no longer does.

A page whose distinct sources add up to 4 KB or more hands the list to rayon; anything smaller stays on the sequential walk, where the whole pass is over faster than the hand-off would take. The threshold counts **bytes rather than snippets** because bytes are what the work is — thirty one-word member types are a fraction of the parsing of one long code sample. I measured 4/8/16/32 snippets and 1K/4K/16K bytes; the byte thresholds landed within 96–98 ms of each other, and the win came from the large pages either way.

## Measured

`docs/content` (102 files, 1.34 MB), alternating prebuilt binaries on an otherwise idle machine.

| | before | after | |
|---|---|---|---|
| the highlight pass alone | 86.8 ms | 68.3 ms | **−21.3%** (three rounds) |
| warm page loop | 123 ms | 105 ms | **−14.6%** (nine rounds) |
| whole warm transform | 121 ms | 103 ms | **−14.7%** (three rounds of ten) |

Three independent harnesses agree, and the 18.5 ms the pass gives up shows up whole in the transform. This is why I trust these rather than my first pass, which read −22% and did not reproduce.

## What it costs

This buys latency with CPU, and the trade is not free:

| | before | after | |
|---|---|---|---|
| user CPU | 2.18 s | 2.34 s | +7.3% |
| sys CPU | 0.09 s | 0.20 s | +122% |
| **total CPU** | **2.27 s** | **2.54 s** | **+11.9%** |

It also needs cores to spare. Under contention the gap narrows and the numbers scatter badly — during one run with two `rustc` processes pegged, warm `before` ranged 132–240 ms. The figures above only reproduce on an idle machine.

**The call worth making explicitly:** ~15% off the developer-facing latency for ~12% more CPU. For a dev-server transform I think that is the right side of the trade, but it is a trade, not a free win.

## This does not block the bigger lever — it compounds with it

The obvious objection is that the real parallelism win is *pages*, not snippets inside one page, and that this change would be superseded by it or fight it. I measured that instead of assuming it.

The pipeline is single-threaded at the napi boundary today: `highlightHtmlCodeBlocks` is a synchronous binding, so it blocks the event loop and concurrent callers serialize. `Promise.all` over all 102 pages runs in 100 ms against 103 ms sequential — no overlap at all. Real page-level parallelism therefore needs an async binding (there is precedent in the crate: `parseAndRenderAsync`).

Driving pages genuinely in parallel with `worker_threads` — 8 workers, six alternating rounds — the two halves come out:

| 8 workers | before | after | |
|---|---|---|---|
| highlight pass | 29.8 ms | 18.6 ms | **−37.6%** |

So this helps *more* under page parallelism, not less. Rayon's pool is process-global, so eight workers submitting page-sized work feed one shared 12-thread pool rather than eight competing ones; the fine-grained work also reaches the four E-cores that eight Node workers alone leave idle. Sequential single-threaded to 8-way-plus-this is 86.8 ms → 18.6 ms, **4.7x**.

An early two-round measurement of this looked alarming — one round put `after` at 45.5 ms against `before`'s 30.6 ms. That was contention from an unrelated build on the same machine, and it did not survive six alternated rounds.

The per-page distribution says where the ceiling is: the work spreads well (the heaviest page is 8.5% of the pass, the top eight are 37.5%), so an ideal 8-core schedule bottoms out near 8 ms. The async binding is the next lever, and it is a separate change.

## Correctness

- Output **byte-identical on all 102 pages** (7.9 MB of rendered output compared).
- Transforming with highlighting off is unchanged at 12 ms — the control confirms the change touches only the highlight path.
- Thread safety is structural, not incidental: grammar configs live in a `OnceLock` whose `static` already forced the compiler to prove `Send + Sync`, and tree-sitter's `Highlighter` cursor is constructed per call, so nothing is shared across workers. The callback is a plain Rust `fn`, not a JS one — this never reaches across the napi boundary from a worker thread.
- Two new tests: one pins the ordering (a page whose highlights landed on the wrong blocks is the plausible failure mode here), one covers the `highlight`-returns-`None` branch, which I restructured from early-return to collect-then-scan and which had no coverage before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
