### PR TITLE
fix(plugin): serve every page that asks for the bindings at once

### DIFF
--- a/npm/vite-plugin-ox-content/src/napi-loading.test.ts
+++ b/npm/vite-plugin-ox-content/src/napi-loading.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vite-plus/test";
+import { transformMarkdown } from "./transform";
+import type { ResolvedOptions } from "./types";
+
+// This file's first use of the plugin has to be the concurrent one, which is
+// why it is a file of its own: the NAPI load is cached per module instance,
+// so any earlier call here would warm it and hide what is being tested.
+describe("loading the NAPI bindings", () => {
+  it("serves every caller that arrives while the first load is in flight", async () => {
+    // A build starts transforming several pages at once, and all of them reach
+    // the loader before any of them has finished loading. Each used to see the
+    // "already attempted" flag with the result still unset, decide the bindings
+    // were unavailable, and throw — so the first page rendered and the rest
+    // failed.
+    const pages = Array.from({ length: 16 }, (_, i) =>
+      transformMarkdown(
+        `# page ${i}\n\nText for page ${i}.\n`,
+        `docs/page-${i}.md`,
+        createResolvedOptions(),
+      ),
+    );
+
+    const settled = await Promise.allSettled(pages);
+    const rejected = settled.filter((result) => result.status === "rejected");
+
+    expect(rejected).toEqual([]);
+    for (const [index, result] of settled.entries()) {
+      expect(result.status).toBe("fulfilled");
+      if (result.status === "fulfilled") {
+        expect(result.value.html).toContain(`page ${index}`);
+      }
+    }
+  });
+});
+
+function createResolvedOptions(overrides: Partial<ResolvedOptions> = {}): ResolvedOptions {
+  return {
+    srcDir: "content",
+    outDir: "dist",
+    base: "/",
+    extensions: [".md", ".markdown", ".mdx"],
+    ssg: {
+      enabled: true,
+      extension: ".html",
+      clean: false,
+      bare: false,
+      generateOgImage: false,
+      lastUpdated: false,
+    },
+    gfm: true,
+    footnotes: true,
+    tables: true,
+    taskLists: true,
+    strikethrough: true,
+    autolinks: true,
+    highlight: false,
+    highlightTheme: "github-dark",
+    highlightLangs: [],
+    codeAnnotations: {
+      enabled: false,
+      notation: "attribute",
+      metaKey: "annotate",
+      defaultLineNumbers: false,
+    },
+    wikiLinks: { enabled: false, baseUrl: "/" },
+    emojiShortcodes: { enabled: false, custom: {} },
+    attrs: { enabled: false },
+    codeImports: { enabled: false },
+    sanitize: { enabled: false },
+    editThisPage: { enabled: false, branch: "main", label: "Edit this page" },
+    cjkEmphasis: false,
+    codeBlockLint: {
+      enabled: false,
+      requireLanguage: false,
+      trailingSpaces: true,
+      mode: "warn",
+    },
+    codeBlockTypecheck: {
+      enabled: false,
+      languages: ["ts", "tsx"],
+      requireMeta: true,
+      tsgoCommand: "tsgo",
+      mode: "warn",
+    },
+    docsTests: { enabled: false, languages: ["js", "jsx", "ts", "tsx"], requireMeta: true },
+    mermaid: false,
+    frontmatter: true,
+    toc: true,
+    tocMaxDepth: 3,
+    ogImage: false,
+    ogImageOptions: {
+      width: 1200,
+      height: 630,
+      cache: true,
+      concurrency: 1,
+      vuePlugin: "vitejs",
+    },
+    transformers: [],
+    docs: false,
+    search: {
+      enabled: true,
+      limit: 10,
+      prefix: true,
+      placeholder: "Search documentation...",
+      hotkey: "/",
+    },
+    collections: { enabled: false, collections: {} },
+    ogViewer: false,
+    embeds: {
+      github: {},
+      openGraph: {},
+      pm: false,
+      spotify: false,
+      stackBlitz: false,
+      twitter: false,
+      bluesky: false,
+      webContainer: false,
+    },
+    i18n: false,
+    ...overrides,
+  };
+}

--- a/npm/vite-plugin-ox-content/src/transform.ts
+++ b/npm/vite-plugin-ox-content/src/transform.ts
@@ -302,26 +302,26 @@ interface JsCodeBlockDiagnostic {
 }
 
 /**
- * Cached NAPI bindings instance.
- * Loaded on first use and reused for subsequent transformations.
+ * The NAPI load, cached as the promise rather than as its result.
+ *
+ * The load yields, and a caller arriving during that yield has to wait for it
+ * rather than read a result that is not there yet. Holding the promise is what
+ * makes every caller wait for the same load; holding an "already attempted"
+ * flag beside an unset result meant the first page to arrive loaded the module
+ * and every page behind it concluded there were no bindings at all.
+ *
  * @internal
  */
-let napiBindings: NapiBindings | null | undefined;
-
-/**
- * Flag to prevent repeated NAPI loading attempts.
- * Set to true after first load attempt (success or failure).
- * @internal
- */
-let napiLoadAttempted = false;
+let napiLoad: Promise<NapiBindings | null> | undefined;
 
 /**
  * Lazily loads and caches NAPI bindings.
  *
  * This function uses lazy loading to defer the import of NAPI bindings
  * until they're actually needed. The bindings are loaded only once and
- * cached for subsequent uses. If loading fails (e.g., bindings not built),
- * the failure is cached to avoid repeated load attempts.
+ * cached for subsequent uses, including by callers that ask for them while
+ * that first load is still in flight. If loading fails (e.g., bindings not
+ * built), the failure is cached to avoid repeated load attempts.
  *
  * ## Performance Considerations
  *
@@ -352,29 +352,20 @@ let napiLoadAttempted = false;
  *
  * @internal
  */
-async function loadNapiBindings(): Promise<NapiBindings | null> {
-  // Return cached result (success or failure)
-  if (napiLoadAttempted) {
-    return napiBindings ?? null;
-  }
-
-  // Mark attempt as made to prevent retry loops
-  napiLoadAttempted = true;
-
-  try {
-    // Dynamic import to handle cases where NAPI isn't built
-    const mod = await importNapiModule();
-    napiBindings = mod;
-    return mod;
-  } catch (error) {
+function loadNapiBindings(): Promise<NapiBindings | null> {
+  // Started once; everyone after that awaits the same load, including the
+  // callers that arrive while it is still in flight.
+  napiLoad ??= importNapiModule().catch((error: unknown) => {
     // NAPI not available (not built, missing dependencies, etc.)
-    // Log for debugging but don't throw - allow graceful degradation
+    // Log for debugging but don't throw - allow graceful degradation.
+    // The rejection is settled here, so the failure is cached too.
     if (process.env.DEBUG) {
       console.debug("[ox-content] NAPI bindings load failed:", error);
     }
-    napiBindings = null;
     return null;
-  }
+  });
+
+  return napiLoad;
 }
 
 /**


### PR DESCRIPTION
`loadNapiBindings` sets its "already attempted" flag, then awaits the import:

```ts
if (napiLoadAttempted) return napiBindings ?? null;   // (1)
napiLoadAttempted = true;                              // (2)
const mod = await importNapiModule();                  // (3) yields
napiBindings = mod;
```

A caller arriving between (2) and (3) resolving passes the check at (1) and reads `napiBindings`, which the load has not assigned yet. It takes the `?? null`, and `transformMarkdown` throws:

```
[ox-content] NAPI bindings not available. Please ensure @ox-content/napi is built.
```

That is exactly the shape of a build's first batch — several pages reach the loader before any of them has finished loading it. Measured against `main`, transforming N pages as the first use of the plugin in a fresh process:

| concurrent first calls | rendered | threw |
|---|---|---|
| 2 | 1 | **1** |
| 8 | 1 | **7** |
| 32 | 1 | **31** |
| 102 | 1 | **101** |

Only the page that wins the race renders, and the error blames a missing native build — which is present and, as the winning page shows, working.

## The fix

Cache the promise rather than its result. The first caller starts the load and everyone behind it awaits the same one. The rejection is settled inside the chain, so a genuinely missing module is still cached as `null` and not retried per page — the behaviour the old `napiLoadAttempted` flag was there to provide.

`napiBindings` and `napiLoadAttempted` were only ever read by this function, so both are replaced by the single cached promise.

## Test

`src/napi-loading.test.ts` fires 16 transforms concurrently and asserts none reject. It is a file of its own on purpose: the load is cached per module instance, so any earlier call in the same file would warm it and the race would never happen. Reverting just the loader turns it red — 15 of the 16 reject — which is the check that it tests anything at all.

## Notes

- This is independent of #630 and #631, and predates both — the function is byte-identical on `main`. It is worth having regardless, but it matters more alongside #631, which exists to make concurrent page transforms actually overlap.
- Plugin suite: 222 tests pass (221 before, plus this one). Typecheck and `vp fmt --check` clean. The two `test/vrt/*.spec.ts` collection failures are Playwright specs picked up by `vp test` and fail the same way on a clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790080776&installation_model_id=422833&pr_number=632&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F632&signature=3ff7a8f06552719af540d8adce4395fd146f5d8de77f61325846976a37251774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when processing multiple Markdown pages at the same time.
  * Prevented duplicate native module loading during concurrent transformations.
  * Ensured loading failures are handled consistently without interrupting content processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->