### PR TITLE
perf(parser): intern large AST nodes so the common cells pack densely

### DIFF
--- a/crates/ox_content_allocator/src/lib.rs
+++ b/crates/ox_content_allocator/src/lib.rs
@@ -77,6 +77,14 @@ impl Allocator {
         &self.bump
     }
 
+    /// Allocates a value in the arena and returns a no-drop box to it.
+    ///
+    /// The box is a thin pointer: it does not run `T`'s destructor, for the
+    /// same reason [`Vec`] does not. `T` must own nothing outside the arena.
+    pub fn boxed<T>(&self, val: T) -> Box<'_, T> {
+        Box::new_in(val, &self.bump)
+    }
+
     /// Allocates a value in the arena and returns a reference to it.
     pub fn alloc<T>(&self, val: T) -> &mut T {
         self.bump.alloc(val)
@@ -128,7 +136,59 @@ impl Deref for Allocator {
 }
 
 /// A boxed value allocated in an arena.
-pub type Box<'a, T> = bumpalo::boxed::Box<'a, T>;
+///
+/// Unlike [`bumpalo::boxed::Box`], this does **not** run `T`'s destructor.
+/// The `Bump` reclaims the slot with everything else; a `Drop` impl here
+/// would make any AST node that stored one need dropping, which is the
+/// tree-walk [`Vec`] exists to avoid. `T` must own nothing outside the arena.
+#[repr(transparent)]
+pub struct Box<'a, T> {
+    ptr: std::ptr::NonNull<T>,
+    _lt: std::marker::PhantomData<&'a mut T>,
+}
+
+impl<'a, T> Box<'a, T> {
+    /// Allocates `value` in `bump` and returns a pointer to it.
+    pub fn new_in(value: T, bump: &'a Bump) -> Self {
+        Self { ptr: std::ptr::NonNull::from(bump.alloc(value)), _lt: std::marker::PhantomData }
+    }
+}
+
+impl<T> std::ops::Deref for Box<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        // SAFETY: `ptr` comes from `Bump::alloc` and lives for `'a`. The box
+        // never deallocates or runs `T`'s destructor; the arena owns the slot.
+        #[allow(unsafe_code)]
+        unsafe {
+            self.ptr.as_ref()
+        }
+    }
+}
+
+impl<T> std::ops::DerefMut for Box<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: same provenance as [`Deref::deref`], and `&mut self` is the
+        // only live handle to this slot.
+        #[allow(unsafe_code)]
+        unsafe {
+            self.ptr.as_mut()
+        }
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for Box<'_, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T: PartialEq> PartialEq for Box<'_, T> {
+    fn eq(&self, other: &Self) -> bool {
+        **self == **other
+    }
+}
 
 /// A vector allocated in an arena.
 ///
@@ -263,5 +323,13 @@ mod tests {
         s.push_str("hello");
         s.push_str(" world");
         assert_eq!(s.as_str(), "hello world");
+    }
+
+    #[test]
+    fn boxed_value_is_derefable_and_does_not_need_drop() {
+        let allocator = Allocator::new();
+        let boxed = allocator.boxed(7u32);
+        assert_eq!(*boxed, 7);
+        assert!(!std::mem::needs_drop::<Box<'static, u32>>());
     }
 }

--- a/crates/ox_content_ast/src/ast.rs
+++ b/crates/ox_content_ast/src/ast.rs
@@ -3,7 +3,7 @@
 //! This module defines the AST structure based on mdast specification,
 //! adapted for arena-based allocation.
 
-use ox_content_allocator::Vec;
+use ox_content_allocator::{Box, Vec};
 
 use crate::Span;
 
@@ -17,27 +17,32 @@ pub struct Document<'a> {
 }
 
 /// A Markdown AST node.
+///
+/// Large variants are interned in the arena behind a no-drop
+/// [`ox_content_allocator::Box`] so this enum stays paragraph-sized
+/// (~48 bytes). The common `Text` / `Emphasis` cells in inline arrays
+/// no longer carry `Definition`-sized holes.
 #[derive(Debug)]
 pub enum Node<'a> {
     // Block nodes
     /// Paragraph.
     Paragraph(Paragraph<'a>),
     /// Heading (h1-h6).
-    Heading(Heading<'a>),
+    Heading(Box<'a, Heading<'a>>),
     /// Thematic break (horizontal rule).
     ThematicBreak(ThematicBreak),
     /// Block quote.
     BlockQuote(BlockQuote<'a>),
     /// Ordered or unordered list.
-    List(List<'a>),
+    List(Box<'a, List<'a>>),
     /// List item.
-    ListItem(ListItem<'a>),
+    ListItem(Box<'a, ListItem<'a>>),
     /// Fenced or indented code block.
-    CodeBlock(CodeBlock<'a>),
+    CodeBlock(Box<'a, CodeBlock<'a>>),
     /// HTML block.
     Html(Html<'a>),
     /// Table (GFM extension).
-    Table(Table<'a>),
+    Table(Box<'a, Table<'a>>),
 
     // Inline nodes
     /// Plain text.
@@ -51,19 +56,19 @@ pub enum Node<'a> {
     /// Line break.
     Break(Break),
     /// Link.
-    Link(Link<'a>),
+    Link(Box<'a, Link<'a>>),
     /// Image.
-    Image(Image<'a>),
+    Image(Box<'a, Image<'a>>),
     /// Strikethrough (GFM extension).
     Delete(Delete<'a>),
     /// Footnote reference (GFM extension).
-    FootnoteReference(FootnoteReference<'a>),
+    FootnoteReference(Box<'a, FootnoteReference<'a>>),
 
     // Definition nodes
     /// Link/image reference definition.
-    Definition(Definition<'a>),
+    Definition(Box<'a, Definition<'a>>),
     /// Footnote definition (GFM extension).
-    FootnoteDefinition(FootnoteDefinition<'a>),
+    FootnoteDefinition(Box<'a, FootnoteDefinition<'a>>),
 }
 
 // Block nodes

--- a/crates/ox_content_ast/src/lib.rs
+++ b/crates/ox_content_ast/src/lib.rs
@@ -18,15 +18,24 @@ pub use visit::*;
 ///
 /// [`ox_content_allocator::Vec`] never runs its elements' destructors, which
 /// is what keeps dropping a parsed document from walking the whole tree. A
-/// field that owned heap memory — a `std::string::String`, a `Box`, an `Rc` —
-/// would therefore leak it on every parse instead of being reclaimed with the
-/// `Bump`. Every field in [`Node`] is either `Copy` or another arena vector,
-/// and this is where that stops being a convention: giving any node a
-/// heap-owning field makes `Node` need dropping and fails the build here.
+/// field that owned heap memory — a `std::string::String`, a `std::boxed::Box`,
+/// an `Rc` — would therefore leak it on every parse instead of being reclaimed
+/// with the `Bump`. Large variants are interned behind
+/// [`ox_content_allocator::Box`], which is a thin pointer with no destructor;
+/// every other field is `Copy` or another arena vector. This is where that
+/// stops being a convention: giving any node a heap-owning field makes `Node`
+/// need dropping and fails the build here.
 ///
 /// The check has to name concrete types. Written generically inside
 /// `Vec::new_in` it is simply never forced, so it would pass while leaking.
 const _AST_IS_ARENA_ONLY: () = {
     assert!(!std::mem::needs_drop::<Node<'static>>());
     assert!(!std::mem::needs_drop::<Document<'static>>());
+    // Boxed large variants keep `Node` at the size of a paragraph: bumpalo
+    // `Vec` is 32 bytes (ptr/len/cap + bump), plus `Span` is 8, plus the
+    // enum discriminant rounds the slot to 48. Text still wastes padding
+    // relative to its 24-byte payload, but the common inline arrays no
+    // longer carry Definition-sized holes (~80 bytes before intern).
+    assert!(std::mem::size_of::<Node<'static>>() <= 48);
+    assert!(std::mem::size_of::<Definition<'static>>() > std::mem::size_of::<Node<'static>>());
 };

--- a/crates/ox_content_lsp/src/preview/text.rs
+++ b/crates/ox_content_lsp/src/preview/text.rs
@@ -61,7 +61,10 @@ mod tests {
 
     use super::*;
 
-    fn first_heading<'a>(allocator: &'a Allocator, source: &'a str) -> Heading<'a> {
+    fn first_heading<'a>(
+        allocator: &'a Allocator,
+        source: &'a str,
+    ) -> ox_content_allocator::Box<'a, Heading<'a>> {
         let parser = Parser::with_options(allocator, source, ParserOptions::default());
         let mut doc = parser.parse().unwrap();
         let node = doc.children.pop().expect("at least one node");

--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -204,11 +204,11 @@ impl<'a> Parser<'a> {
                 self.position = heading_end;
                 let content = self.source[start..content_end].trim();
                 let children = self.parse_inline_block(content, start)?;
-                return Ok(Some(Node::Heading(Heading {
+                return Ok(Some(Node::Heading(self.allocator.boxed(Heading {
                     depth,
                     children,
                     span: Span::new(start as u32, heading_end as u32),
-                })));
+                }))));
             }
 
             // Check for block-level element that would end paragraph. The

--- a/crates/ox_content_parser/src/parser/fenced_code.rs
+++ b/crates/ox_content_parser/src/parser/fenced_code.rs
@@ -195,6 +195,11 @@ impl<'a> Parser<'a> {
             value.into_bump_str()
         };
 
-        Ok(Some(Node::CodeBlock(ox_content_ast::CodeBlock { lang, meta, value, span })))
+        Ok(Some(Node::CodeBlock(self.allocator.boxed(ox_content_ast::CodeBlock {
+            lang,
+            meta,
+            value,
+            span,
+        }))))
     }
 }

--- a/crates/ox_content_parser/src/parser/footnote.rs
+++ b/crates/ox_content_parser/src/parser/footnote.rs
@@ -168,12 +168,12 @@ impl<'a> Parser<'a> {
         let end = content_start + body_len;
         self.position = end;
 
-        Ok(Some(Node::FootnoteDefinition(FootnoteDefinition {
+        Ok(Some(Node::FootnoteDefinition(self.allocator.boxed(FootnoteDefinition {
             identifier,
             label: Some(label),
             children,
             span: Span::new(start as u32, end as u32),
-        })))
+        }))))
     }
 
     /// Whether a definition exists for `label` (already normalized-able).
@@ -216,11 +216,13 @@ impl<'a> Parser<'a> {
 
         let identifier =
             self.allocator.alloc_str(normalize_footnote_label(label).as_str()) as &'a str;
-        children.push(Node::FootnoteReference(ox_content_ast::FootnoteReference {
-            identifier,
-            label: Some(label),
-            span: Span::new((offset + *pos) as u32, (offset + end + 1) as u32),
-        }));
+        children.push(Node::FootnoteReference(self.allocator.boxed(
+            ox_content_ast::FootnoteReference {
+                identifier,
+                label: Some(label),
+                span: Span::new((offset + *pos) as u32, (offset + end + 1) as u32),
+            },
+        )));
         *pos = end + 1;
         true
     }

--- a/crates/ox_content_parser/src/parser/indented_code.rs
+++ b/crates/ox_content_parser/src/parser/indented_code.rs
@@ -65,12 +65,12 @@ impl<'a> Parser<'a> {
 
         self.position = end;
         let span = Span::new(start as u32, end as u32);
-        Ok(Some(Node::CodeBlock(CodeBlock {
+        Ok(Some(Node::CodeBlock(self.allocator.boxed(CodeBlock {
             lang: None,
             meta: None,
             value: value.into_bump_str(),
             span,
-        })))
+        }))))
     }
 
     /// Returns the indentation width in columns of the current line, where

--- a/crates/ox_content_parser/src/parser/inline/autolink.rs
+++ b/crates/ox_content_parser/src/parser/inline/autolink.rs
@@ -71,7 +71,7 @@ impl<'a> Parser<'a> {
             children,
             span: Span::new((offset + pos) as u32, (offset + close + 1) as u32),
         };
-        Some((Node::Link(link), close + 1))
+        Some((Node::Link(self.allocator.boxed(link)), close + 1))
     }
 }
 

--- a/crates/ox_content_parser/src/parser/inline/gfm_autolink.rs
+++ b/crates/ox_content_parser/src/parser/inline/gfm_autolink.rs
@@ -73,12 +73,12 @@ impl<'a> Parser<'a> {
                         );
                         let mut link_children = self.allocator.new_vec();
                         link_children.push(Node::Text(Text { value: link_value, span: link_span }));
-                        let link_node = Node::Link(Link {
+                        let link_node = Node::Link(self.allocator.boxed(Link {
                             url,
                             title: None,
                             children: link_children,
                             span: link_span,
-                        });
+                        }));
 
                         let after = &value[candidate.end..];
                         let after_node = (!after.is_empty()).then(|| {

--- a/crates/ox_content_parser/src/parser/inline_helpers.rs
+++ b/crates/ox_content_parser/src/parser/inline_helpers.rs
@@ -50,12 +50,12 @@ impl<'a> Parser<'a> {
                 && let Some(target) = self.parse_link_target(content, close + 1)
             {
                 let children_nodes = self.parse_inline(link_text, offset + text_start)?;
-                children.push(Node::Link(Link {
+                children.push(Node::Link(self.allocator.boxed(Link {
                     url: target.url,
                     title: target.title,
                     children: children_nodes,
                     span: Span::new((offset + link_start) as u32, (offset + target.end) as u32),
-                }));
+                })));
                 *pos = target.end;
                 return Ok(());
             }
@@ -72,7 +72,7 @@ impl<'a> Parser<'a> {
                     if let Some(reference) = self.lookup_reference(key) {
                         let (url, title) = (reference.url, reference.title);
                         let children_nodes = self.parse_inline(link_text, offset + text_start)?;
-                        children.push(Node::Link(Link {
+                        children.push(Node::Link(self.allocator.boxed(Link {
                             url,
                             title,
                             children: children_nodes,
@@ -80,7 +80,7 @@ impl<'a> Parser<'a> {
                                 (offset + link_start) as u32,
                                 (offset + label_end + 1) as u32,
                             ),
-                        }));
+                        })));
                         *pos = label_end + 1;
                         return Ok(());
                     }
@@ -95,12 +95,12 @@ impl<'a> Parser<'a> {
             {
                 let (url, title) = (reference.url, reference.title);
                 let children_nodes = self.parse_inline(link_text, offset + text_start)?;
-                children.push(Node::Link(Link {
+                children.push(Node::Link(self.allocator.boxed(Link {
                     url,
                     title,
                     children: children_nodes,
                     span: Span::new((offset + link_start) as u32, (offset + close + 1) as u32),
-                }));
+                })));
                 *pos = close + 1;
                 return Ok(());
             }
@@ -141,12 +141,12 @@ impl<'a> Parser<'a> {
             if bytes.get(close + 1) == Some(&b'(')
                 && let Some(target) = self.parse_link_target(content, close + 1)
             {
-                children.push(Node::Image(Image {
+                children.push(Node::Image(self.allocator.boxed(Image {
                     url: target.url,
                     alt,
                     title: target.title,
                     span: Span::new((offset + image_start) as u32, (offset + target.end) as u32),
-                }));
+                })));
                 *pos = target.end;
                 return Ok(());
             }
@@ -160,7 +160,7 @@ impl<'a> Parser<'a> {
                     let raw_label = &content[label_start..label_end];
                     let key = if raw_label.trim().is_empty() { raw_alt } else { raw_label };
                     if let Some(reference) = self.lookup_reference(key) {
-                        children.push(Node::Image(Image {
+                        children.push(Node::Image(self.allocator.boxed(Image {
                             url: reference.url,
                             alt,
                             title: reference.title,
@@ -168,7 +168,7 @@ impl<'a> Parser<'a> {
                                 (offset + image_start) as u32,
                                 (offset + label_end + 1) as u32,
                             ),
-                        }));
+                        })));
                         *pos = label_end + 1;
                         return Ok(());
                     }
@@ -176,12 +176,12 @@ impl<'a> Parser<'a> {
             }
 
             if !well_formed_reference && let Some(reference) = self.lookup_reference(raw_alt) {
-                children.push(Node::Image(Image {
+                children.push(Node::Image(self.allocator.boxed(Image {
                     url: reference.url,
                     alt,
                     title: reference.title,
                     span: Span::new((offset + image_start) as u32, (offset + close + 1) as u32),
-                }));
+                })));
                 *pos = close + 1;
                 return Ok(());
             }

--- a/crates/ox_content_parser/src/parser/leaf.rs
+++ b/crates/ox_content_parser/src/parser/leaf.rs
@@ -132,7 +132,11 @@ impl<'a> Parser<'a> {
             self.allocator.new_vec()
         };
 
-        Ok(Some(Node::Heading(ox_content_ast::Heading { depth, children, span })))
+        Ok(Some(Node::Heading(self.allocator.boxed(ox_content_ast::Heading {
+            depth,
+            children,
+            span,
+        }))))
     }
 
     /// Parses a thematic break.

--- a/crates/ox_content_parser/src/parser/list.rs
+++ b/crates/ox_content_parser/src/parser/list.rs
@@ -102,13 +102,13 @@ impl<'a> Parser<'a> {
         }
 
         let span = Span::new(start as u32, self.position as u32);
-        Ok(Some(Node::List(List {
+        Ok(Some(Node::List(self.allocator.boxed(List {
             ordered,
             start: list_start,
             spread: list_spread,
             children,
             span,
-        })))
+        }))))
     }
 
     /// Consumes one item's continuation lines: indented content

--- a/crates/ox_content_parser/src/parser/reference.rs
+++ b/crates/ox_content_parser/src/parser/reference.rs
@@ -180,13 +180,13 @@ impl<'a> Parser<'a> {
             self.allocator.alloc_str(Self::normalize_reference_label(parsed.label).as_str());
         let end = start + parsed.consumed;
         self.position = end;
-        Some(Node::Definition(Definition {
+        Some(Node::Definition(self.allocator.boxed(Definition {
             identifier,
             label: Some(parsed.label),
             url: parsed.url,
             title: parsed.title,
             span: Span::new(start as u32, end as u32),
-        }))
+        })))
     }
 
     /// Joins the block-quote-stripped lines of the paragraph chunk that

--- a/crates/ox_content_parser/src/parser/table.rs
+++ b/crates/ox_content_parser/src/parser/table.rs
@@ -96,7 +96,7 @@ impl<'a> Parser<'a> {
         }
 
         let span = Span::new(start as u32, self.position as u32);
-        Ok(Some(Node::Table(Table { align, children, span })))
+        Ok(Some(Node::Table(self.allocator.boxed(Table { align, children, span }))))
     }
 
     /// Parses a table row into arena-backed AST cells without temporary heap

--- a/crates/ox_content_search/src/indexer.rs
+++ b/crates/ox_content_search/src/indexer.rs
@@ -201,11 +201,11 @@ mod tests {
         let mut heading_children = ox_content_allocator::Vec::new_in(&allocator);
         heading_children.push(Node::Text(Text { value: "Test Title", span: Span::new(0, 10) }));
 
-        children.push(Node::Heading(Heading {
+        children.push(Node::Heading(allocator.boxed(Heading {
             depth: 1,
             children: heading_children,
             span: Span::new(0, 12),
-        }));
+        })));
 
         let doc = Document { children, span: Span::new(0, 12) };
 


### PR DESCRIPTION
## Summary

- `Node` was sized by `Definition` (~80 bytes) even though the arrays that dominate a parse are `Text`, `Emphasis`, and `Paragraph`.
- Large variants (`Heading`, `List`, `CodeBlock`, `Table`, `Link`, `Image`, definitions) now live behind a no-drop arena `Box`, so the enum is paragraph-sized (48 bytes) and dropping a document still does not walk the tree.
- `bumpalo::boxed::Box` was rejected: its `Drop` impl would make `Node` need dropping and undo the ~4% win that the no-drop `Vec` already bought.

## Risk

- Risk level: medium
- User or production impact: parse/render of every document; AST layout change is visible to matchers that construct boxed variants by value.
- Rollback plan: revert the PR.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_parser --test snapshot_parse --test edge_cases --lib`; CommonMark and GFM spec suites; clippy `-D warnings` on allocator/ast/parser.
- [x] Manual verification completed: native-competitors A/B on Apple M2 Max, alternating prebuilt binaries, seven rounds of `--runs 1`.
- [x] Edge cases or failure modes considered: intern must not introduce Drop glue; compile-time `needs_drop` / `size_of::<Node>() <= 48` / `Definition` larger than `Node` asserts.

Measured:

```
parse  huge    433.0 -> 454.3 MB/s  (+4.93%, every round faster)
parse  large   440.1 -> 455.1 MB/s  (+3.42%, 5/7)
parse  small   431.9 -> 446.8 MB/s  (+3.46%, 5/7)
render huge    270.7 -> 276.1 MB/s  (+2.02%, 4/7)
```

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790085483&installation_model_id=422833&pr_number=633&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F633&signature=6bfbd53c18523ae1f04bc268e09f200dcb88fa342e9314f899d72f45d1178fd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced memory overhead when representing large document structures by storing them in compact, arena-backed allocations.
  - Improved AST layout efficiency, helping keep frequently used inline nodes smaller.

- **API Changes**
  - Added allocator-backed boxed values for supported document elements.
  - Updated AST variants to use the new boxed representation.

- **Compatibility**
  - Parsing behavior and document content remain unchanged, including headings, lists, links, images, code blocks, tables, and footnotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->