### PR TITLE
perf(parser): reserve the document block list from source density

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -206,7 +206,9 @@ impl<'a> Parser<'a> {
     /// Parses the source into a document AST.
     pub fn parse(mut self) -> ParseResult<Document<'a>> {
         profile_span!("parser::parse");
-        let mut children = self.allocator.new_vec();
+        let mut children = self
+            .allocator
+            .new_vec_with_capacity(Self::document_children_capacity(self.source.len()));
 
         while !self.is_at_end() {
             if let Some(node) = self.parse_block()? {
@@ -216,5 +218,17 @@ impl<'a> Parser<'a> {
 
         let span = Span::new(0, self.source.len() as u32);
         Ok(Document { children, span })
+    }
+
+    /// Slots to reserve for the document's top-level block list.
+    ///
+    /// The published sample (and concatenations of it) lands a block every
+    /// ~40 bytes. Inline children already reserve from a similar density
+    /// heuristic; the root list used to grow from zero, which recopied the
+    /// whole array through the doubling ladder on every large parse. One
+    /// vector per document, so over-reserve is cheap compared to that copy.
+    fn document_children_capacity(source_len: usize) -> usize {
+        const BYTES_PER_BLOCK: usize = 40;
+        (source_len / BYTES_PER_BLOCK).max(4)
     }
 }

--- a/crates/ox_content_parser/src/parser/tests.rs
+++ b/crates/ox_content_parser/src/parser/tests.rs
@@ -92,6 +92,34 @@ fn plain_text_paragraph_reserves_one_inline_node() {
 }
 
 #[test]
+fn document_children_capacity_tracks_source_density() {
+    assert_eq!(Parser::document_children_capacity(0), 4);
+    assert_eq!(Parser::document_children_capacity(39), 4);
+    assert_eq!(Parser::document_children_capacity(40), 4);
+    assert_eq!(Parser::document_children_capacity(80), 4);
+    assert_eq!(Parser::document_children_capacity(400), 10);
+
+    // ~44 bytes per paragraph matches the heuristic, so the root list
+    // should not grow past the reserve.
+    let allocator = Allocator::new();
+    let source = "The quick brown fox jumps over a lazy dog.\n\n".repeat(50);
+    let doc = Parser::new(&allocator, &source).parse().unwrap();
+    assert_eq!(doc.children.len(), 50);
+    let reserved = Parser::document_children_capacity(source.len());
+    assert!(
+        doc.children.capacity() >= 50,
+        "capacity {} should cover 50 blocks",
+        doc.children.capacity()
+    );
+    assert!(
+        doc.children.capacity() <= reserved,
+        "capacity {} should not grow past the {}-slot reserve",
+        doc.children.capacity(),
+        reserved
+    );
+}
+
+#[test]
 fn test_parse_thematic_break() {
     let allocator = Allocator::new();
     let doc = Parser::new(&allocator, "---").parse().unwrap();


### PR DESCRIPTION
## Summary

- The root `Document.children` vector grew from zero, so a large parse recopied the whole block list through the doubling ladder.
- Inline children already reserved from a bytes-per-node heuristic. The document list is one vector per parse, so the same density guess (`source_len / 40`, floor 4) is cheaper than those copies.

## Risk

- Risk level: low
- User or production impact: slightly more arena memory on documents denser than one block per 40 bytes; still inside the existing 8× source arena budget.
- Rollback plan: revert the PR.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_parser --lib`; clippy `-D warnings`.
- [x] Manual verification completed: native-competitors A/B on Apple M2 Max, alternating prebuilt binaries, seven rounds of `--runs 1`.
- [x] Edge cases or failure modes considered: tiny docs keep a 4-slot floor; a 50-paragraph fixture matching the density does not grow past the reserve.

Measured:

```
parse  huge    439.3 -> 452.7 MB/s  (+3.05%, 6/7 rounds faster)
parse  large   445.7 -> 452.7 MB/s  (+1.56%, 5/7)
parse  small   444.4 -> 447.1 MB/s  (+0.63%, 5/7)
```

Independent of #633 (AST intern).

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790085704&installation_model_id=422833&pr_number=634&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F634&signature=e7c7ae5e57165b079936458b4c4a381bccbb8ac24e45a4bd3119447e50e619da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->