### PR TITLE
perf(parser): scan inline markers 32 bytes at a time with overlapping tails

### DIFF
--- a/crates/ox_content_parser/src/parser/inline/scan.rs
+++ b/crates/ox_content_parser/src/parser/inline/scan.rs
@@ -165,7 +165,7 @@ unsafe fn next_special_ssse3(bytes: &[u8], from: usize) -> usize {
             // the complement's lowest set bit is the first marker.
             // `movemask` fills only the low 16 bits, so the cast is exact
             // and the complement below stays inside them.
-            let clean = _mm_movemask_epi8(_mm_cmpeq_epi8(m, _mm_setzero_si128()));
+            let clean = _mm_movemask_epi8(_mm_cmpeq_epi8(m, _mm_setzero_si128())) as u32;
             !clean & 0xFFFF
         };
         while i + 32 <= end {

--- a/crates/ox_content_parser/src/parser/inline/scan.rs
+++ b/crates/ox_content_parser/src/parser/inline/scan.rs
@@ -165,8 +165,8 @@ unsafe fn next_special_ssse3(bytes: &[u8], from: usize) -> usize {
             // the complement's lowest set bit is the first marker.
             // `movemask` fills only the low 16 bits, so the cast is exact
             // and the complement below stays inside them.
-            let clean = _mm_movemask_epi8(_mm_cmpeq_epi8(m, _mm_setzero_si128())) as u32;
-            !clean & 0xFFFF
+            let clean = _mm_movemask_epi8(_mm_cmpeq_epi8(m, _mm_setzero_si128()));
+            u32::from_ne_bytes((!clean & 0xFFFF).to_ne_bytes())
         };
         while i + 32 <= end {
             let m0 = classify(_mm_loadu_si128(bytes.as_ptr().add(i).cast()));
@@ -224,7 +224,7 @@ unsafe fn next_special_avx2(bytes: &[u8], from: usize) -> usize {
             let hi = _mm256_shuffle_epi8(high, _mm256_and_si256(_mm256_srli_epi16(v, 4), nibble));
             let m = _mm256_and_si256(lo, hi);
             let clean = _mm256_movemask_epi8(_mm256_cmpeq_epi8(m, _mm256_setzero_si256()));
-            !clean as u32
+            u32::from_ne_bytes((!clean).to_ne_bytes())
         };
         while i + 32 <= end {
             let flagged = classify(_mm256_loadu_si256(bytes.as_ptr().add(i).cast()));

--- a/crates/ox_content_parser/src/parser/inline/scan.rs
+++ b/crates/ox_content_parser/src/parser/inline/scan.rs
@@ -8,8 +8,9 @@
 //! Both SIMD paths replace that with a nibble-pair classifier that needs no
 //! per-byte load at all, and they run the *same* classifier: aarch64 uses
 //! `vqtbl1q_u8` and x86-64 `pshufb`, which are the same 16-entry table
-//! lookup. Every path is checked against the flag table by the differential
-//! tests below, for all 256 byte values at every offset.
+//! lookup. AVX2 broadcasts that table into both 128-bit lanes so one shuffle
+//! pair covers 32 bytes. Every path is checked against the flag table by the
+//! differential tests below, for all 256 byte values at every offset.
 
 #[allow(unused_imports)]
 use crate::profile_span_detail;
@@ -59,6 +60,24 @@ const LOW_NIBBLE: [u8; 16] =
     [0x10, 0x02, 0, 0, 0, 0, 0x02, 0, 0, 0, 0x03, 0x08, 0x0C, 0, 0x20, 0x08];
 const HIGH_NIBBLE: [u8; 16] = [0x01, 0, 0x02, 0x04, 0, 0x08, 0x10, 0x20, 0, 0, 0, 0, 0, 0, 0, 0];
 
+/// Walks at most [`SHORT_RUN_PREFIX`] bytes. Returns the first marker, or
+/// `end` when the prefix is clean and the slice ends there, or the first
+/// unexamined index when the prefix is clean and more bytes remain.
+///
+/// Shared by the scalar scan. Putting the short prefix on the vector paths
+/// too was measured slower: most of the *bytes* sit in long runs, and those
+/// paid eight extra flagged loads before the first vector.
+#[inline]
+fn scan_short_prefix(bytes: &[u8], from: usize) -> usize {
+    let end = bytes.len();
+    let quick = from.saturating_add(SHORT_RUN_PREFIX).min(end);
+    let mut i = from;
+    while i < quick && INLINE_SPECIAL[bytes[i] as usize] == 0 {
+        i += 1;
+    }
+    i
+}
+
 #[cfg(target_arch = "aarch64")]
 #[allow(unsafe_code)]
 #[inline]
@@ -70,19 +89,45 @@ fn next_special_neon(bytes: &[u8], from: usize) -> usize {
         let low = vld1q_u8(LOW_NIBBLE.as_ptr());
         let high = vld1q_u8(HIGH_NIBBLE.as_ptr());
         let nibble = vdupq_n_u8(0x0F);
-        while i + 16 <= end {
-            let v = vld1q_u8(bytes.as_ptr().add(i));
+        let classify = |v: uint8x16_t| {
             let lo = vqtbl1q_u8(low, vandq_u8(v, nibble));
             let hi = vqtbl1q_u8(high, vshrq_n_u8(v, 4));
             // `vtstq_u8` turns the per-lane AND into the all-ones/all-zeros
             // form the nibble-narrowing mask extraction needs.
             let m = vtstq_u8(lo, hi);
             let narrow = vshrn_n_u16(vreinterpretq_u16_u8(m), 4);
-            let mask = vget_lane_u64(vreinterpret_u64_u8(narrow), 0);
+            vget_lane_u64(vreinterpret_u64_u8(narrow), 0)
+        };
+        while i + 32 <= end {
+            let m0 = classify(vld1q_u8(bytes.as_ptr().add(i)));
+            if m0 != 0 {
+                return i + (m0.trailing_zeros() / 4) as usize;
+            }
+            let m1 = classify(vld1q_u8(bytes.as_ptr().add(i + 16)));
+            if m1 != 0 {
+                return i + 16 + (m1.trailing_zeros() / 4) as usize;
+            }
+            i += 32;
+        }
+        while i + 16 <= end {
+            let mask = classify(vld1q_u8(bytes.as_ptr().add(i)));
             if mask != 0 {
                 return i + (mask.trailing_zeros() / 4) as usize;
             }
             i += 16;
+        }
+        if i < end && end >= 16 {
+            // Overlapping tail: re-read the last vector and drop the lanes
+            // the loops already cleared. `vtstq_u8` is exact per lane, so
+            // masking off processed bytes cannot leak a match into a
+            // neighbour the way a SWAR zero-test can.
+            let base = end - 16;
+            let mask =
+                classify(vld1q_u8(bytes.as_ptr().add(base))) & (u64::MAX << ((i - base) * 4));
+            if mask != 0 {
+                return base + (mask.trailing_zeros() / 4) as usize;
+            }
+            return end;
         }
     }
     while i < end && INLINE_SPECIAL[bytes[i] as usize] == 0 {
@@ -98,7 +143,7 @@ fn next_special_neon(bytes: &[u8], from: usize) -> usize {
 /// # Safety
 ///
 /// The caller must have verified SSSE3 support. Every load is bounded by
-/// the `i + 16 <= end` guard.
+/// the length checks around it.
 #[cfg(target_arch = "x86_64")]
 #[allow(unsafe_code)]
 #[target_feature(enable = "ssse3")]
@@ -110,8 +155,7 @@ unsafe fn next_special_ssse3(bytes: &[u8], from: usize) -> usize {
         let low = _mm_loadu_si128(LOW_NIBBLE.as_ptr().cast());
         let high = _mm_loadu_si128(HIGH_NIBBLE.as_ptr().cast());
         let nibble = _mm_set1_epi8(0x0F);
-        while i + 16 <= end {
-            let v = _mm_loadu_si128(bytes.as_ptr().add(i).cast());
+        let classify = |v: __m128i| {
             // `_mm_srli_epi16` shifts 16-bit lanes, so the neighbouring
             // byte's low bits ride along; masking leaves the high nibble.
             let lo = _mm_shuffle_epi8(low, _mm_and_si128(v, nibble));
@@ -122,11 +166,81 @@ unsafe fn next_special_ssse3(bytes: &[u8], from: usize) -> usize {
             // `movemask` fills only the low 16 bits, so the cast is exact
             // and the complement below stays inside them.
             let clean = _mm_movemask_epi8(_mm_cmpeq_epi8(m, _mm_setzero_si128()));
-            let flagged = !clean & 0xFFFF;
+            !clean & 0xFFFF
+        };
+        while i + 32 <= end {
+            let m0 = classify(_mm_loadu_si128(bytes.as_ptr().add(i).cast()));
+            if m0 != 0 {
+                return i + m0.trailing_zeros() as usize;
+            }
+            let m1 = classify(_mm_loadu_si128(bytes.as_ptr().add(i + 16).cast()));
+            if m1 != 0 {
+                return i + 16 + m1.trailing_zeros() as usize;
+            }
+            i += 32;
+        }
+        while i + 16 <= end {
+            let flagged = classify(_mm_loadu_si128(bytes.as_ptr().add(i).cast()));
             if flagged != 0 {
                 return i + flagged.trailing_zeros() as usize;
             }
             i += 16;
+        }
+        if i < end && end >= 16 {
+            let base = end - 16;
+            let flagged = classify(_mm_loadu_si128(bytes.as_ptr().add(base).cast()))
+                & (u32::MAX << (i - base));
+            if flagged != 0 {
+                return base + flagged.trailing_zeros() as usize;
+            }
+            return end;
+        }
+    }
+    next_inline_special_scalar(bytes, i)
+}
+
+/// AVX2 sibling: the same nibble classifier, 32 bytes at a time.
+///
+/// `vpshufb` is per 128-bit lane, so broadcasting the 16-entry tables into
+/// both lanes of a YMM register classifies 32 bytes with one shuffle pair.
+///
+/// # Safety
+///
+/// The caller must have verified AVX2 support. Every load is bounded by
+/// the length checks around it.
+#[cfg(target_arch = "x86_64")]
+#[allow(unsafe_code)]
+#[target_feature(enable = "avx2")]
+unsafe fn next_special_avx2(bytes: &[u8], from: usize) -> usize {
+    use std::arch::x86_64::*;
+    let end = bytes.len();
+    let mut i = from;
+    unsafe {
+        let low = _mm256_broadcastsi128_si256(_mm_loadu_si128(LOW_NIBBLE.as_ptr().cast()));
+        let high = _mm256_broadcastsi128_si256(_mm_loadu_si128(HIGH_NIBBLE.as_ptr().cast()));
+        let nibble = _mm256_set1_epi8(0x0F);
+        let classify = |v: __m256i| {
+            let lo = _mm256_shuffle_epi8(low, _mm256_and_si256(v, nibble));
+            let hi = _mm256_shuffle_epi8(high, _mm256_and_si256(_mm256_srli_epi16(v, 4), nibble));
+            let m = _mm256_and_si256(lo, hi);
+            let clean = _mm256_movemask_epi8(_mm256_cmpeq_epi8(m, _mm256_setzero_si256()));
+            !clean as u32
+        };
+        while i + 32 <= end {
+            let flagged = classify(_mm256_loadu_si256(bytes.as_ptr().add(i).cast()));
+            if flagged != 0 {
+                return i + flagged.trailing_zeros() as usize;
+            }
+            i += 32;
+        }
+        if i < end && end >= 32 {
+            let base = end - 32;
+            let flagged = classify(_mm256_loadu_si256(bytes.as_ptr().add(base).cast()))
+                & (u32::MAX << (i - base));
+            if flagged != 0 {
+                return base + flagged.trailing_zeros() as usize;
+            }
+            return end;
         }
     }
     next_inline_special_scalar(bytes, i)
@@ -141,10 +255,16 @@ pub(super) fn next_inline_special(bytes: &[u8], from: usize) -> usize {
 #[cfg(target_arch = "x86_64")]
 #[inline]
 pub(super) fn next_inline_special(bytes: &[u8], from: usize) -> usize {
-    // SSSE3 is not in the x86-64 baseline, so it is detected rather than
-    // assumed. `is_x86_feature_detected!` caches its answer in an atomic,
-    // and a machine without it keeps the scalar scan unchanged.
-    if std::arch::is_x86_feature_detected!("ssse3") {
+    // AVX2 / SSSE3 are not in the x86-64 baseline, so they are detected
+    // rather than assumed. `is_x86_feature_detected!` caches its answer
+    // in an atomic, and a machine without either keeps the scalar scan.
+    if std::arch::is_x86_feature_detected!("avx2") {
+        // SAFETY: guarded by the detection above.
+        #[allow(unsafe_code)]
+        unsafe {
+            next_special_avx2(bytes, from)
+        }
+    } else if std::arch::is_x86_feature_detected!("ssse3") {
         // SAFETY: guarded by the detection above.
         #[allow(unsafe_code)]
         unsafe {
@@ -173,16 +293,9 @@ fn next_inline_special_scalar(bytes: &[u8], from: usize) -> usize {
     // byte at a time means the common run never pays the chunked scan's eight
     // lookups and seven ORs to find a marker two bytes in, while long runs —
     // where the bytes actually are — still reach the wide scan below.
-    let quick = if from + SHORT_RUN_PREFIX < end { from + SHORT_RUN_PREFIX } else { end };
-    let mut i = from;
-    while i < quick && INLINE_SPECIAL[bytes[i] as usize] == 0 {
-        i += 1;
-    }
-    if i < quick {
+    let mut i = scan_short_prefix(bytes, from);
+    if i >= end || INLINE_SPECIAL[bytes[i] as usize] != 0 {
         return i;
-    }
-    if i == end {
-        return end;
     }
 
     // Skip eight bytes at a time while the OR of their marker flags is zero.
@@ -227,9 +340,9 @@ mod tests {
     fn matches_reference_around_the_prefix_boundary() {
         // A marker at every offset, in inputs long and short enough to exercise
         // the short-run prefix, the prefix/chunk handoff, and the scalar tail.
-        for len in 0..40usize {
+        for len in 0..72usize {
             for marker_at in 0..len {
-                let mut buffer = [b'x'; 40];
+                let mut buffer = [b'x'; 72];
                 buffer[marker_at] = b'*';
                 let bytes = &buffer[..len];
                 for from in 0..=len {
@@ -245,7 +358,7 @@ mod tests {
 
     #[test]
     fn matches_reference_with_no_marker() {
-        let buffer = [b'x'; 40];
+        let buffer = [b'x'; 72];
         for len in 0..=buffer.len() {
             let bytes = &buffer[..len];
             for from in 0..=len {
@@ -259,11 +372,11 @@ mod tests {
         // The vectorized classifiers decide from nibble pairs rather than a
         // 256-entry table, so a wrong entry would admit or drop a byte the
         // flag table disagrees with. Check all 256 values, at every offset
-        // of a buffer long enough to cross the 16-byte step and land in the
-        // scalar tail.
+        // of a buffer long enough to cross the 32-byte AVX2 / dual-NEON
+        // step, the 16-byte overlapping tail, and the scalar remainder.
         for value in 0..=255u8 {
-            for at in 0..40usize {
-                let mut buffer = [b'x'; 40];
+            for at in 0..72usize {
+                let mut buffer = [b'x'; 72];
                 buffer[at] = value;
                 let bytes = &buffer[..];
                 assert_eq!(
@@ -292,6 +405,27 @@ mod tests {
                     reference(bytes, 0),
                     "marker {marker:?} at {lead}"
                 );
+            }
+        }
+    }
+
+    #[test]
+    fn matches_reference_on_overlapping_vector_tails() {
+        // Markers in the last 1..=31 bytes, scanned from every offset, so
+        // the 16-byte and 32-byte overlapping re-reads have to agree with
+        // the flag table after masking off already-cleared lanes.
+        for len in 16..72usize {
+            for marker_at in (len.saturating_sub(31))..len {
+                let mut buffer = [b'x'; 72];
+                buffer[marker_at] = b'*';
+                let bytes = &buffer[..len];
+                for from in 0..=len {
+                    assert_eq!(
+                        next_inline_special(bytes, from),
+                        reference(bytes, from),
+                        "len {len}, marker at {marker_at}, from {from}"
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Keep the nibble-pair inline classifiers, but step 32 bytes per iteration and finish with an overlapping last-vector read instead of a scalar remainder (same shape as the HTML-escape scanners).
- On x86-64, AVX2 broadcasts the 16-entry tables across both lanes so one shuffle pair covers 32 bytes. SSSE3 keeps the 16-byte dual-step loop plus overlapping tail.
- A short scalar prefix on the vector paths was measured slower: most of the *bytes* sit in long runs, and those paid eight extra flagged loads before the first vector.

## Risk

- Risk level: medium
- User or production impact: hottest inline scan on every parse. Differential tests cover all 256 byte values at every offset, including overlapping tails.
- Rollback plan: revert the PR.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_parser --lib parser::inline::scan`; clippy `-D warnings`.
- [x] Manual verification completed: native-competitors A/B on Apple M2 Max (NEON), alternating prebuilt binaries, seven rounds of `--runs 1`. AVX2 is not exercised locally.
- [x] Edge cases or failure modes considered: overlapping tail must not read past the slice; `vtstq_u8` / `movemask` answers are masked to unread lanes only.

Measured (Apple M2 Max, NEON):

```
parse  huge    427.9 -> 439.8 MB/s  (+2.78%, 6/7)
parse  large   414.9 -> 430.6 MB/s  (+3.78%, 6/7)
render huge    266.2 -> 275.1 MB/s  (+3.34%, every round faster)
```

Independent of #633 / #634.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790085773&installation_model_id=422833&pr_number=635&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F635&signature=ede6ba4eb4ab2a98764a7a27b125f6391691fefcb8a888727d910b126831dd85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->