### PR TITLE
fix(jsx): emit HTML attribute names, not React prop names

### DIFF
--- a/npm/vite-plugin-ox-content/src/jsx-html.test.ts
+++ b/npm/vite-plugin-ox-content/src/jsx-html.test.ts
@@ -58,6 +58,27 @@ describe("jsx-html", () => {
       );
     });
 
+    it("maps React meta names to the HTML spellings browsers honor", () => {
+      expect(jsx("meta", { charSet: "UTF-8" }).__html).toBe('<meta charset="UTF-8" />');
+      expect(jsx("meta", { httpEquiv: "refresh", content: "0" }).__html).toBe(
+        '<meta http-equiv="refresh" content="0" />',
+      );
+      expect(jsx("meta", { charset: "UTF-8" }).__html).toBe('<meta charset="UTF-8" />');
+    });
+
+    it("emits class once when both class and className are passed", () => {
+      expect(jsx("div", { class: "x", className: "y" }).__html).toBe('<div class="y"></div>');
+    });
+
+    it("lowercases remaining HTML names and keeps viewBox's case", () => {
+      expect(jsx("input", { autoFocus: true, tabIndex: 0 }).__html).toBe(
+        '<input autofocus tabindex="0" />',
+      );
+      expect(jsx("svg", { viewBox: "0 0 1 1", strokeWidth: 2 }).__html).toBe(
+        '<svg viewBox="0 0 1 1" stroke-width="2"></svg>',
+      );
+    });
+
     it("kebab-cases data-* and aria-* attributes", () => {
       expect(jsx("div", { dataFooBar: "1", ariaLabel: "x" }).__html).toBe(
         '<div data-foo-bar="1" aria-label="x"></div>',

--- a/npm/vite-plugin-ox-content/src/jsx-html.ts
+++ b/npm/vite-plugin-ox-content/src/jsx-html.ts
@@ -95,17 +95,40 @@ function escapeHtml(str: string): string {
 }
 
 /**
- * Converts a camelCase attribute name to kebab-case for HTML.
- * Special handling for data-* and aria-* attributes.
+ * React prop names whose HTML spelling is not the lowercased identifier.
+ */
+const ATTR_ALIASES: Record<string, string> = {
+  className: "class",
+  htmlFor: "for",
+  httpEquiv: "http-equiv",
+  acceptCharset: "accept-charset",
+};
+
+/** SVG attributes that stay camelCase in HTML (they are case-sensitive). */
+const SVG_CAMEL_CASE = new Set(["viewBox"]);
+
+/**
+ * Converts a JSX/React prop name to the HTML attribute the runtime emits.
+ *
+ * HTML attributes are case-insensitive and conventionally lowercase
+ * (`charSet` → `charset`, `tabIndex` → `tabindex`). A few React names are
+ * not a lowercase of themselves (`className`, `httpEquiv`), and SVG names
+ * like `viewBox` must keep their case.
  */
 function toHtmlAttr(name: string): string {
-  // className -> class
-  if (name === "className") return "class";
-  // htmlFor -> for
-  if (name === "htmlFor") return "for";
-  // Keep data-* and aria-* as-is
+  const aliased = ATTR_ALIASES[name];
+  if (aliased !== undefined) return aliased;
+  if (SVG_CAMEL_CASE.has(name)) return name;
   if (name.startsWith("data") || name.startsWith("aria")) {
     return name.replace(/([A-Z])/g, "-$1").toLowerCase();
+  }
+  if (/[A-Z]/.test(name)) {
+    // SVG presentation attributes are kebab-case; remaining HTML names are
+    // just the lowercased identifier (`charSet` → `charset`).
+    if (name.startsWith("stroke") || name === "clipPath") {
+      return name.replace(/([A-Z])/g, "-$1").toLowerCase();
+    }
+    return name.toLowerCase();
   }
   return name;
 }
@@ -213,10 +236,14 @@ export function jsx(type: JSXElementType, props: JSXProps, _key?: string): JSXNo
   const tag = type;
   let html = `<${tag}`;
 
-  // Render attributes
+  // Normalize React aliases first so `class` + `className` become one attribute
+  // (last write wins) instead of emitting `class` twice.
+  const attrs = new Map<string, unknown>();
   for (const [name, value] of Object.entries(restProps)) {
-    // Skip internal props
     if (name === "key" || name === "ref") continue;
+    attrs.set(toHtmlAttr(name), value);
+  }
+  for (const [name, value] of attrs) {
     html += renderAttr(name, value);
   }
 

--- a/npm/vite-plugin-ox-content/src/jsx.d.ts
+++ b/npm/vite-plugin-ox-content/src/jsx.d.ts
@@ -338,8 +338,10 @@ export namespace JSX {
   }
 
   export interface MetaHTMLAttributes extends HTMLAttributes {
+    charset?: string;
     charSet?: string;
     content?: string;
+    "http-equiv"?: string;
     httpEquiv?: string;
     name?: string;
     property?: string;


### PR DESCRIPTION
## Summary
- Serialize React JSX prop names to the HTML attributes browsers actually honor (`className` → `class`, `charSet` → `charset`, `httpEquiv` → `http-equiv`, `autoFocus` → boolean `autofocus`, …).
- Deduplicate after normalization so `class` + `className` no longer emit `class` twice.
- Accept the HTML spellings (`charset`, `http-equiv`) on `<meta>` so a typed `<head>` does not have to use the camelCase names.

Closes #629

## Test plan
- [x] `vp exec --filter @ox-content/vite-plugin -- vp test src/jsx-html.test.ts src/jsx-runtime.test.ts`
- [ ] Confirm a `ssg.render` `<meta charSet>` / `<meta charset>` both emit `charset`, and `<meta httpEquiv>` emits `http-equiv`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790097826&installation_model_id=422833&pr_number=637&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F637&signature=41d92fe3247ff4aa3e7b7e4008cc777091bc6d61bb5b35f64ae1738337b5d970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSX attribute normalization for HTML and SVG output.
  * Added support for common React-style attribute aliases.
  * Preserved SVG `viewBox` casing and normalized other camelCase or SVG attributes.
  * Resolved duplicate `class`/`className` attributes using the latest value.

* **TypeScript**
  * Added support for lowercase `charset` and `http-equiv` meta attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->