### PR TITLE
fix(highlight): keep type cross-reference links after highlighting

### DIFF
--- a/crates/ox_content_transform/src/highlight.rs
+++ b/crates/ox_content_transform/src/highlight.rs
@@ -1,4 +1,5 @@
 mod blocks;
+mod links;
 mod scan;
 mod tag;
 #[cfg(test)]
@@ -198,9 +199,10 @@ fn merge_highlighted_inline_code(original_code: &str, highlighted_block: &str) -
         tag.set_attribute("data-language", &language);
     }
 
-    let mut merged = String::with_capacity(highlighted.inner.len() + 128);
+    let inner = links::reapply_links(original_code, highlighted.inner);
+    let mut merged = String::with_capacity(inner.len() + 128);
     merged.push_str(&tag.to_html());
-    merged.push_str(highlighted.inner);
+    merged.push_str(&inner);
     merged.push_str("</code>");
     Some(merged)
 }

--- a/crates/ox_content_transform/src/highlight/links.rs
+++ b/crates/ox_content_transform/src/highlight/links.rs
@@ -1,0 +1,157 @@
+//! Re-applying type cross-reference links after highlighting.
+//!
+//! The docs generator writes a member type as
+//! `<code>…<a href="…">NavGroup</a>[] | null</code>`. Highlighting reads the
+//! text through those wrappers and replaces the element's children, which
+//! used to drop every `<a>`. The ranges are recovered from the original
+//! markup and laid back over the highlighted tokens.
+
+use super::scan::find_tag_end;
+use super::text::{CodeLink, next_decoded, recover_code};
+
+/// Wrap highlighted inner HTML with the `<a>` ranges from `original_element`.
+pub(super) fn reapply_links(original_element: &str, highlighted_inner: &str) -> String {
+    let Some(recovered) = recover_code(original_element) else {
+        return highlighted_inner.to_string();
+    };
+    if recovered.links.is_empty() {
+        return highlighted_inner.to_string();
+    }
+    apply_links(highlighted_inner, &recovered.links)
+}
+
+fn apply_links(html: &str, links: &[CodeLink]) -> String {
+    let mut out = String::with_capacity(html.len() + links.len() * 32);
+    let mut text_pos = 0;
+    let mut index = 0;
+    let mut open: Option<&CodeLink> = None;
+
+    while index < html.len() {
+        if html.as_bytes()[index] == b'<' {
+            close_link(&mut out, &mut open);
+            if let Some(end) = find_tag_end(html, index) {
+                out.push_str(&html[index..end]);
+                index = end;
+            } else {
+                emit_text(&mut out, &html[index..], &mut text_pos, links, &mut open);
+                break;
+            }
+        } else {
+            let next = html[index..].find('<').map_or(html.len(), |relative| index + relative);
+            emit_text(&mut out, &html[index..next], &mut text_pos, links, &mut open);
+            index = next;
+        }
+    }
+    close_link(&mut out, &mut open);
+    out
+}
+
+fn emit_text<'a>(
+    out: &mut String,
+    raw: &str,
+    text_pos: &mut usize,
+    links: &'a [CodeLink],
+    open: &mut Option<&'a CodeLink>,
+) {
+    let mut index = 0;
+    while index < raw.len() {
+        let (raw_len, decoded_len) = next_decoded(&raw[index..]);
+        if raw_len == 0 {
+            break;
+        }
+        let link = link_at(links, *text_pos);
+        if !same_href(link, *open) {
+            close_link(out, open);
+            if let Some(link) = link {
+                out.push_str("<a href=\"");
+                out.push_str(&link.href);
+                out.push_str("\">");
+            }
+            *open = link;
+        }
+        out.push_str(&raw[index..index + raw_len]);
+        *text_pos += decoded_len;
+        index += raw_len;
+    }
+}
+
+fn link_at(links: &[CodeLink], pos: usize) -> Option<&CodeLink> {
+    links.iter().find(|link| pos >= link.start && pos < link.end)
+}
+
+fn same_href(left: Option<&CodeLink>, right: Option<&CodeLink>) -> bool {
+    match (left, right) {
+        (Some(left), Some(right)) => left.href == right.href,
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+fn close_link(out: &mut String, open: &mut Option<&CodeLink>) {
+    if open.take().is_some() {
+        out.push_str("</a>");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reapply_links;
+    use crate::highlight::highlight_code_blocks;
+
+    #[test]
+    fn wraps_a_linked_identifier_inside_its_token() {
+        let original =
+            r#"<code class="language-ts"><a href="./x.html">NavGroup</a>[] | null</code>"#;
+        let highlighted = r#"<span class="tok">NavGroup</span><span>[] | null</span>"#;
+        assert_eq!(
+            reapply_links(original, highlighted),
+            r#"<span class="tok"><a href="./x.html">NavGroup</a></span><span>[] | null</span>"#
+        );
+    }
+
+    #[test]
+    fn splits_a_span_when_the_link_covers_only_a_prefix() {
+        let original =
+            r#"<code class="language-ts"><a href="./x.html">NavGroup</a>[] | null</code>"#;
+        assert_eq!(
+            reapply_links(original, r"<span>NavGroup[] | null</span>"),
+            r#"<span><a href="./x.html">NavGroup</a>[] | null</span>"#
+        );
+    }
+
+    #[test]
+    fn wraps_each_token_when_a_link_spans_two_of_them() {
+        let original = r#"<code class="language-ts"><a href="./foo.html">Foo.Bar</a></code>"#;
+        assert_eq!(
+            reapply_links(original, r"<span>Foo</span><span>.Bar</span>"),
+            r#"<span><a href="./foo.html">Foo</a></span><span><a href="./foo.html">.Bar</a></span>"#
+        );
+    }
+
+    #[test]
+    fn leaves_unlinked_source_alone() {
+        let original = r#"<code class="language-ts">string</code>"#;
+        let highlighted = r"<span>string</span>";
+        assert_eq!(reapply_links(original, highlighted), highlighted);
+    }
+
+    #[test]
+    fn keeps_the_link_when_the_document_pass_highlights_a_member_type() {
+        let html = "<p><code class=\"mt language-ts\"><a href=\"./x.html\">NavGroup</a>[] | null</code></p>";
+        let result = highlight_code_blocks(
+            html,
+            |_| true,
+            |code, _| {
+                assert_eq!(code, "NavGroup[] | null");
+                Some(format!("<pre><code><span>{code}</span></code></pre>"))
+            },
+        );
+
+        assert!(result.skipped.is_empty());
+        assert!(
+            result.html.contains("<a href=\"./x.html\">NavGroup</a>"),
+            "the type cross-reference must survive highlighting: {}",
+            result.html
+        );
+    }
+}

--- a/crates/ox_content_transform/src/highlight/tag.rs
+++ b/crates/ox_content_transform/src/highlight/tag.rs
@@ -182,7 +182,7 @@ impl ParsedStartTag {
         }
     }
 
-    fn attribute_value(&self, name: &str) -> Option<&str> {
+    pub(super) fn attribute_value(&self, name: &str) -> Option<&str> {
         self.attributes.iter().find_map(|attribute| {
             if attribute.name == name { attribute.value.as_deref() } else { None }
         })

--- a/crates/ox_content_transform/src/highlight/text.rs
+++ b/crates/ox_content_transform/src/highlight/text.rs
@@ -5,6 +5,25 @@
 //! highlighted without an HTML parser in the loop.
 
 use super::scan::find_tag_end;
+use super::tag::ParsedStartTag;
+
+/// A type cross-reference recovered from an `<a>` inside a code element.
+///
+/// Offsets are into the decoded source the highlighter sees, so they line up
+/// with the text nodes of the highlighted markup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CodeLink {
+    pub start: usize,
+    pub end: usize,
+    pub href: String,
+}
+
+/// Source text of a `<code>` element, plus any cross-reference ranges in it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RecoveredCode {
+    pub text: String,
+    pub links: Vec<CodeLink>,
+}
 
 /// The source text of a `<code>` element.
 ///
@@ -23,6 +42,11 @@ use super::scan::find_tag_end;
 /// differently. Those are declined so the DOM path stays the authority on
 /// malformed input.
 pub(super) fn code_text(element: &str) -> Option<String> {
+    recover_code(element).map(|recovered| recovered.text)
+}
+
+/// [`code_text`] plus the `<a href>` ranges that wrapping dropped.
+pub(super) fn recover_code(element: &str) -> Option<RecoveredCode> {
     let code_open = element.find("<code")?;
     let content_start = element[code_open..].find('>')? + code_open + 1;
     let content_end = element.rfind("</code>")?;
@@ -32,27 +56,52 @@ pub(super) fn code_text(element: &str) -> Option<String> {
 
     let content = &element[content_start..content_end];
     if !content.contains('<') {
-        return Some(decode_entities(content));
+        return Some(RecoveredCode { text: decode_entities(content), links: Vec::new() });
     }
 
     let mut text = String::with_capacity(content.len());
+    let mut links = Vec::new();
+    let mut open_link: Option<(usize, String)> = None;
     let mut cursor = 0;
     while let Some(relative) = content[cursor..].find('<') {
         let open = cursor + relative;
-        text.push_str(&content[cursor..open]);
+        text.push_str(&decode_entities(&content[cursor..open]));
         let Some(close) = find_tag_end(content, open) else {
             // A `<` with no closing `>` is text the renderer failed to escape,
             // not a tag; keep it rather than truncating the source.
-            text.push_str(&content[open..]);
-            return Some(decode_entities(&text));
+            text.push_str(&decode_entities(&content[open..]));
+            return Some(RecoveredCode { text, links });
         };
-        if !is_text_wrapper(&content[open..close]) {
+        let tag = &content[open..close];
+        if !is_text_wrapper(tag) {
             return None;
+        }
+        if let Some(href) = anchor_href(tag) {
+            open_link = Some((text.len(), href));
+        } else if is_closing_anchor(tag)
+            && let Some((start, href)) = open_link.take()
+            && start < text.len()
+        {
+            links.push(CodeLink { start, end: text.len(), href });
         }
         cursor = close;
     }
-    text.push_str(&content[cursor..]);
-    Some(decode_entities(&text))
+    text.push_str(&decode_entities(&content[cursor..]));
+    Some(RecoveredCode { text, links })
+}
+
+fn anchor_href(tag: &str) -> Option<String> {
+    let parsed = ParsedStartTag::parse(tag)?;
+    if !parsed.name.eq_ignore_ascii_case("a") {
+        return None;
+    }
+    parsed.attribute_value("href").filter(|href| !href.is_empty()).map(str::to_string)
+}
+
+fn is_closing_anchor(tag: &str) -> bool {
+    tag.strip_prefix("</")
+        .and_then(|rest| rest.strip_suffix('>'))
+        .is_some_and(|rest| rest.trim().eq_ignore_ascii_case("a"))
 }
 
 /// Elements that may wrap part of a code element's text.
@@ -67,6 +116,34 @@ fn is_text_wrapper(tag: &str) -> bool {
     let name = tag.trim_start_matches('<').trim_start_matches('/');
     let end = name.find(|c: char| !c.is_ascii_alphanumeric()).unwrap_or(name.len());
     TEXT_WRAPPERS.iter().any(|wrapper| name[..end].eq_ignore_ascii_case(wrapper))
+}
+
+/// Next HTML character in `text`: raw byte length, then decoded UTF-8 length.
+///
+/// Highlighted markup re-escapes the same five characters the renderer does,
+/// so walking it with this keeps a cursor lined up with [`RecoveredCode::text`].
+pub(super) fn next_decoded(text: &str) -> (usize, usize) {
+    if text.is_empty() {
+        return (0, 0);
+    }
+    if let Some(rest) = text.strip_prefix('&') {
+        let bound = rest.len().min(11);
+        if let Some(semi) = rest.as_bytes()[..bound].iter().position(|&b| b == b';') {
+            let decoded = match &rest[..semi] {
+                "amp" => Some('&'),
+                "lt" => Some('<'),
+                "gt" => Some('>'),
+                "quot" => Some('"'),
+                "apos" => Some('\''),
+                entity => numeric_entity(entity),
+            };
+            if let Some(ch) = decoded {
+                return (semi + 2, ch.len_utf8());
+            }
+        }
+    }
+    let len = text.chars().next().map_or(0, char::len_utf8);
+    (len, len)
 }
 
 /// Reverses the renderer's escaping, plus the numeric forms other producers


### PR DESCRIPTION
## Summary
- Highlighting a member type used to replace the element's children and drop the `<a>` the docs generator put around the referenced type — 711 links on the documentation corpus, 0 surviving.
- Recover the href ranges from the original markup (the same walk that already strips the wrappers to get the source text) and lay them back over the highlighted tokens, including when a link sits inside one span or spans two.

Closes #622

## Test plan
- [x] `cargo test -p ox_content_transform --lib highlight`
- [x] `cargo clippy -p ox_content_transform --all-targets -- -D warnings`
- [ ] On a built docs page, a member type such as `NavGroup[] | null` keeps a clickable `NavGroup` after highlighting

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790098026&installation_model_id=422833&pr_number=638&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F638&signature=6139cce43bde2d255e89d581fad5eae11393866ab1111444f7f68cfcea6a5bbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved links on identifiers and text when highlighting inline code.
  * Maintained links across highlighted tokens and partial text spans.
  * Improved handling of encoded text and malformed markup during highlighting.
  * Ensured unlinked code and document-level highlighting continue to work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->