### PR TITLE
fix(docs): sort JSDoc tag keys so checked-in docs.json is stable

### DIFF
--- a/crates/ox_content_docs/src/data/serialize.rs
+++ b/crates/ox_content_docs/src/data/serialize.rs
@@ -1,7 +1,7 @@
 use serde_json::{Map, Value, json};
 
 use crate::model::{
-    ApiDocEntry, ApiDocMember, ApiDocModule, ApiParamDoc, ApiReturnDoc, ApiThrowsDoc,
+    ApiDocEntry, ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc, ApiReturnDoc, ApiThrowsDoc,
     ApiTypeParamDoc,
 };
 
@@ -13,12 +13,7 @@ pub(super) fn module_to_json(module: &ApiDocModule) -> Value {
         value.insert("examples".to_string(), json!(module.examples));
     }
     if !module.tags.is_empty() {
-        value.insert(
-            "tags".to_string(),
-            Value::Object(
-                module.tags.iter().map(|tag| (tag.tag.clone(), json!(tag.value))).collect(),
-            ),
-        );
+        value.insert("tags".to_string(), tags_object(&module.tags));
     }
     value.insert(
         "entries".to_string(),
@@ -59,12 +54,7 @@ fn entry_to_json(entry: &ApiDocEntry) -> Value {
         value.insert("examples".to_string(), json!(entry.examples));
     }
     if !entry.tags.is_empty() {
-        value.insert(
-            "tags".to_string(),
-            Value::Object(
-                entry.tags.iter().map(|tag| (tag.tag.clone(), json!(tag.value))).collect(),
-            ),
-        );
+        value.insert("tags".to_string(), tags_object(&entry.tags));
     }
     if !entry.members.is_empty() {
         value.insert(
@@ -151,12 +141,7 @@ fn member_to_json(member: &ApiDocMember) -> Value {
         value.insert("private".to_string(), json!(true));
     }
     if !member.tags.is_empty() {
-        value.insert(
-            "tags".to_string(),
-            Value::Object(
-                member.tags.iter().map(|tag| (tag.tag.clone(), json!(tag.value))).collect(),
-            ),
-        );
+        value.insert("tags".to_string(), tags_object(&member.tags));
     }
     if !member.implementation_of.is_empty() {
         value.insert("implementationOf".to_string(), json!(member.implementation_of));
@@ -216,6 +201,13 @@ fn type_param_to_json(type_param: &ApiTypeParamDoc) -> Value {
         value.insert("description".to_string(), json!(type_param.description));
     }
     Value::Object(value)
+}
+
+/// Sort tag keys so `docs.json` stays stable across HashMap NAPI round-trips.
+fn tags_object(tags: &[ApiDocTag]) -> Value {
+    let mut ordered: Vec<_> = tags.iter().collect();
+    ordered.sort_unstable_by(|left, right| left.tag.cmp(&right.tag));
+    Value::Object(ordered.into_iter().map(|tag| (tag.tag.clone(), json!(tag.value))).collect())
 }
 
 fn normalize_doc_file_path(file_path: &str) -> String {

--- a/crates/ox_content_docs/src/data/tests/members.rs
+++ b/crates/ox_content_docs/src/data/tests/members.rs
@@ -2,7 +2,7 @@ use serde_json::Value;
 
 use super::super::generate_docs_data_json;
 use crate::model::{
-    ApiDocEntry, ApiDocMember, ApiDocModule, ApiParamDoc, ApiReturnDoc, ApiThrowsDoc,
+    ApiDocEntry, ApiDocMember, ApiDocModule, ApiDocTag, ApiParamDoc, ApiReturnDoc, ApiThrowsDoc,
     ApiTypeParamDoc,
 };
 
@@ -200,4 +200,42 @@ fn function_valued_property_metadata_serializes_to_json() {
     assert_eq!(member["throws"][0]["type"], "ParseError");
     assert_eq!(member["throws"][0]["description"], "When the raw value cannot be parsed.");
     assert_eq!(member["optional"], true);
+}
+
+#[test]
+fn member_tag_objects_serialize_in_tag_name_order() {
+    let docs = vec![ApiDocModule {
+        file: "/repo/src/options.ts".to_string(),
+        entries: vec![ApiDocEntry {
+            name: "Options".to_string(),
+            kind: "interface".to_string(),
+            file: "/repo/src/options.ts".to_string(),
+            members: vec![ApiDocMember {
+                name: "tocMaxDepth".to_string(),
+                kind: "property".to_string(),
+                tags: vec![
+                    ApiDocTag { tag: "min".to_string(), value: "1".to_string() },
+                    ApiDocTag { tag: "max".to_string(), value: "6".to_string() },
+                ],
+                line: 203,
+                end_line: 203,
+                ..ApiDocMember::default()
+            }],
+            ..ApiDocEntry::default()
+        }],
+        ..ApiDocModule::default()
+    }];
+
+    let json = generate_docs_data_json(&docs, "2026-05-31T00:00:00.000Z").unwrap();
+    let tags = json
+        .split_once("\"tags\": {")
+        .expect("tags object")
+        .1
+        .split_once('}')
+        .expect("tags close")
+        .0;
+    assert!(
+        tags.find("\"max\"").expect("max") < tags.find("\"min\"").expect("min"),
+        "tag keys should be sorted: {tags}"
+    );
 }

--- a/crates/ox_content_napi/src/docs_bindings/markdown.rs
+++ b/crates/ox_content_napi/src/docs_bindings/markdown.rs
@@ -75,12 +75,16 @@ fn convert_markdown_member(member: JsDocMember) -> ApiDocMember {
         readonly: member.readonly.unwrap_or(false),
         r#static: member.r#static.unwrap_or(false),
         private: member.private.unwrap_or(false),
-        tags: member
-            .tags
-            .unwrap_or_default()
-            .into_iter()
-            .map(|(tag, value)| ApiDocTag { tag, value })
-            .collect(),
+        tags: {
+            let mut tags: Vec<_> = member
+                .tags
+                .unwrap_or_default()
+                .into_iter()
+                .map(|(tag, value)| ApiDocTag { tag, value })
+                .collect();
+            tags.sort_unstable_by(|left, right| left.tag.cmp(&right.tag));
+            tags
+        },
         implementation_of: member.implementation_of.unwrap_or_default(),
         line: member.line,
         end_line: member.end_line,

--- a/docs/content/api/docs.json
+++ b/docs/content/api/docs.json
@@ -8794,8 +8794,8 @@
               "default": "3",
               "optional": true,
               "tags": {
-                "min": "1",
-                "max": "6"
+                "max": "6",
+                "min": "1"
               },
               "line": 203,
               "endLine": 203


### PR DESCRIPTION
## Summary

- Package dry-run on #639 failed because `docs.json` JSDoc tag objects (`min`/`max` on `tocMaxDepth`) came back in HashMap order after the NAPI round-trip.
- Sort tag keys when serializing `docs.json` and when converting member tags, and commit the stable order.

## Risk

- Risk level: low
- User or production impact: generated `docs.json` tag object key order only.
- Rollback plan: revert the PR.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_docs --lib data::tests::members::member_tag_objects_serialize_in_tag_name_order`; clippy `-D warnings` on docs + napi.
- [x] Manual verification completed: rebuilt release NAPI and `node scripts/generate-api-docs.mjs --check` matches the committed tree.
- [x] Edge cases or failure modes considered: `serde_json` `preserve_order` would otherwise keep HashMap insertion order.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790099021&installation_model_id=422833&pr_number=640&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F640&signature=07ac226b577824f4c0b8a7b30b5db81be255428c1574cadb4fde61feff662e97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->