### PR TITLE
perf(renderer): gate default autolinks with a reused :// finder

### DIFF
--- a/crates/ox_content_renderer/src/html/autolink.rs
+++ b/crates/ox_content_renderer/src/html/autolink.rs
@@ -4,7 +4,19 @@
 //! first indexes possible leading bytes so most prose is skipped without repeated
 //! prefix checks, then validates word boundaries and trims punctuation around matches.
 
+use std::sync::LazyLock;
+
+use memchr::memmem;
+
 use super::options::AutolinkPatterns;
+
+/// Process-wide finder for the default autolink gate (`://`).
+///
+/// `http://` / `https://` both contain this caseless needle. The previous
+/// gate looped `memchr(':')` and compared `//` after each hit, which
+/// restarted on every `Note:` / `Listing 3-2:` colon that is not a URL.
+static COLON_SLASH_SLASH: LazyLock<memmem::Finder<'static>> =
+    LazyLock::new(|| memmem::Finder::new(b"://"));
 
 /// Case-insensitive index over the first byte of every registered autolink
 /// pattern, used to skip the long runs of text that can't begin a URL.
@@ -163,6 +175,12 @@ impl FirstByteIndex {
         let Some(gate) = self.gate else {
             return true;
         };
+        // Default patterns agree on `://`. One SIMD search rejects the
+        // colon-heavy prose that used to restart the candidate loop on
+        // every `:` that was not followed by `//`.
+        if gate == b':' && self.gate_tail_len == 2 && self.gate_tail == *b"//" {
+            return COLON_SLASH_SLASH.find(haystack).is_some();
+        }
         let tail = &self.gate_tail[..self.gate_tail_len];
         let mut from = 0;
         while let Some(off) = memchr::memchr(gate, &haystack[from..]) {

--- a/crates/ox_content_renderer/src/html/tests/autolink.rs
+++ b/crates/ox_content_renderer/src/html/tests/autolink.rs
@@ -203,3 +203,15 @@ fn test_autolink_single_byte_pattern_bypasses_the_filter() {
     let html = renderer.render(&doc);
     assert_eq!(html.matches("<a ").count(), 1, "single-byte pattern should link in: {html}");
 }
+
+#[test]
+fn default_gate_requires_colon_slash_slash() {
+    use super::super::autolink::FirstByteIndex;
+    use super::super::options::AutolinkPatterns;
+
+    let index = FirstByteIndex::from_patterns(AutolinkPatterns::Defaults(&["http://", "https://"]));
+    assert!(!index.may_match(b"Note: Listing 3-2: foo"));
+    assert!(!index.may_match(b"no colons here"));
+    assert!(index.may_match(b"see http://example.com"));
+    assert!(index.may_match(b"://bare"));
+}


### PR DESCRIPTION
## Summary
- Default autolink patterns (`http://` / `https://`) already require a `://` gate. The previous implementation scanned for every `:` and then compared `//`, which restarts on rust-book-style `Note:` / `Listing 3-2:` colons that are not URLs.
- The default gate now uses one process-wide `memmem::Finder` for `://`. Custom pattern sets keep the existing per-gate-byte loop.

## Test plan
- [x] Autolink unit tests including `default_gate_requires_colon_slash_slash`
- [x] CommonMark + GFM spec tests
- [x] rust-book pipeline vs main (`#641`) on Apple M2 Max, 200 iters, 5 alternating rounds: p50 **4.586 → 4.544 ms (−0.92%, 5/5 faster)**; `visit_paragraph` self dropped in 4/5 rounds
- [x] native-competitors `--runs 1` is noise-only (that sample contains `https://`, so the gate hits immediately)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790103583&installation_model_id=422833&pr_number=642&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F642&signature=c1d79c70949e0b3e618bb9e49c6d3add5d0305248236b8cb9ab4630b4a039701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic link detection for URLs using common `http://` and `https://` patterns.
  * Ensured plain text is not incorrectly treated as a link while preserving valid and partial URL matches.

* **Tests**
  * Added regression coverage for valid URLs, ordinary text, and standalone `://` sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->