### PR TITLE
feat(code-play): add opt-in plugin for on-demand sample execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - **Framework Agnostic** - Works with Vue, React, Svelte, and more
 - **Built-in SSG** - Static site generation with theming, search, and OG images
 - **Built-in Embeds** - Static GitHub repository, source code, and Open Graph link cards
+- **Code Play** - Opt-in `@ox-content/code-play` plugin for on-demand sample execution
 - **API Docs Generation** - Generate docs from JSDoc/TypeScript (like `cargo doc`)
 - **i18n** - ICU MessageFormat 2 parser, dictionary management, static checker, and LSP
 - **Editor Tooling** - Markdown/MDC LSP plus VS Code, Zed, and Neovim integrations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,6 +50,11 @@ Content release artifacts, including:
 - Editor tooling for VS Code, Zed, Neovim, and language server integrations.
 - The documentation site, playground, generated documentation pipeline, and
   examples maintained in this repository.
+- `@ox-content/code-play` execution sandboxes and remote-executor configuration.
+  Sample code is not run during Markdown transform or SSG. JavaScript and
+  TypeScript run in `node:vm` or a browser iframe. Native languages use official
+  playgrounds or a user-configured HTTP executor. The plugin does not spawn a
+  local shell.
 - Build, release, and dependency configuration that could affect distributed
   artifacts.
 

--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -186,6 +186,7 @@ system while still publishing individual crates.
 | `@ox-content/vite-plugin-svelte` | Svelte island runtime and transform integration                                  |
 | `@ox-content/vite-plugin-solid`  | Solid island runtime and transform integration                                   |
 | `@ox-content/islands`            | Framework-agnostic island registration and hydration primitives                  |
+| `@ox-content/code-play`          | Opt-in on-demand sample execution, type-check, and viewers                       |
 | `@ox-content/unplugin`           | Universal bundler plugin wrapper                                                 |
 | `vscode-ox-content`              | VS Code extension that talks to the local LSP server                             |
 

--- a/docs/content/code-play-roadmap.md
+++ b/docs/content/code-play-roadmap.md
@@ -1,0 +1,92 @@
+---
+title: Code Play Roadmap
+description: PR sequence for the opt-in @ox-content/code-play plugin.
+---
+
+# Code Play Roadmap
+
+Tracking issue: [#648](https://github.com/ubugeeei-prod/ox-content/issues/648).
+
+Code Play is an opt-in plugin, `@ox-content/code-play`. Installing
+`@ox-content/vite-plugin` must not pull it in, and installing Code Play must
+not enable any language until the site lists that language.
+
+The work is split into small pull requests so each one can land with its own
+tests and changelog entry. A later PR may depend on an earlier one, never the
+reverse.
+
+## Architecture Principles
+
+1. **Two opt-in layers.** Install the package, then enable languages. Disabled
+   languages stay ordinary highlighted fences.
+2. **Headless first.** `createCodePlay()` / `CodePlaySession` are the source of
+   truth. Presets and viewers render that data; they do not own execution.
+3. **No transform-time execution.** Markdown transform and SSG never run sample
+   code. Readers trigger execute / type-check on demand.
+4. **Sandboxes stay sandboxed.** JavaScript and TypeScript run in `node:vm` or
+   a browser iframe. Native languages use official playgrounds or a
+   user-configured HTTP executor. Code Play does not spawn `sh`, `python`, or
+   `rustc` on the docs host unless a later local-runtime PR says so.
+5. **Observability is API data.** stdio, config, provenance, and timing are
+   returned on every `RunResult`, not only painted in the default UI.
+
+## Language Matrix
+
+| Language                             | Execute | Type-check | Default backend                       |
+| ------------------------------------ | ------- | ---------- | ------------------------------------- |
+| TypeScript                           | yes     | yes        | local `tsc` + `node:vm` / iframe      |
+| Rust                                 | yes     | yes        | play.rust-lang.org                    |
+| Go                                   | yes     | yes        | play.golang.org                       |
+| JavaScript                           | yes     | no         | `node:vm` / iframe                    |
+| Vue, React, Svelte, Solid            | yes     | no         | compiled iframe preview               |
+| Python, PHP, Ruby, sh                | yes     | no         | configured Piston-compatible endpoint |
+| Java, Swift, Kotlin                  | yes     | no         | configured Piston-compatible endpoint |
+| C, C++, Zig, Haskell, OCaml          | yes     | no         | configured Piston-compatible endpoint |
+| C#, Elixir, F#                       | yes     | no         | configured Piston-compatible endpoint |
+| Lean, Rocq, Clojure, Scheme, MoonBit | yes     | no         | configured Piston-compatible endpoint |
+
+## PR Sequence
+
+### 1. `feat(code-play): plugin scaffold, headless API, viewers`
+
+This PR. Ships the package, catalog, headless client, default/compact/headless
+UI, config / stdio / provenance / timing viewers, Vite plugin, and tests with
+injected transports (no live network in CI).
+
+### 2. `feat(code-play): Vite SSG hydration and docs dogfood`
+
+Harden page-level script emission for ox-content SSG (dev middleware + written
+HTML), enable JavaScript / TypeScript widgets on the docs example page, and
+add a visual check for the default preset.
+
+### 3. `feat(code-play): official playground proxies`
+
+Keep the allowlisted `/__ox-code-play/rust` and `/__ox-code-play/go` proxies,
+add production `endpoints` documentation, and cover proxy failure modes.
+
+### 4. `feat(code-play): framework preview compilers`
+
+Optional peer compilers for Vue SFC, React JSX, Svelte, and Solid so previews
+compile locally instead of shipping raw source into an import-map iframe.
+
+### 5. `feat(code-play): optional in-browser runtimes`
+
+Opt-in loaders such as Pyodide or Scheme interpreters. Still off by default;
+each runtime is its own language enable flag.
+
+### 6. `docs(code-play): security and privacy notes`
+
+Document third-party playgrounds, endpoint trust, iframe sandbox flags, and
+the "no local shell" guarantee in SECURITY.md and the package guide.
+
+## Out of Scope
+
+- Making Code Play a built-in `@ox-content/vite-plugin` option.
+- Replacing WebContainer or StackBlitz embeds.
+- Vendoring compilers or a hosted execute service.
+- Running samples during `transformMarkdown` or `buildSsg`.
+
+## Tracking
+
+Progress is tracked through the conventional commit log and #648. This
+document is updated in the same PR when an item lands.

--- a/docs/content/examples/code-play.md
+++ b/docs/content/examples/code-play.md
@@ -1,0 +1,79 @@
+---
+title: Code Play
+description: Opt-in on-demand sample execution with stdio, config, provenance, and timing viewers.
+---
+
+# Code Play
+
+This page uses `@ox-content/code-play` with **JavaScript** and **TypeScript**
+enabled. Other languages stay ordinary fences until a site opts them in.
+
+## Enable the plugin
+
+```ts
+import { oxContent } from "@ox-content/vite-plugin";
+import { codePlay } from "@ox-content/code-play";
+
+export default {
+  plugins: [
+    oxContent({ highlight: true }),
+    codePlay({
+      languages: {
+        javascript: true,
+        typescript: { execute: true, typecheck: true },
+      },
+      ui: "default",
+      viewers: { config: true, stdio: true, provenance: true, timing: true },
+    }),
+  ],
+};
+```
+
+## Live TypeScript sample
+
+The fence below is marked `play`. Use **Run** to execute it and **Typecheck**
+to type-check it. The stdio, config, provenance, and timing tabs are the same
+objects the headless API returns.
+
+```ts play typecheck
+const message: string = "hello from Code Play";
+console.log(message);
+console.warn("this warning is a stderr chunk");
+```
+
+## Live JavaScript sample
+
+```js play
+function add(left, right) {
+  return left + right;
+}
+
+console.log(add(2, 40));
+```
+
+## Headless usage
+
+```ts
+import { createCodePlay } from "@ox-content/code-play";
+
+const play = createCodePlay({ languages: { typescript: true } });
+const session = play.createSession({
+  language: "ts",
+  code: "const n: number = 1;",
+});
+
+const result = await session.run();
+result.stdio;
+result.provenance.compile;
+result.provenance.execute;
+result.timing.phases;
+```
+
+## Remote languages
+
+Python, Rust, Go, and the rest of the catalog are registered but not enabled
+on this page. Give Rust/Go a playground endpoint, or give Python a
+Piston-compatible `endpoint`, before marking those fences `play`.
+
+See [@ox-content/code-play](../packages/code-play.md) and the
+[roadmap](../code-play-roadmap.md).

--- a/docs/content/examples/index.md
+++ b/docs/content/examples/index.md
@@ -157,6 +157,11 @@ oxContent({
 
 ## Other Examples
 
+### [Code Play](./code-play.md)
+
+On-demand sample execution through `@ox-content/code-play`, with stdio, config,
+provenance, and timing viewers.
+
 ### [Playground](./playground.md)
 
 Interactive web playground for testing Markdown parsing.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -96,6 +96,7 @@ Under the hood, Ox Content is not only a docs theme. It also exposes the Markdow
 - [Release Operations](./release.md) - Cut releases, recover failed publishes, and handle first-time crates
 - [Docs Deployment](./deployment.md) - Deploy the documentation site to Void with `vp run deploy#docs`
 - [Editor Extension Roadmap](./editor-extension-roadmap.md) - VS Code and Neovim plan, PR-by-PR
+- [Code Play Roadmap](./code-play-roadmap.md) - Opt-in `@ox-content/code-play` plugin plan
 
 ## Reference
 

--- a/docs/content/packages/code-play.md
+++ b/docs/content/packages/code-play.md
@@ -1,0 +1,117 @@
+---
+title: "@ox-content/code-play"
+description: Opt-in API and UI for on-demand documentation sample execution.
+---
+
+# @ox-content/code-play
+
+Code Play runs documentation samples on demand. It is a separate plugin:
+`@ox-content/vite-plugin` does not enable it, and installing this package does
+nothing until you list languages.
+
+The [Code Play example](../examples/code-play.md) on this site enables
+JavaScript and TypeScript only. Rust, Go, and remote languages stay off unless
+you opt in.
+
+## Install
+
+<pm>npm install @ox-content/code-play</pm>
+
+```ts
+import { oxContent } from "@ox-content/vite-plugin";
+import { codePlay } from "@ox-content/code-play";
+
+export default {
+  plugins: [
+    oxContent({ highlight: true }),
+    codePlay({
+      languages: {
+        typescript: { execute: true, typecheck: true },
+        javascript: true,
+      },
+      ui: "default",
+      viewers: { config: true, stdio: true, provenance: true, timing: true },
+      srcDir: "content",
+    }),
+  ],
+};
+```
+
+## Authoring
+
+Mark a fence with `play`. Add `typecheck` when the language supports it.
+
+````md
+```ts play
+const n: number = 1;
+console.log(n);
+```
+
+```rust play typecheck
+fn main() {
+    println!("ok");
+}
+```
+````
+
+HTML / MDX form:
+
+```html
+<CodePlay lang="python"> print("hello") </CodePlay>
+```
+
+## Headless API
+
+```ts
+import { createCodePlay } from "@ox-content/code-play";
+
+const play = createCodePlay({ languages: { typescript: true } });
+const session = play.createSession({
+  language: "ts",
+  code: "const n: number = 1;\nconsole.log(n);",
+});
+
+const check = await session.typecheck();
+const run = await session.run();
+
+run.stdio; // timestamped stdin / stdout / stderr
+run.provenance; // where it compiled, where it ran
+run.timing; // phase durations and totalMs
+session.config; // editable language config
+```
+
+`createCodePlay()` throws if you ask for a language that is not enabled.
+`session.setConfig({ strict: false })` updates the same object the config
+viewer edits.
+
+## UI
+
+| Preset     | Behavior                                               |
+| ---------- | ------------------------------------------------------ |
+| `default`  | Toolbar plus stdio / config / provenance / timing tabs |
+| `compact`  | Run / type-check and stdio only                        |
+| `headless` | No DOM chrome; use the session API                     |
+
+Viewers can be toggled independently through `viewers`.
+
+## Languages
+
+**Execute and type-check:** TypeScript, Rust, Go.
+
+**On-demand execute:** JavaScript, Vue, React, Svelte, Solid, MoonBit, Java,
+Swift, Kotlin, C, C++, Zig, Haskell, OCaml, Python, PHP, Ruby, sh, C#, Elixir,
+F#, Lean, Rocq, Clojure, Scheme.
+
+Remote languages need `languages.<id>.endpoint` pointing at a
+Piston-compatible executor. Rust and Go default to the official playgrounds.
+JavaScript and TypeScript run locally in `node:vm` or a browser iframe.
+
+## Security
+
+- Samples are not executed during Markdown transform or SSG.
+- `sh` never spawns a local shell.
+- Enabling Rust or Go sends source to `play.rust-lang.org` /
+  `play.golang.org` (or your `endpoints` override).
+- A configured remote endpoint receives source for that language.
+
+See the [Code Play roadmap](../code-play-roadmap.md) for follow-up PRs.

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,6 +10,7 @@
     "gallery": "node ../scripts/theme-gallery.mjs"
   },
   "devDependencies": {
+    "@ox-content/code-play": "workspace:*",
     "@ox-content/vite-plugin": "workspace:*",
     "vite": "catalog:",
     "vite-plus": "catalog:"

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite-plus";
 import { oxContent, defineTheme, defaultTheme } from "@ox-content/vite-plugin";
+import { codePlay } from "@ox-content/code-play";
 import { oxContentHighlightTheme } from "./ox-content-highlight-theme";
 
 /**
@@ -68,6 +69,7 @@ export default defineConfig(({ mode }) => {
                 <link rel="preconnect" href="https://fonts.googleapis.com">
                 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
                 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+                <script type="module" src="${base}ox-code-play.js"></script>
               `,
             },
             footer: {
@@ -122,6 +124,7 @@ export default defineConfig(({ mode }) => {
                     text: "Editor Extension Roadmap",
                     link: "/editor-extension-roadmap.md",
                   },
+                  { text: "Code Play Roadmap", link: "/code-play-roadmap.md" },
                 ],
               },
               {
@@ -143,6 +146,7 @@ export default defineConfig(({ mode }) => {
                     link: "/packages/vite-plugin-ox-content-solid.md",
                   },
                   { text: "i18n Package", link: "/packages/i18n.md" },
+                  { text: "Code Play", link: "/packages/code-play.md" },
                 ],
               },
             ],
@@ -192,6 +196,14 @@ export default defineConfig(({ mode }) => {
           githubUrl: "https://github.com/ubugeeei-prod/ox-content",
           generateNav: true,
         },
+      }),
+      codePlay({
+        languages: {
+          javascript: true,
+          typescript: { execute: true, typecheck: true },
+        },
+        srcDir: "content",
+        outDir: "dist/docs",
       }),
     ],
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,7 @@ This directory contains runnable projects and small source examples.
 | Example                                      | Description               | Shows                                |
 | -------------------------------------------- | ------------------------- | ------------------------------------ |
 | [playground](./playground)                   | Browser playground        | Live Markdown preview                |
+| Code Play (docs page)                        | `@ox-content/code-play`   | On-demand sample run / type-check    |
 | [ssg-vite](./ssg-vite)                       | Vite static site          | SSG output and generated routes      |
 | [gen-source-docs](./gen-source-docs)         | Source documentation      | API docs generated from TypeScript   |
 | [og-image-custom](./og-image-custom)         | Custom OG image templates | React, Svelte, Vue, and TS templates |

--- a/npm/ox-content-code-play/README.md
+++ b/npm/ox-content-code-play/README.md
@@ -1,0 +1,75 @@
+# @ox-content/code-play
+
+Opt-in Code Play plugin for Ox Content. It runs documentation samples on demand
+and exposes a headless API plus Headless / preset UI.
+
+Nothing runs until you install this package **and** enable specific languages.
+
+## Install
+
+```bash
+npm install @ox-content/code-play
+```
+
+```ts
+import { oxContent } from "@ox-content/vite-plugin";
+import { codePlay } from "@ox-content/code-play";
+
+export default {
+  plugins: [
+    oxContent({ highlight: true }),
+    codePlay({
+      languages: {
+        typescript: { execute: true, typecheck: true },
+        rust: true,
+      },
+      ui: "default",
+      viewers: { config: true, stdio: true, provenance: true, timing: true },
+    }),
+  ],
+};
+```
+
+## Authoring
+
+````md
+```ts play
+const n: number = 1;
+console.log(n);
+```
+
+```rust play typecheck
+fn main() {
+    println!("ok");
+}
+```
+````
+
+```html
+<CodePlay lang="python"> print("hello") </CodePlay>
+```
+
+## Headless API
+
+```ts
+import { createCodePlay } from "@ox-content/code-play";
+
+const play = createCodePlay({ languages: { typescript: true } });
+const session = play.createSession({ language: "ts", code: "const n: number = 1;" });
+const check = await session.typecheck();
+const run = await session.run();
+
+run.stdio;
+run.provenance;
+run.timing;
+```
+
+## Security
+
+- No sample is executed during Markdown transform or SSG.
+- JavaScript and TypeScript run in `node:vm` / a browser iframe.
+- Rust and Go use the official playgrounds (or the Vite dev proxy).
+- Other languages need a Piston-compatible `endpoint` you configure.
+- `sh` never spawns a local shell.
+
+See [Code Play](../../docs/content/packages/code-play.md) in the docs site.

--- a/npm/ox-content-code-play/package.json
+++ b/npm/ox-content-code-play/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@ox-content/code-play",
+  "version": "2.90.0",
+  "description": "Opt-in Code Play plugin for on-demand documentation sample execution",
+  "keywords": [
+    "code-play",
+    "documentation",
+    "markdown",
+    "ox-content",
+    "playground"
+  ],
+  "license": "MIT",
+  "author": "ubugeeei",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ubugeeei-prod/ox-content.git",
+    "directory": "npm/ox-content-code-play"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.mts"
+    },
+    "./client": {
+      "import": "./dist/hydrate.mjs",
+      "types": "./dist/hydrate.d.mts"
+    },
+    "./plugin": {
+      "import": "./dist/plugin.mjs",
+      "types": "./dist/plugin.d.mts"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "vp pack",
+    "dev": "vp pack --watch",
+    "typecheck": "tsgo --noEmit",
+    "test": "vp test src"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
+  },
+  "peerDependencies": {
+    "typescript": ">=5.0.0",
+    "vite": "^0.2.8 || ^8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    },
+    "vite": {
+      "optional": true
+    }
+  }
+}

--- a/npm/ox-content-code-play/src/adapters.test.ts
+++ b/npm/ox-content-code-play/src/adapters.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createCodePlay } from "./client";
+import { buildPreviewDocument } from "./framework";
+import { parseGoErrors } from "./go";
+import { parseRustcDiagnostics } from "./rust";
+import { createMemoryTransport } from "./transport";
+
+describe("language adapters", () => {
+  it("sends rust samples to the playground transport and maps rustc output", async () => {
+    const transport = createMemoryTransport((request) => {
+      expect(request.url).toContain("play.rust-lang.org");
+      const body = JSON.parse(request.body ?? "{}") as { crateType: string; code: string };
+      expect(body.crateType).toBe("bin");
+      expect(body.code).toContain("fn main");
+      return {
+        ok: true,
+        status: 200,
+        text: JSON.stringify({
+          success: true,
+          stdout: "ok\n",
+          stderr: "warning: unused variable: `x`\n",
+        }),
+      };
+    });
+    const play = createCodePlay({ languages: { rust: true }, transport });
+    const result = await play
+      .createSession({ language: "rust", code: "fn main() { let x = 1; }" })
+      .run();
+    expect(result.status).toBe("ok");
+    expect(result.stdio[0]).toMatchObject({ stream: "stdout", text: "ok\n" });
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({ severity: "warning", message: "unused variable: `x`" }),
+    ]);
+    expect(result.provenance.compile?.host).toContain("play.rust-lang.org");
+    expect(result.timing.phases.map((phase) => phase.id)).toEqual(
+      expect.arrayContaining(["compile", "collect"]),
+    );
+  });
+
+  it("maps rustc errors during typecheck", async () => {
+    const transport = createMemoryTransport(() => ({
+      ok: true,
+      status: 200,
+      text: JSON.stringify({
+        success: false,
+        stderr: "error[E0308]: mismatched types\n",
+      }),
+    }));
+    const play = createCodePlay({ languages: { rust: true }, transport });
+    const result = await play
+      .createSession({ language: "rs", code: "fn add(x: i32) -> i32 { x }" })
+      .typecheck();
+    expect(result.status).toBe("error");
+    expect(parseRustcDiagnostics("error[E0308]: mismatched types")[0]?.source).toBe("rustc E0308");
+    expect(result.diagnostics[0]?.severity).toBe("error");
+  });
+
+  it("sends go samples to the playground and records events", async () => {
+    const transport = createMemoryTransport((request) => {
+      expect(request.url).toContain("play.golang.org");
+      expect(request.body).toContain("package+main");
+      return {
+        ok: true,
+        status: 200,
+        text: JSON.stringify({
+          Events: [{ Message: "hi\n", Kind: "stdout" }],
+        }),
+      };
+    });
+    const play = createCodePlay({ languages: { go: true }, transport });
+    const result = await play
+      .createSession({ language: "go", code: "package main\nfunc main() {}" })
+      .run();
+    expect(result.status).toBe("ok");
+    expect(result.stdio[0]?.text).toBe("hi\n");
+    expect(result.provenance.execute?.runtime).toBe("go-playground");
+  });
+
+  it("parses go compiler coordinates", () => {
+    expect(parseGoErrors("prog.go:3:1: undefined: foo", "go")).toEqual([
+      { message: "undefined: foo", severity: "error", line: 3, column: 1, source: "go" },
+    ]);
+  });
+
+  it("requires a configured endpoint for remote languages and never mentions local shell spawn", async () => {
+    const play = createCodePlay({ languages: { python: true, sh: true } });
+    const python = await play.createSession({ language: "python", code: "print(1)" }).run();
+    expect(python.status).toBe("unsupported");
+    expect(python.diagnostics[0]?.message).toMatch(/endpoint/);
+
+    const transport = createMemoryTransport((request) => {
+      expect(request.url).toBe("https://exec.example/api/v2/piston/execute");
+      return {
+        ok: true,
+        status: 200,
+        text: JSON.stringify({ run: { stdout: "1\n", stderr: "", code: 0 } }),
+      };
+    });
+    const remote = createCodePlay({
+      languages: { sh: { endpoint: "https://exec.example/api/v2/piston" } },
+      transport,
+    });
+    const sh = await remote.createSession({ language: "bash", code: "echo 1" }).run();
+    expect(sh.status).toBe("ok");
+    expect(sh.provenance.execute?.sandbox).toBe("piston");
+    expect(sh.stdio[0]?.text).toBe("1\n");
+  });
+
+  it("builds framework preview documents instead of executing host UI code", async () => {
+    const play = createCodePlay({ languages: { vue: true, react: true } });
+    const result = await play
+      .createSession({ language: "vue", code: "createApp({}).mount('#app')" })
+      .run();
+    expect(result.status).toBe("ok");
+    expect(result.preview?.html).toContain("esm.sh/vue");
+    expect(result.provenance.execute?.sandbox).toBe("srcdoc");
+    expect(buildPreviewDocument("react", "console.log(1)").includes("esm.sh/react")).toBe(true);
+  });
+});

--- a/npm/ox-content-code-play/src/adapters.ts
+++ b/npm/ox-content-code-play/src/adapters.ts
@@ -1,0 +1,61 @@
+import { runFramework } from "./framework";
+import { runGo } from "./go";
+import { runJavaScript } from "./javascript";
+import { runRemote } from "./remote";
+import { runRust } from "./rust";
+import { runTypeScript, typecheckTypeScript } from "./typescript";
+import type { AdapterRequest, RunResult } from "./types";
+
+export async function executeAdapter(request: AdapterRequest): Promise<RunResult> {
+  if (!request.enabled.execute) {
+    return capabilityDisabled(request, "execute");
+  }
+  switch (request.definition.backend) {
+    case "javascript":
+      return runJavaScript(request);
+    case "typescript":
+      return runTypeScript(request);
+    case "framework":
+      return runFramework(request);
+    case "rust-playground":
+      return runRust(request, "execute");
+    case "go-playground":
+      return runGo(request, "execute");
+    case "remote":
+      return runRemote(request);
+    default:
+      return capabilityDisabled(request, "execute");
+  }
+}
+
+export async function typecheckAdapter(request: AdapterRequest): Promise<RunResult> {
+  if (!request.enabled.typecheck || !request.definition.capabilities.typecheck) {
+    return capabilityDisabled(request, "typecheck");
+  }
+  switch (request.definition.backend) {
+    case "typescript":
+      return typecheckTypeScript(request);
+    case "rust-playground":
+      return runRust(request, "typecheck");
+    case "go-playground":
+      return runGo(request, "typecheck");
+    default:
+      return capabilityDisabled(request, "typecheck");
+  }
+}
+
+function capabilityDisabled(request: AdapterRequest, action: "execute" | "typecheck"): RunResult {
+  return {
+    status: "unsupported",
+    stdio: [],
+    diagnostics: [
+      {
+        message: `${request.definition.name} ${action} is not enabled.`,
+        severity: "error",
+        source: "code-play",
+      },
+    ],
+    provenance: {},
+    timing: { totalMs: 0, phases: [] },
+  };
+}

--- a/npm/ox-content-code-play/src/catalog.test.ts
+++ b/npm/ox-content-code-play/src/catalog.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vite-plus/test";
+import { LANGUAGE_CATALOG, listLanguages, resolveLanguage } from "./catalog";
+import { resolveEnabledLanguages } from "./config";
+
+describe("language catalog", () => {
+  it("registers execute+typecheck languages and on-demand execute languages", () => {
+    const ids = listLanguages().map((language) => language.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        "typescript",
+        "javascript",
+        "rust",
+        "go",
+        "vue",
+        "react",
+        "svelte",
+        "solid",
+        "python",
+        "php",
+        "ruby",
+        "sh",
+        "java",
+        "swift",
+        "kotlin",
+        "c",
+        "cpp",
+        "zig",
+        "haskell",
+        "ocaml",
+        "csharp",
+        "elixir",
+        "fsharp",
+        "clojure",
+        "scheme",
+        "moonbit",
+        "lean",
+        "rocq",
+      ]),
+    );
+    expect(resolveLanguage("ts")?.id).toBe("typescript");
+    expect(resolveLanguage("c++")?.id).toBe("cpp");
+    expect(resolveLanguage("cloujure")?.id).toBe("clojure");
+    expect(resolveLanguage("coq")?.id).toBe("rocq");
+  });
+
+  it("marks rust, go, and typescript as typecheck-capable", () => {
+    for (const id of ["rust", "go", "typescript"]) {
+      expect(resolveLanguage(id)?.capabilities).toEqual({ execute: true, typecheck: true });
+    }
+  });
+
+  it("resolves enabled languages through aliases and ignores false entries", () => {
+    const enabled = resolveEnabledLanguages({
+      ts: { typecheck: true },
+      rust: true,
+      python: false,
+    });
+    expect([...enabled.keys()]).toEqual(["typescript", "rust"]);
+    expect(enabled.get("typescript")?.typecheck).toBe(true);
+    expect(enabled.get("typescript")?.config.strict).toBe(true);
+  });
+
+  it("rejects unknown language keys", () => {
+    expect(() => resolveEnabledLanguages({ brainfuck: true })).toThrow(
+      /Unknown Code Play language/,
+    );
+  });
+
+  it("keeps a config schema on every catalog entry", () => {
+    for (const language of LANGUAGE_CATALOG) {
+      expect(Array.isArray(language.configSchema)).toBe(true);
+    }
+  });
+});

--- a/npm/ox-content-code-play/src/catalog.ts
+++ b/npm/ox-content-code-play/src/catalog.ts
@@ -1,0 +1,214 @@
+import type { ConfigField, LanguageDefinition } from "./types";
+
+const rustSchema: ConfigField[] = [
+  {
+    key: "channel",
+    label: "Channel",
+    type: "select",
+    options: [
+      { value: "stable", label: "stable" },
+      { value: "beta", label: "beta" },
+      { value: "nightly", label: "nightly" },
+    ],
+    default: "stable",
+  },
+  {
+    key: "edition",
+    label: "Edition",
+    type: "select",
+    options: [
+      { value: "2018", label: "2018" },
+      { value: "2021", label: "2021" },
+      { value: "2024", label: "2024" },
+    ],
+    default: "2024",
+  },
+  {
+    key: "mode",
+    label: "Mode",
+    type: "select",
+    options: [
+      { value: "debug", label: "debug" },
+      { value: "release", label: "release" },
+    ],
+    default: "debug",
+  },
+  {
+    key: "crateType",
+    label: "Crate type",
+    type: "select",
+    options: [
+      { value: "auto", label: "auto" },
+      { value: "bin", label: "bin" },
+      { value: "lib", label: "lib" },
+    ],
+    default: "auto",
+  },
+];
+
+const tsSchema: ConfigField[] = [
+  { key: "strict", label: "Strict", type: "boolean", default: true },
+  {
+    key: "target",
+    label: "Target",
+    type: "select",
+    options: [
+      { value: "ES2020", label: "ES2020" },
+      { value: "ES2022", label: "ES2022" },
+      { value: "ESNext", label: "ESNext" },
+    ],
+    default: "ES2022",
+  },
+  {
+    key: "jsx",
+    label: "JSX",
+    type: "select",
+    options: [
+      { value: "react-jsx", label: "react-jsx" },
+      { value: "preserve", label: "preserve" },
+    ],
+    default: "react-jsx",
+  },
+];
+
+function remote(
+  id: string,
+  name: string,
+  aliases: string[],
+  pistonLanguage: string,
+  extra: ConfigField[] = [],
+): LanguageDefinition {
+  return {
+    id,
+    name,
+    aliases,
+    capabilities: { execute: true, typecheck: false },
+    defaultConfig: { version: "*" },
+    configSchema: [
+      { key: "version", label: "Runtime version", type: "string", default: "*" },
+      ...extra,
+    ],
+    backend: "remote",
+    remote: { pistonLanguage },
+  };
+}
+
+function framework(
+  id: "vue" | "react" | "svelte" | "solid",
+  name: string,
+  aliases: string[],
+): LanguageDefinition {
+  return {
+    id,
+    name,
+    aliases,
+    capabilities: { execute: true, typecheck: false },
+    defaultConfig: {},
+    configSchema: [],
+    backend: "framework",
+    framework: id,
+  };
+}
+
+export const LANGUAGE_CATALOG: LanguageDefinition[] = [
+  {
+    id: "typescript",
+    name: "TypeScript",
+    aliases: ["ts", "tsx", "mts", "cts"],
+    capabilities: { execute: true, typecheck: true },
+    defaultConfig: { strict: true, target: "ES2022", jsx: "react-jsx" },
+    configSchema: tsSchema,
+    backend: "typescript",
+  },
+  {
+    id: "javascript",
+    name: "JavaScript",
+    aliases: ["js", "jsx", "mjs", "cjs"],
+    capabilities: { execute: true, typecheck: false },
+    defaultConfig: {},
+    configSchema: [],
+    backend: "javascript",
+  },
+  {
+    id: "rust",
+    name: "Rust",
+    aliases: ["rs"],
+    capabilities: { execute: true, typecheck: true },
+    defaultConfig: { channel: "stable", edition: "2024", mode: "debug", crateType: "auto" },
+    configSchema: rustSchema,
+    backend: "rust-playground",
+  },
+  {
+    id: "go",
+    name: "Go",
+    aliases: ["golang"],
+    capabilities: { execute: true, typecheck: true },
+    defaultConfig: { withVet: true },
+    configSchema: [{ key: "withVet", label: "Run vet", type: "boolean", default: true }],
+    backend: "go-playground",
+  },
+  framework("vue", "Vue", ["vue"]),
+  framework("react", "React", ["react"]),
+  framework("svelte", "Svelte", ["svelte"]),
+  framework("solid", "Solid", ["solid"]),
+  remote("python", "Python", ["py"], "python"),
+  remote("php", "PHP", [], "php"),
+  remote("ruby", "Ruby", ["rb"], "ruby"),
+  remote("sh", "sh", ["bash", "shell", "zsh"], "bash", [
+    {
+      key: "shell",
+      label: "Shell",
+      type: "select",
+      options: [
+        { value: "bash", label: "bash" },
+        { value: "sh", label: "sh" },
+      ],
+      default: "bash",
+    },
+  ]),
+  remote("java", "Java", [], "java"),
+  remote("swift", "Swift", [], "swift"),
+  remote("kotlin", "Kotlin", ["kt"], "kotlin"),
+  remote("c", "C", [], "c"),
+  remote("cpp", "C++", ["c++", "cc", "cxx"], "c++", [
+    {
+      key: "std",
+      label: "Standard",
+      type: "select",
+      options: [
+        { value: "c++17", label: "C++17" },
+        { value: "c++20", label: "C++20" },
+        { value: "c++23", label: "C++23" },
+      ],
+      default: "c++20",
+    },
+  ]),
+  remote("zig", "Zig", [], "zig"),
+  remote("haskell", "Haskell", ["hs"], "haskell"),
+  remote("ocaml", "OCaml", ["ml"], "ocaml"),
+  remote("csharp", "C#", ["cs", "c#"], "csharp"),
+  remote("elixir", "Elixir", ["ex"], "elixir"),
+  remote("fsharp", "F#", ["fs", "f#"], "fsharp"),
+  remote("clojure", "Clojure", ["clj", "cloujure"], "clojure"),
+  remote("scheme", "Scheme", ["scm"], "scheme"),
+  remote("moonbit", "MoonBit", ["mbt"], "moonbit"),
+  remote("lean", "Lean", ["lean4"], "lean"),
+  remote("rocq", "Rocq", ["coq"], "coq"),
+];
+
+const byId = new Map(LANGUAGE_CATALOG.map((language) => [language.id, language]));
+const byAlias = new Map<string, LanguageDefinition>();
+for (const language of LANGUAGE_CATALOG) {
+  byAlias.set(language.id, language);
+  for (const alias of language.aliases) {
+    byAlias.set(alias.toLowerCase(), language);
+  }
+}
+
+export function resolveLanguage(input: string): LanguageDefinition | undefined {
+  return byAlias.get(input.trim().toLowerCase()) ?? byId.get(input.trim().toLowerCase());
+}
+
+export function listLanguages(): LanguageDefinition[] {
+  return LANGUAGE_CATALOG.slice();
+}

--- a/npm/ox-content-code-play/src/client.test.ts
+++ b/npm/ox-content-code-play/src/client.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createCodePlay } from "./client";
+import { stripTypeScript } from "./strip-typescript";
+import { parseTsgoOutput } from "./typescript";
+
+describe("createCodePlay", () => {
+  it("executes opted-in JavaScript and records stdio, provenance, and timing", async () => {
+    const play = createCodePlay({ languages: { javascript: true } });
+    const session = play.createSession({
+      language: "js",
+      code: `console.log("hello"); console.error("oops"); 41 + 1;`,
+    });
+    const result = await session.run();
+
+    expect(result.status).toBe("ok");
+    expect(result.value).toBe("42");
+    expect(result.stdio.map((event) => [event.stream, event.text])).toEqual([
+      ["stdout", "hello\n"],
+      ["stderr", "oops\n"],
+    ]);
+    expect(result.provenance.execute?.runtime).toBe("node:vm");
+    expect(result.timing.totalMs).toBeGreaterThanOrEqual(0);
+    expect(result.timing.phases.some((phase) => phase.id === "execute")).toBe(true);
+  });
+
+  it("type-checks and executes TypeScript samples", async () => {
+    const play = createCodePlay({ languages: { typescript: true } });
+    const good = await play
+      .createSession({ language: "ts", code: "const n: number = 1;\nconsole.log(n);" })
+      .run();
+    expect(good.status).toBe("ok");
+    expect(good.stdio.some((event) => event.text.includes("1"))).toBe(true);
+    expect(good.provenance.compile?.runtime).toBe("strip-types");
+
+    const check = await play
+      .createSession({ language: "tsx", code: "const n: number = 'nope';" })
+      .typecheck();
+    expect(check.status).toBe("error");
+    expect(check.diagnostics.some((diagnostic) => diagnostic.message.length > 0)).toBe(true);
+  });
+
+  it("refuses languages that were not enabled", () => {
+    const play = createCodePlay({ languages: { javascript: true } });
+    expect(play.hasLanguage("python")).toBe(false);
+    expect(() => play.createSession({ language: "python", code: "print(1)" })).toThrow(
+      /Python is not enabled/,
+    );
+  });
+
+  it("surfaces runtime errors as diagnostics and stderr", async () => {
+    const play = createCodePlay({ languages: { javascript: true } });
+    const result = await play
+      .createSession({ language: "js", code: "throw new Error('boom');" })
+      .run();
+    expect(result.status).toBe("error");
+    expect(result.diagnostics[0]?.message).toContain("boom");
+    expect(
+      result.stdio.some((event) => event.stream === "stderr" && event.text.includes("boom")),
+    ).toBe(true);
+  });
+
+  it("strips TypeScript annotations before execute", () => {
+    expect(stripTypeScript("const n: number = 1;\nconsole.log(n);")).toMatch(/const n\s*= 1;/);
+    expect(
+      parseTsgoOutput(
+        "snippet.ts(1,7): error TS2322: Type 'string' is not assignable to type 'number'.",
+      ),
+    ).toEqual([
+      {
+        message: "Type 'string' is not assignable to type 'number'.",
+        severity: "error",
+        line: 1,
+        column: 7,
+        source: "tsgo",
+      },
+    ]);
+  });
+});

--- a/npm/ox-content-code-play/src/client.ts
+++ b/npm/ox-content-code-play/src/client.ts
@@ -1,0 +1,60 @@
+import { resolveLanguage } from "./catalog";
+import {
+  resolveCodePlayOptions,
+  type RawCodePlayOptions,
+  type ResolvedCodePlayOptions,
+} from "./config";
+import { CodePlaySession } from "./session";
+import { createFetchTransport, createUnavailableTransport } from "./transport";
+import type { CodePlayTransport, SessionInput, TypeScriptLike } from "./types";
+
+export interface CodePlayClientOptions extends RawCodePlayOptions {
+  transport?: CodePlayTransport;
+  loadTypeScript?: () => Promise<TypeScriptLike | undefined>;
+}
+
+export interface CodePlayClient {
+  readonly options: ResolvedCodePlayOptions;
+  createSession(input: SessionInput): CodePlaySession;
+  hasLanguage(language: string): boolean;
+}
+
+export function createCodePlay(options: CodePlayClientOptions = {}): CodePlayClient {
+  const resolved = resolveCodePlayOptions(options);
+  const transport = options.transport ?? defaultTransport();
+  return {
+    options: resolved,
+    hasLanguage(language: string) {
+      const definition = resolveLanguage(language);
+      return Boolean(definition && resolved.languages.has(definition.id));
+    },
+    createSession(input: SessionInput) {
+      const definition = resolveLanguage(input.language);
+      if (!definition) {
+        throw new Error(`Unknown Code Play language: ${input.language}.`);
+      }
+      const enabled = resolved.languages.get(definition.id);
+      if (!enabled) {
+        throw new Error(
+          `${definition.name} is not enabled. Pass languages.${definition.id}: true to createCodePlay().`,
+        );
+      }
+      return new CodePlaySession({
+        ...input,
+        definition,
+        enabled,
+        timeoutMs: resolved.timeoutMs,
+        transport,
+        endpoints: resolved.endpoints,
+        loadTypeScript: options.loadTypeScript,
+      });
+    },
+  };
+}
+
+function defaultTransport(): CodePlayTransport {
+  if (typeof fetch === "function") {
+    return createFetchTransport();
+  }
+  return createUnavailableTransport();
+}

--- a/npm/ox-content-code-play/src/config.ts
+++ b/npm/ox-content-code-play/src/config.ts
@@ -1,0 +1,106 @@
+import { listLanguages, resolveLanguage } from "./catalog";
+import type {
+  CodePlayPreset,
+  LanguageEnable,
+  PlaygroundEndpoints,
+  ResolvedLanguageEnable,
+  ViewerFlags,
+} from "./types";
+
+export interface ResolvedCodePlayOptions {
+  languages: Map<string, ResolvedLanguageEnable>;
+  timeoutMs: number;
+  ui: CodePlayPreset;
+  viewers: ViewerFlags;
+  endpoints: PlaygroundEndpoints;
+  srcDir?: string;
+  outDir?: string;
+  base: string;
+  proxy: boolean;
+}
+
+export interface RawCodePlayOptions {
+  languages?: Record<string, LanguageEnable>;
+  timeoutMs?: number;
+  ui?: CodePlayPreset;
+  viewers?: Partial<ViewerFlags>;
+  endpoints?: Partial<PlaygroundEndpoints>;
+  srcDir?: string;
+  outDir?: string;
+  base?: string;
+  proxy?: boolean;
+}
+
+export const DEFAULT_ENDPOINTS: PlaygroundEndpoints = {
+  rust: "https://play.rust-lang.org/execute",
+  go: "https://play.golang.org/compile",
+};
+
+export const DEFAULT_VIEWERS: ViewerFlags = {
+  config: true,
+  stdio: true,
+  provenance: true,
+  timing: true,
+};
+
+export function resolveCodePlayOptions(options: RawCodePlayOptions = {}): ResolvedCodePlayOptions {
+  return {
+    languages: resolveEnabledLanguages(options.languages ?? {}),
+    timeoutMs: options.timeoutMs ?? 10_000,
+    ui: options.ui ?? "default",
+    viewers: { ...DEFAULT_VIEWERS, ...options.viewers },
+    endpoints: { ...DEFAULT_ENDPOINTS, ...options.endpoints },
+    srcDir: options.srcDir,
+    outDir: options.outDir,
+    base: normalizeBase(options.base ?? "/"),
+    proxy: options.proxy ?? true,
+  };
+}
+
+export function resolveEnabledLanguages(
+  languages: Record<string, LanguageEnable>,
+): Map<string, ResolvedLanguageEnable> {
+  const resolved = new Map<string, ResolvedLanguageEnable>();
+  for (const [key, enable] of Object.entries(languages)) {
+    if (enable === false) {
+      continue;
+    }
+    const definition = resolveLanguage(key);
+    if (!definition) {
+      throw new Error(`Unknown Code Play language: ${key}.`);
+    }
+    const explicit = enable === true ? {} : enable;
+    resolved.set(definition.id, {
+      id: definition.id,
+      execute: explicit.execute ?? definition.capabilities.execute,
+      typecheck: explicit.typecheck ?? definition.capabilities.typecheck,
+      endpoint: explicit.endpoint,
+      config: { ...definition.defaultConfig, ...explicit.config },
+    });
+  }
+  return resolved;
+}
+
+export function mergeConfig(
+  languageId: string,
+  enabled: ResolvedLanguageEnable | undefined,
+  override?: Record<string, unknown>,
+): Record<string, unknown> {
+  const definition = resolveLanguage(languageId);
+  return {
+    ...(definition?.defaultConfig ?? {}),
+    ...(enabled?.config ?? {}),
+    ...override,
+  };
+}
+
+export function enabledLanguageIds(): string[] {
+  return listLanguages().map((language) => language.id);
+}
+
+function normalizeBase(base: string): string {
+  if (base === "/" || base === "") {
+    return "/";
+  }
+  return base.endsWith("/") ? base : `${base}/`;
+}

--- a/npm/ox-content-code-play/src/escape.ts
+++ b/npm/ox-content-code-play/src/escape.ts
@@ -1,0 +1,29 @@
+export function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return "&#39;";
+    }
+  });
+}
+
+export function decodeHtml(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+export function escapeAttribute(value: string): string {
+  return escapeHtml(value).replace(/`/g, "&#96;");
+}

--- a/npm/ox-content-code-play/src/framework.ts
+++ b/npm/ox-content-code-play/src/framework.ts
@@ -1,0 +1,56 @@
+import { escapeHtml } from "./escape";
+import { PhaseTracker } from "./timing";
+import type { AdapterRequest, FrameworkId, RunResult } from "./types";
+
+const RUNTIMES: Record<FrameworkId, { specifier: string; cdn: string }> = {
+  vue: { specifier: "vue", cdn: "https://esm.sh/vue@3" },
+  react: { specifier: "react", cdn: "https://esm.sh/react@19" },
+  svelte: { specifier: "svelte", cdn: "https://esm.sh/svelte@5" },
+  solid: { specifier: "solid-js", cdn: "https://esm.sh/solid-js@1" },
+};
+
+export async function runFramework(request: AdapterRequest): Promise<RunResult> {
+  const tracker = new PhaseTracker();
+  tracker.start("compile", "Compile preview");
+  const framework = request.definition.framework ?? "vue";
+  const html = buildPreviewDocument(framework, request.code);
+  tracker.stop();
+  return {
+    status: "ok",
+    stdio: [],
+    diagnostics: [],
+    provenance: {
+      compile: { host: "local", runtime: `${framework}-preview` },
+      execute: { host: "iframe", runtime: framework, sandbox: "srcdoc" },
+    },
+    timing: tracker.report(),
+    preview: { kind: "html", html },
+  };
+}
+
+export function buildPreviewDocument(framework: FrameworkId, code: string): string {
+  const runtime = RUNTIMES[framework];
+  return `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>${escapeHtml(framework)} preview</title>
+  <script type="importmap">${JSON.stringify({ imports: { [runtime.specifier]: runtime.cdn } })}</script>
+  <style>html,body{margin:0;padding:1rem;font:14px/1.5 system-ui,sans-serif;}</style>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module">
+${indentPreview(code)}
+  </script>
+</body>
+</html>
+`;
+}
+
+function indentPreview(code: string): string {
+  return code
+    .split("\n")
+    .map((line) => `    ${line}`)
+    .join("\n");
+}

--- a/npm/ox-content-code-play/src/go.ts
+++ b/npm/ox-content-code-play/src/go.ts
@@ -1,0 +1,112 @@
+import { StdioBuffer } from "./stdio";
+import { PhaseTracker } from "./timing";
+import type { AdapterRequest, Diagnostic, RunResult } from "./types";
+
+interface GoPlaygroundEvent {
+  Message?: string;
+  Kind?: string;
+  Delay?: number;
+}
+
+interface GoPlaygroundResponse {
+  Errors?: string;
+  Events?: GoPlaygroundEvent[];
+  VetErrors?: string;
+}
+
+export async function runGo(
+  request: AdapterRequest,
+  mode: "execute" | "typecheck",
+): Promise<RunResult> {
+  const tracker = new PhaseTracker();
+  const stdio = new StdioBuffer(tracker.startedAt);
+  const params = new URLSearchParams({
+    version: "2",
+    body: request.code,
+    withVet: request.config.withVet === false ? "false" : "true",
+  });
+
+  tracker.start(
+    mode === "typecheck" ? "typecheck" : "compile",
+    mode === "typecheck" ? "Typecheck" : "Compile",
+  );
+  const response = await request.transport.request({
+    url: request.endpoints.go,
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params.toString(),
+  });
+  tracker.start("collect", "Collect output");
+
+  const parsed = parseResponse(response.text);
+  const diagnostics = [
+    ...parseGoErrors(parsed.Errors ?? "", "go"),
+    ...parseGoErrors(parsed.VetErrors ?? "", "vet"),
+  ];
+  for (const event of parsed.Events ?? []) {
+    const stream = event.Kind === "stderr" ? "stderr" : "stdout";
+    stdio.push(stream, event.Message ?? "");
+  }
+  if (parsed.Errors) {
+    stdio.push("stderr", parsed.Errors);
+  }
+
+  tracker.stop();
+  const failed = diagnostics.some((item) => item.severity === "error") || !response.ok;
+  return {
+    status: failed ? "error" : "ok",
+    stdio: stdio.snapshot(),
+    diagnostics,
+    provenance: {
+      compile: {
+        host: hostFromUrl(request.endpoints.go),
+        runtime: "go",
+      },
+      execute:
+        mode === "execute"
+          ? {
+              host: hostFromUrl(request.endpoints.go),
+              runtime: "go-playground",
+              sandbox: "playground",
+            }
+          : undefined,
+    },
+    timing: tracker.report(),
+  };
+}
+
+function parseResponse(text: string): GoPlaygroundResponse {
+  try {
+    return JSON.parse(text) as GoPlaygroundResponse;
+  } catch {
+    return { Errors: text };
+  }
+}
+
+export function parseGoErrors(output: string, source: string): Diagnostic[] {
+  if (!output.trim()) {
+    return [];
+  }
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const match = /^(?:prog\.go:)?(\d+)(?::(\d+))?:\s*(.*)$/.exec(line);
+      return {
+        message: match?.[3] ?? line,
+        severity: "error" as const,
+        line: match?.[1] ? Number(match[1]) : undefined,
+        column: match?.[2] ? Number(match[2]) : undefined,
+        source,
+      };
+    });
+}
+
+function hostFromUrl(url: string): string {
+  try {
+    return new URL(url, "https://code-play.local").host || url;
+  } catch {
+    return url;
+  }
+}

--- a/npm/ox-content-code-play/src/html.ts
+++ b/npm/ox-content-code-play/src/html.ts
@@ -1,0 +1,150 @@
+import { decodeHtml, escapeAttribute } from "./escape";
+import type { PlayPayload } from "./types";
+
+const COMMENT_PATTERN = /<!--ox-code-play:([A-Za-z0-9+/=]+)-->\s*(<pre\b[\s\S]*?<\/pre>)/gi;
+const CODEPLAY_TAG_PATTERN = /<CodePlay\b([^>]*)>([\s\S]*?)<\/CodePlay>/gi;
+const PRE_PATTERN = /<pre\b[^>]*>\s*<code\b([^>]*)>([\s\S]*?)<\/code>\s*<\/pre>/gi;
+
+export interface HtmlEnhanceOptions {
+  scriptSrc?: string;
+  decodePayload: (value: string) => PlayPayload;
+  encodePayload: (payload: PlayPayload) => string;
+  matchFences?: Array<{ language: string; code: string; payload: string }>;
+}
+
+export function enhancePlayHtml(html: string, options: HtmlEnhanceOptions): string {
+  let next = wrapCommentedBlocks(html, options);
+  next = upgradeCodePlayTags(next, options);
+  if (options.matchFences?.length) {
+    next = wrapMatchingFences(next, options.matchFences);
+  }
+  if (
+    options.scriptSrc &&
+    next.includes("data-ox-code-play") &&
+    !next.includes(options.scriptSrc)
+  ) {
+    next += `\n<script type="module" src="${escapeAttribute(options.scriptSrc)}"></script>\n`;
+  }
+  return next;
+}
+
+export function enhanceGeneratedModule(source: string, options: HtmlEnhanceOptions): string {
+  const marker = "export const html = ";
+  const start = source.indexOf(marker);
+  if (start === -1) {
+    return source;
+  }
+  const jsonStart = start + marker.length;
+  if (source[jsonStart] !== '"') {
+    return source;
+  }
+  const parsed = readJsonString(source, jsonStart);
+  if (!parsed) {
+    return source;
+  }
+  const enhanced = enhancePlayHtml(parsed.value, options);
+  return source.slice(0, jsonStart) + JSON.stringify(enhanced) + source.slice(parsed.end);
+}
+
+function wrapCommentedBlocks(html: string, options: HtmlEnhanceOptions): string {
+  return html.replace(COMMENT_PATTERN, (_all, payload: string, pre: string) => {
+    return wrapWidget(payload, pre);
+  });
+}
+
+function upgradeCodePlayTags(html: string, options: HtmlEnhanceOptions): string {
+  return html.replace(CODEPLAY_TAG_PATTERN, (all, attrs: string, body: string) => {
+    if (/\bdata-ox-code-play=/.test(all)) {
+      return all;
+    }
+    const language = readAttr(attrs, "lang") ?? readAttr(attrs, "language") ?? "text";
+    const code = decodeHtml(body).replace(/^\n/, "").replace(/\n$/, "");
+    const payload = options.encodePayload({
+      language,
+      code,
+      capabilities: { execute: true, typecheck: /\btypecheck\b/i.test(attrs) },
+      config: {},
+      viewers: { config: true, stdio: true, provenance: true, timing: true },
+      ui: "default",
+      timeoutMs: 10_000,
+    });
+    return wrapWidget(
+      payload,
+      `<pre><code class="language-${escapeAttribute(language)}">${body}</code></pre>`,
+    );
+  });
+}
+
+function wrapMatchingFences(
+  html: string,
+  matches: Array<{ language: string; code: string; payload: string }>,
+): string {
+  const unused = matches.map((item) => ({ ...item, used: false }));
+  return html.replace(PRE_PATTERN, (all, attrs: string, body: string) => {
+    const className = readAttr(attrs, "class") ?? "";
+    const language = className
+      .split(/\s+/)
+      .find((token) => token.startsWith("language-"))
+      ?.slice("language-".length);
+    const code = normalizeCode(decodeHtml(stripTags(body)));
+    const match = unused.find(
+      (item) =>
+        !item.used && aliasesEqual(item.language, language) && normalizeCode(item.code) === code,
+    );
+    if (!match) {
+      return all;
+    }
+    match.used = true;
+    return wrapWidget(match.payload, all);
+  });
+}
+
+function wrapWidget(payload: string, inner: string): string {
+  return `<ox-code-play data-ox-code-play="${escapeAttribute(payload)}">${inner}</ox-code-play>`;
+}
+
+function readJsonString(source: string, start: number): { value: string; end: number } | undefined {
+  try {
+    const raw = sliceJsonString(source, start);
+    return { value: JSON.parse(raw) as string, end: start + raw.length };
+  } catch {
+    return undefined;
+  }
+}
+
+function sliceJsonString(source: string, start: number): string {
+  let end = start + 1;
+  let escaped = false;
+  while (end < source.length) {
+    const char = source[end];
+    if (escaped) {
+      escaped = false;
+    } else if (char === "\\") {
+      escaped = true;
+    } else if (char === '"') {
+      return source.slice(start, end + 1);
+    }
+    end += 1;
+  }
+  throw new Error("Unterminated HTML JSON string.");
+}
+
+function readAttr(attrs: string, name: string): string | undefined {
+  const match = new RegExp(`(?:^|\\s)${name}\\s*=\\s*"([^"]+)"`, "i").exec(attrs);
+  return match?.[1];
+}
+
+function stripTags(value: string): string {
+  return value.replace(/<[^>]+>/g, "");
+}
+
+function normalizeCode(value: string): string {
+  return value.replace(/\r\n/g, "\n").replace(/\n$/, "");
+}
+
+function aliasesEqual(left: string | undefined, right: string | undefined): boolean {
+  if (!left || !right) {
+    return false;
+  }
+  return left.toLowerCase() === right.toLowerCase();
+}

--- a/npm/ox-content-code-play/src/hydrate.ts
+++ b/npm/ox-content-code-play/src/hydrate.ts
@@ -1,0 +1,191 @@
+import { createCodePlay, type CodePlayClient } from "./client";
+import { decodePayload, encodePayload } from "./payload";
+import { CODE_PLAY_STYLES } from "./styles";
+import { renderPlayUi } from "./ui";
+import type { PlayPayload, RunResult } from "./types";
+import {
+  renderDiagnosticsHtml,
+  renderProvenanceHtml,
+  renderStdioHtml,
+  renderTimingHtml,
+} from "./viewers";
+
+export interface HydrateOptions {
+  client?: CodePlayClient;
+  root?: ParentNode;
+}
+
+const STYLE_ID = "ox-code-play-styles";
+
+export function hydrateCodePlay(
+  root: ParentNode = defaultRoot(),
+  options: HydrateOptions = {},
+): void {
+  ensureStyles();
+  const client = options.client ?? createCodePlayFromPayloads(root);
+  for (const element of queryWidgets(root)) {
+    mountCodePlay(element, { client });
+  }
+}
+
+export function mountCodePlay(element: Element, options: { client?: CodePlayClient } = {}): void {
+  if (!(element instanceof HTMLElement) || element.dataset.oxCodePlayMounted === "true") {
+    return;
+  }
+  const payload = decodePayload(element.getAttribute("data-ox-code-play") ?? "");
+  if (payload.ui === "headless") {
+    return;
+  }
+  const client =
+    options.client ??
+    createCodePlay({
+      languages: { [payload.language]: true },
+      endpoints: payload.endpoints,
+    });
+  const source = element.innerHTML;
+  const ui = document.createElement("div");
+  ui.innerHTML = renderPlayUi({ payload });
+  const widget = ui.firstElementChild;
+  if (!widget) {
+    return;
+  }
+  const sourceSlot = widget.querySelector(".ox-code-play__source");
+  if (sourceSlot) {
+    sourceSlot.innerHTML = source;
+  }
+  element.replaceChildren(widget);
+  element.dataset.oxCodePlayMounted = "true";
+  bindWidget(element, payload, client);
+}
+
+function bindWidget(element: HTMLElement, payload: PlayPayload, client: CodePlayClient): void {
+  let current = payload;
+  const session = client.createSession({
+    language: payload.language,
+    code: payload.code,
+    config: payload.config,
+  });
+  const runButton = element.querySelector<HTMLButtonElement>('[data-ox-action="run"]');
+  const checkButton = element.querySelector<HTMLButtonElement>('[data-ox-action="typecheck"]');
+  runButton?.addEventListener("click", () => void run("execute"));
+  checkButton?.addEventListener("click", () => void run("typecheck"));
+  element.addEventListener("click", (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+    const panel = target.dataset.oxPanel;
+    if (panel) {
+      showPanel(element, panel);
+    }
+  });
+  element.addEventListener("change", (event) => {
+    const form = (event.target as HTMLElement | null)?.closest("form");
+    if (!form) {
+      return;
+    }
+    session.setConfig(readForm(form));
+    current = { ...current, config: session.config };
+  });
+
+  async function run(action: "execute" | "typecheck"): Promise<void> {
+    setBusy(element, true);
+    const result = action === "typecheck" ? await session.typecheck() : await session.run();
+    paintResult(element, current, result);
+    setBusy(element, false);
+  }
+}
+
+function paintResult(element: HTMLElement, _payload: PlayPayload, result: RunResult): void {
+  const stdio = element.querySelector('[data-panel="stdio"]');
+  if (stdio) {
+    stdio.innerHTML = `${renderDiagnosticsHtml(result)}${renderStdioHtml(result.stdio)}`;
+    if (result.preview) {
+      const frame = document.createElement("iframe");
+      frame.setAttribute("sandbox", "allow-scripts");
+      frame.srcdoc = result.preview.html;
+      frame.title = "Code Play preview";
+      frame.style.width = "100%";
+      frame.style.minHeight = "12rem";
+      frame.style.border = "0";
+      stdio.append(frame);
+    }
+  }
+  const provenance = element.querySelector('[data-panel="provenance"]');
+  if (provenance) {
+    provenance.innerHTML = renderProvenanceHtml(result.provenance);
+  }
+  const timing = element.querySelector('[data-panel="timing"]');
+  if (timing) {
+    timing.innerHTML = renderTimingHtml(result.timing);
+  }
+  showPanel(element, "stdio");
+}
+
+function showPanel(element: HTMLElement, panel: string): void {
+  for (const tab of element.querySelectorAll("[data-ox-panel]")) {
+    tab.setAttribute(
+      "aria-selected",
+      tab.getAttribute("data-ox-panel") === panel ? "true" : "false",
+    );
+  }
+  for (const node of element.querySelectorAll<HTMLElement>(".ox-code-play__panel")) {
+    node.hidden = node.dataset.panel !== panel;
+  }
+}
+
+function setBusy(element: HTMLElement, busy: boolean): void {
+  for (const button of element.querySelectorAll("button[data-ox-action]")) {
+    (button as HTMLButtonElement).disabled = busy;
+  }
+}
+
+function readForm(form: HTMLFormElement): Record<string, unknown> {
+  const data = new FormData(form);
+  const config: Record<string, unknown> = {};
+  for (const [key, value] of data.entries()) {
+    config[key] = value === "on" ? true : value;
+  }
+  for (const input of form.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')) {
+    config[input.name] = input.checked;
+  }
+  return config;
+}
+
+function createCodePlayFromPayloads(root: ParentNode) {
+  const languages: Record<string, true> = {};
+  let endpoints;
+  for (const element of queryWidgets(root)) {
+    try {
+      const payload = decodePayload(element.getAttribute("data-ox-code-play") ?? "");
+      languages[payload.language] = true;
+      endpoints = payload.endpoints ?? endpoints;
+    } catch {
+      // Ignore malformed widgets so one bad payload cannot block the page.
+    }
+  }
+  return createCodePlay({ languages, endpoints });
+}
+
+function queryWidgets(root: ParentNode): HTMLElement[] {
+  return [...root.querySelectorAll<HTMLElement>("[data-ox-code-play]")];
+}
+
+function ensureStyles(): void {
+  if (typeof document === "undefined" || document.getElementById(STYLE_ID)) {
+    return;
+  }
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = CODE_PLAY_STYLES;
+  document.head.append(style);
+}
+
+function defaultRoot(): ParentNode {
+  if (typeof document === "undefined") {
+    throw new Error("hydrateCodePlay() needs a DOM root.");
+  }
+  return document;
+}
+
+export { encodePayload, decodePayload };

--- a/npm/ox-content-code-play/src/index.ts
+++ b/npm/ox-content-code-play/src/index.ts
@@ -1,0 +1,43 @@
+/**
+ * `@ox-content/code-play` — opt-in on-demand sample execution for Ox Content.
+ *
+ * @packageDocumentation
+ */
+
+export { createCodePlay } from "./client";
+export type { CodePlayClient, CodePlayClientOptions } from "./client";
+export { listLanguages, resolveLanguage, LANGUAGE_CATALOG } from "./catalog";
+export { resolveCodePlayOptions, DEFAULT_ENDPOINTS, DEFAULT_VIEWERS } from "./config";
+export type { RawCodePlayOptions, ResolvedCodePlayOptions } from "./config";
+export { codePlay } from "./plugin";
+export type { CodePlayPluginOptions } from "./plugin";
+export { CodePlaySession } from "./session";
+export { createFetchTransport, createMemoryTransport } from "./transport";
+export { hydrateCodePlay, mountCodePlay } from "./hydrate";
+export { renderPlayUi } from "./ui";
+export {
+  renderConfigHtml,
+  renderDiagnosticsHtml,
+  renderProvenanceHtml,
+  renderStdioHtml,
+  renderTimingHtml,
+} from "./viewers";
+export { parsePlayFences, parseCodePlayTags, rewritePlayFences, stripPlayMeta } from "./markdown";
+export { enhancePlayHtml, enhanceGeneratedModule } from "./html";
+export { encodePayload, decodePayload } from "./payload";
+export { PhaseTracker } from "./timing";
+export { CODE_PLAY_STYLES } from "./styles";
+export type {
+  CodePlayPreset,
+  ConfigField,
+  Diagnostic,
+  LanguageDefinition,
+  LanguageEnable,
+  PlayPayload,
+  Provenance,
+  RunResult,
+  SessionInput,
+  StdioEvent,
+  TimingReport,
+  ViewerFlags,
+} from "./types";

--- a/npm/ox-content-code-play/src/javascript.ts
+++ b/npm/ox-content-code-play/src/javascript.ts
@@ -1,0 +1,89 @@
+import { formatConsoleArgs, StdioBuffer } from "./stdio";
+import { nowMs, PhaseTracker } from "./timing";
+import type { AdapterRequest, Diagnostic, RunResult } from "./types";
+
+export async function runJavaScript(request: AdapterRequest): Promise<RunResult> {
+  const tracker = new PhaseTracker();
+  tracker.start("execute", "Execute");
+  const stdio = new StdioBuffer(tracker.startedAt);
+  const provenance = {
+    execute: {
+      host: "local",
+      runtime: hasNodeVm() ? "node:vm" : "function",
+      sandbox: hasNodeVm() ? "vm" : "function",
+    },
+  };
+
+  try {
+    const value = await executeScript(request.code, request.timeoutMs, stdio);
+    tracker.stop();
+    return {
+      status: "ok",
+      stdio: stdio.snapshot(),
+      diagnostics: [],
+      provenance,
+      timing: tracker.report(),
+      value: value === undefined ? undefined : String(value),
+    };
+  } catch (error) {
+    tracker.stop();
+    const diagnostic = toDiagnostic(error);
+    stdio.push("stderr", `${diagnostic.message}\n`);
+    return {
+      status: isTimeout(error) ? "timeout" : "error",
+      stdio: stdio.snapshot(),
+      diagnostics: [diagnostic],
+      provenance,
+      timing: tracker.report(),
+    };
+  }
+}
+
+export async function executeScript(
+  code: string,
+  timeoutMs: number,
+  stdio: StdioBuffer,
+): Promise<unknown> {
+  const consoleLike = {
+    log: (...args: unknown[]) => stdio.push("stdout", formatConsoleArgs(args)),
+    info: (...args: unknown[]) => stdio.push("stdout", formatConsoleArgs(args)),
+    warn: (...args: unknown[]) => stdio.push("stderr", formatConsoleArgs(args)),
+    error: (...args: unknown[]) => stdio.push("stderr", formatConsoleArgs(args)),
+  };
+
+  if (hasNodeVm()) {
+    const vm = await import("node:vm");
+    const context = vm.createContext({ console: consoleLike });
+    return vm.runInContext(code, context, { timeout: timeoutMs, displayErrors: true });
+  }
+
+  const started = nowMs();
+  const run = new Function("console", `"use strict";\n${code}`);
+  const value = run(consoleLike);
+  if (nowMs() - started > timeoutMs) {
+    throw Object.assign(new Error("JavaScript execution timed out."), {
+      code: "ERR_SCRIPT_EXECUTION_TIMEOUT",
+    });
+  }
+  return value;
+}
+
+function hasNodeVm(): boolean {
+  return typeof process !== "undefined" && Boolean(process.versions?.node);
+}
+
+function isTimeout(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    error.code === "ERR_SCRIPT_EXECUTION_TIMEOUT",
+  );
+}
+
+function toDiagnostic(error: unknown): Diagnostic {
+  if (error instanceof Error) {
+    return { message: error.message, severity: "error", source: "javascript" };
+  }
+  return { message: String(error), severity: "error", source: "javascript" };
+}

--- a/npm/ox-content-code-play/src/markdown.test.ts
+++ b/npm/ox-content-code-play/src/markdown.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vite-plus/test";
+import { enhanceGeneratedModule, enhancePlayHtml } from "./html";
+import { parseCodePlayTags, parsePlayFences, rewritePlayFences, stripPlayMeta } from "./markdown";
+import { decodePayload, encodePayload } from "./payload";
+import { payloadFromFence } from "./payload-factory";
+import { resolveCodePlayOptions } from "./config";
+import {
+  renderConfigHtml,
+  renderProvenanceHtml,
+  renderStdioHtml,
+  renderTimingHtml,
+} from "./viewers";
+import { renderPlayUi } from "./ui";
+
+describe("markdown and viewers", () => {
+  it("parses only top-level play fences and leaves nested examples alone", () => {
+    const source = [
+      "````md",
+      "```ts play",
+      "const nested = 1;",
+      "```",
+      "````",
+      "",
+      '```ts play typecheck annotate="highlight:1"',
+      "const live = 1;",
+      "```",
+    ].join("\n");
+    const fences = parsePlayFences(source);
+    expect(fences).toHaveLength(1);
+    expect(fences[0]?.code).toBe("const live = 1;");
+    expect(fences[0]?.typecheck).toBe(true);
+    expect(stripPlayMeta(fences[0]?.meta ?? "")).toBe('annotate="highlight:1"');
+  });
+
+  it("rewrites play fences to comments and parses CodePlay tags", () => {
+    const options = resolveCodePlayOptions({ languages: { typescript: true } });
+    const rewritten = rewritePlayFences("```ts play\nconst n = 1;\n```", (fence) =>
+      encodePayload(payloadFromFence(fence, options)),
+    );
+    expect(rewritten).toContain("<!--ox-code-play:");
+    expect(rewritten).toContain("```ts\nconst n = 1;\n```");
+
+    const tags = parseCodePlayTags(`<CodePlay lang="python" typecheck>\nprint(1)\n</CodePlay>`);
+    expect(tags[0]).toMatchObject({ language: "python", typecheck: true, code: "print(1)" });
+  });
+
+  it("wraps commented pre blocks and matching SSG fences in HTML", () => {
+    const options = resolveCodePlayOptions({ languages: { javascript: true } });
+    const payload = encodePayload(
+      payloadFromFence(
+        {
+          language: "js",
+          meta: "play",
+          code: "console.log(1)",
+          raw: "",
+          start: 0,
+          end: 0,
+          typecheck: false,
+        },
+        options,
+      ),
+    );
+    const commented = enhancePlayHtml(
+      `<!--ox-code-play:${payload}-->\n<pre><code class="language-js">console.log(1)</code></pre>`,
+      {
+        decodePayload,
+        encodePayload,
+        scriptSrc: "/ox-code-play.js",
+      },
+    );
+    expect(commented).toContain("<ox-code-play data-ox-code-play=");
+    expect(commented).toContain("/ox-code-play.js");
+
+    const matched = enhancePlayHtml(`<pre><code class="language-js">console.log(1)</code></pre>`, {
+      decodePayload,
+      encodePayload,
+      matchFences: [{ language: "js", code: "console.log(1)", payload }],
+    });
+    expect(matched).toContain("data-ox-code-play");
+
+    const moduleSource = `export const html = ${JSON.stringify(`<!--ox-code-play:${payload}--><pre><code>x</code></pre>`)};`;
+    expect(enhanceGeneratedModule(moduleSource, { decodePayload, encodePayload })).toContain(
+      "ox-code-play",
+    );
+  });
+
+  it("renders config, stdio, provenance, and timing viewers", () => {
+    expect(
+      renderStdioHtml([
+        { stream: "stdout", text: "ok\n", timestampMs: 1.2 },
+        { stream: "stderr", text: "bad\n", timestampMs: 3 },
+      ]),
+    ).toContain("stdout +1.2ms");
+    expect(
+      renderConfigHtml([{ key: "strict", label: "Strict", type: "boolean", default: true }], {
+        strict: true,
+      }),
+    ).toContain('name="strict"');
+    expect(
+      renderProvenanceHtml({
+        compile: { host: "play.rust-lang.org", runtime: "rustc", version: "stable" },
+        execute: { host: "play.rust-lang.org", runtime: "rust-playground", sandbox: "playground" },
+      }),
+    ).toMatch(/Compiled[\s\S]*play\.rust-lang\.org/);
+    expect(
+      renderTimingHtml({
+        totalMs: 10,
+        phases: [{ id: "compile", label: "Compile", startMs: 0, durationMs: 4 }],
+      }),
+    ).toContain("Total 10.0ms");
+    expect(
+      renderPlayUi({
+        payload: {
+          language: "typescript",
+          code: "const n = 1;",
+          capabilities: { execute: true, typecheck: true },
+          config: { strict: true },
+          viewers: { config: true, stdio: true, provenance: true, timing: true },
+          ui: "default",
+          timeoutMs: 1000,
+        },
+      }),
+    ).toContain("Typecheck");
+  });
+
+  it("decodes the same payload it encodes", () => {
+    const payload = {
+      language: "go",
+      code: "package main",
+      capabilities: { execute: true, typecheck: true },
+      config: { withVet: true },
+      viewers: { config: true, stdio: true, provenance: true, timing: true },
+      ui: "compact" as const,
+      timeoutMs: 5,
+    };
+    expect(decodePayload(encodePayload(payload))).toEqual(payload);
+  });
+});

--- a/npm/ox-content-code-play/src/markdown.ts
+++ b/npm/ox-content-code-play/src/markdown.ts
@@ -1,0 +1,169 @@
+export interface PlayFence {
+  language: string;
+  meta: string;
+  code: string;
+  raw: string;
+  start: number;
+  end: number;
+  typecheck: boolean;
+}
+
+export interface ParsedFence {
+  language: string;
+  meta: string;
+  code: string;
+  raw: string;
+  start: number;
+  end: number;
+  indent: string;
+  marker: string;
+}
+
+const FENCE_OPEN = /^( {0,3})(`{3,}|~{3,})([^\n]*)$/;
+
+export function parseTopLevelFences(source: string): ParsedFence[] {
+  const lines = source.split("\n");
+  const fences: ParsedFence[] = [];
+  let index = 0;
+  let offset = 0;
+
+  while (index < lines.length) {
+    const line = lines[index] ?? "";
+    const open = FENCE_OPEN.exec(line);
+    if (!open) {
+      offset += line.length + 1;
+      index += 1;
+      continue;
+    }
+
+    const indent = open[1] ?? "";
+    const marker = open[2] ?? "```";
+    const info = (open[3] ?? "").trim();
+    const [language = "", ...metaParts] = splitInfo(info);
+    const start = offset;
+    index += 1;
+    offset += line.length + 1;
+    const body: string[] = [];
+
+    while (index < lines.length) {
+      const candidate = lines[index] ?? "";
+      const close = new RegExp(`^ {0,3}${escapeRegExp(marker)}[ \t]*$`).exec(candidate);
+      if (close) {
+        const raw = `${line}\n${body.join("\n")}${body.length > 0 ? "\n" : ""}${candidate}`;
+        fences.push({
+          language,
+          meta: metaParts.join(" "),
+          code: body.join("\n"),
+          raw,
+          start,
+          end: start + raw.length,
+          indent,
+          marker,
+        });
+        offset += candidate.length + 1;
+        index += 1;
+        break;
+      }
+      body.push(candidate);
+      offset += candidate.length + 1;
+      index += 1;
+    }
+  }
+
+  return fences;
+}
+
+export function parsePlayFences(source: string): PlayFence[] {
+  return parseTopLevelFences(source)
+    .filter((fence) => hasToken(fence.meta, "play"))
+    .map((fence) => ({
+      language: fence.language,
+      meta: fence.meta,
+      code: fence.code,
+      raw: fence.raw,
+      start: fence.start,
+      end: fence.end,
+      typecheck: hasToken(fence.meta, "typecheck"),
+    }));
+}
+
+export function stripPlayMeta(meta: string): string {
+  return meta
+    .split(/\s+/)
+    .filter(
+      (token) => token && token !== "play" && token !== "typecheck" && !token.startsWith("play-"),
+    )
+    .join(" ");
+}
+
+export function rewritePlayFences(
+  source: string,
+  encode: (fence: PlayFence) => string | null,
+): string {
+  const fences = parsePlayFences(source);
+  if (fences.length === 0) {
+    return source;
+  }
+
+  let cursor = 0;
+  let output = "";
+  for (const fence of fences) {
+    output += source.slice(cursor, fence.start);
+    const encoded = encode(fence);
+    if (encoded === null) {
+      output += source.slice(fence.start, fence.end);
+    } else {
+      const cleanedMeta = stripPlayMeta(fence.meta);
+      const info = [fence.language, cleanedMeta].filter(Boolean).join(" ");
+      output += `<!--ox-code-play:${encoded}-->\n\`\`\`${info}\n${fence.code}\n\`\`\``;
+    }
+    cursor = fence.end;
+  }
+  output += source.slice(cursor);
+  return output;
+}
+
+export function parseCodePlayTags(source: string): PlayFence[] {
+  const tags: PlayFence[] = [];
+  const pattern = /<CodePlay\b([^>]*)>([\s\S]*?)<\/CodePlay>/gi;
+  for (const match of source.matchAll(pattern)) {
+    const attrs = match[1] ?? "";
+    const language = readAttr(attrs, "lang") ?? readAttr(attrs, "language") ?? "text";
+    tags.push({
+      language,
+      meta: "play",
+      code: stripIndent((match[2] ?? "").replace(/^\n/, "").replace(/\n$/, "")),
+      raw: match[0] ?? "",
+      start: match.index ?? 0,
+      end: (match.index ?? 0) + (match[0]?.length ?? 0),
+      typecheck: /\btypecheck\b/i.test(attrs),
+    });
+  }
+  return tags;
+}
+
+function splitInfo(info: string): string[] {
+  return info.trim().split(/\s+/).filter(Boolean);
+}
+
+function hasToken(meta: string, token: string): boolean {
+  return meta.split(/\s+/).includes(token);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function readAttr(attrs: string, name: string): string | undefined {
+  const match = new RegExp(`(?:^|\\s)${name}\\s*=\\s*"([^"]+)"`, "i").exec(attrs);
+  return match?.[1];
+}
+
+function stripIndent(value: string): string {
+  const lines = value.split("\n");
+  const indents = lines
+    .filter((line) => line.trim())
+    .map((line) => line.match(/^ */)?.[0].length ?? 0);
+  const indent = indents.length > 0 ? Math.min(...indents) : 0;
+  return lines.map((line) => line.slice(indent)).join("\n");
+}

--- a/npm/ox-content-code-play/src/payload-factory.ts
+++ b/npm/ox-content-code-play/src/payload-factory.ts
@@ -1,0 +1,22 @@
+import { resolveLanguage } from "./catalog";
+import type { ResolvedCodePlayOptions } from "./config";
+import type { PlayFence } from "./markdown";
+import type { PlayPayload } from "./types";
+
+export function payloadFromFence(fence: PlayFence, options: ResolvedCodePlayOptions): PlayPayload {
+  const definition = resolveLanguage(fence.language);
+  const enabled = definition ? options.languages.get(definition.id) : undefined;
+  return {
+    language: definition?.id ?? fence.language,
+    code: fence.code,
+    capabilities: {
+      execute: enabled?.execute ?? Boolean(definition?.capabilities.execute),
+      typecheck: fence.typecheck || (enabled?.typecheck ?? false),
+    },
+    config: { ...(definition?.defaultConfig ?? {}), ...(enabled?.config ?? {}) },
+    viewers: options.viewers,
+    ui: options.ui,
+    timeoutMs: options.timeoutMs,
+    endpoints: options.endpoints,
+  };
+}

--- a/npm/ox-content-code-play/src/payload.ts
+++ b/npm/ox-content-code-play/src/payload.ts
@@ -1,0 +1,37 @@
+import type { PlayPayload } from "./types";
+
+export function encodePayload(payload: PlayPayload): string {
+  return bytesToBase64(new TextEncoder().encode(JSON.stringify(payload)));
+}
+
+export function decodePayload(value: string): PlayPayload {
+  const json = new TextDecoder().decode(base64ToBytes(value));
+  const parsed = JSON.parse(json) as PlayPayload;
+  if (!parsed || typeof parsed !== "object" || typeof parsed.language !== "string") {
+    throw new Error("Invalid Code Play payload.");
+  }
+  return parsed;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(bytes).toString("base64");
+  }
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  if (typeof Buffer !== "undefined") {
+    return new Uint8Array(Buffer.from(value, "base64"));
+  }
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}

--- a/npm/ox-content-code-play/src/plugin-proxy.ts
+++ b/npm/ox-content-code-play/src/plugin-proxy.ts
@@ -1,0 +1,51 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+export async function typecheckProxy(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  try {
+    const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+      language?: string;
+      code?: string;
+      config?: Record<string, unknown>;
+    };
+    const { createCodePlay } = await import("./client");
+    const language = body.language ?? "typescript";
+    const play = createCodePlay({ languages: { [language]: true } });
+    const result = await play
+      .createSession({ language, code: body.code ?? "", config: body.config })
+      .typecheck();
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.end(JSON.stringify(result));
+  } catch (error) {
+    res.statusCode = 400;
+    res.end(error instanceof Error ? error.message : "Typecheck failed.");
+  }
+}
+
+export async function proxy(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: string,
+  contentType: string,
+): Promise<void> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": contentType },
+      body: Buffer.concat(chunks),
+    });
+    res.statusCode = response.status;
+    res.setHeader("Content-Type", response.headers.get("content-type") ?? "application/json");
+    res.end(await response.text());
+  } catch (error) {
+    res.statusCode = 502;
+    res.end(error instanceof Error ? error.message : "Code Play proxy failed.");
+  }
+}

--- a/npm/ox-content-code-play/src/plugin.test.ts
+++ b/npm/ox-content-code-play/src/plugin.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vite-plus/test";
+import { codePlay } from "./plugin";
+
+describe("codePlay vite plugin", () => {
+  it("is inert until languages are enabled and rewrites only those fences", () => {
+    const plugin = codePlay({ languages: { typescript: true } });
+    expect(plugin.name).toBe("@ox-content/code-play");
+    const transform = hookFn(plugin.transform) as (code: string, id: string) => string | null;
+    expect(transform("```ts play\nconst n = 1;\n```\n", "page.md")).toContain("<!--ox-code-play:");
+    expect(transform("```python play\nprint(1)\n```\n", "page.md")).toBeNull();
+  });
+
+  it("exposes a virtual client module id", () => {
+    const plugin = codePlay();
+    const resolveId = hookFn(plugin.resolveId) as (id: string) => string | null;
+    expect(resolveId("virtual:ox-content/code-play")).toBe("\0virtual:ox-content/code-play");
+  });
+});
+
+function hookFn(hook: unknown): (...args: never[]) => unknown {
+  if (typeof hook === "function") {
+    return hook as (...args: never[]) => unknown;
+  }
+  if (hook && typeof hook === "object" && "handler" in hook && typeof hook.handler === "function") {
+    return hook.handler as (...args: never[]) => unknown;
+  }
+  throw new Error("expected a plugin hook");
+}

--- a/npm/ox-content-code-play/src/plugin.ts
+++ b/npm/ox-content-code-play/src/plugin.ts
@@ -1,0 +1,317 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Plugin, ViteDevServer } from "vite";
+import { resolveLanguage } from "./catalog";
+import {
+  resolveCodePlayOptions,
+  type RawCodePlayOptions,
+  type ResolvedCodePlayOptions,
+} from "./config";
+import { enhanceGeneratedModule, enhancePlayHtml } from "./html";
+import { parseCodePlayTags, parsePlayFences, rewritePlayFences } from "./markdown";
+import { decodePayload, encodePayload } from "./payload";
+import { payloadFromFence } from "./payload-factory";
+import { proxy, typecheckProxy } from "./plugin-proxy";
+
+export type CodePlayPluginOptions = RawCodePlayOptions;
+
+const VIRTUAL_ID = "virtual:ox-content/code-play";
+const RESOLVED_VIRTUAL = `\0${VIRTUAL_ID}`;
+const MARKDOWN_RE = /\.(?:md|markdown|mdx)(?:$|\?)/i;
+
+export function codePlay(options: CodePlayPluginOptions = {}): Plugin {
+  const resolved = resolveCodePlayOptions({
+    ...options,
+    endpoints: {
+      ...options.endpoints,
+      typecheck: options.endpoints?.typecheck ?? "/__ox-code-play/typecheck",
+    },
+  });
+  let base = resolved.base;
+  let command: "build" | "serve" = "serve";
+  let outDir = resolved.outDir;
+  let root = process.cwd();
+
+  const enhanceOptions = (
+    matchFences?: Array<{ language: string; code: string; payload: string }>,
+  ) => ({
+    scriptSrc: `${base}ox-code-play.js`,
+    decodePayload,
+    encodePayload,
+    matchFences,
+  });
+
+  return {
+    name: "@ox-content/code-play",
+
+    configResolved(config) {
+      command = config.command;
+      root = config.root;
+      base = resolved.base === "/" ? normalizeBase(config.base) : resolved.base;
+      outDir = resolved.outDir ?? config.build.outDir;
+    },
+
+    resolveId(id) {
+      return id === VIRTUAL_ID ? RESOLVED_VIRTUAL : null;
+    },
+
+    load(id) {
+      if (id !== RESOLVED_VIRTUAL) {
+        return null;
+      }
+      return `export { hydrateCodePlay, mountCodePlay } from ${JSON.stringify(resolveHydrateSpecifier())};`;
+    },
+
+    transform(code, id) {
+      if (!MARKDOWN_RE.test(id)) {
+        if (code.includes("export const html = ") && code.includes("ox-code-play:")) {
+          return enhanceGeneratedModule(code, enhanceOptions());
+        }
+        return null;
+      }
+      const rewritten = rewritePlayFences(code, (fence) => {
+        const definition = resolveLanguage(fence.language);
+        if (!definition || !resolved.languages.has(definition.id)) {
+          return null;
+        }
+        return encodePayload(payloadFromFence(fence, resolved));
+      });
+      return rewritten === code ? null : rewritten;
+    },
+
+    configureServer(server) {
+      if (resolved.proxy) {
+        mountProxies(server, resolved.endpoints.rust, resolved.endpoints.go);
+      }
+      server.middlewares.use(async (req, res, next) => {
+        const urlPath = req.url?.split("?")[0] ?? "";
+        if (urlPath === `${base}ox-code-play.js`.replace(/\/{2,}/g, "/")) {
+          const file = resolveClientFile();
+          if (!file) {
+            return next();
+          }
+          res.setHeader("Content-Type", "text/javascript; charset=utf-8");
+          res.end(await readFile(file, "utf8"));
+          return;
+        }
+        interceptHtml(res, (html) =>
+          enhanceHtmlForUrl(urlPath, html, root, resolved, enhanceOptions),
+        );
+        next();
+      });
+    },
+
+    async generateBundle() {
+      const file = resolveClientFile();
+      if (!file || command !== "build") {
+        return;
+      }
+      this.emitFile({
+        type: "asset",
+        fileName: "ox-code-play.js",
+        source: await readFile(file, "utf8"),
+      });
+    },
+
+    async closeBundle() {
+      if (command !== "build") {
+        return;
+      }
+      const srcDir = path.resolve(root, resolved.srcDir ?? "docs");
+      const destination = path.resolve(root, outDir ?? "dist");
+      if (!existsSync(srcDir) || !existsSync(destination)) {
+        return;
+      }
+      await enhanceWrittenPages(srcDir, destination, resolved, enhanceOptions);
+    },
+  };
+}
+
+function interceptHtml(
+  res: import("node:http").ServerResponse,
+  enhance: (html: string) => string | undefined,
+): void {
+  const originalEnd = res.end.bind(res);
+  res.end = ((chunk?: unknown, encoding?: BufferEncoding | (() => void), cb?: () => void) => {
+    const html =
+      typeof chunk === "string"
+        ? chunk
+        : Buffer.isBuffer(chunk)
+          ? chunk.toString("utf8")
+          : undefined;
+    const type = String(res.getHeader("content-type") ?? "");
+    if (html && (type.includes("html") || html.includes("<pre"))) {
+      const next = enhance(html);
+      if (next && next !== html) {
+        if (typeof encoding === "function") {
+          return originalEnd(next, encoding);
+        }
+        return originalEnd(next, encoding ?? "utf8", cb);
+      }
+    }
+    if (typeof encoding === "function") {
+      return originalEnd(chunk as never, encoding);
+    }
+    return originalEnd(chunk as never, encoding ?? "utf8", cb);
+  }) as typeof res.end;
+}
+
+function enhanceHtmlForUrl(
+  urlPath: string,
+  html: string,
+  root: string,
+  resolved: ResolvedCodePlayOptions,
+  enhance: (matchFences?: Array<{ language: string; code: string; payload: string }>) => {
+    scriptSrc: string;
+    decodePayload: typeof decodePayload;
+    encodePayload: typeof encodePayload;
+    matchFences?: Array<{ language: string; code: string; payload: string }>;
+  },
+): string | undefined {
+  const markdownPath = urlToMarkdown(urlPath, root, resolved.srcDir ?? "docs", resolved.base);
+  if (!markdownPath || !existsSync(markdownPath)) {
+    return undefined;
+  }
+  const source = readFileSync(markdownPath, "utf8");
+  const fences = [...parsePlayFences(source), ...parseCodePlayTags(source)].filter((fence) => {
+    const definition = resolveLanguage(fence.language);
+    return Boolean(definition && resolved.languages.has(definition.id));
+  });
+  if (fences.length === 0) {
+    return undefined;
+  }
+  return enhancePlayHtml(
+    html,
+    enhance(
+      fences.map((fence) => ({
+        language: fence.language,
+        code: fence.code,
+        payload: encodePayload(payloadFromFence(fence, resolved)),
+      })),
+    ),
+  );
+}
+
+function urlToMarkdown(
+  urlPath: string,
+  root: string,
+  srcDir: string,
+  base: string,
+): string | undefined {
+  let relative = urlPath;
+  if (base !== "/" && relative.startsWith(base)) {
+    relative = relative.slice(base.length);
+  }
+  relative = relative.replace(/^\//, "").replace(/\.html$/, "");
+  if (!relative || relative.includes("..")) {
+    return undefined;
+  }
+  const candidates = [
+    path.resolve(root, srcDir, `${relative}.md`),
+    path.resolve(root, srcDir, relative, "index.md"),
+  ];
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+function mountProxies(server: ViteDevServer, rustUrl: string, goUrl: string): void {
+  server.middlewares.use("/__ox-code-play/rust", (req, res) => {
+    void proxy(req, res, rustUrl, "application/json");
+  });
+  server.middlewares.use("/__ox-code-play/go", (req, res) => {
+    void proxy(req, res, goUrl, "application/x-www-form-urlencoded");
+  });
+  server.middlewares.use("/__ox-code-play/typecheck", (req, res) => {
+    void typecheckProxy(req, res);
+  });
+}
+
+async function enhanceWrittenPages(
+  srcDir: string,
+  outDir: string,
+  resolved: ResolvedCodePlayOptions,
+  enhance: (matchFences?: Array<{ language: string; code: string; payload: string }>) => {
+    scriptSrc: string;
+    decodePayload: typeof decodePayload;
+    encodePayload: typeof encodePayload;
+    matchFences?: Array<{ language: string; code: string; payload: string }>;
+  },
+): Promise<void> {
+  for (const file of walkFiles(srcDir)) {
+    if (!MARKDOWN_RE.test(file)) {
+      continue;
+    }
+    const source = await readFile(file, "utf8");
+    const fences = [...parsePlayFences(source), ...parseCodePlayTags(source)].filter((fence) => {
+      const definition = resolveLanguage(fence.language);
+      return Boolean(definition && resolved.languages.has(definition.id));
+    });
+    if (fences.length === 0) {
+      continue;
+    }
+    const htmlPath = guessHtmlPath(file, srcDir, outDir);
+    if (!htmlPath || !existsSync(htmlPath)) {
+      continue;
+    }
+    const html = await readFile(htmlPath, "utf8");
+    const enhanced = enhancePlayHtml(
+      html,
+      enhance(
+        fences.map((fence) => ({
+          language: fence.language,
+          code: fence.code,
+          payload: encodePayload(payloadFromFence(fence, resolved)),
+        })),
+      ),
+    );
+    if (enhanced !== html) {
+      await writeFile(htmlPath, enhanced);
+    }
+  }
+}
+
+function guessHtmlPath(file: string, srcDir: string, outDir: string): string | undefined {
+  const relative = path.relative(srcDir, file).replace(/\.(?:md|markdown|mdx)$/i, "");
+  const candidates = [
+    path.join(outDir, `${relative}.html`),
+    path.join(outDir, relative, "index.html"),
+  ];
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+function walkFiles(dir: string): string[] {
+  const entries = readdirSync(dir);
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      files.push(...walkFiles(full));
+    } else {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function resolveClientFile(): string | undefined {
+  const candidates = [
+    fileURLToPath(new URL("./hydrate.mjs", import.meta.url)),
+    fileURLToPath(new URL("./hydrate.js", import.meta.url)),
+  ];
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+function resolveHydrateSpecifier(): string {
+  return resolveClientFile() ?? fileURLToPath(new URL("./hydrate.ts", import.meta.url));
+}
+
+function normalizeBase(base: string): string {
+  if (!base || base === "/") {
+    return "/";
+  }
+  return base.endsWith("/") ? base : `${base}/`;
+}
+
+export type { CodePlayPluginOptions as CodePlayOptions };

--- a/npm/ox-content-code-play/src/remote.ts
+++ b/npm/ox-content-code-play/src/remote.ts
@@ -1,0 +1,118 @@
+import { StdioBuffer } from "./stdio";
+import { PhaseTracker } from "./timing";
+import type { AdapterRequest, RunResult } from "./types";
+
+interface PistonExecuteResponse {
+  compile?: { stdout?: string; stderr?: string; code?: number };
+  run?: { stdout?: string; stderr?: string; code?: number; signal?: string | null };
+  message?: string;
+}
+
+export async function runRemote(request: AdapterRequest): Promise<RunResult> {
+  const tracker = new PhaseTracker();
+  const stdio = new StdioBuffer(tracker.startedAt);
+  const endpoint = request.enabled.endpoint;
+  const language = request.definition.remote?.pistonLanguage ?? request.definition.id;
+
+  if (!endpoint) {
+    tracker.stop();
+    return {
+      status: "unsupported",
+      stdio: [],
+      diagnostics: [
+        {
+          message:
+            `${request.definition.name} execution needs a configured HTTP executor. ` +
+            `Pass languages.${request.definition.id}.endpoint (Piston-compatible).`,
+          severity: "error",
+          source: "code-play",
+        },
+      ],
+      provenance: {},
+      timing: tracker.report(),
+    };
+  }
+
+  tracker.start("queue", "Queue");
+  tracker.start("compile", "Compile / execute");
+  const response = await request.transport.request({
+    url: joinEndpoint(endpoint, "execute"),
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      language,
+      version: request.config.version ?? request.definition.remote?.pistonVersion ?? "*",
+      files: [{ content: request.code }],
+    }),
+  });
+  tracker.start("collect", "Collect output");
+
+  const parsed = parseResponse(response.text);
+  if (parsed.compile?.stdout) {
+    stdio.push("stdout", parsed.compile.stdout);
+  }
+  if (parsed.compile?.stderr) {
+    stdio.push("stderr", parsed.compile.stderr);
+  }
+  if (parsed.run?.stdout) {
+    stdio.push("stdout", parsed.run.stdout);
+  }
+  if (parsed.run?.stderr) {
+    stdio.push("stderr", parsed.run.stderr);
+  }
+  if (parsed.message && !parsed.run && !parsed.compile) {
+    stdio.push("stderr", `${parsed.message}\n`);
+  }
+
+  const compileFailed = (parsed.compile?.code ?? 0) !== 0;
+  const runFailed = (parsed.run?.code ?? 0) !== 0 || Boolean(parsed.run?.signal);
+  const failed =
+    !response.ok || compileFailed || runFailed || Boolean(parsed.message && !parsed.run);
+  tracker.stop();
+
+  return {
+    status: failed ? "error" : "ok",
+    stdio: stdio.snapshot(),
+    diagnostics: failed
+      ? [
+          {
+            message:
+              parsed.message ??
+              parsed.run?.stderr ??
+              parsed.compile?.stderr ??
+              "Remote execution failed.",
+            severity: "error",
+            source: language,
+          },
+        ]
+      : [],
+    provenance: {
+      compile: parsed.compile
+        ? { host: hostFromUrl(endpoint), runtime: language, sandbox: "piston" }
+        : undefined,
+      execute: { host: hostFromUrl(endpoint), runtime: language, sandbox: "piston" },
+    },
+    timing: tracker.report(),
+  };
+}
+
+function parseResponse(text: string): PistonExecuteResponse {
+  try {
+    return JSON.parse(text) as PistonExecuteResponse;
+  } catch {
+    return { message: text };
+  }
+}
+
+function joinEndpoint(endpoint: string, action: string): string {
+  const trimmed = endpoint.replace(/\/+$/, "");
+  return trimmed.endsWith(action) ? trimmed : `${trimmed}/${action}`;
+}
+
+function hostFromUrl(url: string): string {
+  try {
+    return new URL(url, "https://code-play.local").host || url;
+  } catch {
+    return url;
+  }
+}

--- a/npm/ox-content-code-play/src/rust.ts
+++ b/npm/ox-content-code-play/src/rust.ts
@@ -1,0 +1,116 @@
+import { StdioBuffer } from "./stdio";
+import { PhaseTracker } from "./timing";
+import type { AdapterRequest, Diagnostic, RunResult } from "./types";
+
+interface RustPlaygroundResponse {
+  success?: boolean;
+  stdout?: string;
+  stderr?: string;
+  error?: string;
+}
+
+export async function runRust(
+  request: AdapterRequest,
+  mode: "execute" | "typecheck",
+): Promise<RunResult> {
+  const tracker = new PhaseTracker();
+  const stdio = new StdioBuffer(tracker.startedAt);
+  const crateType = resolveCrateType(request.code, String(request.config.crateType ?? "auto"));
+  const body = {
+    channel: request.config.channel ?? "stable",
+    mode: request.config.mode ?? "debug",
+    edition: String(request.config.edition ?? "2024"),
+    crateType,
+    tests: false,
+    code: request.code,
+    backtrace: false,
+  };
+
+  tracker.start(
+    mode === "typecheck" ? "typecheck" : "compile",
+    mode === "typecheck" ? "Typecheck" : "Compile",
+  );
+  const response = await request.transport.request({
+    url: request.endpoints.rust,
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  tracker.start("collect", "Collect output");
+
+  const parsed = parseResponse(response.text);
+  const diagnostics = parseRustcDiagnostics(parsed.stderr ?? parsed.error ?? "");
+  if (parsed.stdout) {
+    stdio.push("stdout", parsed.stdout);
+  }
+  if (parsed.stderr) {
+    stdio.push("stderr", parsed.stderr);
+  }
+  if (parsed.error && !parsed.stderr) {
+    stdio.push("stderr", parsed.error);
+  }
+
+  const success = parsed.success === true && response.ok;
+  const compileFailed = diagnostics.some((item) => item.severity === "error") || !success;
+  tracker.stop();
+
+  return {
+    status: compileFailed ? "error" : "ok",
+    stdio: stdio.snapshot(),
+    diagnostics,
+    provenance: {
+      compile: {
+        host: hostFromUrl(request.endpoints.rust),
+        runtime: "rustc",
+        version: String(request.config.channel ?? "stable"),
+        target: crateType,
+      },
+      execute:
+        mode === "execute"
+          ? {
+              host: hostFromUrl(request.endpoints.rust),
+              runtime: "rust-playground",
+              sandbox: "playground",
+            }
+          : undefined,
+    },
+    timing: tracker.report(),
+  };
+}
+
+function resolveCrateType(code: string, configured: string): "bin" | "lib" {
+  if (configured === "bin" || configured === "lib") {
+    return configured;
+  }
+  return /\bfn\s+main\s*\(/.test(code) ? "bin" : "lib";
+}
+
+function parseResponse(text: string): RustPlaygroundResponse {
+  try {
+    return JSON.parse(text) as RustPlaygroundResponse;
+  } catch {
+    return { success: false, error: text };
+  }
+}
+
+export function parseRustcDiagnostics(stderr: string): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+  const pattern = /^(error|warning|note)(?:\[([^\]]+)\])?:\s+(.*)$/gm;
+  for (const match of stderr.matchAll(pattern)) {
+    const severity = match[1] === "warning" ? "warning" : match[1] === "note" ? "info" : "error";
+    diagnostics.push({
+      message: match[3] ?? "",
+      severity,
+      source: match[2] ? `rustc ${match[2]}` : "rustc",
+    });
+  }
+  return diagnostics;
+}
+
+function hostFromUrl(url: string): string {
+  try {
+    return new URL(url, "https://code-play.local").host || url;
+  } catch {
+    return url;
+  }
+}

--- a/npm/ox-content-code-play/src/session.ts
+++ b/npm/ox-content-code-play/src/session.ts
@@ -1,0 +1,100 @@
+import { executeAdapter, typecheckAdapter } from "./adapters";
+import { mergeConfig } from "./config";
+import type {
+  AdapterRequest,
+  CodePlayTransport,
+  PlaygroundEndpoints,
+  ResolvedLanguageEnable,
+  RunResult,
+  SessionEventMap,
+  SessionEventName,
+  SessionInput,
+  TypeScriptLike,
+} from "./types";
+import type { LanguageDefinition } from "./types";
+
+type Listener<T> = (value: T) => void;
+
+export class CodePlaySession {
+  readonly language: LanguageDefinition;
+  code: string;
+  config: Record<string, unknown>;
+  lastResult: RunResult | undefined;
+  private readonly enabled: ResolvedLanguageEnable;
+  private readonly timeoutMs: number;
+  private readonly transport: CodePlayTransport;
+  private readonly endpoints: PlaygroundEndpoints;
+  private readonly loadTypeScript?: () => Promise<TypeScriptLike | undefined>;
+  private readonly listeners = new Map<SessionEventName, Set<Listener<unknown>>>();
+
+  constructor(input: SessionConstructorInput) {
+    this.language = input.definition;
+    this.enabled = input.enabled;
+    this.code = input.code;
+    this.config = mergeConfig(input.definition.id, input.enabled, input.config);
+    this.timeoutMs = input.timeoutMs;
+    this.transport = input.transport;
+    this.endpoints = input.endpoints;
+    this.loadTypeScript = input.loadTypeScript;
+  }
+
+  on<K extends SessionEventName>(event: K, listener: Listener<SessionEventMap[K]>): () => void {
+    const bucket = this.listeners.get(event) ?? new Set();
+    bucket.add(listener as Listener<unknown>);
+    this.listeners.set(event, bucket);
+    return () => bucket.delete(listener as Listener<unknown>);
+  }
+
+  setCode(code: string): void {
+    this.code = code;
+  }
+
+  setConfig(config: Record<string, unknown>): void {
+    this.config = { ...this.config, ...config };
+    this.emit("config", this.config);
+  }
+
+  async run(): Promise<RunResult> {
+    return this.dispatch("execute");
+  }
+
+  async typecheck(): Promise<RunResult> {
+    return this.dispatch("typecheck");
+  }
+
+  private async dispatch(action: "execute" | "typecheck"): Promise<RunResult> {
+    const request: AdapterRequest = {
+      definition: this.language,
+      enabled: this.enabled,
+      code: this.code,
+      config: this.config,
+      timeoutMs: this.timeoutMs,
+      transport: this.transport,
+      loadTypeScript: this.loadTypeScript,
+      endpoints: this.endpoints,
+    };
+    const result =
+      action === "typecheck" ? await typecheckAdapter(request) : await executeAdapter(request);
+    this.lastResult = result;
+    for (const event of result.stdio) {
+      this.emit("stdio", event);
+    }
+    this.emit("result", result);
+    return result;
+  }
+
+  private emit<K extends SessionEventName>(event: K, value: SessionEventMap[K]): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(value);
+    }
+  }
+}
+
+export interface SessionConstructorInput extends SessionInput {
+  definition: LanguageDefinition;
+  enabled: ResolvedLanguageEnable;
+  timeoutMs: number;
+  transport: CodePlayTransport;
+  endpoints: PlaygroundEndpoints;
+  loadTypeScript?: () => Promise<TypeScriptLike | undefined>;
+}

--- a/npm/ox-content-code-play/src/stdio.ts
+++ b/npm/ox-content-code-play/src/stdio.ts
@@ -1,0 +1,49 @@
+import type { StdioEvent, StdioStream } from "./types";
+
+export class StdioBuffer {
+  readonly events: StdioEvent[] = [];
+  private readonly startedAt: number;
+
+  constructor(startedAt = 0) {
+    this.startedAt = startedAt;
+  }
+
+  push(stream: StdioStream, text: string, timestampMs = elapsed(this.startedAt)): StdioEvent {
+    const event: StdioEvent = { stream, text, timestampMs };
+    this.events.push(event);
+    return event;
+  }
+
+  snapshot(): StdioEvent[] {
+    return this.events.slice();
+  }
+}
+
+export function formatConsoleArgs(args: unknown[]): string {
+  return `${args.map(formatConsoleArg).join(" ")}\n`;
+}
+
+function formatConsoleArg(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (value === null) {
+    return "null";
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return Object.prototype.toString.call(value);
+  }
+}
+
+function elapsed(startedAt: number): number {
+  const now = typeof performance !== "undefined" ? performance.now() : Date.now();
+  return Math.max(0, now - startedAt);
+}

--- a/npm/ox-content-code-play/src/strip-typescript.ts
+++ b/npm/ox-content-code-play/src/strip-typescript.ts
@@ -1,0 +1,16 @@
+/**
+ * Conservative TypeScript-to-JavaScript stripper for documentation samples.
+ * Full checking goes through tsgo; this path only needs to run the snippet.
+ */
+export function stripTypeScript(code: string): string {
+  return code
+    .replace(/^\s*import\s+type\s+.*$/gm, "")
+    .replace(/^\s*export\s+type\s+\w[\s\S]*?;\s*$/gm, "")
+    .replace(/^\s*type\s+\w[\s\S]*?;\s*$/gm, "")
+    .replace(/^\s*(?:export\s+)?interface\s+\w[\s\S]*?\{[\s\S]*?\n\}\s*$/gm, "")
+    .replace(/\s+as\s+const\b/g, "")
+    .replace(/\s+as\s+[^=,;)\n]+/g, "")
+    .replace(/\s+satisfies\s+[^=,;)\n]+/g, "")
+    .replace(/\)\s*:\s*[^{;=\n]+/g, ")")
+    .replace(/([?]?)\s*:\s*[^,)=;{\n]+/g, "$1");
+}

--- a/npm/ox-content-code-play/src/styles.ts
+++ b/npm/ox-content-code-play/src/styles.ts
@@ -1,0 +1,86 @@
+export const CODE_PLAY_STYLES = `
+.ox-code-play {
+  border: 1px solid var(--octc-border, color-mix(in srgb, currentColor 16%, transparent));
+  border-radius: 12px;
+  background: var(--octc-surface, Canvas);
+  color: inherit;
+  overflow: hidden;
+  margin: 1.25rem 0;
+}
+.ox-code-play__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--octc-border, color-mix(in srgb, currentColor 12%, transparent));
+}
+.ox-code-play__lang {
+  font: 600 0.8rem/1.2 ui-sans-serif, system-ui, sans-serif;
+  margin-right: auto;
+}
+.ox-code-play__toolbar button {
+  appearance: none;
+  border: 1px solid var(--octc-border, color-mix(in srgb, currentColor 20%, transparent));
+  background: var(--octc-button, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font: 600 0.75rem/1.4 ui-sans-serif, system-ui, sans-serif;
+  cursor: pointer;
+}
+.ox-code-play__toolbar button:disabled { opacity: 0.55; cursor: progress; }
+.ox-code-play__source pre { margin: 0; border: 0; border-radius: 0; }
+.ox-code-play__tabs {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.4rem 0.7rem 0;
+}
+.ox-code-play__tabs button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  padding: 0.35rem 0.55rem;
+  border-radius: 8px 8px 0 0;
+  font: 600 0.75rem/1.2 ui-sans-serif, system-ui, sans-serif;
+  cursor: pointer;
+}
+.ox-code-play__tabs button[aria-selected="true"] {
+  background: color-mix(in srgb, currentColor 8%, transparent);
+}
+.ox-code-play__panel { padding: 0.7rem 0.8rem 0.9rem; }
+.ox-code-play__empty { margin: 0; opacity: 0.7; font-size: 0.85rem; }
+.ox-code-play__stdio { font: 12px/1.45 ui-monospace, SFMono-Regular, monospace; }
+.ox-code-play__stdio-line { display: grid; grid-template-columns: 8.5rem 1fr; gap: 0.6rem; white-space: pre-wrap; }
+.ox-code-play__stdio-line--stderr { color: var(--octc-danger, #b42318); }
+.ox-code-play__stdio-line--stdin { opacity: 0.75; }
+.ox-code-play__stdio-meta { opacity: 0.6; }
+.ox-code-play__config { display: grid; gap: 0.55rem; }
+.ox-code-play__field { display: grid; gap: 0.25rem; font-size: 0.85rem; }
+.ox-code-play__field input, .ox-code-play__field select {
+  font: inherit;
+  padding: 0.3rem 0.45rem;
+  border-radius: 8px;
+  border: 1px solid var(--octc-border, color-mix(in srgb, currentColor 18%, transparent));
+  background: transparent;
+  color: inherit;
+}
+.ox-code-play__provenance { display: grid; gap: 0.6rem; margin: 0; }
+.ox-code-play__provenance dt { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em; opacity: 0.65; }
+.ox-code-play__provenance dd { margin: 0.15rem 0 0; }
+.ox-code-play__phase { margin: 0.45rem 0; }
+.ox-code-play__phase-meta { display: flex; justify-content: space-between; font-size: 0.8rem; }
+.ox-code-play__phase-bar {
+  height: 0.35rem;
+  margin-top: 0.25rem;
+  border-radius: 999px;
+  background: var(--octc-accent, #4f46e5);
+}
+.ox-code-play__timing-total { margin: 0 0 0.4rem; font-weight: 600; }
+.ox-code-play__diags { margin: 0 0 0.6rem; padding-left: 1.1rem; }
+.ox-code-play__diag--error { color: var(--octc-danger, #b42318); }
+.ox-code-play__diag--warning { color: var(--octc-warning, #b54708); }
+.ox-code-play--compact .ox-code-play__tabs { display: none; }
+.ox-code-play--compact .ox-code-play__panel[data-panel]:not([data-panel="stdio"]) { display: none; }
+`;

--- a/npm/ox-content-code-play/src/timing.ts
+++ b/npm/ox-content-code-play/src/timing.ts
@@ -1,0 +1,49 @@
+import type { TimingPhase, TimingReport } from "./types";
+
+export class PhaseTracker {
+  readonly startedAt: number;
+  private readonly phases: TimingPhase[] = [];
+  private current: { id: string; label: string; startMs: number } | undefined;
+
+  constructor(now: () => number = nowMs) {
+    this.now = now;
+    this.startedAt = now();
+  }
+
+  private readonly now: () => number;
+
+  start(id: string, label: string): void {
+    this.stop();
+    this.current = { id, label, startMs: this.now() - this.startedAt };
+  }
+
+  stop(): void {
+    if (!this.current) {
+      return;
+    }
+    const durationMs = Math.max(0, this.now() - this.startedAt - this.current.startMs);
+    this.phases.push({
+      id: this.current.id,
+      label: this.current.label,
+      startMs: this.current.startMs,
+      durationMs,
+    });
+    this.current = undefined;
+  }
+
+  report(): TimingReport {
+    this.stop();
+    return {
+      totalMs: Math.max(0, this.now() - this.startedAt),
+      phases: this.phases.slice(),
+    };
+  }
+}
+
+export function nowMs(): number {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
+
+export function emptyTiming(): TimingReport {
+  return { totalMs: 0, phases: [] };
+}

--- a/npm/ox-content-code-play/src/transport.ts
+++ b/npm/ox-content-code-play/src/transport.ts
@@ -1,0 +1,41 @@
+import type { CodePlayTransport, TransportRequest, TransportResponse } from "./types";
+
+export function createFetchTransport(fetchImpl: typeof fetch = fetch): CodePlayTransport {
+  return {
+    async request(input: TransportRequest): Promise<TransportResponse> {
+      const response = await fetchImpl(input.url, {
+        method: input.method,
+        headers: input.headers,
+        body: input.body,
+      });
+      return {
+        ok: response.ok,
+        status: response.status,
+        text: await response.text(),
+      };
+    },
+  };
+}
+
+export function createMemoryTransport(
+  handler: (input: TransportRequest) => TransportResponse | Promise<TransportResponse>,
+): CodePlayTransport {
+  return {
+    request: (input) => Promise.resolve(handler(input)),
+  };
+}
+
+export class MissingTransportError extends Error {
+  constructor(host: string) {
+    super(`No Code Play transport is configured for ${host}.`);
+    this.name = "MissingTransportError";
+  }
+}
+
+export function createUnavailableTransport(): CodePlayTransport {
+  return {
+    request(input) {
+      return Promise.reject(new MissingTransportError(input.url));
+    },
+  };
+}

--- a/npm/ox-content-code-play/src/types.ts
+++ b/npm/ox-content-code-play/src/types.ts
@@ -1,0 +1,236 @@
+/**
+ * Shared Code Play types for the headless API, adapters, and UI.
+ */
+
+export type StdioStream = "stdin" | "stdout" | "stderr";
+
+export interface StdioEvent {
+  stream: StdioStream;
+  text: string;
+  timestampMs: number;
+}
+
+export interface RuntimeLocation {
+  /** Hostname, playground origin, or `local`. */
+  host: string;
+  /** Compiler or runtime name (`tsc`, `rustc`, `node:vm`, …). */
+  runtime: string;
+  version?: string;
+  sandbox?: string;
+  target?: string;
+}
+
+export interface Provenance {
+  compile?: RuntimeLocation;
+  execute?: RuntimeLocation;
+}
+
+export interface TimingPhase {
+  id: string;
+  label: string;
+  startMs: number;
+  durationMs: number;
+}
+
+export interface TimingReport {
+  totalMs: number;
+  phases: TimingPhase[];
+}
+
+export type RunStatus = "ok" | "error" | "timeout" | "cancelled" | "unsupported";
+
+export interface Diagnostic {
+  message: string;
+  severity: "error" | "warning" | "info";
+  line?: number;
+  column?: number;
+  source?: string;
+}
+
+export interface PreviewDocument {
+  kind: "html";
+  html: string;
+}
+
+export interface RunResult {
+  status: RunStatus;
+  stdio: StdioEvent[];
+  diagnostics: Diagnostic[];
+  provenance: Provenance;
+  timing: TimingReport;
+  preview?: PreviewDocument;
+  value?: string;
+}
+
+export type ConfigFieldType = "string" | "boolean" | "select" | "number";
+
+export interface ConfigFieldOption {
+  value: string;
+  label: string;
+}
+
+export interface ConfigField {
+  key: string;
+  label: string;
+  type: ConfigFieldType;
+  options?: ConfigFieldOption[];
+  default?: unknown;
+  description?: string;
+}
+
+export type LanguageBackend =
+  | "javascript"
+  | "typescript"
+  | "framework"
+  | "rust-playground"
+  | "go-playground"
+  | "remote";
+
+export type FrameworkId = "vue" | "react" | "svelte" | "solid";
+
+export interface LanguageCapabilities {
+  execute: boolean;
+  typecheck: boolean;
+}
+
+export interface RemoteLanguageSpec {
+  pistonLanguage: string;
+  pistonVersion?: string;
+  notes?: string;
+}
+
+export interface LanguageDefinition {
+  id: string;
+  name: string;
+  aliases: string[];
+  capabilities: LanguageCapabilities;
+  defaultConfig: Record<string, unknown>;
+  configSchema: ConfigField[];
+  backend: LanguageBackend;
+  remote?: RemoteLanguageSpec;
+  framework?: FrameworkId;
+}
+
+export interface LanguageEnableOptions {
+  execute?: boolean;
+  typecheck?: boolean;
+  endpoint?: string;
+  config?: Record<string, unknown>;
+}
+
+export type LanguageEnable = boolean | LanguageEnableOptions;
+
+export interface ResolvedLanguageEnable {
+  id: string;
+  execute: boolean;
+  typecheck: boolean;
+  endpoint?: string;
+  config: Record<string, unknown>;
+}
+
+export interface TransportRequest {
+  url: string;
+  method: "GET" | "POST";
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+export interface TransportResponse {
+  ok: boolean;
+  status: number;
+  text: string;
+}
+
+export interface CodePlayTransport {
+  request(input: TransportRequest): Promise<TransportResponse>;
+}
+
+export interface ViewerFlags {
+  config: boolean;
+  stdio: boolean;
+  provenance: boolean;
+  timing: boolean;
+}
+
+export type CodePlayPreset = "default" | "compact" | "headless";
+
+export interface SessionInput {
+  language: string;
+  code: string;
+  config?: Record<string, unknown>;
+}
+
+export interface PlayPayload {
+  language: string;
+  code: string;
+  capabilities: LanguageCapabilities;
+  config: Record<string, unknown>;
+  viewers: ViewerFlags;
+  ui: CodePlayPreset;
+  timeoutMs: number;
+  endpoints?: PlaygroundEndpoints;
+}
+
+export interface TypeScriptLike {
+  transpileModule: (
+    input: string,
+    options: {
+      compilerOptions?: Record<string, unknown>;
+      reportDiagnostics?: boolean;
+      fileName?: string;
+    },
+  ) => {
+    outputText: string;
+    diagnostics?: Array<{
+      messageText: string | { messageText: string };
+      start?: number;
+      category: number;
+    }>;
+  };
+  createSourceFile: (
+    fileName: string,
+    code: string,
+    languageVersion: number,
+    setParentNodes?: boolean,
+  ) => unknown;
+  createProgram: (
+    rootNames: string[],
+    options: Record<string, unknown>,
+    host: unknown,
+  ) => {
+    getSyntacticDiagnostics: () => unknown[];
+    getSemanticDiagnostics: () => unknown[];
+  };
+  flattenDiagnosticMessageText: (message: unknown, newLine: string) => string;
+  getLineAndCharacterOfPosition: (
+    file: unknown,
+    position: number,
+  ) => { line: number; character: number };
+  ScriptTarget: { Latest: number; ES2022: number };
+  ModuleKind: { ESNext: number };
+}
+
+export interface AdapterRequest {
+  definition: LanguageDefinition;
+  enabled: ResolvedLanguageEnable;
+  code: string;
+  config: Record<string, unknown>;
+  timeoutMs: number;
+  transport: CodePlayTransport;
+  loadTypeScript?: () => Promise<TypeScriptLike | undefined>;
+  endpoints: PlaygroundEndpoints;
+}
+
+export interface PlaygroundEndpoints {
+  rust: string;
+  go: string;
+  typecheck?: string;
+}
+
+export type SessionEventMap = {
+  stdio: StdioEvent;
+  result: RunResult;
+  config: Record<string, unknown>;
+};
+
+export type SessionEventName = keyof SessionEventMap;

--- a/npm/ox-content-code-play/src/typescript.ts
+++ b/npm/ox-content-code-play/src/typescript.ts
@@ -1,0 +1,190 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { executeScript } from "./javascript";
+import { StdioBuffer } from "./stdio";
+import { stripTypeScript } from "./strip-typescript";
+import { PhaseTracker } from "./timing";
+import type { AdapterRequest, Diagnostic, RunResult } from "./types";
+
+const execFileAsync = promisify(execFile);
+
+export async function typecheckTypeScript(request: AdapterRequest): Promise<RunResult> {
+  const tracker = new PhaseTracker();
+  tracker.start("typecheck", "Typecheck");
+
+  if (request.endpoints.typecheck && !hasNodeVm()) {
+    return typecheckViaEndpoint(request, tracker);
+  }
+
+  try {
+    const diagnostics = await typecheckWithTsgo(
+      request.code,
+      String(request.config.tsgoCommand ?? "tsgo"),
+    );
+    tracker.stop();
+    return {
+      status: diagnostics.some((item) => item.severity === "error") ? "error" : "ok",
+      stdio: [],
+      diagnostics,
+      provenance: { compile: { host: "local", runtime: "tsgo" } },
+      timing: tracker.report(),
+    };
+  } catch (error) {
+    tracker.stop();
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      status: message.includes("ENOENT") ? "unsupported" : "error",
+      stdio: [],
+      diagnostics: [
+        {
+          message: message.includes("ENOENT")
+            ? "tsgo is not available. Install @typescript/native-preview or set languages.typescript.config.tsgoCommand."
+            : message,
+          severity: "error",
+          source: "tsgo",
+        },
+      ],
+      provenance: { compile: { host: "local", runtime: "tsgo" } },
+      timing: tracker.report(),
+    };
+  }
+}
+
+export async function runTypeScript(request: AdapterRequest): Promise<RunResult> {
+  const tracker = new PhaseTracker();
+  const stdio = new StdioBuffer(tracker.startedAt);
+  tracker.start("compile", "Strip types");
+  const javascript = stripTypeScript(request.code);
+  tracker.start("execute", "Execute");
+  try {
+    const value = await executeScript(javascript, request.timeoutMs, stdio);
+    tracker.stop();
+    return {
+      status: "ok",
+      stdio: stdio.snapshot(),
+      diagnostics: [],
+      provenance: {
+        compile: { host: "local", runtime: "strip-types" },
+        execute: {
+          host: "local",
+          runtime: hasNodeVm() ? "node:vm" : "function",
+          sandbox: hasNodeVm() ? "vm" : "function",
+        },
+      },
+      timing: tracker.report(),
+      value: value === undefined ? undefined : String(value),
+    };
+  } catch (error) {
+    tracker.stop();
+    const message = error instanceof Error ? error.message : String(error);
+    stdio.push("stderr", `${message}\n`);
+    return {
+      status: "error",
+      stdio: stdio.snapshot(),
+      diagnostics: [{ message, severity: "error", source: "javascript" }],
+      provenance: {
+        compile: { host: "local", runtime: "strip-types" },
+        execute: { host: "local", runtime: hasNodeVm() ? "node:vm" : "function" },
+      },
+      timing: tracker.report(),
+    };
+  }
+}
+
+async function typecheckViaEndpoint(
+  request: AdapterRequest,
+  tracker: PhaseTracker,
+): Promise<RunResult> {
+  const response = await request.transport.request({
+    url: request.endpoints.typecheck ?? "",
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ language: "typescript", code: request.code, config: request.config }),
+  });
+  tracker.stop();
+  try {
+    return JSON.parse(response.text) as RunResult;
+  } catch {
+    return {
+      status: "error",
+      stdio: [],
+      diagnostics: [
+        {
+          message: response.text || "Typecheck endpoint failed.",
+          severity: "error",
+          source: "tsgo",
+        },
+      ],
+      provenance: {
+        compile: { host: hostFromUrl(request.endpoints.typecheck ?? ""), runtime: "tsgo" },
+      },
+      timing: tracker.report(),
+    };
+  }
+}
+
+export async function typecheckWithTsgo(code: string, command = "tsgo"): Promise<Diagnostic[]> {
+  const dir = await mkdtemp(join(tmpdir(), "ox-code-play-"));
+  const file = join(dir, "snippet.ts");
+  await writeFile(file, code);
+  try {
+    await execFileAsync(command, ["--noEmit", "--pretty", "false", "--strict", file], {
+      cwd: dir,
+      maxBuffer: 1024 * 1024,
+    });
+    return [];
+  } catch (error) {
+    const output = commandOutput(error);
+    if ((error as { code?: string }).code === "ENOENT") {
+      throw error;
+    }
+    return parseTsgoOutput(output);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+export function parseTsgoOutput(output: string): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+  const pattern =
+    /^(?:.*[\\/])?snippet\.ts\((\d+),(\d+)\):\s+(error|warning|info)\s+TS\d+:\s+(.*)$/gm;
+  for (const match of output.matchAll(pattern)) {
+    diagnostics.push({
+      message: match[4] ?? output,
+      severity: match[3] === "warning" ? "warning" : match[3] === "info" ? "info" : "error",
+      line: Number(match[1]),
+      column: Number(match[2]),
+      source: "tsgo",
+    });
+  }
+  if (diagnostics.length === 0 && output.trim()) {
+    diagnostics.push({ message: output.trim(), severity: "error", source: "tsgo" });
+  }
+  return diagnostics;
+}
+
+function commandOutput(error: unknown): string {
+  if (!error || typeof error !== "object") {
+    return String(error);
+  }
+  const value = error as { stdout?: unknown; stderr?: unknown; message?: unknown };
+  return [value.stdout, value.stderr, value.message]
+    .filter((part): part is string => typeof part === "string" && part.trim().length > 0)
+    .join("\n")
+    .trim();
+}
+
+function hasNodeVm(): boolean {
+  return typeof process !== "undefined" && Boolean(process.versions?.node);
+}
+
+function hostFromUrl(url: string): string {
+  try {
+    return new URL(url, "https://code-play.local").host || url;
+  } catch {
+    return url;
+  }
+}

--- a/npm/ox-content-code-play/src/ui.ts
+++ b/npm/ox-content-code-play/src/ui.ts
@@ -1,0 +1,65 @@
+import { resolveLanguage } from "./catalog";
+import { escapeHtml } from "./escape";
+import type { CodePlayPreset, PlayPayload, RunResult } from "./types";
+import {
+  renderConfigHtml,
+  renderDiagnosticsHtml,
+  renderProvenanceHtml,
+  renderStdioHtml,
+  renderTimingHtml,
+} from "./viewers";
+
+export interface UiState {
+  payload: PlayPayload;
+  result?: RunResult;
+  busy?: boolean;
+  panel?: "stdio" | "config" | "provenance" | "timing";
+}
+
+export function renderPlayUi(state: UiState): string {
+  const definition = resolveLanguage(state.payload.language);
+  const preset: CodePlayPreset = state.payload.ui === "headless" ? "headless" : state.payload.ui;
+  if (preset === "headless") {
+    return "";
+  }
+  const panel = state.panel ?? "stdio";
+  const canTypecheck = state.payload.capabilities.typecheck;
+  const tabs = renderTabs(state, panel);
+  return `<div class="ox-code-play ox-code-play--${preset}" data-ox-code-play-ui>
+  <div class="ox-code-play__toolbar">
+    <span class="ox-code-play__lang">${escapeHtml(definition?.name ?? state.payload.language)}</span>
+    <button type="button" data-ox-action="run"${state.busy ? " disabled" : ""}>Run</button>
+    ${canTypecheck ? `<button type="button" data-ox-action="typecheck"${state.busy ? " disabled" : ""}>Typecheck</button>` : ""}
+  </div>
+  <div class="ox-code-play__source"></div>
+  ${tabs}
+  <div class="ox-code-play__panel" data-panel="stdio">${renderDiagnosticsHtml(state.result)}${renderStdioHtml(state.result?.stdio ?? [])}</div>
+  <div class="ox-code-play__panel" data-panel="config"${hidden(panel, "config")}>${renderConfigHtml(definition?.configSchema ?? [], state.payload.config)}</div>
+  <div class="ox-code-play__panel" data-panel="provenance"${hidden(panel, "provenance")}>${renderProvenanceHtml(state.result?.provenance)}</div>
+  <div class="ox-code-play__panel" data-panel="timing"${hidden(panel, "timing")}>${renderTimingHtml(state.result?.timing)}</div>
+</div>`;
+}
+
+function renderTabs(state: UiState, panel: string): string {
+  if (state.payload.ui === "compact") {
+    return "";
+  }
+  const viewers = state.payload.viewers;
+  const buttons = [
+    viewers.stdio ? tab("stdio", "stdio", panel) : "",
+    viewers.config ? tab("config", "config", panel) : "",
+    viewers.provenance ? tab("provenance", "provenance", panel) : "",
+    viewers.timing ? tab("timing", "timing", panel) : "",
+  ]
+    .filter(Boolean)
+    .join("");
+  return buttons ? `<div class="ox-code-play__tabs" role="tablist">${buttons}</div>` : "";
+}
+
+function tab(id: string, label: string, selected: string): string {
+  return `<button type="button" role="tab" data-ox-panel="${id}" aria-selected="${selected === id ? "true" : "false"}">${label}</button>`;
+}
+
+function hidden(current: string, id: string): string {
+  return current === id ? "" : " hidden";
+}

--- a/npm/ox-content-code-play/src/viewers.ts
+++ b/npm/ox-content-code-play/src/viewers.ts
@@ -1,0 +1,94 @@
+import { escapeHtml } from "./escape";
+import type { ConfigField, Provenance, RunResult, StdioEvent, TimingReport } from "./types";
+
+export function renderStdioHtml(events: StdioEvent[]): string {
+  if (events.length === 0) {
+    return `<pre class="ox-code-play__stdio ox-code-play__empty">No stdio yet.</pre>`;
+  }
+  const lines = events
+    .map((event) => {
+      const time = event.timestampMs.toFixed(1);
+      return `<div class="ox-code-play__stdio-line ox-code-play__stdio-line--${event.stream}"><span class="ox-code-play__stdio-meta">${escapeHtml(event.stream)} +${escapeHtml(time)}ms</span><span class="ox-code-play__stdio-text">${escapeHtml(event.text)}</span></div>`;
+    })
+    .join("");
+  return `<div class="ox-code-play__stdio" role="log">${lines}</div>`;
+}
+
+export function renderConfigHtml(schema: ConfigField[], config: Record<string, unknown>): string {
+  if (schema.length === 0) {
+    return `<p class="ox-code-play__empty">This language has no editable config.</p>`;
+  }
+  const fields = schema
+    .map((field) => {
+      const value = config[field.key] ?? field.default ?? "";
+      const label = `<label class="ox-code-play__field"><span>${escapeHtml(field.label)}</span>${renderField(field, value)}</label>`;
+      return field.description
+        ? `${label}<p class="ox-code-play__field-help">${escapeHtml(field.description)}</p>`
+        : label;
+    })
+    .join("");
+  return `<form class="ox-code-play__config">${fields}</form>`;
+}
+
+export function renderProvenanceHtml(provenance: Provenance | undefined): string {
+  if (!provenance?.compile && !provenance?.execute) {
+    return `<p class="ox-code-play__empty">No provenance yet. Run or type-check a sample.</p>`;
+  }
+  return `<dl class="ox-code-play__provenance">${renderLocation("Compiled", provenance.compile)}${renderLocation("Executed", provenance.execute)}</dl>`;
+}
+
+export function renderTimingHtml(timing: TimingReport | undefined): string {
+  if (!timing || timing.phases.length === 0) {
+    return `<p class="ox-code-play__empty">No timing yet. Run or type-check a sample.</p>`;
+  }
+  const rows = timing.phases
+    .map((phase) => {
+      const width = timing.totalMs > 0 ? Math.max(2, (phase.durationMs / timing.totalMs) * 100) : 0;
+      return `<div class="ox-code-play__phase"><div class="ox-code-play__phase-meta"><span>${escapeHtml(phase.label)}</span><span>${phase.durationMs.toFixed(1)}ms</span></div><div class="ox-code-play__phase-bar" style="width:${width.toFixed(1)}%"></div></div>`;
+    })
+    .join("");
+  return `<div class="ox-code-play__timing"><p class="ox-code-play__timing-total">Total ${timing.totalMs.toFixed(1)}ms</p>${rows}</div>`;
+}
+
+export function renderDiagnosticsHtml(result: RunResult | undefined): string {
+  if (!result?.diagnostics.length) {
+    return "";
+  }
+  const items = result.diagnostics
+    .map((diagnostic) => {
+      const place = diagnostic.line
+        ? `:${diagnostic.line}${diagnostic.column ? `:${diagnostic.column}` : ""}`
+        : "";
+      return `<li class="ox-code-play__diag ox-code-play__diag--${diagnostic.severity}">${escapeHtml(diagnostic.severity)}${escapeHtml(place)} ${escapeHtml(diagnostic.message)}</li>`;
+    })
+    .join("");
+  return `<ul class="ox-code-play__diags">${items}</ul>`;
+}
+
+function renderField(field: ConfigField, value: unknown): string {
+  const name = escapeHtml(field.key);
+  if (field.type === "boolean") {
+    return `<input type="checkbox" name="${name}" ${value ? "checked" : ""}>`;
+  }
+  if (field.type === "select") {
+    const options = (field.options ?? [])
+      .map(
+        (option) =>
+          `<option value="${escapeHtml(option.value)}" ${String(value) === option.value ? "selected" : ""}>${escapeHtml(option.label)}</option>`,
+      )
+      .join("");
+    return `<select name="${name}">${options}</select>`;
+  }
+  const inputType = field.type === "number" ? "number" : "text";
+  return `<input type="${inputType}" name="${name}" value="${escapeHtml(String(value))}">`;
+}
+
+function renderLocation(label: string, location: Provenance["compile"]): string {
+  if (!location) {
+    return "";
+  }
+  const details = [location.runtime, location.version, location.sandbox, location.target]
+    .filter(Boolean)
+    .join(" · ");
+  return `<div><dt>${escapeHtml(label)}</dt><dd><strong>${escapeHtml(location.host)}</strong>${details ? ` <span>${escapeHtml(details)}</span>` : ""}</dd></div>`;
+}

--- a/npm/ox-content-code-play/tsconfig.json
+++ b/npm/ox-content-code-play/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"],
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/npm/ox-content-code-play/vite.config.ts
+++ b/npm/ox-content-code-play/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite-plus";
+import { defineConfig as definePackConfig } from "vite-plus/pack";
+
+export default defineConfig({
+  fmt: {
+    ignorePatterns: ["dist/**"],
+  },
+  pack: definePackConfig({
+    entry: ["src/index.ts", "src/plugin.ts", "src/hydrate.ts"],
+    format: ["esm"],
+    dts: true,
+    clean: true,
+    hash: false,
+    deps: {
+      neverBundle: ["vite", "typescript"],
+    },
+  }),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,9 @@ importers:
 
   docs:
     devDependencies:
+      '@ox-content/code-play':
+        specifier: workspace:*
+        version: link:../npm/ox-content-code-play
       '@ox-content/vite-plugin':
         specifier: workspace:*
         version: link:../npm/vite-plugin-ox-content
@@ -599,6 +602,25 @@ importers:
       webpack-cli:
         specifier: ^7.2.2
         version: 7.2.2(js-yaml@4.3.1)(json5@2.2.3)(webpack@5.109.2)
+
+  npm/ox-content-code-play:
+    dependencies:
+      vite:
+        specifier: npm:@voidzero-dev/vite-plus-core@0.2.8
+        version: '@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)'
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.1.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260707.2
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.2.8(@types/node@26.1.2)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(jiti@1.21.7)(svelte@5.56.8)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)
 
   npm/ox-content-islands:
     devDependencies:
@@ -2370,28 +2392,24 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@astrojs/compiler-binding-linux-arm64-musl@0.3.2':
     resolution: {integrity: sha512-f0heT9ZZEseSu5bHCeb80eL2DH07ArE6U9xi1WT/PEusNjzPmEr3GJsjG1tRLo5VYUUYX7h3ScaqGmGrMOVGmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@astrojs/compiler-binding-linux-x64-gnu@0.3.2':
     resolution: {integrity: sha512-M8fOUt0itRpqiGyoEA/ij184s8O+hqbCz3+YozRusOOM3osgGljpDThhbKAJjqh82wOo6FioQ4w8PBvU1XMD5Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@astrojs/compiler-binding-linux-x64-musl@0.3.2':
     resolution: {integrity: sha512-/Kebk8sO6HnLeSd691JkaAPfN7CqR9/KEXmWvyNPkaKNGmj8rTZ/lf2uXtnPu92Lan84UrKdIKVPy1fSo2encQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@astrojs/compiler-binding-wasm32-wasi@0.3.2':
     resolution: {integrity: sha512-pUA6xbcOSB7DhfzIArB8BCAkFfAIqriiR7zl5zOStd6oU2G0kIKj+GUdGnyXyhfiv881Hffyk5tC0mR18sDjDw==}
@@ -2683,25 +2701,21 @@ packages:
     resolution: {integrity: sha512-u51id17uJwNEMK9nBlICsq6U31c+XVqQueVBkwRIzZG+gMpS8TOJctt5h5Wz33Z8xnMdTd+adtACVz0yHgGuOA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@bruits/satteri-linux-arm64-musl@0.9.5':
     resolution: {integrity: sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@bruits/satteri-linux-x64-gnu@0.9.5':
     resolution: {integrity: sha512-F3uO8uFp3pAP5ZGXttwvh57GS7s0lL953tnNdyI2gRyP4kOOkp6pyGojNJzCjkDvWI2Cvb9iNrKok3aqQPauAw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@bruits/satteri-linux-x64-musl@0.9.5':
     resolution: {integrity: sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@bruits/satteri-wasm32-wasi@0.9.5':
     resolution: {integrity: sha512-zauAuMwfPnKPUkd4AFixRFpXdgKwP2mKgxrIIo2gJzW0/ZneF9dbHnLkojSpaBnCCp7VUL1hIi5WWZvB1CqmAQ==}
@@ -3272,105 +3286,89 @@ packages:
     resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.3.2':
     resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.3.2':
     resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.3.2':
     resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.3.2':
     resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.3.2':
     resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
     resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.3.2':
     resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.35.3':
     resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.35.3':
     resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.35.3':
     resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.35.3':
     resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
     engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.35.3':
     resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.35.3':
     resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.35.3':
     resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.35.3':
     resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.35.3':
     resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
@@ -3631,35 +3629,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.100':
     resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
     resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.100':
     resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.100':
     resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
     resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
@@ -3769,49 +3762,42 @@ packages:
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/lzma-linux-arm64-musl@1.5.1':
     resolution: {integrity: sha512-kB/xhlVN1eLvVmDJSKZEjp5Gg2xDYexNrB5jwpSMbOkeGS6N9AasByPBg5VqCpMYC+zZi7DM458DRhtWYhqXTQ==}
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/lzma-linux-ppc64-gnu@1.5.1':
     resolution: {integrity: sha512-s28RW0W1yBWQc1nbPdF7tp14koqslY3ZWLVI8uaanX292Dc6ezd4NPVwxEoCNBVON/oD7BmUbWGtyFvmm7dQ5A==}
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/lzma-linux-riscv64-gnu@1.5.1':
     resolution: {integrity: sha512-+lGNwYlIN14YPMTNvYtIJJqHFevDTd6Juw/1NmXbWx/iRd/LLrjhlM/yluMX6pxs6NkOGsuuEXJJrbbEUS59OQ==}
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/lzma-linux-s390x-gnu@1.5.1':
     resolution: {integrity: sha512-PB44FFWWFrLeQowhcep1hPD1YcLqKlnnY60RMU74qrxTlr4YGEyzeMItJqh2uivBfv9kQScOF/B0J9+Vab/oyw==}
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/lzma-linux-x64-musl@1.5.1':
     resolution: {integrity: sha512-I3nsYrWtrW9JpeCr+mkJIVDt0HY3m6qVUBs5vTtoIvJQxwqf1PBXSy5IS7T53ksQFH2kd2UX8rLxJ7B4WISpZg==}
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/lzma-wasm32-wasi@1.5.1':
     resolution: {integrity: sha512-gy3wwPBa6+XEyA4fUzq6CClrXA1ajXjuVf5zbnHytJRgoHznj+mvpU3+co2fxXwqTCmIpn6KrzqH5bRDztBPhA==}
@@ -3881,42 +3867,36 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/tar-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-Rh6UFhNtj3i4deJHOBINFIeRL0072mgbeyuK5rl1HokKnNoMKx8qKIZNEzBTTqpogMfDHWGvzyTQdnVxes5dpA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/tar-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-Cp+AxFbv9zcyAXtnzQi0OzmgDnQgy2w9D4Ubr+iwzMtVgJcztzcEoCcCrN1k2ATdEB01LX2Vb49IaocGOZhC9Q==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/tar-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-ZyscC3SYKTBWyDRYjLOKAd5TyJ7q0KACRdQ8bWrb3rgrra1CCIJD66CsGTH6Dh0AVSdfLwZ8MfIIXU6+14BMjQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/tar-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-LlIv+zg4fiOQge9LQX/ieBdRWE2fhVDjCTHxnunZkbugNmdhdelxWf1RpZb/6ZujWpNF4LPu4N/MW7ygg2oYAQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/tar-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-gZBeoKLjanOVj55qk4EMu13P2i9M0SuINmlGQkOxm1niIJofexzddHUYtqO5o/5QqtyL8lADmAcZplLILMLhHA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/tar-wasm32-wasi@1.1.1':
     resolution: {integrity: sha512-rwtQ1Mdt/ft6g6I54fJzbUeLspl4yTwj6I3UJ6mitKnrN42soJkcDrdh3Y/FGvlpqZTad2YMQ96fGJl3EtAm2Q==}
@@ -3994,28 +3974,24 @@ packages:
     engines: {node: '>= 12.22.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/wasm-tools-linux-arm64-musl@1.1.0':
     resolution: {integrity: sha512-7rw3nlubTjNAVRH2LwphCxHy1b/N2/TerXocQ6XRn4Q+buaY1Z7P/hbdALy1i1ex2yfOU2Xcij7ib7ZLi/lKfw==}
     engines: {node: '>= 12.22.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/wasm-tools-linux-x64-gnu@1.1.0':
     resolution: {integrity: sha512-1sel0t9MRjI/tdT89M8Dd6gPfANeeFP24Xa46R11WeHNwhjsXXZh+xUk50uWCRTSGcaCy3ugm3AMK/lmHYQJkg==}
     engines: {node: '>= 12.22.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/wasm-tools-linux-x64-musl@1.1.0':
     resolution: {integrity: sha512-o2jH5AMfor4EKF2HII1LBnMQxoWu7+usPifTEY8Zk6e9OiSi4EJkAXf9v3ANlX7TI2V/cUEV34OEW7r10GiVIA==}
     engines: {node: '>= 12.22.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/wasm-tools-wasm32-wasi@1.1.0':
     resolution: {integrity: sha512-s6YDtDR1UWrsqJPtaxf+JLYLceWVyn3l8OpQYElHkDhf3Qfz9R6Ba3S0OgznTBv38L5/TIHysQ9Q4yO73Z0csg==}
@@ -4177,56 +4153,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.61.0':
     resolution: {integrity: sha512-S6uvJ6MXnRXl+zTs0CARNDvkE+cymj0EVWEKKsyKnlLlqTyQJBjw5s4D2pSIOZc+S46cy4STefzcr/sm0VzVPA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.61.0':
     resolution: {integrity: sha512-6VDlRcytvZG6UlSIdAFKDLbppo9tvPxrWzle6vHldYFMeuDPQEfMKrkwezp7FaBq1wik9ra554ZZeRPsyIkFpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.61.0':
     resolution: {integrity: sha512-KkBTYbzExpbmn15XjKPLu2fRV2PVlq+KWt+brad5rwIa03vdYoaDRWiS7raHII/dCTR6Ro4UpYUCH4t6lif4WQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.61.0':
     resolution: {integrity: sha512-69tzIq7sJLVB9dxYYtvMzcSSsnZHSO+U2U19O2RqDqgj6+Q4O7HjSXdaszbcgqzhsUwzSH7z5kWvk8nmf6BHTg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.61.0':
     resolution: {integrity: sha512-Oqi/N0OvtOVXsPKAOOhKgGH3msRYF8BLJaNBbWiupRiKoKVyc8JRKPCfarkQJC+RgP9U8raUKLe+bNwd0HUMiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.61.0':
     resolution: {integrity: sha512-3TKwv/ed4uwJSemAA8P9XcoqETpjQI4waquF9UilhA9Mn/dhr1PdUEXWlL74mtc6ZNfmKPA9+NEJm01nRF8CVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.61.0':
     resolution: {integrity: sha512-uFso4u4nLkVSlMCpgjyvWV60Gt7GvDQHnk1mmRxHIkZTMB0ljpUKwCD9FYGgN9H97x2wYl0UwEjgRZaPIuhEhw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.61.0':
     resolution: {integrity: sha512-keGLkzeOvkMpNmPp4hffXWpfoSsY6e1K8++KXD4mSSfxdvM8q9QUDsYY689TB1k6Co832DZn1MnaaVx6cIBMWQ==}
@@ -4329,56 +4297,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.76.0':
     resolution: {integrity: sha512-oPFkkKTgl0K/EIg9fQ8oA3IGcI05/Mq1en04iFa41mmNPT+6KEiByVazTOZZJiHMBBrbsns1YJ2e1Scqwzesjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.76.0':
     resolution: {integrity: sha512-gN7yZ0eqflA5Fhf1wvHxGUltIV3FsvmB1zhNMDEK9vSHhc7E6qg9CuPeBgPZab66Tjzq6w6kHAtNEvnTHf4cyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.76.0':
     resolution: {integrity: sha512-S/HqMbn22mQrjtErUxEoS/a55u8kIeXvreIxiJu5G7Le3UecEd6SQZxrDIpuhtgaFnsY/nVra3ytP+pRljDilA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.76.0':
     resolution: {integrity: sha512-ZIga3097VJZolGZk6SrIAUokIGfRkxRlhiHDUznZptGBfwrhD7pNfD1rzEzsCwvk/1DX0A1bLz+liuNh5QKIVQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.76.0':
     resolution: {integrity: sha512-ZGiiA7pFzMJSyMWYZTVlPgbTsx+Vl8ihLGMIujPwaslUF7kIPPWAbVmAlTc+9lWDV+DCiB8Ikixu+lSHeOIIWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.76.0':
     resolution: {integrity: sha512-JLiy5WuvEBFTT6ErIFV35SLzi0R7Iri6MKU6dZbTxfIx8pndbbPs3Mj780nMipBFcPkti+okAPOJ9POKkHFEgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.76.0':
     resolution: {integrity: sha512-z7lgKQtbo/I1NIe8G5NHLesxJDv0tRSUWTpXKb9Pm3E9nKFKfO4IOSDtFroKgXtOYb0jQbcdH+0wzTyMXVes+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.76.0':
     resolution: {integrity: sha512-JOjKymIpb9QcYfEhZsN6h4V9Ivd474W38cNIBRv6bg2TbIvogbMTH0Mg6YWW9TiRDqfcX+/Hyfsbo5vcSE5guQ==}
@@ -4515,84 +4475,72 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.2.3':
     resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.2':
     resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.2.3':
     resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.3':
     resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.2':
     resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.3':
     resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.2':
     resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.3':
     resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.2':
     resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.2.3':
     resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.2':
     resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
@@ -4703,79 +4651,66 @@ packages:
     resolution: {integrity: sha512-r9fGh3eFs3e/udWh5ZjXQtxiYK/xoFxQaYR/cELxac/Udkl5Th+IsFm0CX3Kl9hmUH/we7EoMpjJgeQNnE0+IA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.5':
     resolution: {integrity: sha512-xdvFdp7OM6KLJviJT2g/YuRSUjnZgGHk4RNgwIbN7X6cPugOucV60DdHXWzsBVCUdrGb6qSXnJQrrAKMmQuj3Q==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.5':
     resolution: {integrity: sha512-rRqILAndyzHzP7T9NFQrq+4HFWNhqkqkKur7eiBpfLmz01PO0JKx5Vchu3YllE4YXI/Ftgq/szrDWg5GJ0mI8g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.5':
     resolution: {integrity: sha512-Gf4X3qVMucayUvux6aXXPgXovocSFUC0rrffDuPI/S2nHhNMhjcZxsrAFYCOF350PRreW1XwzFj3CT/3bKsWCw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.5':
     resolution: {integrity: sha512-+s5qA0TNM0qm8PK/a5gt/1Hpx+NV08uSuCncvhziIlQzT6AEV2fnUQo7eBtFTFO0nA9scauvoR2HusfXmQnO4w==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.5':
     resolution: {integrity: sha512-ybb6QvWwWJCbBWqERpc8K3pYVGIrXlG8MEQ8IIuJY6Y9KdHQxoFoNyfkAOtKn1VHu3KuLidXvwrvGR1mEjeWCw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.5':
     resolution: {integrity: sha512-nZb1DtnOyhCmYvsC8A2CwOkopVg+IS1+fPUa7rMOAXtNw5+lLCLLPqd6XAiNrGtoQKsbvIBOwsHnBH/3wnb4HQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.5':
     resolution: {integrity: sha512-yMbj63Sp89ryrXLWyz+sy+fYD2HpOnMCLGbe4Oa1smclFSUukdtD/BgdiHaAetJNb74URD8U4hM+qG5KVzMEkg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.5':
     resolution: {integrity: sha512-mhoan3OJw2kYV/e1jtIdmvUZgyBFeA6zGWsOswmR0Tg19TQbowZuR+JMLID6spbbBN7Zee2ejrgmy3+FxGrIdA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.5':
     resolution: {integrity: sha512-5ZTLmjWbb1VZdjuyhe83K/8QO0/h11midQCBP+X5OYn32ra7eOBoM0ZqtaY4nkgNsYgmdVhMYPoyVPTjUpHf3w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.5':
     resolution: {integrity: sha512-m53kG+br6PGxOTmgBEM2DHSDs9RVjsyEbUwjJPJGTFm1grWOG8EKJggDCTb60unD4Tjby8fi7/m9XfkEWasVWg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.5':
     resolution: {integrity: sha512-6RHPJR1g/uvdYU8uXBnfq3nlqyZCP82Fr6NHgfGoaIeSh0YEqnX/x6uA9MmJJbnSH7swqX4F+CkGdUF+6doiQA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.5':
     resolution: {integrity: sha512-xs+OXQtEXgpXT0DmA5+U3qnRZHdCST/5HRQxS8wSPZTUZN/EMWeHuSIod32LQklTBZBV9DyfncKBQ8n5V3eFdw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.5':
     resolution: {integrity: sha512-e7hD+sl3s+mcLQDZ8pbudBVsdG6r5yN4w3LqG2TJ8sQHDpblWj5lrJs/3m01Cvlxbt4x13zu5thLjgypgtkYzw==}
@@ -5424,28 +5359,24 @@ packages:
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@voidzero-dev/vite-plus-linux-arm64-musl@0.2.8':
     resolution: {integrity: sha512-VbWUwaSAw0Ndql5uYy/Gfqt7duSy1sxTacLngD5M5kF4ZK7yoKKcx8iFiA0il1Gf3J7OGojPonKi5b3NSn3K7A==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@voidzero-dev/vite-plus-linux-x64-gnu@0.2.8':
     resolution: {integrity: sha512-gZfnd3l9vNiP7QXQIEN9r2M9ZKCh8sg2vhBv04sZjMNAeQ05IXJMkWYkcfTUO7jhf8pdVt3VHQ4x6ULm0OnELg==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@voidzero-dev/vite-plus-linux-x64-musl@0.2.8':
     resolution: {integrity: sha512-5NtDUvjzF/HcjQraebpiVUgjX2CMKv2Jdmi5YpzHlt4g86sFA9M5a+OqBlgUctdzTeolnjxRsfurKiefG/hILA==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@voidzero-dev/vite-plus-win32-arm64-msvc@0.2.8':
     resolution: {integrity: sha512-Atjz6KsG42ntfQkM6Ks09Ifxm+ZIca2DnA31tO2FcPlHetBxYEGZwSNCOHAnoNnLrh2qNm+7aOC329a2ijhxLg==}
@@ -5696,37 +5627,31 @@ packages:
     resolution: {integrity: sha512-DuSQlk8bH4gpmW3/00P0NLagAcMv8jOxjT40cQmxKRkktr+SUOALCfkT89tdDq3qtY95NR2GXOZ7AjNh7KKqCw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-codegen/binding-linux-arm-musl@0.5.48':
     resolution: {integrity: sha512-bxj4Ee+wlaJcWJwft2ReJXWw5sfl1qavDz6+dlRdU1xfTEtjPSNiAWhiCHnJR0R4Ygd57DnzSQmAVGvFv6RcGw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@yuku-codegen/binding-linux-arm64-gnu@0.5.48':
     resolution: {integrity: sha512-mk5JVWh+0JOe5ue8k17kbYX8uGBoKt3ZqoCyxNh4nYAAcX7+X1tFUiU7jbjctu4vHeejCBFSTdQ021+V31cUCQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-codegen/binding-linux-arm64-musl@0.5.48':
     resolution: {integrity: sha512-4q3vkrNghbllyxOm2KesFLxCPKHF7r3JyQ7BWZccY1j2Y05yKoIFhoWCqIuQ2W/dpte9RI0+OVfwyxnrKg6fkA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@yuku-codegen/binding-linux-x64-gnu@0.5.48':
     resolution: {integrity: sha512-csd4M1EVrGaohM8acM6gq1zpUA/Rwe2ulUMBKUcwQXm/k6n7cq1A++qdew78SOVb4do3JH1WE+WFwoGQAcWc1w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-codegen/binding-linux-x64-musl@0.5.48':
     resolution: {integrity: sha512-KcDuEOT+GFoVKdvAWOv1v9iYjwnmvMZlO+j1Rw+5PYdeFLGWGzv/DD11y4SAAdwXIFcil4T0hibeIaF82WStMg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@yuku-codegen/binding-win32-arm64@0.5.48':
     resolution: {integrity: sha512-HI8qNrI8dWM5BuqIMKsqornRvTNFrE6sm5zToIJ9YIa9zt5+29P7fJ7Nr39EVf6dAWSb6q7JSpScJnRsQ+FgZA==}
@@ -5757,37 +5682,31 @@ packages:
     resolution: {integrity: sha512-8S5T5wjCC73dmmpQeZ49aYsSunIUM3D4Fc6rdK96c+Ayg/p3FmeSPF3xuLZHejcTmqJIIvnbfPlUF+rB6DITjQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-parser/binding-linux-arm-musl@0.5.48':
     resolution: {integrity: sha512-tTmbxvnUHcK2/crS9547vk2SMmsajH1yqJ8ltXhIuHJgqR1v+d9n9KT+kSayo/5CS76LegeYxhMFjEivBH2hFA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@yuku-parser/binding-linux-arm64-gnu@0.5.48':
     resolution: {integrity: sha512-KGYCBMqI2zfwyhgq5tpPVNe7jpUeYTBm8DhjdS+zqWNumde/PEC170QE5RHxcOAlsirIDeIUk0jqx+r/axoFSw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-parser/binding-linux-arm64-musl@0.5.48':
     resolution: {integrity: sha512-2wTSMsCSXLTc2lZUjMAuU5X4cje55u205WJqfV5NWNF6j9pW/tXyxr15dJeekj8ziLqBXzIsj4DbRh4sY/WcjA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@yuku-parser/binding-linux-x64-gnu@0.5.48':
     resolution: {integrity: sha512-d/6v9UnGglVu1WC2JQyv/5aWSi5fXZeGSlidCfmHp4+N65N1GDKUnFtys5MK5eAPeAjTgSHGGtOc/yCcKTlv3A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-parser/binding-linux-x64-musl@0.5.48':
     resolution: {integrity: sha512-gX19gw6u4ApPy7SYMPKfFlEkrtj6WlORvrTKK3sBQqjyV+8+mUAkQgxXNjHw4RnOiAmVYg7TOlZcg8d+Qqod9A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@yuku-parser/binding-win32-arm64@0.5.48':
     resolution: {integrity: sha512-w6cQQLbqj3Jcom5Q7ifm103NUOQ9d+Cb4VU5lkrZDjMnwVJ9Hzzg1vCQR7miJuF44vhCXldbme5UryE3giEKlA==}
@@ -7218,28 +7137,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -13,6 +13,7 @@ const ROOT = path.resolve(__dirname, "..");
 const NPM_PACKAGES = [
   "crates/ox_content_napi",
   "npm/ox-content-islands",
+  "npm/ox-content-code-play",
   "npm/unplugin-ox-content",
   "npm/vite-plugin-ox-content",
   "npm/vite-plugin-ox-content-react",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -137,9 +137,11 @@ export default defineConfig({
         "test:vscode-unit",
         "test:vrt",
       ]),
-      "test:ts-unit": task("vp exec --filter @ox-content/vite-plugin -- vp test src", {
+      "test:ts-unit": noopTask(["test:vite-plugin", "test:code-play"]),
+      "test:vite-plugin": task("vp exec --filter @ox-content/vite-plugin -- vp test src", {
         dependsOn: ["build:napi"],
       }),
+      "test:code-play": task("vp exec --filter @ox-content/code-play -- vp test src"),
       "build:vite-plugin": task("vp run --filter @ox-content/vite-plugin build", {
         dependsOn: ["build:napi"],
       }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `@ox-content/code-play`, an opt-in plugin for on-demand documentation sample execution.

- Headless API: `createCodePlay()` / `CodePlaySession` for execute and type-check
- UI: Headless controller plus `default` and `compact` presets
- Viewers: **config**, **stdio** (timestamped stdin/stdout/stderr), **provenance** (where compiled / where ran), **timing** (phase durations)
- Languages are disabled until listed. JS/TS run in `node:vm` / iframe; Rust and Go use the official playgrounds (or the Vite dev proxy); other languages need a Piston-compatible `endpoint`
- Markdown `play` fences and `<CodePlay>` tags; no execution during transform or SSG
- Docs: package guide, example page (JS/TS dogfood), and [roadmap](docs/content/code-play-roadmap.md)

Tracking: #648

## Risk

- Risk level: medium
- User or production impact: none unless a site installs `@ox-content/code-play` and enables languages. Existing docs sites are unchanged.
- Rollback plan: revert this PR / do not publish the new package.

## Validation

- [x] Automated tests or checks run: `vp test src` in `@ox-content/code-play` (23 tests), `tsgo --noEmit`
- [ ] Manual verification completed: live JS/TS widgets on the docs example page still need a browser pass after the package is built
- [x] Edge cases or failure modes considered: disabled languages stay static; remote languages refuse to run without an endpoint; `sh` never spawns a local shell; transports are injectable so CI hits no network

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790142813&installation_model_id=422833&pr_number=649&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F649&signature=6c4fd530d12905b0268d1b4b3f75d241636a4dcbd3d45cee12ef4c58aaa131c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the opt-in Code Play plugin for running and type-checking JavaScript and TypeScript samples.
  * Added interactive sample controls with output, diagnostics, configuration, provenance, and timing views.
  * Added support for framework previews and remote execution for additional languages.
  * Added headless session APIs for programmatic execution and type-checking.

* **Documentation**
  * Added setup guides, examples, architecture details, security guidance, and a Code Play roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->