### PR TITLE
feat(code-play): dedicated stderr viewer and stdout/stderr API

### DIFF
--- a/docs/content/code-play-roadmap.md
+++ b/docs/content/code-play-roadmap.md
@@ -27,8 +27,9 @@ reverse.
    a browser iframe. Native languages use official playgrounds or a
    user-configured HTTP executor. Code Play does not spawn `sh`, `python`, or
    `rustc` on the docs host unless a later local-runtime PR says so.
-5. **Observability is API data.** stdio, config, provenance, and timing are
-   returned on every `RunResult`, not only painted in the default UI.
+5. **Observability is API data.** stdio, dedicated `stdout` / `stderr` strings,
+   config, provenance, and timing are returned on every `RunResult`, not only
+   painted in the default UI.
 
 ## Language Matrix
 
@@ -49,9 +50,15 @@ reverse.
 
 ### 1. `feat(code-play): plugin scaffold, headless API, viewers`
 
-This PR. Ships the package, catalog, headless client, default/compact/headless
+Shipped in #649. Package, catalog, headless client, default/compact/headless
 UI, config / stdio / provenance / timing viewers, Vite plugin, and tests with
 injected transports (no live network in CI).
+
+### 1b. `feat(code-play): dedicated stderr viewer`
+
+This PR. First-class `RunResult.stdout` / `RunResult.stderr`, a dedicated
+stderr viewer (stream chunks plus error/warning diagnostics), and compact
+preset coverage for stderr.
 
 ### 2. `feat(code-play): Vite SSG hydration and docs dogfood`
 

--- a/docs/content/examples/code-play.md
+++ b/docs/content/examples/code-play.md
@@ -1,6 +1,6 @@
 ---
 title: Code Play
-description: Opt-in on-demand sample execution with stdio, config, provenance, and timing viewers.
+description: Opt-in on-demand sample execution with stdio, stderr, config, provenance, and timing viewers.
 ---
 
 # Code Play
@@ -23,7 +23,7 @@ export default {
         typescript: { execute: true, typecheck: true },
       },
       ui: "default",
-      viewers: { config: true, stdio: true, provenance: true, timing: true },
+      viewers: { config: true, stdio: true, stderr: true, provenance: true, timing: true },
     }),
   ],
 };
@@ -32,8 +32,8 @@ export default {
 ## Live TypeScript sample
 
 The fence below is marked `play`. Use **Run** to execute it and **Typecheck**
-to type-check it. The stdio, config, provenance, and timing tabs are the same
-objects the headless API returns.
+to type-check it. The stdio, stderr, config, provenance, and timing tabs are
+the same objects the headless API returns. `console.warn` lands in `run.stderr`.
 
 ```ts play typecheck
 const message: string = "hello from Code Play";
@@ -64,6 +64,8 @@ const session = play.createSession({
 
 const result = await session.run();
 result.stdio;
+result.stdout;
+result.stderr;
 result.provenance.compile;
 result.provenance.execute;
 result.timing.phases;

--- a/docs/content/examples/index.md
+++ b/docs/content/examples/index.md
@@ -159,8 +159,8 @@ oxContent({
 
 ### [Code Play](./code-play.md)
 
-On-demand sample execution through `@ox-content/code-play`, with stdio, config,
-provenance, and timing viewers.
+On-demand sample execution through `@ox-content/code-play`, with stdio, stderr,
+config, provenance, and timing viewers.
 
 ### [Playground](./playground.md)
 

--- a/docs/content/packages/code-play.md
+++ b/docs/content/packages/code-play.md
@@ -30,7 +30,7 @@ export default {
         javascript: true,
       },
       ui: "default",
-      viewers: { config: true, stdio: true, provenance: true, timing: true },
+      viewers: { config: true, stdio: true, stderr: true, provenance: true, timing: true },
       srcDir: "content",
     }),
   ],
@@ -74,7 +74,9 @@ const session = play.createSession({
 const check = await session.typecheck();
 const run = await session.run();
 
-run.stdio; // timestamped stdin / stdout / stderr
+run.stdio; // timestamped stdin / stdout / stderr events
+run.stdout; // concatenated stdout text
+run.stderr; // concatenated stderr text
 run.provenance; // where it compiled, where it ran
 run.timing; // phase durations and totalMs
 session.config; // editable language config
@@ -88,9 +90,9 @@ viewer edits.
 
 | Preset     | Behavior                                               |
 | ---------- | ------------------------------------------------------ |
-| `default`  | Toolbar plus stdio / config / provenance / timing tabs |
-| `compact`  | Run / type-check and stdio only                        |
-| `headless` | No DOM chrome; use the session API                     |
+| `default`  | Toolbar plus stdio / stderr / config / provenance / timing tabs |
+| `compact`  | Run / type-check plus stdio and stderr                          |
+| `headless` | No DOM chrome; use the session API                              |
 
 Viewers can be toggled independently through `viewers`.
 

--- a/docs/content/packages/code-play.md
+++ b/docs/content/packages/code-play.md
@@ -88,8 +88,8 @@ viewer edits.
 
 ## UI
 
-| Preset     | Behavior                                               |
-| ---------- | ------------------------------------------------------ |
+| Preset     | Behavior                                                        |
+| ---------- | --------------------------------------------------------------- |
 | `default`  | Toolbar plus stdio / stderr / config / provenance / timing tabs |
 | `compact`  | Run / type-check plus stdio and stderr                          |
 | `headless` | No DOM chrome; use the session API                              |

--- a/npm/ox-content-code-play/README.md
+++ b/npm/ox-content-code-play/README.md
@@ -24,7 +24,7 @@ export default {
         rust: true,
       },
       ui: "default",
-      viewers: { config: true, stdio: true, provenance: true, timing: true },
+      viewers: { config: true, stdio: true, stderr: true, provenance: true, timing: true },
     }),
   ],
 };
@@ -60,6 +60,8 @@ const check = await session.typecheck();
 const run = await session.run();
 
 run.stdio;
+run.stdout;
+run.stderr;
 run.provenance;
 run.timing;
 ```

--- a/npm/ox-content-code-play/src/adapters.test.ts
+++ b/npm/ox-content-code-play/src/adapters.test.ts
@@ -27,6 +27,8 @@ describe("language adapters", () => {
       .createSession({ language: "rust", code: "fn main() { let x = 1; }" })
       .run();
     expect(result.status).toBe("ok");
+    expect(result.stdout).toBe("ok\n");
+    expect(result.stderr).toBe("warning: unused variable: `x`\n");
     expect(result.stdio[0]).toMatchObject({ stream: "stdout", text: "ok\n" });
     expect(result.diagnostics).toEqual([
       expect.objectContaining({ severity: "warning", message: "unused variable: `x`" }),
@@ -51,6 +53,8 @@ describe("language adapters", () => {
       .createSession({ language: "rs", code: "fn add(x: i32) -> i32 { x }" })
       .typecheck();
     expect(result.status).toBe("error");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("error[E0308]: mismatched types\n");
     expect(parseRustcDiagnostics("error[E0308]: mismatched types")[0]?.source).toBe("rustc E0308");
     expect(result.diagnostics[0]?.severity).toBe("error");
   });
@@ -72,6 +76,8 @@ describe("language adapters", () => {
       .createSession({ language: "go", code: "package main\nfunc main() {}" })
       .run();
     expect(result.status).toBe("ok");
+    expect(result.stdout).toBe("hi\n");
+    expect(result.stderr).toBe("");
     expect(result.stdio[0]?.text).toBe("hi\n");
     expect(result.provenance.execute?.runtime).toBe("go-playground");
   });
@@ -102,6 +108,8 @@ describe("language adapters", () => {
     });
     const sh = await remote.createSession({ language: "bash", code: "echo 1" }).run();
     expect(sh.status).toBe("ok");
+    expect(sh.stdout).toBe("1\n");
+    expect(sh.stderr).toBe("");
     expect(sh.provenance.execute?.sandbox).toBe("piston");
     expect(sh.stdio[0]?.text).toBe("1\n");
   });

--- a/npm/ox-content-code-play/src/adapters.ts
+++ b/npm/ox-content-code-play/src/adapters.ts
@@ -4,9 +4,9 @@ import { runJavaScript } from "./javascript";
 import { runRemote } from "./remote";
 import { runRust } from "./rust";
 import { runTypeScript, typecheckTypeScript } from "./typescript";
-import type { AdapterRequest, RunResult } from "./types";
+import type { AdapterRequest, AdapterResult } from "./types";
 
-export async function executeAdapter(request: AdapterRequest): Promise<RunResult> {
+export async function executeAdapter(request: AdapterRequest): Promise<AdapterResult> {
   if (!request.enabled.execute) {
     return capabilityDisabled(request, "execute");
   }
@@ -28,7 +28,7 @@ export async function executeAdapter(request: AdapterRequest): Promise<RunResult
   }
 }
 
-export async function typecheckAdapter(request: AdapterRequest): Promise<RunResult> {
+export async function typecheckAdapter(request: AdapterRequest): Promise<AdapterResult> {
   if (!request.enabled.typecheck || !request.definition.capabilities.typecheck) {
     return capabilityDisabled(request, "typecheck");
   }
@@ -44,7 +44,7 @@ export async function typecheckAdapter(request: AdapterRequest): Promise<RunResu
   }
 }
 
-function capabilityDisabled(request: AdapterRequest, action: "execute" | "typecheck"): RunResult {
+function capabilityDisabled(request: AdapterRequest, action: "execute" | "typecheck"): AdapterResult {
   return {
     status: "unsupported",
     stdio: [],

--- a/npm/ox-content-code-play/src/adapters.ts
+++ b/npm/ox-content-code-play/src/adapters.ts
@@ -44,7 +44,10 @@ export async function typecheckAdapter(request: AdapterRequest): Promise<Adapter
   }
 }
 
-function capabilityDisabled(request: AdapterRequest, action: "execute" | "typecheck"): AdapterResult {
+function capabilityDisabled(
+  request: AdapterRequest,
+  action: "execute" | "typecheck",
+): AdapterResult {
   return {
     status: "unsupported",
     stdio: [],

--- a/npm/ox-content-code-play/src/client.test.ts
+++ b/npm/ox-content-code-play/src/client.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { createCodePlay } from "./client";
 import { stripTypeScript } from "./strip-typescript";
 import { parseTsgoOutput } from "./typescript";
+import { renderStderrHtml } from "./viewers";
 
 describe("createCodePlay", () => {
   it("executes opted-in JavaScript and records stdio, provenance, and timing", async () => {
@@ -18,6 +19,10 @@ describe("createCodePlay", () => {
       ["stdout", "hello\n"],
       ["stderr", "oops\n"],
     ]);
+    expect(result.stdout).toBe("hello\n");
+    expect(result.stderr).toBe("oops\n");
+    expect(session.stdout).toBe("hello\n");
+    expect(session.stderr).toBe("oops\n");
     expect(result.provenance.execute?.runtime).toBe("node:vm");
     expect(result.timing.totalMs).toBeGreaterThanOrEqual(0);
     expect(result.timing.phases.some((phase) => phase.id === "execute")).toBe(true);
@@ -36,7 +41,11 @@ describe("createCodePlay", () => {
       .createSession({ language: "tsx", code: "const n: number = 'nope';" })
       .typecheck();
     expect(check.status).toBe("error");
+    expect(check.stdout).toBe("");
+    expect(check.stderr).toBe("");
     expect(check.diagnostics.some((diagnostic) => diagnostic.message.length > 0)).toBe(true);
+    expect(renderStderrHtml(check)).toContain("ox-code-play__diag--error");
+    expect(renderStderrHtml(check)).not.toContain("No stderr.");
   });
 
   it("refuses languages that were not enabled", () => {
@@ -53,10 +62,28 @@ describe("createCodePlay", () => {
       .createSession({ language: "js", code: "throw new Error('boom');" })
       .run();
     expect(result.status).toBe("error");
-    expect(result.diagnostics[0]?.message).toContain("boom");
+    expect(result.diagnostics[0]?.message).toBe("boom");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("boom\n");
     expect(
       result.stdio.some((event) => event.stream === "stderr" && event.text.includes("boom")),
     ).toBe(true);
+  });
+
+  it("routes console.warn and console.error to stderr, never stdout", async () => {
+    const play = createCodePlay({ languages: { javascript: true } });
+    const result = await play
+      .createSession({
+        language: "js",
+        code: `console.log("out"); console.warn("warn"); console.error("err");`,
+      })
+      .run();
+    expect(result.status).toBe("ok");
+    expect(result.stdout).toBe("out\n");
+    expect(result.stderr).toBe("warn\nerr\n");
+    expect(result.stdio.filter((event) => event.stream === "stdout")).toEqual([
+      expect.objectContaining({ text: "out\n" }),
+    ]);
   });
 
   it("strips TypeScript annotations before execute", () => {

--- a/npm/ox-content-code-play/src/config.ts
+++ b/npm/ox-content-code-play/src/config.ts
@@ -39,6 +39,7 @@ export const DEFAULT_ENDPOINTS: PlaygroundEndpoints = {
 export const DEFAULT_VIEWERS: ViewerFlags = {
   config: true,
   stdio: true,
+  stderr: true,
   provenance: true,
   timing: true,
 };

--- a/npm/ox-content-code-play/src/framework.ts
+++ b/npm/ox-content-code-play/src/framework.ts
@@ -1,6 +1,6 @@
 import { escapeHtml } from "./escape";
 import { PhaseTracker } from "./timing";
-import type { AdapterRequest, FrameworkId, RunResult } from "./types";
+import type { AdapterRequest, AdapterResult, FrameworkId } from "./types";
 
 const RUNTIMES: Record<FrameworkId, { specifier: string; cdn: string }> = {
   vue: { specifier: "vue", cdn: "https://esm.sh/vue@3" },
@@ -9,7 +9,7 @@ const RUNTIMES: Record<FrameworkId, { specifier: string; cdn: string }> = {
   solid: { specifier: "solid-js", cdn: "https://esm.sh/solid-js@1" },
 };
 
-export async function runFramework(request: AdapterRequest): Promise<RunResult> {
+export async function runFramework(request: AdapterRequest): Promise<AdapterResult> {
   const tracker = new PhaseTracker();
   tracker.start("compile", "Compile preview");
   const framework = request.definition.framework ?? "vue";

--- a/npm/ox-content-code-play/src/go.ts
+++ b/npm/ox-content-code-play/src/go.ts
@@ -1,6 +1,6 @@
 import { StdioBuffer } from "./stdio";
 import { PhaseTracker } from "./timing";
-import type { AdapterRequest, Diagnostic, RunResult } from "./types";
+import type { AdapterRequest, AdapterResult, Diagnostic } from "./types";
 
 interface GoPlaygroundEvent {
   Message?: string;
@@ -17,7 +17,7 @@ interface GoPlaygroundResponse {
 export async function runGo(
   request: AdapterRequest,
   mode: "execute" | "typecheck",
-): Promise<RunResult> {
+): Promise<AdapterResult> {
   const tracker = new PhaseTracker();
   const stdio = new StdioBuffer(tracker.startedAt);
   const params = new URLSearchParams({

--- a/npm/ox-content-code-play/src/html.ts
+++ b/npm/ox-content-code-play/src/html.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_VIEWERS } from "./config";
 import { decodeHtml, escapeAttribute } from "./escape";
 import type { PlayPayload } from "./types";
 
@@ -64,7 +65,7 @@ function upgradeCodePlayTags(html: string, options: HtmlEnhanceOptions): string 
       code,
       capabilities: { execute: true, typecheck: /\btypecheck\b/i.test(attrs) },
       config: {},
-      viewers: { config: true, stdio: true, provenance: true, timing: true },
+      viewers: { ...DEFAULT_VIEWERS },
       ui: "default",
       timeoutMs: 10_000,
     });

--- a/npm/ox-content-code-play/src/hydrate.ts
+++ b/npm/ox-content-code-play/src/hydrate.ts
@@ -126,7 +126,8 @@ function paintResult(element: HTMLElement, _payload: PlayPayload, result: RunRes
   }
   const focusStderr =
     Boolean(stderr) &&
-    (Boolean(result.stderr) || result.diagnostics.some((diagnostic) => diagnostic.severity === "error"));
+    (Boolean(result.stderr) ||
+      result.diagnostics.some((diagnostic) => diagnostic.severity === "error"));
   showPanel(element, focusStderr ? "stderr" : "stdio");
 }
 

--- a/npm/ox-content-code-play/src/hydrate.ts
+++ b/npm/ox-content-code-play/src/hydrate.ts
@@ -6,6 +6,7 @@ import type { PlayPayload, RunResult } from "./types";
 import {
   renderDiagnosticsHtml,
   renderProvenanceHtml,
+  renderStderrHtml,
   renderStdioHtml,
   renderTimingHtml,
 } from "./viewers";
@@ -119,10 +120,18 @@ function paintResult(element: HTMLElement, _payload: PlayPayload, result: RunRes
   if (timing) {
     timing.innerHTML = renderTimingHtml(result.timing);
   }
-  showPanel(element, "stdio");
+  const stderr = element.querySelector('[data-panel="stderr"]');
+  if (stderr) {
+    stderr.innerHTML = renderStderrHtml(result);
+  }
+  const focusStderr =
+    Boolean(stderr) &&
+    (Boolean(result.stderr) || result.diagnostics.some((diagnostic) => diagnostic.severity === "error"));
+  showPanel(element, focusStderr ? "stderr" : "stdio");
 }
 
 function showPanel(element: HTMLElement, panel: string): void {
+  const compact = Boolean(element.querySelector(".ox-code-play--compact"));
   for (const tab of element.querySelectorAll("[data-ox-panel]")) {
     tab.setAttribute(
       "aria-selected",
@@ -130,7 +139,12 @@ function showPanel(element: HTMLElement, panel: string): void {
     );
   }
   for (const node of element.querySelectorAll<HTMLElement>(".ox-code-play__panel")) {
-    node.hidden = node.dataset.panel !== panel;
+    const id = node.dataset.panel;
+    if (compact && (id === "stdio" || id === "stderr")) {
+      node.hidden = false;
+      continue;
+    }
+    node.hidden = id !== panel;
   }
 }
 

--- a/npm/ox-content-code-play/src/index.ts
+++ b/npm/ox-content-code-play/src/index.ts
@@ -12,6 +12,7 @@ export type { RawCodePlayOptions, ResolvedCodePlayOptions } from "./config";
 export { codePlay } from "./plugin";
 export type { CodePlayPluginOptions } from "./plugin";
 export { CodePlaySession } from "./session";
+export { joinStream, selectStream, withStdioText } from "./stdio";
 export { createFetchTransport, createMemoryTransport } from "./transport";
 export { hydrateCodePlay, mountCodePlay } from "./hydrate";
 export { renderPlayUi } from "./ui";
@@ -19,6 +20,7 @@ export {
   renderConfigHtml,
   renderDiagnosticsHtml,
   renderProvenanceHtml,
+  renderStderrHtml,
   renderStdioHtml,
   renderTimingHtml,
 } from "./viewers";
@@ -28,6 +30,7 @@ export { encodePayload, decodePayload } from "./payload";
 export { PhaseTracker } from "./timing";
 export { CODE_PLAY_STYLES } from "./styles";
 export type {
+  AdapterResult,
   CodePlayPreset,
   ConfigField,
   Diagnostic,

--- a/npm/ox-content-code-play/src/javascript.ts
+++ b/npm/ox-content-code-play/src/javascript.ts
@@ -1,8 +1,8 @@
 import { formatConsoleArgs, StdioBuffer } from "./stdio";
 import { nowMs, PhaseTracker } from "./timing";
-import type { AdapterRequest, Diagnostic, RunResult } from "./types";
+import type { AdapterRequest, AdapterResult, Diagnostic } from "./types";
 
-export async function runJavaScript(request: AdapterRequest): Promise<RunResult> {
+export async function runJavaScript(request: AdapterRequest): Promise<AdapterResult> {
   const tracker = new PhaseTracker();
   tracker.start("execute", "Execute");
   const stdio = new StdioBuffer(tracker.startedAt);
@@ -82,8 +82,18 @@ function isTimeout(error: unknown): boolean {
 }
 
 function toDiagnostic(error: unknown): Diagnostic {
-  if (error instanceof Error) {
+  if (isErrorLike(error)) {
     return { message: error.message, severity: "error", source: "javascript" };
   }
   return { message: String(error), severity: "error", source: "javascript" };
+}
+
+function isErrorLike(error: unknown): error is { message: string } {
+  return Boolean(
+    error &&
+    typeof error === "object" &&
+    "message" in error &&
+    typeof error.message === "string" &&
+    error.message.length > 0,
+  );
 }

--- a/npm/ox-content-code-play/src/markdown.test.ts
+++ b/npm/ox-content-code-play/src/markdown.test.ts
@@ -3,7 +3,7 @@ import { enhanceGeneratedModule, enhancePlayHtml } from "./html";
 import { parseCodePlayTags, parsePlayFences, rewritePlayFences, stripPlayMeta } from "./markdown";
 import { decodePayload, encodePayload } from "./payload";
 import { payloadFromFence } from "./payload-factory";
-import { resolveCodePlayOptions } from "./config";
+import { DEFAULT_VIEWERS, resolveCodePlayOptions } from "./config";
 import {
   renderConfigHtml,
   renderProvenanceHtml,
@@ -115,7 +115,7 @@ describe("markdown and viewers", () => {
           code: "const n = 1;",
           capabilities: { execute: true, typecheck: true },
           config: { strict: true },
-          viewers: { config: true, stdio: true, provenance: true, timing: true },
+          viewers: { ...DEFAULT_VIEWERS },
           ui: "default",
           timeoutMs: 1000,
         },
@@ -129,10 +129,26 @@ describe("markdown and viewers", () => {
       code: "package main",
       capabilities: { execute: true, typecheck: true },
       config: { withVet: true },
-      viewers: { config: true, stdio: true, provenance: true, timing: true },
+      viewers: { ...DEFAULT_VIEWERS },
       ui: "compact" as const,
       timeoutMs: 5,
     };
     expect(decodePayload(encodePayload(payload))).toEqual(payload);
+  });
+
+  it("fills a missing stderr viewer flag when decoding older payloads", () => {
+    const encoded = Buffer.from(
+      JSON.stringify({
+        language: "javascript",
+        code: "1",
+        capabilities: { execute: true, typecheck: false },
+        config: {},
+        viewers: { config: true, stdio: true, provenance: true, timing: true },
+        ui: "default",
+        timeoutMs: 1,
+      }),
+    ).toString("base64");
+    expect(decodePayload(encoded).viewers.stderr).toBe(true);
+    expect(decodePayload(encoded).viewers.stdio).toBe(true);
   });
 });

--- a/npm/ox-content-code-play/src/payload.ts
+++ b/npm/ox-content-code-play/src/payload.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_VIEWERS } from "./config";
 import type { PlayPayload } from "./types";
 
 export function encodePayload(payload: PlayPayload): string {
@@ -10,7 +11,10 @@ export function decodePayload(value: string): PlayPayload {
   if (!parsed || typeof parsed !== "object" || typeof parsed.language !== "string") {
     throw new Error("Invalid Code Play payload.");
   }
-  return parsed;
+  return {
+    ...parsed,
+    viewers: { ...DEFAULT_VIEWERS, ...parsed.viewers },
+  };
 }
 
 function bytesToBase64(bytes: Uint8Array): string {

--- a/npm/ox-content-code-play/src/remote.ts
+++ b/npm/ox-content-code-play/src/remote.ts
@@ -1,6 +1,6 @@
 import { StdioBuffer } from "./stdio";
 import { PhaseTracker } from "./timing";
-import type { AdapterRequest, RunResult } from "./types";
+import type { AdapterRequest, AdapterResult } from "./types";
 
 interface PistonExecuteResponse {
   compile?: { stdout?: string; stderr?: string; code?: number };
@@ -8,7 +8,7 @@ interface PistonExecuteResponse {
   message?: string;
 }
 
-export async function runRemote(request: AdapterRequest): Promise<RunResult> {
+export async function runRemote(request: AdapterRequest): Promise<AdapterResult> {
   const tracker = new PhaseTracker();
   const stdio = new StdioBuffer(tracker.startedAt);
   const endpoint = request.enabled.endpoint;

--- a/npm/ox-content-code-play/src/rust.ts
+++ b/npm/ox-content-code-play/src/rust.ts
@@ -1,6 +1,6 @@
 import { StdioBuffer } from "./stdio";
 import { PhaseTracker } from "./timing";
-import type { AdapterRequest, Diagnostic, RunResult } from "./types";
+import type { AdapterRequest, AdapterResult, Diagnostic } from "./types";
 
 interface RustPlaygroundResponse {
   success?: boolean;
@@ -12,7 +12,7 @@ interface RustPlaygroundResponse {
 export async function runRust(
   request: AdapterRequest,
   mode: "execute" | "typecheck",
-): Promise<RunResult> {
+): Promise<AdapterResult> {
   const tracker = new PhaseTracker();
   const stdio = new StdioBuffer(tracker.startedAt);
   const crateType = resolveCrateType(request.code, String(request.config.crateType ?? "auto"));

--- a/npm/ox-content-code-play/src/session.ts
+++ b/npm/ox-content-code-play/src/session.ts
@@ -1,5 +1,6 @@
 import { executeAdapter, typecheckAdapter } from "./adapters";
 import { mergeConfig } from "./config";
+import { withStdioText } from "./stdio";
 import type {
   AdapterRequest,
   CodePlayTransport,
@@ -20,6 +21,17 @@ export class CodePlaySession {
   code: string;
   config: Record<string, unknown>;
   lastResult: RunResult | undefined;
+
+  /** Last run's concatenated stdout (same as `lastResult.stdout`). */
+  get stdout(): string {
+    return this.lastResult?.stdout ?? "";
+  }
+
+  /** Last run's concatenated stderr (same as `lastResult.stderr`). */
+  get stderr(): string {
+    return this.lastResult?.stderr ?? "";
+  }
+
   private readonly enabled: ResolvedLanguageEnable;
   private readonly timeoutMs: number;
   private readonly transport: CodePlayTransport;
@@ -73,8 +85,9 @@ export class CodePlaySession {
       loadTypeScript: this.loadTypeScript,
       endpoints: this.endpoints,
     };
-    const result =
-      action === "typecheck" ? await typecheckAdapter(request) : await executeAdapter(request);
+    const result = withStdioText(
+      action === "typecheck" ? await typecheckAdapter(request) : await executeAdapter(request),
+    );
     this.lastResult = result;
     for (const event of result.stdio) {
       this.emit("stdio", event);

--- a/npm/ox-content-code-play/src/stdio.test.ts
+++ b/npm/ox-content-code-play/src/stdio.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vite-plus/test";
+import { joinStream, selectStream, StdioBuffer, withStdioText } from "./stdio";
+import type { StdioEvent } from "./types";
+
+const events: StdioEvent[] = [
+  { stream: "stdout", text: "a", timestampMs: 1 },
+  { stream: "stderr", text: "e1", timestampMs: 2 },
+  { stream: "stdout", text: "b", timestampMs: 3 },
+  { stream: "stderr", text: "e2", timestampMs: 4 },
+  { stream: "stdin", text: "in", timestampMs: 5 },
+];
+
+describe("stdio helpers", () => {
+  it("joins stdout and stderr in stream order without mixing the other stream", () => {
+    expect(joinStream(events, "stdout")).toBe("ab");
+    expect(joinStream(events, "stderr")).toBe("e1e2");
+    expect(joinStream(events, "stdin")).toBe("in");
+    expect(joinStream([], "stdout")).toBe("");
+  });
+
+  it("selects only the requested stream and preserves timestamps", () => {
+    expect(selectStream(events, "stderr")).toEqual([
+      { stream: "stderr", text: "e1", timestampMs: 2 },
+      { stream: "stderr", text: "e2", timestampMs: 4 },
+    ]);
+    expect(selectStream(events, "stdout")).toHaveLength(2);
+  });
+
+  it("attaches exact stdout and stderr strings without mutating the original result", () => {
+    const result = {
+      status: "ok" as const,
+      stdio: events,
+      extra: true,
+    };
+    const next = withStdioText(result);
+    expect(next.stdout).toBe("ab");
+    expect(next.stderr).toBe("e1e2");
+    expect(next.extra).toBe(true);
+    expect(result).not.toHaveProperty("stdout");
+    expect(result).not.toHaveProperty("stderr");
+  });
+
+  it("records buffer events with stream identity", () => {
+    const buffer = new StdioBuffer(0);
+    buffer.push("stdout", "out\n", 1);
+    buffer.push("stderr", "err\n", 2);
+    expect(buffer.snapshot()).toEqual([
+      { stream: "stdout", text: "out\n", timestampMs: 1 },
+      { stream: "stderr", text: "err\n", timestampMs: 2 },
+    ]);
+  });
+});

--- a/npm/ox-content-code-play/src/stdio.ts
+++ b/npm/ox-content-code-play/src/stdio.ts
@@ -19,6 +19,27 @@ export class StdioBuffer {
   }
 }
 
+export function joinStream(events: StdioEvent[], stream: StdioStream): string {
+  return events
+    .filter((event) => event.stream === stream)
+    .map((event) => event.text)
+    .join("");
+}
+
+export function selectStream(events: StdioEvent[], stream: StdioStream): StdioEvent[] {
+  return events.filter((event) => event.stream === stream);
+}
+
+export function withStdioText<T extends { stdio: StdioEvent[] }>(
+  result: T,
+): T & { stdout: string; stderr: string } {
+  return {
+    ...result,
+    stdout: joinStream(result.stdio, "stdout"),
+    stderr: joinStream(result.stdio, "stderr"),
+  };
+}
+
 export function formatConsoleArgs(args: unknown[]): string {
   return `${args.map(formatConsoleArg).join(" ")}\n`;
 }

--- a/npm/ox-content-code-play/src/styles.ts
+++ b/npm/ox-content-code-play/src/styles.ts
@@ -82,5 +82,5 @@ export const CODE_PLAY_STYLES = `
 .ox-code-play__diag--error { color: var(--octc-danger, #b42318); }
 .ox-code-play__diag--warning { color: var(--octc-warning, #b54708); }
 .ox-code-play--compact .ox-code-play__tabs { display: none; }
-.ox-code-play--compact .ox-code-play__panel[data-panel]:not([data-panel="stdio"]) { display: none; }
+.ox-code-play--compact .ox-code-play__panel[data-panel]:not([data-panel="stdio"]):not([data-panel="stderr"]) { display: none; }
 `;

--- a/npm/ox-content-code-play/src/types.ts
+++ b/npm/ox-content-code-play/src/types.ts
@@ -52,7 +52,7 @@ export interface PreviewDocument {
   html: string;
 }
 
-export interface RunResult {
+export interface AdapterResult {
   status: RunStatus;
   stdio: StdioEvent[];
   diagnostics: Diagnostic[];
@@ -60,6 +60,13 @@ export interface RunResult {
   timing: TimingReport;
   preview?: PreviewDocument;
   value?: string;
+}
+
+export interface RunResult extends AdapterResult {
+  /** Concatenated `stdout` chunks from `stdio`. */
+  stdout: string;
+  /** Concatenated `stderr` chunks from `stdio`. */
+  stderr: string;
 }
 
 export type ConfigFieldType = "string" | "boolean" | "select" | "number";
@@ -148,6 +155,7 @@ export interface CodePlayTransport {
 export interface ViewerFlags {
   config: boolean;
   stdio: boolean;
+  stderr: boolean;
   provenance: boolean;
   timing: boolean;
 }

--- a/npm/ox-content-code-play/src/typescript.ts
+++ b/npm/ox-content-code-play/src/typescript.ts
@@ -7,11 +7,11 @@ import { executeScript } from "./javascript";
 import { StdioBuffer } from "./stdio";
 import { stripTypeScript } from "./strip-typescript";
 import { PhaseTracker } from "./timing";
-import type { AdapterRequest, Diagnostic, RunResult } from "./types";
+import type { AdapterRequest, AdapterResult, Diagnostic } from "./types";
 
 const execFileAsync = promisify(execFile);
 
-export async function typecheckTypeScript(request: AdapterRequest): Promise<RunResult> {
+export async function typecheckTypeScript(request: AdapterRequest): Promise<AdapterResult> {
   const tracker = new PhaseTracker();
   tracker.start("typecheck", "Typecheck");
 
@@ -53,7 +53,7 @@ export async function typecheckTypeScript(request: AdapterRequest): Promise<RunR
   }
 }
 
-export async function runTypeScript(request: AdapterRequest): Promise<RunResult> {
+export async function runTypeScript(request: AdapterRequest): Promise<AdapterResult> {
   const tracker = new PhaseTracker();
   const stdio = new StdioBuffer(tracker.startedAt);
   tracker.start("compile", "Strip types");
@@ -97,7 +97,7 @@ export async function runTypeScript(request: AdapterRequest): Promise<RunResult>
 async function typecheckViaEndpoint(
   request: AdapterRequest,
   tracker: PhaseTracker,
-): Promise<RunResult> {
+): Promise<AdapterResult> {
   const response = await request.transport.request({
     url: request.endpoints.typecheck ?? "",
     method: "POST",
@@ -106,7 +106,7 @@ async function typecheckViaEndpoint(
   });
   tracker.stop();
   try {
-    return JSON.parse(response.text) as RunResult;
+    return JSON.parse(response.text) as AdapterResult;
   } catch {
     return {
       status: "error",

--- a/npm/ox-content-code-play/src/ui.ts
+++ b/npm/ox-content-code-play/src/ui.ts
@@ -5,6 +5,7 @@ import {
   renderConfigHtml,
   renderDiagnosticsHtml,
   renderProvenanceHtml,
+  renderStderrHtml,
   renderStdioHtml,
   renderTimingHtml,
 } from "./viewers";
@@ -13,7 +14,7 @@ export interface UiState {
   payload: PlayPayload;
   result?: RunResult;
   busy?: boolean;
-  panel?: "stdio" | "config" | "provenance" | "timing";
+  panel?: "stdio" | "stderr" | "config" | "provenance" | "timing";
 }
 
 export function renderPlayUi(state: UiState): string {
@@ -25,6 +26,7 @@ export function renderPlayUi(state: UiState): string {
   const panel = state.panel ?? "stdio";
   const canTypecheck = state.payload.capabilities.typecheck;
   const tabs = renderTabs(state, panel);
+  const viewers = state.payload.viewers;
   return `<div class="ox-code-play ox-code-play--${preset}" data-ox-code-play-ui>
   <div class="ox-code-play__toolbar">
     <span class="ox-code-play__lang">${escapeHtml(definition?.name ?? state.payload.language)}</span>
@@ -33,10 +35,11 @@ export function renderPlayUi(state: UiState): string {
   </div>
   <div class="ox-code-play__source"></div>
   ${tabs}
-  <div class="ox-code-play__panel" data-panel="stdio">${renderDiagnosticsHtml(state.result)}${renderStdioHtml(state.result?.stdio ?? [])}</div>
-  <div class="ox-code-play__panel" data-panel="config"${hidden(panel, "config")}>${renderConfigHtml(definition?.configSchema ?? [], state.payload.config)}</div>
-  <div class="ox-code-play__panel" data-panel="provenance"${hidden(panel, "provenance")}>${renderProvenanceHtml(state.result?.provenance)}</div>
-  <div class="ox-code-play__panel" data-panel="timing"${hidden(panel, "timing")}>${renderTimingHtml(state.result?.timing)}</div>
+  ${viewers.stdio ? `<div class="ox-code-play__panel" data-panel="stdio">${renderDiagnosticsHtml(state.result)}${renderStdioHtml(state.result?.stdio ?? [])}</div>` : ""}
+  ${viewers.stderr ? `<div class="ox-code-play__panel" data-panel="stderr"${hidden(panel, "stderr", preset)}>${renderStderrHtml(state.result)}</div>` : ""}
+  <div class="ox-code-play__panel" data-panel="config"${hidden(panel, "config", preset)}>${renderConfigHtml(definition?.configSchema ?? [], state.payload.config)}</div>
+  <div class="ox-code-play__panel" data-panel="provenance"${hidden(panel, "provenance", preset)}>${renderProvenanceHtml(state.result?.provenance)}</div>
+  <div class="ox-code-play__panel" data-panel="timing"${hidden(panel, "timing", preset)}>${renderTimingHtml(state.result?.timing)}</div>
 </div>`;
 }
 
@@ -47,6 +50,7 @@ function renderTabs(state: UiState, panel: string): string {
   const viewers = state.payload.viewers;
   const buttons = [
     viewers.stdio ? tab("stdio", "stdio", panel) : "",
+    viewers.stderr ? tab("stderr", "stderr", panel) : "",
     viewers.config ? tab("config", "config", panel) : "",
     viewers.provenance ? tab("provenance", "provenance", panel) : "",
     viewers.timing ? tab("timing", "timing", panel) : "",
@@ -60,6 +64,9 @@ function tab(id: string, label: string, selected: string): string {
   return `<button type="button" role="tab" data-ox-panel="${id}" aria-selected="${selected === id ? "true" : "false"}">${label}</button>`;
 }
 
-function hidden(current: string, id: string): string {
+function hidden(current: string, id: string, preset: CodePlayPreset): string {
+  if (preset === "compact" && (id === "stdio" || id === "stderr")) {
+    return "";
+  }
   return current === id ? "" : " hidden";
 }

--- a/npm/ox-content-code-play/src/viewers.test.ts
+++ b/npm/ox-content-code-play/src/viewers.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vite-plus/test";
+import { DEFAULT_VIEWERS } from "./config";
+import { withStdioText } from "./stdio";
+import type { PlayPayload, RunResult } from "./types";
+import { renderPlayUi } from "./ui";
+import { renderStderrHtml } from "./viewers";
+
+function result(partial: Partial<RunResult> = {}): RunResult {
+  return withStdioText({
+    status: "ok",
+    stdio: [],
+    diagnostics: [],
+    provenance: {},
+    timing: { totalMs: 0, phases: [] },
+    ...partial,
+  });
+}
+
+function payload(overrides: Partial<PlayPayload> = {}): PlayPayload {
+  return {
+    language: "javascript",
+    code: "console.log(1)",
+    capabilities: { execute: true, typecheck: false },
+    config: {},
+    viewers: { ...DEFAULT_VIEWERS },
+    ui: "default",
+    timeoutMs: 1000,
+    ...overrides,
+  };
+}
+
+describe("stderr viewer", () => {
+  it("shows the empty state when there is no stderr and no error or warning", () => {
+    expect(renderStderrHtml(undefined)).toBe(`<p class="ox-code-play__empty">No stderr.</p>`);
+    expect(renderStderrHtml(result())).toBe(`<p class="ox-code-play__empty">No stderr.</p>`);
+    expect(
+      renderStderrHtml(
+        result({
+          diagnostics: [{ message: "note", severity: "info", source: "code-play" }],
+        }),
+      ),
+    ).toBe(`<p class="ox-code-play__empty">No stderr.</p>`);
+  });
+
+  it("renders only stderr chunks and never stdout text", () => {
+    const html = renderStderrHtml(
+      result({
+        stdio: [
+          { stream: "stdout", text: "ok\n", timestampMs: 1.2 },
+          { stream: "stderr", text: "bad\n", timestampMs: 3 },
+        ],
+      }),
+    );
+    expect(html).toContain("stderr +3.0ms");
+    expect(html).toContain("bad\n");
+    expect(html).not.toContain("stdout");
+    expect(html).not.toContain("ok\n");
+  });
+
+  it("surfaces typecheck diagnostics when the stderr stream is empty", () => {
+    const html = renderStderrHtml(
+      result({
+        status: "error",
+        diagnostics: [
+          {
+            message: "Type 'string' is not assignable to type 'number'.",
+            severity: "error",
+            line: 1,
+            column: 7,
+            source: "tsgo",
+          },
+        ],
+      }),
+    );
+    expect(html).toContain("ox-code-play__diag--error");
+    expect(html).toContain(":1:7");
+    expect(html).toContain("Type &#39;string&#39; is not assignable to type &#39;number&#39;.");
+    expect(html).not.toContain("No stderr.");
+    expect(html).not.toContain("ox-code-play__stdio");
+  });
+
+  it("renders stderr chunks and warning diagnostics together", () => {
+    const html = renderStderrHtml(
+      result({
+        stdio: [{ stream: "stderr", text: "warning: unused\n", timestampMs: 4 }],
+        diagnostics: [{ message: "unused", severity: "warning", source: "rustc" }],
+      }),
+    );
+    expect(html).toContain("warning: unused");
+    expect(html).toContain("ox-code-play__diag--warning");
+  });
+});
+
+describe("stderr UI flags", () => {
+  it("adds a stderr tab and panel when viewers.stderr is enabled", () => {
+    const html = renderPlayUi({ payload: payload() });
+    expect(html).toContain('data-ox-panel="stderr"');
+    expect(html).toContain('data-panel="stderr"');
+    expect(html).toContain("No stderr.");
+  });
+
+  it("omits the stderr tab and panel when viewers.stderr is false", () => {
+    const html = renderPlayUi({
+      payload: payload({ viewers: { ...DEFAULT_VIEWERS, stderr: false } }),
+    });
+    expect(html).not.toContain('data-ox-panel="stderr"');
+    expect(html).not.toContain('data-panel="stderr"');
+    expect(html).toContain('data-panel="stdio"');
+  });
+
+  it("keeps the compact stderr panel visible and hides compact tabs", () => {
+    const html = renderPlayUi({ payload: payload({ ui: "compact" }) });
+    expect(html).toContain("ox-code-play--compact");
+    expect(html).not.toContain("ox-code-play__tabs");
+    expect(html).toContain('data-panel="stderr"');
+    expect(html).not.toMatch(/data-panel="stderr"[^>]*\bhidden\b/);
+    expect(html).toMatch(/data-panel="config"[^>]*\bhidden\b/);
+  });
+});

--- a/npm/ox-content-code-play/src/viewers.ts
+++ b/npm/ox-content-code-play/src/viewers.ts
@@ -1,4 +1,5 @@
 import { escapeHtml } from "./escape";
+import { selectStream } from "./stdio";
 import type { ConfigField, Provenance, RunResult, StdioEvent, TimingReport } from "./types";
 
 export function renderStdioHtml(events: StdioEvent[]): string {
@@ -12,6 +13,30 @@ export function renderStdioHtml(events: StdioEvent[]): string {
     })
     .join("");
   return `<div class="ox-code-play__stdio" role="log">${lines}</div>`;
+}
+
+/** Dedicated stderr viewer: stderr chunks plus error/warning diagnostics. */
+export function renderStderrHtml(result: RunResult | undefined): string {
+  const chunks = selectStream(result?.stdio ?? [], "stderr");
+  const diagnostics = (result?.diagnostics ?? []).filter(
+    (diagnostic) => diagnostic.severity === "error" || diagnostic.severity === "warning",
+  );
+  if (chunks.length === 0 && diagnostics.length === 0) {
+    return `<p class="ox-code-play__empty">No stderr.</p>`;
+  }
+  const stream = chunks.length === 0 ? "" : renderStdioHtml(chunks);
+  if (diagnostics.length === 0) {
+    return stream;
+  }
+  const items = diagnostics
+    .map((diagnostic) => {
+      const place = diagnostic.line
+        ? `:${diagnostic.line}${diagnostic.column ? `:${diagnostic.column}` : ""}`
+        : "";
+      return `<li class="ox-code-play__diag ox-code-play__diag--${diagnostic.severity}">${escapeHtml(diagnostic.severity)}${escapeHtml(place)} ${escapeHtml(diagnostic.message)}</li>`;
+    })
+    .join("");
+  return `${stream}<ul class="ox-code-play__diags">${items}</ul>`;
 }
 
 export function renderConfigHtml(schema: ConfigField[], config: Record<string, unknown>): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #649 / #648. `RunResult` now always exposes concatenated `stdout` and `stderr` strings, and the default UI gets a dedicated **stderr** viewer.

- `withStdioText()` derives exact `stdout` / `stderr` from timestamped stdio events (join order preserved).
- New `renderStderrHtml()` shows stderr chunks plus error/warning diagnostics, so type-check failures still appear when the stream is empty.
- Default preset adds a stderr tab; compact keeps stderr visible next to stdio.
- `console.warn` / `console.error` stay on stderr. VM-thrown errors use the error `message` (not `String(error)`).
- Older payloads missing `viewers.stderr` default it to `true` on decode.

## Risk

- Risk level: low
- User or production impact: additive API/UI only. Existing `stdio` events are unchanged. Sites that construct `ViewerFlags` by hand must include `stderr`.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run: `tsgo --noEmit` and `vp test src` in `@ox-content/code-play` (36 tests)
- [x] Manual verification completed: N/A for this API/unit-test change (no live playground calls)
- [x] Edge cases or failure modes considered: empty stderr, info-only diagnostics, HTML escaping, compact hidden attributes, older payloads

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

Refs: #648

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790143706&installation_model_id=422833&pr_number=662&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F662&signature=169c8cd75b875c2db0d8cfca06d4d6c5ffc6670a4e36135a46646420ad3cb38b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated stderr viewer with tabs and panels for errors, warnings, and diagnostic output.
  * Execution results and sessions now expose separate stdout and stderr text.
  * Console warnings and errors are routed to stderr, while console logs remain in stdout.
  * Compact layouts keep both standard output and error output visible.
* **Documentation**
  * Updated Code Play guides, examples, and roadmap to describe stderr viewing and separate output fields.
* **Bug Fixes**
  * Older configurations now retain compatibility with stderr viewing by applying the default setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->