### PR TITLE
feat(code-play): harden playground proxies and document endpoints

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,7 +54,8 @@ Content release artifacts, including:
   Sample code is not run during Markdown transform or SSG. JavaScript and
   TypeScript run in `node:vm` or a browser iframe. Native languages use official
   playgrounds or a user-configured HTTP executor. The plugin does not spawn a
-  local shell.
+  local shell. The Vite `/__ox-code-play/*` proxies are dev-only, accept POST
+  only, and do not leak upstream fetch errors to the client.
 - Build, release, and dependency configuration that could affect distributed
   artifacts.
 

--- a/docs/content/code-play-roadmap.md
+++ b/docs/content/code-play-roadmap.md
@@ -61,8 +61,10 @@ add a visual check for the default preset.
 
 ### 3. `feat(code-play): official playground proxies`
 
-Keep the allowlisted `/__ox-code-play/rust` and `/__ox-code-play/go` proxies,
-add production `endpoints` documentation, and cover proxy failure modes.
+This PR. Keep the `/__ox-code-play/rust`, `/__ox-code-play/go`, and
+`/__ox-code-play/typecheck` dev proxies. Reject non-POST requests, oversize
+bodies, and non-http(s) destinations; return generic JSON errors; document
+production `endpoints`.
 
 ### 4. `feat(code-play): framework preview compilers`
 

--- a/docs/content/packages/code-play.md
+++ b/docs/content/packages/code-play.md
@@ -110,11 +110,11 @@ JavaScript and TypeScript run locally in `node:vm` or a browser iframe.
 
 Vite **dev server** only. `codePlay({ proxy: true })` (the default) mounts:
 
-| Path | Forwards to |
-| ---- | ----------- |
-| `POST /__ox-code-play/rust` | `endpoints.rust` (default `https://play.rust-lang.org/execute`) |
-| `POST /__ox-code-play/go` | `endpoints.go` (default `https://play.golang.org/compile`) |
-| `POST /__ox-code-play/typecheck` | local `tsgo` (no remote compiler) |
+| Path                             | Forwards to                                                     |
+| -------------------------------- | --------------------------------------------------------------- |
+| `POST /__ox-code-play/rust`      | `endpoints.rust` (default `https://play.rust-lang.org/execute`) |
+| `POST /__ox-code-play/go`        | `endpoints.go` (default `https://play.golang.org/compile`)      |
+| `POST /__ox-code-play/typecheck` | local `tsgo` (no remote compiler)                               |
 
 These routes accept **POST** only, cap the body at 256 KiB, and refuse
 non-`http(s)` destinations or URLs with embedded credentials. Upstream

--- a/docs/content/packages/code-play.md
+++ b/docs/content/packages/code-play.md
@@ -106,6 +106,25 @@ Remote languages need `languages.<id>.endpoint` pointing at a
 Piston-compatible executor. Rust and Go default to the official playgrounds.
 JavaScript and TypeScript run locally in `node:vm` or a browser iframe.
 
+## Playground proxies
+
+Vite **dev server** only. `codePlay({ proxy: true })` (the default) mounts:
+
+| Path | Forwards to |
+| ---- | ----------- |
+| `POST /__ox-code-play/rust` | `endpoints.rust` (default `https://play.rust-lang.org/execute`) |
+| `POST /__ox-code-play/go` | `endpoints.go` (default `https://play.golang.org/compile`) |
+| `POST /__ox-code-play/typecheck` | local `tsgo` (no remote compiler) |
+
+These routes accept **POST** only, cap the body at 256 KiB, and refuse
+non-`http(s)` destinations or URLs with embedded credentials. Upstream
+failures return generic JSON `{ "error": "..." }` and do not leak fetch
+details.
+
+The proxy is not installed in production SSG output. Set `endpoints` to the
+official playgrounds (or your own HTTPS executor) for published pages, or
+`proxy: false` if you do not want the dev middleware.
+
 ## Security
 
 - Samples are not executed during Markdown transform or SSG.

--- a/npm/ox-content-code-play/src/plugin-proxy.test.ts
+++ b/npm/ox-content-code-play/src/plugin-proxy.test.ts
@@ -1,0 +1,197 @@
+import { Readable } from "node:stream";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import {
+  assertHttpUrl,
+  PROXY_MAX_BODY_BYTES,
+  ProxyRequestError,
+  proxy,
+  readLimitedBody,
+  typecheckProxy,
+  writeProxyError,
+} from "./plugin-proxy";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("assertHttpUrl", () => {
+  it("accepts http and https destinations", () => {
+    expect(assertHttpUrl("https://play.rust-lang.org/execute").host).toBe("play.rust-lang.org");
+    expect(assertHttpUrl("http://127.0.0.1:8080/execute").protocol).toBe("http:");
+  });
+
+  it("rejects non-http schemes, invalid URLs, and embedded credentials", () => {
+    expect(() => assertHttpUrl("file:///etc/passwd")).toThrow(ProxyRequestError);
+    expect(() => assertHttpUrl("not a url")).toThrow(/Invalid Code Play proxy destination/);
+    expect(() => assertHttpUrl("https://user:secret@play.rust-lang.org/execute")).toThrow(
+      /must not include credentials/,
+    );
+    try {
+      assertHttpUrl("ftp://play.rust-lang.org/execute");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProxyRequestError);
+      expect((error as ProxyRequestError).statusCode).toBe(400);
+    }
+  });
+});
+
+describe("readLimitedBody", () => {
+  it("reads a POST body and rejects other methods", async () => {
+    await expect(readLimitedBody(request("hello", "GET"))).rejects.toMatchObject({
+      statusCode: 405,
+      message: "Code Play proxy only accepts POST.",
+    });
+    await expect(readLimitedBody(request("hello", "POST"))).resolves.toEqual(Buffer.from("hello"));
+  });
+
+  it("rejects bodies that exceed the limit before concatenating the rest", async () => {
+    await expect(readLimitedBody(request("abcdef"), 4)).rejects.toMatchObject({
+      statusCode: 413,
+      message: "Code Play proxy request body is too large.",
+    });
+    expect(PROXY_MAX_BODY_BYTES).toBe(256 * 1024);
+  });
+});
+
+describe("proxy", () => {
+  it("forwards POST bodies to the configured destination", async () => {
+    const calls: Array<{ url: string; body: string; type: string | undefined }> = [];
+    globalThis.fetch = (async (url, init) => {
+      calls.push({
+        url: String(url),
+        body: decodeBody(init?.body),
+        type: new Headers(init?.headers).get("content-type") ?? undefined,
+      });
+      return new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const res = response();
+    await proxy(request(JSON.stringify({ code: "fn main() {}" })), res, "https://play.rust-lang.org/execute", "application/json");
+    expect(res.statusCode).toBe(200);
+    expect(res.state.body).toBe(JSON.stringify({ success: true }));
+    expect(res.state.headers["content-type"]).toBe("application/json");
+    expect(calls).toEqual([
+      {
+        url: "https://play.rust-lang.org/execute",
+        body: JSON.stringify({ code: "fn main() {}" }),
+        type: "application/json",
+      },
+    ]);
+  });
+
+  it("returns 405 for GET without calling fetch", async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response("nope");
+    }) as typeof fetch;
+    const res = response();
+    await proxy(request("{}", "GET"), res, "https://play.golang.org/compile", "application/x-www-form-urlencoded");
+    expect(called).toBe(false);
+    expect(res.statusCode).toBe(405);
+    expect(JSON.parse(res.state.body)).toEqual({ error: "Code Play proxy only accepts POST." });
+  });
+
+  it("returns 400 for a non-http destination without calling fetch", async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response("nope");
+    }) as typeof fetch;
+    const res = response();
+    await proxy(request("{}"), res, "file:///tmp/rust", "application/json");
+    expect(called).toBe(false);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.state.body).error).toMatch(/http\(s\)/);
+  });
+
+  it("returns a generic 502 and never leaks the fetch error", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("ECONNREFUSED 10.0.0.5:443 secret-token");
+    }) as typeof fetch;
+    const res = response();
+    await proxy(request("{}"), res, "https://play.rust-lang.org/execute", "application/json");
+    expect(res.statusCode).toBe(502);
+    expect(res.state.body).toBe(JSON.stringify({ error: "Code Play proxy failed." }));
+    expect(res.state.body).not.toContain("secret-token");
+    expect(res.state.body).not.toContain("10.0.0.5");
+  });
+});
+
+describe("typecheckProxy", () => {
+  it("type-checks TypeScript and returns JSON", async () => {
+    const res = response();
+    await typecheckProxy(
+      request(JSON.stringify({ language: "typescript", code: "const n: number = 1;" })),
+      res,
+    );
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.state.body) as { status: string; diagnostics: unknown[] };
+    expect(body.status).toBe("ok");
+    expect(body.diagnostics).toEqual([]);
+  });
+
+  it("returns 400 for invalid JSON and 405 for GET", async () => {
+    const bad = response();
+    await typecheckProxy(request("{not-json"), bad);
+    expect(bad.statusCode).toBe(400);
+    expect(JSON.parse(bad.state.body)).toEqual({ error: "Typecheck failed." });
+    expect(bad.state.body).not.toContain("SyntaxError");
+
+    const get = response();
+    await typecheckProxy(request("{}", "GET"), get);
+    expect(get.statusCode).toBe(405);
+    expect(JSON.parse(get.state.body).error).toMatch(/POST/);
+  });
+});
+
+describe("writeProxyError", () => {
+  it("preserves ProxyRequestError status and hides unknown errors", () => {
+    const typed = response();
+    writeProxyError(typed, new ProxyRequestError(413, "too big"), 502, "fallback");
+    expect(typed.statusCode).toBe(413);
+    expect(JSON.parse(typed.state.body)).toEqual({ error: "too big" });
+
+    const hidden = response();
+    writeProxyError(hidden, new Error("internal stack"), 502, "Code Play proxy failed.");
+    expect(hidden.statusCode).toBe(502);
+    expect(hidden.state.body).toBe(JSON.stringify({ error: "Code Play proxy failed." }));
+  });
+});
+
+function decodeBody(body: unknown): string {
+  if (typeof body === "string") {
+    return body;
+  }
+  if (body instanceof Uint8Array) {
+    return Buffer.from(body).toString("utf8");
+  }
+  return String(body);
+}
+
+function request(body: string, method = "POST"): IncomingMessage {
+  const req = Readable.from([Buffer.from(body)]) as IncomingMessage;
+  req.method = method;
+  return req;
+}
+
+function response(): ServerResponse & { state: { body: string; headers: Record<string, string> } } {
+  const state = { body: "", headers: {} as Record<string, string> };
+  const res = {
+    statusCode: 200,
+    state,
+    setHeader(name: string, value: unknown) {
+      state.headers[String(name).toLowerCase()] = String(value);
+    },
+    end(chunk?: unknown) {
+      state.body = chunk == null ? "" : String(chunk);
+    },
+  };
+  return res as unknown as ServerResponse & { state: typeof state };
+}

--- a/npm/ox-content-code-play/src/plugin-proxy.test.ts
+++ b/npm/ox-content-code-play/src/plugin-proxy.test.ts
@@ -61,7 +61,7 @@ describe("proxy", () => {
     const calls: Array<{ url: string; body: string; type: string | undefined }> = [];
     globalThis.fetch = (async (url, init) => {
       calls.push({
-        url: String(url),
+        url: requestUrl(url),
         body: decodeBody(init?.body),
         type: new Headers(init?.headers).get("content-type") ?? undefined,
       });
@@ -72,7 +72,12 @@ describe("proxy", () => {
     }) as typeof fetch;
 
     const res = response();
-    await proxy(request(JSON.stringify({ code: "fn main() {}" })), res, "https://play.rust-lang.org/execute", "application/json");
+    await proxy(
+      request(JSON.stringify({ code: "fn main() {}" })),
+      res,
+      "https://play.rust-lang.org/execute",
+      "application/json",
+    );
     expect(res.statusCode).toBe(200);
     expect(res.state.body).toBe(JSON.stringify({ success: true }));
     expect(res.state.headers["content-type"]).toBe("application/json");
@@ -92,7 +97,12 @@ describe("proxy", () => {
       return new Response("nope");
     }) as typeof fetch;
     const res = response();
-    await proxy(request("{}", "GET"), res, "https://play.golang.org/compile", "application/x-www-form-urlencoded");
+    await proxy(
+      request("{}", "GET"),
+      res,
+      "https://play.golang.org/compile",
+      "application/x-www-form-urlencoded",
+    );
     expect(called).toBe(false);
     expect(res.statusCode).toBe(405);
     expect(JSON.parse(res.state.body)).toEqual({ error: "Code Play proxy only accepts POST." });
@@ -165,6 +175,19 @@ describe("writeProxyError", () => {
   });
 });
 
+function requestUrl(url: unknown): string {
+  if (typeof url === "string") {
+    return url;
+  }
+  if (url instanceof URL) {
+    return url.href;
+  }
+  if (url instanceof Request) {
+    return url.url;
+  }
+  return "";
+}
+
 function decodeBody(body: unknown): string {
   if (typeof body === "string") {
     return body;
@@ -172,7 +195,7 @@ function decodeBody(body: unknown): string {
   if (body instanceof Uint8Array) {
     return Buffer.from(body).toString("utf8");
   }
-  return String(body);
+  return "";
 }
 
 function request(body: string, method = "POST"): IncomingMessage {
@@ -190,7 +213,7 @@ function response(): ServerResponse & { state: { body: string; headers: Record<s
       state.headers[String(name).toLowerCase()] = String(value);
     },
     end(chunk?: unknown) {
-      state.body = chunk == null ? "" : String(chunk);
+      state.body = typeof chunk === "string" ? chunk : "";
     },
   };
   return res as unknown as ServerResponse & { state: typeof state };

--- a/npm/ox-content-code-play/src/plugin-proxy.ts
+++ b/npm/ox-content-code-play/src/plugin-proxy.ts
@@ -1,12 +1,56 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 
-export async function typecheckProxy(req: IncomingMessage, res: ServerResponse): Promise<void> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of req) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+export const PROXY_MAX_BODY_BYTES = 256 * 1024;
+
+export class ProxyRequestError extends Error {
+  readonly statusCode: number;
+
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.name = "ProxyRequestError";
+    this.statusCode = statusCode;
   }
+}
+
+export function assertHttpUrl(url: string): URL {
+  let parsed: URL;
   try {
-    const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+    parsed = new URL(url);
+  } catch {
+    throw new ProxyRequestError(400, "Invalid Code Play proxy destination.");
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new ProxyRequestError(400, "Code Play proxy destination must be http(s).");
+  }
+  if (parsed.username || parsed.password) {
+    throw new ProxyRequestError(400, "Code Play proxy destination must not include credentials.");
+  }
+  return parsed;
+}
+
+export async function readLimitedBody(
+  req: IncomingMessage,
+  limit = PROXY_MAX_BODY_BYTES,
+): Promise<Buffer> {
+  if (req.method !== "POST") {
+    throw new ProxyRequestError(405, "Code Play proxy only accepts POST.");
+  }
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.byteLength;
+    if (size > limit) {
+      throw new ProxyRequestError(413, "Code Play proxy request body is too large.");
+    }
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks);
+}
+
+export async function typecheckProxy(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  try {
+    const body = JSON.parse((await readLimitedBody(req)).toString("utf8")) as {
       language?: string;
       code?: string;
       config?: Record<string, unknown>;
@@ -17,11 +61,9 @@ export async function typecheckProxy(req: IncomingMessage, res: ServerResponse):
     const result = await play
       .createSession({ language, code: body.code ?? "", config: body.config })
       .typecheck();
-    res.setHeader("Content-Type", "application/json; charset=utf-8");
-    res.end(JSON.stringify(result));
+    writeJson(res, 200, result);
   } catch (error) {
-    res.statusCode = 400;
-    res.end(error instanceof Error ? error.message : "Typecheck failed.");
+    writeProxyError(res, error, 400, "Typecheck failed.");
   }
 }
 
@@ -31,21 +73,37 @@ export async function proxy(
   url: string,
   contentType: string,
 ): Promise<void> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of req) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-  }
   try {
+    assertHttpUrl(url);
+    const body = await readLimitedBody(req);
     const response = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": contentType },
-      body: Buffer.concat(chunks),
+      body: Uint8Array.from(body),
     });
     res.statusCode = response.status;
     res.setHeader("Content-Type", response.headers.get("content-type") ?? "application/json");
     res.end(await response.text());
   } catch (error) {
-    res.statusCode = 502;
-    res.end(error instanceof Error ? error.message : "Code Play proxy failed.");
+    writeProxyError(res, error, 502, "Code Play proxy failed.");
   }
+}
+
+export function writeProxyError(
+  res: ServerResponse,
+  error: unknown,
+  fallbackStatus: number,
+  fallbackMessage: string,
+): void {
+  if (error instanceof ProxyRequestError) {
+    writeJson(res, error.statusCode, { error: error.message });
+    return;
+  }
+  writeJson(res, fallbackStatus, { error: fallbackMessage });
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(JSON.stringify(body));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Roadmap item 3 / #648. Harden the Vite **dev-only** Code Play proxies and document how production pages should set `endpoints`.

- `POST` only (`405` otherwise)
- 256 KiB body cap (`413`)
- Destination must be `http(s)` with no embedded credentials (`400`)
- Fetch / parse failures return generic JSON `{ "error": "..." }` and never leak upstream messages (hostnames, tokens, `SyntaxError`)
- Docs for `/__ox-code-play/rust|go|typecheck` and `proxy: false`

## Risk

- Risk level: low
- User or production impact: stricter request validation on the existing dev middleware only. Production SSG is unchanged.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run: `tsgo --noEmit` and `vp test src` (34 tests, including new proxy failure cases)
- [x] Manual verification completed: N/A (unit-tested middleware helpers; no live playground calls)
- [x] Edge cases or failure modes considered: GET, oversize body, `file://`, credentials in URL, fetch throw

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

Refs: #648

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790143891&installation_model_id=422833&pr_number=663&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F663&signature=f7f843df4bb3b45cfb934335ad27aa24f52761845d80e70d79dbe057c08cfb46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure development proxy support for Rust, Go, and TypeScript playground workflows.
  * Proxies now enforce POST requests, limit request bodies to 256 KB, and accept only valid HTTP(S) destinations.
  * Added safe, structured JSON responses for validation and upstream errors.

* **Bug Fixes**
  * Prevented sensitive upstream error details from being exposed to clients.

* **Documentation**
  * Documented proxy routes, restrictions, error behavior, and production configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->