### PR TITLE
docs(code-play): expand the guide and add a standalone example

### DIFF
--- a/docs/content/built-in/code-blocks.md
+++ b/docs/content/built-in/code-blocks.md
@@ -10,6 +10,10 @@ highlighting, annotation syntax for highlighting and diff markers, and
 importing snippets from real source files. This site enables all three, so
 every example below is rendered live.
 
+On-demand **Run** / **Typecheck** for samples is a separate package,
+[`@ox-content/code-play`](../packages/code-play.md). It is not part of
+`@ox-content/vite-plugin`. See the [Code Play example](../examples/code-play.md).
+
 | Option            | Type                                 | Default         |
 | ----------------- | ------------------------------------ | --------------- |
 | `highlight`       | `boolean`                            | `false`         |

--- a/docs/content/code-play-roadmap.md
+++ b/docs/content/code-play-roadmap.md
@@ -62,9 +62,9 @@ preset coverage for stderr.
 
 ### 2. `feat(code-play): Vite SSG hydration and docs dogfood`
 
-Harden page-level script emission for ox-content SSG (dev middleware + written
-HTML), enable JavaScript / TypeScript widgets on the docs example page, and
-add a visual check for the default preset.
+Docs example page, package guide, and `examples/code-play` ship with this
+work. Remaining: a visual check that the default preset hydrates on the
+written SSG HTML in CI.
 
 ### 3. `feat(code-play): official playground proxies`
 

--- a/docs/content/examples/code-play.md
+++ b/docs/content/examples/code-play.md
@@ -8,6 +8,10 @@ description: Opt-in on-demand sample execution with stdio, stderr, config, prove
 This page uses `@ox-content/code-play` with **JavaScript** and **TypeScript**
 enabled. Other languages stay ordinary fences until a site opts them in.
 
+A copy-paste Vite app lives at
+[`examples/code-play`](https://github.com/ubugeeei-prod/ox-content/tree/main/examples/code-play)
+in the repository.
+
 ## Enable the plugin
 
 ```ts
@@ -51,6 +55,26 @@ function add(left, right) {
 console.log(add(2, 40));
 ```
 
+## Typecheck failure
+
+**Typecheck** should fail. **Run** still executes after types are stripped, so
+this sample also shows that execute and type-check are separate.
+
+```ts play typecheck
+const n: number = "not a number";
+console.log(n);
+```
+
+## Runtime error
+
+`throw` becomes a diagnostic and a stderr chunk. The stderr tab opens when the
+run produces stderr or an error diagnostic.
+
+```js play
+console.log("before");
+throw new Error("boom from the example");
+```
+
 ## Headless usage
 
 ```ts
@@ -70,6 +94,9 @@ result.provenance.compile;
 result.provenance.execute;
 result.timing.phases;
 ```
+
+`ui: "compact"` hides the tab list and keeps stdio plus stderr. `ui: "headless"`
+renders no chrome — use `createCodePlay()` from your own UI.
 
 ## Remote languages
 

--- a/docs/content/examples/index.md
+++ b/docs/content/examples/index.md
@@ -160,7 +160,8 @@ oxContent({
 ### [Code Play](./code-play.md)
 
 On-demand sample execution through `@ox-content/code-play`, with stdio, stderr,
-config, provenance, and timing viewers.
+config, provenance, and timing viewers. Live fences on the docs page; a
+standalone Vite app is [`examples/code-play`](https://github.com/ubugeeei-prod/ox-content/tree/main/examples/code-play).
 
 ### [Playground](./playground.md)
 
@@ -183,4 +184,7 @@ npm install
 # Run an example
 cd examples/integ-vue
 npm run dev
+
+# Code Play (JS / TS widgets)
+corepack pnpm --filter ./examples/code-play dev
 ```

--- a/docs/content/packages/code-play.md
+++ b/docs/content/packages/code-play.md
@@ -9,9 +9,10 @@ Code Play runs documentation samples on demand. It is a separate plugin:
 `@ox-content/vite-plugin` does not enable it, and installing this package does
 nothing until you list languages.
 
-The [Code Play example](../examples/code-play.md) on this site enables
-JavaScript and TypeScript only. Rust, Go, and remote languages stay off unless
-you opt in.
+The [docs example](../examples/code-play.md) on this site and the standalone
+[`examples/code-play`](https://github.com/ubugeeei-prod/ox-content/tree/main/examples/code-play)
+app enable JavaScript and TypeScript only. Rust, Go, and remote languages stay
+off unless you opt in.
 
 ## Install
 
@@ -36,6 +37,28 @@ export default {
   ],
 };
 ```
+
+The plugin is a second opt-in layer on top of the package install. A fence
+without `play`, or a language that is not listed, stays an ordinary highlighted
+block.
+
+## Plugin options
+
+| Option      | Type                                            | Default   | Role                                     |
+| ----------- | ----------------------------------------------- | --------- | ---------------------------------------- |
+| `languages` | `Record<string, true \| LanguageEnableOptions>` | `{}`      | Enable execute / typecheck / `endpoint`  |
+| `ui`        | `"default" \| "compact" \| "headless"`          | `default` | Chrome around the sample                 |
+| `viewers`   | `Partial<ViewerFlags>`                          | all on    | Show or hide stdio / stderr / config / … |
+| `timeoutMs` | `number`                                        | `10000`   | Per-run timeout                          |
+| `endpoints` | `{ rust?, go?, typecheck? }`                    | official  | Playground / typecheck URLs              |
+| `proxy`     | `boolean`                                       | `true`    | Mount Vite **dev** `/__ox-code-play/*`   |
+| `srcDir`    | `string`                                        | `"docs"`  | Markdown root used to match play fences  |
+| `outDir`    | `string`                                        | Vite out  | Written HTML to enhance after SSG        |
+| `base`      | `string`                                        | `"/"`     | Public path for `ox-code-play.js`        |
+
+`LanguageEnableOptions` accepts `execute`, `typecheck`, `endpoint`, and
+`config` overrides for that language's schema (TypeScript `strict`, Rust
+`crateType`, Go `withVet`, …).
 
 ## Authoring
 
@@ -84,7 +107,21 @@ session.config; // editable language config
 
 `createCodePlay()` throws if you ask for a language that is not enabled.
 `session.setConfig({ strict: false })` updates the same object the config
-viewer edits.
+viewer edits. Inject `transport` (for example `createMemoryTransport`) in tests
+so CI never hits a live playground.
+
+| Field             | Meaning                                                  |
+| ----------------- | -------------------------------------------------------- |
+| `run.status`      | `ok` / `error` / `timeout` / `cancelled` / `unsupported` |
+| `run.stdio`       | Timestamped `stdin` / `stdout` / `stderr` events         |
+| `run.stdout`      | Concatenated stdout text                                 |
+| `run.stderr`      | Concatenated stderr text                                 |
+| `run.diagnostics` | Compiler / runtime messages with optional line/col       |
+| `run.provenance`  | Where it compiled and where it ran                       |
+| `run.timing`      | Phase durations and `totalMs`                            |
+| `run.preview`     | Framework iframe `srcdoc` when the backend is UI         |
+| `session.stdout`  | Same as `lastResult.stdout`                              |
+| `session.stderr`  | Same as `lastResult.stderr`                              |
 
 ## UI
 
@@ -98,15 +135,17 @@ Viewers can be toggled independently through `viewers`.
 
 ## Languages
 
-**Execute and type-check:** TypeScript, Rust, Go.
+| Languages                 | Execute | Type-check | Backend                                     |
+| ------------------------- | ------- | ---------- | ------------------------------------------- |
+| TypeScript                | yes     | yes        | local strip-types + `tsgo` + `node:vm`      |
+| Rust                      | yes     | yes        | `play.rust-lang.org` (or `endpoints.rust`)  |
+| Go                        | yes     | yes        | `play.golang.org` (or `endpoints.go`)       |
+| JavaScript                | yes     | no         | `node:vm` / `Function`                      |
+| Vue, React, Svelte, Solid | yes     | no         | iframe `srcdoc` + esm.sh import map         |
+| Python, PHP, Ruby, sh, …  | yes     | no         | Piston-compatible `languages.<id>.endpoint` |
 
-**On-demand execute:** JavaScript, Vue, React, Svelte, Solid, MoonBit, Java,
-Swift, Kotlin, C, C++, Zig, Haskell, OCaml, Python, PHP, Ruby, sh, C#, Elixir,
-F#, Lean, Rocq, Clojure, Scheme.
-
-Remote languages need `languages.<id>.endpoint` pointing at a
-Piston-compatible executor. Rust and Go default to the official playgrounds.
-JavaScript and TypeScript run locally in `node:vm` or a browser iframe.
+The full catalog is the same list as the [roadmap](../code-play-roadmap.md).
+Aliases such as `ts`, `c++`, `bash`, and `coq` resolve to the canonical id.
 
 ## Playground proxies
 
@@ -134,5 +173,12 @@ official playgrounds (or your own HTTPS executor) for published pages, or
 - Enabling Rust or Go sends source to `play.rust-lang.org` /
   `play.golang.org` (or your `endpoints` override).
 - A configured remote endpoint receives source for that language.
+
+## First publish
+
+`@ox-content/code-play` is new on npm. Trusted publishing cannot create the
+package, so a maintainer publishes **once** from a laptop, then adds the
+trusted publisher. Commands and the exact npmjs.com fields live in
+[Release Operations](../release.md#first-time-npm-publishing).
 
 See the [Code Play roadmap](../code-play-roadmap.md) for follow-up PRs.

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,7 @@ This directory contains runnable projects and small source examples.
 | Example                                      | Description               | Shows                                |
 | -------------------------------------------- | ------------------------- | ------------------------------------ |
 | [playground](./playground)                   | Browser playground        | Live Markdown preview                |
-| Code Play (docs page)                        | `@ox-content/code-play`   | On-demand sample run / type-check    |
+| [code-play](./code-play)                     | `@ox-content/code-play`   | On-demand sample run / type-check    |
 | [ssg-vite](./ssg-vite)                       | Vite static site          | SSG output and generated routes      |
 | [gen-source-docs](./gen-source-docs)         | Source documentation      | API docs generated from TypeScript   |
 | [og-image-custom](./og-image-custom)         | Custom OG image templates | React, Svelte, Vue, and TS templates |

--- a/examples/code-play/README.md
+++ b/examples/code-play/README.md
@@ -1,0 +1,20 @@
+# Code Play example
+
+Minimal Vite + Ox Content site that opts into `@ox-content/code-play` for
+JavaScript and TypeScript only.
+
+From the repository root:
+
+```bash
+corepack pnpm --filter ./examples/code-play dev
+```
+
+Then open the printed local URL. Click **Run** on a `play` fence.
+
+```bash
+corepack pnpm --filter ./examples/code-play build
+corepack pnpm --filter ./examples/code-play preview
+```
+
+The plugin never executes samples during Markdown transform or SSG. Readers
+trigger execute / type-check in the browser (or Node, for the headless API).

--- a/examples/code-play/content/index.md
+++ b/examples/code-play/content/index.md
@@ -1,0 +1,22 @@
+---
+title: Code Play example
+description: Minimal Vite site that runs documentation samples on demand.
+---
+
+# Code Play example
+
+This site enables **JavaScript** and **TypeScript** only. Mark a fence with
+`play` (and `typecheck` when you want the Typecheck button).
+
+```ts play typecheck
+const message: string = "hello from examples/code-play";
+console.log(message);
+console.warn("stderr from console.warn");
+```
+
+```js play
+console.log(2 + 40);
+```
+
+See [@ox-content/code-play](https://github.com/ubugeeei-prod/ox-content/blob/main/docs/content/packages/code-play.md)
+for the full language list and the headless API.

--- a/examples/code-play/index.html
+++ b/examples/code-play/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ox Content Code Play Example</title>
+  </head>
+  <body>
+    <!-- SSG generates actual pages -->
+  </body>
+</html>

--- a/examples/code-play/package.json
+++ b/examples/code-play/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "ox-content-code-play-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vp dev",
+    "build": "vp build",
+    "preview": "vp preview"
+  },
+  "devDependencies": {
+    "@ox-content/code-play": "workspace:*",
+    "@ox-content/vite-plugin": "workspace:*",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
+  }
+}

--- a/examples/code-play/tsconfig.json
+++ b/examples/code-play/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/code-play/vite.config.ts
+++ b/examples/code-play/vite.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from "vite-plus";
+import { oxContent } from "@ox-content/vite-plugin";
+import { codePlay } from "@ox-content/code-play";
+
+export default defineConfig({
+  plugins: [
+    oxContent({
+      srcDir: "content",
+      outDir: "dist",
+      highlight: true,
+    }),
+    codePlay({
+      languages: {
+        javascript: true,
+        typescript: { execute: true, typecheck: true },
+      },
+      srcDir: "content",
+      outDir: "dist",
+    }),
+  ],
+  server: {
+    port: 4177,
+  },
+  preview: {
+    port: 4177,
+  },
+  build: {
+    outDir: "dist",
+  },
+});

--- a/npm/ox-content-code-play/README.md
+++ b/npm/ox-content-code-play/README.md
@@ -74,4 +74,15 @@ run.timing;
 - Other languages need a Piston-compatible `endpoint` you configure.
 - `sh` never spawns a local shell.
 
+## Example
+
+A runnable Vite site lives in [`examples/code-play`](../../examples/code-play):
+
+```bash
+corepack pnpm --filter ./examples/code-play dev
+```
+
+The docs site also dogfoods JavaScript and TypeScript widgets on
+[Code Play](../../docs/content/examples/code-play.md).
+
 See [Code Play](../../docs/content/packages/code-play.md) in the docs site.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,24 @@ importers:
         specifier: 'catalog:'
         version: 0.2.9(@types/node@26.2.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(jiti@1.21.7)(svelte@5.56.10)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)
 
+  examples/code-play:
+    devDependencies:
+      '@ox-content/code-play':
+        specifier: workspace:*
+        version: link:../../npm/ox-content-code-play
+      '@ox-content/vite-plugin':
+        specifier: workspace:*
+        version: link:../../npm/vite-plugin-ox-content
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite:
+        specifier: npm:@voidzero-dev/vite-plus-core@0.2.8
+        version: '@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)'
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.2.9(@types/node@26.2.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(jiti@1.21.7)(svelte@5.56.10)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)
+
   examples/gen-source-docs:
     dependencies:
       vue:
@@ -2460,10 +2478,6 @@ packages:
       astro: ^7.0.0
       vue: ^3.5.24
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
@@ -2591,6 +2605,11 @@ packages:
   '@babel/helpers@7.29.7':
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
   '@babel/parser@7.29.8':
     resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
@@ -4837,8 +4856,8 @@ packages:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
 
-  '@testing-library/user-event@14.6.5':
-    resolution: {integrity: sha512-FhqjldLTpteueBaKflhNFlMT3+PM0O5fiBUivht6b9CZ1eesJyy7+g3Jr7XwJzt/Hip3ZG5hWwK1MX1FuDiE4w==}
+  '@testing-library/user-event@14.6.3':
+    resolution: {integrity: sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
@@ -5010,6 +5029,9 @@ packages:
 
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
+
+  '@types/node@26.1.2':
+    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
   '@types/node@26.2.0':
     resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
@@ -6545,9 +6567,6 @@ packages:
   devalue@5.9.0:
     resolution: {integrity: sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==}
 
-  devalue@5.9.1:
-    resolution: {integrity: sha512-+17vil3EVQRzvtDJSFuTWEb8XJRvXqAiV3qZyQWD398QeXUa6CxsUyMdD1fxzEhUrd4FojitFz7lhIHBTlV4fw==}
-
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -6659,9 +6678,6 @@ packages:
 
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
-
-  es-module-lexer@2.3.2:
-    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
   es-toolkit@1.50.0:
     resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
@@ -7383,9 +7399,6 @@ packages:
   magic-string@1.1.0:
     resolution: {integrity: sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==}
 
-  magic-string@1.2.2:
-    resolution: {integrity: sha512-veT/+7iXrXzT39XnEN4lOxtNl72dMgJ8Lp+5Bd6YcMSWpb0n0MjBM8Uuooi6jgJr8dhUW2swQgBmoZVMni5SVg==}
-
   magicast@0.5.4:
     resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
 
@@ -7764,8 +7777,8 @@ packages:
   ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
 
-  ohash@2.0.12:
-    resolution: {integrity: sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==}
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -8017,9 +8030,6 @@ packages:
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
-
-  property-information@7.1.0:
-    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
@@ -8345,8 +8355,8 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
-  smol-toml@1.8.0:
-    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
+  smol-toml@1.7.1:
+    resolution: {integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==}
     engines: {node: '>= 18'}
 
   solid-js@1.9.15:
@@ -9312,7 +9322,7 @@ snapshots:
       picomatch: 4.0.5
       retext-smartypants: 6.2.0
       shiki: 4.4.3
-      smol-toml: 1.8.0
+      smol-toml: 1.7.1
       unified: 11.0.5
 
   '@astrojs/markdown-remark@7.2.4':
@@ -9385,12 +9395,6 @@ snapshots:
       - unrun
       - yaml
 
-  '@babel/code-frame@7.29.0':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.29.7
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -9403,7 +9407,7 @@ snapshots:
 
   '@babel/core@7.29.0':
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
@@ -9411,7 +9415,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -9578,6 +9582,10 @@ snapshots:
     dependencies:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.8
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.8':
     dependencies:
@@ -11408,7 +11416,7 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  '@testing-library/user-event@14.6.5(@testing-library/dom@10.4.1)':
+  '@testing-library/user-event@14.6.3(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
 
@@ -11616,6 +11624,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/node@26.1.2':
+    dependencies:
+      undici-types: 8.3.0
+
   '@types/node@26.2.0':
     dependencies:
       undici-types: 8.3.0
@@ -11769,7 +11781,7 @@ snapshots:
   '@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))':
     dependencies:
       '@testing-library/dom': 10.4.1
-      '@testing-library/user-event': 14.6.5(@testing-library/dom@10.4.1)
+      '@testing-library/user-event': 14.6.3(@testing-library/dom@10.4.1)
       '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))
       vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11))(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
     transitivePeerDependencies:
@@ -11781,7 +11793,7 @@ snapshots:
   '@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11)':
     dependencies:
       '@testing-library/dom': 10.4.1
-      '@testing-library/user-event': 14.6.5(@testing-library/dom@10.4.1)
+      '@testing-library/user-event': 14.6.3(@testing-library/dom@10.4.1)
       '@vitest/browser': 4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))
       vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11))(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
     transitivePeerDependencies:
@@ -12130,7 +12142,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.34':
     dependencies:
-      '@babel/parser': 7.29.8
+      '@babel/parser': 7.29.3
       '@vue/compiler-core': 3.5.34
       '@vue/compiler-dom': 3.5.34
       '@vue/compiler-ssr': 3.5.34
@@ -12547,10 +12559,10 @@ snapshots:
       clsx: 2.1.1
       common-ancestor-path: 2.0.0
       cookie: 2.0.1
-      devalue: 5.9.1
+      devalue: 5.9.0
       diff: 8.0.4
       dset: 3.1.4
-      es-module-lexer: 2.3.2
+      es-module-lexer: 2.3.1
       esbuild: 0.28.2
       find-process: 2.1.1
       flattie: 1.1.1
@@ -12561,7 +12573,7 @@ snapshots:
       http-cache-semantics: 4.2.0
       js-yaml: 4.3.1
       jsonc-parser: 3.3.1
-      magic-string: 1.2.2
+      magic-string: 1.1.0
       magicast: 0.5.4
       mrmime: 2.0.1
       neotraverse: 1.0.1
@@ -12573,7 +12585,7 @@ snapshots:
       picomatch: 4.0.5
       semver: 7.8.5
       shiki: 4.4.3
-      smol-toml: 1.8.0
+      smol-toml: 1.7.1
       svgo: 4.0.2
       tinyclip: 0.1.15
       tinyexec: 1.3.0
@@ -12886,7 +12898,7 @@ snapshots:
     dependencies:
       '@cspell/cspell-types': 10.0.1
       comment-json: 5.0.0
-      smol-toml: 1.8.0
+      smol-toml: 1.7.1
       yaml: 2.9.0
 
   cspell-dictionary@10.0.1:
@@ -13193,8 +13205,6 @@ snapshots:
 
   devalue@5.9.0: {}
 
-  devalue@5.9.1: {}
-
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
@@ -13281,8 +13291,6 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@2.3.1: {}
-
-  es-module-lexer@2.3.2: {}
 
   es-toolkit@1.50.0: {}
 
@@ -13615,7 +13623,7 @@ snapshots:
       hast-util-whitespace: 3.0.0
       html-void-elements: 3.0.0
       mdast-util-to-hast: 13.2.1
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
       zwitch: 2.0.4
@@ -13642,7 +13650,7 @@ snapshots:
       '@types/hast': 3.0.5
       comma-separated-tokens: 2.0.3
       devlop: 1.1.0
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
       web-namespaces: 2.0.1
       zwitch: 2.0.4
@@ -13833,7 +13841,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 26.2.0
+      '@types/node': 26.1.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -13987,10 +13995,6 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   magic-string@1.1.0:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-
-  magic-string@1.2.2:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
@@ -14592,7 +14596,7 @@ snapshots:
       node-fetch-native: 1.6.7
       ufo: 1.6.4
 
-  ohash@2.0.12: {}
+  ohash@2.0.11: {}
 
   onetime@7.0.0:
     dependencies:
@@ -14968,8 +14972,6 @@ snapshots:
   process-ancestry@0.1.0: {}
 
   process-nextick-args@2.0.1: {}
-
-  property-information@7.1.0: {}
 
   property-information@7.2.0: {}
 
@@ -15516,7 +15518,7 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  smol-toml@1.8.0: {}
+  smol-toml@1.7.1: {}
 
   solid-js@1.9.15:
     dependencies:
@@ -15635,7 +15637,7 @@ snapshots:
       aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1
-      devalue: 5.9.1
+      devalue: 5.9.0
       esm-env: 1.2.2
       esrap: 2.3.2
       is-reference: 3.0.3
@@ -15830,7 +15832,7 @@ snapshots:
   unifont@0.7.5:
     dependencies:
       css-tree: 3.2.1
-      ohash: 2.0.12
+      ohash: 2.0.11
       undici: 8.10.0
 
   unist-util-find-after@5.0.0:
@@ -15961,7 +15963,7 @@ snapshots:
       ansis: 4.3.1
       error-stack-parser-es: 1.0.5
       obug: 2.1.4
-      ohash: 2.0.12
+      ohash: 2.0.11
       open: 11.0.0
       perfect-debounce: 2.1.0
       sirv: 3.0.2
@@ -16270,7 +16272,7 @@ snapshots:
       '@vitest/snapshot': 4.1.11
       '@vitest/spy': 4.1.11
       '@vitest/utils': 4.1.11
-      es-module-lexer: 2.3.2
+      es-module-lexer: 2.3.1
       expect-type: 1.4.0
       magic-string: 0.30.21
       obug: 2.1.4
@@ -16298,7 +16300,7 @@ snapshots:
       '@vitest/snapshot': 4.1.11
       '@vitest/spy': 4.1.11
       '@vitest/utils': 4.1.11
-      es-module-lexer: 2.3.2
+      es-module-lexer: 2.3.1
       expect-type: 1.4.0
       magic-string: 0.30.21
       obug: 2.1.4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Docs and a copy-paste example for #648. The package is not “done” — this fills the author-facing gaps.

- Package guide: plugin options, `RunResult` fields, language matrix, first-publish pointer
- Docs example page: typecheck failure and runtime-error samples
- Standalone `examples/code-play` Vite site (JS + TS only)
- Cross-links from code-blocks, examples index, package README

## Risk

- Risk level: low
- User or production impact: documentation and a private example app only
- Rollback plan: revert this PR

## Validation

- [x] Automated tests or checks run: `vp check --fix` on the touched docs / example files
- [x] Manual verification completed: example is a standard oxContent SSG stub (same shape as `docs/`)
- [x] Edge cases or failure modes considered: disabled languages stay ordinary fences

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

Refs: #648

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790144928&installation_model_id=422833&pr_number=697&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F697&signature=526f5817af0d78b87eb6ce8ae1925c8c8ee687d22a025acce6a89dd4c020b4b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->