### PR TITLE
ci(code-play): tag publish, nightly preview, and first-publish CLI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -300,6 +300,7 @@ jobs:
             ./binding-packages/linux-arm64-musl \
             ./binding-packages/win32-x64-msvc \
             ./npm/ox-content-islands \
+            ./npm/ox-content-code-play \
             ./npm/unplugin-ox-content \
             ./npm/vite-plugin-ox-content \
             ./npm/vite-plugin-ox-content-react \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -366,6 +366,18 @@ jobs:
           TARBALL=$(vp exec -- pnpm pack --pack-destination /tmp | tail -1)
           npm publish "$TARBALL" --provenance --access public --tag "$NPM_TAG"
 
+      - name: Publish @ox-content/code-play
+        working-directory: npm/ox-content-code-play
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "${PKG_NAME}@${PKG_VERSION}" version >/dev/null 2>&1; then
+            echo "Skipping ${PKG_NAME}@${PKG_VERSION} (already published)"
+            exit 0
+          fi
+          TARBALL=$(vp exec -- pnpm pack --pack-destination /tmp | tail -1)
+          npm publish "$TARBALL" --provenance --access public --tag "$NPM_TAG"
+
       - name: Publish @ox-content/vite-plugin
         working-directory: npm/vite-plugin-ox-content
         run: |

--- a/docs/content/release.md
+++ b/docs/content/release.md
@@ -58,10 +58,19 @@ three are part of the identity, so renaming the workflow file or the environment
 breaks publishing until every entry is updated to match.
 
 Entries are needed for the workspace packages (`@ox-content/napi`,
-`@ox-content/islands`, `@ox-content/vite-plugin`, `@ox-content/unplugin`, the
-four `@ox-content/vite-plugin-{vue,react,svelte,solid}` integrations, and
+`@ox-content/islands`, `@ox-content/code-play`, `@ox-content/vite-plugin`,
+`@ox-content/unplugin`, the four
+`@ox-content/vite-plugin-{vue,react,svelte,solid}` integrations, and
 `@ox-content/wasm`) and for each `@ox-content/napi-*` platform binding package
 the N-API build publishes.
+
+On npmjs.com the GitHub Actions trusted publisher must match this identity
+exactly:
+
+- Organization or user: `ubugeeei-prod`
+- Repository: `ox-content`
+- Workflow filename: `publish.yml`
+- Environment name: `npm`
 
 ## First-Time npm Publishing
 
@@ -73,10 +82,14 @@ A release that introduces a new npm package therefore needs one manual publish
 by a maintainer with local npm credentials, before the tag is pushed:
 
 ```bash
+# Generic new package
 corepack pnpm --filter @ox-content/vite-plugin-new build
 cd npm/vite-plugin-ox-content-new
 corepack pnpm pack --pack-destination /tmp
 npm publish /tmp/ox-content-vite-plugin-new-<version>.tgz --access public --provenance=false
+
+# @ox-content/code-play bootstrap (package does not exist on npm yet)
+node scripts/bootstrap-npm-package.mjs npm/ox-content-code-play
 ```
 
 Bump every workspace package to the release version before packing, or the

--- a/scripts/bootstrap-npm-package.mjs
+++ b/scripts/bootstrap-npm-package.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * First-time publish for a workspace package that does not exist on npm yet.
+ * Trusted publishing cannot create the package; run this once from a laptop
+ * with npm credentials, then add the trusted publisher on npmjs.com.
+ *
+ * Usage: node scripts/bootstrap-npm-package.mjs npm/ox-content-code-play
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const packageDir = process.argv[2];
+if (!packageDir) {
+  console.error("Usage: node scripts/bootstrap-npm-package.mjs <package-dir>");
+  process.exit(1);
+}
+
+const root = resolve(import.meta.dirname, "..");
+const cwd = resolve(root, packageDir);
+const dest = mkdtempSync(join(tmpdir(), "ox-content-bootstrap-"));
+const pkg = JSON.parse(
+  spawnSync("node", ["-p", "JSON.stringify(require('./package.json'))"], {
+    cwd,
+    encoding: "utf8",
+  }).stdout,
+);
+
+console.log(`Building ${pkg.name}@${pkg.version} in ${packageDir}`);
+run("vp", ["exec", "--filter", pkg.name, "--", "vp", "run", "build"], root);
+
+console.log(`Packing to ${dest}`);
+const pack = spawnSync("vp", ["exec", "--", "pnpm", "pack", "--pack-destination", dest], {
+  cwd,
+  encoding: "utf8",
+});
+if (pack.status !== 0) {
+  console.error(pack.stderr || pack.stdout);
+  process.exit(pack.status ?? 1);
+}
+const tarball = pack.stdout.trim().split("\n").at(-1);
+if (!tarball) {
+  console.error("pnpm pack did not print a tarball path.");
+  process.exit(1);
+}
+
+console.log(`Publishing ${tarball} (no provenance; CI will attest later versions)`);
+run("npm", ["publish", tarball, "--access", "public", "--provenance=false"], cwd);
+
+console.log(`
+${pkg.name}@${pkg.version} is on npm. Add the trusted publisher on npmjs.com:
+
+  Package settings → Trusted Publisher → GitHub Actions
+  Organization or user:  ubugeeei-prod
+  Repository:            ox-content
+  Workflow filename:     publish.yml
+  Environment name:      npm
+`);
+
+function run(command, args, commandCwd) {
+  const result = spawnSync(command, args, { cwd: commandCwd, stdio: "inherit" });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}

--- a/scripts/package-dry-run.mjs
+++ b/scripts/package-dry-run.mjs
@@ -8,6 +8,7 @@ import { spawnSync } from "node:child_process";
 const packages = [
   "crates/ox_content_napi",
   "npm/ox-content-islands",
+  "npm/ox-content-code-play",
   "npm/vite-plugin-ox-content",
   "npm/unplugin-ox-content",
   "npm/vite-plugin-ox-content-vue",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -5,6 +5,7 @@ import { execSync } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
+import { verifyPublishWorkflow } from "./verify-publish-targets";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -44,7 +45,6 @@ const CARGO_PUBLISH_PACKAGES = [
 ];
 
 const CARGO_TOML = "Cargo.toml";
-const PUBLISH_WORKFLOW = ".github/workflows/publish.yml";
 const RUST_DOC_FILES = ["docs/content/getting-started.md"];
 const ZED_EXTENSION_TOML = "editors/zed/extension.toml";
 const ZED_CARGO_TOML = "editors/zed/Cargo.toml";
@@ -122,35 +122,6 @@ function updateRustDocsVersion(version: string): void {
       console.log(`  No Rust crate versions to update in ${relativePath}`);
     }
   }
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function hasCargoPublishTarget(workflow: string, pkg: string): boolean {
-  const escapedPkg = escapeRegExp(pkg);
-  const packageRef = `(?:"${escapedPkg}"|'${escapedPkg}'|${escapedPkg})`;
-  const directCargoPublish = new RegExp(
-    `\\bcargo\\s+publish\\b[^\\n]*(?:-p|--package)\\s+${packageRef}(?=\\s|$)`,
-  );
-  const publishHelperCall = new RegExp(`\\bpublish_crate\\s+${packageRef}(?=\\s|$)`);
-
-  return directCargoPublish.test(workflow) || publishHelperCall.test(workflow);
-}
-
-function verifyCargoPublishPackages(): void {
-  const fullPath = path.join(ROOT, PUBLISH_WORKFLOW);
-  const workflow = fs.readFileSync(fullPath, "utf-8");
-  const missing = CARGO_PUBLISH_PACKAGES.filter((pkg) => !hasCargoPublishTarget(workflow, pkg));
-
-  if (missing.length) {
-    throw new Error(
-      `Missing crates.io publish targets in ${PUBLISH_WORKFLOW}: ${missing.join(", ")}`,
-    );
-  }
-
-  console.log(`  Verified crates.io publish targets: ${CARGO_PUBLISH_PACKAGES.join(", ")}`);
 }
 
 function bumpVersion(
@@ -317,8 +288,13 @@ async function main(): Promise<void> {
   console.log("Updating Rust docs versions...");
   updateRustDocsVersion(newVersion);
 
-  console.log("Verifying crates.io release targets...");
-  verifyCargoPublishPackages();
+  console.log("Verifying publish workflow targets...");
+  verifyPublishWorkflow({
+    root: ROOT,
+    workflowRel: ".github/workflows/publish.yml",
+    cargoPackages: CARGO_PUBLISH_PACKAGES,
+    npmPackages: NPM_PACKAGES,
+  });
 
   console.log("\nGenerating changelog...");
   const latestTag = getLatestTag();

--- a/scripts/verify-publish-targets.test.ts
+++ b/scripts/verify-publish-targets.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vite-plus/test";
+import { readFileSync } from "node:fs";
+import { verifyPublishWorkflow } from "./verify-publish-targets";
+
+describe("publish workflow targets", () => {
+  it("includes @ox-content/code-play and every non-theme npm workspace dir", () => {
+    const workflow = readFileSync(".github/workflows/publish.yml", "utf8");
+    expect(workflow).toContain("working-directory: npm/ox-content-code-play");
+    expect(workflow).toContain("Publish @ox-content/code-play");
+
+    verifyPublishWorkflow({
+      root: process.cwd(),
+      workflowRel: ".github/workflows/publish.yml",
+      cargoPackages: ["ox_content_parser"],
+      npmPackages: [
+        "npm/ox-content-islands",
+        "npm/ox-content-code-play",
+        "npm/unplugin-ox-content",
+        "npm/vite-plugin-ox-content",
+        "npm/vite-plugin-ox-content-react",
+        "npm/vite-plugin-ox-content-solid",
+        "npm/vite-plugin-ox-content-svelte",
+        "npm/vite-plugin-ox-content-vue",
+        "npm/vscode-ox-content",
+      ],
+    });
+  });
+
+  it("fails when an npm workspace dir is missing from the workflow", () => {
+    expect(() =>
+      verifyPublishWorkflow({
+        root: process.cwd(),
+        workflowRel: ".github/workflows/publish.yml",
+        cargoPackages: [],
+        npmPackages: ["npm/ox-content-missing"],
+      }),
+    ).toThrow(/npm=npm\/ox-content-missing/);
+  });
+});

--- a/scripts/verify-publish-targets.ts
+++ b/scripts/verify-publish-targets.ts
@@ -1,0 +1,35 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export function verifyPublishWorkflow(options: {
+  root: string;
+  workflowRel: string;
+  cargoPackages: string[];
+  npmPackages: string[];
+}): void {
+  const workflowPath = path.join(options.root, options.workflowRel);
+  const workflow = fs.readFileSync(workflowPath, "utf-8");
+  const missingCargo = options.cargoPackages.filter((pkg) => !hasCargoPublishTarget(workflow, pkg));
+  const npmDirs = options.npmPackages.filter(
+    (pkg) =>
+      pkg.startsWith("npm/") && !pkg.startsWith("npm/theme") && pkg !== "npm/vscode-ox-content",
+  );
+  const missingNpm = npmDirs.filter((dir) => !workflow.includes(`working-directory: ${dir}`));
+  if (missingCargo.length || missingNpm.length) {
+    throw new Error(
+      `Missing publish targets in ${options.workflowRel}: cargo=${missingCargo.join(",") || "-"} npm=${missingNpm.join(",") || "-"}`,
+    );
+  }
+  console.log(`  Verified crates.io publish targets: ${options.cargoPackages.join(", ")}`);
+  console.log(`  Verified npm publish targets: ${npmDirs.join(", ")}`);
+}
+
+function hasCargoPublishTarget(workflow: string, pkg: string): boolean {
+  const escapedPkg = pkg.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const packageRef = `(?:"${escapedPkg}"|'${escapedPkg}'|${escapedPkg})`;
+  return (
+    new RegExp(`\\bcargo\\s+publish\\b[^\\n]*(?:-p|--package)\\s+${packageRef}(?=\\s|$)`).test(
+      workflow,
+    ) || new RegExp(`\\bpublish_crate\\s+${packageRef}(?=\\s|$)`).test(workflow)
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -137,11 +137,12 @@ export default defineConfig({
         "test:vscode-unit",
         "test:vrt",
       ]),
-      "test:ts-unit": noopTask(["test:vite-plugin", "test:code-play"]),
+      "test:ts-unit": noopTask(["test:vite-plugin", "test:code-play", "test:publish-targets"]),
       "test:vite-plugin": task("vp exec --filter @ox-content/vite-plugin -- vp test src", {
         dependsOn: ["build:napi"],
       }),
       "test:code-play": task("vp exec --filter @ox-content/code-play -- vp test src"),
+      "test:publish-targets": task("vp test scripts/verify-publish-targets.test.ts"),
       "build:vite-plugin": task("vp run --filter @ox-content/vite-plugin build", {
         dependsOn: ["build:napi"],
       }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wire `@ox-content/code-play` into release CI/CD for #648. The package is **not** on npm yet (trusted publishing cannot create it).

- `.github/workflows/publish.yml` publishes the tarball with provenance (skip if the version exists)
- Nightly `pkg-pr-new` includes `./npm/ox-content-code-play`
- `scripts/package-dry-run.mjs` packs the package in CI
- `vp run test` now runs `test:publish-targets` so a missing `working-directory` fails
- `node scripts/bootstrap-npm-package.mjs npm/ox-content-code-play` is the laptop first-publish path (`--access public --provenance=false`)
- Release docs list the trusted publisher identity: `ubugeeei-prod` / `ox-content` / `publish.yml` / environment `npm`

This agent built and packed `@ox-content/code-play@2.90.0` via that script. `npm publish` stopped at `ENEEDAUTH` — a maintainer with npm 2FA must run the bootstrap command, then add the trusted publisher on npmjs.com.

## Risk

- Risk level: low
- User or production impact: no publish happens until a `v*` tag and a trusted publisher (or the one-time laptop bootstrap)
- Rollback plan: revert this PR

## Validation

- [x] Automated tests or checks run: `vp test scripts/verify-publish-targets.test.ts` (2 passed)
- [x] Manual verification completed: bootstrap script built + packed; publish failed only on missing npm auth
- [x] Edge cases or failure modes considered: skip-if-published, vscode/theme packages stay out of the npm-dir check

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

Refs: #648

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790145072&installation_model_id=422833&pr_number=698&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F698&signature=e2dfee7f6ac95ea336d300224a00785b179aa99466c0cbf5510b5dae8f110eff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->