### PR TITLE
feat(code-play): emit a self-contained auto-hydrating browser client

### DIFF
--- a/docs/content/code-play-roadmap.md
+++ b/docs/content/code-play-roadmap.md
@@ -56,22 +56,22 @@ injected transports (no live network in CI).
 
 ### 1b. `feat(code-play): dedicated stderr viewer`
 
-This PR. First-class `RunResult.stdout` / `RunResult.stderr`, a dedicated
-stderr viewer (stream chunks plus error/warning diagnostics), and compact
-preset coverage for stderr.
+Shipped in #662. First-class `RunResult.stdout` / `RunResult.stderr`, a
+dedicated stderr viewer, and compact preset coverage for stderr.
 
 ### 2. `feat(code-play): Vite SSG hydration and docs dogfood`
 
-Docs example page, package guide, and `examples/code-play` ship with this
-work. Remaining: a visual check that the default preset hydrates on the
-written SSG HTML in CI.
+Docs example page, package guide, and `examples/code-play` shipped in #697.
+This PR emits a standalone `ox-code-play.js` that calls `bootCodePlay()` so
+SSG pages become interactive. One malformed widget or a thrown run no longer
+freezes the toolbar. Remaining: a visual check that the default preset
+hydrates on the written SSG HTML in CI.
 
 ### 3. `feat(code-play): official playground proxies`
 
-This PR. Keep the `/__ox-code-play/rust`, `/__ox-code-play/go`, and
-`/__ox-code-play/typecheck` dev proxies. Reject non-POST requests, oversize
-bodies, and non-http(s) destinations; return generic JSON errors; document
-production `endpoints`.
+Shipped in #663. Dev proxies stay POST-only, cap bodies, refuse non-http(s)
+destinations, and hide upstream fetch details. Production pages must set
+`endpoints` (the proxy is not in SSG output).
 
 ### 4. `feat(code-play): framework preview compilers`
 

--- a/npm/ox-content-code-play/package.json
+++ b/npm/ox-content-code-play/package.json
@@ -34,13 +34,17 @@
     "./plugin": {
       "import": "./dist/plugin.mjs",
       "types": "./dist/plugin.d.mts"
+    },
+    "./browser": {
+      "import": "./dist/browser.mjs",
+      "types": "./dist/browser.d.mts"
     }
   },
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "build": "vp pack",
+    "build": "vp pack && node scripts/bundle-browser.mjs",
     "dev": "vp pack --watch",
     "typecheck": "tsgo --noEmit",
     "test": "vp test src"

--- a/npm/ox-content-code-play/scripts/bundle-browser.mjs
+++ b/npm/ox-content-code-play/scripts/bundle-browser.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const result = spawnSync(
+  process.execPath,
+  [
+    "--experimental-strip-types",
+    fileURLToPath(new URL("../src/bundle-browser.ts", import.meta.url)),
+  ],
+  { stdio: "inherit" },
+);
+
+process.exit(result.status ?? 1);

--- a/npm/ox-content-code-play/src/boot.test.ts
+++ b/npm/ox-content-code-play/src/boot.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { bootCodePlay } from "./boot";
+
+describe("bootCodePlay", () => {
+  it("does nothing without a document", () => {
+    const hydrate = vi.fn();
+    bootCodePlay(hydrate, undefined);
+    expect(hydrate).not.toHaveBeenCalled();
+  });
+
+  it("hydrates immediately when the document is already ready", () => {
+    const hydrate = vi.fn();
+    bootCodePlay(hydrate, { readyState: "complete", addEventListener: vi.fn() });
+    expect(hydrate).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for DOMContentLoaded while the document is loading", () => {
+    const hydrate = vi.fn();
+    let listener: (() => void) | undefined;
+    const addEventListener = vi.fn((type: string, next: () => void) => {
+      expect(type).toBe("DOMContentLoaded");
+      listener = next;
+    });
+    bootCodePlay(hydrate, { readyState: "loading", addEventListener });
+    expect(hydrate).not.toHaveBeenCalled();
+    expect(addEventListener).toHaveBeenCalledWith("DOMContentLoaded", expect.any(Function), {
+      once: true,
+    });
+    listener?.();
+    expect(hydrate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/npm/ox-content-code-play/src/boot.ts
+++ b/npm/ox-content-code-play/src/boot.ts
@@ -1,0 +1,26 @@
+import { hydrateCodePlay } from "./hydrate";
+
+export interface BootDocument {
+  readyState: string;
+  addEventListener(type: string, listener: () => void, options?: { once?: boolean }): void;
+}
+
+/**
+ * Mount every `[data-ox-code-play]` widget. The SSG client (`ox-code-play.js`)
+ * calls this on load; apps that import `@ox-content/code-play/client` call it
+ * themselves.
+ */
+export function bootCodePlay(
+  hydrate: (root?: ParentNode) => void = hydrateCodePlay,
+  doc: BootDocument | undefined = typeof document === "undefined" ? undefined : document,
+): void {
+  if (!doc) {
+    return;
+  }
+  const run = () => hydrate();
+  if (doc.readyState === "loading") {
+    doc.addEventListener("DOMContentLoaded", run, { once: true });
+    return;
+  }
+  run();
+}

--- a/npm/ox-content-code-play/src/browser-bundle.test.ts
+++ b/npm/ox-content-code-play/src/browser-bundle.test.ts
@@ -1,0 +1,20 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+import { bundleBrowserClient } from "./bundle-browser";
+import { assertBrowserClientSource } from "./plugin-client";
+
+describe("browser client bundle", () => {
+  it("inlines the widget runtime and calls bootCodePlay", async () => {
+    const outDir = await mkdtemp(path.join(tmpdir(), "ox-code-play-browser-"));
+    try {
+      await bundleBrowserClient(outDir);
+      const source = await readFile(path.join(outDir, "browser.mjs"), "utf8");
+      expect(assertBrowserClientSource(source)).toContain("bootCodePlay");
+      expect(source).toMatch(/hydrateCodePlay|data-ox-code-play/);
+    } finally {
+      await rm(outDir, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/npm/ox-content-code-play/src/browser.ts
+++ b/npm/ox-content-code-play/src/browser.ts
@@ -1,0 +1,5 @@
+import { bootCodePlay } from "./boot";
+
+export { bootCodePlay };
+
+bootCodePlay();

--- a/npm/ox-content-code-play/src/bundle-browser.ts
+++ b/npm/ox-content-code-play/src/bundle-browser.ts
@@ -1,0 +1,41 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { build, type UserConfig } from "vite";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+export async function bundleBrowserClient(outDir = path.join(root, "dist")): Promise<void> {
+  const config = {
+    configFile: false,
+    root,
+    publicDir: false,
+    logLevel: "warn",
+    build: {
+      emptyOutDir: false,
+      minify: false,
+      outDir,
+      lib: {
+        entry: path.join(root, "src/browser.ts"),
+        formats: ["es"],
+        fileName: () => "browser",
+      },
+      rollupOptions: {
+        external: (id: string) => id.startsWith("node:"),
+        output: {
+          codeSplitting: false,
+          entryFileNames: "browser.mjs",
+        },
+      },
+    },
+  } as UserConfig;
+  await build(config);
+}
+
+function isDirectRun(): boolean {
+  const entry = process.argv[1];
+  return Boolean(entry) && fileURLToPath(import.meta.url) === path.resolve(entry);
+}
+
+if (isDirectRun()) {
+  await bundleBrowserClient();
+}

--- a/npm/ox-content-code-play/src/client.test.ts
+++ b/npm/ox-content-code-play/src/client.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vite-plus/test";
 import { createCodePlay } from "./client";
 import { stripTypeScript } from "./strip-typescript";
-import { parseTsgoOutput } from "./typescript";
+import { createMemoryTransport } from "./transport";
+import {
+  adapterResultFromTypecheckResponse,
+  parseTsgoOutput,
+  typecheckEndpointFailureMessage,
+} from "./typescript";
+import { PhaseTracker } from "./timing";
 import { renderStderrHtml } from "./viewers";
 
 describe("createCodePlay", () => {
@@ -84,6 +90,37 @@ describe("createCodePlay", () => {
     expect(result.stdio.filter((event) => event.stream === "stdout")).toEqual([
       expect.objectContaining({ text: "out\n" }),
     ]);
+  });
+
+  it("times out infinite JavaScript loops in node:vm", async () => {
+    const play = createCodePlay({ languages: { javascript: true }, timeoutMs: 50 });
+    const result = await play.createSession({ language: "js", code: "while (true) {}" }).run();
+    expect(result.status).toBe("timeout");
+    expect(result.diagnostics[0]?.message.length).toBeGreaterThan(0);
+  });
+
+  it("turns transport throws into error results instead of rejecting", async () => {
+    const play = createCodePlay({
+      languages: { rust: true },
+      transport: createMemoryTransport(() => {
+        throw new Error("offline");
+      }),
+    });
+    const result = await play.createSession({ language: "rust", code: "fn main() {}" }).run();
+    expect(result.status).toBe("error");
+    expect(result.diagnostics[0]?.message).toBe("offline");
+  });
+
+  it("explains a missing static-host typecheck endpoint", () => {
+    expect(typecheckEndpointFailureMessage(404, "")).toMatch(/vite dev/);
+    const tracker = new PhaseTracker();
+    const result = adapterResultFromTypecheckResponse(
+      { ok: false, status: 404, text: "" },
+      "/__ox-code-play/typecheck",
+      tracker,
+    );
+    expect(result.status).toBe("error");
+    expect(result.diagnostics[0]?.message).toMatch(/endpoints\.typecheck/);
   });
 
   it("strips TypeScript annotations before execute", () => {

--- a/npm/ox-content-code-play/src/config.ts
+++ b/npm/ox-content-code-play/src/config.ts
@@ -89,8 +89,8 @@ export function mergeConfig(
 ): Record<string, unknown> {
   const definition = resolveLanguage(languageId);
   return {
-    ...(definition?.defaultConfig ?? {}),
-    ...(enabled?.config ?? {}),
+    ...definition?.defaultConfig,
+    ...enabled?.config,
     ...override,
   };
 }

--- a/npm/ox-content-code-play/src/hydrate-action.test.ts
+++ b/npm/ox-content-code-play/src/hydrate-action.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { readPlayPayload, runPlayAction } from "./hydrate-action";
+import { encodePayload } from "./payload";
+import { DEFAULT_VIEWERS } from "./config";
+import { errorResult } from "./result";
+
+describe("readPlayPayload", () => {
+  it("returns undefined for malformed widgets instead of throwing", () => {
+    expect(readPlayPayload("")).toBeUndefined();
+    expect(readPlayPayload("%%%not-base64%%%")).toBeUndefined();
+    expect(readPlayPayload(Buffer.from("[]").toString("base64"))).toBeUndefined();
+  });
+
+  it("decodes a valid payload", () => {
+    const encoded = encodePayload({
+      language: "javascript",
+      code: "1",
+      capabilities: { execute: true, typecheck: false },
+      config: {},
+      viewers: { ...DEFAULT_VIEWERS },
+      ui: "default",
+      timeoutMs: 1,
+    });
+    expect(readPlayPayload(encoded)?.language).toBe("javascript");
+  });
+});
+
+describe("runPlayAction", () => {
+  it("re-enables controls after success and after a thrown action", async () => {
+    const busy: boolean[] = [];
+    const results: unknown[] = [];
+    const errors: unknown[] = [];
+
+    await runPlayAction({
+      action: async () => errorResult("ok"),
+      setBusy: (value) => busy.push(value),
+      onResult: (result) => results.push(result.status),
+      onError: (error) => errors.push(error),
+    });
+    expect(busy).toEqual([true, false]);
+    expect(results).toEqual(["error"]);
+    expect(errors).toEqual([]);
+
+    const setBusy = vi.fn();
+    await runPlayAction({
+      action: async () => {
+        throw new Error("adapter exploded");
+      },
+      setBusy,
+      onResult: () => {
+        throw new Error("should not paint a result");
+      },
+      onError: (error) => errors.push(error),
+    });
+    expect(setBusy.mock.calls.map((call) => call[0])).toEqual([true, false]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(Error);
+  });
+});

--- a/npm/ox-content-code-play/src/hydrate-action.ts
+++ b/npm/ox-content-code-play/src/hydrate-action.ts
@@ -1,0 +1,26 @@
+import { decodePayload } from "./payload";
+import type { PlayPayload, RunResult } from "./types";
+
+export function readPlayPayload(encoded: string): PlayPayload | undefined {
+  try {
+    return decodePayload(encoded);
+  } catch {
+    return undefined;
+  }
+}
+
+export async function runPlayAction(input: {
+  action: () => Promise<RunResult>;
+  setBusy: (busy: boolean) => void;
+  onResult: (result: RunResult) => void;
+  onError: (error: unknown) => void;
+}): Promise<void> {
+  input.setBusy(true);
+  try {
+    input.onResult(await input.action());
+  } catch (error) {
+    input.onError(error);
+  } finally {
+    input.setBusy(false);
+  }
+}

--- a/npm/ox-content-code-play/src/hydrate.ts
+++ b/npm/ox-content-code-play/src/hydrate.ts
@@ -1,5 +1,7 @@
 import { createCodePlay, type CodePlayClient } from "./client";
+import { readPlayPayload, runPlayAction } from "./hydrate-action";
 import { decodePayload, encodePayload } from "./payload";
+import { errorMessage, errorResult } from "./result";
 import { CODE_PLAY_STYLES } from "./styles";
 import { renderPlayUi } from "./ui";
 import type { PlayPayload, RunResult } from "./types";
@@ -25,7 +27,11 @@ export function hydrateCodePlay(
   ensureStyles();
   const client = options.client ?? createCodePlayFromPayloads(root);
   for (const element of queryWidgets(root)) {
-    mountCodePlay(element, { client });
+    try {
+      mountCodePlay(element, { client });
+    } catch {
+      // One broken widget must not abort the rest of the page.
+    }
   }
 }
 
@@ -33,8 +39,8 @@ export function mountCodePlay(element: Element, options: { client?: CodePlayClie
   if (!(element instanceof HTMLElement) || element.dataset.oxCodePlayMounted === "true") {
     return;
   }
-  const payload = decodePayload(element.getAttribute("data-ox-code-play") ?? "");
-  if (payload.ui === "headless") {
+  const payload = readPlayPayload(element.getAttribute("data-ox-code-play") ?? "");
+  if (!payload || payload.ui === "headless") {
     return;
   }
   const client =
@@ -90,10 +96,12 @@ function bindWidget(element: HTMLElement, payload: PlayPayload, client: CodePlay
   });
 
   async function run(action: "execute" | "typecheck"): Promise<void> {
-    setBusy(element, true);
-    const result = action === "typecheck" ? await session.typecheck() : await session.run();
-    paintResult(element, current, result);
-    setBusy(element, false);
+    await runPlayAction({
+      action: () => (action === "typecheck" ? session.typecheck() : session.run()),
+      setBusy: (busy) => setBusy(element, busy),
+      onResult: (result) => paintResult(element, current, result),
+      onError: (error) => paintResult(element, current, errorResult(errorMessage(error))),
+    });
   }
 }
 

--- a/npm/ox-content-code-play/src/index.ts
+++ b/npm/ox-content-code-play/src/index.ts
@@ -14,6 +14,7 @@ export type { CodePlayPluginOptions } from "./plugin";
 export { CodePlaySession } from "./session";
 export { joinStream, selectStream, withStdioText } from "./stdio";
 export { createFetchTransport, createMemoryTransport } from "./transport";
+export { bootCodePlay } from "./boot";
 export { hydrateCodePlay, mountCodePlay } from "./hydrate";
 export { renderPlayUi } from "./ui";
 export {

--- a/npm/ox-content-code-play/src/javascript.ts
+++ b/npm/ox-content-code-play/src/javascript.ts
@@ -1,3 +1,4 @@
+import { hasNodeVm } from "./runtime-host";
 import { formatConsoleArgs, StdioBuffer } from "./stdio";
 import { nowMs, PhaseTracker } from "./timing";
 import type { AdapterRequest, AdapterResult, Diagnostic } from "./types";
@@ -66,10 +67,6 @@ export async function executeScript(
     });
   }
   return value;
-}
-
-function hasNodeVm(): boolean {
-  return typeof process !== "undefined" && Boolean(process.versions?.node);
 }
 
 function isTimeout(error: unknown): boolean {

--- a/npm/ox-content-code-play/src/payload-factory.ts
+++ b/npm/ox-content-code-play/src/payload-factory.ts
@@ -13,7 +13,7 @@ export function payloadFromFence(fence: PlayFence, options: ResolvedCodePlayOpti
       execute: enabled?.execute ?? Boolean(definition?.capabilities.execute),
       typecheck: fence.typecheck || (enabled?.typecheck ?? false),
     },
-    config: { ...(definition?.defaultConfig ?? {}), ...(enabled?.config ?? {}) },
+    config: { ...definition?.defaultConfig, ...enabled?.config },
     viewers: options.viewers,
     ui: options.ui,
     timeoutMs: options.timeoutMs,

--- a/npm/ox-content-code-play/src/plugin-client.test.ts
+++ b/npm/ox-content-code-play/src/plugin-client.test.ts
@@ -1,0 +1,37 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vite-plus/test";
+import {
+  assertBrowserClientSource,
+  isAutoHydratingClient,
+  isStandaloneBrowserClient,
+  resolveClientFile,
+} from "./plugin-client";
+
+describe("plugin client emission", () => {
+  it("prefers the auto-hydrating browser entry over hydrate", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "ox-code-play-client-"));
+    writeFileSync(path.join(dir, "browser.mjs"), "bootCodePlay();\n");
+    writeFileSync(path.join(dir, "hydrate.mjs"), "export function hydrateCodePlay() {}\n");
+    expect(resolveClientFile(pathToFileURL(path.join(dir, "plugin.mjs")).href)).toMatch(
+      /browser\.mjs$/,
+    );
+  });
+
+  it("rejects a chunked hydrate module as the published SSG client", () => {
+    const hydrate = `export { hydrateCodePlay } from "./hydrate2.mjs";\n`;
+    expect(isAutoHydratingClient(hydrate)).toBe(false);
+    expect(isStandaloneBrowserClient(hydrate)).toBe(false);
+    expect(() => assertBrowserClientSource(hydrate)).toThrow(/bootCodePlay/);
+  });
+
+  it("accepts a standalone boot entry", () => {
+    const source =
+      'function bootCodePlay() {}\ndocument.addEventListener("DOMContentLoaded", bootCodePlay);\n';
+    expect(isAutoHydratingClient(source)).toBe(true);
+    expect(isStandaloneBrowserClient(source)).toBe(true);
+    expect(assertBrowserClientSource(source)).toBe(source);
+  });
+});

--- a/npm/ox-content-code-play/src/plugin-client.ts
+++ b/npm/ox-content-code-play/src/plugin-client.ts
@@ -1,0 +1,39 @@
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+export const CLIENT_FILE_CANDIDATES = [
+  "browser.mjs",
+  "browser.js",
+  "hydrate.mjs",
+  "hydrate.js",
+] as const;
+
+export function resolveClientFile(baseUrl = import.meta.url): string | undefined {
+  return CLIENT_FILE_CANDIDATES.map((name) => fileURLToPath(new URL(`./${name}`, baseUrl))).find(
+    (candidate) => existsSync(candidate),
+  );
+}
+
+export function resolveHydrateSpecifier(baseUrl = import.meta.url): string {
+  return resolveClientFile(baseUrl) ?? fileURLToPath(new URL("./hydrate.ts", baseUrl));
+}
+
+export function isStandaloneBrowserClient(source: string): boolean {
+  return (
+    !/\bfrom\s+["']\.\.?\/[^"']+["']/.test(source) &&
+    !/\bimport\s*\(\s*["']\.\.?\/[^"']+["']/.test(source)
+  );
+}
+
+export function isAutoHydratingClient(source: string): boolean {
+  return source.includes("bootCodePlay") && source.includes("DOMContentLoaded");
+}
+
+export function assertBrowserClientSource(source: string): string {
+  if (!isAutoHydratingClient(source) || !isStandaloneBrowserClient(source)) {
+    throw new Error(
+      "@ox-content/code-play must emit a standalone ox-code-play.js that calls bootCodePlay(). Run the package build.",
+    );
+  }
+  return source;
+}

--- a/npm/ox-content-code-play/src/plugin.ts
+++ b/npm/ox-content-code-play/src/plugin.ts
@@ -1,7 +1,6 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import type { Plugin, ViteDevServer } from "vite";
 import { resolveLanguage } from "./catalog";
 import {
@@ -13,6 +12,11 @@ import { enhanceGeneratedModule, enhancePlayHtml } from "./html";
 import { parseCodePlayTags, parsePlayFences, rewritePlayFences } from "./markdown";
 import { decodePayload, encodePayload } from "./payload";
 import { payloadFromFence } from "./payload-factory";
+import {
+  assertBrowserClientSource,
+  resolveClientFile,
+  resolveHydrateSpecifier,
+} from "./plugin-client";
 import { proxy, typecheckProxy } from "./plugin-proxy";
 
 export type CodePlayPluginOptions = RawCodePlayOptions;
@@ -93,7 +97,7 @@ export function codePlay(options: CodePlayPluginOptions = {}): Plugin {
             return next();
           }
           res.setHeader("Content-Type", "text/javascript; charset=utf-8");
-          res.end(await readFile(file, "utf8"));
+          res.end(assertBrowserClientSource(await readFile(file, "utf8")));
           return;
         }
         interceptHtml(res, (html) =>
@@ -111,7 +115,7 @@ export function codePlay(options: CodePlayPluginOptions = {}): Plugin {
       this.emitFile({
         type: "asset",
         fileName: "ox-code-play.js",
-        source: await readFile(file, "utf8"),
+        source: assertBrowserClientSource(await readFile(file, "utf8")),
       });
     },
 
@@ -293,18 +297,6 @@ function walkFiles(dir: string): string[] {
     }
   }
   return files;
-}
-
-function resolveClientFile(): string | undefined {
-  const candidates = [
-    fileURLToPath(new URL("./hydrate.mjs", import.meta.url)),
-    fileURLToPath(new URL("./hydrate.js", import.meta.url)),
-  ];
-  return candidates.find((candidate) => existsSync(candidate));
-}
-
-function resolveHydrateSpecifier(): string {
-  return resolveClientFile() ?? fileURLToPath(new URL("./hydrate.ts", import.meta.url));
 }
 
 function normalizeBase(base: string): string {

--- a/npm/ox-content-code-play/src/result.ts
+++ b/npm/ox-content-code-play/src/result.ts
@@ -1,0 +1,21 @@
+import { withStdioText } from "./stdio";
+import { emptyTiming } from "./timing";
+import type { RunResult, RunStatus } from "./types";
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error && error.message ? error.message : String(error);
+}
+
+export function errorResult(
+  message: string,
+  source = "code-play",
+  status: RunStatus = "error",
+): RunResult {
+  return withStdioText({
+    status,
+    stdio: [],
+    diagnostics: [{ message, severity: "error", source }],
+    provenance: {},
+    timing: emptyTiming(),
+  });
+}

--- a/npm/ox-content-code-play/src/runtime-host.ts
+++ b/npm/ox-content-code-play/src/runtime-host.ts
@@ -1,0 +1,4 @@
+/** True when the current isolate can load `node:vm`. */
+export function hasNodeVm(): boolean {
+  return typeof process !== "undefined" && Boolean(process.versions?.node);
+}

--- a/npm/ox-content-code-play/src/session.ts
+++ b/npm/ox-content-code-play/src/session.ts
@@ -1,5 +1,6 @@
 import { executeAdapter, typecheckAdapter } from "./adapters";
 import { mergeConfig } from "./config";
+import { errorMessage, errorResult } from "./result";
 import { withStdioText } from "./stdio";
 import type {
   AdapterRequest,
@@ -85,9 +86,17 @@ export class CodePlaySession {
       loadTypeScript: this.loadTypeScript,
       endpoints: this.endpoints,
     };
-    const result = withStdioText(
-      action === "typecheck" ? await typecheckAdapter(request) : await executeAdapter(request),
-    );
+    try {
+      const result = withStdioText(
+        action === "typecheck" ? await typecheckAdapter(request) : await executeAdapter(request),
+      );
+      return this.finish(result);
+    } catch (error) {
+      return this.finish(errorResult(errorMessage(error)));
+    }
+  }
+
+  private finish(result: RunResult): RunResult {
     this.lastResult = result;
     for (const event of result.stdio) {
       this.emit("stdio", event);

--- a/npm/ox-content-code-play/src/typescript.ts
+++ b/npm/ox-content-code-play/src/typescript.ts
@@ -1,15 +1,9 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import { executeScript } from "./javascript";
+import { hasNodeVm } from "./runtime-host";
 import { StdioBuffer } from "./stdio";
 import { stripTypeScript } from "./strip-typescript";
 import { PhaseTracker } from "./timing";
-import type { AdapterRequest, AdapterResult, Diagnostic } from "./types";
-
-const execFileAsync = promisify(execFile);
+import type { AdapterRequest, AdapterResult, Diagnostic, TransportResponse } from "./types";
 
 export async function typecheckTypeScript(request: AdapterRequest): Promise<AdapterResult> {
   const tracker = new PhaseTracker();
@@ -98,13 +92,45 @@ async function typecheckViaEndpoint(
   request: AdapterRequest,
   tracker: PhaseTracker,
 ): Promise<AdapterResult> {
+  const url = request.endpoints.typecheck ?? "";
   const response = await request.transport.request({
-    url: request.endpoints.typecheck ?? "",
+    url,
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ language: "typescript", code: request.code, config: request.config }),
   });
   tracker.stop();
+  return adapterResultFromTypecheckResponse(response, url, tracker);
+}
+
+export function typecheckEndpointFailureMessage(status: number, text: string): string {
+  if (status === 404 || status === 405) {
+    return "Typecheck needs a reachable endpoints.typecheck. The Vite /__ox-code-play/typecheck proxy exists only during vite dev.";
+  }
+  const trimmed = text.trim();
+  return trimmed || "Typecheck endpoint failed.";
+}
+
+export function adapterResultFromTypecheckResponse(
+  response: TransportResponse,
+  url: string,
+  tracker: PhaseTracker,
+): AdapterResult {
+  if (!response.ok) {
+    return {
+      status: "error",
+      stdio: [],
+      diagnostics: [
+        {
+          message: typecheckEndpointFailureMessage(response.status, response.text),
+          severity: "error",
+          source: "tsgo",
+        },
+      ],
+      provenance: { compile: { host: hostFromUrl(url), runtime: "tsgo" } },
+      timing: tracker.report(),
+    };
+  }
   try {
     return JSON.parse(response.text) as AdapterResult;
   } catch {
@@ -118,15 +144,22 @@ async function typecheckViaEndpoint(
           source: "tsgo",
         },
       ],
-      provenance: {
-        compile: { host: hostFromUrl(request.endpoints.typecheck ?? ""), runtime: "tsgo" },
-      },
+      provenance: { compile: { host: hostFromUrl(url), runtime: "tsgo" } },
       timing: tracker.report(),
     };
   }
 }
 
 export async function typecheckWithTsgo(code: string, command = "tsgo"): Promise<Diagnostic[]> {
+  const [{ mkdtemp, rm, writeFile }, { tmpdir }, { join }, { execFile }, { promisify }] =
+    await Promise.all([
+      import("node:fs/promises"),
+      import("node:os"),
+      import("node:path"),
+      import("node:child_process"),
+      import("node:util"),
+    ]);
+  const execFileAsync = promisify(execFile);
   const dir = await mkdtemp(join(tmpdir(), "ox-code-play-"));
   const file = join(dir, "snippet.ts");
   await writeFile(file, code);
@@ -175,10 +208,6 @@ function commandOutput(error: unknown): string {
     .filter((part): part is string => typeof part === "string" && part.trim().length > 0)
     .join("\n")
     .trim();
-}
-
-function hasNodeVm(): boolean {
-  return typeof process !== "undefined" && Boolean(process.versions?.node);
 }
 
 function hostFromUrl(url: string): string {

--- a/npm/ox-content-code-play/vite.config.ts
+++ b/npm/ox-content-code-play/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     ignorePatterns: ["dist/**"],
   },
   pack: definePackConfig({
-    entry: ["src/index.ts", "src/plugin.ts", "src/hydrate.ts"],
+    entry: ["src/index.ts", "src/plugin.ts", "src/hydrate.ts", "src/browser.ts"],
     format: ["esm"],
     dts: true,
     clean: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

SSG pages injected `ox-code-play.js` but that file was a chunked `hydrate` export with **no boot call**, so published widgets stayed static.

This PR:

- Bundles a standalone `dist/browser.mjs` and emits it as `ox-code-play.js`
- Calls `bootCodePlay()` on `DOMContentLoaded` (or immediately if the document is already ready)
- Skips malformed payloads so one bad widget cannot abort the page
- Keeps Run / Typecheck enabled after a thrown adapter or transport failure
- Explains 404 typecheck endpoints (the Vite proxy is **dev-only**)
- Turns `node:vm` timeouts and transport throws into `RunResult` instead of rejected promises

Tracking: #648 (roadmap item 2). Docs/example pages landed in #697; this PR is the missing client boot.

Rebased onto `main` after #697 and #698.

## Risk

- Risk level: medium
- User or production impact: docs and consumer SSG sites that already inject `ox-code-play.js` become interactive. Typecheck on static hosts still needs `endpoints.typecheck`; the message is now explicit.
- Rollback plan: revert this PR; sites fall back to a non-booting client.

## Validation

- [x] Automated tests or checks run: `vp test src` in `@ox-content/code-play` (68 tests), `tsgo --noEmit`, `vp check --fix`, `npm run build` (standalone `dist/browser.mjs` calls `bootCodePlay()`)
- [ ] Manual verification completed: browser click-through of the docs example is still outstanding (no visual SSG job yet)
- [x] Edge cases or failure modes considered: malformed payload, transport throw, typecheck 404, JS `while (true)` timeout, chunked hydrate rejected as the emitted client

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed. Roadmap item 2 updated.
- [x] Configuration, migration, or environment changes documented, or not needed. Package `build` is now `vp pack && node scripts/bundle-browser.mjs`.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed. Node builtins stay dynamic imports so the browser bundle does not load `fs` / `child_process` unless typecheck runs on Node.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790145779&installation_model_id=422833&pr_number=703&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F703&signature=c13d67611b97d06cd64d5d61c47e952c59142edb795add956a954f75756bdd89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->