### PR TITLE
docs(code-play): document sandboxes, playgrounds, and endpoint trust

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,12 +54,13 @@ Content release artifacts, including:
   Sample code is not run during Markdown transform or SSG. `play` fences are
   trusted site content. JavaScript and TypeScript run in `node:vm` on Node,
   or in an iframe with `sandbox="allow-scripts"` (no `allow-same-origin`) in
-  the browser — never via page-origin `Function`. Native languages POST
-  source to official playgrounds or a user-configured HTTPS executor. Treat
-  `endpoints` and
-  `languages.<id>.endpoint` as trusted destinations. The plugin does not
-  spawn a local shell. The Vite `/__ox-code-play/*` proxies are dev-only,
-  accept POST only, and do not leak upstream fetch errors to the client.
+  the browser — never via page-origin `Function`. Framework previews use the
+  same iframe flags. Native languages POST source to official playgrounds
+  or a user-configured HTTPS executor. Treat `endpoints` and
+  `languages.<id>.endpoint` as trusted destinations; they receive sample
+  source. The plugin does not spawn a local shell. The Vite
+  `/__ox-code-play/*` proxies are dev-only, accept POST only, and do not
+  leak upstream fetch errors to the client.
 - Build, release, and dependency configuration that could affect distributed
   artifacts.
 

--- a/docs/content/code-play-roadmap.md
+++ b/docs/content/code-play-roadmap.md
@@ -86,9 +86,10 @@ each runtime is its own language enable flag.
 
 ### 6. `docs(code-play): security and privacy notes`
 
-This PR. Trusted `play` fences, iframe `sandbox="allow-scripts"`, third-party
-playgrounds, endpoint trust, production typecheck / CORS, and the "no local
-shell" guarantee in SECURITY.md and the package guide.
+This PR. Trusted `play` fences, iframe `sandbox="allow-scripts"` for JS/TS
+execute and framework previews, third-party playgrounds, endpoint trust,
+production typecheck / CORS, and the "no local shell" guarantee in
+SECURITY.md and the package guide.
 
 ## Out of Scope
 

--- a/docs/content/packages/code-play.md
+++ b/docs/content/packages/code-play.md
@@ -181,21 +181,23 @@ control.
 
 ## Security
 
-`play` fences are **trusted site content**. Do not mark visitor-supplied or
-unreviewed snippets as `play`.
+`play` fences are **trusted site content**, same as any other script you
+ship. Do not mark visitor-supplied or unreviewed snippets as `play`.
 
 - Samples are not executed during Markdown transform or SSG.
-- JavaScript and TypeScript execute in `node:vm` on Node, or in
+- **JavaScript / TypeScript execute** in `node:vm` on Node, or in
   `<iframe sandbox="allow-scripts">` in the browser (no `allow-same-origin`).
-  They are never run with page-origin `Function`.
-- Vue / React / Svelte / Solid previews use the same iframe flags and load
-  runtimes from `esm.sh`.
-- `sh` never spawns a local shell.
-- Enabling Rust or Go sends source to `play.rust-lang.org` /
-  `play.golang.org` (or your `endpoints` override). Their privacy policy
-  applies.
-- A configured remote endpoint receives source for that language. Only set
-  HTTPS endpoints you trust, without embedded credentials.
+  They are never run with page-origin `Function`. The sample cannot read the
+  host page's DOM or storage.
+- **Vue / React / Svelte / Solid** previews use the same iframe flags and
+  `srcdoc`. Preview runtimes load from `esm.sh`.
+- `sh` never spawns a local shell on the docs host.
+- **Rust / Go** POST source to `play.rust-lang.org` / `play.golang.org`
+  (or your `endpoints` override). Those hosts see the sample and their
+  privacy policy applies.
+- A Piston-compatible `languages.<id>.endpoint` receives source for that
+  language. Only set HTTPS endpoints you trust, without embedded
+  credentials.
 
 ## First publish
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Roadmap item 6 for #648. Rebased onto `main` after #711 and #712 so this PR is no longer conflicting.

Those PRs already landed the core trust model (sandboxed iframe, no page-origin `Function`, hidden SSG Typecheck, Cancel, first-publish notes). This change keeps that wording and adds the remaining notes:

- Framework previews use the same iframe flags
- Configured `endpoints` receive sample source
- JS/TS samples cannot read the host page's DOM or storage
- Piston-compatible remotes and official playgrounds are trusted destinations

Updates `SECURITY.md`, the package guide, and the roadmap.

## Risk

- Risk level: low
- User or production impact: documentation only.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run: docs-only change; `vp check` on the three files
- [x] Manual verification completed: wording checked against the iframe sandbox runner and current `main`
- [x] Edge cases or failure modes considered: static-host typecheck, official playground CORS

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790145874&installation_model_id=422833&pr_number=704&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F704&signature=56545f3043ba37909c8782d8db869b1e12beff2cd404fab761388da8522c7b92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->