### PR TITLE
feat(code-play): run browser JavaScript in a sandboxed iframe

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,8 +52,9 @@ Content release artifacts, including:
   examples maintained in this repository.
 - `@ox-content/code-play` execution sandboxes and remote-executor configuration.
   Sample code is not run during Markdown transform or SSG. JavaScript and
-  TypeScript run in `node:vm` or a browser iframe. Native languages use official
-  playgrounds or a user-configured HTTP executor. The plugin does not spawn a
+  TypeScript run in `node:vm` on Node, or in an iframe with
+  `sandbox="allow-scripts"` (no `allow-same-origin`) in the browser. Native
+  languages use official playgrounds or a user-configured HTTP executor. The plugin does not spawn a
   local shell. The Vite `/__ox-code-play/*` proxies are dev-only, accept POST
   only, and do not leak upstream fetch errors to the client.
 - Build, release, and dependency configuration that could affect distributed

--- a/docs/content/packages/code-play.md
+++ b/docs/content/packages/code-play.md
@@ -169,6 +169,8 @@ official playgrounds (or your own HTTPS executor) for published pages, or
 ## Security
 
 - Samples are not executed during Markdown transform or SSG.
+- JavaScript and TypeScript execute in `node:vm` on Node, or in
+  `<iframe sandbox="allow-scripts">` in the browser (no `allow-same-origin`).
 - `sh` never spawns a local shell.
 - Enabling Rust or Go sends source to `play.rust-lang.org` /
   `play.golang.org` (or your `endpoints` override).

--- a/npm/ox-content-code-play/README.md
+++ b/npm/ox-content-code-play/README.md
@@ -69,7 +69,8 @@ run.timing;
 ## Security
 
 - No sample is executed during Markdown transform or SSG.
-- JavaScript and TypeScript run in `node:vm` / a browser iframe.
+- JavaScript and TypeScript run in `node:vm` on Node, or in
+  `<iframe sandbox="allow-scripts">` in the browser.
 - Rust and Go use the official playgrounds (or the Vite dev proxy).
 - Other languages need a Piston-compatible `endpoint` you configure.
 - `sh` never spawns a local shell.

--- a/npm/ox-content-code-play/src/javascript-sandbox.test.ts
+++ b/npm/ox-content-code-play/src/javascript-sandbox.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vite-plus/test";
+import { StdioBuffer } from "./stdio";
+import {
+  applySandboxStreams,
+  buildJavaScriptSandboxDocument,
+  embedJson,
+  JS_SANDBOX_FLAGS,
+} from "./javascript-sandbox";
+
+describe("JavaScript browser sandbox", () => {
+  it("uses allow-scripts only and never allow-same-origin", () => {
+    expect(JS_SANDBOX_FLAGS).toBe("allow-scripts");
+    expect(JS_SANDBOX_FLAGS).not.toMatch(/same-origin|allow-forms|allow-popups/);
+  });
+
+  it("embeds sample source as JSON so </script> cannot break srcdoc", () => {
+    const code = `</script><script>parent.steal()</script>`;
+    const html = buildJavaScriptSandboxDocument(code, "msg-1");
+    expect(html).toContain("\\u003c/script>");
+    expect(html).not.toContain("</script><script>parent.steal()");
+    expect(html).toContain("new Function");
+    expect(html).toContain("parent.postMessage");
+    expect(html).toContain(embedJson("msg-1"));
+  });
+
+  it("escapes raw < in JSON payloads", () => {
+    expect(embedJson({ html: "<img>" })).toBe('{"html":"\\u003cimg>"}');
+  });
+
+  it("copies sandbox stdout and stderr onto the host stdio buffer", () => {
+    const stdio = new StdioBuffer(0);
+    applySandboxStreams(stdio, {
+      stdout: ["hello\n"],
+      stderr: ["warn\n"],
+    });
+    expect(stdio.snapshot().map((event) => [event.stream, event.text])).toEqual([
+      ["stdout", "hello\n"],
+      ["stderr", "warn\n"],
+    ]);
+  });
+});

--- a/npm/ox-content-code-play/src/javascript-sandbox.ts
+++ b/npm/ox-content-code-play/src/javascript-sandbox.ts
@@ -1,0 +1,106 @@
+import type { StdioBuffer } from "./stdio";
+
+export const JS_SANDBOX_FLAGS = "allow-scripts";
+
+export function embedJson(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}
+
+export function buildJavaScriptSandboxDocument(code: string, messageId: string): string {
+  return `<!doctype html><html><head><meta charset="utf-8"></head><body><script>
+(function () {
+  var id = ${embedJson(messageId)};
+  var stdout = [];
+  var stderr = [];
+  function format(args) {
+    return Array.prototype.map.call(args, function (value) {
+      if (typeof value === "string") return value;
+      if (value === undefined) return "undefined";
+      if (value === null) return "null";
+      try { return JSON.stringify(value); } catch (error) { return String(value); }
+    }).join(" ") + "\\n";
+  }
+  var consoleLike = {
+    log: function () { stdout.push(format(arguments)); },
+    info: function () { stdout.push(format(arguments)); },
+    warn: function () { stderr.push(format(arguments)); },
+    error: function () { stderr.push(format(arguments)); }
+  };
+  try {
+    var run = new Function("console", ${embedJson(`"use strict";\n${code}`)});
+    var value = run(consoleLike);
+    parent.postMessage({
+      id: id,
+      stdout: stdout,
+      stderr: stderr,
+      value: value === undefined ? undefined : String(value)
+    }, "*");
+  } catch (error) {
+    var message = error && error.message ? String(error.message) : String(error);
+    parent.postMessage({ id: id, stdout: stdout, stderr: stderr, error: message }, "*");
+  }
+})();
+</script></body></html>`;
+}
+
+export interface SandboxMessage {
+  id?: string;
+  stdout?: string[];
+  stderr?: string[];
+  value?: string;
+  error?: string;
+}
+
+export function applySandboxStreams(stdio: StdioBuffer, message: SandboxMessage): void {
+  for (const text of message.stdout ?? []) {
+    stdio.push("stdout", text);
+  }
+  for (const text of message.stderr ?? []) {
+    stdio.push("stderr", text);
+  }
+}
+
+export async function executeInSandboxIframe(
+  code: string,
+  timeoutMs: number,
+  stdio: StdioBuffer,
+): Promise<unknown> {
+  if (typeof document === "undefined" || typeof window === "undefined") {
+    throw new Error("JavaScript sandbox iframe needs a document.");
+  }
+  const messageId = `ox-code-play-${Math.random().toString(36).slice(2)}`;
+  return new Promise((resolve, reject) => {
+    const frame = document.createElement("iframe");
+    frame.setAttribute("sandbox", JS_SANDBOX_FLAGS);
+    frame.setAttribute("title", "Code Play JavaScript sandbox");
+    frame.hidden = true;
+    const cleanup = () => {
+      window.clearTimeout(timer);
+      window.removeEventListener("message", onMessage);
+      frame.remove();
+    };
+    const onMessage = (event: MessageEvent<SandboxMessage>) => {
+      if (event.source !== frame.contentWindow || event.data?.id !== messageId) {
+        return;
+      }
+      cleanup();
+      applySandboxStreams(stdio, event.data);
+      if (event.data.error) {
+        reject(new Error(event.data.error));
+        return;
+      }
+      resolve(event.data.value);
+    };
+    const timer = window.setTimeout(() => {
+      cleanup();
+      reject(
+        Object.assign(new Error("JavaScript execution timed out."), {
+          code: "ERR_SCRIPT_EXECUTION_TIMEOUT",
+        }),
+      );
+    }, timeoutMs);
+    window.addEventListener("message", onMessage);
+    frame.srcdoc = buildJavaScriptSandboxDocument(code, messageId);
+    document.body.append(frame);
+  });
+}

--- a/npm/ox-content-code-play/src/javascript.ts
+++ b/npm/ox-content-code-play/src/javascript.ts
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 import { hasNodeVm } from "./runtime-host";
+=======
+import { executeInSandboxIframe } from "./javascript-sandbox";
+>>>>>>> 12b14051 (feat(code-play): run browser JavaScript in a sandboxed iframe)
 import { formatConsoleArgs, StdioBuffer } from "./stdio";
 import { nowMs, PhaseTracker } from "./timing";
 import type { AdapterRequest, AdapterResult, Diagnostic } from "./types";
@@ -10,8 +14,8 @@ export async function runJavaScript(request: AdapterRequest): Promise<AdapterRes
   const provenance = {
     execute: {
       host: "local",
-      runtime: hasNodeVm() ? "node:vm" : "function",
-      sandbox: hasNodeVm() ? "vm" : "function",
+      runtime: hasNodeVm() ? "node:vm" : "iframe",
+      sandbox: hasNodeVm() ? "vm" : "srcdoc",
     },
   };
 
@@ -56,6 +60,10 @@ export async function executeScript(
     const vm = await import("node:vm");
     const context = vm.createContext({ console: consoleLike });
     return vm.runInContext(code, context, { timeout: timeoutMs, displayErrors: true });
+  }
+
+  if (typeof document !== "undefined") {
+    return executeInSandboxIframe(code, timeoutMs, stdio);
   }
 
   const started = nowMs();

--- a/npm/ox-content-code-play/src/javascript.ts
+++ b/npm/ox-content-code-play/src/javascript.ts
@@ -1,8 +1,5 @@
-<<<<<<< HEAD
-import { hasNodeVm } from "./runtime-host";
-=======
 import { executeInSandboxIframe } from "./javascript-sandbox";
->>>>>>> 12b14051 (feat(code-play): run browser JavaScript in a sandboxed iframe)
+import { hasNodeVm } from "./runtime-host";
 import { formatConsoleArgs, StdioBuffer } from "./stdio";
 import { nowMs, PhaseTracker } from "./timing";
 import type { AdapterRequest, AdapterResult, Diagnostic } from "./types";

--- a/npm/ox-content-code-play/src/typescript.ts
+++ b/npm/ox-content-code-play/src/typescript.ts
@@ -64,8 +64,8 @@ export async function runTypeScript(request: AdapterRequest): Promise<AdapterRes
         compile: { host: "local", runtime: "strip-types" },
         execute: {
           host: "local",
-          runtime: hasNodeVm() ? "node:vm" : "function",
-          sandbox: hasNodeVm() ? "vm" : "function",
+          runtime: hasNodeVm() ? "node:vm" : "iframe",
+          sandbox: hasNodeVm() ? "vm" : "srcdoc",
         },
       },
       timing: tracker.report(),
@@ -81,7 +81,11 @@ export async function runTypeScript(request: AdapterRequest): Promise<AdapterRes
       diagnostics: [{ message, severity: "error", source: "javascript" }],
       provenance: {
         compile: { host: "local", runtime: "strip-types" },
-        execute: { host: "local", runtime: hasNodeVm() ? "node:vm" : "function" },
+        execute: {
+          host: "local",
+          runtime: hasNodeVm() ? "node:vm" : "iframe",
+          sandbox: hasNodeVm() ? "vm" : "srcdoc",
+        },
       },
       timing: tracker.report(),
     };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Browser JavaScript / TypeScript **Run** used `new Function` in the published page's origin, so a `play` fence could read that origin's DOM and storage.

This PR:

- Executes browser samples in a hidden `<iframe sandbox="allow-scripts">` (`srcdoc`, no `allow-same-origin`)
- JSON-embeds the sample (`<` → `\\u003c`) so `</script>` in source cannot break `srcdoc`
- Keeps `node:vm` (with timeout) on Node
- Records provenance as `runtime: "iframe"` / `sandbox: "srcdoc"`
- Updates SECURITY.md and the package guide to match

Tracking: #648.

Rebased onto `main` after #703 (`hasNodeVm` lives in `runtime-host.ts`).

## Risk

- Risk level: medium
- User or production impact: published JS/TS widgets no longer run in the host page origin. `postMessage` is filtered by `event.source`. Tight loops can still burn CPU until `timeoutMs`.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run: `vp test src` in `@ox-content/code-play` (72 tests after rebase), `tsgo --noEmit`
- [ ] Manual verification completed: no browser click-through in this environment
- [x] Edge cases or failure modes considered: `</script>` in sample source, timeout abort removes the iframe, Node path unchanged

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790146012&installation_model_id=422833&pr_number=705&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F705&signature=9086392b0cf04507092fd18a19f6e6f7ab0d5b1aaa7638db061c09c8519825c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->