### PR TITLE
docs: add Ox Content 3.0 and docs-site feature roadmaps

### DIFF
--- a/docs/content/docs-site-feature-roadmap.md
+++ b/docs/content/docs-site-feature-roadmap.md
@@ -1,0 +1,75 @@
+---
+title: Docs Site Feature Roadmap
+description: Opt-in built-in documentation-site features tracked as focused issues.
+---
+
+# Docs Site Feature Roadmap
+
+Tracking issue: [#650](https://github.com/ubugeeei-prod/ox-content/issues/650).
+This list is a 3.0 workstream; the release tracker is
+[#699](https://github.com/ubugeeei-prod/ox-content/issues/699).
+
+Ox Content keeps non-standard Markdown and extra site behavior **opt-in**. Each
+item below is a first-party built-in that stays off until a site enables it.
+Work lands in small conventional PRs with failing tests first.
+
+Already tracked elsewhere:
+
+- Interactive sample execution: [#648](https://github.com/ubugeeei-prod/ox-content/issues/648)
+- i18n / MF2 core: [#451](https://github.com/ubugeeei-prod/ox-content/issues/451)
+
+## Phase A — Authoring
+
+| Feature | Issue | Status |
+| ------- | ----- | ------ |
+| Custom containers (`::: tip`) | [#665](https://github.com/ubugeeei-prod/ox-content/issues/665) | planned |
+| Math (inline `$` / block `$$`) | [#666](https://github.com/ubugeeei-prod/ox-content/issues/666) | planned |
+| Markdown file includes | [#667](https://github.com/ubugeeei-prod/ox-content/issues/667) | planned |
+| Figures, captions, and lazy images | [#668](https://github.com/ubugeeei-prod/ox-content/issues/668) | planned |
+| Inline badges | [#669](https://github.com/ubugeeei-prod/ox-content/issues/669) | planned |
+| File tree blocks | [#670](https://github.com/ubugeeei-prod/ox-content/issues/670) | planned |
+| Step lists | [#671](https://github.com/ubugeeei-prod/ox-content/issues/671) | planned |
+| Card / link-card / card-grid blocks | [#672](https://github.com/ubugeeei-prod/ox-content/issues/672) | planned |
+
+## Phase B — Site outputs
+
+| Feature | Issue | Status |
+| ------- | ----- | ------ |
+| `sitemap.xml`, `robots.txt`, `llms.txt` | [#673](https://github.com/ubugeeei-prod/ox-content/issues/673) | planned |
+| RSS / Atom / JSON feeds | [#674](https://github.com/ubugeeei-prod/ox-content/issues/674) | planned |
+| Redirects, aliases, and path rewrites | [#675](https://github.com/ubugeeei-prod/ox-content/issues/675) | planned |
+| Draft, unlisted, and scheduled pages | [#676](https://github.com/ubugeeei-prod/ox-content/issues/676) | planned |
+| Custom 404 page | [#677](https://github.com/ubugeeei-prod/ox-content/issues/677) | planned |
+| Permalinks and frontmatter cascade | [#678](https://github.com/ubugeeei-prod/ox-content/issues/678) | planned |
+
+## Phase C — Theme chrome
+
+| Feature | Issue | Status |
+| ------- | ----- | ------ |
+| Previous / next page links | [#679](https://github.com/ubugeeei-prod/ox-content/issues/679) | planned |
+| Code copy, external-link icons, back-to-top | [#680](https://github.com/ubugeeei-prod/ox-content/issues/680) | planned |
+| Header nav, announcement bar, per-page chrome | [#681](https://github.com/ubugeeei-prod/ox-content/issues/681) | planned |
+| Breadcrumbs | [#682](https://github.com/ubugeeei-prod/ox-content/issues/682) | planned |
+| Team / members page | [#683](https://github.com/ubugeeei-prod/ox-content/issues/683) | planned |
+| Locale switcher | [#684](https://github.com/ubugeeei-prod/ox-content/issues/684) | planned |
+| Skip link and print styles | [#685](https://github.com/ubugeeei-prod/ox-content/issues/685) | planned |
+
+## Phase D — Content model
+
+| Feature | Issue | Status |
+| ------- | ----- | ------ |
+| Taxonomies and related pages | [#687](https://github.com/ubugeeei-prod/ox-content/issues/687) | planned |
+| Blog (index, authors, tags, reading time, archive) | [#688](https://github.com/ubugeeei-prod/ox-content/issues/688) | planned |
+| Documentation versioning | [#689](https://github.com/ubugeeei-prod/ox-content/issues/689) | planned |
+| Generated section index pages | [#690](https://github.com/ubugeeei-prod/ox-content/issues/690) | planned |
+| Page resources and image processing | [#691](https://github.com/ubugeeei-prod/ox-content/issues/691) | planned |
+
+## Phase E — Integrations
+
+| Feature | Issue | Status |
+| ------- | ----- | ------ |
+| Git contributors | [#692](https://github.com/ubugeeei-prod/ox-content/issues/692) | planned |
+| Typed hover overlays for TypeScript fences | [#693](https://github.com/ubugeeei-prod/ox-content/issues/693) | planned |
+| Hosted search provider adapter | [#694](https://github.com/ubugeeei-prod/ox-content/issues/694) | planned |
+| PWA manifest and service worker | [#695](https://github.com/ubugeeei-prod/ox-content/issues/695) | planned |
+| Structured data (JSON-LD) | [#696](https://github.com/ubugeeei-prod/ox-content/issues/696) | planned |

--- a/docs/content/docs-site-feature-roadmap.md
+++ b/docs/content/docs-site-feature-roadmap.md
@@ -20,56 +20,56 @@ Already tracked elsewhere:
 
 ## Phase A — Authoring
 
-| Feature | Issue | Status |
-| ------- | ----- | ------ |
-| Custom containers (`::: tip`) | [#665](https://github.com/ubugeeei-prod/ox-content/issues/665) | planned |
-| Math (inline `$` / block `$$`) | [#666](https://github.com/ubugeeei-prod/ox-content/issues/666) | planned |
-| Markdown file includes | [#667](https://github.com/ubugeeei-prod/ox-content/issues/667) | planned |
-| Figures, captions, and lazy images | [#668](https://github.com/ubugeeei-prod/ox-content/issues/668) | planned |
-| Inline badges | [#669](https://github.com/ubugeeei-prod/ox-content/issues/669) | planned |
-| File tree blocks | [#670](https://github.com/ubugeeei-prod/ox-content/issues/670) | planned |
-| Step lists | [#671](https://github.com/ubugeeei-prod/ox-content/issues/671) | planned |
+| Feature                             | Issue                                                          | Status  |
+| ----------------------------------- | -------------------------------------------------------------- | ------- |
+| Custom containers (`::: tip`)       | [#665](https://github.com/ubugeeei-prod/ox-content/issues/665) | planned |
+| Math (inline `$` / block `$$`)      | [#666](https://github.com/ubugeeei-prod/ox-content/issues/666) | planned |
+| Markdown file includes              | [#667](https://github.com/ubugeeei-prod/ox-content/issues/667) | planned |
+| Figures, captions, and lazy images  | [#668](https://github.com/ubugeeei-prod/ox-content/issues/668) | planned |
+| Inline badges                       | [#669](https://github.com/ubugeeei-prod/ox-content/issues/669) | planned |
+| File tree blocks                    | [#670](https://github.com/ubugeeei-prod/ox-content/issues/670) | planned |
+| Step lists                          | [#671](https://github.com/ubugeeei-prod/ox-content/issues/671) | planned |
 | Card / link-card / card-grid blocks | [#672](https://github.com/ubugeeei-prod/ox-content/issues/672) | planned |
 
 ## Phase B — Site outputs
 
-| Feature | Issue | Status |
-| ------- | ----- | ------ |
+| Feature                                 | Issue                                                          | Status  |
+| --------------------------------------- | -------------------------------------------------------------- | ------- |
 | `sitemap.xml`, `robots.txt`, `llms.txt` | [#673](https://github.com/ubugeeei-prod/ox-content/issues/673) | planned |
-| RSS / Atom / JSON feeds | [#674](https://github.com/ubugeeei-prod/ox-content/issues/674) | planned |
-| Redirects, aliases, and path rewrites | [#675](https://github.com/ubugeeei-prod/ox-content/issues/675) | planned |
-| Draft, unlisted, and scheduled pages | [#676](https://github.com/ubugeeei-prod/ox-content/issues/676) | planned |
-| Custom 404 page | [#677](https://github.com/ubugeeei-prod/ox-content/issues/677) | planned |
-| Permalinks and frontmatter cascade | [#678](https://github.com/ubugeeei-prod/ox-content/issues/678) | planned |
+| RSS / Atom / JSON feeds                 | [#674](https://github.com/ubugeeei-prod/ox-content/issues/674) | planned |
+| Redirects, aliases, and path rewrites   | [#675](https://github.com/ubugeeei-prod/ox-content/issues/675) | planned |
+| Draft, unlisted, and scheduled pages    | [#676](https://github.com/ubugeeei-prod/ox-content/issues/676) | planned |
+| Custom 404 page                         | [#677](https://github.com/ubugeeei-prod/ox-content/issues/677) | planned |
+| Permalinks and frontmatter cascade      | [#678](https://github.com/ubugeeei-prod/ox-content/issues/678) | planned |
 
 ## Phase C — Theme chrome
 
-| Feature | Issue | Status |
-| ------- | ----- | ------ |
-| Previous / next page links | [#679](https://github.com/ubugeeei-prod/ox-content/issues/679) | planned |
-| Code copy, external-link icons, back-to-top | [#680](https://github.com/ubugeeei-prod/ox-content/issues/680) | planned |
+| Feature                                       | Issue                                                          | Status  |
+| --------------------------------------------- | -------------------------------------------------------------- | ------- |
+| Previous / next page links                    | [#679](https://github.com/ubugeeei-prod/ox-content/issues/679) | planned |
+| Code copy, external-link icons, back-to-top   | [#680](https://github.com/ubugeeei-prod/ox-content/issues/680) | planned |
 | Header nav, announcement bar, per-page chrome | [#681](https://github.com/ubugeeei-prod/ox-content/issues/681) | planned |
-| Breadcrumbs | [#682](https://github.com/ubugeeei-prod/ox-content/issues/682) | planned |
-| Team / members page | [#683](https://github.com/ubugeeei-prod/ox-content/issues/683) | planned |
-| Locale switcher | [#684](https://github.com/ubugeeei-prod/ox-content/issues/684) | planned |
-| Skip link and print styles | [#685](https://github.com/ubugeeei-prod/ox-content/issues/685) | planned |
+| Breadcrumbs                                   | [#682](https://github.com/ubugeeei-prod/ox-content/issues/682) | planned |
+| Team / members page                           | [#683](https://github.com/ubugeeei-prod/ox-content/issues/683) | planned |
+| Locale switcher                               | [#684](https://github.com/ubugeeei-prod/ox-content/issues/684) | planned |
+| Skip link and print styles                    | [#685](https://github.com/ubugeeei-prod/ox-content/issues/685) | planned |
 
 ## Phase D — Content model
 
-| Feature | Issue | Status |
-| ------- | ----- | ------ |
-| Taxonomies and related pages | [#687](https://github.com/ubugeeei-prod/ox-content/issues/687) | planned |
+| Feature                                            | Issue                                                          | Status  |
+| -------------------------------------------------- | -------------------------------------------------------------- | ------- |
+| Taxonomies and related pages                       | [#687](https://github.com/ubugeeei-prod/ox-content/issues/687) | planned |
 | Blog (index, authors, tags, reading time, archive) | [#688](https://github.com/ubugeeei-prod/ox-content/issues/688) | planned |
-| Documentation versioning | [#689](https://github.com/ubugeeei-prod/ox-content/issues/689) | planned |
-| Generated section index pages | [#690](https://github.com/ubugeeei-prod/ox-content/issues/690) | planned |
-| Page resources and image processing | [#691](https://github.com/ubugeeei-prod/ox-content/issues/691) | planned |
+| Documentation versioning                           | [#689](https://github.com/ubugeeei-prod/ox-content/issues/689) | planned |
+| Generated section index pages                      | [#690](https://github.com/ubugeeei-prod/ox-content/issues/690) | planned |
+| Page resources and image processing                | [#691](https://github.com/ubugeeei-prod/ox-content/issues/691) | planned |
 
 ## Phase E — Integrations
 
-| Feature | Issue | Status |
-| ------- | ----- | ------ |
-| Git contributors | [#692](https://github.com/ubugeeei-prod/ox-content/issues/692) | planned |
+| Feature                                    | Issue                                                          | Status  |
+| ------------------------------------------ | -------------------------------------------------------------- | ------- |
+| Git contributors                           | [#692](https://github.com/ubugeeei-prod/ox-content/issues/692) | planned |
 | Typed hover overlays for TypeScript fences | [#693](https://github.com/ubugeeei-prod/ox-content/issues/693) | planned |
-| Hosted search provider adapter | [#694](https://github.com/ubugeeei-prod/ox-content/issues/694) | planned |
-| PWA manifest and service worker | [#695](https://github.com/ubugeeei-prod/ox-content/issues/695) | planned |
-| Structured data (JSON-LD) | [#696](https://github.com/ubugeeei-prod/ox-content/issues/696) | planned |
+| Hosted search provider adapter             | [#694](https://github.com/ubugeeei-prod/ox-content/issues/694) | planned |
+| PWA manifest and service worker            | [#695](https://github.com/ubugeeei-prod/ox-content/issues/695) | planned |
+| Structured data (JSON-LD)                  | [#696](https://github.com/ubugeeei-prod/ox-content/issues/696) | planned |

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -97,6 +97,8 @@ Under the hood, Ox Content is not only a docs theme. It also exposes the Markdow
 - [Docs Deployment](./deployment.md) - Deploy the documentation site to Void with `vp run deploy#docs`
 - [Editor Extension Roadmap](./editor-extension-roadmap.md) - VS Code and Neovim plan, PR-by-PR
 - [Code Play Roadmap](./code-play-roadmap.md) - Opt-in `@ox-content/code-play` plugin plan
+- [Ox Content 3.0 Roadmap](./v3-roadmap.md) - Theme packages, MDX, Code Play, built-ins, tree-sitter highlighting
+- [Docs Site Feature Roadmap](./docs-site-feature-roadmap.md) - Opt-in built-in docs-site features
 
 ## Reference
 

--- a/docs/content/v3-roadmap.md
+++ b/docs/content/v3-roadmap.md
@@ -11,13 +11,13 @@ Tracking issue: [#699](https://github.com/ubugeeei-prod/ox-content/issues/699).
 highlighting breaking change. New Markdown and extra chrome stay **opt-in**.
 Work lands in small conventional PRs with failing tests first.
 
-| Pillar | Issue | Notes |
-| ------ | ----- | ----- |
-| Stable theme packages | [#700](https://github.com/ubugeeei-prod/ox-content/issues/700) | Skins and color schemes become an official contract |
-| Complete MDX support | [#701](https://github.com/ubugeeei-prod/ox-content/issues/701) | JSX, imports, markdown-in-JSX; islands stay JS-free by default |
-| Code Play | [#648](https://github.com/ubugeeei-prod/ox-content/issues/648) | Linked pillar; see the [Code Play Roadmap](./code-play-roadmap.md) |
-| Built-in docs-site features | [#650](https://github.com/ubugeeei-prod/ox-content/issues/650) | Authoring, site outputs, theme chrome — default OFF |
-| Tree-sitter highlighting | [#702](https://github.com/ubugeeei-prod/ox-content/issues/702) | Landed in [#710](https://github.com/ubugeeei-prod/ox-content/pull/710); `highlight: true` is native only |
+| Pillar                      | Issue                                                          | Notes                                                                                                    |
+| --------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Stable theme packages       | [#700](https://github.com/ubugeeei-prod/ox-content/issues/700) | Skins and color schemes become an official contract                                                      |
+| Complete MDX support        | [#701](https://github.com/ubugeeei-prod/ox-content/issues/701) | JSX, imports, markdown-in-JSX; islands stay JS-free by default                                           |
+| Code Play                   | [#648](https://github.com/ubugeeei-prod/ox-content/issues/648) | Linked pillar; see the [Code Play Roadmap](./code-play-roadmap.md)                                       |
+| Built-in docs-site features | [#650](https://github.com/ubugeeei-prod/ox-content/issues/650) | Authoring, site outputs, theme chrome — default OFF                                                      |
+| Tree-sitter highlighting    | [#702](https://github.com/ubugeeei-prod/ox-content/issues/702) | Landed in [#710](https://github.com/ubugeeei-prod/ox-content/pull/710); `highlight: true` is native only |
 
 Also tracked elsewhere and not duplicated here:
 

--- a/docs/content/v3-roadmap.md
+++ b/docs/content/v3-roadmap.md
@@ -1,0 +1,40 @@
+---
+title: Ox Content 3.0 Roadmap
+description: Release tracker for theme packages, complete MDX, Code Play, opt-in built-ins, and tree-sitter highlighting.
+---
+
+# Ox Content 3.0 Roadmap
+
+Tracking issue: [#699](https://github.com/ubugeeei-prod/ox-content/issues/699).
+
+3.0 is the release that graduates experimental surfaces and accepts the
+highlighting breaking change. New Markdown and extra chrome stay **opt-in**.
+Work lands in small conventional PRs with failing tests first.
+
+| Pillar | Issue | Notes |
+| ------ | ----- | ----- |
+| Stable theme packages | [#700](https://github.com/ubugeeei-prod/ox-content/issues/700) | Skins and color schemes become an official contract |
+| Complete MDX support | [#701](https://github.com/ubugeeei-prod/ox-content/issues/701) | JSX, imports, markdown-in-JSX; islands stay JS-free by default |
+| Code Play | [#648](https://github.com/ubugeeei-prod/ox-content/issues/648) | Linked pillar; see the [Code Play Roadmap](./code-play-roadmap.md) |
+| Built-in docs-site features | [#650](https://github.com/ubugeeei-prod/ox-content/issues/650) | Authoring, site outputs, theme chrome — default OFF |
+| Tree-sitter highlighting | [#702](https://github.com/ubugeeei-prod/ox-content/issues/702) | Landed in [#710](https://github.com/ubugeeei-prod/ox-content/pull/710); `highlight: true` is native only |
+
+Also tracked elsewhere and not duplicated here:
+
+- i18n / MF2 core: [#451](https://github.com/ubugeeei-prod/ox-content/issues/451)
+
+## Breaking changes
+
+- `highlightTheme` and `highlightLangs` go away. There is one highlighter.
+- Languages with no tree-sitter grammar stay plain.
+- Theme package peer ranges move to 3.x.
+- Built-ins and Code Play do **not** turn on just because the major version
+  changed. Each still needs an explicit install or option.
+
+Syntax token CSS (`--octc-shiki-*`, `class="shiki"`) stays so published color
+packages keep working. Those names are historical.
+
+## Built-ins
+
+The feature list lives on the [Docs Site Feature Roadmap](./docs-site-feature-roadmap.md)
+and in [#650](https://github.com/ubugeeei-prod/ox-content/issues/650).

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -124,6 +124,11 @@ export default defineConfig(({ mode }) => {
                     link: "/editor-extension-roadmap.md",
                   },
                   { text: "Code Play Roadmap", link: "/code-play-roadmap.md" },
+                  { text: "Ox Content 3.0 Roadmap", link: "/v3-roadmap.md" },
+                  {
+                    text: "Docs Site Feature Roadmap",
+                    link: "/docs-site-feature-roadmap.md",
+                  },
                 ],
               },
               {


### PR DESCRIPTION
## Summary
- Add the 3.0 roadmap page linking #699 (theme packages, MDX, Code Play, built-ins, tree-sitter).
- Add the opt-in docs-site feature checklist linking #650.
- Link both from the docs index and Advanced nav.

## Test plan
- [ ] Docs site sidebar shows both roadmap pages
- [ ] Links resolve to the GitHub issues


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790146331&installation_model_id=422833&pr_number=708&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F708&signature=4b5e4e9980c7af7390f76d1c0efb5b708c612d3609daf52918306782f7678eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->