### PR TITLE
feat(code-play): prove SSG hydrate+Run in CI and add session.cancel()

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,12 +51,14 @@ Content release artifacts, including:
 - The documentation site, playground, generated documentation pipeline, and
   examples maintained in this repository.
 - `@ox-content/code-play` execution sandboxes and remote-executor configuration.
-  Sample code is not run during Markdown transform or SSG. JavaScript and
-  TypeScript run in `node:vm` on Node, or in an iframe with
-  `sandbox="allow-scripts"` (no `allow-same-origin`) in the browser. Native
-  languages use official playgrounds or a user-configured HTTP executor. The plugin does not spawn a
-  local shell. The Vite `/__ox-code-play/*` proxies are dev-only, accept POST
-  only, and do not leak upstream fetch errors to the client.
+  Sample code is not run during Markdown transform or SSG. `play` fences are
+  trusted site content. JavaScript and TypeScript run in `node:vm` on Node,
+  or in an iframe with `sandbox="allow-scripts"` (no `allow-same-origin`) in
+  the browser. Native languages POST source to official playgrounds or a
+  user-configured HTTPS executor. Treat `endpoints` and
+  `languages.<id>.endpoint` as trusted destinations. The plugin does not
+  spawn a local shell. The Vite `/__ox-code-play/*` proxies are dev-only,
+  accept POST only, and do not leak upstream fetch errors to the client.
 - Build, release, and dependency configuration that could affect distributed
   artifacts.
 

--- a/docs/content/code-play-roadmap.md
+++ b/docs/content/code-play-roadmap.md
@@ -62,10 +62,9 @@ dedicated stderr viewer, and compact preset coverage for stderr.
 ### 2. `feat(code-play): Vite SSG hydration and docs dogfood`
 
 Docs example page, package guide, and `examples/code-play` shipped in #697.
-This PR emits a standalone `ox-code-play.js` that calls `bootCodePlay()` so
-SSG pages become interactive. One malformed widget or a thrown run no longer
-freezes the toolbar. Remaining: a visual check that the default preset
-hydrates on the written SSG HTML in CI.
+Standalone `ox-code-play.js` + `bootCodePlay()` shipped in #703. This PR
+adds a Playwright check that written SSG HTML hydrates and **Run** prints
+stdio, plus `session.cancel()`.
 
 ### 3. `feat(code-play): official playground proxies`
 
@@ -85,8 +84,9 @@ each runtime is its own language enable flag.
 
 ### 6. `docs(code-play): security and privacy notes`
 
-Document third-party playgrounds, endpoint trust, iframe sandbox flags, and
-the "no local shell" guarantee in SECURITY.md and the package guide.
+This PR. Trusted `play` fences, iframe `sandbox="allow-scripts"`, third-party
+playgrounds, endpoint trust, production typecheck / CORS, and the "no local
+shell" guarantee in SECURITY.md and the package guide.
 
 ## Out of Scope
 

--- a/docs/content/packages/code-play.md
+++ b/docs/content/packages/code-play.md
@@ -107,8 +107,9 @@ session.config; // editable language config
 
 `createCodePlay()` throws if you ask for a language that is not enabled.
 `session.setConfig({ strict: false })` updates the same object the config
-viewer edits. Inject `transport` (for example `createMemoryTransport`) in tests
-so CI never hits a live playground.
+viewer edits. `session.cancel()` aborts an in-flight remote / typecheck
+request and returns `status: "cancelled"`. Inject `transport` (for example
+`createMemoryTransport`) in tests so CI never hits a live playground.
 
 | Field             | Meaning                                                  |
 | ----------------- | -------------------------------------------------------- |
@@ -166,15 +167,31 @@ The proxy is not installed in production SSG output. Set `endpoints` to the
 official playgrounds (or your own HTTPS executor) for published pages, or
 `proxy: false` if you do not want the dev middleware.
 
+Static hosts do not serve `POST /__ox-code-play/typecheck`. TypeScript
+**Run** still works in the browser (strip types, then a sandboxed iframe).
+**Typecheck** on a published page needs a reachable `endpoints.typecheck`.
+
+Rust and Go on a published page call `endpoints.rust` / `endpoints.go`
+directly from the browser. Official playgrounds may reject that as CORS;
+keep the Vite proxy for local docs, or point `endpoints` at an executor you
+control.
+
 ## Security
+
+`play` fences are **trusted site content**. Do not mark visitor-supplied or
+unreviewed snippets as `play`.
 
 - Samples are not executed during Markdown transform or SSG.
 - JavaScript and TypeScript execute in `node:vm` on Node, or in
   `<iframe sandbox="allow-scripts">` in the browser (no `allow-same-origin`).
+- Vue / React / Svelte / Solid previews use the same iframe flags and load
+  runtimes from `esm.sh`.
 - `sh` never spawns a local shell.
 - Enabling Rust or Go sends source to `play.rust-lang.org` /
-  `play.golang.org` (or your `endpoints` override).
-- A configured remote endpoint receives source for that language.
+  `play.golang.org` (or your `endpoints` override). Their privacy policy
+  applies.
+- A configured remote endpoint receives source for that language. Only set
+  HTTPS endpoints you trust, without embedded credentials.
 
 ## First publish
 

--- a/npm/ox-content-code-play/README.md
+++ b/npm/ox-content-code-play/README.md
@@ -68,11 +68,16 @@ run.timing;
 
 ## Security
 
+`play` fences are trusted site content. Do not mark unreviewed or
+visitor-supplied snippets as `play`.
+
 - No sample is executed during Markdown transform or SSG.
 - JavaScript and TypeScript run in `node:vm` on Node, or in
-  `<iframe sandbox="allow-scripts">` in the browser.
-- Rust and Go use the official playgrounds (or the Vite dev proxy).
-- Other languages need a Piston-compatible `endpoint` you configure.
+  `<iframe sandbox="allow-scripts">` in the browser (no `allow-same-origin`).
+- Framework previews use the same iframe flags and load runtimes from esm.sh.
+- Rust and Go POST source to the official playgrounds (or your `endpoints`).
+  The Vite `/__ox-code-play/*` proxy is **dev-only**.
+- Other languages need a Piston-compatible `endpoint` you trust.
 - `sh` never spawns a local shell.
 
 ## Example

--- a/npm/ox-content-code-play/src/client.test.ts
+++ b/npm/ox-content-code-play/src/client.test.ts
@@ -99,6 +99,32 @@ describe("createCodePlay", () => {
     expect(result.diagnostics[0]?.message.length).toBeGreaterThan(0);
   });
 
+  it("cancels an in-flight remote run without rejecting the session", async () => {
+    const transport = createMemoryTransport(async (request) => {
+      await new Promise<never>((_, reject) => {
+        const fail = () =>
+          reject(
+            Object.assign(new Error("The Code Play run was cancelled."), { name: "AbortError" }),
+          );
+        if (request.signal?.aborted) {
+          fail();
+          return;
+        }
+        request.signal?.addEventListener("abort", fail, { once: true });
+      });
+      return { ok: true, status: 200, text: "{}" };
+    });
+    const session = createCodePlay({ languages: { rust: true }, transport }).createSession({
+      language: "rust",
+      code: "fn main() {}",
+    });
+    const pending = session.run();
+    session.cancel();
+    const result = await pending;
+    expect(result.status).toBe("cancelled");
+    expect(result.diagnostics[0]?.message).toMatch(/cancelled/i);
+  });
+
   it("turns transport throws into error results instead of rejecting", async () => {
     const play = createCodePlay({
       languages: { rust: true },

--- a/npm/ox-content-code-play/src/go.ts
+++ b/npm/ox-content-code-play/src/go.ts
@@ -35,6 +35,7 @@ export async function runGo(
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: params.toString(),
+    signal: request.signal,
   });
   tracker.start("collect", "Collect output");
 

--- a/npm/ox-content-code-play/src/javascript-sandbox.ts
+++ b/npm/ox-content-code-play/src/javascript-sandbox.ts
@@ -1,4 +1,5 @@
 import type { StdioBuffer } from "./stdio";
+import { abortError } from "./transport";
 
 export const JS_SANDBOX_FLAGS = "allow-scripts";
 
@@ -64,9 +65,13 @@ export async function executeInSandboxIframe(
   code: string,
   timeoutMs: number,
   stdio: StdioBuffer,
+  signal?: AbortSignal,
 ): Promise<unknown> {
   if (typeof document === "undefined" || typeof window === "undefined") {
     throw new Error("JavaScript sandbox iframe needs a document.");
+  }
+  if (signal?.aborted) {
+    throw abortError();
   }
   const messageId = `ox-code-play-${Math.random().toString(36).slice(2)}`;
   return new Promise((resolve, reject) => {
@@ -77,7 +82,12 @@ export async function executeInSandboxIframe(
     const cleanup = () => {
       window.clearTimeout(timer);
       window.removeEventListener("message", onMessage);
+      signal?.removeEventListener("abort", onAbort);
       frame.remove();
+    };
+    const onAbort = () => {
+      cleanup();
+      reject(abortError());
     };
     const onMessage = (event: MessageEvent<SandboxMessage>) => {
       if (event.source !== frame.contentWindow || event.data?.id !== messageId) {
@@ -100,6 +110,7 @@ export async function executeInSandboxIframe(
       );
     }, timeoutMs);
     window.addEventListener("message", onMessage);
+    signal?.addEventListener("abort", onAbort, { once: true });
     frame.srcdoc = buildJavaScriptSandboxDocument(code, messageId);
     document.body.append(frame);
   });

--- a/npm/ox-content-code-play/src/javascript.ts
+++ b/npm/ox-content-code-play/src/javascript.ts
@@ -17,7 +17,7 @@ export async function runJavaScript(request: AdapterRequest): Promise<AdapterRes
   };
 
   try {
-    const value = await executeScript(request.code, request.timeoutMs, stdio);
+    const value = await executeScript(request.code, request.timeoutMs, stdio, request.signal);
     tracker.stop();
     return {
       status: "ok",
@@ -45,6 +45,7 @@ export async function executeScript(
   code: string,
   timeoutMs: number,
   stdio: StdioBuffer,
+  signal?: AbortSignal,
 ): Promise<unknown> {
   const consoleLike = {
     log: (...args: unknown[]) => stdio.push("stdout", formatConsoleArgs(args)),
@@ -60,7 +61,7 @@ export async function executeScript(
   }
 
   if (typeof document !== "undefined") {
-    return executeInSandboxIframe(code, timeoutMs, stdio);
+    return executeInSandboxIframe(code, timeoutMs, stdio, signal);
   }
 
   const started = nowMs();

--- a/npm/ox-content-code-play/src/plugin-ssg.test.ts
+++ b/npm/ox-content-code-play/src/plugin-ssg.test.ts
@@ -1,0 +1,50 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+import { codePlay } from "./plugin";
+
+describe("codePlay SSG HTML enhance", () => {
+  it("wraps written SSG fences and injects the browser client script", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "ox-code-play-ssg-"));
+    const srcDir = path.join(root, "content");
+    const outDir = path.join(root, "dist");
+    mkdirSync(srcDir, { recursive: true });
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(path.join(srcDir, "index.md"), "```js play\nconsole.log(42);\n```\n");
+    writeFileSync(
+      path.join(outDir, "index.html"),
+      `<pre><code class="language-js">console.log(42);</code></pre>\n`,
+    );
+
+    const plugin = codePlay({
+      languages: { javascript: true },
+      srcDir: "content",
+      outDir: "dist",
+    });
+    const configResolved = hookFn(plugin.configResolved) as (config: {
+      command: string;
+      root: string;
+      base: string;
+      build: { outDir: string };
+    }) => void;
+    configResolved({ command: "build", root, base: "/", build: { outDir: "dist" } });
+    await hookFn(plugin.closeBundle)();
+
+    const html = readFileSync(path.join(outDir, "index.html"), "utf8");
+    expect(html).toContain("data-ox-code-play");
+    expect(html).toContain("<ox-code-play");
+    expect(html).toContain("ox-code-play.js");
+    expect(html).toContain('type="module"');
+  });
+});
+
+function hookFn(hook: unknown): (...args: never[]) => unknown {
+  if (typeof hook === "function") {
+    return hook as (...args: never[]) => unknown;
+  }
+  if (hook && typeof hook === "object" && "handler" in hook && typeof hook.handler === "function") {
+    return hook.handler as (...args: never[]) => unknown;
+  }
+  throw new Error("expected a plugin hook");
+}

--- a/npm/ox-content-code-play/src/remote.ts
+++ b/npm/ox-content-code-play/src/remote.ts
@@ -44,6 +44,7 @@ export async function runRemote(request: AdapterRequest): Promise<AdapterResult>
       version: request.config.version ?? request.definition.remote?.pistonVersion ?? "*",
       files: [{ content: request.code }],
     }),
+    signal: request.signal,
   });
   tracker.start("collect", "Collect output");
 

--- a/npm/ox-content-code-play/src/rust.ts
+++ b/npm/ox-content-code-play/src/rust.ts
@@ -35,6 +35,7 @@ export async function runRust(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
+    signal: request.signal,
   });
   tracker.start("collect", "Collect output");
 

--- a/npm/ox-content-code-play/src/session.ts
+++ b/npm/ox-content-code-play/src/session.ts
@@ -2,6 +2,7 @@ import { executeAdapter, typecheckAdapter } from "./adapters";
 import { mergeConfig } from "./config";
 import { errorMessage, errorResult } from "./result";
 import { withStdioText } from "./stdio";
+import { isAbortError } from "./transport";
 import type {
   AdapterRequest,
   CodePlayTransport,
@@ -39,6 +40,7 @@ export class CodePlaySession {
   private readonly endpoints: PlaygroundEndpoints;
   private readonly loadTypeScript?: () => Promise<TypeScriptLike | undefined>;
   private readonly listeners = new Map<SessionEventName, Set<Listener<unknown>>>();
+  private abort: AbortController | undefined;
 
   constructor(input: SessionConstructorInput) {
     this.language = input.definition;
@@ -75,7 +77,14 @@ export class CodePlaySession {
     return this.dispatch("typecheck");
   }
 
+  cancel(): void {
+    this.abort?.abort();
+  }
+
   private async dispatch(action: "execute" | "typecheck"): Promise<RunResult> {
+    this.abort?.abort();
+    this.abort = new AbortController();
+    const { signal } = this.abort;
     const request: AdapterRequest = {
       definition: this.language,
       enabled: this.enabled,
@@ -85,6 +94,7 @@ export class CodePlaySession {
       transport: this.transport,
       loadTypeScript: this.loadTypeScript,
       endpoints: this.endpoints,
+      signal,
     };
     try {
       const result = withStdioText(
@@ -92,6 +102,9 @@ export class CodePlaySession {
       );
       return this.finish(result);
     } catch (error) {
+      if (signal.aborted || isAbortError(error)) {
+        return this.finish(errorResult("Run cancelled.", "code-play", "cancelled"));
+      }
       return this.finish(errorResult(errorMessage(error)));
     }
   }

--- a/npm/ox-content-code-play/src/transport.ts
+++ b/npm/ox-content-code-play/src/transport.ts
@@ -7,6 +7,7 @@ export function createFetchTransport(fetchImpl: typeof fetch = fetch): CodePlayT
         method: input.method,
         headers: input.headers,
         body: input.body,
+        signal: input.signal,
       });
       return {
         ok: response.ok,
@@ -21,7 +22,12 @@ export function createMemoryTransport(
   handler: (input: TransportRequest) => TransportResponse | Promise<TransportResponse>,
 ): CodePlayTransport {
   return {
-    request: (input) => Promise.resolve(handler(input)),
+    async request(input) {
+      if (input.signal?.aborted) {
+        throw abortError();
+      }
+      return handler(input);
+    },
   };
 }
 
@@ -32,9 +38,24 @@ export class MissingTransportError extends Error {
   }
 }
 
+export function abortError(): Error {
+  const error = new Error("The Code Play run was cancelled.");
+  error.name = "AbortError";
+  return error;
+}
+
+export function isAbortError(error: unknown): boolean {
+  return Boolean(
+    error && typeof error === "object" && "name" in error && error.name === "AbortError",
+  );
+}
+
 export function createUnavailableTransport(): CodePlayTransport {
   return {
     request(input) {
+      if (input.signal?.aborted) {
+        return Promise.reject(abortError());
+      }
       return Promise.reject(new MissingTransportError(input.url));
     },
   };

--- a/npm/ox-content-code-play/src/types.ts
+++ b/npm/ox-content-code-play/src/types.ts
@@ -140,6 +140,7 @@ export interface TransportRequest {
   method: "GET" | "POST";
   headers?: Record<string, string>;
   body?: string;
+  signal?: AbortSignal;
 }
 
 export interface TransportResponse {
@@ -227,6 +228,7 @@ export interface AdapterRequest {
   transport: CodePlayTransport;
   loadTypeScript?: () => Promise<TypeScriptLike | undefined>;
   endpoints: PlaygroundEndpoints;
+  signal?: AbortSignal;
 }
 
 export interface PlaygroundEndpoints {

--- a/npm/ox-content-code-play/src/typescript.ts
+++ b/npm/ox-content-code-play/src/typescript.ts
@@ -54,7 +54,7 @@ export async function runTypeScript(request: AdapterRequest): Promise<AdapterRes
   const javascript = stripTypeScript(request.code);
   tracker.start("execute", "Execute");
   try {
-    const value = await executeScript(javascript, request.timeoutMs, stdio);
+    const value = await executeScript(javascript, request.timeoutMs, stdio, request.signal);
     tracker.stop();
     return {
       status: "ok",
@@ -102,6 +102,7 @@ async function typecheckViaEndpoint(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ language: "typescript", code: request.code, config: request.config }),
+    signal: request.signal,
   });
   tracker.stop();
   return adapterResultFromTypecheckResponse(response, url, tracker);

--- a/npm/vite-plugin-ox-content/test/vrt/code-play.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/code-play.spec.ts
@@ -1,0 +1,52 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { bundleBrowserClient } from "../../../ox-content-code-play/src/bundle-browser";
+import { resolveCodePlayOptions } from "../../../ox-content-code-play/src/config";
+import { enhancePlayHtml } from "../../../ox-content-code-play/src/html";
+import { decodePayload, encodePayload } from "../../../ox-content-code-play/src/payload";
+import { payloadFromFence } from "../../../ox-content-code-play/src/payload-factory";
+
+test("hydrates written SSG HTML and runs JavaScript in the sandbox iframe", async ({ page }) => {
+  const outDir = await mkdtemp(path.join(tmpdir(), "ox-code-play-vrt-"));
+  try {
+    await bundleBrowserClient(outDir);
+    const client = await readFile(path.join(outDir, "browser.mjs"), "utf8");
+    const options = resolveCodePlayOptions({ languages: { javascript: true } });
+    const code = `console.log("ssg-ready");`;
+    const payload = encodePayload(
+      payloadFromFence(
+        {
+          language: "js",
+          meta: "play",
+          code,
+          raw: "",
+          start: 0,
+          end: 0,
+          typecheck: false,
+        },
+        options,
+      ),
+    );
+    const widget = enhancePlayHtml(`<pre><code class="language-js">${code}</code></pre>`, {
+      decodePayload,
+      encodePayload,
+      matchFences: [{ language: "js", code, payload }],
+    });
+    expect(widget).toContain("data-ox-code-play");
+    await page.setContent(
+      `<!doctype html><html><head><meta charset="utf-8"></head><body>${widget}<script type="module">${client}</script></body></html>`,
+      { waitUntil: "domcontentloaded" },
+    );
+    const run = page.locator('[data-ox-action="run"]');
+    await expect(run).toBeVisible();
+    await run.click();
+    await expect(page.locator(".ox-code-play__stdio-text")).toContainText("ssg-ready", {
+      timeout: 10_000,
+    });
+    await expect(page.locator(".ox-code-play__stdio-line--stdout")).toBeVisible();
+  } finally {
+    await rm(outDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the remaining roadmap item 2 visual check and item 6 security notes for Code Play (#648).

- `session.cancel()` aborts the in-flight run via `AbortSignal` (transports, Rust/Go/remote/typecheck, sandbox iframe) and returns `status: "cancelled"` instead of rejecting the session.
- Unit test: `closeBundle` wraps written SSG HTML with `<ox-code-play>` and injects `ox-code-play.js`.
- Playwright VRT: written SSG HTML hydrates and **Run** prints `ssg-ready` from the sandbox iframe.
- Docs: trusted `play` fences, iframe flags, production Typecheck / CORS, endpoint trust (supersedes the conflicting security-docs portion of #704).

## Risk

- Risk level: low
- User or production impact: new `cancel()` API; aborting a previous run when starting another. Published SSG Run path is unchanged except cancel/abort plumbing.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run: `vp test src` (15 files, 74 tests) and `tsgo --noEmit` in `@ox-content/code-play`; `CI=1 playwright test test/vrt/code-play.spec.ts` (1 passed)
- [x] Manual verification completed: Playwright hydrates fixture SSG HTML and clicks Run
- [x] Edge cases or failure modes considered: cancel maps to `RunResult`; malformed widgets already isolated

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

## Follow-up (not in this PR)

- Hide Typecheck on static hosts unless `endpoints.typecheck` is a real URL (plugin still defaults to the Vite-only proxy).
- Expose Cancel in the default toolbar (`session.cancel()` is API-only today).
- #704 is DIRTY after #703/#705; close or rebase once this lands.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790146933&installation_model_id=422833&pr_number=711&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F711&signature=8826947d9bf3c8c9848e03a8e10325305affcfb76ebb560a1426c6f42a8fce3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->