### PR TITLE
feat(code-play): hide dead SSG Typecheck and expose Cancel

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,8 +54,9 @@ Content release artifacts, including:
   Sample code is not run during Markdown transform or SSG. `play` fences are
   trusted site content. JavaScript and TypeScript run in `node:vm` on Node,
   or in an iframe with `sandbox="allow-scripts"` (no `allow-same-origin`) in
-  the browser. Native languages POST source to official playgrounds or a
-  user-configured HTTPS executor. Treat `endpoints` and
+  the browser — never via page-origin `Function`. Native languages POST
+  source to official playgrounds or a user-configured HTTPS executor. Treat
+  `endpoints` and
   `languages.<id>.endpoint` as trusted destinations. The plugin does not
   spawn a local shell. The Vite `/__ox-code-play/*` proxies are dev-only,
   accept POST only, and do not leak upstream fetch errors to the client.

--- a/docs/content/code-play-roadmap.md
+++ b/docs/content/code-play-roadmap.md
@@ -64,7 +64,9 @@ dedicated stderr viewer, and compact preset coverage for stderr.
 Docs example page, package guide, and `examples/code-play` shipped in #697.
 Standalone `ox-code-play.js` + `bootCodePlay()` shipped in #703. This PR
 adds a Playwright check that written SSG HTML hydrates and **Run** prints
-stdio, plus `session.cancel()`.
+stdio, `session.cancel()` plus a toolbar **Cancel** control, and hides
+TypeScript **Typecheck** on published pages unless `endpoints.typecheck` is
+set.
 
 ### 3. `feat(code-play): official playground proxies`
 

--- a/docs/content/examples/code-play.md
+++ b/docs/content/examples/code-play.md
@@ -60,8 +60,9 @@ console.log(add(2, 40));
 
 ## Typecheck failure
 
-**Typecheck** should fail. **Run** still executes after types are stripped, so
-this sample also shows that execute and type-check are separate.
+During `vite dev`, **Typecheck** should fail on this sample. On a published
+page the button is omitted unless `endpoints.typecheck` is set. **Run** still
+executes after types are stripped, so execute and type-check stay separate.
 
 ```ts play typecheck
 const n: number = "not a number";

--- a/docs/content/examples/code-play.md
+++ b/docs/content/examples/code-play.md
@@ -35,9 +35,12 @@ export default {
 
 ## Live TypeScript sample
 
-The fence below is marked `play`. Use **Run** to execute it and **Typecheck**
-to type-check it. The stdio, stderr, config, provenance, and timing tabs are
-the same objects the headless API returns. `console.warn` lands in `run.stderr`.
+The fence below is marked `play`. Use **Run** to execute it. **Typecheck**
+appears during `vite dev` (the `/__ox-code-play/typecheck` proxy) or when
+the site sets a reachable `endpoints.typecheck`. Published pages still run
+TypeScript by stripping types into the sandbox iframe. The stdio, stderr,
+config, provenance, and timing tabs are the same objects the headless API
+returns. `console.warn` lands in `run.stderr`.
 
 ```ts play typecheck
 const message: string = "hello from Code Play";

--- a/docs/content/packages/code-play.md
+++ b/docs/content/packages/code-play.md
@@ -107,9 +107,10 @@ session.config; // editable language config
 
 `createCodePlay()` throws if you ask for a language that is not enabled.
 `session.setConfig({ strict: false })` updates the same object the config
-viewer edits. `session.cancel()` aborts an in-flight remote / typecheck
-request and returns `status: "cancelled"`. Inject `transport` (for example
-`createMemoryTransport`) in tests so CI never hits a live playground.
+viewer edits. `session.cancel()` aborts an in-flight run or typecheck and
+returns `status: "cancelled"`. The default toolbar shows **Cancel** while a
+run is busy. Inject `transport` (for example `createMemoryTransport`) in
+tests so CI never hits a live playground.
 
 | Field             | Meaning                                                  |
 | ----------------- | -------------------------------------------------------- |
@@ -169,7 +170,9 @@ official playgrounds (or your own HTTPS executor) for published pages, or
 
 Static hosts do not serve `POST /__ox-code-play/typecheck`. TypeScript
 **Run** still works in the browser (strip types, then a sandboxed iframe).
-**Typecheck** on a published page needs a reachable `endpoints.typecheck`.
+The **Typecheck** button is omitted from published widgets unless you set a
+reachable `endpoints.typecheck`. The Vite proxy path is used only during
+`vite dev`.
 
 Rust and Go on a published page call `endpoints.rust` / `endpoints.go`
 directly from the browser. Official playgrounds may reject that as CORS;
@@ -184,6 +187,7 @@ unreviewed snippets as `play`.
 - Samples are not executed during Markdown transform or SSG.
 - JavaScript and TypeScript execute in `node:vm` on Node, or in
   `<iframe sandbox="allow-scripts">` in the browser (no `allow-same-origin`).
+  They are never run with page-origin `Function`.
 - Vue / React / Svelte / Solid previews use the same iframe flags and load
   runtimes from `esm.sh`.
 - `sh` never spawns a local shell.

--- a/docs/content/packages/code-play.md
+++ b/docs/content/packages/code-play.md
@@ -142,7 +142,7 @@ Viewers can be toggled independently through `viewers`.
 | TypeScript                | yes     | yes        | local strip-types + `tsgo` + `node:vm`      |
 | Rust                      | yes     | yes        | `play.rust-lang.org` (or `endpoints.rust`)  |
 | Go                        | yes     | yes        | `play.golang.org` (or `endpoints.go`)       |
-| JavaScript                | yes     | no         | `node:vm` / `Function`                      |
+| JavaScript                | yes     | no         | `node:vm` / sandbox iframe                  |
 | Vue, React, Svelte, Solid | yes     | no         | iframe `srcdoc` + esm.sh import map         |
 | Python, PHP, Ruby, sh, …  | yes     | no         | Piston-compatible `languages.<id>.endpoint` |
 

--- a/examples/code-play/README.md
+++ b/examples/code-play/README.md
@@ -17,4 +17,5 @@ corepack pnpm --filter ./examples/code-play preview
 ```
 
 The plugin never executes samples during Markdown transform or SSG. Readers
-trigger execute / type-check in the browser (or Node, for the headless API).
+trigger **Run** in the browser. TypeScript **Typecheck** needs the Vite dev
+proxy or a reachable `endpoints.typecheck`.

--- a/examples/code-play/content/index.md
+++ b/examples/code-play/content/index.md
@@ -6,7 +6,8 @@ description: Minimal Vite site that runs documentation samples on demand.
 # Code Play example
 
 This site enables **JavaScript** and **TypeScript** only. Mark a fence with
-`play` (and `typecheck` when you want the Typecheck button).
+`play`. **Typecheck** shows during `vite dev`, or on a published page if you
+set `endpoints.typecheck`.
 
 ```ts play typecheck
 const message: string = "hello from examples/code-play";

--- a/npm/ox-content-code-play/README.md
+++ b/npm/ox-content-code-play/README.md
@@ -74,6 +74,9 @@ visitor-supplied snippets as `play`.
 - No sample is executed during Markdown transform or SSG.
 - JavaScript and TypeScript run in `node:vm` on Node, or in
   `<iframe sandbox="allow-scripts">` in the browser (no `allow-same-origin`).
+  They are never run with page-origin `Function`.
+- Published widgets hide **Typecheck** unless `endpoints.typecheck` is set.
+  **Cancel** appears while a run is in flight.
 - Framework previews use the same iframe flags and load runtimes from esm.sh.
 - Rust and Go POST source to the official playgrounds (or your `endpoints`).
   The Vite `/__ox-code-play/*` proxy is **dev-only**.

--- a/npm/ox-content-code-play/src/adapters.test.ts
+++ b/npm/ox-content-code-play/src/adapters.test.ts
@@ -123,5 +123,8 @@ describe("language adapters", () => {
     expect(result.preview?.html).toContain("esm.sh/vue");
     expect(result.provenance.execute?.sandbox).toBe("srcdoc");
     expect(buildPreviewDocument("react", "console.log(1)").includes("esm.sh/react")).toBe(true);
+    const hostile = buildPreviewDocument("vue", "</script><script>steal()");
+    expect(hostile).toContain("<\\/script>");
+    expect(hostile).not.toContain("</script><script>steal()");
   });
 });

--- a/npm/ox-content-code-play/src/browser-bundle.test.ts
+++ b/npm/ox-content-code-play/src/browser-bundle.test.ts
@@ -13,6 +13,10 @@ describe("browser client bundle", () => {
       const source = await readFile(path.join(outDir, "browser.mjs"), "utf8");
       expect(assertBrowserClientSource(source)).toContain("bootCodePlay");
       expect(source).toMatch(/hydrateCodePlay|data-ox-code-play/);
+      expect(source).toContain("data-ox-action");
+      expect(source).toContain("cancel");
+      expect(source).toContain("allow-scripts");
+      expect(source).not.toMatch(/allow-same-origin/);
     } finally {
       await rm(outDir, { recursive: true, force: true });
     }

--- a/npm/ox-content-code-play/src/client.test.ts
+++ b/npm/ox-content-code-play/src/client.test.ts
@@ -126,6 +126,7 @@ describe("createCodePlay", () => {
     const result = await pending;
     expect(result.status).toBe("cancelled");
     expect(result.diagnostics[0]?.message).toMatch(/cancelled/i);
+    expect(result.diagnostics[0]?.severity).toBe("info");
   });
 
   it("explains browser CORS failures instead of a raw fetch TypeError", () => {

--- a/npm/ox-content-code-play/src/client.test.ts
+++ b/npm/ox-content-code-play/src/client.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vite-plus/test";
 import { createCodePlay } from "./client";
+import { javascriptExecuteRuntime } from "./javascript";
+import { friendlyTransportMessage } from "./result";
 import { stripTypeScript } from "./strip-typescript";
 import { createMemoryTransport } from "./transport";
 import {
   adapterResultFromTypecheckResponse,
   parseTsgoOutput,
+  resolveTypecheckBackend,
   typecheckEndpointFailureMessage,
 } from "./typescript";
 import { PhaseTracker } from "./timing";
@@ -123,6 +126,24 @@ describe("createCodePlay", () => {
     const result = await pending;
     expect(result.status).toBe("cancelled");
     expect(result.diagnostics[0]?.message).toMatch(/cancelled/i);
+  });
+
+  it("explains browser CORS failures instead of a raw fetch TypeError", () => {
+    const error = new TypeError("Failed to fetch");
+    expect(friendlyTransportMessage(error)).toMatch(/CORS/);
+    expect(friendlyTransportMessage(new Error("offline"))).toBe("offline");
+  });
+
+  it("does not run JavaScript through page-origin Function", () => {
+    expect(javascriptExecuteRuntime(true, false)).toBe("vm");
+    expect(javascriptExecuteRuntime(false, true)).toBe("iframe");
+    expect(() => javascriptExecuteRuntime(false, false)).toThrow(/sandbox iframe/);
+  });
+
+  it("picks a typecheck backend that cannot call a missing static-host proxy", () => {
+    expect(resolveTypecheckBackend(true, undefined)).toBe("tsgo");
+    expect(resolveTypecheckBackend(false, "/__ox-code-play/typecheck")).toBe("endpoint");
+    expect(resolveTypecheckBackend(false, undefined)).toBe("unavailable");
   });
 
   it("turns transport throws into error results instead of rejecting", async () => {

--- a/npm/ox-content-code-play/src/config.ts
+++ b/npm/ox-content-code-play/src/config.ts
@@ -36,6 +36,9 @@ export const DEFAULT_ENDPOINTS: PlaygroundEndpoints = {
   go: "https://play.golang.org/compile",
 };
 
+/** Vite dev middleware only. Not present in production SSG output. */
+export const DEV_TYPECHECK_PATH = "/__ox-code-play/typecheck";
+
 export const DEFAULT_VIEWERS: ViewerFlags = {
   config: true,
   stdio: true,

--- a/npm/ox-content-code-play/src/framework.ts
+++ b/npm/ox-content-code-play/src/framework.ts
@@ -50,6 +50,7 @@ ${indentPreview(code)}
 
 function indentPreview(code: string): string {
   return code
+    .replace(/<\/script/gi, "<\\/script")
     .split("\n")
     .map((line) => `    ${line}`)
     .join("\n");

--- a/npm/ox-content-code-play/src/html.ts
+++ b/npm/ox-content-code-play/src/html.ts
@@ -1,6 +1,8 @@
-import { DEFAULT_VIEWERS } from "./config";
+import { resolveLanguage } from "./catalog";
+import { DEFAULT_ENDPOINTS, DEFAULT_VIEWERS } from "./config";
 import { decodeHtml, escapeAttribute } from "./escape";
-import type { PlayPayload } from "./types";
+import { payloadTypecheckEnabled } from "./payload-factory";
+import type { PlaygroundEndpoints, PlayPayload } from "./types";
 
 const COMMENT_PATTERN = /<!--ox-code-play:([A-Za-z0-9+/=]+)-->\s*(<pre\b[\s\S]*?<\/pre>)/gi;
 const CODEPLAY_TAG_PATTERN = /<CodePlay\b([^>]*)>([\s\S]*?)<\/CodePlay>/gi;
@@ -11,6 +13,7 @@ export interface HtmlEnhanceOptions {
   decodePayload: (value: string) => PlayPayload;
   encodePayload: (payload: PlayPayload) => string;
   matchFences?: Array<{ language: string; code: string; payload: string }>;
+  endpoints?: PlaygroundEndpoints;
 }
 
 export function enhancePlayHtml(html: string, options: HtmlEnhanceOptions): string {
@@ -47,7 +50,7 @@ export function enhanceGeneratedModule(source: string, options: HtmlEnhanceOptio
   return source.slice(0, jsonStart) + JSON.stringify(enhanced) + source.slice(parsed.end);
 }
 
-function wrapCommentedBlocks(html: string, options: HtmlEnhanceOptions): string {
+function wrapCommentedBlocks(html: string, _options: HtmlEnhanceOptions): string {
   return html.replace(COMMENT_PATTERN, (_all, payload: string, pre: string) => {
     return wrapWidget(payload, pre);
   });
@@ -60,14 +63,25 @@ function upgradeCodePlayTags(html: string, options: HtmlEnhanceOptions): string 
     }
     const language = readAttr(attrs, "lang") ?? readAttr(attrs, "language") ?? "text";
     const code = decodeHtml(body).replace(/^\n/, "").replace(/\n$/, "");
+    const definition = resolveLanguage(language);
+    const endpoints = options.endpoints ?? DEFAULT_ENDPOINTS;
     const payload = options.encodePayload({
-      language,
+      language: definition?.id ?? language,
       code,
-      capabilities: { execute: true, typecheck: /\btypecheck\b/i.test(attrs) },
+      capabilities: {
+        execute: true,
+        typecheck: payloadTypecheckEnabled(
+          /\btypecheck\b/i.test(attrs),
+          undefined,
+          definition,
+          endpoints,
+        ),
+      },
       config: {},
       viewers: { ...DEFAULT_VIEWERS },
       ui: "default",
       timeoutMs: 10_000,
+      endpoints,
     });
     return wrapWidget(
       payload,

--- a/npm/ox-content-code-play/src/hydrate.ts
+++ b/npm/ox-content-code-play/src/hydrate.ts
@@ -3,7 +3,7 @@ import { readPlayPayload, runPlayAction } from "./hydrate-action";
 import { decodePayload, encodePayload } from "./payload";
 import { errorMessage, errorResult } from "./result";
 import { CODE_PLAY_STYLES } from "./styles";
-import { renderPlayUi } from "./ui";
+import { applyActionBusy, renderPlayUi } from "./ui";
 import type { PlayPayload, RunResult } from "./types";
 import {
   renderDiagnosticsHtml,
@@ -74,8 +74,10 @@ function bindWidget(element: HTMLElement, payload: PlayPayload, client: CodePlay
   });
   const runButton = element.querySelector<HTMLButtonElement>('[data-ox-action="run"]');
   const checkButton = element.querySelector<HTMLButtonElement>('[data-ox-action="typecheck"]');
+  const cancelButton = element.querySelector<HTMLButtonElement>('[data-ox-action="cancel"]');
   runButton?.addEventListener("click", () => void run("execute"));
   checkButton?.addEventListener("click", () => void run("typecheck"));
+  cancelButton?.addEventListener("click", () => session.cancel());
   element.addEventListener("click", (event) => {
     const target = event.target;
     if (!(target instanceof HTMLElement)) {
@@ -98,7 +100,7 @@ function bindWidget(element: HTMLElement, payload: PlayPayload, client: CodePlay
   async function run(action: "execute" | "typecheck"): Promise<void> {
     await runPlayAction({
       action: () => (action === "typecheck" ? session.typecheck() : session.run()),
-      setBusy: (busy) => setBusy(element, busy),
+      setBusy: (busy) => applyActionBusy(element, busy),
       onResult: (result) => paintResult(element, current, result),
       onError: (error) => paintResult(element, current, errorResult(errorMessage(error))),
     });
@@ -154,12 +156,6 @@ function showPanel(element: HTMLElement, panel: string): void {
       continue;
     }
     node.hidden = id !== panel;
-  }
-}
-
-function setBusy(element: HTMLElement, busy: boolean): void {
-  for (const button of element.querySelectorAll("button[data-ox-action]")) {
-    (button as HTMLButtonElement).disabled = busy;
   }
 }
 

--- a/npm/ox-content-code-play/src/hydrate.ts
+++ b/npm/ox-content-code-play/src/hydrate.ts
@@ -3,6 +3,7 @@ import { readPlayPayload, runPlayAction } from "./hydrate-action";
 import { decodePayload, encodePayload } from "./payload";
 import { errorMessage, errorResult } from "./result";
 import { CODE_PLAY_STYLES } from "./styles";
+import { JS_SANDBOX_FLAGS } from "./javascript-sandbox";
 import { applyActionBusy, renderPlayUi } from "./ui";
 import type { PlayPayload, RunResult } from "./types";
 import {
@@ -113,7 +114,7 @@ function paintResult(element: HTMLElement, _payload: PlayPayload, result: RunRes
     stdio.innerHTML = `${renderDiagnosticsHtml(result)}${renderStdioHtml(result.stdio)}`;
     if (result.preview) {
       const frame = document.createElement("iframe");
-      frame.setAttribute("sandbox", "allow-scripts");
+      frame.setAttribute("sandbox", JS_SANDBOX_FLAGS);
       frame.srcdoc = result.preview.html;
       frame.title = "Code Play preview";
       frame.style.width = "100%";

--- a/npm/ox-content-code-play/src/javascript.ts
+++ b/npm/ox-content-code-play/src/javascript.ts
@@ -1,7 +1,8 @@
 import { executeInSandboxIframe } from "./javascript-sandbox";
 import { hasNodeVm } from "./runtime-host";
 import { formatConsoleArgs, StdioBuffer } from "./stdio";
-import { nowMs, PhaseTracker } from "./timing";
+import { PhaseTracker } from "./timing";
+import { abortError, isAbortError } from "./transport";
 import type { AdapterRequest, AdapterResult, Diagnostic } from "./types";
 
 export async function runJavaScript(request: AdapterRequest): Promise<AdapterResult> {
@@ -28,6 +29,9 @@ export async function runJavaScript(request: AdapterRequest): Promise<AdapterRes
       value: value === undefined ? undefined : String(value),
     };
   } catch (error) {
+    if (isAbortError(error) || request.signal?.aborted) {
+      throw error;
+    }
     tracker.stop();
     const diagnostic = toDiagnostic(error);
     stdio.push("stderr", `${diagnostic.message}\n`);
@@ -54,25 +58,28 @@ export async function executeScript(
     error: (...args: unknown[]) => stdio.push("stderr", formatConsoleArgs(args)),
   };
 
-  if (hasNodeVm()) {
+  if (signal?.aborted) {
+    throw abortError();
+  }
+
+  const runtime = javascriptExecuteRuntime(hasNodeVm(), typeof document !== "undefined");
+  if (runtime === "vm") {
     const vm = await import("node:vm");
     const context = vm.createContext({ console: consoleLike });
     return vm.runInContext(code, context, { timeout: timeoutMs, displayErrors: true });
   }
 
-  if (typeof document !== "undefined") {
-    return executeInSandboxIframe(code, timeoutMs, stdio, signal);
-  }
+  return executeInSandboxIframe(code, timeoutMs, stdio, signal);
+}
 
-  const started = nowMs();
-  const run = new Function("console", `"use strict";\n${code}`);
-  const value = run(consoleLike);
-  if (nowMs() - started > timeoutMs) {
-    throw Object.assign(new Error("JavaScript execution timed out."), {
-      code: "ERR_SCRIPT_EXECUTION_TIMEOUT",
-    });
+export function javascriptExecuteRuntime(hasVm: boolean, hasDocument: boolean): "vm" | "iframe" {
+  if (hasVm) {
+    return "vm";
   }
-  return value;
+  if (hasDocument) {
+    return "iframe";
+  }
+  throw new Error("JavaScript execute needs node:vm or a document for the sandbox iframe.");
 }
 
 function isTimeout(error: unknown): boolean {

--- a/npm/ox-content-code-play/src/markdown.test.ts
+++ b/npm/ox-content-code-play/src/markdown.test.ts
@@ -84,6 +84,18 @@ describe("markdown and viewers", () => {
     );
   });
 
+  it("does not advertise TypeScript typecheck on a CodePlay tag without an endpoint", () => {
+    const html = enhancePlayHtml(`<CodePlay lang="ts" typecheck>\nconst n = 1;\n</CodePlay>`, {
+      decodePayload,
+      encodePayload,
+    });
+    const encoded = /data-ox-code-play="([^"]+)"/.exec(html)?.[1];
+    expect(encoded).toBeTruthy();
+    const payload = decodePayload(encoded ?? "");
+    expect(payload.capabilities.typecheck).toBe(false);
+    expect(payload.endpoints?.typecheck).toBeUndefined();
+  });
+
   it("renders config, stdio, provenance, and timing viewers", () => {
     expect(
       renderStdioHtml([

--- a/npm/ox-content-code-play/src/payload-factory.ts
+++ b/npm/ox-content-code-play/src/payload-factory.ts
@@ -1,7 +1,7 @@
 import { resolveLanguage } from "./catalog";
 import type { ResolvedCodePlayOptions } from "./config";
 import type { PlayFence } from "./markdown";
-import type { PlayPayload } from "./types";
+import type { LanguageDefinition, PlayPayload, PlaygroundEndpoints } from "./types";
 
 export function payloadFromFence(fence: PlayFence, options: ResolvedCodePlayOptions): PlayPayload {
   const definition = resolveLanguage(fence.language);
@@ -11,7 +11,12 @@ export function payloadFromFence(fence: PlayFence, options: ResolvedCodePlayOpti
     code: fence.code,
     capabilities: {
       execute: enabled?.execute ?? Boolean(definition?.capabilities.execute),
-      typecheck: fence.typecheck || (enabled?.typecheck ?? false),
+      typecheck: payloadTypecheckEnabled(
+        fence.typecheck,
+        enabled?.typecheck,
+        definition,
+        options.endpoints,
+      ),
     },
     config: { ...definition?.defaultConfig, ...enabled?.config },
     viewers: options.viewers,
@@ -19,4 +24,20 @@ export function payloadFromFence(fence: PlayFence, options: ResolvedCodePlayOpti
     timeoutMs: options.timeoutMs,
     endpoints: options.endpoints,
   };
+}
+
+/** TypeScript typecheck in the browser needs a reachable endpoint; hide the dead button otherwise. */
+export function payloadTypecheckEnabled(
+  fenceTypecheck: boolean,
+  enabledTypecheck: boolean | undefined,
+  definition: LanguageDefinition | undefined,
+  endpoints: PlaygroundEndpoints,
+): boolean {
+  if (!(fenceTypecheck || enabledTypecheck)) {
+    return false;
+  }
+  if (definition?.id === "typescript") {
+    return Boolean(endpoints.typecheck);
+  }
+  return true;
 }

--- a/npm/ox-content-code-play/src/plugin-ssg.test.ts
+++ b/npm/ox-content-code-play/src/plugin-ssg.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vite-plus/test";
+import { decodePayload } from "./payload";
 import { codePlay } from "./plugin";
 
 describe("codePlay SSG HTML enhance", () => {
@@ -36,6 +37,39 @@ describe("codePlay SSG HTML enhance", () => {
     expect(html).toContain("<ox-code-play");
     expect(html).toContain("ox-code-play.js");
     expect(html).toContain('type="module"');
+  });
+
+  it("omits TypeScript typecheck from written SSG payloads without an endpoint", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "ox-code-play-ssg-ts-"));
+    const srcDir = path.join(root, "content");
+    const outDir = path.join(root, "dist");
+    mkdirSync(srcDir, { recursive: true });
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(path.join(srcDir, "index.md"), "```ts play\nconst n: number = 1;\n```\n");
+    writeFileSync(
+      path.join(outDir, "index.html"),
+      `<pre><code class="language-ts">const n: number = 1;</code></pre>\n`,
+    );
+
+    const plugin = codePlay({
+      languages: { typescript: { execute: true, typecheck: true } },
+      srcDir: "content",
+      outDir: "dist",
+    });
+    hookFn(plugin.configResolved)({
+      command: "build",
+      root,
+      base: "/",
+      build: { outDir: "dist" },
+    } as never);
+    await hookFn(plugin.closeBundle)();
+
+    const html = readFileSync(path.join(outDir, "index.html"), "utf8");
+    const encoded = /data-ox-code-play="([^"]+)"/.exec(html)?.[1];
+    expect(encoded).toBeTruthy();
+    const payload = decodePayload(encoded ?? "");
+    expect(payload.capabilities.typecheck).toBe(false);
+    expect(payload.endpoints?.typecheck).toBeUndefined();
   });
 });
 

--- a/npm/ox-content-code-play/src/plugin.test.ts
+++ b/npm/ox-content-code-play/src/plugin.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
+import { DEV_TYPECHECK_PATH } from "./config";
+import { decodePayload } from "./payload";
 import { codePlay } from "./plugin";
 
 describe("codePlay vite plugin", () => {
@@ -15,7 +17,56 @@ describe("codePlay vite plugin", () => {
     const resolveId = hookFn(plugin.resolveId) as (id: string) => string | null;
     expect(resolveId("virtual:ox-content/code-play")).toBe("\0virtual:ox-content/code-play");
   });
+
+  it("does not embed the Vite typecheck proxy into SSG payloads", () => {
+    const plugin = codePlay({ languages: { typescript: { execute: true, typecheck: true } } });
+    resolveCommand(plugin, "build");
+    const payload = payloadFromTransform(plugin, "```ts play\nconst n = 1;\n```\n");
+    expect(payload.capabilities.typecheck).toBe(false);
+    expect(payload.endpoints?.typecheck).toBeUndefined();
+  });
+
+  it("keeps an explicit typecheck endpoint in SSG payloads", () => {
+    const plugin = codePlay({
+      languages: { typescript: { execute: true, typecheck: true } },
+      endpoints: { typecheck: "https://example.test/typecheck" },
+    });
+    resolveCommand(plugin, "build");
+    const payload = payloadFromTransform(plugin, "```ts play\nconst n = 1;\n```\n");
+    expect(payload.capabilities.typecheck).toBe(true);
+    expect(payload.endpoints?.typecheck).toBe("https://example.test/typecheck");
+  });
+
+  it("keeps the Vite typecheck proxy on the dev server", () => {
+    const plugin = codePlay({ languages: { typescript: { execute: true, typecheck: true } } });
+    resolveCommand(plugin, "serve");
+    const payload = payloadFromTransform(plugin, "```ts play\nconst n = 1;\n```\n");
+    expect(payload.capabilities.typecheck).toBe(true);
+    expect(payload.endpoints?.typecheck).toBe(DEV_TYPECHECK_PATH);
+  });
 });
+
+function resolveCommand(plugin: { configResolved?: unknown }, command: "build" | "serve"): void {
+  hookFn(plugin.configResolved)({
+    command,
+    root: "/",
+    base: "/",
+    build: { outDir: "dist" },
+  } as never);
+}
+
+function payloadFromTransform(plugin: { transform?: unknown }, code: string) {
+  const rewritten = (hookFn(plugin.transform) as (source: string, id: string) => string | null)(
+    code,
+    "page.md",
+  );
+  const match =
+    typeof rewritten === "string" ? /<!--ox-code-play:([A-Za-z0-9+/=]+)-->/.exec(rewritten) : null;
+  if (!match?.[1]) {
+    throw new Error("expected a Code Play payload comment");
+  }
+  return decodePayload(match[1]);
+}
 
 function hookFn(hook: unknown): (...args: never[]) => unknown {
   if (typeof hook === "function") {

--- a/npm/ox-content-code-play/src/plugin.test.ts
+++ b/npm/ox-content-code-play/src/plugin.test.ts
@@ -44,6 +44,17 @@ describe("codePlay vite plugin", () => {
     expect(payload.capabilities.typecheck).toBe(true);
     expect(payload.endpoints?.typecheck).toBe(DEV_TYPECHECK_PATH);
   });
+
+  it("does not embed the Vite typecheck proxy when proxy is disabled", () => {
+    const plugin = codePlay({
+      languages: { typescript: { execute: true, typecheck: true } },
+      proxy: false,
+    });
+    resolveCommand(plugin, "serve");
+    const payload = payloadFromTransform(plugin, "```ts play\nconst n = 1;\n```\n");
+    expect(payload.capabilities.typecheck).toBe(false);
+    expect(payload.endpoints?.typecheck).toBeUndefined();
+  });
 });
 
 function resolveCommand(plugin: { configResolved?: unknown }, command: "build" | "serve"): void {

--- a/npm/ox-content-code-play/src/plugin.ts
+++ b/npm/ox-content-code-play/src/plugin.ts
@@ -9,7 +9,7 @@ import {
   type RawCodePlayOptions,
   type ResolvedCodePlayOptions,
 } from "./config";
-import { enhanceGeneratedModule, enhancePlayHtml } from "./html";
+import { enhanceGeneratedModule, enhancePlayHtml, type HtmlEnhanceOptions } from "./html";
 import { parseCodePlayTags, parsePlayFences, rewritePlayFences } from "./markdown";
 import { decodePayload, encodePayload } from "./payload";
 import { payloadFromFence } from "./payload-factory";
@@ -41,6 +41,7 @@ export function codePlay(options: CodePlayPluginOptions = {}): Plugin {
     decodePayload,
     encodePayload,
     matchFences,
+    endpoints: resolved.endpoints,
   });
 
   return {
@@ -170,12 +171,9 @@ function enhanceHtmlForUrl(
   html: string,
   root: string,
   resolved: ResolvedCodePlayOptions,
-  enhance: (matchFences?: Array<{ language: string; code: string; payload: string }>) => {
-    scriptSrc: string;
-    decodePayload: typeof decodePayload;
-    encodePayload: typeof encodePayload;
-    matchFences?: Array<{ language: string; code: string; payload: string }>;
-  },
+  enhance: (
+    matchFences?: Array<{ language: string; code: string; payload: string }>,
+  ) => HtmlEnhanceOptions,
 ): string | undefined {
   const markdownPath = urlToMarkdown(urlPath, root, resolved.srcDir ?? "docs", resolved.base);
   if (!markdownPath || !existsSync(markdownPath)) {
@@ -238,12 +236,9 @@ async function enhanceWrittenPages(
   srcDir: string,
   outDir: string,
   resolved: ResolvedCodePlayOptions,
-  enhance: (matchFences?: Array<{ language: string; code: string; payload: string }>) => {
-    scriptSrc: string;
-    decodePayload: typeof decodePayload;
-    encodePayload: typeof encodePayload;
-    matchFences?: Array<{ language: string; code: string; payload: string }>;
-  },
+  enhance: (
+    matchFences?: Array<{ language: string; code: string; payload: string }>,
+  ) => HtmlEnhanceOptions,
 ): Promise<void> {
   for (const file of walkFiles(srcDir)) {
     if (!MARKDOWN_RE.test(file)) {

--- a/npm/ox-content-code-play/src/plugin.ts
+++ b/npm/ox-content-code-play/src/plugin.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { Plugin, ViteDevServer } from "vite";
 import { resolveLanguage } from "./catalog";
 import {
+  DEV_TYPECHECK_PATH,
   resolveCodePlayOptions,
   type RawCodePlayOptions,
   type ResolvedCodePlayOptions,
@@ -26,13 +27,8 @@ const RESOLVED_VIRTUAL = `\0${VIRTUAL_ID}`;
 const MARKDOWN_RE = /\.(?:md|markdown|mdx)(?:$|\?)/i;
 
 export function codePlay(options: CodePlayPluginOptions = {}): Plugin {
-  const resolved = resolveCodePlayOptions({
-    ...options,
-    endpoints: {
-      ...options.endpoints,
-      typecheck: options.endpoints?.typecheck ?? "/__ox-code-play/typecheck",
-    },
-  });
+  const resolved = resolveCodePlayOptions(options);
+  const explicitTypecheck = options.endpoints?.typecheck;
   let base = resolved.base;
   let command: "build" | "serve" = "serve";
   let outDir = resolved.outDir;
@@ -55,6 +51,13 @@ export function codePlay(options: CodePlayPluginOptions = {}): Plugin {
       root = config.root;
       base = resolved.base === "/" ? normalizeBase(config.base) : resolved.base;
       outDir = resolved.outDir ?? config.build.outDir;
+      if (explicitTypecheck === undefined) {
+        if (command === "serve") {
+          resolved.endpoints.typecheck = DEV_TYPECHECK_PATH;
+        } else {
+          delete resolved.endpoints.typecheck;
+        }
+      }
     },
 
     resolveId(id) {
@@ -226,7 +229,7 @@ function mountProxies(server: ViteDevServer, rustUrl: string, goUrl: string): vo
   server.middlewares.use("/__ox-code-play/go", (req, res) => {
     void proxy(req, res, goUrl, "application/x-www-form-urlencoded");
   });
-  server.middlewares.use("/__ox-code-play/typecheck", (req, res) => {
+  server.middlewares.use(DEV_TYPECHECK_PATH, (req, res) => {
     void typecheckProxy(req, res);
   });
 }

--- a/npm/ox-content-code-play/src/plugin.ts
+++ b/npm/ox-content-code-play/src/plugin.ts
@@ -53,7 +53,7 @@ export function codePlay(options: CodePlayPluginOptions = {}): Plugin {
       base = resolved.base === "/" ? normalizeBase(config.base) : resolved.base;
       outDir = resolved.outDir ?? config.build.outDir;
       if (explicitTypecheck === undefined) {
-        if (command === "serve") {
+        if (command === "serve" && resolved.proxy) {
           resolved.endpoints.typecheck = DEV_TYPECHECK_PATH;
         } else {
           delete resolved.endpoints.typecheck;

--- a/npm/ox-content-code-play/src/result.ts
+++ b/npm/ox-content-code-play/src/result.ts
@@ -27,7 +27,13 @@ export function errorResult(
   return withStdioText({
     status,
     stdio: [],
-    diagnostics: [{ message, severity: "error", source }],
+    diagnostics: [
+      {
+        message,
+        severity: status === "cancelled" ? "info" : "error",
+        source,
+      },
+    ],
     provenance: {},
     timing: emptyTiming(),
   });

--- a/npm/ox-content-code-play/src/result.ts
+++ b/npm/ox-content-code-play/src/result.ts
@@ -6,6 +6,19 @@ export function errorMessage(error: unknown): string {
   return error instanceof Error && error.message ? error.message : String(error);
 }
 
+export function friendlyTransportMessage(error: unknown): string {
+  const message = errorMessage(error);
+  const typeError =
+    error instanceof TypeError || (error instanceof Error && error.name === "TypeError");
+  if (
+    typeError &&
+    /failed to fetch|networkerror|load failed|network request failed/i.test(message)
+  ) {
+    return "The executor could not be reached from this page (often CORS). Set endpoints to a host that allows browser POST, or use the Vite dev proxy.";
+  }
+  return message;
+}
+
 export function errorResult(
   message: string,
   source = "code-play",

--- a/npm/ox-content-code-play/src/session.ts
+++ b/npm/ox-content-code-play/src/session.ts
@@ -1,6 +1,6 @@
 import { executeAdapter, typecheckAdapter } from "./adapters";
 import { mergeConfig } from "./config";
-import { errorMessage, errorResult } from "./result";
+import { friendlyTransportMessage, errorResult } from "./result";
 import { withStdioText } from "./stdio";
 import { isAbortError } from "./transport";
 import type {
@@ -105,7 +105,7 @@ export class CodePlaySession {
       if (signal.aborted || isAbortError(error)) {
         return this.finish(errorResult("Run cancelled.", "code-play", "cancelled"));
       }
-      return this.finish(errorResult(errorMessage(error)));
+      return this.finish(errorResult(friendlyTransportMessage(error)));
     }
   }
 

--- a/npm/ox-content-code-play/src/typescript.ts
+++ b/npm/ox-content-code-play/src/typescript.ts
@@ -1,16 +1,50 @@
 import { executeScript } from "./javascript";
 import { hasNodeVm } from "./runtime-host";
+import { isAbortError } from "./transport";
 import { StdioBuffer } from "./stdio";
 import { stripTypeScript } from "./strip-typescript";
 import { PhaseTracker } from "./timing";
 import type { AdapterRequest, AdapterResult, Diagnostic, TransportResponse } from "./types";
 
+export type TypecheckBackend = "endpoint" | "tsgo" | "unavailable";
+
+export function resolveTypecheckBackend(
+  hasVm: boolean,
+  typecheckUrl: string | undefined,
+): TypecheckBackend {
+  if (typecheckUrl && !hasVm) {
+    return "endpoint";
+  }
+  if (!hasVm) {
+    return "unavailable";
+  }
+  return "tsgo";
+}
+
 export async function typecheckTypeScript(request: AdapterRequest): Promise<AdapterResult> {
   const tracker = new PhaseTracker();
   tracker.start("typecheck", "Typecheck");
+  const backend = resolveTypecheckBackend(hasNodeVm(), request.endpoints.typecheck);
 
-  if (request.endpoints.typecheck && !hasNodeVm()) {
+  if (backend === "endpoint") {
     return typecheckViaEndpoint(request, tracker);
+  }
+  if (backend === "unavailable") {
+    tracker.stop();
+    return {
+      status: "unsupported",
+      stdio: [],
+      diagnostics: [
+        {
+          message:
+            "Typecheck needs a reachable endpoints.typecheck. The Vite /__ox-code-play/typecheck proxy exists only during vite dev.",
+          severity: "error",
+          source: "tsgo",
+        },
+      ],
+      provenance: { compile: { host: "local", runtime: "tsgo" } },
+      timing: tracker.report(),
+    };
   }
 
   try {
@@ -27,6 +61,9 @@ export async function typecheckTypeScript(request: AdapterRequest): Promise<Adap
       timing: tracker.report(),
     };
   } catch (error) {
+    if (isAbortError(error) || request.signal?.aborted) {
+      throw error;
+    }
     tracker.stop();
     const message = error instanceof Error ? error.message : String(error);
     return {
@@ -72,6 +109,9 @@ export async function runTypeScript(request: AdapterRequest): Promise<AdapterRes
       value: value === undefined ? undefined : String(value),
     };
   } catch (error) {
+    if (isAbortError(error) || request.signal?.aborted) {
+      throw error;
+    }
     tracker.stop();
     const message = error instanceof Error ? error.message : String(error);
     stdio.push("stderr", `${message}\n`);

--- a/npm/ox-content-code-play/src/ui.ts
+++ b/npm/ox-content-code-play/src/ui.ts
@@ -30,8 +30,9 @@ export function renderPlayUi(state: UiState): string {
   return `<div class="ox-code-play ox-code-play--${preset}" data-ox-code-play-ui>
   <div class="ox-code-play__toolbar">
     <span class="ox-code-play__lang">${escapeHtml(definition?.name ?? state.payload.language)}</span>
-    <button type="button" data-ox-action="run"${state.busy ? " disabled" : ""}>Run</button>
-    ${canTypecheck ? `<button type="button" data-ox-action="typecheck"${state.busy ? " disabled" : ""}>Typecheck</button>` : ""}
+    <button type="button" data-ox-action="run"${actionButtonAttrs("run", Boolean(state.busy))}>Run</button>
+    ${canTypecheck ? `<button type="button" data-ox-action="typecheck"${actionButtonAttrs("typecheck", Boolean(state.busy))}>Typecheck</button>` : ""}
+    <button type="button" data-ox-action="cancel"${actionButtonAttrs("cancel", Boolean(state.busy))}>Cancel</button>
   </div>
   <div class="ox-code-play__source"></div>
   ${tabs}
@@ -62,6 +63,29 @@ function renderTabs(state: UiState, panel: string): string {
 
 function tab(id: string, label: string, selected: string): string {
   return `<button type="button" role="tab" data-ox-panel="${id}" aria-selected="${selected === id ? "true" : "false"}">${label}</button>`;
+}
+
+export function actionButtonAttrs(action: string, busy: boolean): string {
+  const state = actionBusyState(action, busy);
+  return `${state.disabled ? " disabled" : ""}${state.hidden ? " hidden" : ""}`;
+}
+
+export function actionBusyState(
+  action: string,
+  busy: boolean,
+): { disabled: boolean; hidden: boolean } {
+  if (action === "cancel") {
+    return { disabled: !busy, hidden: !busy };
+  }
+  return { disabled: busy, hidden: false };
+}
+
+export function applyActionBusy(root: ParentNode, busy: boolean): void {
+  for (const button of root.querySelectorAll<HTMLButtonElement>("button[data-ox-action]")) {
+    const state = actionBusyState(button.dataset.oxAction ?? "", busy);
+    button.disabled = state.disabled;
+    button.hidden = state.hidden;
+  }
 }
 
 function hidden(current: string, id: string, preset: CodePlayPreset): string {

--- a/npm/ox-content-code-play/src/viewers.test.ts
+++ b/npm/ox-content-code-play/src/viewers.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { DEFAULT_VIEWERS } from "./config";
 import { withStdioText } from "./stdio";
 import type { PlayPayload, RunResult } from "./types";
-import { renderPlayUi } from "./ui";
+import { actionBusyState, renderPlayUi } from "./ui";
 import { renderStderrHtml } from "./viewers";
 
 function result(partial: Partial<RunResult> = {}): RunResult {
@@ -106,6 +106,18 @@ describe("stderr UI flags", () => {
     expect(html).not.toContain('data-ox-panel="stderr"');
     expect(html).not.toContain('data-panel="stderr"');
     expect(html).toContain('data-panel="stdio"');
+  });
+
+  it("hides Cancel until a run is in flight and keeps it enabled while busy", () => {
+    const idle = renderPlayUi({ payload: payload() });
+    expect(idle).toContain('data-ox-action="cancel"');
+    expect(idle).toMatch(/data-ox-action="cancel"[^>]*\bhidden\b/);
+    expect(actionBusyState("cancel", false)).toEqual({ disabled: true, hidden: true });
+    expect(actionBusyState("cancel", true)).toEqual({ disabled: false, hidden: false });
+    expect(actionBusyState("run", true)).toEqual({ disabled: true, hidden: false });
+    const busy = renderPlayUi({ payload: payload(), busy: true });
+    expect(busy).toMatch(/data-ox-action="run"[^>]*\bdisabled\b/);
+    expect(busy).not.toMatch(/data-ox-action="cancel"[^>]*\bhidden\b/);
   });
 
   it("keeps the compact stderr panel visible and hides compact tabs", () => {

--- a/npm/vite-plugin-ox-content/test/vrt/code-play.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/code-play.spec.ts
@@ -95,3 +95,45 @@ test("published TypeScript widgets run without a dead Typecheck button", async (
     await rm(outDir, { recursive: true, force: true });
   }
 });
+
+test("Cancel aborts an in-flight sandbox run and re-enables Run", async ({ page }) => {
+  const outDir = await mkdtemp(path.join(tmpdir(), "ox-code-play-vrt-cancel-"));
+  try {
+    await bundleBrowserClient(outDir);
+    const client = await readFile(path.join(outDir, "browser.mjs"), "utf8");
+    const options = resolveCodePlayOptions({ languages: { javascript: true } });
+    const code = `while (true) {}`;
+    const payload = encodePayload(
+      payloadFromFence(
+        {
+          language: "js",
+          meta: "play",
+          code,
+          raw: "",
+          start: 0,
+          end: 0,
+          typecheck: false,
+        },
+        options,
+      ),
+    );
+    const widget = enhancePlayHtml(`<pre><code class="language-js">${code}</code></pre>`, {
+      decodePayload,
+      encodePayload,
+      matchFences: [{ language: "js", code, payload }],
+    });
+    await page.setContent(
+      `<!doctype html><html><head><meta charset="utf-8"></head><body>${widget}<script type="module">${client}</script></body></html>`,
+      { waitUntil: "domcontentloaded" },
+    );
+    await page.locator('[data-ox-action="run"]').click();
+    const cancel = page.locator('[data-ox-action="cancel"]');
+    await expect(cancel).toBeVisible();
+    await cancel.click();
+    await expect(page.getByText(/run cancelled/i).first()).toBeVisible();
+    await expect(page.locator('[data-ox-action="run"]')).toBeEnabled();
+    await expect(cancel).toBeHidden();
+  } finally {
+    await rm(outDir, { recursive: true, force: true });
+  }
+});

--- a/npm/vite-plugin-ox-content/test/vrt/code-play.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/code-play.spec.ts
@@ -46,6 +46,51 @@ test("hydrates written SSG HTML and runs JavaScript in the sandbox iframe", asyn
       timeout: 10_000,
     });
     await expect(page.locator(".ox-code-play__stdio-line--stdout")).toBeVisible();
+    await expect(page.locator('[data-ox-action="typecheck"]')).toHaveCount(0);
+    await expect(page.locator('[data-ox-action="cancel"]')).toBeHidden();
+  } finally {
+    await rm(outDir, { recursive: true, force: true });
+  }
+});
+
+test("published TypeScript widgets run without a dead Typecheck button", async ({ page }) => {
+  const outDir = await mkdtemp(path.join(tmpdir(), "ox-code-play-vrt-ts-"));
+  try {
+    await bundleBrowserClient(outDir);
+    const client = await readFile(path.join(outDir, "browser.mjs"), "utf8");
+    const options = resolveCodePlayOptions({
+      languages: { typescript: { execute: true, typecheck: true } },
+    });
+    const code = `const msg: string = "ssg-ts";\nconsole.log(msg);`;
+    const payload = encodePayload(
+      payloadFromFence(
+        {
+          language: "ts",
+          meta: "play",
+          code,
+          raw: "",
+          start: 0,
+          end: 0,
+          typecheck: true,
+        },
+        options,
+      ),
+    );
+    expect(decodePayload(payload).capabilities.typecheck).toBe(false);
+    const widget = enhancePlayHtml(`<pre><code class="language-ts">${code}</code></pre>`, {
+      decodePayload,
+      encodePayload,
+      matchFences: [{ language: "ts", code, payload }],
+    });
+    await page.setContent(
+      `<!doctype html><html><head><meta charset="utf-8"></head><body>${widget}<script type="module">${client}</script></body></html>`,
+      { waitUntil: "domcontentloaded" },
+    );
+    await expect(page.locator('[data-ox-action="typecheck"]')).toHaveCount(0);
+    await page.locator('[data-ox-action="run"]').click();
+    await expect(page.locator(".ox-code-play__stdio-text")).toContainText("ssg-ts", {
+      timeout: 10_000,
+    });
   } finally {
     await rm(outDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #711 for published-page UX (#648).

- Published pages no longer embed the Vite-only `/__ox-code-play/typecheck` proxy. TypeScript **Typecheck** is omitted unless `endpoints.typecheck` is set. An explicit URL is kept in SSG payloads. `<CodePlay typecheck>` tags use the same rule.
- Default toolbar shows **Cancel** while a run is busy (`session.cancel()`). Playwright clicks Cancel on an infinite sandbox loop and checks that Run comes back. Cancelled diagnostics are `info` so the stderr tab does not steal focus.
- JavaScript execute needs `node:vm` or the sandbox iframe — no page-origin `Function`. Docs list that backend as `node:vm` / sandbox iframe.
- Preview iframes reuse `JS_SANDBOX_FLAGS`. Framework preview source cannot close the host `srcdoc` script tag.
- CORS / failed-fetch errors explain the official-playground limitation.
- Docs/example copy now says Typecheck is `vite dev` (or `endpoints.typecheck`), not a published-page guarantee.
- `codePlay({ proxy: false })` no longer assigns the implicit Vite typecheck path. Typecheck stays unavailable unless the caller set `endpoints.typecheck`.

#711 already landed on main; its CI **Test** job succeeded, including the first SSG hydrate+Run Playwright check.

## Risk

- Risk level: low
- User or production impact: Typecheck hidden on static hosts without `endpoints.typecheck`; Cancel appears during runs; `proxy: false` does not advertise a dead typecheck route.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run: `vp test src` (unit), `tsgo --noEmit`, `CI=1 playwright test test/vrt/code-play.spec.ts` (3 passed locally); added a plugin unit test for `proxy: false`
- [x] Manual verification completed: Playwright hydrates JS/TS SSG fixtures, clicks Run, and cancels an in-flight loop
- [x] Edge cases or failure modes considered: explicit typecheck URL kept; abort errors rethrown so status stays `cancelled`; implicit typecheck path only when serve + proxy

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, or alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

## Follow-up

- #704 is DIRTY and overlaps the security notes now in #711 + this PR.
- First npm publish of `@ox-content/code-play` still needs a one-time maintainer `npm login` (package is 404 on the registry).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be9c34b0-d879-42b9-ad86-6a4c3e060f13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790147256&installation_model_id=422833&pr_number=712&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F712&signature=e59b5100edd0777aedfc0f2e6ebd583332b827275007781e7e5c443bb6d59825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Cancel control for active runs and typechecks; Run and Typecheck are disabled while busy.
  - Typecheck is available in development or when a published endpoint is configured.
  - Published pages hide unsupported Typecheck controls while keeping Run available.

- **Bug Fixes**
  - Improved transport error guidance and cancellation status reporting.
  - Strengthened preview protection and sandboxed JavaScript execution.

- **Documentation**
  - Updated Code Play setup, security, deployment, and Typecheck guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->