### PR TITLE
test(theme): lock the official theme package contract

### DIFF
--- a/docs/content/theme-presets.md
+++ b/docs/content/theme-presets.md
@@ -1,9 +1,14 @@
 ---
 title: Theme Presets
-description: Ready-made Ox Content themes — pick a skin for the form, a color scheme for the palette, and compose them.
+description: Official Ox Content theme catalog — pick a skin for the form, a color scheme for the palette, and compose them.
 ---
 
 # Theme Presets
+
+This page and the [theme gallery](/theme-gallery.html) are the **official
+catalog** of published skins and color schemes — a stable product surface, not
+an experiment. Packages follow the [authoring contract](#authoring-a-package)
+below so any skin pairs with any scheme.
 
 Ox Content splits a theme into two independent axes, published as two families
 of packages:
@@ -306,11 +311,35 @@ That ordering is why a skin declares its surface variables through `tokens`
 rather than raw `css`: tokens resolve declaratively before any stylesheet runs,
 which keeps the outcome independent of the order you list the packages in.
 
-## Writing your own
+## Authoring a package
 
 A preset is a plain [`ThemeConfig`](/theming.md) — there is no plugin API to
 implement. A skin sets `css`, `fonts`, `layout` and motion `tokens`; a scheme
-sets `colors`, `darkColors`, `tokens` and `darkTokens`.
+sets `colors`, `darkColors`, `tokens` and `darkTokens`. New packages must meet
+the compatibility contract below so they compose with every other published
+layer.
+
+### Compatibility
+
+- **Light and dark.** Color schemes must export a `ThemeConfig` (default or
+  named) with both `colors` and `darkColors`. Required palette keys:
+  `primary`, `background`, `text`, `textMuted`, `border`, `codeBackground`,
+  and `codeText`. Catalog schemes also ship `primaryHover` and
+  `backgroundAlt`.
+- **Required syntax tokens.** Schemes must define historical highlighter
+  tokens under `tokens` and `darkTokens`: at least `shiki-foreground`,
+  `shiki-background`, and several `shiki-token-*` keys. Keep the
+  `--octc-shiki-*` names (the `shiki` prefix is historical) so existing sites
+  keep working.
+- **Skins must not hard-code colors.** A skin owns form, not palette. Do not
+  put hex or rgb values in `ThemeConfig.colors` / `darkColors`. CSS variables
+  and omitted color fields are allowed. In `css`, reference `--octc-color-*`
+  and `--octc-accent-*`, and use `color-mix()` for tints. Neutral black/white
+  alpha for depth is fine.
+- **Compose left to right.** List layers in `ssg.theme` as an array. Object
+  fields merge key-by-key; `css` and `js` concatenate. Later layers win.
+- **Screenshot.** Include a screenshot of the skin (or a representative
+  pairing) for the gallery above.
 
 ```ts
 import { defineTheme } from "@ox-content/vite-plugin";
@@ -322,8 +351,3 @@ export default defineTheme({
   css: `.header { border-bottom: 2px solid var(--octc-color-primary); }`,
 });
 ```
-
-The one rule that keeps a skin composable: **never name a color.** Reference
-`--octc-color-*` and `--octc-accent-*`, and reach for `color-mix()` when you
-need a tint. Neutral black/white alpha for depth is fine, since it reads
-correctly over any palette.

--- a/docs/content/theming.md
+++ b/docs/content/theming.md
@@ -7,9 +7,12 @@ description: Customize the appearance of your documentation site with ox-content
 
 ox-content provides a flexible Theme API that allows you to customize the appearance of your documentation site. You can use CSS variables for simple customization or write full JSX themes for complete control.
 
-Prefer not to build one from scratch? [Theme Presets](/theme-presets.md) ships
-18 ready-made skins and 22 color schemes as `@ox-content/theme-*` and
-`@ox-content/theme-color-*` packages that compose freely.
+Prefer not to build one from scratch? The [Theme Presets](/theme-presets.md)
+**official catalog** ships 27 skins and 45 color schemes as
+`@ox-content/theme-*` and `@ox-content/theme-color-*` packages that compose
+through `ssg.theme`. See [Authoring a package](/theme-presets.md#authoring-a-package)
+for the compatibility contract (required tokens, light and dark, screenshots,
+and the rule that skins must not hard-code colors).
 
 ## Quick Start
 

--- a/npm/vite-plugin-ox-content/src/theme-contract.test.ts
+++ b/npm/vite-plugin-ox-content/src/theme-contract.test.ts
@@ -1,0 +1,243 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vite-plus/test";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "../../..");
+const PLUGIN_PEER = "@ox-content/vite-plugin";
+
+/** Catalog schemes must ship a full light/dark palette. ThemeColors stays optional for site overrides. */
+const PALETTE_KEYS = [
+  "primary",
+  "primaryHover",
+  "background",
+  "backgroundAlt",
+  "text",
+  "textMuted",
+  "border",
+  "codeBackground",
+  "codeText",
+] as const;
+
+const SHIKI_BASE = ["shiki-foreground", "shiki-background"] as const;
+const HARD_CODED_COLOR = /#(?:[0-9a-f]{3,8})\b|\brgba?\(|\bhsla?\(/i;
+
+type PkgJson = {
+  name?: string;
+  files?: string[];
+  exports?: Record<string, unknown>;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+};
+
+type ThemePkg = { dir: string; json: PkgJson };
+
+function listPackages(familyDir: string): ThemePkg[] {
+  const root = join(repoRoot, familyDir);
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    if (!entry.isDirectory()) {
+      return [];
+    }
+    const dir = join(root, entry.name);
+    const manifest = join(dir, "package.json");
+    if (!existsSync(manifest)) {
+      return [];
+    }
+    return [{ dir, json: JSON.parse(readFileSync(manifest, "utf8")) as PkgJson }];
+  });
+}
+
+function collectSrc(dir: string): string[] {
+  const src = join(dir, "src");
+  if (!existsSync(src)) {
+    return [];
+  }
+  const files: string[] = [];
+  const walk = (current: string) => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const path = join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(path);
+      } else if (/\.[cm]?[jt]s$/.test(entry.name) && !entry.name.endsWith(".d.ts")) {
+        files.push(path);
+      }
+    }
+  };
+  walk(src);
+  return files;
+}
+
+function sliceObject(source: string, openBrace: number): string {
+  let depth = 0;
+  let quote: string | undefined;
+  for (let i = openBrace; i < source.length; i++) {
+    const ch = source[i];
+    const prev = source[i - 1];
+    if (quote) {
+      if (ch === quote && prev !== "\\") {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      continue;
+    }
+    if (ch === "{") {
+      depth++;
+    } else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        return source.slice(openBrace + 1, i);
+      }
+    }
+  }
+  throw new Error("unbalanced object literal");
+}
+
+function themeConfigBodies(source: string): string[] {
+  const bodies: string[] = [];
+  const pattern = /:\s*ThemeConfig\s*=\s*\{/g;
+  for (const match of source.matchAll(pattern)) {
+    bodies.push(sliceObject(source, match.index + match[0].length - 1));
+  }
+  return bodies;
+}
+
+function namedObject(body: string, name: string): string | undefined {
+  const match = new RegExp(`\\b${name}\\s*:\\s*\\{`).exec(body);
+  return match ? sliceObject(body, match.index + match[0].length - 1) : undefined;
+}
+
+function objectKeys(body: string): string[] {
+  return [...body.matchAll(/(?:^|[,{])\s*(?:["']([^"']+)["']|([A-Za-z_][\w-]*))\s*:/g)].map(
+    (match) => match[1] ?? match[2] ?? "",
+  );
+}
+
+function stringValues(body: string): string[] {
+  return [...body.matchAll(/:\s*(["'`])((?:\\.|(?!\1).)*)\1/g)].map((match) => match[2] ?? "");
+}
+
+function missing(required: readonly string[], actual: string[]): string[] {
+  return required.filter((key) => !actual.includes(key));
+}
+
+function configsIn(pkg: ThemePkg): string[] {
+  return collectSrc(pkg.dir).flatMap((file) => themeConfigBodies(readFileSync(file, "utf8")));
+}
+
+const schemes = listPackages("npm/theme-color");
+const skins = listPackages("npm/theme");
+
+describe("theme package contract", () => {
+  it("discovers published theme-color and theme packages from the filesystem", () => {
+    expect(schemes.length).toBeGreaterThan(10);
+    expect(skins.length).toBeGreaterThan(10);
+  });
+
+  it("exports a ThemeConfig with required light and dark palette keys from every theme-color package", () => {
+    for (const pkg of schemes) {
+      const configs = configsIn(pkg);
+      expect(configs.length, pkg.json.name).toBeGreaterThan(0);
+      for (const config of configs) {
+        const colors = namedObject(config, "colors");
+        const darkColors = namedObject(config, "darkColors");
+        expect(colors, `${pkg.json.name} colors`).toBeTruthy();
+        expect(darkColors, `${pkg.json.name} darkColors`).toBeTruthy();
+        expect(missing(PALETTE_KEYS, objectKeys(colors ?? "")), `${pkg.json.name} colors`).toEqual(
+          [],
+        );
+        expect(
+          missing(PALETTE_KEYS, objectKeys(darkColors ?? "")),
+          `${pkg.json.name} darkColors`,
+        ).toEqual([]);
+      }
+    }
+  });
+
+  it("includes historical --octc-shiki-* syntax tokens on every color scheme", () => {
+    for (const pkg of schemes) {
+      for (const config of configsIn(pkg)) {
+        for (const field of ["tokens", "darkTokens"] as const) {
+          const tokens = namedObject(config, field);
+          const keys = tokens ? objectKeys(tokens) : [];
+          const label = `${pkg.json.name} ${field}`;
+          expect(missing(SHIKI_BASE, keys), label).toEqual([]);
+          expect(
+            keys.filter((key) => key.startsWith("shiki-token-")).length,
+            label,
+          ).toBeGreaterThanOrEqual(4);
+          for (const key of keys.filter((item) => item.startsWith("shiki-"))) {
+            expect(key, `${label} ${key}`).toMatch(/^shiki-(foreground|background|token-)/);
+          }
+        }
+      }
+    }
+  });
+
+  it("does not let skins hard-code hex or rgb palette colors in ThemeConfig", () => {
+    for (const pkg of skins) {
+      const configs = configsIn(pkg);
+      expect(configs.length, pkg.json.name).toBeGreaterThan(0);
+      for (const config of configs) {
+        for (const field of ["colors", "darkColors"] as const) {
+          const palette = namedObject(config, field);
+          if (!palette?.trim()) {
+            continue;
+          }
+          // CSS variables and empty/omitted fields are allowed. Hex/rgb here
+          // would mean the skin owns color instead of form.
+          const hardcoded = stringValues(palette).filter((value) => HARD_CODED_COLOR.test(value));
+          expect(hardcoded, `${pkg.json.name} ${field}`).toEqual([]);
+        }
+      }
+    }
+  });
+
+  it("declares @ox-content/vite-plugin as a peer on every theme package", () => {
+    for (const pkg of [...schemes, ...skins]) {
+      const range = pkg.json.peerDependencies?.[PLUGIN_PEER];
+      expect(range, pkg.json.name).toBeTruthy();
+      const meta = pkg.json.peerDependenciesMeta?.[PLUGIN_PEER];
+      expect(meta === undefined || meta.optional === true, pkg.json.name).toBe(true);
+    }
+  });
+
+  it("records that 3.0.0 will tighten the vite-plugin peer range", () => {
+    // Published line is still 2.90.x. The 3.0.0 release PR should require >=3
+    // and update this assertion — do not bump peers in this contract PR.
+    for (const pkg of [...schemes, ...skins]) {
+      const range = pkg.json.peerDependencies?.[PLUGIN_PEER] ?? "";
+      expect(range, pkg.json.name).not.toMatch(/>=\s*3(?:\.0){0,2}(?:\s|$)|^\^?3(?:\.|$)/);
+    }
+  });
+
+  it("publishes a stable export shape for every theme and theme-color package", () => {
+    for (const pkg of schemes) {
+      expect(pkg.json.name, pkg.dir).toMatch(/^@ox-content\/theme-color-[a-z0-9-]+$/);
+      expect(pkg.json.exports?.["."], pkg.json.name).toBeTruthy();
+      expect(
+        pkg.json.files?.some((file) => file === "dist" || file.startsWith("dist/")),
+        pkg.json.name,
+      ).toBe(true);
+    }
+    for (const pkg of skins) {
+      expect(pkg.json.name, pkg.dir).toMatch(/^@ox-content\/theme-(?!color-)[a-z0-9-]+$/);
+      expect(pkg.json.exports?.["."], pkg.json.name).toBeTruthy();
+      expect(
+        pkg.json.files?.some((file) => file === "dist" || file.startsWith("dist/")),
+        pkg.json.name,
+      ).toBe(true);
+    }
+  });
+
+  it("declares the Theme Presets catalog official and documents authoring", () => {
+    const page = readFileSync(join(repoRoot, "docs/content/theme-presets.md"), "utf8");
+    expect(page).toMatch(/official\s+catalog/i);
+    expect(page).toMatch(/## Authoring a package/);
+    expect(page).toMatch(/ssg\.theme/);
+    expect(page).toMatch(/--octc-shiki-\*/);
+    expect(page).toMatch(/must not hard-code/i);
+  });
+});

--- a/npm/vite-plugin-ox-content/src/theme.test.ts
+++ b/npm/vite-plugin-ox-content/src/theme.test.ts
@@ -291,3 +291,51 @@ describe("theme composition", () => {
     );
   });
 });
+
+describe("stable theme package layer composition", () => {
+  const scheme = defineTheme({
+    name: "scheme",
+    colors: { primary: "#235fb1", background: "#e1e2e7", text: "#3760bf" },
+    darkColors: { primary: "#7aa2f7", background: "#1a1b26", text: "#c0caf5" },
+    tokens: {
+      "shiki-foreground": "#3358b0",
+      "shiki-background": "#d0d5e3",
+      "shiki-token-keyword": "#9854f1",
+    },
+    darkTokens: {
+      "shiki-foreground": "#c0caf5",
+      "shiki-background": "#16161e",
+      "shiki-token-keyword": "#bb9af7",
+    },
+  });
+  const skin = defineTheme({
+    name: "skin",
+    layout: { sidebarWidth: "268px", headerHeight: "66px" },
+    tokens: { "motion-base": "420ms" },
+    css: ".skin-header { border-radius: 12px; }",
+  });
+
+  it("defineTheme + mergeThemes produce scheme tokens and skin css/layout", () => {
+    const merged = mergeThemes(scheme, skin);
+
+    expect(merged.colors?.primary).toBe("#235fb1");
+    expect(merged.darkColors?.primary).toBe("#7aa2f7");
+    expect(merged.tokens?.["shiki-foreground"]).toBe("#3358b0");
+    expect(merged.tokens?.["shiki-token-keyword"]).toBe("#9854f1");
+    expect(merged.tokens?.["motion-base"]).toBe("420ms");
+    expect(merged.darkTokens?.["shiki-background"]).toBe("#16161e");
+    expect(merged.layout?.sidebarWidth).toBe("268px");
+    expect(merged.css).toContain(".skin-header { border-radius: 12px; }");
+  });
+
+  it("resolveTheme stacks a scheme layer and a skin layer left to right", () => {
+    const resolved = resolveTheme([scheme, skin]);
+
+    expect(resolved.tokens["shiki-foreground"]).toBe("#3358b0");
+    expect(resolved.tokens["motion-base"]).toBe("420ms");
+    expect(resolved.layout.sidebarWidth).toBe("268px");
+    expect(resolved.css).toContain(".skin-header { border-radius: 12px; }");
+    expect(resolved.colors.primary).toBe("#235fb1");
+    expect(resolved.darkColors.background).toBe("#1a1b26");
+  });
+});


### PR DESCRIPTION
## Summary

- Progress on #700. Partial. Peer range bump waits for the 3.0.0 release.
- Filesystem Vitest contract for every `@ox-content/theme-*` / `@ox-content/theme-color-*` package: required light/dark palette keys, historical `--octc-shiki-*` tokens, skins must not hard-code palette colors, export/peer shape.
- `defineTheme` / `mergeThemes` layer composition: a scheme layer plus a skin layer produces tokens and skin css/layout.
- Theme Presets and Theming docs declare the catalog official and add an Authoring / compatibility section.

Does not close #700 — 3.x peer ranges and the rest of the release checklist remain.

## Test plan

- [x] `vp test src/theme-contract.test.ts src/theme.test.ts` in `npm/vite-plugin-ox-content`
- [ ] CI green on this branch


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790149317&installation_model_id=422833&pr_number=714&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F714&signature=feb3f8b424cddf4724d1fbe6e857b3aa043d7e98d81dd45bc8a851a9c346f96c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->