### PR TITLE
fix(docs): build Code Play before Void docs deploy

### DIFF
--- a/docs/content/deployment.md
+++ b/docs/content/deployment.md
@@ -28,8 +28,9 @@ whatever is already published to the registry.
 2. `napi build --release` in `crates/ox_content_napi`
 3. `vp pack` in `npm/ox-content-islands`
 4. `vp pack` in `npm/vite-plugin-ox-content`
-5. `vp build` in `docs`
-6. `vpx void@0.10.8 deploy`
+5. `vp run build` in `npm/ox-content-code-play`
+6. `vp build` in `docs`
+7. `vpx void@0.10.8 deploy`
 
 The deploy command defaults to the Void project and docs output directory used
 by this repository.

--- a/scripts/deploy-docs-to-void.mjs
+++ b/scripts/deploy-docs-to-void.mjs
@@ -65,6 +65,7 @@ run("cargo", ["build", "--workspace"]);
 run("napi", ["build", "--release"], { cwd: "crates/ox_content_napi" });
 run("vp", ["pack"], { cwd: "npm/ox-content-islands" });
 run("vp", ["pack"], { cwd: "npm/vite-plugin-ox-content" });
+run("vp", ["run", "build"], { cwd: "npm/ox-content-code-play" });
 run("vp", ["build"], {
   cwd: "docs",
   env: {

--- a/scripts/verify-publish-targets.test.ts
+++ b/scripts/verify-publish-targets.test.ts
@@ -26,6 +26,12 @@ describe("publish workflow targets", () => {
     });
   });
 
+  it("builds @ox-content/code-play before the Void docs site", () => {
+    const script = readFileSync("scripts/deploy-docs-to-void.mjs", "utf8");
+    expect(script).toContain('cwd: "npm/ox-content-code-play"');
+    expect(script).toMatch(/ox-content-code-play[\s\S]*docs/);
+  });
+
   it("fails when an npm workspace dir is missing from the workflow", () => {
     expect(() =>
       verifyPublishWorkflow({


### PR DESCRIPTION
## Summary
- Void docs deploy failed on every `main` push after the docs site started importing `@ox-content/code-play`.
- Build that workspace package (pack + browser client) before `vp build` in `docs`.
- Guard the step with a script test so the deploy path cannot drop Code Play again.

## Test plan
- [x] `vp test scripts/verify-publish-targets.test.ts`
- [ ] Void deploy on this PR's merge to `main`


Made with [Cursor](https://cursor.com)