### PR TITLE
fix(docs): keep CI NAPI JSDoc newline encoding in API examples

### DIFF
--- a/docs/content/api/docs.json
+++ b/docs/content/api/docs.json
@@ -8631,8 +8631,8 @@
               "default": "3",
               "optional": true,
               "tags": {
-                "min": "1",
-                "max": "6"
+                "max": "6",
+                "min": "1"
               },
               "line": 201,
               "endLine": 201

--- a/docs/content/api/docs.md
+++ b/docs/content/api/docs.md
@@ -74,8 +74,7 @@
 <h4>Examples</h4>
 <div class="ox-api-entry__example">
 <div class="ox-api-entry__example-heading">Example 1</div>
-<pre><code class="language-typescript">import { extractDocs, generateMarkdown, writeDocs } from &#39;./docs&#39;;
-
+<pre><code class="language-typescript">import { extractDocs, generateMarkdown, writeDocs } from &#39;./docs&#39;;&#10;
 const docsOptions = {
   enabled: true,
   src: [&#39;./src&#39;],
@@ -84,8 +83,7 @@ const docsOptions = {
   exclude: [&#39;**\/*.test.ts&#39;],
   groupBy: &#39;file&#39;,
   githubUrl: &#39;https://github.com/user/project&#39;,
-};
-
+};&#10;
 const extracted = await extractDocs([&#39;./src&#39;], docsOptions);
 const markdown = generateMarkdown(extracted, docsOptions);
 await writeDocs(markdown, &#39;./docs/api&#39;, extracted, docsOptions);</code></pre>
@@ -204,8 +202,7 @@ await writeDocs(markdown, &#39;./docs/api&#39;, extracted, docsOptions);</code><
     groupBy: &#39;file&#39;,
     generateNav: true,
   }
-);
-
+);&#10;
 // Returns:
 // [
 //   {

--- a/docs/content/api/jsx-html.md
+++ b/docs/content/api/jsx-html.md
@@ -254,8 +254,7 @@
     &quot;jsx&quot;: &quot;react-jsx&quot;,
     &quot;jsxImportSource&quot;: &quot;@ox-content/vite-plugin&quot;
   }
-}
-
+}&#10;
 // MyComponent.tsx
 export function Hero({ title }: { title: string }) {
   return (

--- a/docs/content/api/page-context.md
+++ b/docs/content/api/page-context.md
@@ -326,8 +326,7 @@
 <div class="ox-api-entry__example">
 <div class="ox-api-entry__example-heading">Example 1</div>
 <pre><code class="language-tsx">// theme/Layout.tsx
-import { usePageProps, PageProps } from &#39;@ox-content/vite-plugin&#39;;
-
+import { usePageProps, PageProps } from &#39;@ox-content/vite-plugin&#39;;&#10;
 export function Layout({ children }: { children: JSX.Element }) {
   const page = usePageProps&lt;MyPageProps&gt;();
   return (

--- a/docs/content/api/theme-renderer.md
+++ b/docs/content/api/theme-renderer.md
@@ -103,8 +103,7 @@
 <div class="ox-api-entry__example-heading">Example 1</div>
 <pre><code class="language-tsx">import { createTheme } from &#39;@ox-content/vite-plugin&#39;;
 import { DefaultLayout } from &#39;./layouts/Default&#39;;
-import { EntryLayout } from &#39;./layouts/Entry&#39;;
-
+import { EntryLayout } from &#39;./layouts/Entry&#39;;&#10;
 export default createTheme({
   layouts: {
     default: DefaultLayout,

--- a/docs/content/api/transform.md
+++ b/docs/content/api/transform.md
@@ -555,14 +555,12 @@
 <h4>Examples</h4>
 <div class="ox-api-entry__example">
 <div class="ox-api-entry__example-heading">Example 1</div>
-<pre><code class="language-typescript">import { transformMarkdown } from &#39;./transform&#39;;
-
+<pre><code class="language-typescript">import { transformMarkdown } from &#39;./transform&#39;;&#10;
 const content = await transformMarkdown(
   &#39;# Hello\n\nWorld&#39;,
   &#39;path/to/file.md&#39;,
   resolvedOptions
-);
-
+);&#10;
 console.log(content.html); // &#39;&lt;h1&gt;Hello&lt;/h1&gt;&lt;p&gt;World&lt;/p&gt;&#39;
 console.log(content.toc);  // [{ depth: 1, text: &#39;Hello&#39;, slug: &#39;hello&#39;, children: [] }]</code></pre>
 </div>


### PR DESCRIPTION
## Summary
- Follow-up to #718: Package dry-run failed because checked-in API examples used real blank lines, while CI's NAPI binary encodes those as `&#10;` on the previous line.
- Restored the CI encoding in existing JSDoc examples and the `max`/`min` tag key order in `docs.json`. Includes / `JsIncludeOptions` docs from #718 are unchanged.

## Test plan
- [ ] Package dry-run `node scripts/generate-api-docs.mjs --check` passes on CI
- [ ] Existing API examples still contain `&#10;` (docs.md, transform.md, jsx-html.md, page-context.md, theme-renderer.md)
- [ ] Includes feature docs remain present (`JsIncludeOptions` / `includes`)


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790151938&installation_model_id=422833&pr_number=721&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F721&signature=d0aef2de4af3e462693b2722869b318c7783f108b55537d28d21c597202449e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->