### PR TITLE
feat(mdx): parse JSX elements when mdx is enabled

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -22,6 +22,7 @@ mod leaf;
 mod line_scan;
 mod list;
 mod list_item;
+mod mdx_jsx;
 mod prepass;
 mod reference;
 mod spans;
@@ -87,7 +88,11 @@ pub struct ParserOptions {
     /// Default: `false`.
     pub cjk_emphasis: bool,
 
-    /// Enable MDX (JSX, ESM, and expressions). Off by default.
+    /// Enable MDX. Off by default.
+    ///
+    /// When set, PascalCase JSX elements parse as [`ox_content_ast::MdxJsxFlowElement`]
+    /// / [`ox_content_ast::MdxJsxTextElement`]. `import` / `export` and
+    /// `{expression}` children are not parsed yet. Lowercase HTML stays HTML.
     ///
     /// Default: `false`.
     pub mdx: bool,

--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -84,6 +84,11 @@ impl<'a> Parser<'a> {
                 }
             }
             b'<' => {
+                if self.options.mdx
+                    && let Some(node) = self.try_parse_mdx_jsx_flow(start, trimmed_start)?
+                {
+                    return Ok(Some(node));
+                }
                 let line = self.line_at(start);
                 let trimmed = &line[trimmed_start - start..];
                 if let Some(html_start) = Self::parse_html_block_start(trimmed) {

--- a/crates/ox_content_parser/src/parser/cursor.rs
+++ b/crates/ox_content_parser/src/parser/cursor.rs
@@ -155,8 +155,13 @@ impl<'a> Parser<'a> {
                 Self::try_parse_fenced_code_at(line, trimmed)
             }
             b'<' => {
-                let line = self.line_at(line_start);
-                Self::parse_html_block_start(&line[trimmed_start - line_start..]).is_some()
+                let bytes = self.source.as_bytes();
+                if self.options.mdx && super::mdx_jsx::looks_like_jsx_open(bytes, trimmed_start) {
+                    true
+                } else {
+                    let line = self.line_at(line_start);
+                    Self::parse_html_block_start(&line[trimmed_start - line_start..]).is_some()
+                }
             }
             b'+' | b'0'..=b'9' => {
                 let line = self.line_at(line_start);

--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -159,7 +159,7 @@ impl<'a> Parser<'a> {
                     *pos += 1;
                 }
             }
-            b'<' => self.parse_inline_html_or_text(content, offset, children, pos),
+            b'<' => self.parse_inline_html_or_text(content, offset, children, pos)?,
             b'\\' if *pos + 1 < content.len() && bytes[*pos + 1].is_ascii_punctuation() => {
                 // A backslash escapes only ASCII punctuation (CommonMark
                 // "Backslash escapes"). The escaped character is emitted as
@@ -253,9 +253,12 @@ impl<'a> Parser<'a> {
         offset: usize,
         children: &mut Vec<'a, Node<'a>>,
         pos: &mut usize,
-    ) {
+    ) -> ParseResult<()> {
         if let Some((link, end)) = self.parse_autolink(content, *pos, offset) {
             children.push(link);
+            *pos = end;
+        } else if let Some((node, end)) = self.try_parse_mdx_jsx_text(content, *pos, offset)? {
+            children.push(node);
             *pos = end;
         } else if let Some((html, end)) = Self::parse_inline_html(content, *pos, offset) {
             children.push(Node::Html(html));
@@ -264,6 +267,7 @@ impl<'a> Parser<'a> {
             Self::push_text(children, "<", offset + *pos, offset + *pos + 1);
             *pos += 1;
         }
+        Ok(())
     }
 
     fn parse_strikethrough(

--- a/crates/ox_content_parser/src/parser/mdx_jsx.rs
+++ b/crates/ox_content_parser/src/parser/mdx_jsx.rs
@@ -1,0 +1,115 @@
+//! MDX JSX element parse: PascalCase flow and text tags.
+
+use ox_content_ast::{MdxJsxFlowElement, MdxJsxTextElement, Node, Span};
+
+use super::Parser;
+use crate::error::ParseResult;
+
+mod scan;
+
+pub(super) fn looks_like_jsx_open(bytes: &[u8], at: usize) -> bool {
+    scan::looks_like_jsx_open(bytes, at)
+}
+
+impl<'a> Parser<'a> {
+    /// Parses a flow JSX element starting at the current line.
+    ///
+    /// On failure the cursor is left unchanged so HTML / paragraph dispatch
+    /// can run. Unclosed tags and spreads do not panic.
+    pub(super) fn try_parse_mdx_jsx_flow(
+        &mut self,
+        start: usize,
+        trimmed_start: usize,
+    ) -> ParseResult<Option<Node<'a>>> {
+        if !self.options.mdx || !scan::looks_like_jsx_open(self.source.as_bytes(), trimmed_start) {
+            return Ok(None);
+        }
+
+        let mut attributes = self.allocator.new_vec();
+        let Some(open) = scan::scan_jsx_open(self.source, trimmed_start, 0, &mut attributes) else {
+            return Ok(None);
+        };
+
+        let (self_closing, children, element_end) = if open.self_closing {
+            if !scan::only_ws_until_eol(self.source.as_bytes(), open.end) {
+                return Ok(None);
+            }
+            (true, self.allocator.new_vec(), open.end)
+        } else {
+            let Some((close_start, close_end)) =
+                scan::find_matching_close(self.source, open.end, open.name)
+            else {
+                return Ok(None);
+            };
+            let children = self.parse_jsx_flow_children(open.end, close_start)?;
+            (false, children, close_end)
+        };
+
+        self.position = scan::after_trailing_line_ws(self.source.as_bytes(), element_end);
+        Ok(Some(Node::MdxJsxFlowElement(self.allocator.boxed(MdxJsxFlowElement {
+            name: Some(open.name),
+            attributes,
+            children,
+            self_closing,
+            span: Span::new(start as u32, self.position as u32),
+        }))))
+    }
+
+    /// Parses a text JSX element at `pos` inside inline `content`.
+    pub(super) fn try_parse_mdx_jsx_text(
+        &self,
+        content: &'a str,
+        pos: usize,
+        offset: usize,
+    ) -> ParseResult<Option<(Node<'a>, usize)>> {
+        if !self.options.mdx || !scan::looks_like_jsx_open(content.as_bytes(), pos) {
+            return Ok(None);
+        }
+
+        let mut attributes = self.allocator.new_vec();
+        let Some(open) = scan::scan_jsx_open(content, pos, offset, &mut attributes) else {
+            return Ok(None);
+        };
+
+        let (self_closing, children, end) = if open.self_closing {
+            (true, self.allocator.new_vec(), open.end)
+        } else {
+            let Some((close_start, close_end)) =
+                scan::find_matching_close(content, open.end, open.name)
+            else {
+                return Ok(None);
+            };
+            let children = self.parse_inline(&content[open.end..close_start], offset + open.end)?;
+            (false, children, close_end)
+        };
+
+        Ok(Some((
+            Node::MdxJsxTextElement(self.allocator.boxed(MdxJsxTextElement {
+                name: Some(open.name),
+                attributes,
+                children,
+                self_closing,
+                span: Span::new((offset + pos) as u32, (offset + end) as u32),
+            })),
+            end,
+        )))
+    }
+
+    fn parse_jsx_flow_children(
+        &self,
+        inner_start: usize,
+        inner_end: usize,
+    ) -> ParseResult<ox_content_allocator::Vec<'a, Node<'a>>> {
+        if inner_start >= inner_end || self.source[inner_start..inner_end].trim().is_empty() {
+            return Ok(self.allocator.new_vec());
+        }
+        let inner = &self.source[inner_start..inner_end];
+        let mut sub = self.sub_parser_with_lazy_lines(inner, rustc_hash::FxHashSet::default());
+        sub.nesting_depth = self.nesting_depth + 1;
+        let mut children = sub.parse()?.children;
+        for child in &mut children {
+            Self::offset_node_spans(child, inner_start as u32);
+        }
+        Ok(children)
+    }
+}

--- a/crates/ox_content_parser/src/parser/mdx_jsx/scan.rs
+++ b/crates/ox_content_parser/src/parser/mdx_jsx/scan.rs
@@ -1,0 +1,347 @@
+//! JSX tag scanning: PascalCase names and named attributes.
+
+use ox_content_allocator::Vec;
+use ox_content_ast::{
+    MdxJsxAttribute, MdxJsxAttributeEntry, MdxJsxAttributeValue, MdxJsxAttributeValueExpression,
+    Span,
+};
+
+/// Opening tag accepted by this slice.
+pub(super) struct JsxOpen<'a> {
+    pub name: &'a str,
+    pub self_closing: bool,
+    pub end: usize,
+}
+
+struct TagSkip<'a> {
+    name: &'a str,
+    start: usize,
+    closing: bool,
+    self_closing: bool,
+    end: usize,
+}
+
+#[inline]
+pub(super) fn looks_like_jsx_open(bytes: &[u8], at: usize) -> bool {
+    bytes.get(at) == Some(&b'<') && bytes.get(at + 1).is_some_and(u8::is_ascii_uppercase)
+}
+
+pub(super) fn only_ws_until_eol(bytes: &[u8], mut cursor: usize) -> bool {
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b' ' | b'\t' | b'\r' => cursor += 1,
+            b'\n' => return true,
+            _ => return false,
+        }
+    }
+    true
+}
+
+pub(super) fn after_trailing_line_ws(bytes: &[u8], mut cursor: usize) -> usize {
+    while cursor < bytes.len() && matches!(bytes[cursor], b' ' | b'\t' | b'\r') {
+        cursor += 1;
+    }
+    if cursor < bytes.len() && bytes[cursor] == b'\n' { cursor + 1 } else { cursor }
+}
+
+pub(super) fn scan_jsx_open<'a>(
+    source: &'a str,
+    start: usize,
+    offset: usize,
+    attributes: &mut Vec<'a, MdxJsxAttributeEntry<'a>>,
+) -> Option<JsxOpen<'a>> {
+    let bytes = source.as_bytes();
+    if !looks_like_jsx_open(bytes, start) {
+        return None;
+    }
+    let name_start = start + 1;
+    let name_end = scan_jsx_name(bytes, name_start)?;
+    let name = &source[name_start..name_end];
+    let (self_closing, end) = scan_named_attributes(source, name_end, offset, attributes)?;
+    Some(JsxOpen { name, self_closing, end })
+}
+
+pub(super) fn find_matching_close(source: &str, from: usize, name: &str) -> Option<(usize, usize)> {
+    let bytes = source.as_bytes();
+    let mut cursor = from;
+    let mut depth = 1u32;
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'{' => cursor = skip_braces(bytes, cursor)?,
+            b'`' => cursor = skip_backticks(bytes, cursor).unwrap_or(cursor + 1),
+            b'<' => {
+                let Some(tag) = scan_tag_skip(source, cursor) else {
+                    cursor += 1;
+                    continue;
+                };
+                if tag.name == name {
+                    if tag.closing {
+                        depth = depth.saturating_sub(1);
+                        if depth == 0 {
+                            return Some((tag.start, tag.end));
+                        }
+                    } else if !tag.self_closing {
+                        depth = depth.saturating_add(1);
+                    }
+                }
+                cursor = tag.end;
+            }
+            _ => cursor += 1,
+        }
+    }
+    None
+}
+
+fn scan_jsx_name(bytes: &[u8], start: usize) -> Option<usize> {
+    let first = *bytes.get(start)?;
+    if !first.is_ascii_uppercase() {
+        return None;
+    }
+    let mut end = start + 1;
+    while end < bytes.len()
+        && (bytes[end].is_ascii_alphanumeric() || matches!(bytes[end], b'_' | b'$'))
+    {
+        end += 1;
+    }
+    Some(end)
+}
+
+fn scan_named_attributes<'a>(
+    source: &'a str,
+    mut cursor: usize,
+    offset: usize,
+    attributes: &mut Vec<'a, MdxJsxAttributeEntry<'a>>,
+) -> Option<(bool, usize)> {
+    let bytes = source.as_bytes();
+    loop {
+        let had_ws = skip_ws(bytes, &mut cursor);
+        match bytes.get(cursor)? {
+            b'/' if bytes.get(cursor + 1) == Some(&b'>') => return Some((true, cursor + 2)),
+            b'>' => return Some((false, cursor + 1)),
+            b'{' => return None,
+            _ if !had_ws => return None,
+            _ => cursor = push_named_attribute(source, cursor, offset, attributes)?,
+        }
+    }
+}
+
+fn push_named_attribute<'a>(
+    source: &'a str,
+    start: usize,
+    offset: usize,
+    attributes: &mut Vec<'a, MdxJsxAttributeEntry<'a>>,
+) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let name_end = scan_attr_name(bytes, start)?;
+    let name = &source[start..name_end];
+    let mut cursor = name_end;
+    skip_ws(bytes, &mut cursor);
+    if bytes.get(cursor) != Some(&b'=') {
+        attributes.push(MdxJsxAttributeEntry::Attribute(MdxJsxAttribute {
+            name,
+            value: None,
+            span: Span::new((offset + start) as u32, (offset + name_end) as u32),
+        }));
+        return Some(name_end);
+    }
+    cursor += 1;
+    skip_ws(bytes, &mut cursor);
+    let (value, value_end) = scan_attr_value(source, cursor, offset)?;
+    attributes.push(MdxJsxAttributeEntry::Attribute(MdxJsxAttribute {
+        name,
+        value: Some(value),
+        span: Span::new((offset + start) as u32, (offset + value_end) as u32),
+    }));
+    Some(value_end)
+}
+
+fn scan_attr_value<'a>(
+    source: &'a str,
+    start: usize,
+    offset: usize,
+) -> Option<(MdxJsxAttributeValue<'a>, usize)> {
+    let bytes = source.as_bytes();
+    match *bytes.get(start)? {
+        b'"' | b'\'' => {
+            let end = skip_quoted(bytes, start)?;
+            Some((MdxJsxAttributeValue::Literal(&source[start + 1..end - 1]), end))
+        }
+        b'{' => {
+            let end = skip_braces(bytes, start)?;
+            Some((
+                MdxJsxAttributeValue::Expression(MdxJsxAttributeValueExpression {
+                    value: &source[start + 1..end - 1],
+                    span: Span::new((offset + start) as u32, (offset + end) as u32),
+                }),
+                end,
+            ))
+        }
+        _ => None,
+    }
+}
+
+fn scan_tag_skip(source: &str, start: usize) -> Option<TagSkip<'_>> {
+    let bytes = source.as_bytes();
+    if bytes.get(start)? != &b'<' {
+        return None;
+    }
+    let mut cursor = start + 1;
+    let closing = bytes.get(cursor) == Some(&b'/');
+    if closing {
+        cursor += 1;
+    }
+    let name_end = scan_any_name(bytes, cursor)?;
+    let name = &source[cursor..name_end];
+    cursor = name_end;
+    let self_closing = skip_tag_rest(bytes, &mut cursor)?;
+    if closing && self_closing {
+        return None;
+    }
+    Some(TagSkip { name, start, closing, self_closing, end: cursor })
+}
+
+fn skip_tag_rest(bytes: &[u8], cursor: &mut usize) -> Option<bool> {
+    loop {
+        skip_ws(bytes, cursor);
+        match bytes.get(*cursor)? {
+            b'/' if bytes.get(*cursor + 1) == Some(&b'>') => {
+                *cursor += 2;
+                return Some(true);
+            }
+            b'>' => {
+                *cursor += 1;
+                return Some(false);
+            }
+            b'{' => *cursor = skip_braces(bytes, *cursor)?,
+            b'"' | b'\'' | b'`' => *cursor = skip_quoted(bytes, *cursor)?,
+            byte if is_attr_name_start(*byte) => {
+                *cursor = scan_attr_name(bytes, *cursor)?;
+                skip_ws(bytes, cursor);
+                if bytes.get(*cursor) == Some(&b'=') {
+                    *cursor += 1;
+                    skip_ws(bytes, cursor);
+                    match bytes.get(*cursor)? {
+                        b'"' | b'\'' => *cursor = skip_quoted(bytes, *cursor)?,
+                        b'{' => *cursor = skip_braces(bytes, *cursor)?,
+                        _ => skip_unquoted_value(bytes, cursor),
+                    }
+                }
+            }
+            _ => return None,
+        }
+    }
+}
+
+fn scan_any_name(bytes: &[u8], start: usize) -> Option<usize> {
+    let first = *bytes.get(start)?;
+    if !(first.is_ascii_alphabetic() || matches!(first, b'_' | b'$')) {
+        return None;
+    }
+    let mut end = start + 1;
+    while end < bytes.len()
+        && (bytes[end].is_ascii_alphanumeric() || matches!(bytes[end], b'_' | b'$'))
+    {
+        end += 1;
+    }
+    Some(end)
+}
+
+fn scan_attr_name(bytes: &[u8], start: usize) -> Option<usize> {
+    if !bytes.get(start).is_some_and(|byte| is_attr_name_start(*byte)) {
+        return None;
+    }
+    let mut end = start + 1;
+    while end < bytes.len()
+        && (bytes[end].is_ascii_alphanumeric()
+            || matches!(bytes[end], b'_' | b'$' | b'-' | b':' | b'.'))
+    {
+        end += 1;
+    }
+    Some(end)
+}
+
+#[inline]
+fn is_attr_name_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || matches!(byte, b'_' | b'$')
+}
+
+fn skip_ws(bytes: &[u8], cursor: &mut usize) -> bool {
+    let start = *cursor;
+    while *cursor < bytes.len() && matches!(bytes[*cursor], b' ' | b'\t' | b'\n' | b'\r') {
+        *cursor += 1;
+    }
+    *cursor > start
+}
+
+fn skip_quoted(bytes: &[u8], start: usize) -> Option<usize> {
+    let quote = *bytes.get(start)?;
+    let mut cursor = start + 1;
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'\\' && cursor + 1 < bytes.len() {
+            cursor += 2;
+            continue;
+        }
+        if bytes[cursor] == quote {
+            return Some(cursor + 1);
+        }
+        cursor += 1;
+    }
+    None
+}
+
+fn skip_braces(bytes: &[u8], start: usize) -> Option<usize> {
+    if bytes.get(start) != Some(&b'{') {
+        return None;
+    }
+    let mut cursor = start;
+    let mut depth = 0u32;
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'"' | b'\'' | b'`' => cursor = skip_quoted(bytes, cursor)?,
+            b'{' => {
+                depth = depth.saturating_add(1);
+                cursor += 1;
+            }
+            b'}' => {
+                depth = depth.saturating_sub(1);
+                cursor += 1;
+                if depth == 0 {
+                    return Some(cursor);
+                }
+            }
+            _ => cursor += 1,
+        }
+    }
+    None
+}
+
+fn skip_backticks(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut open = 0usize;
+    while start + open < bytes.len() && bytes[start + open] == b'`' {
+        open += 1;
+    }
+    if open == 0 {
+        return None;
+    }
+    let mut cursor = start + open;
+    while cursor + open <= bytes.len() {
+        if bytes[cursor..cursor + open].iter().all(|byte| *byte == b'`')
+            && bytes.get(cursor + open) != Some(&b'`')
+        {
+            return Some(cursor + open);
+        }
+        cursor += 1;
+    }
+    None
+}
+
+fn skip_unquoted_value(bytes: &[u8], cursor: &mut usize) {
+    while *cursor < bytes.len()
+        && !matches!(
+            bytes[*cursor],
+            b' ' | b'\t' | b'\n' | b'\r' | b'"' | b'\'' | b'=' | b'<' | b'>' | b'`' | b'/'
+        )
+    {
+        *cursor += 1;
+    }
+}

--- a/crates/ox_content_parser/tests/mdx_jsx.rs
+++ b/crates/ox_content_parser/tests/mdx_jsx.rs
@@ -1,0 +1,183 @@
+//! JSX element parse when `ParserOptions.mdx` is true.
+//!
+//! This slice covers PascalCase elements (flow + text), literal / boolean /
+//! `{expr}` attributes, self-closing tags, and simple open/close children.
+//! Lowercase HTML stays `Html`. Spreads, fragments, JSX comments, ESM, and
+//! `{expression}` children are deferred — tests below pin that subset.
+
+use ox_content_allocator::Allocator;
+use ox_content_parser::{Parser, ParserOptions};
+
+#[path = "support/pretty.rs"]
+mod pretty;
+
+fn pretty_ast(source: &str, options: ParserOptions) -> String {
+    let allocator = Allocator::new();
+    let doc = Parser::with_options(&allocator, source, options)
+        .parse()
+        .expect("parser should not fail on MDX JSX fixtures");
+    let mut out = String::new();
+    pretty::format_document(&doc, source, &mut out);
+    out
+}
+
+fn mdx_tree(source: &str) -> String {
+    pretty_ast(source, ParserOptions::mdx())
+}
+
+#[test]
+fn mdx_false_does_not_emit_jsx_for_pascal_case() {
+    let tree = pretty_ast("<Alert title=\"hi\" />\n", ParserOptions::default());
+    assert!(!tree.contains("MdxJsx"), "mdx=false must not emit JSX:\n{tree}");
+}
+
+#[test]
+fn flow_self_closing_literal_attr() {
+    let tree = mdx_tree("<Alert title=\"hi\" />\n");
+    assert!(
+        tree.contains("MdxJsxFlowElement name=Some(\"Alert\") self_closing=true"),
+        "expected flow Alert:\n{tree}"
+    );
+    assert!(
+        tree.contains("Attr name=\"title\" value=literal(\"hi\")"),
+        "expected literal title:\n{tree}"
+    );
+    assert!(!tree.contains("Paragraph"), "standalone tag must not wrap in a paragraph:\n{tree}");
+}
+
+#[test]
+fn text_self_closing_inside_paragraph() {
+    let tree = mdx_tree("Hello <Badge /> world.\n");
+    assert!(tree.contains("Paragraph"), "expected a paragraph:\n{tree}");
+    assert!(
+        tree.contains("MdxJsxTextElement name=Some(\"Badge\") self_closing=true"),
+        "expected text Badge:\n{tree}"
+    );
+    assert!(tree.contains("Text \"Hello \""), "expected leading text:\n{tree}");
+    assert!(tree.contains("Text \" world.\""), "expected trailing text:\n{tree}");
+}
+
+#[test]
+fn boolean_and_expression_attrs() {
+    let tree = mdx_tree("<Btn disabled count={1+1} />\n");
+    assert!(
+        tree.contains("MdxJsxFlowElement name=Some(\"Btn\") self_closing=true"),
+        "expected flow Btn:\n{tree}"
+    );
+    assert!(tree.contains("Attr name=\"disabled\" value=boolean"), "expected boolean:\n{tree}");
+    assert!(
+        tree.contains("Attr name=\"count\" value=expression(\"1+1\")"),
+        "expression attrs store source, not a evaluated result:\n{tree}"
+    );
+}
+
+#[test]
+fn hostile_quoted_attr_is_literal_source() {
+    let tree = mdx_tree("<Alert title=\"<script>\" />\n");
+    assert!(
+        tree.contains("Attr name=\"title\" value=literal(\"<script>\")"),
+        "quoted attr must keep source text:\n{tree}"
+    );
+}
+
+#[test]
+fn unclosed_tag_does_not_panic_or_emit_jsx() {
+    let tree = mdx_tree("<Alert\n");
+    assert!(!tree.contains("MdxJsx"), "unclosed opener stays non-JSX:\n{tree}");
+}
+
+#[test]
+fn fenced_and_inline_code_are_not_components() {
+    let fenced = mdx_tree("```js\nconst x = <div />;\n```\n");
+    assert!(fenced.contains("Code"), "expected a fence:\n{fenced}");
+    assert!(!fenced.contains("MdxJsx"), "fence contents are not JSX:\n{fenced}");
+
+    let inline = mdx_tree("Use `<Alert />` in prose.\n");
+    assert!(inline.contains("InlineCode"), "expected inline code:\n{inline}");
+    assert!(!inline.contains("MdxJsx"), "inline code is not JSX:\n{inline}");
+}
+
+#[test]
+fn lowercase_html_stays_html_when_mdx_is_on() {
+    let block = mdx_tree("<div>\nraw\n</div>\n\nAfter\n");
+    assert!(block.contains("Html"), "lowercase block stays Html:\n{block}");
+    assert!(!block.contains("MdxJsx"), "lowercase HTML is not JSX in this slice:\n{block}");
+
+    let inline = mdx_tree("Hello <span class=\"x\">there</span>.\n");
+    assert!(inline.contains("Html"), "lowercase inline stays Html:\n{inline}");
+    assert!(!inline.contains("MdxJsx"), "lowercase HTML is not JSX in this slice:\n{inline}");
+}
+
+#[test]
+fn flow_open_close_parses_markdown_children() {
+    let tree = mdx_tree("<Alert>\nHello **world**\n</Alert>\n");
+    assert!(
+        tree.contains("MdxJsxFlowElement name=Some(\"Alert\") self_closing=false"),
+        "expected open/close flow:\n{tree}"
+    );
+    assert!(tree.contains("Strong"), "markdown children should parse:\n{tree}");
+    assert!(!tree.contains("MdxFlowExpression"), "child expressions are deferred:\n{tree}");
+}
+
+#[test]
+fn text_open_close_parses_phrasing_children() {
+    let tree = mdx_tree("Hello <Badge>x</Badge> world.\n");
+    assert!(
+        tree.contains("MdxJsxTextElement name=Some(\"Badge\") self_closing=false"),
+        "expected open/close text:\n{tree}"
+    );
+    assert!(tree.contains("Text \"x\""), "expected phrasing child:\n{tree}");
+}
+
+#[test]
+fn pascal_case_flow_interrupts_paragraph() {
+    let tree = mdx_tree("Hello\n<Alert />\n");
+    assert!(tree.contains("Paragraph"), "leading prose stays a paragraph:\n{tree}");
+    assert!(
+        tree.contains("MdxJsxFlowElement name=Some(\"Alert\") self_closing=true"),
+        "PascalCase at line start is flow:\n{tree}"
+    );
+}
+
+#[test]
+fn spread_attr_is_not_parsed_yet() {
+    let tree = mdx_tree("<Alert {...props} />\n");
+    assert!(
+        !tree.contains("MdxJsx") && !tree.contains("AttrExpr"),
+        "spreads are deferred:\n{tree}"
+    );
+}
+
+#[test]
+fn fragment_is_not_parsed_yet() {
+    let tree = mdx_tree("<>hello</>\n");
+    assert!(!tree.contains("MdxJsx"), "fragments are deferred:\n{tree}");
+}
+
+#[test]
+fn jsx_comment_is_not_parsed_yet() {
+    let tree = mdx_tree("{/* hide */}\n");
+    assert!(
+        !tree.contains("MdxJsx") && !tree.contains("MdxFlowExpression"),
+        "JSX comments are deferred:\n{tree}"
+    );
+}
+
+#[test]
+fn member_expression_name_is_not_parsed_yet() {
+    let tree = mdx_tree("<Foo.Bar />\n");
+    assert!(!tree.contains("MdxJsx"), "member names are deferred:\n{tree}");
+}
+
+#[test]
+fn children_brace_expression_is_not_an_mdx_expression() {
+    let tree = mdx_tree("<Alert>{items.map}</Alert>\n");
+    assert!(
+        tree.contains("MdxJsxFlowElement name=Some(\"Alert\")"),
+        "wrapper still parses:\n{tree}"
+    );
+    assert!(
+        !tree.contains("MdxFlowExpression") && !tree.contains("MdxTextExpression"),
+        "{{items.map}} children are deferred:\n{tree}"
+    );
+}

--- a/crates/ox_content_parser/tests/mdx_options.rs
+++ b/crates/ox_content_parser/tests/mdx_options.rs
@@ -1,7 +1,7 @@
 //! Strict tests for `ParserOptions.mdx`.
 //!
-//! This slice only adds the flag. Enabling it must not change CommonMark or
-//! GFM parse output until the JSX/ESM/expression PRs land.
+//! Enabling the flag must not change CommonMark or GFM parse output for
+//! non-JSX Markdown. PascalCase JSX is covered in `mdx_jsx.rs`.
 
 use ox_content_allocator::Allocator;
 use ox_content_parser::{Parser, ParserOptions};
@@ -26,7 +26,7 @@ fn assert_mdx_flag_is_noop(source: &str, mut options: ParserOptions) {
     let on = pretty_ast(source, options);
     assert_eq!(
         off, on,
-        "ParserOptions.mdx must not change parse output until MDX syntax lands\n--- mdx=false ---\n{off}\n--- mdx=true ---\n{on}"
+        "ParserOptions.mdx must not change parse output for non-JSX Markdown\n--- mdx=false ---\n{off}\n--- mdx=true ---\n{on}"
     );
 }
 
@@ -135,16 +135,6 @@ fn mdx_flag_is_noop_for_gfm_task_list() {
 }
 
 #[test]
-fn mdx_flag_is_noop_for_jsx_looking_flow() {
-    assert_mdx_flag_is_noop("<Alert title=\"hi\" />\n", ParserOptions::default());
-}
-
-#[test]
-fn mdx_flag_is_noop_for_jsx_looking_text() {
-    assert_mdx_flag_is_noop("Hello <Badge /> world.\n", ParserOptions::default());
-}
-
-#[test]
 fn mdx_flag_is_noop_for_import_line() {
     assert_mdx_flag_is_noop("import { Chart } from './Chart'\n", ParserOptions::default());
 }
@@ -167,16 +157,5 @@ fn mdx_flag_is_noop_for_nested_blockquote() {
 #[test]
 fn mdx_false_does_not_emit_mdx_nodes_for_jsx() {
     let tree = pretty_ast("<Counter count={1} />\n", ParserOptions::default());
-    assert!(!tree.contains("MdxJsx"), "mdx=false must not emit MDX JSX nodes yet:\n{tree}");
-}
-
-#[test]
-fn mdx_true_does_not_emit_mdx_nodes_until_parse_lands() {
-    let tree = pretty_ast("<Counter count={1} />\n", ParserOptions::mdx());
-    assert!(
-        !tree.contains("MdxJsx")
-            && !tree.contains("MdxjsEsm")
-            && !tree.contains("MdxFlowExpression"),
-        "this slice only adds the option; JSX parse comes next:\n{tree}"
-    );
+    assert!(!tree.contains("MdxJsx"), "mdx=false must not emit MDX JSX nodes:\n{tree}");
 }

--- a/docs/content/mdx.md
+++ b/docs/content/mdx.md
@@ -8,10 +8,13 @@ description: Embed Vue, React, or Svelte components in Markdown using island hyd
 Ox Content lets you embed framework components inside Markdown and `.mdx` files.
 It is worth understanding how this works, because it differs from "classic" MDX:
 
-- **`.md` and `.mdx` are parsed identically** — both go through the same Rust
-  Markdown parser (CommonMark + GFM). The parser does **not** parse JSX. The
-  `.mdx` extension is simply recognised as a content file.
-- **Components are resolved by a framework plugin**, not the parser. The
+- **JSX elements parse when MDX is enabled.** With `mdx: true` /
+  `ParserOptions.mdx`, the Rust parser turns PascalCase tags into
+  `MdxJsxFlowElement` / `MdxJsxTextElement` nodes (self-closing or simple
+  open/close, with literal, boolean, and `{expr}` attributes). `.md` stays
+  CommonMark + GFM unless that option is on. `import` / `export` and
+  `{expression}` children are not parsed yet.
+- **Components are resolved by a framework plugin**, not the renderer. The
   React/Vue/Svelte plugins scan the content for PascalCase component tags,
   replace them with **island** placeholders, and hydrate them on the client.
 
@@ -69,10 +72,11 @@ Regular **Markdown** prose.
 </Callout>
 ```
 
-Only tags that start with an uppercase letter are treated as components, so your
-ordinary HTML (`<div>`, `<span>`, …) is left untouched. Tags inside fenced code
-blocks are **not** transformed, so you can document component usage without it
-being executed.
+Only tags that start with an uppercase letter are treated as JSX / components,
+so ordinary HTML (`<div>`, `<span>`, …) stays raw HTML. Tags inside fenced
+code blocks and inline code are **not** components, so you can document
+component usage without it being executed. Spreads, fragments, JSX comments,
+and `import` / `export` are not parsed yet.
 
 ### Props
 


### PR DESCRIPTION
## Summary

- Parse PascalCase JSX elements when `ParserOptions.mdx` is true: flow (`MdxJsxFlowElement`) and text (`MdxJsxTextElement`), with literal / boolean / `{expr}` attributes (expression source is stored, not evaluated).
- Support self-closing tags and simple open/close with Markdown or phrasing children. `mdx=false` / `.md` and lowercase HTML are unchanged; fences and inline code are not components.
- Document the deferred subset with passing tests: spreads, fragments, JSX comments, member names (`Foo.Bar`), `import` / `export`, and `{expression}` children.

Parent #701

## Risk

- Risk level: low
- User or production impact: none unless `mdx: true` is set. Default CommonMark / GFM output is unchanged. MDX AST nodes still render as nothing.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run: `rustup run 1.95.0 cargo test -p ox_content_parser` and `clippy -D warnings`
- [x] Manual verification completed: existing CommonMark/GFM snapshots still pass; `mdx_options` noops remain for non-JSX Markdown
- [x] Edge cases or failure modes considered: unclosed `<Alert` does not panic or emit JSX; `title="<script>"` is a literal; expression attrs keep source (`1+1`)

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

## Test plan

- [ ] CI green on this PR
- [ ] Confirm `.md` / `mdx=false` fixtures and CommonMark/GFM spec tests are unchanged
- [ ] Confirm `<Alert title="hi" />` is flow JSX and `Hello <Badge /> world.` is text JSX when `mdx=true`
- [ ] Confirm spreads, fragments, JSX comments, and `import` / `export` still do not emit MDX nodes


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790152194&installation_model_id=422833&pr_number=722&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F722&signature=bc4862416b5208d1813804ef1099c7eec86052410b964a41ff8c0709ae50f9f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->