### PR TITLE
feat(mdx): parse import and export as MdxjsEsm

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -22,6 +22,7 @@ mod leaf;
 mod line_scan;
 mod list;
 mod list_item;
+mod mdx_esm;
 mod mdx_jsx;
 mod prepass;
 mod reference;
@@ -91,8 +92,10 @@ pub struct ParserOptions {
     /// Enable MDX. Off by default.
     ///
     /// When set, PascalCase JSX elements parse as [`ox_content_ast::MdxJsxFlowElement`]
-    /// / [`ox_content_ast::MdxJsxTextElement`]. `import` / `export` and
-    /// `{expression}` children are not parsed yet. Lowercase HTML stays HTML.
+    /// / [`ox_content_ast::MdxJsxTextElement`], and module-level `import` /
+    /// `export` parse as [`ox_content_ast::MdxjsEsm`] (raw source, not evaluated).
+    /// `{expression}` children, fragments, and spreads are not parsed yet.
+    /// Lowercase HTML stays HTML.
     ///
     /// Default: `false`.
     pub mdx: bool,

--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -110,6 +110,13 @@ impl<'a> Parser<'a> {
                     return self.parse_list(start, line_indent, first_item, line.len());
                 }
             }
+            b'i' | b'e' => {
+                if self.options.mdx
+                    && let Some(node) = self.try_parse_mdxjs_esm(start, trimmed_start)
+                {
+                    return Ok(Some(node));
+                }
+            }
             _ => {}
         }
 

--- a/crates/ox_content_parser/src/parser/cursor.rs
+++ b/crates/ox_content_parser/src/parser/cursor.rs
@@ -167,6 +167,7 @@ impl<'a> Parser<'a> {
                 let line = self.line_at(line_start);
                 Self::try_parse_list_interrupt(&line[trimmed_start - line_start..])
             }
+            b'i' | b'e' => self.options.mdx && super::mdx_esm::looks_like_esm(bytes, trimmed_start),
             _ => false,
         };
 

--- a/crates/ox_content_parser/src/parser/mdx_esm.rs
+++ b/crates/ox_content_parser/src/parser/mdx_esm.rs
@@ -1,0 +1,189 @@
+//! Module-level MDX `import` / `export` (`MdxjsEsm`).
+//!
+//! Recognition is keyword-based (`import` / `export` plus a boundary). The
+//! statement is closed by a naive brace / paren / bracket / string / comment
+//! scan — not a JavaScript parser. Source is stored and never evaluated.
+//!
+//! Limits: regex literals, ASI edge cases, and `${}` inside templates are not
+//! fully handled. Import resolution and hydration are left to framework plugins.
+
+use ox_content_ast::{MdxjsEsm, Node, Span};
+
+use super::Parser;
+
+#[inline]
+pub(super) fn looks_like_esm(bytes: &[u8], at: usize) -> bool {
+    keyword_then_boundary(bytes, at, b"import") || keyword_then_boundary(bytes, at, b"export")
+}
+
+fn keyword_then_boundary(bytes: &[u8], at: usize, keyword: &[u8]) -> bool {
+    let rest = bytes.get(at..).unwrap_or(&[]);
+    if !rest.starts_with(keyword) {
+        return false;
+    }
+    match rest.get(keyword.len()) {
+        None => true,
+        Some(b) => is_keyword_boundary(*b),
+    }
+}
+
+fn is_keyword_boundary(b: u8) -> bool {
+    matches!(b, b' ' | b'\t' | b'\n' | b'\r' | b'{' | b'*' | b'\'' | b'"' | b'`' | b'/')
+}
+
+#[derive(Clone, Copy)]
+enum Scan {
+    Normal,
+    Squote,
+    Dquote,
+    Template,
+    LineComment,
+    BlockComment,
+}
+
+/// Returns the exclusive end of the ESM construct, including a trailing newline.
+fn scan_esm_statement(source: &str, start: usize) -> usize {
+    let bytes = source.as_bytes();
+    let mut i = start;
+    let mut brace = 0u32;
+    let mut paren = 0u32;
+    let mut bracket = 0u32;
+    let mut state = Scan::Normal;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+        match state {
+            Scan::Normal => match b {
+                b'{' => {
+                    brace += 1;
+                    i += 1;
+                }
+                b'}' => {
+                    brace = brace.saturating_sub(1);
+                    i += 1;
+                }
+                b'(' => {
+                    paren += 1;
+                    i += 1;
+                }
+                b')' => {
+                    paren = paren.saturating_sub(1);
+                    i += 1;
+                }
+                b'[' => {
+                    bracket += 1;
+                    i += 1;
+                }
+                b']' => {
+                    bracket = bracket.saturating_sub(1);
+                    i += 1;
+                }
+                b'\'' => {
+                    state = Scan::Squote;
+                    i += 1;
+                }
+                b'"' => {
+                    state = Scan::Dquote;
+                    i += 1;
+                }
+                b'`' => {
+                    state = Scan::Template;
+                    i += 1;
+                }
+                b'/' => match bytes.get(i + 1) {
+                    Some(b'/') => {
+                        state = Scan::LineComment;
+                        i += 2;
+                    }
+                    Some(b'*') => {
+                        state = Scan::BlockComment;
+                        i += 2;
+                    }
+                    _ => i += 1,
+                },
+                b';' if brace == 0 && paren == 0 && bracket == 0 => {
+                    return after_trailing_line_ws(bytes, i + 1);
+                }
+                b'\n' if brace == 0 && paren == 0 && bracket == 0 => return i + 1,
+                _ => i += 1,
+            },
+            Scan::Squote => {
+                if b == b'\\' {
+                    i = (i + 2).min(bytes.len());
+                } else if b == b'\'' {
+                    state = Scan::Normal;
+                    i += 1;
+                } else {
+                    i += 1;
+                }
+            }
+            Scan::Dquote => {
+                if b == b'\\' {
+                    i = (i + 2).min(bytes.len());
+                } else if b == b'"' {
+                    state = Scan::Normal;
+                    i += 1;
+                } else {
+                    i += 1;
+                }
+            }
+            Scan::Template => {
+                if b == b'\\' {
+                    i = (i + 2).min(bytes.len());
+                } else if b == b'`' {
+                    state = Scan::Normal;
+                    i += 1;
+                } else {
+                    i += 1;
+                }
+            }
+            Scan::LineComment => {
+                if b == b'\n' {
+                    if brace == 0 && paren == 0 && bracket == 0 {
+                        return i + 1;
+                    }
+                    state = Scan::Normal;
+                }
+                i += 1;
+            }
+            Scan::BlockComment => {
+                if b == b'*' && bytes.get(i + 1) == Some(&b'/') {
+                    state = Scan::Normal;
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+        }
+    }
+    bytes.len()
+}
+
+fn after_trailing_line_ws(bytes: &[u8], mut cursor: usize) -> usize {
+    while cursor < bytes.len() && matches!(bytes[cursor], b' ' | b'\t' | b'\r') {
+        cursor += 1;
+    }
+    if cursor < bytes.len() && bytes[cursor] == b'\n' { cursor + 1 } else { cursor }
+}
+
+impl<'a> Parser<'a> {
+    /// Parses a module-level `import` / `export` starting at the current line.
+    ///
+    /// On mismatch the cursor is left unchanged so paragraph dispatch can run.
+    /// Unbalanced braces and hostile strings store source and do not panic.
+    pub(super) fn try_parse_mdxjs_esm(
+        &mut self,
+        start: usize,
+        trimmed_start: usize,
+    ) -> Option<Node<'a>> {
+        if !self.options.mdx || !looks_like_esm(self.source.as_bytes(), trimmed_start) {
+            return None;
+        }
+        let end = scan_esm_statement(self.source, trimmed_start);
+        self.position = end;
+        Some(Node::MdxjsEsm(MdxjsEsm {
+            value: self.source[trimmed_start..end].trim_end(),
+            span: Span::new(start as u32, end as u32),
+        }))
+    }
+}

--- a/crates/ox_content_parser/tests/mdx_esm.rs
+++ b/crates/ox_content_parser/tests/mdx_esm.rs
@@ -1,0 +1,137 @@
+//! Module-level `import` / `export` (`MdxjsEsm`) when `ParserOptions.mdx` is true.
+//!
+//! This slice stores raw ESM source. It does not evaluate JavaScript, resolve
+//! imports, or hydrate components. Fences and inline code are not ESM.
+
+use ox_content_allocator::Allocator;
+use ox_content_parser::{Parser, ParserOptions};
+
+#[path = "support/pretty.rs"]
+mod pretty;
+
+fn pretty_ast(source: &str, options: ParserOptions) -> String {
+    let allocator = Allocator::new();
+    let doc = Parser::with_options(&allocator, source, options)
+        .parse()
+        .expect("parser should not fail on MDX ESM fixtures");
+    let mut out = String::new();
+    pretty::format_document(&doc, source, &mut out);
+    out
+}
+
+fn mdx_tree(source: &str) -> String {
+    pretty_ast(source, ParserOptions::mdx())
+}
+
+fn assert_esm_value(tree: &str, value: &str) {
+    let needle = format!("MdxjsEsm value={value:?}");
+    assert!(tree.contains(&needle), "expected {needle} in:\n{tree}");
+}
+
+#[test]
+fn mdx_false_import_stays_paragraph() {
+    let tree = pretty_ast("import { Chart } from './Chart'\n", ParserOptions::default());
+    assert!(tree.contains("Paragraph"), "mdx=false import stays a paragraph:\n{tree}");
+    assert!(tree.contains("Text \"import { Chart } from './Chart'\""), "expected text:\n{tree}");
+    assert!(!tree.contains("MdxjsEsm"), "mdx=false must not emit MdxjsEsm:\n{tree}");
+}
+
+#[test]
+fn mdx_false_export_stays_paragraph() {
+    let tree = pretty_ast("export const meta = { title: 'Hi' }\n", ParserOptions::default());
+    assert!(tree.contains("Paragraph"), "mdx=false export stays a paragraph:\n{tree}");
+    assert!(!tree.contains("MdxjsEsm"), "mdx=false must not emit MdxjsEsm:\n{tree}");
+}
+
+#[test]
+fn import_named_is_esm() {
+    let tree = mdx_tree("import { Chart } from './Chart'\n");
+    assert_esm_value(&tree, "import { Chart } from './Chart'");
+    assert!(!tree.contains("Paragraph"), "top-level import must not wrap in a paragraph:\n{tree}");
+}
+
+#[test]
+fn export_const_is_esm() {
+    let tree = mdx_tree("export const meta = { title: 'Hi' }\n");
+    assert_esm_value(&tree, "export const meta = { title: 'Hi' }");
+    assert!(!tree.contains("Paragraph"), "top-level export must not wrap in a paragraph:\n{tree}");
+}
+
+#[test]
+fn consecutive_import_then_export() {
+    let tree = mdx_tree("import { Chart } from './Chart'\nexport const meta = { title: 'Hi' }\n");
+    assert_esm_value(&tree, "import { Chart } from './Chart'");
+    assert_esm_value(&tree, "export const meta = { title: 'Hi' }");
+    assert_eq!(tree.matches("MdxjsEsm").count(), 2, "expected two ESM nodes:\n{tree}");
+}
+
+#[test]
+fn multiline_import() {
+    let source = "import {\n  Chart\n} from './Chart'\n";
+    let tree = mdx_tree(source);
+    assert_esm_value(&tree, "import {\n  Chart\n} from './Chart'");
+    assert!(!tree.contains("Paragraph"), "multiline import is one ESM node:\n{tree}");
+}
+
+#[test]
+fn multiline_export() {
+    let source = "export const meta = {\n  title: 'Hi',\n}\n";
+    let tree = mdx_tree(source);
+    assert_esm_value(&tree, "export const meta = {\n  title: 'Hi',\n}");
+}
+
+#[test]
+fn fenced_import_is_not_esm() {
+    let tree = mdx_tree("```js\nimport { Chart } from './Chart'\n```\n");
+    assert!(tree.contains("Code"), "expected a fence:\n{tree}");
+    assert!(!tree.contains("MdxjsEsm"), "fence contents are not ESM:\n{tree}");
+}
+
+#[test]
+fn inline_code_import_is_not_esm() {
+    let tree = mdx_tree("Use `import { Chart } from './Chart'` in prose.\n");
+    assert!(tree.contains("InlineCode"), "expected inline code:\n{tree}");
+    assert!(!tree.contains("MdxjsEsm"), "inline code is not ESM:\n{tree}");
+}
+
+#[test]
+fn hostile_script_string_stores_source_without_panic() {
+    let source = "import x from \"<script>\"\n";
+    let tree = mdx_tree(source);
+    assert_esm_value(&tree, "import x from \"<script>\"");
+    assert!(!tree.contains("<script>alert"), "source is stored, not evaluated:\n{tree}");
+}
+
+#[test]
+fn important_word_is_not_esm() {
+    let tree = mdx_tree("important note\n");
+    assert!(tree.contains("Paragraph"), "identifier prefix must stay prose:\n{tree}");
+    assert!(!tree.contains("MdxjsEsm"), "`important` is not `import`:\n{tree}");
+}
+
+#[test]
+fn esm_then_heading_and_jsx() {
+    let tree = mdx_tree("import { Chart } from './Chart'\n\n# Title\n\n<Chart />\n");
+    assert_esm_value(&tree, "import { Chart } from './Chart'");
+    assert!(tree.contains("Heading"), "markdown after ESM still parses:\n{tree}");
+    assert!(
+        tree.contains("MdxJsxFlowElement name=Some(\"Chart\")"),
+        "JSX after ESM must stay green:\n{tree}"
+    );
+}
+
+#[test]
+fn value_is_source_not_evaluated() {
+    let tree = mdx_tree("export const n = 1 + 1\n");
+    assert_esm_value(&tree, "export const n = 1 + 1");
+    assert!(!tree.contains("value=\"2\""), "must not evaluate JS:\n{tree}");
+}
+
+#[test]
+fn unclosed_import_does_not_panic() {
+    let tree = mdx_tree("import {\n");
+    assert!(
+        tree.contains("MdxjsEsm") || tree.contains("Paragraph"),
+        "unclosed import must not panic:\n{tree}"
+    );
+}

--- a/crates/ox_content_parser/tests/mdx_jsx.rs
+++ b/crates/ox_content_parser/tests/mdx_jsx.rs
@@ -2,8 +2,9 @@
 //!
 //! This slice covers PascalCase elements (flow + text), literal / boolean /
 //! `{expr}` attributes, self-closing tags, and simple open/close children.
-//! Lowercase HTML stays `Html`. Spreads, fragments, JSX comments, ESM, and
+//! Lowercase HTML stays `Html`. Spreads, fragments, JSX comments, and
 //! `{expression}` children are deferred — tests below pin that subset.
+//! Module-level `import` / `export` is covered in `mdx_esm.rs`.
 
 use ox_content_allocator::Allocator;
 use ox_content_parser::{Parser, ParserOptions};

--- a/crates/ox_content_parser/tests/mdx_options.rs
+++ b/crates/ox_content_parser/tests/mdx_options.rs
@@ -1,7 +1,8 @@
 //! Strict tests for `ParserOptions.mdx`.
 //!
 //! Enabling the flag must not change CommonMark or GFM parse output for
-//! non-JSX Markdown. PascalCase JSX is covered in `mdx_jsx.rs`.
+//! non-JSX, non-ESM Markdown. PascalCase JSX is covered in `mdx_jsx.rs`.
+//! Module-level `import` / `export` is covered in `mdx_esm.rs`.
 
 use ox_content_allocator::Allocator;
 use ox_content_parser::{Parser, ParserOptions};
@@ -132,16 +133,6 @@ fn mdx_flag_is_noop_for_gfm_table() {
 #[test]
 fn mdx_flag_is_noop_for_gfm_task_list() {
     assert_mdx_flag_is_noop("- [ ] todo\n- [x] done\n", ParserOptions::gfm());
-}
-
-#[test]
-fn mdx_flag_is_noop_for_import_line() {
-    assert_mdx_flag_is_noop("import { Chart } from './Chart'\n", ParserOptions::default());
-}
-
-#[test]
-fn mdx_flag_is_noop_for_export_line() {
-    assert_mdx_flag_is_noop("export const meta = { title: 'Hi' }\n", ParserOptions::default());
 }
 
 #[test]

--- a/docs/content/mdx.md
+++ b/docs/content/mdx.md
@@ -8,12 +8,14 @@ description: Embed Vue, React, or Svelte components in Markdown using island hyd
 Ox Content lets you embed framework components inside Markdown and `.mdx` files.
 It is worth understanding how this works, because it differs from "classic" MDX:
 
-- **JSX elements parse when MDX is enabled.** With `mdx: true` /
-  `ParserOptions.mdx`, the Rust parser turns PascalCase tags into
-  `MdxJsxFlowElement` / `MdxJsxTextElement` nodes (self-closing or simple
-  open/close, with literal, boolean, and `{expr}` attributes). `.md` stays
-  CommonMark + GFM unless that option is on. `import` / `export` and
-  `{expression}` children are not parsed yet.
+- **JSX elements and module-level `import` / `export` parse when MDX is
+  enabled.** With `mdx: true` / `ParserOptions.mdx`, the Rust parser turns
+  PascalCase tags into `MdxJsxFlowElement` / `MdxJsxTextElement` nodes
+  (self-closing or simple open/close, with literal, boolean, and `{expr}`
+  attributes), and turns file-level `import` / `export` into `MdxjsEsm`
+  nodes (raw source, not evaluated). `.md` stays CommonMark + GFM unless
+  that option is on. `{expression}` children, fragments, and spreads are
+  not parsed yet.
 - **Components are resolved by a framework plugin**, not the renderer. The
   React/Vue/Svelte plugins scan the content for PascalCase component tags,
   replace them with **island** placeholders, and hydrate them on the client.
@@ -75,8 +77,17 @@ Regular **Markdown** prose.
 Only tags that start with an uppercase letter are treated as JSX / components,
 so ordinary HTML (`<div>`, `<span>`, …) stays raw HTML. Tags inside fenced
 code blocks and inline code are **not** components, so you can document
-component usage without it being executed. Spreads, fragments, JSX comments,
-and `import` / `export` are not parsed yet.
+component usage without it being executed.
+
+Module-level `import` and `export` at the start of a file (and after other
+ESM) become `MdxjsEsm` nodes. Multi-line statements are collected with a
+naive brace / paren / string / comment scan — not a JavaScript parser —
+so regex literals and `${}` inside templates may confuse statement
+boundaries. `import` / `export` inside fences or inline code is not ESM.
+Hostile strings such as `import x from "<script>"` store source and do not
+panic. The HTML renderer currently emits nothing for `MdxjsEsm`; framework
+plugins will resolve imports later. Spreads, fragments, and JSX comments
+are not parsed yet.
 
 ### Props
 


### PR DESCRIPTION
## Summary

- Parse module-level `import` / `export` as `MdxjsEsm` when `ParserOptions.mdx` is true. Source is stored, not evaluated. `mdx=false` keeps import/export as paragraphs.
- Multi-line statements use a naive brace / paren / string / comment scan (not a JS parser). Fences and inline code are not ESM. Hostile strings such as `import x from "<script>"` store source and do not panic.
- HTML renderer still no-ops `MdxjsEsm`; framework plugins will resolve imports later. Fragments, spreads, import resolution, and hydration stay deferred.

Parent #701

## Risk

- Risk level: low
- User or production impact: none unless `mdx: true` is set. Default CommonMark / GFM output is unchanged. `MdxjsEsm` still renders as nothing.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run: `rustup run 1.95.0 cargo test -p ox_content_parser` and `clippy -D warnings`
- [x] Manual verification completed: JSX tests stay green; `mdx_options` noops remain for non-JSX / non-ESM Markdown
- [x] Edge cases or failure modes considered: `important` is not ESM; fence/inline code stay non-ESM; unclosed `import {` does not panic

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

## Test plan

- [ ] CI green on this PR
- [ ] Confirm `.md` / `mdx=false` fixtures and CommonMark/GFM spec tests are unchanged
- [ ] Confirm `import { Chart } from './Chart'` and `export const meta = { title: 'Hi' }` are `MdxjsEsm` when `mdx=true`
- [ ] Confirm fences, inline code, and `important note` do not emit `MdxjsEsm`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790153937&installation_model_id=422833&pr_number=729&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F729&signature=bd7ee5fb6e557ea0b134e0238debe4ae1168a86851db878c6dca6c3adca405fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->