### PR TITLE
feat(ssg): add opt-in redirects and aliases

### DIFF
--- a/crates/ox_content_ssg/src/lib.rs
+++ b/crates/ox_content_ssg/src/lib.rs
@@ -56,6 +56,7 @@
 
 mod assets;
 mod html;
+mod redirects;
 mod routes;
 mod site_maps;
 mod vitepress;
@@ -69,6 +70,10 @@ pub use html::{
     SocialLinks, SsgConfig, ThemeColors, ThemeConfig, ThemeEmbed, ThemeEntryPage, ThemeFonts,
     ThemeFooter, ThemeHeader, ThemeLayout, TocEntry, generate_bare_html, generate_bare_page,
     generate_html,
+};
+pub use redirects::{
+    RedirectEntry, RedirectPage, RedirectsOptions, RedirectsOutput, generate_redirect_html,
+    generate_redirects, is_safe_dest, normalize_path,
 };
 pub use routes::{
     ManualNavigationGroup, ManualNavigationItem, RoutePaths, SidebarItem, build_nav_items,

--- a/crates/ox_content_ssg/src/redirects.rs
+++ b/crates/ox_content_ssg/src/redirects.rs
@@ -1,0 +1,167 @@
+//! Opt-in static redirect HTML and optional host `_redirects` bodies.
+
+use rustc_hash::FxHashMap;
+
+/// One published page that may declare aliases or a single `redirect` source.
+#[derive(Debug, Clone)]
+pub struct RedirectPage {
+    /// Current page path. Aliases and `redirect` point here.
+    pub dest: String,
+    /// Frontmatter `aliases` — each value is an old path.
+    pub aliases: Vec<String>,
+    /// Frontmatter `redirect` — a single extra old path.
+    pub redirect: Option<String>,
+}
+
+/// Switches and the config rewrite map.
+#[derive(Debug, Clone, Default)]
+pub struct RedirectsOptions {
+    /// When false, no files or host rules are generated.
+    pub enabled: bool,
+    /// Config map from old path to new path, in author order.
+    pub map: Vec<(String, String)>,
+    /// When true, also build a Netlify-style `_redirects` body.
+    pub netlify: bool,
+}
+
+/// One static HTML redirect to write at `from`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RedirectEntry {
+    /// Normalized source path (`/old`).
+    pub from: String,
+    /// Normalized destination path (`/guide`).
+    pub to: String,
+    /// Escaped static HTML body.
+    pub html: String,
+}
+
+/// Generated redirect pages and an optional host rewrite file.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RedirectsOutput {
+    /// Static HTML redirects, first-seen source order, last-wins dest.
+    pub pages: Vec<RedirectEntry>,
+    /// Netlify `_redirects` body when requested.
+    pub netlify: Option<String>,
+}
+
+/// Builds redirect HTML (and optional `_redirects`) without writing files.
+pub fn generate_redirects(options: &RedirectsOptions, pages: &[RedirectPage]) -> RedirectsOutput {
+    if !options.enabled {
+        return RedirectsOutput::default();
+    }
+
+    let mut entries = Vec::new();
+    let mut index: FxHashMap<String, usize> = FxHashMap::default();
+
+    for page in pages {
+        let Some(to) = normalize_path(&page.dest) else {
+            continue;
+        };
+        for alias in &page.aliases {
+            upsert(&mut entries, &mut index, alias, &to);
+        }
+        if let Some(redirect) = page.redirect.as_deref() {
+            upsert(&mut entries, &mut index, redirect, &to);
+        }
+    }
+    for (from, to) in &options.map {
+        let Some(to) = normalize_path(to) else {
+            continue;
+        };
+        upsert(&mut entries, &mut index, from, &to);
+    }
+
+    let netlify = options.netlify.then(|| netlify_body(&entries));
+    RedirectsOutput { pages: entries, netlify }
+}
+
+/// Static HTML redirect body. `dest` is escaped; callers still validate it.
+pub fn generate_redirect_html(dest: &str) -> String {
+    let escaped = escape_html(dest);
+    format!(
+        "<!DOCTYPE html>\n\
+         <html lang=\"en\">\n\
+         <head>\n\
+         <meta charset=\"utf-8\">\n\
+         <meta http-equiv=\"refresh\" content=\"0;url={escaped}\">\n\
+         <link rel=\"canonical\" href=\"{escaped}\">\n\
+         <title>Redirecting</title>\n\
+         </head>\n\
+         <body>\n\
+         <p>Redirecting to <a href=\"{escaped}\">{escaped}</a>.</p>\n\
+         </body>\n\
+         </html>\n"
+    )
+}
+
+/// Same-origin path: leading `/`, not `//`, and no scheme.
+pub fn is_safe_dest(value: &str) -> bool {
+    let trimmed = value.trim();
+    if !trimmed.starts_with('/') || trimmed.starts_with("//") {
+        return false;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    !lower.contains("javascript:") && !lower.contains("data:") && !lower.contains("://")
+}
+
+/// Strips a trailing slash except for `/`. Unsafe values become `None`.
+pub fn normalize_path(value: &str) -> Option<String> {
+    if !is_safe_dest(value) {
+        return None;
+    }
+    let trimmed = value.trim();
+    if trimmed == "/" {
+        return Some("/".to_string());
+    }
+    Some(trimmed.trim_end_matches('/').to_string())
+}
+
+fn upsert(
+    entries: &mut Vec<RedirectEntry>,
+    index: &mut FxHashMap<String, usize>,
+    from: &str,
+    to: &str,
+) {
+    let Some(from) = normalize_path(from) else {
+        return;
+    };
+    if from == to {
+        return;
+    }
+    if let Some(slot) = index.get(&from).copied() {
+        entries[slot].to = to.to_string();
+        entries[slot].html = generate_redirect_html(to);
+        return;
+    }
+    index.insert(from.clone(), entries.len());
+    entries.push(RedirectEntry { from, to: to.to_string(), html: generate_redirect_html(to) });
+}
+
+fn netlify_body(entries: &[RedirectEntry]) -> String {
+    let mut body = String::new();
+    for entry in entries {
+        body.push_str(&entry.from);
+        body.push(' ');
+        body.push_str(&entry.to);
+        body.push_str(" 301\n");
+    }
+    body
+}
+
+fn escape_html(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '&' => output.push_str("&amp;"),
+            '<' => output.push_str("&lt;"),
+            '>' => output.push_str("&gt;"),
+            '"' => output.push_str("&quot;"),
+            '\'' => output.push_str("&#39;"),
+            _ => output.push(ch),
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/ox_content_ssg/src/redirects/tests.rs
+++ b/crates/ox_content_ssg/src/redirects/tests.rs
@@ -1,0 +1,147 @@
+use super::{
+    RedirectPage, RedirectsOptions, generate_redirect_html, generate_redirects, is_safe_dest,
+};
+
+fn page(dest: &str, aliases: &[&str], redirect: Option<&str>) -> RedirectPage {
+    RedirectPage {
+        dest: dest.to_string(),
+        aliases: aliases.iter().map(|alias| (*alias).to_string()).collect(),
+        redirect: redirect.map(str::to_string),
+    }
+}
+
+fn enabled(map: &[(&str, &str)]) -> RedirectsOptions {
+    RedirectsOptions {
+        enabled: true,
+        map: map.iter().map(|(from, to)| ((*from).to_string(), (*to).to_string())).collect(),
+        netlify: false,
+    }
+}
+
+fn html_for(dest: &str) -> String {
+    generate_redirects(&enabled(&[]), &[page(dest, &["/old"], None)])
+        .pages
+        .into_iter()
+        .find(|entry| entry.from == "/old")
+        .map(|entry| entry.html)
+        .unwrap_or_default()
+}
+
+#[test]
+fn disabled_by_default() {
+    let output =
+        generate_redirects(&RedirectsOptions::default(), &[page("/guide", &["/old"], None)]);
+
+    assert!(output.pages.is_empty(), "{output:?}");
+    assert_eq!(output.netlify, None);
+}
+
+#[test]
+fn frontmatter_alias_emits_redirect_html() {
+    let output = generate_redirects(&enabled(&[]), &[page("/guide", &["/old", "/legacy"], None)]);
+
+    assert_eq!(output.pages.len(), 2, "{output:?}");
+    assert_eq!(output.pages[0].from, "/old");
+    assert_eq!(output.pages[0].to, "/guide");
+    assert!(output.pages[0].html.contains("url=/guide"), "{}", output.pages[0].html);
+    assert!(
+        output.pages[0].html.contains(r#"<link rel="canonical" href="/guide">"#),
+        "{}",
+        output.pages[0].html
+    );
+    assert_eq!(output.pages[1].from, "/legacy");
+    assert_eq!(output.pages[1].to, "/guide");
+}
+
+#[test]
+fn config_map_emits_redirect() {
+    let output = generate_redirects(&enabled(&[("/old-guide", "/guide")]), &[]);
+
+    assert_eq!(output.pages.len(), 1, "{output:?}");
+    assert_eq!(output.pages[0].from, "/old-guide");
+    assert_eq!(output.pages[0].to, "/guide");
+    assert!(output.pages[0].html.contains(r#"href="/guide""#), "{}", output.pages[0].html);
+}
+
+#[test]
+fn javascript_destination_rejected() {
+    let output = generate_redirects(
+        &enabled(&[("/old", "javascript:alert(1)")]),
+        &[page("javascript:alert(1)", &["/legacy"], None)],
+    );
+
+    assert!(output.pages.is_empty(), "{output:?}");
+    assert!(!is_safe_dest("javascript:alert(1)"));
+    assert!(!is_safe_dest("JAVASCRIPT:alert(1)"));
+}
+
+#[test]
+fn protocol_relative_destination_rejected() {
+    let output = generate_redirects(
+        &enabled(&[("/old", "//evil.example"), ("/also", "https://evil.example")]),
+        &[page("//evil.example", &["/legacy"], None)],
+    );
+
+    assert!(output.pages.is_empty(), "{output:?}");
+    assert!(!is_safe_dest("//evil.example"));
+    assert!(!is_safe_dest("https://evil.example"));
+    assert!(!is_safe_dest("data:text/html,hi"));
+}
+
+#[test]
+fn trailing_slash_normalization() {
+    let output = generate_redirects(
+        &enabled(&[("/old/", "/guide/"), ("/old", "/other")]),
+        &[page("/page/", &["/alias/"], None)],
+    );
+
+    let from_old = output.pages.iter().find(|entry| entry.from == "/old").expect("normalized /old");
+    assert_eq!(from_old.to, "/other", "last-wins after slash folding: {output:?}");
+    assert!(output.pages.iter().all(|entry| entry.from != "/old/"), "{output:?}");
+
+    let from_alias =
+        output.pages.iter().find(|entry| entry.from == "/alias").expect("normalized /alias/");
+    assert_eq!(from_alias.to, "/page");
+}
+
+#[test]
+fn hostile_dest_escaped_in_html() {
+    let html = html_for("/foo<bar>");
+
+    assert!(!html.contains("url=/foo<bar>"), "{html}");
+    assert!(!html.contains(r#"href="/foo<bar>""#), "{html}");
+    assert!(html.contains("url=/foo&lt;bar&gt;"), "{html}");
+    assert!(html.contains(r#"href="/foo&lt;bar&gt;""#), "{html}");
+    assert_eq!(generate_redirect_html("/foo<bar>"), html);
+}
+
+#[test]
+fn overlapping_rules_last_wins() {
+    let output = generate_redirects(
+        &enabled(&[("/old", "/first"), ("/old", "/second")]),
+        &[page("/frontmatter", &["/old"], None)],
+    );
+
+    assert_eq!(output.pages.len(), 1, "{output:?}");
+    assert_eq!(output.pages[0].to, "/second");
+}
+
+#[test]
+fn frontmatter_redirect_is_an_alias() {
+    let output = generate_redirects(&enabled(&[]), &[page("/guide", &[], Some("/legacy"))]);
+
+    assert_eq!(output.pages.len(), 1, "{output:?}");
+    assert_eq!(output.pages[0].from, "/legacy");
+    assert_eq!(output.pages[0].to, "/guide");
+}
+
+#[test]
+fn netlify_body_is_opt_in() {
+    let off = generate_redirects(&enabled(&[("/old", "/guide")]), &[]);
+    assert_eq!(off.netlify, None);
+
+    let mut on = enabled(&[("/old", "/guide")]);
+    on.netlify = true;
+    let output = generate_redirects(&on, &[]);
+    assert_eq!(output.netlify.as_deref(), Some("/old /guide 301\n"));
+}

--- a/docs/content/built-in-features.md
+++ b/docs/content/built-in-features.md
@@ -36,6 +36,7 @@ inline**.
 | [Site Generation](./built-in/site-generation.md)       | SSG, OG images, edit links, collections, API docs, transformers           |
 | [Previous / Next](./built-in/pagination.md)            | Opt-in previous and next page links                                       |
 | [Sitemap / robots / llms.txt](./built-in/site-maps.md) | Opt-in crawl manifests written next to generated HTML                     |
+| [Redirects and aliases](./built-in/redirects.md)       | Opt-in static HTML redirects from aliases and a rewrite map               |
 
 ## Default vs Opt-in
 
@@ -61,6 +62,7 @@ inline**.
 | Editing links    | `editThisPage`                                                                                                | `false`              | [Site Generation](./built-in/site-generation.md)       |
 | Page pager       | `ssg.pagination`                                                                                              | `false`              | [Previous / Next](./built-in/pagination.md)            |
 | Crawl manifests  | `siteMaps`                                                                                                    | `false`              | [Sitemap / robots / llms.txt](./built-in/site-maps.md) |
+| Redirects        | `redirects`                                                                                                   | `false`              | [Redirects and aliases](./built-in/redirects.md)       |
 | Code checks      | `codeBlockLint`, `codeBlockTypecheck`, `docsTests`                                                            | `false`              | [Quality Checks](./built-in/quality-checks.md)         |
 | Custom pipeline  | `transformers`                                                                                                | `[]`                 | [Site Generation](./built-in/site-generation.md)       |
 

--- a/docs/content/built-in/redirects.md
+++ b/docs/content/built-in/redirects.md
@@ -1,0 +1,92 @@
+---
+title: Redirects and aliases
+description: Opt-in static HTML redirects from frontmatter aliases and a rewrite map.
+---
+
+# Redirects and aliases
+
+When `redirects` is enabled, the SSG build writes a small static HTML page at
+each old path. The page uses a meta refresh and a canonical link so inbound
+URLs keep working after a rename.
+
+The feature is off unless you turn it on. Existing sites stay unchanged. This
+documentation site does not enable a live redirect.
+
+```ts
+import { oxContent } from "@ox-content/vite-plugin";
+
+export default {
+  plugins: [
+    oxContent({
+      redirects: true,
+    }),
+  ],
+};
+```
+
+`false` or omitted writes nothing. `true` or `{}` enables the defaults. A path
+map enables the feature with those rewrites. An options object enables the
+feature and overrides only the fields you set:
+
+```ts
+oxContent({
+  redirects: {
+    map: {
+      "/old-guide": "/guide",
+    },
+  },
+});
+```
+
+| Option         | Type                                      | Default |
+| -------------- | ----------------------------------------- | ------- |
+| `redirects`    | `boolean` / path map / `RedirectsOptions` | `false` |
+| `map`          | `Record<string, string>`                  | `{}`    |
+| `netlify`      | `boolean`                                 | `false` |
+| `writeNetlify` | alias for `netlify`                       | `false` |
+
+## Frontmatter
+
+On a page, `aliases` and `redirect` name **old** paths. Each one emits a
+redirect page that points at the current page path:
+
+```md
+---
+title: Guide
+aliases:
+  - /old
+  - /legacy
+redirect: /retired
+---
+```
+
+`/old`, `/legacy`, and `/retired` each become `old/index.html`,
+`legacy/index.html`, and `retired/index.html` with a refresh to `/guide`.
+
+## Safety
+
+Destinations must be same-origin paths: they start with `/` and must not start
+with `//`. `javascript:`, `data:`, and absolute URLs such as `https://evil`
+are ignored.
+
+A destination that is allowed but contains markup characters is HTML-escaped
+in the refresh URL, canonical href, and visible link.
+
+## Trailing slashes and overlaps
+
+`/old` and `/old/` are the same source after a trailing slash is stripped
+(except `/` itself). Destinations are normalized the same way.
+
+When two rules share a normalized source, **the last rule wins**. Frontmatter
+aliases and `redirect` are applied first. The config `map` is applied last, so
+an explicit map entry overrides a page alias for the same old path.
+
+## Host `_redirects`
+
+Set `netlify: true` or `writeNetlify: true` to also write a Netlify-style
+`_redirects` file (`/old /guide 301`). The HTML pages are still written.
+
+## Related
+
+- [Site Generation](./site-generation.md)
+- [Built-in Features overview](../built-in-features.md)

--- a/docs/content/built-in/site-generation.md
+++ b/docs/content/built-in/site-generation.md
@@ -292,6 +292,7 @@ array order.
 
 - [Previous / Next](./pagination.md) — opt-in previous and next page links.
 - [Sitemap / robots / llms.txt](./site-maps.md) — opt-in crawl manifests.
+- [Redirects and aliases](./redirects.md) — opt-in static HTML redirects.
 - [Theming](../theming.md) — the theme system used by SSG.
 - [API Docs from JSDoc](../jsdoc.md) — the full `docs` option reference.
 - [Internationalization](../i18n.md) — locale-aware sites on top of SSG.

--- a/docs/content/docs-site-feature-roadmap.md
+++ b/docs/content/docs-site-feature-roadmap.md
@@ -37,7 +37,7 @@ Already tracked elsewhere:
 | --------------------------------------- | -------------------------------------------------------------- | ------- |
 | `sitemap.xml`, `robots.txt`, `llms.txt` | [#673](https://github.com/ubugeeei-prod/ox-content/issues/673) | shipped |
 | RSS / Atom / JSON feeds                 | [#674](https://github.com/ubugeeei-prod/ox-content/issues/674) | planned |
-| Redirects, aliases, and path rewrites   | [#675](https://github.com/ubugeeei-prod/ox-content/issues/675) | planned |
+| Redirects, aliases, and path rewrites   | [#675](https://github.com/ubugeeei-prod/ox-content/issues/675) | shipped |
 | Draft, unlisted, and scheduled pages    | [#676](https://github.com/ubugeeei-prod/ox-content/issues/676) | planned |
 | Custom 404 page                         | [#677](https://github.com/ubugeeei-prod/ox-content/issues/677) | planned |
 | Permalinks and frontmatter cascade      | [#678](https://github.com/ubugeeei-prod/ox-content/issues/678) | planned |

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -106,6 +106,7 @@ export default defineConfig(({ mode }) => {
                       { text: "Site Generation", link: "/built-in/site-generation.md" },
                       { text: "Previous / Next", link: "/built-in/pagination.md" },
                       { text: "Sitemap / robots / llms.txt", link: "/built-in/site-maps.md" },
+                      { text: "Redirects and aliases", link: "/built-in/redirects.md" },
                     ],
                   },
                   { text: "Theming", link: "/theming.md" },

--- a/npm/vite-plugin-ox-content/src/framework.ts
+++ b/npm/vite-plugin-ox-content/src/framework.ts
@@ -53,6 +53,7 @@ export function createFrameworkMarkdownOptions(options: FrameworkMarkdownOptions
       pagination: false,
     },
     siteMaps: { enabled: false, robots: true, llms: true },
+    redirects: { enabled: false, map: {}, netlify: false },
     gfm: options.gfm,
     frontmatter: options.frontmatter ?? false,
     toc: options.toc,

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -13,6 +13,7 @@ import { transformMarkdown } from "./transform";
 import { extractDocs, generateMarkdown, writeDocs, resolveDocsOptions } from "./docs";
 import { buildSsg, resolveSsgOptions } from "./ssg";
 import { resolveSiteMapsOptions } from "./site-maps";
+import { resolveRedirectsOptions } from "./redirects";
 import {
   resolveSearchOptions,
   buildSearchIndex,
@@ -79,6 +80,8 @@ export type {
   ResolvedSsgOptions,
   SiteMapsOptions,
   ResolvedSiteMapsOptions,
+  RedirectsOptions,
+  ResolvedRedirectsOptions,
   SearchOptions,
   ResolvedSearchOptions,
   SearchDocument,
@@ -550,6 +553,7 @@ function resolveOptions(options: OxContentOptions): ResolvedOptions {
     extensions: normalizeMarkdownExtensions(options.extensions),
     ssg: resolveSsgOptions(options.ssg),
     siteMaps: resolveSiteMapsOptions(options.siteMaps),
+    redirects: resolveRedirectsOptions(options.redirects),
     gfm: options.gfm ?? true,
     footnotes: options.footnotes ?? true,
     tables: options.tables ?? true,
@@ -942,6 +946,7 @@ export type {
 } from "./lint-files";
 export { buildSsg, resolveSsgOptions, DEFAULT_HTML_TEMPLATE } from "./ssg";
 export { resolveSiteMapsOptions } from "./site-maps";
+export { resolveRedirectsOptions } from "./redirects";
 export { resolveSearchOptions, buildSearchIndex, writeSearchIndex } from "./search";
 export {
   buildCollectionManifest,

--- a/npm/vite-plugin-ox-content/src/lint-files.ts
+++ b/npm/vite-plugin-ox-content/src/lint-files.ts
@@ -128,19 +128,23 @@ export async function lintMarkdownFiles(
   );
   const results = await lintMarkdownDocumentsAsync(sources, resolvedOptions.lintOptions);
 
-  const files = matchedFiles.map((file, index): MarkdownLintFileResult => ({
-    ...(results[index] ?? createEmptyLintResult()),
-    filePath: file.filePath,
-    relativePath: file.relativePath,
-    skipped: false,
-  }));
+  const files = matchedFiles.map(
+    (file, index): MarkdownLintFileResult => ({
+      ...(results[index] ?? createEmptyLintResult()),
+      filePath: file.filePath,
+      relativePath: file.relativePath,
+      skipped: false,
+    }),
+  );
 
   const diagnostics = files.flatMap((fileResult) =>
-    fileResult.diagnostics.map((diagnostic): MarkdownLintFileDiagnostic => ({
-      ...diagnostic,
-      filePath: fileResult.filePath,
-      relativePath: fileResult.relativePath,
-    })),
+    fileResult.diagnostics.map(
+      (diagnostic): MarkdownLintFileDiagnostic => ({
+        ...diagnostic,
+        filePath: fileResult.filePath,
+        relativePath: fileResult.relativePath,
+      }),
+    ),
   );
 
   return {

--- a/npm/vite-plugin-ox-content/src/public-exports.test.ts
+++ b/npm/vite-plugin-ox-content/src/public-exports.test.ts
@@ -32,6 +32,7 @@ describe("public export surface", () => {
       "resolveI18nOptions",
       "resolveOgImageOptions",
       "resolveSearchOptions",
+      "resolveRedirectsOptions",
       "resolveSiteMapsOptions",
       "resolveSsgOptions",
       "runDocsTests",

--- a/npm/vite-plugin-ox-content/src/redirects.test.ts
+++ b/npm/vite-plugin-ox-content/src/redirects.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { planRedirectFiles, resolveRedirectsOptions, writeRedirectFiles } from "./redirects";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("resolveRedirectsOptions", () => {
+  it("omitted => false", () => {
+    expect(resolveRedirectsOptions(undefined)).toEqual({
+      enabled: false,
+      map: {},
+      netlify: false,
+    });
+    expect(resolveRedirectsOptions(false).enabled).toBe(false);
+  });
+
+  it("true => true", () => {
+    expect(resolveRedirectsOptions(true)).toEqual({
+      enabled: true,
+      map: {},
+      netlify: false,
+    });
+  });
+
+  it("{} => true", () => {
+    expect(resolveRedirectsOptions({})).toEqual({
+      enabled: true,
+      map: {},
+      netlify: false,
+    });
+  });
+
+  it("treats a path map as enabled defaults plus that map", () => {
+    expect(resolveRedirectsOptions({ "/old-guide": "/guide" })).toEqual({
+      enabled: true,
+      map: { "/old-guide": "/guide" },
+      netlify: false,
+    });
+  });
+
+  it("enables from an options object and honors netlify aliases", () => {
+    expect(
+      resolveRedirectsOptions({
+        enabled: true,
+        map: { "/old": "/guide" },
+        writeNetlify: true,
+      }),
+    ).toEqual({
+      enabled: true,
+      map: { "/old": "/guide" },
+      netlify: true,
+    });
+    expect(resolveRedirectsOptions({ netlify: true }).netlify).toBe(true);
+  });
+});
+
+describe("planRedirectFiles", () => {
+  it("plans nothing when the feature is omitted or disabled", () => {
+    expect(planRedirectFiles({ pages: [{ dest: "/guide", aliases: ["/old"] }] })).toEqual({
+      files: [],
+    });
+    expect(
+      planRedirectFiles({
+        options: { enabled: false, map: { "/old": "/guide" }, netlify: false },
+        pages: [{ dest: "/guide", aliases: ["/old"] }],
+      }),
+    ).toEqual({ files: [] });
+  });
+
+  it("plans frontmatter alias HTML at the old pretty path", () => {
+    const plan = planRedirectFiles({
+      options: { enabled: true, map: {}, netlify: false },
+      pages: [{ dest: "/guide", aliases: ["/old", "/legacy"], redirect: "/retired" }],
+    });
+
+    expect(plan.files.map((file) => file.relativePath)).toEqual([
+      "old/index.html",
+      "legacy/index.html",
+      "retired/index.html",
+    ]);
+    expect(plan.files[0]).toMatchObject({ from: "/old", to: "/guide" });
+    expect(plan.files[0]?.html).toContain("url=/guide");
+    expect(plan.files[0]?.html).toContain('<link rel="canonical" href="/guide">');
+  });
+
+  it("plans config-map redirects and last-wins after slash folding", () => {
+    const plan = planRedirectFiles({
+      options: {
+        enabled: true,
+        map: { "/old/": "/guide/", "/old": "/other" },
+        netlify: true,
+      },
+      pages: [],
+    });
+
+    expect(plan.files).toHaveLength(1);
+    expect(plan.files[0]).toMatchObject({
+      from: "/old",
+      to: "/other",
+      relativePath: "old/index.html",
+    });
+    expect(plan.netlify).toBe("/old /other 301\n");
+  });
+
+  it("ignores open-redirect destinations", () => {
+    const plan = planRedirectFiles({
+      options: {
+        enabled: true,
+        map: {
+          "/js": "javascript:alert(1)",
+          "/proto": "//evil.example",
+          "/abs": "https://evil.example",
+        },
+        netlify: false,
+      },
+      pages: [{ dest: "javascript:alert(1)", aliases: ["/legacy"] }],
+    });
+
+    expect(plan.files).toEqual([]);
+  });
+
+  it("escapes a weird but allowed dest in the file plan HTML", () => {
+    const plan = planRedirectFiles({
+      options: { enabled: true, map: { "/old": "/foo<bar>" }, netlify: false },
+      pages: [],
+    });
+
+    expect(plan.files[0]?.html).toContain("url=/foo&lt;bar&gt;");
+    expect(plan.files[0]?.html).not.toContain("url=/foo<bar>");
+  });
+});
+
+describe("writeRedirectFiles", () => {
+  it("writes planned HTML and an optional host _redirects file", async () => {
+    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-redirects-"));
+    tempDirs.push(outDir);
+
+    const result = await writeRedirectFiles({
+      outDir,
+      options: {
+        enabled: true,
+        map: { "/old-guide": "/guide" },
+        netlify: true,
+      },
+      pages: [{ dest: "/guide", aliases: ["/old"] }],
+    });
+
+    const oldHtml = await fs.readFile(path.join(outDir, "old", "index.html"), "utf8");
+    const mapHtml = await fs.readFile(path.join(outDir, "old-guide", "index.html"), "utf8");
+    const netlify = await fs.readFile(path.join(outDir, "_redirects"), "utf8");
+
+    expect(result.files).toHaveLength(3);
+    expect(oldHtml).toContain("url=/guide");
+    expect(mapHtml).toContain("url=/guide");
+    expect(netlify).toContain("/old /guide 301");
+    expect(netlify).toContain("/old-guide /guide 301");
+  });
+
+  it("writes nothing when disabled", async () => {
+    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-redirects-off-"));
+    tempDirs.push(outDir);
+
+    const result = await writeRedirectFiles({
+      outDir,
+      pages: [{ dest: "/guide", aliases: ["/old"] }],
+    });
+
+    expect(result.files).toEqual([]);
+    await expect(fs.access(path.join(outDir, "old", "index.html"))).rejects.toThrow();
+  });
+});

--- a/npm/vite-plugin-ox-content/src/redirects.ts
+++ b/npm/vite-plugin-ox-content/src/redirects.ts
@@ -1,0 +1,228 @@
+/**
+ * Opt-in static redirects / aliases.
+ *
+ * HTML bodies follow `ox_content_ssg::generate_redirects`. The Vite plugin
+ * writes those files during SSG without adding a NAPI surface.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { RedirectsOptions, ResolvedRedirectsOptions } from "./types";
+
+const OPTION_KEYS = new Set(["enabled", "map", "netlify", "writeNetlify"]);
+
+/** One page that may declare aliases or a single `redirect` source. */
+export interface RedirectPageInput {
+  dest: string;
+  aliases?: unknown;
+  redirect?: unknown;
+}
+
+/** Inputs for planning redirect files. */
+export interface RedirectPlanInput {
+  options?: ResolvedRedirectsOptions | null;
+  pages: readonly RedirectPageInput[];
+}
+
+/** One planned static HTML redirect. */
+export interface RedirectFilePlan {
+  from: string;
+  to: string;
+  relativePath: string;
+  html: string;
+}
+
+/** Planned redirect files and an optional host `_redirects` body. */
+export interface RedirectPlan {
+  files: RedirectFilePlan[];
+  netlify?: string;
+}
+
+/** Inputs for writing redirect files next to generated HTML. */
+export interface WriteRedirectFilesInput {
+  outDir: string;
+  options?: ResolvedRedirectsOptions;
+  pages: readonly RedirectPageInput[];
+}
+
+/**
+ * Resolves `redirects` with defaults.
+ *
+ * `false` / omitted stays off. `true` or `{}` enables empty defaults.
+ * A path map (`{ "/old": "/new" }`) enables the feature with that map.
+ * `{ enabled, map, netlify | writeNetlify }` overrides only set fields.
+ */
+export function resolveRedirectsOptions(
+  value: boolean | RedirectsOptions | Record<string, string> | undefined,
+): ResolvedRedirectsOptions {
+  if (!value) {
+    return { enabled: false, map: {}, netlify: false };
+  }
+  if (value === true) {
+    return { enabled: true, map: {}, netlify: false };
+  }
+  if (isOptionsObject(value)) {
+    return {
+      enabled: value.enabled ?? true,
+      map: { ...value.map },
+      netlify: value.netlify ?? value.writeNetlify ?? false,
+    };
+  }
+  return { enabled: true, map: { ...value }, netlify: false };
+}
+
+/** Plans redirect HTML files without writing them. */
+export function planRedirectFiles(input: RedirectPlanInput): RedirectPlan {
+  if (!input.options?.enabled) {
+    return { files: [] };
+  }
+
+  const files: RedirectFilePlan[] = [];
+  const index = new Map<string, number>();
+
+  for (const page of input.pages) {
+    const to = normalizePath(page.dest);
+    if (!to) {
+      continue;
+    }
+    for (const alias of readStringList(page.aliases)) {
+      upsert(files, index, alias, to);
+    }
+    if (typeof page.redirect === "string") {
+      upsert(files, index, page.redirect, to);
+    }
+  }
+  for (const [from, to] of Object.entries(input.options.map)) {
+    const dest = normalizePath(to);
+    if (!dest) {
+      continue;
+    }
+    upsert(files, index, from, dest);
+  }
+
+  const plan: RedirectPlan = { files };
+  if (input.options.netlify && files.length > 0) {
+    plan.netlify = files.map((file) => `${file.from} ${file.to} 301`).join("\n") + "\n";
+  }
+  return plan;
+}
+
+/** Writes planned redirect HTML (and optional `_redirects`) into `outDir`. */
+export async function writeRedirectFiles(
+  input: WriteRedirectFilesInput,
+): Promise<{ files: string[] }> {
+  const plan = planRedirectFiles(input);
+  if (plan.files.length === 0 && !plan.netlify) {
+    return { files: [] };
+  }
+
+  await fs.mkdir(input.outDir, { recursive: true });
+  const files: string[] = [];
+  for (const entry of plan.files) {
+    const outputPath = path.join(input.outDir, entry.relativePath);
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, entry.html, "utf8");
+    files.push(outputPath);
+  }
+  if (plan.netlify) {
+    const outputPath = path.join(input.outDir, "_redirects");
+    await fs.writeFile(outputPath, plan.netlify, "utf8");
+    files.push(outputPath);
+  }
+  return { files };
+}
+
+/** Static HTML redirect body. `dest` is escaped. */
+export function generateRedirectHtml(dest: string): string {
+  const escaped = escapeHtml(dest);
+  return `\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="0;url=${escaped}">
+<link rel="canonical" href="${escaped}">
+<title>Redirecting</title>
+</head>
+<body>
+<p>Redirecting to <a href="${escaped}">${escaped}</a>.</p>
+</body>
+</html>
+`;
+}
+
+/** Same-origin path: leading `/`, not `//`, and no scheme. */
+export function isSafeDest(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("/") || trimmed.startsWith("//")) {
+    return false;
+  }
+  const lower = trimmed.toLowerCase();
+  return !lower.includes("javascript:") && !lower.includes("data:") && !lower.includes("://");
+}
+
+/** Strips a trailing slash except for `/`. Unsafe values become `null`. */
+export function normalizePath(value: string): string | null {
+  if (!isSafeDest(value)) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed === "/") {
+    return "/";
+  }
+  return trimmed.replace(/\/+$/u, "");
+}
+
+function isOptionsObject(
+  value: RedirectsOptions | Record<string, string>,
+): value is RedirectsOptions {
+  return Object.keys(value).some((key) => OPTION_KEYS.has(key));
+}
+
+function readStringList(value: unknown): string[] {
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+function upsert(
+  files: RedirectFilePlan[],
+  index: Map<string, number>,
+  from: string,
+  to: string,
+): void {
+  const source = normalizePath(from);
+  if (!source || source === to) {
+    return;
+  }
+  const html = generateRedirectHtml(to);
+  const relativePath = source === "/" ? "index.html" : `${source.slice(1)}/index.html`;
+  const slot = index.get(source);
+  if (slot !== undefined) {
+    files[slot] = { from: source, to, relativePath, html };
+    return;
+  }
+  index.set(source, files.length);
+  files.push({ from: source, to, relativePath, html });
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (ch) => {
+    switch (ch) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return "&#39;";
+    }
+  });
+}

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -29,6 +29,7 @@ import { normalizeVitePressFrontmatter } from "./vitepress";
 import { renderPage } from "./theme-renderer";
 import type { PageData as ThemePageData } from "./theme-renderer";
 import { writeSiteMapFiles } from "./site-maps";
+import { writeRedirectFiles } from "./redirects";
 
 /**
  * Navigation item for SSG.
@@ -1005,6 +1006,14 @@ function toThemePageData(pageResult: PageProcessResult): ThemePageData {
   };
 }
 
+/** Turns an SSG `urlPath` (`guide` or `/`) into a same-origin dest (`/guide`). */
+function sitePathFromUrlPath(urlPath: string): string {
+  if (!urlPath || urlPath === "/") {
+    return "/";
+  }
+  return urlPath.startsWith("/") ? urlPath : `/${urlPath}`;
+}
+
 /**
  * Absolute URL of a page, or `undefined` when `ssg.siteUrl` is not set.
  *
@@ -1088,4 +1097,15 @@ async function writeGeneratedPages(
     errors.push(siteMaps.warning);
     console.warn(siteMaps.warning);
   }
+
+  const redirects = await writeRedirectFiles({
+    outDir: context.outDir,
+    options: context.options.redirects,
+    pages: pageResults.map((page) => ({
+      dest: sitePathFromUrlPath(page.routePaths.urlPath),
+      aliases: page.frontmatter.aliases,
+      redirect: page.frontmatter.redirect,
+    })),
+  });
+  generatedFiles.push(...redirects.files);
 }

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -395,6 +395,44 @@ export interface ResolvedSiteMapsOptions {
 }
 
 /**
+ * Opt-in static redirects, aliases, and path rewrites.
+ *
+ * A path map such as `{ "/old-guide": "/guide" }` is also accepted in place
+ * of this object and enables the feature with that map.
+ */
+export interface RedirectsOptions {
+  /**
+   * Enable the feature when an options object is supplied.
+   * @default true
+   */
+  enabled?: boolean;
+  /**
+   * Old path to new path. Destinations must be same-origin (`/` but not `//`).
+   * @default {}
+   */
+  map?: Record<string, string>;
+  /**
+   * Write a Netlify-style `_redirects` file next to the HTML pages.
+   * @default false
+   */
+  netlify?: boolean;
+  /**
+   * Alias for `netlify`.
+   * @default false
+   */
+  writeNetlify?: boolean;
+}
+
+/**
+ * Resolved redirect options.
+ */
+export interface ResolvedRedirectsOptions {
+  enabled: boolean;
+  map: Record<string, string>;
+  netlify: boolean;
+}
+
+/**
  * Options for the core `oxContent()` Vite plugin.
  *
  * The top-level options describe where content lives, which Markdown features
@@ -469,6 +507,19 @@ export interface OxContentOptions {
    * @default false
    */
   siteMaps?: boolean | SiteMapsOptions;
+
+  /**
+   * Write static HTML redirect pages for frontmatter aliases and a config map.
+   *
+   * Off by default. `true` or `{}` enables empty defaults. A path map such as
+   * `{ "/old-guide": "/guide" }` enables the feature with that map. Destinations
+   * must be same-origin paths (`/` but not `//`); `javascript:`, `data:`, and
+   * absolute URLs are ignored. Overlapping sources last-win after trailing
+   * slashes are folded (`/old` and `/old/` are the same source).
+   *
+   * @default false
+   */
+  redirects?: boolean | RedirectsOptions | Record<string, string>;
 
   /**
    * Enable GitHub Flavored Markdown extensions.
@@ -785,6 +836,7 @@ export interface ResolvedOptions {
   extensions: string[];
   ssg: ResolvedSsgOptions;
   siteMaps?: ResolvedSiteMapsOptions;
+  redirects?: ResolvedRedirectsOptions;
   gfm: boolean;
   footnotes: boolean;
   tables: boolean;

--- a/npm/vite-plugin-ox-content/test/fixtures/docs-fixture.ts
+++ b/npm/vite-plugin-ox-content/test/fixtures/docs-fixture.ts
@@ -108,6 +108,7 @@ export function createDocsResolvedOptions(
       pagination: false,
     },
     siteMaps: { enabled: false, robots: true, llms: true },
+    redirects: { enabled: false, map: {}, netlify: false },
     gfm: true,
     footnotes: true,
     tables: true,


### PR DESCRIPTION
## Summary
- Add opt-in `redirects` for static HTML alias / rewrite pages (meta refresh + canonical). Default remains off.
- Frontmatter `aliases` / `redirect` and a config map emit escaped same-origin redirect HTML. Open redirects (`javascript:`, `data:`, `//…`, absolute URLs) are ignored.
- Trailing slashes fold (`/old` and `/old/` are the same source). Overlapping sources last-win, with the config map applied after frontmatter. Optional Netlify `_redirects` via `netlify` / `writeNetlify`.

Closes #675. Parent #650.

## Test plan
- [x] Rust: `disabled_by_default`, `frontmatter_alias_emits_redirect_html`, `config_map_emits_redirect`, `javascript_destination_rejected`, `protocol_relative_destination_rejected`, `trailing_slash_normalization`, `hostile_dest_escaped_in_html`, plus last-wins / Netlify
- [x] Vite: omitted => false; `true` => true; `{}` => true; file plan + write
- [ ] CI green


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790154277&installation_model_id=422833&pr_number=730&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F730&signature=9d7c52998b1b547b60d750d94f67e469e0b1bc17e99ab34ef57f21dfe53ec275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->