### PR TITLE
feat(mdx): parse import and export when mdx is enabled

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -22,6 +22,7 @@ mod leaf;
 mod line_scan;
 mod list;
 mod list_item;
+mod mdx_esm;
 mod mdx_jsx;
 mod prepass;
 mod reference;
@@ -91,7 +92,9 @@ pub struct ParserOptions {
     /// Enable MDX. Off by default.
     ///
     /// When set, PascalCase JSX elements parse as [`ox_content_ast::MdxJsxFlowElement`]
-    /// / [`ox_content_ast::MdxJsxTextElement`]. `import` / `export` and
+    /// / [`ox_content_ast::MdxJsxTextElement`], and block-level `import` /
+    /// `export` statements parse as [`ox_content_ast::MdxjsEsm`]. The ESM
+    /// source is stored on the node; it is not executed.
     /// `{expression}` children are not parsed yet. Lowercase HTML stays HTML.
     ///
     /// Default: `false`.

--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -101,6 +101,11 @@ impl<'a> Parser<'a> {
                     return self.parse_html_block(start, super::html::HtmlBlockStart::Other);
                 }
             }
+            b'i' | b'e' if self.options.mdx => {
+                if let Some(node) = self.try_parse_mdx_esm(start, trimmed_start)? {
+                    return Ok(Some(node));
+                }
+            }
             b'+' | b'0'..=b'9' => {
                 let line = self.line_at(start);
                 let trimmed = &line[trimmed_start - start..];

--- a/crates/ox_content_parser/src/parser/cursor.rs
+++ b/crates/ox_content_parser/src/parser/cursor.rs
@@ -167,6 +167,9 @@ impl<'a> Parser<'a> {
                 let line = self.line_at(line_start);
                 Self::try_parse_list_interrupt(&line[trimmed_start - line_start..])
             }
+            b'i' | b'e' => {
+                self.options.mdx && super::mdx_esm::looks_like_esm(self.source, trimmed_start)
+            }
             _ => false,
         };
 

--- a/crates/ox_content_parser/src/parser/mdx_esm.rs
+++ b/crates/ox_content_parser/src/parser/mdx_esm.rs
@@ -1,0 +1,41 @@
+//! MDX ESM parse: block-level `import` / `export`.
+
+use ox_content_ast::{MdxjsEsm, Node, Span};
+
+use super::Parser;
+use crate::error::ParseResult;
+
+mod scan;
+
+#[cfg(test)]
+mod tests;
+
+pub(super) fn looks_like_esm(source: &str, at: usize) -> bool {
+    scan::scan_esm(source, at).is_some()
+}
+
+impl<'a> Parser<'a> {
+    /// Parses a block-level `import` / `export` starting at the current line.
+    ///
+    /// On failure the cursor is left unchanged so paragraph dispatch can run.
+    /// The statement source is stored on the node; nothing is executed or read
+    /// from the filesystem.
+    pub(super) fn try_parse_mdx_esm(
+        &mut self,
+        start: usize,
+        trimmed_start: usize,
+    ) -> ParseResult<Option<Node<'a>>> {
+        if !self.options.mdx {
+            return Ok(None);
+        }
+        let Some(scanned) = scan::scan_esm(self.source, trimmed_start) else {
+            return Ok(None);
+        };
+
+        self.position = scanned.end;
+        Ok(Some(Node::MdxjsEsm(MdxjsEsm {
+            value: scanned.value,
+            span: Span::new(start as u32, scanned.end as u32),
+        })))
+    }
+}

--- a/crates/ox_content_parser/src/parser/mdx_esm/scan.rs
+++ b/crates/ox_content_parser/src/parser/mdx_esm/scan.rs
@@ -1,0 +1,339 @@
+//! Conservative ESM statement scan. Invalid input returns `None`.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct EsmScan<'a> {
+    pub value: &'a str,
+    pub end: usize,
+    pub module_source: Option<&'a str>,
+}
+
+pub(super) fn scan_esm(source: &str, start: usize) -> Option<EsmScan<'_>> {
+    let bytes = source.as_bytes();
+    let cursor = start + 6;
+    if match_word(bytes, start, b"import") {
+        scan_import(source, start, cursor)
+    } else if match_word(bytes, start, b"export") {
+        scan_export(source, start, cursor)
+    } else {
+        None
+    }
+}
+
+fn scan_import(source: &str, start: usize, mut cursor: usize) -> Option<EsmScan<'_>> {
+    let bytes = source.as_bytes();
+    skip_after_keyword(bytes, &mut cursor)?;
+    if matches!(bytes.get(cursor), Some(b'"' | b'\'')) {
+        let (module_source, next) = scan_string(source, cursor)?;
+        return finish(source, start, next, Some(module_source));
+    }
+    cursor = scan_import_clause(source, cursor)?;
+    expect_word(bytes, &mut cursor, b"from")?;
+    skip_stmt_ws(bytes, &mut cursor)?;
+    let (module_source, next) = scan_string(source, cursor)?;
+    finish(source, start, next, Some(module_source))
+}
+
+fn scan_import_clause(source: &str, mut cursor: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    skip_stmt_ws(bytes, &mut cursor)?;
+    match bytes.get(cursor)? {
+        b'*' => scan_namespace_import(bytes, cursor),
+        b'{' => scan_named_imports(source, cursor),
+        _ => {
+            cursor = scan_ident(bytes, cursor)?;
+            let after_default = cursor;
+            skip_stmt_ws(bytes, &mut cursor)?;
+            if bytes.get(cursor) != Some(&b',') {
+                return Some(after_default);
+            }
+            cursor += 1;
+            skip_stmt_ws(bytes, &mut cursor)?;
+            match bytes.get(cursor)? {
+                b'*' => scan_namespace_import(bytes, cursor),
+                b'{' => scan_named_imports(source, cursor),
+                _ => None,
+            }
+        }
+    }
+}
+
+fn scan_namespace_import(bytes: &[u8], mut cursor: usize) -> Option<usize> {
+    if bytes.get(cursor)? != &b'*' {
+        return None;
+    }
+    cursor += 1;
+    expect_word(bytes, &mut cursor, b"as")?;
+    skip_stmt_ws(bytes, &mut cursor)?;
+    scan_ident(bytes, cursor)
+}
+
+fn scan_named_imports(source: &str, start: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    if bytes.get(start)? != &b'{' {
+        return None;
+    }
+    let mut cursor = start + 1;
+    skip_stmt_ws(bytes, &mut cursor)?;
+    if bytes.get(cursor) == Some(&b'}') {
+        return Some(cursor + 1);
+    }
+    loop {
+        cursor = scan_import_specifier(source, cursor)?;
+        skip_stmt_ws(bytes, &mut cursor)?;
+        match bytes.get(cursor)? {
+            b',' => {
+                cursor += 1;
+                skip_stmt_ws(bytes, &mut cursor)?;
+                if bytes.get(cursor) == Some(&b'}') {
+                    return Some(cursor + 1);
+                }
+            }
+            b'}' => return Some(cursor + 1),
+            _ => return None,
+        }
+    }
+}
+
+fn scan_import_specifier(source: &str, mut cursor: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    skip_stmt_ws(bytes, &mut cursor)?;
+    if matches!(bytes.get(cursor), Some(b'"' | b'\'')) {
+        cursor = skip_quoted(bytes, cursor)?;
+        expect_word(bytes, &mut cursor, b"as")?;
+        skip_stmt_ws(bytes, &mut cursor)?;
+        return scan_ident(bytes, cursor);
+    }
+    cursor = scan_ident(bytes, cursor)?;
+    let after_name = cursor;
+    skip_stmt_ws(bytes, &mut cursor)?;
+    if !match_word(bytes, cursor, b"as") {
+        return Some(after_name);
+    }
+    cursor += 2;
+    skip_stmt_ws(bytes, &mut cursor)?;
+    scan_ident(bytes, cursor)
+}
+
+fn scan_export(source: &str, start: usize, mut cursor: usize) -> Option<EsmScan<'_>> {
+    let bytes = source.as_bytes();
+    skip_after_keyword(bytes, &mut cursor)?;
+    if match_word(bytes, cursor, b"default") {
+        cursor += 7;
+        skip_stmt_ws(bytes, &mut cursor)?;
+        cursor = scan_primary(bytes, cursor)?;
+        return finish(source, start, cursor, None);
+    }
+    if match_word(bytes, cursor, b"const") || match_word(bytes, cursor, b"let") {
+        cursor += if bytes[cursor] == b'c' { 5 } else { 3 };
+        return scan_export_binding(source, start, cursor);
+    }
+    if match_word(bytes, cursor, b"var") {
+        cursor += 3;
+        return scan_export_binding(source, start, cursor);
+    }
+    None
+}
+
+fn scan_export_binding(source: &str, start: usize, mut cursor: usize) -> Option<EsmScan<'_>> {
+    let bytes = source.as_bytes();
+    skip_stmt_ws(bytes, &mut cursor)?;
+    cursor = scan_ident(bytes, cursor)?;
+    skip_stmt_ws(bytes, &mut cursor)?;
+    if bytes.get(cursor)? != &b'=' {
+        return None;
+    }
+    cursor += 1;
+    skip_stmt_ws(bytes, &mut cursor)?;
+    cursor = scan_primary(bytes, cursor)?;
+    finish(source, start, cursor, None)
+}
+
+fn scan_primary(bytes: &[u8], cursor: usize) -> Option<usize> {
+    match bytes.get(cursor)? {
+        b'"' | b'\'' => skip_quoted(bytes, cursor),
+        b'{' => skip_balanced(bytes, cursor, b'{', b'}'),
+        b'[' => skip_balanced(bytes, cursor, b'[', b']'),
+        b'(' => skip_balanced(bytes, cursor, b'(', b')'),
+        b'0'..=b'9' => {
+            let mut end = cursor + 1;
+            while end < bytes.len() && (bytes[end].is_ascii_digit() || bytes[end] == b'.') {
+                end += 1;
+            }
+            Some(end)
+        }
+        byte if is_ident_start(*byte) => scan_ident(bytes, cursor),
+        _ => None,
+    }
+}
+
+fn finish<'a>(
+    source: &'a str,
+    start: usize,
+    mut cursor: usize,
+    module_source: Option<&'a str>,
+) -> Option<EsmScan<'a>> {
+    let bytes = source.as_bytes();
+    skip_line_ws(bytes, &mut cursor);
+    if bytes.get(cursor) == Some(&b';') {
+        cursor += 1;
+        skip_line_ws(bytes, &mut cursor);
+    }
+    if bytes.get(cursor) == Some(&b'/') && bytes.get(cursor.saturating_add(1)) == Some(&b'/') {
+        cursor = line_end(bytes, cursor);
+    }
+    if cursor < bytes.len() && bytes[cursor] != b'\n' {
+        return None;
+    }
+    let mut value_end = cursor;
+    while value_end > start && matches!(bytes[value_end - 1], b' ' | b'\t' | b'\r') {
+        value_end -= 1;
+    }
+    let end = if cursor < bytes.len() { cursor + 1 } else { cursor };
+    Some(EsmScan { value: &source[start..value_end], end, module_source })
+}
+
+fn scan_string(source: &str, start: usize) -> Option<(&str, usize)> {
+    let end = skip_quoted(source.as_bytes(), start)?;
+    Some((&source[start + 1..end - 1], end))
+}
+
+fn expect_word(bytes: &[u8], cursor: &mut usize, word: &[u8]) -> Option<()> {
+    skip_stmt_ws(bytes, cursor)?;
+    if !match_word(bytes, *cursor, word) {
+        return None;
+    }
+    *cursor += word.len();
+    Some(())
+}
+
+fn skip_after_keyword(bytes: &[u8], cursor: &mut usize) -> Option<()> {
+    match bytes.get(*cursor) {
+        Some(b' ' | b'\t' | b'\r' | b'\n' | b'/') => skip_stmt_ws(bytes, cursor),
+        Some(b'{' | b'*' | b'"' | b'\'') => Some(()),
+        _ => None,
+    }
+}
+
+fn skip_stmt_ws(bytes: &[u8], cursor: &mut usize) -> Option<()> {
+    loop {
+        skip_line_ws(bytes, cursor);
+        match bytes.get(*cursor) {
+            Some(b'/') if bytes.get(cursor.saturating_add(1)) == Some(&b'/') => {
+                *cursor = line_end(bytes, *cursor);
+            }
+            Some(b'/') if bytes.get(cursor.saturating_add(1)) == Some(&b'*') => {
+                *cursor = skip_block_comment(bytes, *cursor)?;
+            }
+            Some(b'\n') => {
+                let mut peek = *cursor + 1;
+                skip_line_ws(bytes, &mut peek);
+                if peek >= bytes.len() || bytes[peek] == b'\n' {
+                    return None;
+                }
+                *cursor = peek;
+            }
+            _ => return Some(()),
+        }
+    }
+}
+
+fn skip_line_ws(bytes: &[u8], cursor: &mut usize) {
+    while matches!(bytes.get(*cursor), Some(b' ' | b'\t' | b'\r')) {
+        *cursor += 1;
+    }
+}
+
+fn line_end(bytes: &[u8], mut cursor: usize) -> usize {
+    while cursor < bytes.len() && bytes[cursor] != b'\n' {
+        cursor += 1;
+    }
+    cursor
+}
+
+fn skip_block_comment(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut cursor = start + 2;
+    while cursor + 1 < bytes.len() {
+        if bytes[cursor] == b'*' && bytes[cursor + 1] == b'/' {
+            return Some(cursor + 2);
+        }
+        cursor += 1;
+    }
+    None
+}
+
+fn skip_quoted(bytes: &[u8], start: usize) -> Option<usize> {
+    let quote = *bytes.get(start)?;
+    if !matches!(quote, b'"' | b'\'') {
+        return None;
+    }
+    let mut cursor = start + 1;
+    while cursor < bytes.len() && bytes[cursor] != b'\n' {
+        if bytes[cursor] == b'\\' && cursor + 1 < bytes.len() {
+            cursor += 2;
+            continue;
+        }
+        if bytes[cursor] == quote {
+            return Some(cursor + 1);
+        }
+        cursor += 1;
+    }
+    None
+}
+
+fn skip_balanced(bytes: &[u8], start: usize, open: u8, close: u8) -> Option<usize> {
+    if bytes.get(start) != Some(&open) {
+        return None;
+    }
+    let mut cursor = start + 1;
+    let mut depth = 1u32;
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'"' | b'\'' => cursor = skip_quoted(bytes, cursor)?,
+            b'/' if bytes.get(cursor.saturating_add(1)) == Some(&b'/') => {
+                cursor = line_end(bytes, cursor);
+            }
+            b'/' if bytes.get(cursor.saturating_add(1)) == Some(&b'*') => {
+                cursor = skip_block_comment(bytes, cursor)?;
+            }
+            byte if byte == open => {
+                depth = depth.saturating_add(1);
+                cursor += 1;
+            }
+            byte if byte == close => {
+                cursor += 1;
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return Some(cursor);
+                }
+            }
+            _ => cursor += 1,
+        }
+    }
+    None
+}
+
+fn scan_ident(bytes: &[u8], start: usize) -> Option<usize> {
+    if !bytes.get(start).is_some_and(|byte| is_ident_start(*byte)) {
+        return None;
+    }
+    let mut end = start + 1;
+    while end < bytes.len() && is_ident_continue(bytes[end]) {
+        end += 1;
+    }
+    Some(end)
+}
+
+fn match_word(bytes: &[u8], at: usize, word: &[u8]) -> bool {
+    let Some(rest) = bytes.get(at..) else {
+        return false;
+    };
+    rest.starts_with(word) && !rest.get(word.len()).is_some_and(|byte| is_ident_continue(*byte))
+}
+
+fn is_ident_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || matches!(byte, b'_' | b'$')
+}
+
+fn is_ident_continue(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$')
+}

--- a/crates/ox_content_parser/src/parser/mdx_esm/tests.rs
+++ b/crates/ox_content_parser/src/parser/mdx_esm/tests.rs
@@ -1,0 +1,89 @@
+#![allow(clippy::disallowed_macros, clippy::disallowed_methods, clippy::disallowed_types)]
+
+use super::scan::{EsmScan, scan_esm};
+
+fn scanned(source: &str) -> EsmScan<'_> {
+    scan_esm(source, 0).unwrap_or_else(|| panic!("expected ESM for {source:?}"))
+}
+
+#[test]
+fn scan_default_import_keeps_source_and_specifier() {
+    let esm = scanned("import Foo from \"./Foo\"\n");
+    assert_eq!(esm.value, "import Foo from \"./Foo\"");
+    assert_eq!(esm.module_source, Some("./Foo"));
+    assert_eq!(esm.end, "import Foo from \"./Foo\"\n".len());
+}
+
+#[test]
+fn scan_named_import_with_alias() {
+    let esm = scanned("import { Foo, Bar as Baz } from \"./mod\"");
+    assert_eq!(esm.value, "import { Foo, Bar as Baz } from \"./mod\"");
+    assert_eq!(esm.module_source, Some("./mod"));
+}
+
+#[test]
+fn scan_namespace_and_side_effect_imports() {
+    let ns = scanned("import * as ns from './ns'");
+    assert_eq!(ns.module_source, Some("./ns"));
+    let side = scanned("import \"./side\"");
+    assert_eq!(side.module_source, Some("./side"));
+    assert_eq!(side.value, "import \"./side\"");
+}
+
+#[test]
+fn scan_export_const_object_and_default() {
+    let exported = scanned("export const meta = { title: \"Hi\" }");
+    assert_eq!(exported.value, "export const meta = { title: \"Hi\" }");
+    assert_eq!(exported.module_source, None);
+    assert_eq!(
+        scanned("export const compact = {title:\"Hi\"}").value,
+        "export const compact = {title:\"Hi\"}"
+    );
+    assert_eq!(scanned("export default Foo").value, "export default Foo");
+}
+
+#[test]
+fn scan_keeps_hostile_specifier_as_text() {
+    let esm = scanned("import Foo from \"../../../../etc/passwd\"");
+    assert_eq!(esm.module_source, Some("../../../../etc/passwd"));
+    assert!(esm.value.contains("../../../../etc/passwd"));
+}
+
+#[test]
+fn scan_rejects_invalid_and_unclosed_imports() {
+    for source in [
+        "import",
+        "import Foo",
+        "import Foo from",
+        "import { Foo",
+        "import Foo from \"./Foo",
+        "important thing",
+        "importantly Foo from \"./Foo\"",
+        "import.meta",
+        "export",
+        "export const",
+        "export const meta =",
+        "export const meta = { title: \"Hi\"",
+    ] {
+        assert!(scan_esm(source, 0).is_none(), "should reject {source:?}");
+    }
+}
+
+#[test]
+fn scan_allows_optional_semicolon_and_single_quotes() {
+    assert_eq!(scanned("import Foo from './Foo';").value, "import Foo from './Foo';");
+}
+
+#[test]
+fn scan_allows_multiline_named_import() {
+    let source = "import {\n  Foo,\n  Bar as Baz,\n} from \"./mod\"\n";
+    let esm = scanned(source);
+    assert!(esm.value.contains("Bar as Baz"));
+    assert_eq!(esm.module_source, Some("./mod"));
+}
+
+#[test]
+fn scan_rejects_blank_line_inside_statement() {
+    assert!(scan_esm("import Foo from\n\n\"./Foo\"\n", 0).is_none());
+    assert!(scan_esm("import {\n\nFoo } from \"./mod\"\n", 0).is_none());
+}

--- a/crates/ox_content_parser/tests/mdx_esm.rs
+++ b/crates/ox_content_parser/tests/mdx_esm.rs
@@ -1,0 +1,201 @@
+//! ESM `import` / `export` parse when `ParserOptions.mdx` is true.
+//!
+//! Block-level statements become `MdxjsEsm` and keep their source text.
+//! Fences, inline code, and invalid or unclosed statements stay Markdown.
+//! JSX from the previous slice must keep working.
+
+use ox_content_allocator::Allocator;
+use ox_content_ast::{Document, MdxjsEsm, Node};
+use ox_content_parser::{Parser, ParserOptions};
+
+#[path = "support/pretty.rs"]
+mod pretty;
+
+fn pretty_ast(source: &str, options: ParserOptions) -> String {
+    let allocator = Allocator::new();
+    let doc = Parser::with_options(&allocator, source, options)
+        .parse()
+        .expect("parser should not fail on MDX ESM fixtures");
+    let mut out = String::new();
+    pretty::format_document(&doc, source, &mut out);
+    out
+}
+
+fn mdx_tree(source: &str) -> String {
+    pretty_ast(source, ParserOptions::mdx())
+}
+
+fn parse_mdx<'a>(allocator: &'a Allocator, source: &'a str) -> Document<'a> {
+    Parser::with_options(allocator, source, ParserOptions::mdx())
+        .parse()
+        .expect("parser should not fail on MDX ESM fixtures")
+}
+
+fn only_esm<'a>(doc: &'a Document<'a>) -> &'a MdxjsEsm<'a> {
+    assert_eq!(doc.children.len(), 1, "expected a single top-level node, got {:?}", doc.children);
+    match &doc.children[0] {
+        Node::MdxjsEsm(esm) => esm,
+        other => panic!("expected MdxjsEsm, got {other:?}"),
+    }
+}
+
+#[test]
+fn disabled_mdx_leaves_import_as_paragraph() {
+    let source = "import Foo from \"./Foo\"\n";
+    let tree = pretty_ast(source, ParserOptions::default());
+    assert!(!tree.contains("MdxjsEsm"), "mdx=false must not emit ESM:\n{tree}");
+    assert!(tree.contains("Paragraph"), "import stays a paragraph when mdx is off:\n{tree}");
+    assert!(tree.contains("import Foo from"), "source text is preserved:\n{tree}");
+}
+
+#[test]
+fn import_default_becomes_esm_node() {
+    let source = "import Foo from \"./Foo\"\n";
+    let allocator = Allocator::new();
+    let doc = parse_mdx(&allocator, source);
+    let esm = only_esm(&doc);
+    assert_eq!(esm.value, "import Foo from \"./Foo\"");
+    assert!(esm.value.contains("./Foo"), "module source stays on the node: {}", esm.value);
+    let tree = mdx_tree(source);
+    assert!(tree.contains("MdxjsEsm"), "expected ESM node:\n{tree}");
+    assert!(!tree.contains("Paragraph"), "standalone import is not a paragraph:\n{tree}");
+}
+
+#[test]
+fn import_named_becomes_esm_node() {
+    let source = "import { Foo, Bar as Baz } from \"./mod\"\n";
+    let allocator = Allocator::new();
+    let doc = parse_mdx(&allocator, source);
+    let esm = only_esm(&doc);
+    assert_eq!(esm.value, "import { Foo, Bar as Baz } from \"./mod\"");
+    assert!(esm.value.contains("Bar as Baz"), "named specifiers stay source text: {}", esm.value);
+    assert!(esm.value.contains("./mod"), "module source stays source text: {}", esm.value);
+}
+
+#[test]
+fn export_const_becomes_esm_node() {
+    let source = "export const meta = { title: \"Hi\" }\n";
+    let allocator = Allocator::new();
+    let doc = parse_mdx(&allocator, source);
+    let esm = only_esm(&doc);
+    assert_eq!(esm.value, "export const meta = { title: \"Hi\" }");
+    assert!(esm.value.contains("title"), "export initializer stays source text: {}", esm.value);
+    let tree = mdx_tree(source);
+    assert!(!tree.contains("Paragraph"), "standalone export is not a paragraph:\n{tree}");
+}
+
+#[test]
+fn export_default_becomes_esm_node() {
+    let source = "export default Foo\n";
+    let allocator = Allocator::new();
+    let doc = parse_mdx(&allocator, source);
+    let esm = only_esm(&doc);
+    assert_eq!(esm.value, "export default Foo");
+}
+
+#[test]
+fn skips_fenced_code() {
+    let tree =
+        mdx_tree("```js\nimport Foo from \"./Foo\"\nexport const meta = { title: \"Hi\" }\n```\n");
+    assert!(tree.contains("CodeBlock"), "expected a fence:\n{tree}");
+    assert!(!tree.contains("MdxjsEsm"), "fence contents are not ESM:\n{tree}");
+}
+
+#[test]
+fn skips_inline_code() {
+    let tree = mdx_tree("Use `import Foo from \"./Foo\"` in prose.\n");
+    assert!(tree.contains("InlineCode"), "expected inline code:\n{tree}");
+    assert!(!tree.contains("MdxjsEsm"), "inline code is not ESM:\n{tree}");
+    assert!(tree.contains("Paragraph"), "prose stays a paragraph:\n{tree}");
+}
+
+#[test]
+fn invalid_import_stays_markdown() {
+    let fixtures = [
+        "import\n",
+        "import Foo\n",
+        "import Foo from\n",
+        "import { Foo\n",
+        "import Foo from \"./Foo\n",
+        "important thing\n",
+        "importantly Foo from \"./Foo\"\n",
+        "import Foo from\n\n\"./Foo\"\n",
+    ];
+    for source in fixtures {
+        let tree = mdx_tree(source);
+        assert!(
+            !tree.contains("MdxjsEsm"),
+            "invalid or unclosed import must stay Markdown for {source:?}:\n{tree}"
+        );
+        assert!(
+            tree.contains("Paragraph") || tree.contains("Text"),
+            "invalid import must remain Markdown for {source:?}:\n{tree}"
+        );
+    }
+}
+
+#[test]
+fn existing_jsx_parse_still_works() {
+    let tree = mdx_tree("<Alert title=\"hi\" />\n");
+    assert!(
+        tree.contains("MdxJsxFlowElement name=Some(\"Alert\") self_closing=true"),
+        "JSX flow parse must still work:\n{tree}"
+    );
+    assert!(
+        tree.contains("Attr name=\"title\" value=literal(\"hi\")"),
+        "JSX attributes must still parse:\n{tree}"
+    );
+
+    let mixed = mdx_tree("import Foo from \"./Foo\"\n\n<Alert title=\"hi\" />\n");
+    assert!(mixed.contains("MdxjsEsm"), "import should parse beside JSX:\n{mixed}");
+    assert!(
+        mixed.contains("MdxJsxFlowElement name=Some(\"Alert\")"),
+        "JSX after import must still parse:\n{mixed}"
+    );
+    assert!(!mixed.contains("Paragraph"), "mixed ESM + JSX must not wrap in paragraphs:\n{mixed}");
+}
+
+#[test]
+fn disabled_mdx_leaves_export_as_paragraph() {
+    let tree = pretty_ast("export const meta = { title: \"Hi\" }\n", ParserOptions::default());
+    assert!(!tree.contains("MdxjsEsm"), "mdx=false must not emit ESM:\n{tree}");
+    assert!(tree.contains("Paragraph"), "export stays a paragraph when mdx is off:\n{tree}");
+}
+
+#[test]
+fn hostile_module_source_is_kept_as_text() {
+    let source = "import Foo from \"../../../../etc/passwd\"\n";
+    let allocator = Allocator::new();
+    let doc = parse_mdx(&allocator, source);
+    let esm = only_esm(&doc);
+    assert_eq!(esm.value, "import Foo from \"../../../../etc/passwd\"");
+    assert!(
+        !std::path::Path::new("../../../../etc/passwd").exists()
+            || esm.value.contains("../../../../etc/passwd"),
+        "hostile paths are stored as text; the parser must not resolve them"
+    );
+}
+
+#[test]
+fn optional_semicolon_is_kept_on_the_node() {
+    let source = "import Foo from \"./Foo\";\n";
+    let allocator = Allocator::new();
+    let doc = parse_mdx(&allocator, source);
+    let esm = only_esm(&doc);
+    assert_eq!(esm.value, "import Foo from \"./Foo\";");
+}
+
+#[test]
+fn import_interrupts_paragraph() {
+    let tree = mdx_tree("Hello\nimport Foo from \"./Foo\"\n");
+    assert!(tree.contains("Paragraph"), "leading prose stays a paragraph:\n{tree}");
+    assert!(tree.contains("MdxjsEsm"), "import at line start is a block:\n{tree}");
+    assert!(tree.contains("Text \"Hello\""), "prose text is unchanged:\n{tree}");
+}
+
+#[test]
+fn invalid_import_does_not_interrupt_paragraph() {
+    let tree = mdx_tree("Hello\nimport Foo from\n");
+    assert!(!tree.contains("MdxjsEsm"), "incomplete import must not become ESM:\n{tree}");
+    assert!(tree.contains("Paragraph"), "incomplete import stays Markdown with the prose:\n{tree}");
+}

--- a/crates/ox_content_parser/tests/mdx_jsx.rs
+++ b/crates/ox_content_parser/tests/mdx_jsx.rs
@@ -2,8 +2,9 @@
 //!
 //! This slice covers PascalCase elements (flow + text), literal / boolean /
 //! `{expr}` attributes, self-closing tags, and simple open/close children.
-//! Lowercase HTML stays `Html`. Spreads, fragments, JSX comments, ESM, and
+//! Lowercase HTML stays `Html`. Spreads, fragments, JSX comments, and
 //! `{expression}` children are deferred — tests below pin that subset.
+//! Block-level `import` / `export` are covered in `mdx_esm.rs`.
 
 use ox_content_allocator::Allocator;
 use ox_content_parser::{Parser, ParserOptions};

--- a/crates/ox_content_parser/tests/mdx_options.rs
+++ b/crates/ox_content_parser/tests/mdx_options.rs
@@ -1,7 +1,8 @@
 //! Strict tests for `ParserOptions.mdx`.
 //!
 //! Enabling the flag must not change CommonMark or GFM parse output for
-//! non-JSX Markdown. PascalCase JSX is covered in `mdx_jsx.rs`.
+//! non-JSX / non-ESM Markdown. PascalCase JSX is covered in `mdx_jsx.rs`.
+//! `import` / `export` are covered in `mdx_esm.rs`.
 
 use ox_content_allocator::Allocator;
 use ox_content_parser::{Parser, ParserOptions};
@@ -132,16 +133,6 @@ fn mdx_flag_is_noop_for_gfm_table() {
 #[test]
 fn mdx_flag_is_noop_for_gfm_task_list() {
     assert_mdx_flag_is_noop("- [ ] todo\n- [x] done\n", ParserOptions::gfm());
-}
-
-#[test]
-fn mdx_flag_is_noop_for_import_line() {
-    assert_mdx_flag_is_noop("import { Chart } from './Chart'\n", ParserOptions::default());
-}
-
-#[test]
-fn mdx_flag_is_noop_for_export_line() {
-    assert_mdx_flag_is_noop("export const meta = { title: 'Hi' }\n", ParserOptions::default());
 }
 
 #[test]

--- a/docs/content/mdx.md
+++ b/docs/content/mdx.md
@@ -8,12 +8,14 @@ description: Embed Vue, React, or Svelte components in Markdown using island hyd
 Ox Content lets you embed framework components inside Markdown and `.mdx` files.
 It is worth understanding how this works, because it differs from "classic" MDX:
 
-- **JSX elements parse when MDX is enabled.** With `mdx: true` /
-  `ParserOptions.mdx`, the Rust parser turns PascalCase tags into
-  `MdxJsxFlowElement` / `MdxJsxTextElement` nodes (self-closing or simple
-  open/close, with literal, boolean, and `{expr}` attributes). `.md` stays
-  CommonMark + GFM unless that option is on. `import` / `export` and
-  `{expression}` children are not parsed yet.
+- **JSX elements and `import` / `export` parse when MDX is enabled.** With
+  `mdx: true` / `ParserOptions.mdx`, the Rust parser turns PascalCase tags
+  into `MdxJsxFlowElement` / `MdxJsxTextElement` nodes (self-closing or
+  simple open/close, with literal, boolean, and `{expr}` attributes), and
+  block-level ESM `import` / `export` statements into `MdxjsEsm` nodes. The
+  statement source is stored on the node; it is not executed. `.md` stays
+  CommonMark + GFM unless that option is on. `{expression}` children are
+  not parsed yet.
 - **Components are resolved by a framework plugin**, not the renderer. The
   React/Vue/Svelte plugins scan the content for PascalCase component tags,
   replace them with **island** placeholders, and hydrate them on the client.
@@ -73,10 +75,26 @@ Regular **Markdown** prose.
 ```
 
 Only tags that start with an uppercase letter are treated as JSX / components,
-so ordinary HTML (`<div>`, `<span>`, …) stays raw HTML. Tags inside fenced
-code blocks and inline code are **not** components, so you can document
-component usage without it being executed. Spreads, fragments, JSX comments,
-and `import` / `export` are not parsed yet.
+so ordinary HTML (`<div>`, `<span>`, …) stays raw HTML. Tags and ESM
+statements inside fenced code blocks and inline code are **not** parsed as
+MDX, so you can document usage without it being executed. Spreads, fragments,
+JSX comments, and `{expression}` children are not parsed yet.
+
+When MDX is on, module-level `import` and `export` become `MdxjsEsm` nodes:
+
+```md
+import Foo from "./Foo"
+import { Foo, Bar as Baz } from "./mod"
+
+export const meta = { title: "Hi" }
+export default Foo
+```
+
+The parser keeps the source string (including hostile path text) and does
+not read the filesystem. Framework plugins may later resolve local
+components from that source. Invalid or unclosed `import` / `export` lines
+stay ordinary Markdown. This documentation site does not enable MDX
+globally, so the snippet above is an example, not a live module.
 
 ### Props
 


### PR DESCRIPTION
## Summary

- When `ParserOptions.mdx` is true, block-level ESM `import` / `export` become `MdxjsEsm` nodes. The statement source (and optional module specifier) is stored; nothing is executed or read from disk.
- Supported shapes: default and named imports (`import Foo from "./Foo"`, `import { Foo, Bar as Baz } from "./mod"`), `export const meta = { title: "Hi" }`, and straightforward `export default Foo`. `mdx=false` leaves these lines as Markdown paragraphs.
- Fenced code, inline code, and invalid / unclosed `import` stay Markdown. Existing PascalCase JSX parse is unchanged. Docs updated in `docs/content/mdx.md` (example is fenced; the docs site does not enable MDX globally).

Refs #701. Parent #699.

## Risk

- Risk level: low
- User or production impact: none unless `mdx: true` is set. Default CommonMark / GFM output is unchanged. `MdxjsEsm` still renders as nothing.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run: `rustup run 1.95.0 cargo test -p ox_content_parser` and `clippy -D warnings`; `vp check --fix`
- [x] Manual verification completed: existing CommonMark/GFM snapshots still pass; JSX regression tests still pass
- [x] Edge cases or failure modes considered: unclosed / incomplete `import` stays Markdown; hostile path strings are kept as text; fences and inline code are skipped

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

## Test plan

- [ ] CI green on this PR
- [ ] Confirm `.md` / `mdx=false` fixtures still treat `import` / `export` as paragraphs
- [ ] Confirm `import Foo from "./Foo"` and `export const meta = { title: "Hi" }` become `MdxjsEsm` when `mdx=true`
- [ ] Confirm fences, inline code, and invalid imports do not emit ESM
- [ ] Confirm JSX parse from #722 still works beside an import


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790154315&installation_model_id=422833&pr_number=731&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F731&signature=6d83b7f7e7aea8dca41355c327e19f0a1bdad09531bea3b30f026138a82aab2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->