### PR TITLE
feat(mdx): parse JSX fragments, spreads, and member names

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -1211,6 +1211,16 @@ export interface JsPublicExport {
   source: JsExportSource
 }
 
+/** Opt-in reader chrome flags. Presence of the object enables the feature. */
+export interface JsReaderChrome {
+  /** Copy button on fenced code blocks. */
+  copy?: boolean
+  /** Icon and `rel` on outbound links. */
+  externalLinks?: boolean
+  /** Back-to-top control that appears after scroll. */
+  backToTop?: boolean
+}
+
 /** Resolved source module. */
 export interface JsResolvedModule {
   path: string
@@ -1443,16 +1453,6 @@ export interface JsSsgConfig {
   readerChrome?: JsReaderChrome
 }
 
-/** Opt-in reader chrome flags. Presence of the object enables the feature. */
-export interface JsReaderChrome {
-  /** Copy button on fenced code blocks. */
-  copy?: boolean
-  /** Icon and `rel` on outbound links. */
-  externalLinks?: boolean
-  /** Back-to-top control that appears after scroll. */
-  backToTop?: boolean
-}
-
 /** Result of SSG shared asset extraction. */
 export interface JsSsgExternalizedAssets {
   /** HTML pages with inline assets replaced. */
@@ -1567,13 +1567,8 @@ export interface JsSsgSidebarItem {
   stickyCollapsed?: boolean
 }
 
-/** Opt-in `::: steps` ordered lists. */
+/** Opt-in `::: steps` wrappers. `enabled` defaults to `false`. */
 export interface JsStepsOptions {
-  /**
-   * Enable `::: steps` wrappers around ordered lists.
-   *
-   * Default: `false`.
-   */
   enabled?: boolean
 }
 
@@ -1891,12 +1886,6 @@ export interface JsTransformOptions {
    */
   containers?: JsContainerOptions
   /**
-   * Opt-in figures, captions, and lazy images.
-   *
-   * Default: disabled.
-   */
-  images?: JsImageOptions
-  /**
    * Opt-in Markdown file includes via `<!-- @include: PATH -->`.
    *
    * Default: disabled.
@@ -1914,6 +1903,12 @@ export interface JsTransformOptions {
    * Default: disabled.
    */
   badges?: JsBadgeOptions
+  /**
+   * Opt-in figures, captions, and lazy images.
+   *
+   * Default: disabled.
+   */
+  images?: JsImageOptions
 }
 
 /** Type parameter documentation (`<T extends C = D>`) used by generated API docs. */

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -1216,6 +1216,16 @@ export interface JsPublicExport {
   source: JsExportSource
 }
 
+/** Opt-in reader chrome flags. Presence of the object enables the feature. */
+export interface JsReaderChrome {
+  /** Copy button on fenced code blocks. */
+  copy?: boolean
+  /** Icon and `rel` on outbound links. */
+  externalLinks?: boolean
+  /** Back-to-top control that appears after scroll. */
+  backToTop?: boolean
+}
+
 /** Resolved source module. */
 export interface JsResolvedModule {
   path: string
@@ -1448,16 +1458,6 @@ export interface JsSsgConfig {
   readerChrome?: JsReaderChrome
 }
 
-/** Opt-in reader chrome flags. Presence of the object enables the feature. */
-export interface JsReaderChrome {
-  /** Copy button on fenced code blocks. */
-  copy?: boolean
-  /** Icon and `rel` on outbound links. */
-  externalLinks?: boolean
-  /** Back-to-top control that appears after scroll. */
-  backToTop?: boolean
-}
-
 /** Result of SSG shared asset extraction. */
 export interface JsSsgExternalizedAssets {
   /** HTML pages with inline assets replaced. */
@@ -1572,13 +1572,8 @@ export interface JsSsgSidebarItem {
   stickyCollapsed?: boolean
 }
 
-/** Opt-in `::: steps` ordered lists. */
+/** Opt-in `::: steps` wrappers. `enabled` defaults to `false`. */
 export interface JsStepsOptions {
-  /**
-   * Enable `::: steps` wrappers around ordered lists.
-   *
-   * Default: `false`.
-   */
   enabled?: boolean
 }
 
@@ -1896,12 +1891,6 @@ export interface JsTransformOptions {
    */
   containers?: JsContainerOptions
   /**
-   * Opt-in figures, captions, and lazy images.
-   *
-   * Default: disabled.
-   */
-  images?: JsImageOptions
-  /**
    * Opt-in Markdown file includes via `<!-- @include: PATH -->`.
    *
    * Default: disabled.
@@ -1919,6 +1908,12 @@ export interface JsTransformOptions {
    * Default: disabled.
    */
   badges?: JsBadgeOptions
+  /**
+   * Opt-in figures, captions, and lazy images.
+   *
+   * Default: disabled.
+   */
+  images?: JsImageOptions
 }
 
 /** Type parameter documentation (`<T extends C = D>`) used by generated API docs. */

--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -1,5 +1,7 @@
 //! Markdown parser implementation.
 
+use std::cell::Cell;
+
 use ox_content_allocator::Allocator;
 use ox_content_ast::{Document, Span};
 
@@ -91,11 +93,11 @@ pub struct ParserOptions {
 
     /// Enable MDX. Off by default.
     ///
-    /// When set, PascalCase JSX elements parse as [`ox_content_ast::MdxJsxFlowElement`]
-    /// / [`ox_content_ast::MdxJsxTextElement`], and module-level `import` /
-    /// `export` parse as [`ox_content_ast::MdxjsEsm`] (raw source, not evaluated).
-    /// `{expression}` children, fragments, and spreads are not parsed yet.
-    /// Lowercase HTML stays HTML.
+    /// When set, PascalCase and member-name JSX elements, fragments, spreads,
+    /// JSX comments, and `{expression}` children parse as MDX AST nodes.
+    /// Module-level `import` / `export` parse as [`ox_content_ast::MdxjsEsm`].
+    /// Expression and ESM source is stored, not evaluated. Lowercase HTML
+    /// stays HTML.
     ///
     /// Default: `false`.
     pub mdx: bool,
@@ -169,6 +171,11 @@ pub struct Parser<'a> {
     /// construction and must not be reinterpreted as setext underlines
     /// during the re-parse.
     lazy_lines: Option<std::rc::Rc<rustc_hash::FxHashSet<u32>>>,
+
+    /// When set, `{expression}` is parsed in phrasing (JSX children).
+    /// Document-level prose keeps braces as text so `import { x }` is left
+    /// for the ESM scanner.
+    mdx_in_jsx: Cell<bool>,
 }
 
 impl<'a> Parser<'a> {
@@ -190,6 +197,7 @@ impl<'a> Parser<'a> {
             definitions: None,
             footnote_labels: None,
             lazy_lines: None,
+            mdx_in_jsx: Cell::new(false),
         };
         // A single fused pre-pass collects both the reference definitions
         // and the footnote labels (see `prepass.rs`).
@@ -220,6 +228,7 @@ impl<'a> Parser<'a> {
             // Most sub-sources are entered without any lazy continuation
             // line, and every block quote and list item builds one of these.
             lazy_lines: (!lazy_lines.is_empty()).then(|| std::rc::Rc::new(lazy_lines)),
+            mdx_in_jsx: Cell::new(self.mdx_in_jsx.get()),
         }
     }
 

--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -83,6 +83,13 @@ impl<'a> Parser<'a> {
                     return self.parse_fenced_code(start);
                 }
             }
+            b'{' => {
+                if self.options.mdx
+                    && let Some(node) = self.try_parse_mdx_flow_expression(start, trimmed_start)?
+                {
+                    return Ok(Some(node));
+                }
+            }
             b'<' => {
                 if self.options.mdx
                     && let Some(node) = self.try_parse_mdx_jsx_flow(start, trimmed_start)?

--- a/crates/ox_content_parser/src/parser/cursor.rs
+++ b/crates/ox_content_parser/src/parser/cursor.rs
@@ -154,6 +154,10 @@ impl<'a> Parser<'a> {
                 let trimmed = &line[trimmed_start - line_start..];
                 Self::try_parse_fenced_code_at(line, trimmed)
             }
+            b'{' => {
+                self.options.mdx
+                    && super::mdx_jsx::looks_like_flow_expression(self.source, trimmed_start)
+            }
             b'<' => {
                 let bytes = self.source.as_bytes();
                 if self.options.mdx && super::mdx_jsx::looks_like_jsx_open(bytes, trimmed_start) {

--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -46,6 +46,18 @@ impl<'a> Parser<'a> {
         Ok(children)
     }
 
+    fn allows_mdx_text_expression(&self) -> bool {
+        self.options.mdx && self.mdx_in_jsx.get()
+    }
+
+    fn next_inline_marker(&self, bytes: &[u8], from: usize) -> usize {
+        let special = next_inline_special(bytes, from);
+        if !self.allows_mdx_text_expression() || from >= special {
+            return special;
+        }
+        memchr(b'{', &bytes[from..special]).map_or(special, |rel| from + rel)
+    }
+
     pub(super) fn parse_inline(
         &self,
         content: &'a str,
@@ -53,7 +65,7 @@ impl<'a> Parser<'a> {
     ) -> ParseResult<Vec<'a, Node<'a>>> {
         profile_span!("parser::parse_inline");
         let bytes = content.as_bytes();
-        let first_special = next_inline_special(bytes, 0);
+        let first_special = self.next_inline_marker(bytes, 0);
 
         // Plain text is both the most common inline shape and exactly one AST
         // node. Reserving the general four-node floor here wasted three
@@ -82,7 +94,7 @@ impl<'a> Parser<'a> {
             // one Text node. This keeps the parser on bulk byte scans for
             // prose and only enters the slower match when a real marker byte
             // has been reached.
-            pos = first_scan.take().unwrap_or_else(|| next_inline_special(bytes, pos));
+            pos = first_scan.take().unwrap_or_else(|| self.next_inline_marker(bytes, pos));
 
             // Fold soft line breaks into the running text node. A newline
             // with non-whitespace on both sides is a soft break with nothing
@@ -100,7 +112,7 @@ impl<'a> Parser<'a> {
                 && !matches!(bytes[pos - 1], b' ' | b'\t')
                 && !matches!(bytes[pos + 1], b' ' | b'\t' | b'\n')
             {
-                pos = next_inline_special(bytes, pos + 1);
+                pos = self.next_inline_marker(bytes, pos + 1);
             }
 
             if pos > start {
@@ -156,6 +168,16 @@ impl<'a> Parser<'a> {
                     *pos = end;
                 } else {
                     Self::push_text(children, "&", offset + *pos, offset + *pos + 1);
+                    *pos += 1;
+                }
+            }
+            b'{' if self.allows_mdx_text_expression() => {
+                if let Some((node, end)) = self.try_parse_mdx_text_expression(content, *pos, offset)
+                {
+                    children.push(node);
+                    *pos = end;
+                } else {
+                    Self::push_text(children, "{", offset + *pos, offset + *pos + 1);
                     *pos += 1;
                 }
             }

--- a/crates/ox_content_parser/src/parser/mdx_jsx.rs
+++ b/crates/ox_content_parser/src/parser/mdx_jsx.rs
@@ -1,21 +1,27 @@
-//! MDX JSX element parse: PascalCase flow and text tags.
+//! MDX JSX parse: PascalCase / member names, fragments, spreads, expressions.
 
 use ox_content_ast::{MdxJsxFlowElement, MdxJsxTextElement, Node, Span};
 
 use super::Parser;
 use crate::error::ParseResult;
 
+mod braces;
+mod expression;
 mod scan;
 
 pub(super) fn looks_like_jsx_open(bytes: &[u8], at: usize) -> bool {
     scan::looks_like_jsx_open(bytes, at)
 }
 
+pub(super) fn looks_like_flow_expression(source: &str, at: usize) -> bool {
+    expression::looks_like_flow_expression(source, at)
+}
+
 impl<'a> Parser<'a> {
     /// Parses a flow JSX element starting at the current line.
     ///
     /// On failure the cursor is left unchanged so HTML / paragraph dispatch
-    /// can run. Unclosed tags and spreads do not panic.
+    /// can run. Unclosed tags do not panic or emit a half-parsed node.
     pub(super) fn try_parse_mdx_jsx_flow(
         &mut self,
         start: usize,
@@ -47,7 +53,7 @@ impl<'a> Parser<'a> {
 
         self.position = scan::after_trailing_line_ws(self.source.as_bytes(), element_end);
         Ok(Some(Node::MdxJsxFlowElement(self.allocator.boxed(MdxJsxFlowElement {
-            name: Some(open.name),
+            name: open.name,
             attributes,
             children,
             self_closing,
@@ -79,13 +85,14 @@ impl<'a> Parser<'a> {
             else {
                 return Ok(None);
             };
-            let children = self.parse_inline(&content[open.end..close_start], offset + open.end)?;
+            let children =
+                self.parse_jsx_phrasing(&content[open.end..close_start], offset + open.end)?;
             (false, children, close_end)
         };
 
         Ok(Some((
             Node::MdxJsxTextElement(self.allocator.boxed(MdxJsxTextElement {
-                name: Some(open.name),
+                name: open.name,
                 attributes,
                 children,
                 self_closing,
@@ -93,6 +100,17 @@ impl<'a> Parser<'a> {
             })),
             end,
         )))
+    }
+
+    fn parse_jsx_phrasing(
+        &self,
+        content: &'a str,
+        offset: usize,
+    ) -> ParseResult<ox_content_allocator::Vec<'a, Node<'a>>> {
+        let previous = self.mdx_in_jsx.replace(true);
+        let children = self.parse_inline(content, offset);
+        self.mdx_in_jsx.set(previous);
+        children
     }
 
     fn parse_jsx_flow_children(
@@ -106,6 +124,7 @@ impl<'a> Parser<'a> {
         let inner = &self.source[inner_start..inner_end];
         let mut sub = self.sub_parser_with_lazy_lines(inner, rustc_hash::FxHashSet::default());
         sub.nesting_depth = self.nesting_depth + 1;
+        sub.mdx_in_jsx.set(true);
         let mut children = sub.parse()?.children;
         for child in &mut children {
             Self::offset_node_spans(child, inner_start as u32);

--- a/crates/ox_content_parser/src/parser/mdx_jsx/braces.rs
+++ b/crates/ox_content_parser/src/parser/mdx_jsx/braces.rs
@@ -1,0 +1,100 @@
+//! Brace, string, and comment skip for JSX tags and MDX expressions.
+//!
+//! This is not a JavaScript parser. Unclosed input returns `None` so the
+//! caller can refuse to emit a half-parsed node.
+
+/// Inner source and byte offset after the matching `}`.
+pub(super) fn scan_balanced_braces(source: &str, start: usize) -> Option<(&str, usize)> {
+    let end = skip_braces(source.as_bytes(), start)?;
+    Some((&source[start + 1..end - 1], end))
+}
+
+pub(super) fn skip_braces(bytes: &[u8], start: usize) -> Option<usize> {
+    if bytes.get(start) != Some(&b'{') {
+        return None;
+    }
+    let mut cursor = start;
+    let mut depth = 0u32;
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'"' | b'\'' | b'`' => cursor = skip_quoted(bytes, cursor)?,
+            b'/' if bytes.get(cursor + 1) == Some(&b'/') => {
+                cursor = skip_line_comment(bytes, cursor);
+            }
+            b'/' if bytes.get(cursor + 1) == Some(&b'*') => {
+                cursor = skip_block_comment(bytes, cursor)?;
+            }
+            b'{' => {
+                depth = depth.saturating_add(1);
+                cursor += 1;
+            }
+            b'}' => {
+                depth = depth.saturating_sub(1);
+                cursor += 1;
+                if depth == 0 {
+                    return Some(cursor);
+                }
+            }
+            _ => cursor += 1,
+        }
+    }
+    None
+}
+
+pub(super) fn skip_quoted(bytes: &[u8], start: usize) -> Option<usize> {
+    let quote = *bytes.get(start)?;
+    let mut cursor = start + 1;
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'\\' && cursor + 1 < bytes.len() {
+            cursor += 2;
+            continue;
+        }
+        if bytes[cursor] == quote {
+            return Some(cursor + 1);
+        }
+        cursor += 1;
+    }
+    None
+}
+
+pub(super) fn skip_backticks(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut open = 0usize;
+    while start + open < bytes.len() && bytes[start + open] == b'`' {
+        open += 1;
+    }
+    if open == 0 {
+        return None;
+    }
+    let mut cursor = start + open;
+    while cursor + open <= bytes.len() {
+        if bytes[cursor..cursor + open].iter().all(|byte| *byte == b'`')
+            && bytes.get(cursor + open) != Some(&b'`')
+        {
+            return Some(cursor + open);
+        }
+        cursor += 1;
+    }
+    None
+}
+
+fn skip_line_comment(bytes: &[u8], start: usize) -> usize {
+    let mut cursor = start + 2;
+    while cursor < bytes.len() && bytes[cursor] != b'\n' {
+        cursor += 1;
+    }
+    cursor
+}
+
+fn skip_block_comment(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut cursor = start + 2;
+    while cursor + 1 < bytes.len() {
+        if bytes[cursor] == b'*' && bytes[cursor + 1] == b'/' {
+            return Some(cursor + 2);
+        }
+        cursor += 1;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/ox_content_parser/src/parser/mdx_jsx/braces/tests.rs
+++ b/crates/ox_content_parser/src/parser/mdx_jsx/braces/tests.rs
@@ -1,0 +1,31 @@
+#![allow(clippy::disallowed_macros, clippy::disallowed_methods, clippy::disallowed_types)]
+
+use super::{scan_balanced_braces, skip_braces};
+
+#[test]
+fn scan_keeps_inner_source_without_braces() {
+    let (value, end) = scan_balanced_braces("{items.map}", 0).expect("balanced");
+    assert_eq!(value, "items.map");
+    assert_eq!(end, 11);
+}
+
+#[test]
+fn scan_skips_block_comment_with_braces_inside() {
+    let (value, _) = scan_balanced_braces("{/* hide } */}", 0).expect("comment");
+    assert_eq!(value, "/* hide } */");
+}
+
+#[test]
+fn scan_skips_nested_braces_and_strings() {
+    let source = "{...{html:\"<script>\"}}";
+    let (value, end) = scan_balanced_braces(source, 0).expect("nested");
+    assert_eq!(value, "...{html:\"<script>\"}");
+    assert_eq!(end, source.len());
+}
+
+#[test]
+fn unclosed_brace_or_comment_is_none() {
+    assert!(skip_braces(b"{items.map", 0).is_none());
+    assert!(skip_braces(b"{/* hide", 0).is_none());
+    assert!(skip_braces(b"{foo /* bar", 0).is_none());
+}

--- a/crates/ox_content_parser/src/parser/mdx_jsx/expression.rs
+++ b/crates/ox_content_parser/src/parser/mdx_jsx/expression.rs
@@ -1,0 +1,66 @@
+//! MDX `{expression}` parse: flow, text, and JSX comments.
+//!
+//! Source inside the braces is stored. Nothing is evaluated.
+
+use ox_content_ast::{MdxFlowExpression, MdxTextExpression, Node, Span};
+
+use super::Parser;
+use super::braces;
+use super::scan;
+use crate::error::ParseResult;
+
+pub(super) fn looks_like_flow_expression(source: &str, at: usize) -> bool {
+    let Some((_, brace_end)) = braces::scan_balanced_braces(source, at) else {
+        return false;
+    };
+    scan::only_ws_until_eol(source.as_bytes(), brace_end)
+}
+
+impl<'a> Parser<'a> {
+    /// Parses a block `{expression}` or `{/* comment */}` at the current line.
+    ///
+    /// Succeeds only when the closing `}` is followed by line whitespace.
+    /// On failure the cursor is left unchanged.
+    pub(in crate::parser) fn try_parse_mdx_flow_expression(
+        &mut self,
+        start: usize,
+        trimmed_start: usize,
+    ) -> ParseResult<Option<Node<'a>>> {
+        if !self.options.mdx {
+            return Ok(None);
+        }
+        let Some((value, brace_end)) = braces::scan_balanced_braces(self.source, trimmed_start)
+        else {
+            return Ok(None);
+        };
+        if !scan::only_ws_until_eol(self.source.as_bytes(), brace_end) {
+            return Ok(None);
+        }
+
+        self.position = scan::after_trailing_line_ws(self.source.as_bytes(), brace_end);
+        Ok(Some(Node::MdxFlowExpression(MdxFlowExpression {
+            value,
+            span: Span::new(start as u32, self.position as u32),
+        })))
+    }
+
+    /// Parses an inline `{expression}` or `{/* comment */}` at `pos`.
+    pub(in crate::parser) fn try_parse_mdx_text_expression(
+        &self,
+        content: &'a str,
+        pos: usize,
+        offset: usize,
+    ) -> Option<(Node<'a>, usize)> {
+        if !self.options.mdx {
+            return None;
+        }
+        let (value, end) = braces::scan_balanced_braces(content, pos)?;
+        Some((
+            Node::MdxTextExpression(MdxTextExpression {
+                value,
+                span: Span::new((offset + pos) as u32, (offset + end) as u32),
+            }),
+            end,
+        ))
+    }
+}

--- a/crates/ox_content_parser/src/parser/mdx_jsx/scan.rs
+++ b/crates/ox_content_parser/src/parser/mdx_jsx/scan.rs
@@ -1,20 +1,22 @@
-//! JSX tag scanning: PascalCase names and named attributes.
+//! JSX tag scanning: fragments, member names, named attrs, and spreads.
 
 use ox_content_allocator::Vec;
 use ox_content_ast::{
     MdxJsxAttribute, MdxJsxAttributeEntry, MdxJsxAttributeValue, MdxJsxAttributeValueExpression,
-    Span,
+    MdxJsxExpressionAttribute, Span,
 };
+
+use super::braces::{skip_backticks, skip_braces, skip_quoted};
 
 /// Opening tag accepted by this slice.
 pub(super) struct JsxOpen<'a> {
-    pub name: &'a str,
+    pub name: Option<&'a str>,
     pub self_closing: bool,
     pub end: usize,
 }
 
 struct TagSkip<'a> {
-    name: &'a str,
+    name: Option<&'a str>,
     start: usize,
     closing: bool,
     self_closing: bool,
@@ -23,7 +25,12 @@ struct TagSkip<'a> {
 
 #[inline]
 pub(super) fn looks_like_jsx_open(bytes: &[u8], at: usize) -> bool {
-    bytes.get(at) == Some(&b'<') && bytes.get(at + 1).is_some_and(u8::is_ascii_uppercase)
+    bytes.get(at) == Some(&b'<')
+        && match bytes.get(at + 1) {
+            Some(b'>') => true,
+            Some(byte) => byte.is_ascii_uppercase(),
+            None => false,
+        }
 }
 
 pub(super) fn only_ws_until_eol(bytes: &[u8], mut cursor: usize) -> bool {
@@ -54,20 +61,27 @@ pub(super) fn scan_jsx_open<'a>(
     if !looks_like_jsx_open(bytes, start) {
         return None;
     }
+    if bytes.get(start + 1) == Some(&b'>') {
+        return Some(JsxOpen { name: None, self_closing: false, end: start + 2 });
+    }
     let name_start = start + 1;
     let name_end = scan_jsx_name(bytes, name_start)?;
     let name = &source[name_start..name_end];
-    let (self_closing, end) = scan_named_attributes(source, name_end, offset, attributes)?;
-    Some(JsxOpen { name, self_closing, end })
+    let (self_closing, end) = scan_attributes(source, name_end, offset, attributes)?;
+    Some(JsxOpen { name: Some(name), self_closing, end })
 }
 
-pub(super) fn find_matching_close(source: &str, from: usize, name: &str) -> Option<(usize, usize)> {
+pub(super) fn find_matching_close(
+    source: &str,
+    from: usize,
+    name: Option<&str>,
+) -> Option<(usize, usize)> {
     let bytes = source.as_bytes();
     let mut cursor = from;
     let mut depth = 1u32;
     while cursor < bytes.len() {
         match bytes[cursor] {
-            b'{' => cursor = skip_braces(bytes, cursor)?,
+            b'{' => cursor = skip_braces(bytes, cursor).unwrap_or(cursor + 1),
             b'`' => cursor = skip_backticks(bytes, cursor).unwrap_or(cursor + 1),
             b'<' => {
                 let Some(tag) = scan_tag_skip(source, cursor) else {
@@ -93,20 +107,13 @@ pub(super) fn find_matching_close(source: &str, from: usize, name: &str) -> Opti
 }
 
 fn scan_jsx_name(bytes: &[u8], start: usize) -> Option<usize> {
-    let first = *bytes.get(start)?;
-    if !first.is_ascii_uppercase() {
+    if !bytes.get(start)?.is_ascii_uppercase() {
         return None;
     }
-    let mut end = start + 1;
-    while end < bytes.len()
-        && (bytes[end].is_ascii_alphanumeric() || matches!(bytes[end], b'_' | b'$'))
-    {
-        end += 1;
-    }
-    Some(end)
+    scan_member_name(bytes, start)
 }
 
-fn scan_named_attributes<'a>(
+fn scan_attributes<'a>(
     source: &'a str,
     mut cursor: usize,
     offset: usize,
@@ -118,11 +125,27 @@ fn scan_named_attributes<'a>(
         match bytes.get(cursor)? {
             b'/' if bytes.get(cursor + 1) == Some(&b'>') => return Some((true, cursor + 2)),
             b'>' => return Some((false, cursor + 1)),
-            b'{' => return None,
+            b'{' if had_ws => {
+                cursor = push_expression_attribute(source, cursor, offset, attributes)?;
+            }
             _ if !had_ws => return None,
             _ => cursor = push_named_attribute(source, cursor, offset, attributes)?,
         }
     }
+}
+
+fn push_expression_attribute<'a>(
+    source: &'a str,
+    start: usize,
+    offset: usize,
+    attributes: &mut Vec<'a, MdxJsxAttributeEntry<'a>>,
+) -> Option<usize> {
+    let end = skip_braces(source.as_bytes(), start)?;
+    attributes.push(MdxJsxAttributeEntry::Expression(MdxJsxExpressionAttribute {
+        value: &source[start + 1..end - 1],
+        span: Span::new((offset + start) as u32, (offset + end) as u32),
+    }));
+    Some(end)
 }
 
 fn push_named_attribute<'a>(
@@ -190,14 +213,17 @@ fn scan_tag_skip(source: &str, start: usize) -> Option<TagSkip<'_>> {
     if closing {
         cursor += 1;
     }
-    let name_end = scan_any_name(bytes, cursor)?;
+    if bytes.get(cursor) == Some(&b'>') {
+        return Some(TagSkip { name: None, start, closing, self_closing: false, end: cursor + 1 });
+    }
+    let name_end = scan_member_name(bytes, cursor)?;
     let name = &source[cursor..name_end];
     cursor = name_end;
     let self_closing = skip_tag_rest(bytes, &mut cursor)?;
     if closing && self_closing {
         return None;
     }
-    Some(TagSkip { name, start, closing, self_closing, end: cursor })
+    Some(TagSkip { name: Some(name), start, closing, self_closing, end: cursor })
 }
 
 fn skip_tag_rest(bytes: &[u8], cursor: &mut usize) -> Option<bool> {
@@ -232,7 +258,15 @@ fn skip_tag_rest(bytes: &[u8], cursor: &mut usize) -> Option<bool> {
     }
 }
 
-fn scan_any_name(bytes: &[u8], start: usize) -> Option<usize> {
+fn scan_member_name(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut end = scan_ident(bytes, start)?;
+    while bytes.get(end) == Some(&b'.') {
+        end = scan_ident(bytes, end + 1)?;
+    }
+    Some(end)
+}
+
+fn scan_ident(bytes: &[u8], start: usize) -> Option<usize> {
     let first = *bytes.get(start)?;
     if !(first.is_ascii_alphabetic() || matches!(first, b'_' | b'$')) {
         return None;
@@ -271,68 +305,6 @@ fn skip_ws(bytes: &[u8], cursor: &mut usize) -> bool {
         *cursor += 1;
     }
     *cursor > start
-}
-
-fn skip_quoted(bytes: &[u8], start: usize) -> Option<usize> {
-    let quote = *bytes.get(start)?;
-    let mut cursor = start + 1;
-    while cursor < bytes.len() {
-        if bytes[cursor] == b'\\' && cursor + 1 < bytes.len() {
-            cursor += 2;
-            continue;
-        }
-        if bytes[cursor] == quote {
-            return Some(cursor + 1);
-        }
-        cursor += 1;
-    }
-    None
-}
-
-fn skip_braces(bytes: &[u8], start: usize) -> Option<usize> {
-    if bytes.get(start) != Some(&b'{') {
-        return None;
-    }
-    let mut cursor = start;
-    let mut depth = 0u32;
-    while cursor < bytes.len() {
-        match bytes[cursor] {
-            b'"' | b'\'' | b'`' => cursor = skip_quoted(bytes, cursor)?,
-            b'{' => {
-                depth = depth.saturating_add(1);
-                cursor += 1;
-            }
-            b'}' => {
-                depth = depth.saturating_sub(1);
-                cursor += 1;
-                if depth == 0 {
-                    return Some(cursor);
-                }
-            }
-            _ => cursor += 1,
-        }
-    }
-    None
-}
-
-fn skip_backticks(bytes: &[u8], start: usize) -> Option<usize> {
-    let mut open = 0usize;
-    while start + open < bytes.len() && bytes[start + open] == b'`' {
-        open += 1;
-    }
-    if open == 0 {
-        return None;
-    }
-    let mut cursor = start + open;
-    while cursor + open <= bytes.len() {
-        if bytes[cursor..cursor + open].iter().all(|byte| *byte == b'`')
-            && bytes.get(cursor + open) != Some(&b'`')
-        {
-            return Some(cursor + open);
-        }
-        cursor += 1;
-    }
-    None
 }
 
 fn skip_unquoted_value(bytes: &[u8], cursor: &mut usize) {

--- a/crates/ox_content_parser/tests/mdx_jsx.rs
+++ b/crates/ox_content_parser/tests/mdx_jsx.rs
@@ -1,10 +1,10 @@
 //! JSX element parse when `ParserOptions.mdx` is true.
 //!
-//! This slice covers PascalCase elements (flow + text), literal / boolean /
-//! `{expr}` attributes, self-closing tags, and simple open/close children.
-//! Lowercase HTML stays `Html`. Spreads, fragments, JSX comments, and
-//! `{expression}` children are deferred — tests below pin that subset.
-//! Module-level `import` / `export` is covered in `mdx_esm.rs`.
+//! Covers PascalCase elements (flow + text), literal / boolean / `{expr}`
+//! attributes, self-closing tags, and simple open/close children. Lowercase
+//! HTML stays `Html`. Fragments, spreads, comments, member names, and
+//! children expressions live in `mdx_jsx_remainder.rs`. Module-level
+//! `import` / `export` is covered in `mdx_esm.rs`.
 
 use ox_content_allocator::Allocator;
 use ox_content_parser::{Parser, ParserOptions};
@@ -117,7 +117,7 @@ fn flow_open_close_parses_markdown_children() {
         "expected open/close flow:\n{tree}"
     );
     assert!(tree.contains("Strong"), "markdown children should parse:\n{tree}");
-    assert!(!tree.contains("MdxFlowExpression"), "child expressions are deferred:\n{tree}");
+    assert!(!tree.contains("MdxFlowExpression"), "this fixture has no child expression:\n{tree}");
 }
 
 #[test]
@@ -141,44 +141,56 @@ fn pascal_case_flow_interrupts_paragraph() {
 }
 
 #[test]
-fn spread_attr_is_not_parsed_yet() {
+fn spread_attr_is_expression_entry() {
     let tree = mdx_tree("<Alert {...props} />\n");
     assert!(
-        !tree.contains("MdxJsx") && !tree.contains("AttrExpr"),
-        "spreads are deferred:\n{tree}"
+        tree.contains("MdxJsxFlowElement name=Some(\"Alert\") self_closing=true"),
+        "expected flow Alert with spread:\n{tree}"
+    );
+    assert!(
+        tree.contains("AttrExpr value=\"...props\""),
+        "spreads store source, not a evaluated object:\n{tree}"
     );
 }
 
 #[test]
-fn fragment_is_not_parsed_yet() {
+fn fragment_parses_as_nameless_jsx() {
     let tree = mdx_tree("<>hello</>\n");
-    assert!(!tree.contains("MdxJsx"), "fragments are deferred:\n{tree}");
+    assert!(
+        tree.contains("MdxJsxFlowElement name=None self_closing=false"),
+        "expected a fragment:\n{tree}"
+    );
+    assert!(tree.contains("Text \"hello\""), "fragment children stay markdown:\n{tree}");
 }
 
 #[test]
-fn jsx_comment_is_not_parsed_yet() {
+fn jsx_comment_is_flow_expression() {
     let tree = mdx_tree("{/* hide */}\n");
     assert!(
-        !tree.contains("MdxJsx") && !tree.contains("MdxFlowExpression"),
-        "JSX comments are deferred:\n{tree}"
+        tree.contains("MdxFlowExpression value=\"/* hide */\""),
+        "JSX comments store source as an expression:\n{tree}"
+    );
+    assert!(!tree.contains("MdxJsx"), "a comment is not a JSX element:\n{tree}");
+}
+
+#[test]
+fn member_expression_name_parses() {
+    let tree = mdx_tree("<Foo.Bar />\n");
+    assert!(
+        tree.contains("MdxJsxFlowElement name=Some(\"Foo.Bar\") self_closing=true"),
+        "expected member name:\n{tree}"
     );
 }
 
 #[test]
-fn member_expression_name_is_not_parsed_yet() {
-    let tree = mdx_tree("<Foo.Bar />\n");
-    assert!(!tree.contains("MdxJsx"), "member names are deferred:\n{tree}");
-}
-
-#[test]
-fn children_brace_expression_is_not_an_mdx_expression() {
+fn children_brace_expression_stores_source() {
     let tree = mdx_tree("<Alert>{items.map}</Alert>\n");
     assert!(
         tree.contains("MdxJsxFlowElement name=Some(\"Alert\")"),
         "wrapper still parses:\n{tree}"
     );
     assert!(
-        !tree.contains("MdxFlowExpression") && !tree.contains("MdxTextExpression"),
-        "{{items.map}} children are deferred:\n{tree}"
+        tree.contains("MdxFlowExpression value=\"items.map\""),
+        "children expressions store source, not a evaluated result:\n{tree}"
     );
 }

--- a/crates/ox_content_parser/tests/mdx_jsx_remainder.rs
+++ b/crates/ox_content_parser/tests/mdx_jsx_remainder.rs
@@ -1,0 +1,247 @@
+//! Remaining JSX grammar when `ParserOptions.mdx` is true.
+//!
+//! Fragments, spreads, JSX comments, member names, children expressions,
+//! and markdown-in-JSX. Source is stored; nothing is evaluated. `mdx=false`,
+//! fences, inline code, and unclosed input must not emit MDX nodes.
+
+use ox_content_allocator::Allocator;
+use ox_content_parser::{Parser, ParserOptions};
+
+#[path = "support/pretty.rs"]
+mod pretty;
+
+fn pretty_ast(source: &str, options: ParserOptions) -> String {
+    let allocator = Allocator::new();
+    let doc = Parser::with_options(&allocator, source, options)
+        .parse()
+        .expect("parser should not fail on MDX JSX remainder fixtures");
+    let mut out = String::new();
+    pretty::format_document(&doc, source, &mut out);
+    out
+}
+
+fn mdx_tree(source: &str) -> String {
+    pretty_ast(source, ParserOptions::mdx())
+}
+
+#[test]
+fn disabled_mdx_does_not_emit_remainder_constructs() {
+    let sources = [
+        "<>hello</>\n",
+        "<Alert {...props} />\n",
+        "{/* hide */}\n",
+        "<Foo.Bar />\n",
+        "<Alert>{items.map}</Alert>\n",
+        "<Foo.Bar.Baz title=\"hi\" />\n",
+    ];
+    for source in sources {
+        let tree = pretty_ast(source, ParserOptions::default());
+        assert!(
+            !tree.contains("MdxJsx")
+                && !tree.contains("MdxFlowExpression")
+                && !tree.contains("MdxTextExpression")
+                && !tree.contains("AttrExpr"),
+            "mdx=false must not emit MDX nodes for {source:?}:\n{tree}"
+        );
+    }
+}
+
+#[test]
+fn text_fragment_parses_inside_paragraph() {
+    let tree = mdx_tree("Hello <>x</> world.\n");
+    assert!(tree.contains("Paragraph"), "expected a paragraph:\n{tree}");
+    assert!(
+        tree.contains("MdxJsxTextElement name=None self_closing=false"),
+        "expected a text fragment:\n{tree}"
+    );
+    assert!(tree.contains("Text \"x\""), "expected fragment child:\n{tree}");
+}
+
+#[test]
+fn named_fragment_component_stays_pascal_case() {
+    let tree = mdx_tree("<Fragment>hello</Fragment>\n");
+    assert!(
+        tree.contains("MdxJsxFlowElement name=Some(\"Fragment\") self_closing=false"),
+        "expected named Fragment:\n{tree}"
+    );
+    assert!(tree.contains("Text \"hello\""), "expected markdown child:\n{tree}");
+}
+
+#[test]
+fn nested_fragments_match_by_depth() {
+    let tree = mdx_tree("<><>inner</>outer</>\n");
+    let flow = tree.matches("MdxJsxFlowElement name=None").count();
+    assert!(flow >= 2, "expected nested fragments:\n{tree}");
+    assert!(tree.contains("Text \"inner\""), "expected inner text:\n{tree}");
+    assert!(tree.contains("Text \"outer\""), "expected outer text:\n{tree}");
+}
+
+#[test]
+fn spread_can_mix_with_named_attrs() {
+    let tree = mdx_tree("<Btn disabled {...rest} title=\"hi\" />\n");
+    assert!(tree.contains("Attr name=\"disabled\" value=boolean"), "expected boolean:\n{tree}");
+    assert!(tree.contains("AttrExpr value=\"...rest\""), "expected spread:\n{tree}");
+    assert!(
+        tree.contains("Attr name=\"title\" value=literal(\"hi\")"),
+        "expected literal after spread:\n{tree}"
+    );
+}
+
+#[test]
+fn hostile_spread_stores_source_without_evaluating() {
+    let tree = mdx_tree("<Alert {...{dangerouslySetInnerHTML:{__html:\"<script>\"}}} />\n");
+    assert!(
+        tree.contains("AttrExpr value=") && tree.contains("<script>"),
+        "hostile spread must keep source text:\n{tree}"
+    );
+    assert!(tree.contains("MdxJsxFlowElement name=Some(\"Alert\")"), "tag still parses:\n{tree}");
+}
+
+#[test]
+fn jsx_comment_inside_element_is_expression() {
+    let tree = mdx_tree("<Alert>{/* note */}hello</Alert>\n");
+    assert!(tree.contains("MdxJsxFlowElement name=Some(\"Alert\")"), "expected wrapper:\n{tree}");
+    assert!(
+        tree.contains("MdxTextExpression value=\"/* note */\"")
+            || tree.contains("MdxFlowExpression value=\"/* note */\""),
+        "comment child stores source:\n{tree}"
+    );
+    assert!(tree.contains("Text \"hello\""), "text after comment remains:\n{tree}");
+}
+
+#[test]
+fn jsx_comment_in_text_jsx_is_text_expression() {
+    let tree = mdx_tree("Hello <Badge>{/* n */}x</Badge>.\n");
+    assert!(
+        tree.contains("MdxJsxTextElement name=Some(\"Badge\")"),
+        "expected text Badge:\n{tree}"
+    );
+    assert!(tree.contains("MdxTextExpression value=\"/* n */\""), "expected text comment:\n{tree}");
+}
+
+#[test]
+fn member_name_can_nest_and_take_attrs() {
+    let tree = mdx_tree("<Foo.Bar.Baz title=\"hi\" />\n");
+    assert!(
+        tree.contains("MdxJsxFlowElement name=Some(\"Foo.Bar.Baz\") self_closing=true"),
+        "expected dotted name:\n{tree}"
+    );
+    assert!(
+        tree.contains("Attr name=\"title\" value=literal(\"hi\")"),
+        "expected literal attr:\n{tree}"
+    );
+}
+
+#[test]
+fn text_member_name_parses_inside_paragraph() {
+    let tree = mdx_tree("Use <Icons.Star /> here.\n");
+    assert!(
+        tree.contains("MdxJsxTextElement name=Some(\"Icons.Star\") self_closing=true"),
+        "expected text member:\n{tree}"
+    );
+}
+
+#[test]
+fn text_children_expression_stores_source() {
+    let tree = mdx_tree("Hello <Badge>{label}</Badge> world.\n");
+    assert!(
+        tree.contains("MdxJsxTextElement name=Some(\"Badge\")"),
+        "expected text Badge:\n{tree}"
+    );
+    assert!(
+        tree.contains("MdxTextExpression value=\"label\""),
+        "text children expressions store source:\n{tree}"
+    );
+}
+
+#[test]
+fn mixed_phrasing_and_expression_children() {
+    let tree = mdx_tree("Hi <Badge>**{label}**</Badge>.\n");
+    assert!(tree.contains("MdxJsxTextElement name=Some(\"Badge\")"), "expected Badge:\n{tree}");
+    assert!(tree.contains("Strong"), "phrasing markdown still parses:\n{tree}");
+    assert!(
+        tree.contains("MdxTextExpression value=\"label\""),
+        "expression inside emphasis stores source:\n{tree}"
+    );
+}
+
+#[test]
+fn fenced_and_inline_code_ignore_remainder_constructs() {
+    let fenced = mdx_tree("```js\n<>x</>\n<Foo.Bar {...p} />\n{/* c */}\n```\n");
+    assert!(fenced.contains("Code"), "expected a fence:\n{fenced}");
+    assert!(
+        !fenced.contains("MdxJsx")
+            && !fenced.contains("MdxFlowExpression")
+            && !fenced.contains("AttrExpr"),
+        "fence contents are not JSX:\n{fenced}"
+    );
+
+    let inline = mdx_tree("Use `<>x</>` and `{/* c */}` and `<Foo.Bar />`.\n");
+    assert!(inline.contains("InlineCode"), "expected inline code:\n{inline}");
+    assert!(
+        !inline.contains("MdxJsx") && !inline.contains("MdxTextExpression"),
+        "inline code is not JSX:\n{inline}"
+    );
+}
+
+#[test]
+fn unclosed_remainder_constructs_do_not_panic_or_emit() {
+    for source in ["<>hello\n", "<Alert {...props\n", "{/* hide\n", "<Foo.Bar\n", "<Foo.\n"] {
+        let tree = mdx_tree(source);
+        assert!(
+            !tree.contains("MdxJsx") && !tree.contains("MdxFlowExpression"),
+            "unclosed {source:?} stays non-JSX:\n{tree}"
+        );
+    }
+}
+
+#[test]
+fn unclosed_children_expression_does_not_emit_expression() {
+    let tree = mdx_tree("<Alert>{items.map</Alert>\n");
+    assert!(
+        !tree.contains("MdxFlowExpression") && !tree.contains("MdxTextExpression"),
+        "unclosed children expr is not an expression node:\n{tree}"
+    );
+}
+
+#[test]
+fn flow_jsx_parses_heading_list_and_nested_markdown() {
+    let tree = mdx_tree("<Alert>\n# Title\n\n- one\n- two\n\n> quote\n</Alert>\n");
+    assert!(
+        tree.contains("MdxJsxFlowElement name=Some(\"Alert\") self_closing=false"),
+        "expected flow Alert:\n{tree}"
+    );
+    assert!(tree.contains("Heading depth=1"), "heading child:\n{tree}");
+    assert!(tree.contains("List "), "list child:\n{tree}");
+    assert!(tree.contains("BlockQuote"), "blockquote child:\n{tree}");
+}
+
+#[test]
+fn flow_jsx_parses_nested_jsx_and_paragraphs() {
+    let tree = mdx_tree("<Alert>\nHello **world**\n\n<Badge />\n</Alert>\n");
+    assert!(tree.contains("Strong"), "paragraph phrasing:\n{tree}");
+    assert!(tree.contains("MdxJsxFlowElement name=Some(\"Badge\")"), "nested flow JSX:\n{tree}");
+}
+
+#[test]
+fn text_jsx_keeps_phrasing_not_flow() {
+    let tree = mdx_tree("Hello <Badge>**x**</Badge> world.\n");
+    assert!(tree.contains("Paragraph"), "outer prose is a paragraph:\n{tree}");
+    assert!(
+        tree.contains("MdxJsxTextElement name=Some(\"Badge\")"),
+        "inline tag is text JSX:\n{tree}"
+    );
+    assert!(tree.contains("Strong"), "phrasing child:\n{tree}");
+    assert!(!tree.contains("MdxJsxFlowElement"), "phrasing children must not become flow:\n{tree}");
+}
+
+#[test]
+fn same_line_open_close_is_flow_with_paragraph_child() {
+    let tree = mdx_tree("<Alert>hello</Alert>\n");
+    assert!(
+        tree.contains("MdxJsxFlowElement name=Some(\"Alert\") self_closing=false"),
+        "line-start tag is flow:\n{tree}"
+    );
+    assert!(tree.contains("Paragraph"), "markdown child is a paragraph:\n{tree}");
+    assert!(tree.contains("Text \"hello\""), "expected text:\n{tree}");
+}

--- a/docs/content/mdx.md
+++ b/docs/content/mdx.md
@@ -10,12 +10,12 @@ It is worth understanding how this works, because it differs from "classic" MDX:
 
 - **JSX elements and module-level `import` / `export` parse when MDX is
   enabled.** With `mdx: true` / `ParserOptions.mdx`, the Rust parser turns
-  PascalCase tags into `MdxJsxFlowElement` / `MdxJsxTextElement` nodes
-  (self-closing or simple open/close, with literal, boolean, and `{expr}`
-  attributes), and turns file-level `import` / `export` into `MdxjsEsm`
-  nodes (raw source, not evaluated). `.md` stays CommonMark + GFM unless
-  that option is on. `{expression}` children, fragments, and spreads are
-  not parsed yet.
+  PascalCase and member-name tags into `MdxJsxFlowElement` /
+  `MdxJsxTextElement` nodes (self-closing or open/close, with literal,
+  boolean, `{expr}`, and spread attributes), and turns file-level
+  `import` / `export` into `MdxjsEsm` nodes. Fragments (`<>...</>`), JSX
+  comments, and `{expression}` children are stored as AST source. Nothing
+  is evaluated. `.md` stays CommonMark + GFM unless that option is on.
 - **Components are resolved by a framework plugin**, not the renderer. The
   React/Vue/Svelte plugins scan the content for PascalCase component tags,
   replace them with **island** placeholders, and hydrate them on the client.
@@ -72,12 +72,23 @@ Regular **Markdown** prose.
 <Callout type="tip">
   This child content is passed to the component.
 </Callout>
+
+<>
+  <Icons.Star />
+  {label}
+</>
+
+<Card {...cardProps} />
+
+{/* Hidden from the rendered page */}
 ```
 
 Only tags that start with an uppercase letter are treated as JSX / components,
-so ordinary HTML (`<div>`, `<span>`, …) stays raw HTML. Tags inside fenced
-code blocks and inline code are **not** components, so you can document
-component usage without it being executed.
+so ordinary HTML (`<div>`, `<span>`, …) stays raw HTML. Member names
+(`Foo.Bar`), fragments (`<>...</>`), spreads (`{...props}`), JSX comments
+(`{/* note */}`), and `{expression}` children are parsed when MDX is on;
+expression source is stored and not run. Tags inside fenced code blocks and
+inline code are **not** components.
 
 Module-level `import` and `export` at the start of a file (and after other
 ESM) become `MdxjsEsm` nodes. Multi-line statements are collected with a
@@ -86,8 +97,7 @@ so regex literals and `${}` inside templates may confuse statement
 boundaries. `import` / `export` inside fences or inline code is not ESM.
 Hostile strings such as `import x from "<script>"` store source and do not
 panic. The HTML renderer currently emits nothing for `MdxjsEsm`; framework
-plugins will resolve imports later. Spreads, fragments, and JSX comments
-are not parsed yet.
+plugins will resolve imports later.
 
 ### Props
 
@@ -100,6 +110,7 @@ Props use JSX-like syntax. The following forms are recognised:
 | `prop={true}`      | boolean             |
 | `prop={ {"a":1} }` | object (JSON)       |
 | `prop`             | boolean `true`      |
+| `{...props}`       | spread (source)     |
 
 Props are serialized to a `data-ox-props` attribute on the island element and
 handed to your component at hydration time.

--- a/docs/content/mdx.md
+++ b/docs/content/mdx.md
@@ -74,13 +74,13 @@ Regular **Markdown** prose.
 </Callout>
 
 <>
-  <Icons.Star />
-  {label}
+<Icons.Star />
+{label}
 </>
 
 <Card {...cardProps} />
 
-{/* Hidden from the rendered page */}
+{/_ Hidden from the rendered page _/}
 ```
 
 Only tags that start with an uppercase letter are treated as JSX / components,


### PR DESCRIPTION
## Summary

- Parse the remaining JSX grammar when `ParserOptions.mdx` is true: fragments (`<>...</>` / `<Fragment>`), spreads (`{...props}`), JSX comments (`{/* ... */}`), member names (`Foo.Bar`, `Foo.Bar.Baz`), and children `{expression}` nodes. Source is stored, not evaluated.
- `mdx=false` / omitted stays CommonMark. Fences, inline code, lowercase HTML, and unclosed / hostile input do not emit a half-parsed JSX node. The HTML renderer still no-ops MDX nodes (no JS runtime).
- Markdown-in-JSX headings, lists, blockquotes, nested JSX, and phrasing-vs-flow children are covered by tests. Document-level prose `{name}` stays text so ESM `import { x }` is unchanged.

Parent #701

## Risk

- Risk level: low
- User or production impact: none unless `mdx: true` is set. Default CommonMark / GFM output is unchanged. MDX AST nodes still render as nothing.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run: `rustup run 1.95.0 cargo test -p ox_content_parser -p ox_content_ast -p ox_content_renderer` and `clippy -D warnings`
- [x] Manual verification completed: existing JSX and ESM tests stay green; `mdx_options` noops remain for non-JSX / non-expression Markdown
- [x] Edge cases or failure modes considered: unclosed `<>`, `{...props`, `{/*`, and `<Foo.Bar` do not panic; hostile spreads keep source (`<script>`)

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

## Test plan

- [ ] CI green on this PR
- [ ] Confirm `.md` / `mdx=false` fixtures and CommonMark/GFM spec tests are unchanged
- [ ] Confirm `<>hello</>`, `<Alert {...props} />`, `{/* hide */}`, `<Foo.Bar />`, and `<Alert>{items.map}</Alert>` emit the new nodes when `mdx=true`
- [ ] Confirm fences, inline code, and unclosed input do not emit MDX nodes
- [ ] Confirm `import` / `export` from #729 still parse as `MdxjsEsm`


Made with [Cursor](https://cursor.com)