### PR TITLE
fix(transform): keep steps preamble and refresh NAPI declarations

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -1211,6 +1211,16 @@ export interface JsPublicExport {
   source: JsExportSource
 }
 
+/** Opt-in reader chrome flags. Presence of the object enables the feature. */
+export interface JsReaderChrome {
+  /** Copy button on fenced code blocks. */
+  copy?: boolean
+  /** Icon and `rel` on outbound links. */
+  externalLinks?: boolean
+  /** Back-to-top control that appears after scroll. */
+  backToTop?: boolean
+}
+
 /** Resolved source module. */
 export interface JsResolvedModule {
   path: string
@@ -1443,16 +1453,6 @@ export interface JsSsgConfig {
   readerChrome?: JsReaderChrome
 }
 
-/** Opt-in reader chrome flags. Presence of the object enables the feature. */
-export interface JsReaderChrome {
-  /** Copy button on fenced code blocks. */
-  copy?: boolean
-  /** Icon and `rel` on outbound links. */
-  externalLinks?: boolean
-  /** Back-to-top control that appears after scroll. */
-  backToTop?: boolean
-}
-
 /** Result of SSG shared asset extraction. */
 export interface JsSsgExternalizedAssets {
   /** HTML pages with inline assets replaced. */
@@ -1567,13 +1567,8 @@ export interface JsSsgSidebarItem {
   stickyCollapsed?: boolean
 }
 
-/** Opt-in `::: steps` ordered lists. */
+/** Opt-in `::: steps` wrappers. `enabled` defaults to `false`. */
 export interface JsStepsOptions {
-  /**
-   * Enable `::: steps` wrappers around ordered lists.
-   *
-   * Default: `false`.
-   */
   enabled?: boolean
 }
 
@@ -1891,12 +1886,6 @@ export interface JsTransformOptions {
    */
   containers?: JsContainerOptions
   /**
-   * Opt-in figures, captions, and lazy images.
-   *
-   * Default: disabled.
-   */
-  images?: JsImageOptions
-  /**
    * Opt-in Markdown file includes via `<!-- @include: PATH -->`.
    *
    * Default: disabled.
@@ -1914,6 +1903,12 @@ export interface JsTransformOptions {
    * Default: disabled.
    */
   badges?: JsBadgeOptions
+  /**
+   * Opt-in figures, captions, and lazy images.
+   *
+   * Default: disabled.
+   */
+  images?: JsImageOptions
 }
 
 /** Type parameter documentation (`<T extends C = D>`) used by generated API docs. */

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -1216,6 +1216,16 @@ export interface JsPublicExport {
   source: JsExportSource
 }
 
+/** Opt-in reader chrome flags. Presence of the object enables the feature. */
+export interface JsReaderChrome {
+  /** Copy button on fenced code blocks. */
+  copy?: boolean
+  /** Icon and `rel` on outbound links. */
+  externalLinks?: boolean
+  /** Back-to-top control that appears after scroll. */
+  backToTop?: boolean
+}
+
 /** Resolved source module. */
 export interface JsResolvedModule {
   path: string
@@ -1448,16 +1458,6 @@ export interface JsSsgConfig {
   readerChrome?: JsReaderChrome
 }
 
-/** Opt-in reader chrome flags. Presence of the object enables the feature. */
-export interface JsReaderChrome {
-  /** Copy button on fenced code blocks. */
-  copy?: boolean
-  /** Icon and `rel` on outbound links. */
-  externalLinks?: boolean
-  /** Back-to-top control that appears after scroll. */
-  backToTop?: boolean
-}
-
 /** Result of SSG shared asset extraction. */
 export interface JsSsgExternalizedAssets {
   /** HTML pages with inline assets replaced. */
@@ -1572,13 +1572,8 @@ export interface JsSsgSidebarItem {
   stickyCollapsed?: boolean
 }
 
-/** Opt-in `::: steps` ordered lists. */
+/** Opt-in `::: steps` wrappers. `enabled` defaults to `false`. */
 export interface JsStepsOptions {
-  /**
-   * Enable `::: steps` wrappers around ordered lists.
-   *
-   * Default: `false`.
-   */
   enabled?: boolean
 }
 
@@ -1896,12 +1891,6 @@ export interface JsTransformOptions {
    */
   containers?: JsContainerOptions
   /**
-   * Opt-in figures, captions, and lazy images.
-   *
-   * Default: disabled.
-   */
-  images?: JsImageOptions
-  /**
    * Opt-in Markdown file includes via `<!-- @include: PATH -->`.
    *
    * Default: disabled.
@@ -1919,6 +1908,12 @@ export interface JsTransformOptions {
    * Default: disabled.
    */
   badges?: JsBadgeOptions
+  /**
+   * Opt-in figures, captions, and lazy images.
+   *
+   * Default: disabled.
+   */
+  images?: JsImageOptions
 }
 
 /** Type parameter documentation (`<T extends C = D>`) used by generated API docs. */

--- a/crates/ox_content_transform/src/features/steps.rs
+++ b/crates/ox_content_transform/src/features/steps.rs
@@ -111,8 +111,14 @@ fn collect_body(lines: &[(&str, &str)]) -> String {
 }
 
 fn emit_steps(out: &mut String, body: &str) {
-    out.push_str("<div class=\"ox-steps\">\n<ol class=\"ox-steps__list\">\n");
-    let items = split_ordered_items(body);
+    let (preamble, items) = split_ordered_items(body);
+    out.push_str("<div class=\"ox-steps\">\n");
+    if !items.is_empty() && !preamble.trim().is_empty() {
+        let escaped_preamble = escape_item_markdown(&preamble);
+        out.push_str(escaped_preamble.trim_end());
+        out.push_str("\n\n");
+    }
+    out.push_str("<ol class=\"ox-steps__list\">\n");
     if items.is_empty() {
         let escaped = escape_item_markdown(body);
         if !escaped.trim().is_empty() {
@@ -130,7 +136,8 @@ fn emit_steps(out: &mut String, body: &str) {
     out.push_str("</ol>\n</div>\n");
 }
 
-fn split_ordered_items(body: &str) -> Vec<String> {
+fn split_ordered_items(body: &str) -> (String, Vec<String>) {
+    let mut preamble = String::new();
     let mut items = Vec::new();
     let mut current: Option<String> = None;
     let mut item_indent: Option<usize> = None;
@@ -142,7 +149,7 @@ fn split_ordered_items(body: &str) -> Vec<String> {
         let (line, ending) = split_ending(line_with_end);
 
         if in_fence {
-            push_item_line(&mut current, line, ending);
+            push_item_line(&mut current, &mut preamble, line, ending);
             if is_closing_fence(line, fence_char, fence_len) {
                 in_fence = false;
             }
@@ -153,7 +160,7 @@ fn split_ordered_items(body: &str) -> Vec<String> {
             in_fence = true;
             fence_char = open.0;
             fence_len = open.1;
-            push_item_line(&mut current, line, ending);
+            push_item_line(&mut current, &mut preamble, line, ending);
             continue;
         }
 
@@ -176,19 +183,25 @@ fn split_ordered_items(body: &str) -> Vec<String> {
             let stripped = strip_item_indent(line, item_indent.unwrap_or(0));
             buf.push_str(stripped);
             buf.push_str(ending);
+        } else {
+            preamble.push_str(line);
+            preamble.push_str(ending);
         }
     }
 
     if let Some(item) = current.take() {
         items.push(escape_item_markdown(&item));
     }
-    items
+    (preamble, items)
 }
 
-fn push_item_line(current: &mut Option<String>, line: &str, ending: &str) {
+fn push_item_line(current: &mut Option<String>, preamble: &mut String, line: &str, ending: &str) {
     if let Some(buf) = current.as_mut() {
         buf.push_str(line);
         buf.push_str(ending);
+    } else {
+        preamble.push_str(line);
+        preamble.push_str(ending);
     }
 }
 

--- a/crates/ox_content_transform/src/features/steps/tests.rs
+++ b/crates/ox_content_transform/src/features/steps/tests.rs
@@ -120,6 +120,20 @@ fn hostile_text_escaped() {
 }
 
 #[test]
+fn preamble_before_first_marker_is_preserved() {
+    let html =
+        transform_html("::: steps\nFollow these steps:\n\n1. First\n2. Second\n:::\n", steps_on());
+    assert!(html.contains("Follow these steps:"), "leading prose must stay:\n{html}");
+    assert!(html.contains("ox-steps"), "{html}");
+    assert_eq!(html.matches(r#"<li class="ox-steps__item">"#).count(), 2, "{html}");
+    assert!(html.contains("First"), "{html}");
+    assert!(html.contains("Second"), "{html}");
+    let preamble_at = html.find("Follow these steps:").unwrap_or_else(|| panic!("{html}"));
+    let list_at = html.find(r#"<ol class="ox-steps__list">"#).unwrap_or_else(|| panic!("{html}"));
+    assert!(preamble_at < list_at, "preamble must appear before the list:\n{html}");
+}
+
+#[test]
 fn ordinary_ordered_list_unchanged() {
     let html = transform_html("1. foo\n2. bar\n", steps_on());
     assert!(!html.contains("ox-steps"), "{html}");

--- a/docs/content/built-in-features.md
+++ b/docs/content/built-in-features.md
@@ -54,7 +54,7 @@ inline**.
 | Opt-in embeds    | `embeds.pm`, `embeds.twitter`, `embeds.bluesky`, `embeds.spotify`, `embeds.stackBlitz`, `embeds.webContainer` | `false`              | [Embeds](./built-in/embeds.md)                         |
 | Syntax highlight | `highlight`                                                                                                   | `false`              | [Code Blocks](./built-in/code-blocks.md)               |
 | Code authoring   | `codeAnnotations`, `codeImports`                                                                              | `false`              | [Code Blocks](./built-in/code-blocks.md)               |
-| Extra syntax     | `wikiLinks`, `emojiShortcodes`, `attrs`, `cjkEmphasis`, `containers`, `badges`, `steps`                       | `false`              | [Syntax Extensions](./built-in/syntax-extensions.md)   |
+| Extra syntax     | `wikiLinks`, `emojiShortcodes`, `attrs`, `cjkEmphasis`, `containers`, `badges`                                | `false`              | [Syntax Extensions](./built-in/syntax-extensions.md)   |
 | File includes    | `includes`                                                                                                    | `false`              | [File Includes](./built-in/includes.md)                |
 | Step lists       | `steps`                                                                                                       | `false`              | [Step Lists](./built-in/steps.md)                      |
 | Images           | `images`                                                                                                      | `false`              | [Images](./built-in/images.md)                         |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #727. Addresses the Package dry-run failure and CodeRabbit review comments that landed after merge.

- Preserve author prose written before the first `1.` inside a `::: steps` block, instead of dropping it.
- Move `images` / `JsReaderChrome` / `JsStepsOptions` in `index.d.ts` to the generated NAPI order so `git diff --exit-code -- crates/ox_content_napi/index.d.ts` passes.
- Remove the duplicate `steps` listing from the Extra syntax row in `built-in-features.md`.

#671

## Risk

- Risk level: low
- User or production impact: steps blocks with leading prose now keep that text; NAPI declaration order matches the generator.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run: `rustup run 1.95.0 cargo test -p ox_content_transform steps` (20 passed, including `preamble_before_first_marker_is_preserved`); `cargo clippy -p ox_content_transform --all-targets -- -D warnings`
- [ ] Manual verification completed: not run in a browser (no docs preview)
- [x] Edge cases or failure modes considered: no-marker bodies still wrap as a single item; fence lines before the first marker go into the preamble

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-323afdbe-6152-4203-aba0-ebcc91439132?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-323afdbe-6152-4203-aba0-ebcc91439132&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

