### PR TITLE
feat(mdx): parse document-level flow and text expressions

### DIFF
--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -1,7 +1,5 @@
 //! Markdown parser implementation.
 
-use std::cell::Cell;
-
 use ox_content_allocator::Allocator;
 use ox_content_ast::{Document, Span};
 
@@ -94,7 +92,8 @@ pub struct ParserOptions {
     /// Enable MDX. Off by default.
     ///
     /// When set, PascalCase and member-name JSX elements, fragments, spreads,
-    /// JSX comments, and `{expression}` children parse as MDX AST nodes.
+    /// JSX comments, `{expression}` children, and document-level
+    /// `{expression}` constructs parse as MDX AST nodes.
     /// Module-level `import` / `export` parse as [`ox_content_ast::MdxjsEsm`].
     /// Expression and ESM source is stored, not evaluated. Lowercase HTML
     /// stays HTML.
@@ -171,11 +170,6 @@ pub struct Parser<'a> {
     /// construction and must not be reinterpreted as setext underlines
     /// during the re-parse.
     lazy_lines: Option<std::rc::Rc<rustc_hash::FxHashSet<u32>>>,
-
-    /// When set, `{expression}` is parsed in phrasing (JSX children).
-    /// Document-level prose keeps braces as text so `import { x }` is left
-    /// for the ESM scanner.
-    mdx_in_jsx: Cell<bool>,
 }
 
 impl<'a> Parser<'a> {
@@ -197,7 +191,6 @@ impl<'a> Parser<'a> {
             definitions: None,
             footnote_labels: None,
             lazy_lines: None,
-            mdx_in_jsx: Cell::new(false),
         };
         // A single fused pre-pass collects both the reference definitions
         // and the footnote labels (see `prepass.rs`).
@@ -228,7 +221,6 @@ impl<'a> Parser<'a> {
             // Most sub-sources are entered without any lazy continuation
             // line, and every block quote and list item builds one of these.
             lazy_lines: (!lazy_lines.is_empty()).then(|| std::rc::Rc::new(lazy_lines)),
-            mdx_in_jsx: Cell::new(self.mdx_in_jsx.get()),
         }
     }
 

--- a/crates/ox_content_parser/src/parser/inline.rs
+++ b/crates/ox_content_parser/src/parser/inline.rs
@@ -47,7 +47,7 @@ impl<'a> Parser<'a> {
     }
 
     fn allows_mdx_text_expression(&self) -> bool {
-        self.options.mdx && self.mdx_in_jsx.get()
+        self.options.mdx
     }
 
     fn next_inline_marker(&self, bytes: &[u8], from: usize) -> usize {

--- a/crates/ox_content_parser/src/parser/mdx_jsx.rs
+++ b/crates/ox_content_parser/src/parser/mdx_jsx.rs
@@ -107,10 +107,7 @@ impl<'a> Parser<'a> {
         content: &'a str,
         offset: usize,
     ) -> ParseResult<ox_content_allocator::Vec<'a, Node<'a>>> {
-        let previous = self.mdx_in_jsx.replace(true);
-        let children = self.parse_inline(content, offset);
-        self.mdx_in_jsx.set(previous);
-        children
+        self.parse_inline(content, offset)
     }
 
     fn parse_jsx_flow_children(
@@ -124,7 +121,6 @@ impl<'a> Parser<'a> {
         let inner = &self.source[inner_start..inner_end];
         let mut sub = self.sub_parser_with_lazy_lines(inner, rustc_hash::FxHashSet::default());
         sub.nesting_depth = self.nesting_depth + 1;
-        sub.mdx_in_jsx.set(true);
         let mut children = sub.parse()?.children;
         for child in &mut children {
             Self::offset_node_spans(child, inner_start as u32);

--- a/crates/ox_content_parser/src/parser/mdx_jsx/expression.rs
+++ b/crates/ox_content_parser/src/parser/mdx_jsx/expression.rs
@@ -1,4 +1,4 @@
-//! MDX `{expression}` parse: flow, text, and JSX comments.
+//! MDX `{expression}` parse: flow, text, JSX comments, and prose braces.
 //!
 //! Source inside the braces is stored. Nothing is evaluated.
 
@@ -45,6 +45,8 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses an inline `{expression}` or `{/* comment */}` at `pos`.
+    ///
+    /// Used for document-level prose and for JSX children.
     pub(in crate::parser) fn try_parse_mdx_text_expression(
         &self,
         content: &'a str,

--- a/crates/ox_content_parser/tests/mdx_expressions.rs
+++ b/crates/ox_content_parser/tests/mdx_expressions.rs
@@ -1,0 +1,184 @@
+//! Document-level / prose `{expression}` when `ParserOptions.mdx` is true.
+//!
+//! Flow and text expressions store raw source. Nothing is evaluated.
+//! Fences, inline code, `mdx=false`, and unclosed `{` must not emit a
+//! half-parsed expression node. `import` / `export` braces stay ESM.
+
+use ox_content_allocator::Allocator;
+use ox_content_parser::{Parser, ParserOptions};
+
+#[path = "support/pretty.rs"]
+mod pretty;
+
+fn pretty_ast(source: &str, options: ParserOptions) -> String {
+    let allocator = Allocator::new();
+    let doc = Parser::with_options(&allocator, source, options)
+        .parse()
+        .expect("parser should not fail on MDX expression fixtures");
+    let mut out = String::new();
+    pretty::format_document(&doc, source, &mut out);
+    out
+}
+
+fn mdx_tree(source: &str) -> String {
+    pretty_ast(source, ParserOptions::mdx())
+}
+
+fn assert_flow(tree: &str, value: &str) {
+    let needle = format!("MdxFlowExpression value={value:?}");
+    assert!(tree.contains(&needle), "expected {needle} in:\n{tree}");
+}
+
+fn assert_text(tree: &str, value: &str) {
+    let needle = format!("MdxTextExpression value={value:?}");
+    assert!(tree.contains(&needle), "expected {needle} in:\n{tree}");
+}
+
+#[test]
+fn mdx_false_flow_brace_stays_paragraph() {
+    let tree = pretty_ast("{foo}\n", ParserOptions::default());
+    assert!(tree.contains("Paragraph"), "mdx=false flow brace stays a paragraph:\n{tree}");
+    assert!(tree.contains("Text \"{foo}\""), "expected literal text:\n{tree}");
+    assert!(!tree.contains("MdxFlowExpression"), "mdx=false must not emit flow expr:\n{tree}");
+}
+
+#[test]
+fn mdx_false_text_brace_stays_text() {
+    let tree = pretty_ast("Hello {name}.\n", ParserOptions::default());
+    assert!(tree.contains("Text \"Hello {name}.\""), "mdx=false keeps braces as text:\n{tree}");
+    assert!(!tree.contains("MdxTextExpression"), "mdx=false must not emit text expr:\n{tree}");
+}
+
+#[test]
+fn flow_identifier_is_expression() {
+    let tree = mdx_tree("{foo}\n");
+    assert_flow(&tree, "foo");
+    assert!(!tree.contains("Paragraph"), "standalone flow expr is not a paragraph:\n{tree}");
+}
+
+#[test]
+fn flow_arithmetic_stores_source() {
+    let tree = mdx_tree("{count + 1}\n");
+    assert_flow(&tree, "count + 1");
+    assert!(!tree.contains("value=\"2\""), "must not evaluate JS:\n{tree}");
+}
+
+#[test]
+fn text_identifier_in_prose() {
+    let tree = mdx_tree("Hello {name}.\n");
+    assert!(tree.contains("Paragraph"), "prose stays a paragraph:\n{tree}");
+    assert!(tree.contains("Text \"Hello \""), "expected leading text:\n{tree}");
+    assert_text(&tree, "name");
+    assert!(tree.contains("Text \".\""), "expected trailing text:\n{tree}");
+}
+
+#[test]
+fn text_arithmetic_in_prose() {
+    let tree = mdx_tree("Total {count + 1} items.\n");
+    assert_text(&tree, "count + 1");
+    assert!(!tree.contains("value=\"2\""), "must not evaluate JS:\n{tree}");
+}
+
+#[test]
+fn nested_braces_and_member_access() {
+    let tree = mdx_tree("{foo({ bar: 1 })}\n");
+    assert_flow(&tree, "foo({ bar: 1 })");
+
+    let text = mdx_tree("See {user.name}.\n");
+    assert_text(&text, "user.name");
+}
+
+#[test]
+fn string_and_template_may_contain_closing_brace() {
+    let tree = mdx_tree("{ foo(\"}\") }\n");
+    assert_flow(&tree, " foo(\"}\") ");
+
+    let template = mdx_tree("{ `close } here` }\n");
+    assert_flow(&template, " `close } here` ");
+}
+
+#[test]
+fn fenced_and_inline_code_are_not_expressions() {
+    let fenced = mdx_tree("```js\nconst x = {foo};\n```\n");
+    assert!(fenced.contains("Code"), "expected a fence:\n{fenced}");
+    assert!(
+        !fenced.contains("MdxFlowExpression") && !fenced.contains("MdxTextExpression"),
+        "fence contents are not expressions:\n{fenced}"
+    );
+
+    let inline = mdx_tree("Use `{foo}` and `{count + 1}` in prose.\n");
+    assert!(inline.contains("InlineCode"), "expected inline code:\n{inline}");
+    assert!(
+        !inline.contains("MdxTextExpression") && !inline.contains("MdxFlowExpression"),
+        "inline code is not an expression:\n{inline}"
+    );
+}
+
+#[test]
+fn unclosed_brace_does_not_panic_or_emit_half_node() {
+    for source in ["{foo\n", "Hello {name\n", "{ foo(\"\n", "{ /* hide\n"] {
+        let tree = mdx_tree(source);
+        assert!(
+            !tree.contains("MdxFlowExpression") && !tree.contains("MdxTextExpression"),
+            "unclosed {source:?} must not emit an expression:\n{tree}"
+        );
+    }
+}
+
+#[test]
+fn hostile_script_stores_source_without_evaluating() {
+    let tree = mdx_tree("{ \"<script>alert(1)</script>\" }\n");
+    assert_flow(&tree, " \"<script>alert(1)</script>\" ");
+    assert!(!tree.contains("value=\"2\""), "source is stored, not evaluated:\n{tree}");
+}
+
+#[test]
+fn import_and_export_braces_stay_esm() {
+    let import = mdx_tree("import { Chart } from './Chart'\n");
+    assert!(
+        import.contains("MdxjsEsm value=\"import { Chart } from './Chart'\""),
+        "import:\n{import}"
+    );
+    assert!(
+        !import.contains("MdxFlowExpression") && !import.contains("MdxTextExpression"),
+        "ESM braces are not prose expressions:\n{import}"
+    );
+
+    let export = mdx_tree("export const meta = { title: 'Hi' }\n");
+    assert!(export.contains("MdxjsEsm"), "export stays ESM:\n{export}");
+    assert!(
+        !export.contains("MdxFlowExpression") && !export.contains("MdxTextExpression"),
+        "export object is not a flow expression:\n{export}"
+    );
+}
+
+#[test]
+fn flow_expression_interrupts_paragraph() {
+    let tree = mdx_tree("Hello\n{name}\n");
+    assert!(tree.contains("Paragraph"), "leading prose stays a paragraph:\n{tree}");
+    assert!(tree.contains("Text \"Hello\""), "expected leading text:\n{tree}");
+    assert_flow(&tree, "name");
+}
+
+#[test]
+fn trailing_text_on_same_line_is_text_expression() {
+    let tree = mdx_tree("{foo} extra\n");
+    assert!(tree.contains("Paragraph"), "same-line trailing text is a paragraph:\n{tree}");
+    assert_text(&tree, "foo");
+    assert!(tree.contains("Text \" extra\""), "expected trailing text:\n{tree}");
+    assert!(!tree.contains("MdxFlowExpression"), "not a flow construct:\n{tree}");
+}
+
+#[test]
+fn escaped_brace_is_not_an_expression() {
+    let tree = mdx_tree("Hello \\{name}\n");
+    assert!(!tree.contains("MdxTextExpression"), "backslash-escaped brace is text:\n{tree}");
+    assert!(tree.contains("Text \"{\""), "escaped {{ is literal:\n{tree}");
+}
+
+#[test]
+fn multiline_flow_expression_stores_source() {
+    let tree = mdx_tree("{\n  count + 1\n}\n");
+    assert_flow(&tree, "\n  count + 1\n");
+    assert!(!tree.contains("Paragraph"), "multiline flow is not a paragraph:\n{tree}");
+}

--- a/crates/ox_content_parser/tests/mdx_jsx.rs
+++ b/crates/ox_content_parser/tests/mdx_jsx.rs
@@ -3,7 +3,8 @@
 //! Covers PascalCase elements (flow + text), literal / boolean / `{expr}`
 //! attributes, self-closing tags, and simple open/close children. Lowercase
 //! HTML stays `Html`. Fragments, spreads, comments, member names, and
-//! children expressions live in `mdx_jsx_remainder.rs`. Module-level
+//! children expressions live in `mdx_jsx_remainder.rs`. Document-level
+//! `{expression}` is covered in `mdx_expressions.rs`. Module-level
 //! `import` / `export` is covered in `mdx_esm.rs`.
 
 use ox_content_allocator::Allocator;

--- a/crates/ox_content_parser/tests/mdx_options.rs
+++ b/crates/ox_content_parser/tests/mdx_options.rs
@@ -1,8 +1,9 @@
 //! Strict tests for `ParserOptions.mdx`.
 //!
 //! Enabling the flag must not change CommonMark or GFM parse output for
-//! non-JSX, non-ESM Markdown. PascalCase JSX is covered in `mdx_jsx.rs`.
-//! Module-level `import` / `export` is covered in `mdx_esm.rs`.
+//! non-JSX, non-ESM, non-expression Markdown. PascalCase JSX is covered in
+//! `mdx_jsx.rs`. Module-level `import` / `export` is covered in `mdx_esm.rs`.
+//! Document-level `{expression}` is covered in `mdx_expressions.rs`.
 
 use ox_content_allocator::Allocator;
 use ox_content_parser::{Parser, ParserOptions};
@@ -27,7 +28,7 @@ fn assert_mdx_flag_is_noop(source: &str, mut options: ParserOptions) {
     let on = pretty_ast(source, options);
     assert_eq!(
         off, on,
-        "ParserOptions.mdx must not change parse output for non-JSX Markdown\n--- mdx=false ---\n{off}\n--- mdx=true ---\n{on}"
+        "ParserOptions.mdx must not change parse output for non-MDX Markdown\n--- mdx=false ---\n{off}\n--- mdx=true ---\n{on}"
     );
 }
 
@@ -136,8 +137,12 @@ fn mdx_flag_is_noop_for_gfm_task_list() {
 }
 
 #[test]
-fn mdx_flag_is_noop_for_brace_expression() {
-    assert_mdx_flag_is_noop("Hello {name}.\n", ParserOptions::default());
+fn mdx_flag_parses_brace_expression_when_enabled() {
+    let off = pretty_ast("Hello {name}.\n", ParserOptions::default());
+    let on = pretty_ast("Hello {name}.\n", ParserOptions::mdx());
+    assert!(off.contains("Text \"Hello {name}.\""), "mdx=false keeps braces as text:\n{off}");
+    assert!(!off.contains("MdxTextExpression"), "mdx=false must not emit expr:\n{off}");
+    assert!(on.contains("MdxTextExpression value=\"name\""), "mdx=true parses prose expr:\n{on}");
 }
 
 #[test]

--- a/crates/ox_content_renderer/src/html/tests.rs
+++ b/crates/ox_content_renderer/src/html/tests.rs
@@ -4,6 +4,7 @@ mod code;
 mod inline_media;
 mod links;
 mod lists_tables;
+mod mdx;
 
 use crate::html::{HtmlRenderer, HtmlRendererOptions};
 use ox_content_allocator::Allocator;

--- a/crates/ox_content_renderer/src/html/tests/mdx.rs
+++ b/crates/ox_content_renderer/src/html/tests/mdx.rs
@@ -1,0 +1,28 @@
+use ox_content_allocator::Allocator;
+use ox_content_parser::{Parser, ParserOptions};
+
+use crate::html::HtmlRenderer;
+
+fn render_mdx(source: &str) -> String {
+    let allocator = Allocator::new();
+    let doc = Parser::with_options(&allocator, source, ParserOptions::mdx())
+        .parse()
+        .expect("parser should not fail on MDX render fixtures");
+    HtmlRenderer::new().render(&doc)
+}
+
+#[test]
+fn prose_expressions_do_not_emit_javascript() {
+    let html = render_mdx("Hello {name}.\n\n{count + 1}\n");
+    assert!(!html.contains("<script"), "pages without islands stay JS-free:\n{html}");
+    assert!(!html.contains("data-ox-island"), "expressions are not islands:\n{html}");
+    assert!(!html.contains("{name}"), "expression source is not leaked as text:\n{html}");
+    assert!(!html.contains("{count + 1}"), "flow source is not leaked as text:\n{html}");
+}
+
+#[test]
+fn hostile_expression_does_not_emit_raw_markup() {
+    let html = render_mdx("{ \"<script>alert(1)</script>\" }\n");
+    assert!(!html.contains("<script"), "hostile source must not render as HTML:\n{html}");
+    assert!(!html.contains("alert(1)"), "expression source is not evaluated or emitted:\n{html}");
+}

--- a/docs/content/mdx.md
+++ b/docs/content/mdx.md
@@ -8,14 +8,16 @@ description: Embed Vue, React, or Svelte components in Markdown using island hyd
 Ox Content lets you embed framework components inside Markdown and `.mdx` files.
 It is worth understanding how this works, because it differs from "classic" MDX:
 
-- **JSX elements and module-level `import` / `export` parse when MDX is
-  enabled.** With `mdx: true` / `ParserOptions.mdx`, the Rust parser turns
-  PascalCase and member-name tags into `MdxJsxFlowElement` /
-  `MdxJsxTextElement` nodes (self-closing or open/close, with literal,
-  boolean, `{expr}`, and spread attributes), and turns file-level
-  `import` / `export` into `MdxjsEsm` nodes. Fragments (`<>...</>`), JSX
-  comments, and `{expression}` children are stored as AST source. Nothing
-  is evaluated. `.md` stays CommonMark + GFM unless that option is on.
+- **JSX elements, module-level `import` / `export`, and prose
+  `{expression}` parse when MDX is enabled.** With `mdx: true` /
+  `ParserOptions.mdx`, the Rust parser turns PascalCase and member-name
+  tags into `MdxJsxFlowElement` / `MdxJsxTextElement` nodes (self-closing
+  or open/close, with literal, boolean, `{expr}`, and spread attributes),
+  turns file-level `import` / `export` into `MdxjsEsm` nodes, and turns
+  document-level `{foo}` / `Hello {name}` into `MdxFlowExpression` /
+  `MdxTextExpression`. Fragments (`<>...</>`), JSX comments, and
+  `{expression}` children are stored as AST source. Nothing is evaluated.
+  `.md` stays CommonMark + GFM unless that option is on.
 - **Components are resolved by a framework plugin**, not the renderer. The
   React/Vue/Svelte plugins scan the content for PascalCase component tags,
   replace them with **island** placeholders, and hydrate them on the client.
@@ -65,7 +67,9 @@ children:
 ```md
 # My Page
 
-Regular **Markdown** prose.
+Regular **Markdown** prose. Hello {name}.
+
+{count + 1}
 
 <Counter initial={5} />
 
@@ -86,9 +90,10 @@ Regular **Markdown** prose.
 Only tags that start with an uppercase letter are treated as JSX / components,
 so ordinary HTML (`<div>`, `<span>`, …) stays raw HTML. Member names
 (`Foo.Bar`), fragments (`<>...</>`), spreads (`{...props}`), JSX comments
-(`{/* note */}`), and `{expression}` children are parsed when MDX is on;
-expression source is stored and not run. Tags inside fenced code blocks and
-inline code are **not** components.
+(`{/* note */}`), `{expression}` children, and document-level
+`{expression}` are parsed when MDX is on; expression source is stored and
+not run. Tags inside fenced code blocks and inline code are **not**
+components or expressions.
 
 Module-level `import` and `export` at the start of a file (and after other
 ESM) become `MdxjsEsm` nodes. Multi-line statements are collected with a
@@ -96,8 +101,15 @@ naive brace / paren / string / comment scan — not a JavaScript parser —
 so regex literals and `${}` inside templates may confuse statement
 boundaries. `import` / `export` inside fences or inline code is not ESM.
 Hostile strings such as `import x from "<script>"` store source and do not
-panic. The HTML renderer currently emits nothing for `MdxjsEsm`; framework
-plugins will resolve imports later.
+panic. The HTML renderer currently emits nothing for `MdxjsEsm` or
+`{expression}` nodes; framework plugins will resolve imports and evaluate
+expressions later.
+
+Document-level `{expression}` uses a naive brace / string / comment scan —
+not a JavaScript parser — so regex literals may confuse boundaries.
+Unclosed `{` stays ordinary text. Fences and inline code never become
+expressions. Hostile source such as `{ "<script>" }` is stored and is not
+emitted as HTML.
 
 ### Props
 


### PR DESCRIPTION
## Summary

- Parse document-level / prose `{expression}` when `ParserOptions.mdx` is true: flow (`MdxFlowExpression`) and text (`MdxTextExpression`). Source is stored, not evaluated.
- `mdx=false` / omitted keeps `{foo}` as text. Fences, inline code, and unclosed `{` do not emit a half-parsed node. Hostile source such as `{ "<script>" }` is stored; the HTML renderer still no-ops expression nodes (no JS runtime, no raw markup).
- `import` / `export` braces from #729 stay `MdxjsEsm`. Based on latest main after #736 (fragments / spreads / children expressions). Island prop serialization of expression sources is deferred so pages without islands stay JS-free.

Parent #701

## Risk

- Risk level: low
- User or production impact: none unless `mdx: true` is set. Default CommonMark / GFM output is unchanged. MDX expression nodes still render as nothing.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run: `rustup run 1.95.0 cargo test -p ox_content_parser -p ox_content_ast -p ox_content_renderer` and `clippy -D warnings`
- [x] Manual verification completed: existing JSX, ESM, and remainder tests stay green; `mdx_options` noops remain for non-expression Markdown
- [x] Edge cases or failure modes considered: unclosed `{`, strings / templates containing `}`, fences, inline code, escaped `\{`, and hostile `<script>` source

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

## Test plan

- [ ] CI green on this PR
- [ ] Confirm `.md` / `mdx=false` fixtures and CommonMark/GFM spec tests are unchanged
- [ ] Confirm `{foo}` is flow and `Hello {name}` is text when `mdx=true`
- [ ] Confirm fences, inline code, unclosed `{`, and `import { Chart }` do not emit prose expression nodes
- [ ] Confirm HTML output for expression-only pages has no `<script>` and no islands


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790155747&installation_model_id=422833&pr_number=741&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F741&signature=9725ec2fbab65dc8f0b45d13c080570667ea449a00cb24d5624fe946910ec8ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->