### PR TITLE
feat(mdx): serialize XSS-safe island props from JSX attributes

### DIFF
--- a/crates/ox_content_renderer/Cargo.toml
+++ b/crates/ox_content_renderer/Cargo.toml
@@ -23,11 +23,11 @@ rustc-hash = { workspace = true }
 compact_str = { workspace = true }
 smallvec = { workspace = true }
 ox_content_profiler = { workspace = true, optional = true }
-serde_json = { workspace = true, optional = true }
+serde_json = { workspace = true }
 
 [features]
 default = []
-frameworks = ["dep:serde_json"]
+frameworks = []
 # See `ox_content_parser`'s `profile` feature — same trade-off, but
 # instruments the HTML renderer's visitor entry points instead.
 profile = ["dep:ox_content_profiler"]

--- a/crates/ox_content_renderer/src/html.rs
+++ b/crates/ox_content_renderer/src/html.rs
@@ -11,6 +11,7 @@ mod code_annotations;
 mod escape;
 mod heading;
 mod html_attr;
+mod mdx_payload;
 mod options;
 mod renderer;
 mod tagfilter;

--- a/crates/ox_content_renderer/src/html/mdx_payload.rs
+++ b/crates/ox_content_renderer/src/html/mdx_payload.rs
@@ -1,0 +1,167 @@
+//! XSS-safe island payloads from MDX JSX attributes.
+//!
+//! Literal props become JSON values. `{expression}` and `{...spread}` store
+//! source text and are never evaluated. The serialized JSON unicode-escapes
+//! `<`, `>`, and `&` so it is safe inside a non-executed script or an
+//! HTML-escaped attribute.
+
+use ox_content_ast::{MdxJsxAttributeEntry, MdxJsxAttributeValue};
+use serde_json::{Map, Value};
+
+/// Structured island payload: literals, expression sources, and spreads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct IslandPayload {
+    pub(super) props: Map<String, Value>,
+    pub(super) expressions: Map<String, Value>,
+    pub(super) spreads: Vec<Value>,
+}
+
+impl IslandPayload {
+    pub(super) fn is_empty(&self) -> bool {
+        self.props.is_empty() && self.expressions.is_empty() && self.spreads.is_empty()
+    }
+
+    pub(super) fn into_json_value(self) -> Value {
+        let mut object = Map::new();
+        object.insert("props".into(), Value::Object(self.props));
+        object.insert("expressions".into(), Value::Object(self.expressions));
+        object.insert("spreads".into(), Value::Array(self.spreads));
+        Value::Object(object)
+    }
+}
+
+pub(super) fn collect_island_payload(attributes: &[MdxJsxAttributeEntry<'_>]) -> IslandPayload {
+    let mut payload =
+        IslandPayload { props: Map::new(), expressions: Map::new(), spreads: Vec::new() };
+
+    for entry in attributes {
+        match entry {
+            MdxJsxAttributeEntry::Attribute(attribute) => match &attribute.value {
+                None => {
+                    payload.props.insert(attribute.name.to_owned(), Value::Bool(true));
+                }
+                Some(MdxJsxAttributeValue::Literal(value)) => {
+                    payload
+                        .props
+                        .insert(attribute.name.to_owned(), Value::String((*value).to_owned()));
+                }
+                Some(MdxJsxAttributeValue::Expression(expr)) => {
+                    match serde_json::from_str::<Value>(expr.value.trim()) {
+                        Ok(value) => {
+                            payload.props.insert(attribute.name.to_owned(), value);
+                        }
+                        Err(_) => {
+                            payload.expressions.insert(
+                                attribute.name.to_owned(),
+                                Value::String(expr.value.to_owned()),
+                            );
+                        }
+                    }
+                }
+            },
+            MdxJsxAttributeEntry::Expression(expr) => {
+                payload.spreads.push(Value::String(expr.value.to_owned()));
+            }
+        }
+    }
+
+    payload
+}
+
+/// JSON text that cannot break out of `<script>` or HTML attributes.
+pub(super) fn stringify_xss_safe(value: &Value) -> String {
+    let json = serde_json::to_string(value).unwrap_or_else(|_| "{}".to_owned());
+    escape_json_for_html(&json)
+}
+
+pub(super) fn escape_json_for_html(json: &str) -> String {
+    let mut out = String::with_capacity(json.len());
+    for ch in json.chars() {
+        match ch {
+            '<' => out.push_str("\\u003c"),
+            '>' => out.push_str("\\u003e"),
+            '&' => out.push_str("\\u0026"),
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            ch => out.push(ch),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use ox_content_allocator::Allocator;
+    use ox_content_ast::{
+        MdxJsxAttribute, MdxJsxAttributeEntry, MdxJsxAttributeValue,
+        MdxJsxAttributeValueExpression, MdxJsxExpressionAttribute, Span,
+    };
+
+    use super::{collect_island_payload, stringify_xss_safe};
+
+    #[test]
+    fn literals_and_json_expressions_become_props() {
+        let allocator = Allocator::new();
+        let mut attributes = allocator.new_vec();
+        attributes.push(MdxJsxAttributeEntry::Attribute(MdxJsxAttribute {
+            name: "title",
+            value: Some(MdxJsxAttributeValue::Literal("hi")),
+            span: Span::new(0, 1),
+        }));
+        attributes.push(MdxJsxAttributeEntry::Attribute(MdxJsxAttribute {
+            name: "count",
+            value: Some(MdxJsxAttributeValue::Expression(MdxJsxAttributeValueExpression {
+                value: "42",
+                span: Span::new(0, 1),
+            })),
+            span: Span::new(0, 1),
+        }));
+        attributes.push(MdxJsxAttributeEntry::Attribute(MdxJsxAttribute {
+            name: "disabled",
+            value: None,
+            span: Span::new(0, 1),
+        }));
+
+        let payload = collect_island_payload(&attributes);
+        assert_eq!(payload.props["title"], "hi");
+        assert_eq!(payload.props["count"], 42);
+        assert_eq!(payload.props["disabled"], true);
+        assert!(payload.expressions.is_empty());
+    }
+
+    #[test]
+    fn non_json_expression_and_spread_store_source() {
+        let allocator = Allocator::new();
+        let mut attributes = allocator.new_vec();
+        attributes.push(MdxJsxAttributeEntry::Attribute(MdxJsxAttribute {
+            name: "onClick",
+            value: Some(MdxJsxAttributeValue::Expression(MdxJsxAttributeValueExpression {
+                value: "alert(1)",
+                span: Span::new(0, 1),
+            })),
+            span: Span::new(0, 1),
+        }));
+        attributes.push(MdxJsxAttributeEntry::Expression(MdxJsxExpressionAttribute {
+            value: "...cardProps",
+            span: Span::new(0, 1),
+        }));
+
+        let payload = collect_island_payload(&attributes);
+        assert_eq!(payload.expressions["onClick"], "alert(1)");
+        assert_eq!(payload.spreads, vec![serde_json::json!("...cardProps")]);
+        assert!(payload.props.is_empty());
+    }
+
+    #[test]
+    fn stringify_escapes_script_breakout() {
+        let value = serde_json::json!({
+            "props": { "title": "</script><script>alert(1)" },
+            "expressions": {},
+            "spreads": []
+        });
+        let json = stringify_xss_safe(&value);
+        assert!(!json.contains("</script>"), "raw </script> must not appear: {json}");
+        assert!(!json.contains('<'), "raw < must not appear: {json}");
+        assert!(json.contains("\\u003c"), "expected unicode-escaped markup: {json}");
+    }
+}

--- a/crates/ox_content_renderer/src/html/renderer.rs
+++ b/crates/ox_content_renderer/src/html/renderer.rs
@@ -11,6 +11,7 @@ mod code_block;
 mod incremental;
 mod inlines;
 mod links;
+mod mdx;
 mod visit;
 mod write;
 
@@ -204,11 +205,9 @@ impl HtmlRenderer {
             Node::FootnoteReference(node) => self.render_footnote_reference(node),
             Node::Definition(_) => {}
             Node::FootnoteDefinition(node) => self.render_footnote_definition(node),
-            Node::MdxJsxFlowElement(_)
-            | Node::MdxJsxTextElement(_)
-            | Node::MdxjsEsm(_)
-            | Node::MdxFlowExpression(_)
-            | Node::MdxTextExpression(_) => {}
+            Node::MdxJsxFlowElement(node) => self.render_mdx_jsx_flow_element(node),
+            Node::MdxJsxTextElement(node) => self.render_mdx_jsx_text_element(node),
+            Node::MdxjsEsm(_) | Node::MdxFlowExpression(_) | Node::MdxTextExpression(_) => {}
         }
     }
 

--- a/crates/ox_content_renderer/src/html/renderer/mdx.rs
+++ b/crates/ox_content_renderer/src/html/renderer/mdx.rs
@@ -1,0 +1,79 @@
+//! Render MDX JSX elements as island placeholders with serialized props.
+//!
+//! Named PascalCase / member-name tags become `data-ox-island` wrappers.
+//! Fragments render children only. Document-level `{expression}` and ESM
+//! stay silent. Pages without named components emit no `<script>`.
+
+use ox_content_ast::{MdxJsxAttributeEntry, MdxJsxFlowElement, MdxJsxTextElement, Node};
+
+use super::super::escape::write_escaped_into;
+use super::super::mdx_payload::{collect_island_payload, stringify_xss_safe};
+use super::HtmlRenderer;
+
+impl HtmlRenderer {
+    pub(in crate::html::renderer) fn render_mdx_jsx_flow_element(
+        &mut self,
+        node: &MdxJsxFlowElement<'_>,
+    ) {
+        self.render_mdx_jsx(node.name, &node.attributes, &node.children, "div", true);
+    }
+
+    pub(in crate::html::renderer) fn render_mdx_jsx_text_element(
+        &mut self,
+        node: &MdxJsxTextElement<'_>,
+    ) {
+        self.render_mdx_jsx(node.name, &node.attributes, &node.children, "span", false);
+    }
+
+    fn render_mdx_jsx(
+        &mut self,
+        name: Option<&str>,
+        attributes: &[MdxJsxAttributeEntry<'_>],
+        children: &[Node<'_>],
+        tag: &str,
+        block: bool,
+    ) {
+        let Some(name) = name else {
+            self.render_mdx_children(children, block);
+            return;
+        };
+
+        self.output.push('<');
+        self.output.push_str(tag);
+        self.output.push_str(" class=\"ox-island\" data-ox-island=\"");
+        write_escaped_into(&mut self.output, name);
+        self.output.push('"');
+
+        let payload = collect_island_payload(attributes);
+        let json = (!payload.is_empty()).then(|| stringify_xss_safe(&payload.into_json_value()));
+        if let Some(json) = json.as_deref() {
+            self.output.push_str(" data-ox-props=\"");
+            write_escaped_into(&mut self.output, json);
+            self.output.push('"');
+        }
+
+        self.output.push('>');
+        if let Some(json) = json.as_deref() {
+            self.output.push_str("<script type=\"application/json\">");
+            self.output.push_str(json);
+            self.output.push_str("</script>");
+        }
+        self.render_mdx_children(children, block);
+        self.output.push_str("</");
+        self.output.push_str(tag);
+        self.output.push('>');
+        if block {
+            self.output.push('\n');
+        }
+    }
+
+    fn render_mdx_children(&mut self, children: &[Node<'_>], block: bool) {
+        for child in children {
+            if block {
+                self.render_node(child);
+            } else {
+                self.visit_inline_node(child);
+            }
+        }
+    }
+}

--- a/crates/ox_content_renderer/src/html/renderer/visit.rs
+++ b/crates/ox_content_renderer/src/html/renderer/visit.rs
@@ -6,8 +6,9 @@
 
 use ox_content_ast::{
     BlockQuote, Break, CodeBlock, Definition, Delete, Document, Emphasis, FootnoteDefinition,
-    FootnoteReference, Heading, Html, Image, InlineCode, Link, List, ListItem, Node, Paragraph,
-    Strong, Table, Text, ThematicBreak, Visit,
+    FootnoteReference, Heading, Html, Image, InlineCode, Link, List, ListItem, MdxFlowExpression,
+    MdxJsxFlowElement, MdxJsxTextElement, MdxTextExpression, MdxjsEsm, Node, Paragraph, Strong,
+    Table, Text, ThematicBreak, Visit,
 };
 
 use super::HtmlRenderer;
@@ -101,4 +102,18 @@ impl<'a> Visit<'a> for HtmlRenderer {
     fn visit_footnote_definition(&mut self, footnote_def: &FootnoteDefinition<'a>) {
         self.render_footnote_definition(footnote_def);
     }
+
+    fn visit_mdx_jsx_flow_element(&mut self, node: &MdxJsxFlowElement<'a>) {
+        self.render_mdx_jsx_flow_element(node);
+    }
+
+    fn visit_mdx_jsx_text_element(&mut self, node: &MdxJsxTextElement<'a>) {
+        self.render_mdx_jsx_text_element(node);
+    }
+
+    fn visit_mdxjs_esm(&mut self, _node: &MdxjsEsm<'a>) {}
+
+    fn visit_mdx_flow_expression(&mut self, _node: &MdxFlowExpression<'a>) {}
+
+    fn visit_mdx_text_expression(&mut self, _node: &MdxTextExpression<'a>) {}
 }

--- a/crates/ox_content_renderer/src/html/tests.rs
+++ b/crates/ox_content_renderer/src/html/tests.rs
@@ -5,6 +5,7 @@ mod inline_media;
 mod links;
 mod lists_tables;
 mod mdx;
+mod mdx_islands;
 
 use crate::html::{HtmlRenderer, HtmlRendererOptions};
 use ox_content_allocator::Allocator;

--- a/crates/ox_content_renderer/src/html/tests/mdx_islands.rs
+++ b/crates/ox_content_renderer/src/html/tests/mdx_islands.rs
@@ -1,0 +1,153 @@
+//! Island payload serialization when MDX JSX is present.
+//!
+//! Named components become `data-ox-island` placeholders. Literal props are
+//! JSON values; `{expression}` and `{...spread}` store source and are never
+//! evaluated. Pages without components stay JS-free. `mdx=false` is unchanged.
+
+use ox_content_allocator::Allocator;
+use ox_content_parser::{Parser, ParserOptions};
+use serde_json::Value;
+
+use crate::html::HtmlRenderer;
+
+fn render_with(source: &str, options: ParserOptions) -> String {
+    let allocator = Allocator::new();
+    let doc = Parser::with_options(&allocator, source, options)
+        .parse()
+        .expect("parser should not fail on island render fixtures");
+    HtmlRenderer::new().render(&doc)
+}
+
+fn render_mdx(source: &str) -> String {
+    render_with(source, ParserOptions::mdx())
+}
+
+fn html_unescape(value: &str) -> String {
+    value
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
+}
+
+fn json_attr(html: &str, name: &str) -> Option<Value> {
+    let needle = format!("{name}=\"");
+    let start = html.find(&needle)? + needle.len();
+    let rest = &html[start..];
+    let end = rest.find('"')?;
+    let raw = html_unescape(&rest[..end]);
+    Some(
+        serde_json::from_str(&raw).unwrap_or_else(|error| {
+            panic!("attribute {name} is not JSON ({error}): {raw:?}\n{html}")
+        }),
+    )
+}
+
+fn script_payload(html: &str) -> Option<Value> {
+    const OPEN: &str = "<script type=\"application/json\">";
+    let start = html.find(OPEN)? + OPEN.len();
+    let rest = &html[start..];
+    let end = rest.find("</script>")?;
+    Some(serde_json::from_str(&rest[..end]).unwrap_or_else(|error| {
+        panic!("island script is not JSON ({error}): {:?}\n{html}", &rest[..end])
+    }))
+}
+
+fn island_payload(html: &str) -> Value {
+    if let Some(value) = script_payload(html) {
+        return value;
+    }
+    if let Some(value) = json_attr(html, "data-ox-props") {
+        if value.get("props").is_some() || value.get("expressions").is_some() {
+            return value;
+        }
+        let mut wrapped = serde_json::Map::new();
+        wrapped.insert("props".into(), value);
+        if let Some(expressions) = json_attr(html, "data-ox-expressions") {
+            wrapped.insert("expressions".into(), expressions);
+        }
+        if let Some(spreads) = json_attr(html, "data-ox-spreads") {
+            wrapped.insert("spreads".into(), spreads);
+        }
+        return Value::Object(wrapped);
+    }
+    panic!("expected an island payload in:\n{html}");
+}
+
+#[test]
+fn page_without_islands_stays_js_free() {
+    let html = render_mdx("# Hello\n\nJust prose. Hello {name}.\n\n{count + 1}\n");
+    assert!(!html.contains("<script"), "pages without islands stay JS-free:\n{html}");
+    assert!(!html.contains("data-ox-island"), "prose is not an island:\n{html}");
+    assert!(!html.contains("ox-island"), "no island runtime markers:\n{html}");
+}
+
+#[test]
+fn island_literal_props_serialize() {
+    let html = render_mdx("<Alert title=\"hi\" count={42} disabled />\n");
+    assert!(html.contains("data-ox-island=\"Alert\""), "expected an Alert island:\n{html}");
+    let payload = island_payload(&html);
+    assert_eq!(payload["props"]["title"], "hi", "quoted string is a JSON string:\n{html}");
+    assert_eq!(payload["props"]["count"], 42, "{{42}} is a JSON number:\n{html}");
+    assert_eq!(payload["props"]["disabled"], true, "boolean attr is true:\n{html}");
+}
+
+#[test]
+fn island_expression_stores_source_and_does_not_eval() {
+    let html = render_mdx("<Alert title={foo} count={count + 1} onClick={alert(1)} />\n");
+    let payload = island_payload(&html);
+    assert_eq!(payload["expressions"]["title"], "foo", "expression source is stored:\n{html}");
+    assert_eq!(
+        payload["expressions"]["count"], "count + 1",
+        "arithmetic is not evaluated:\n{html}"
+    );
+    assert_eq!(
+        payload["expressions"]["onClick"], "alert(1)",
+        "{{alert(1)}} stores source, not a result:\n{html}"
+    );
+    assert!(
+        payload["props"].get("count").is_none(),
+        "non-JSON expressions must not appear as literal props:\n{html}"
+    );
+}
+
+#[test]
+fn island_spread_stores_source_and_does_not_eval() {
+    let html = render_mdx("<Card title=\"hi\" {...cardProps} {...rest} />\n");
+    let payload = island_payload(&html);
+    assert_eq!(payload["props"]["title"], "hi");
+    assert_eq!(
+        payload["spreads"],
+        serde_json::json!(["...cardProps", "...rest"]),
+        "spreads are a source list, not a merged object:\n{html}"
+    );
+}
+
+#[test]
+fn hostile_expression_source_cannot_break_out() {
+    let html =
+        render_mdx("<Alert title={\"</script><script>alert(1)\"} label={foo + \"<bar>\"} />\n");
+    assert!(!html.contains("</script><script>"), "raw script breakout must not appear:\n{html}");
+    assert!(!html.contains("<script>alert"), "alert must not become executable HTML:\n{html}");
+    let payload = island_payload(&html);
+    let title = payload["props"].get("title").or_else(|| payload["expressions"].get("title"));
+    assert_eq!(
+        title,
+        Some(&Value::String("</script><script>alert(1)".into())),
+        "hostile string is recovered from the escaped payload:\n{html}"
+    );
+    assert_eq!(
+        payload["expressions"]["label"], "foo + \"<bar>\"",
+        "quotes and < stay in the source string:\n{html}"
+    );
+}
+
+#[test]
+fn mdx_false_does_not_emit_islands() {
+    let html =
+        render_with("<Alert title=\"hi\" count={42} {...props} />\n", ParserOptions::default());
+    assert!(!html.contains("data-ox-island"), "mdx=false must not emit islands:\n{html}");
+    assert!(!html.contains("data-ox-props"), "mdx=false must not emit a payload:\n{html}");
+    assert!(!html.contains("type=\"application/json\""), "mdx=false stays JS-free:\n{html}");
+}

--- a/crates/ox_content_renderer/src/html/toc.rs
+++ b/crates/ox_content_renderer/src/html/toc.rs
@@ -83,6 +83,16 @@ fn scan_node_for_render(node: &Node<'_>, scan: &mut DocumentRenderScan) {
                 scan_node_for_render(child, scan);
             }
         }
+        Node::MdxJsxFlowElement(node) => {
+            for child in &node.children {
+                scan_node_for_render(child, scan);
+            }
+        }
+        Node::MdxJsxTextElement(node) => {
+            for child in &node.children {
+                scan_node_for_render(child, scan);
+            }
+        }
         _ => {}
     }
 }
@@ -180,6 +190,16 @@ fn collect_inline_toc_node(
         }
         Node::FootnoteDefinition(definition) => {
             for child in &definition.children {
+                collect_inline_toc_node(child, max_depth, counts, entries);
+            }
+        }
+        Node::MdxJsxFlowElement(node) => {
+            for child in &node.children {
+                collect_inline_toc_node(child, max_depth, counts, entries);
+            }
+        }
+        Node::MdxJsxTextElement(node) => {
+            for child in &node.children {
                 collect_inline_toc_node(child, max_depth, counts, entries);
             }
         }

--- a/docs/content/mdx.md
+++ b/docs/content/mdx.md
@@ -19,8 +19,10 @@ It is worth understanding how this works, because it differs from "classic" MDX:
   `{expression}` children are stored as AST source. Nothing is evaluated.
   `.md` stays CommonMark + GFM unless that option is on.
 - **Components are resolved by a framework plugin**, not the renderer. The
-  React/Vue/Svelte plugins scan the content for PascalCase component tags,
-  replace them with **island** placeholders, and hydrate them on the client.
+  HTML renderer turns named MDX JSX into island placeholders and
+  serializes props (literals as JSON, `{expression}` / spreads as source).
+  The React/Vue/Svelte plugins still discover PascalCase tags for hydration
+  and will evaluate expressions later.
 
 So you get Markdown's speed for prose plus real interactive components where you
 need them — without shipping a JavaScript bundle for pages that have none.
@@ -111,21 +113,40 @@ Unclosed `{` stays ordinary text. Fences and inline code never become
 expressions. Hostile source such as `{ "<script>" }` is stored and is not
 emitted as HTML.
 
+When MDX is on, a named JSX component becomes an island placeholder in the
+HTML (`data-ox-island="Name"`). Its attributes are serialized onto that
+island — they are not run:
+
+- quoted strings, boolean attributes, and JSON-literal `{42}` / `{true}` /
+  `{"a":1}` values become JSON-safe props
+- any other `{expression}` is stored as a **source string**
+- `{...spread}` attributes become a **spread-source list**
+
+The payload is JSON that unicode-escapes `<`, `>`, and `&`, then sits in
+`data-ox-props` (HTML-escaped) and in a `<script type="application/json">`
+that the browser does not execute. Hostile source such as
+`{"</script><script>"}` or `{alert(1)}` cannot break out of the payload
+and is not evaluated. Pages with no components emit no `<script>` and no
+island runtime. Framework plugins still resolve and hydrate components
+later.
+
 ### Props
 
 Props use JSX-like syntax. The following forms are recognised:
 
-| Syntax             | Parsed as           |
-| ------------------ | ------------------- |
-| `prop="text"`      | string              |
-| `prop={42}`        | number / JSON value |
-| `prop={true}`      | boolean             |
-| `prop={ {"a":1} }` | object (JSON)       |
-| `prop`             | boolean `true`      |
-| `{...props}`       | spread (source)     |
+| Syntax             | Serialized as                     |
+| ------------------ | --------------------------------- |
+| `prop="text"`      | string                            |
+| `prop={42}`        | number / JSON value               |
+| `prop={true}`      | boolean                           |
+| `prop={ {"a":1} }` | object (JSON)                     |
+| `prop`             | boolean `true`                    |
+| `prop={count + 1}` | expression source (not evaluated) |
+| `{...props}`       | spread source (not evaluated)     |
 
-Props are serialized to a `data-ox-props` attribute on the island element and
-handed to your component at hydration time.
+Literal props, expression sources, and spreads are serialized together on
+the island element. Hydration still happens later; this slice only stores
+the payload.
 
 ## How islands hydrate
 


### PR DESCRIPTION
## Summary

- When `ParserOptions.mdx` is on, named JSX components render as `data-ox-island` placeholders. Literal props (`"text"`, `{42}`, `{true}`, boolean attrs) become JSON-safe values; `{expression}` and `{...spread}` store source and are never evaluated.
- The payload is JSON with `<` / `>` / `&` unicode-escaped, then HTML-escaped into `data-ox-props` and copied into a `<script type="application/json">` that the browser does not execute. Hostile source such as `{"</script><script>"}` or `{alert(1)}` cannot break out. Pages with no components emit no `<script>` and no island runtime.
- `mdx=false` / omitted is unchanged. Document-level prose `{expression}` from #741 still renders as nothing. No new `JsTransformOptions` field. Import resolution / hydration / JS evaluation stay deferred.

Parent #701

## Risk

- Risk level: low
- User or production impact: none unless `mdx: true` is set. Default CommonMark / GFM output is unchanged.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run: `rustup run 1.95.0 cargo test -p ox_content_renderer --lib` and `clippy -D warnings` on the renderer lib; `vp check --fix`
- [x] Manual verification completed: existing MDX expression renderer tests stay JS-free; `mdx=false` does not emit islands
- [x] Edge cases or failure modes considered: JSON literals vs non-JSON expressions, multiple spreads, `</script>` / quotes / `<` in expression source, fragments (no island)

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

## Test plan

- [ ] CI green on this PR
- [ ] Confirm pages without components have no `<script>` and no `data-ox-island`
- [ ] Confirm `<Alert title="hi" count={42} disabled />` serializes literals
- [ ] Confirm `{count + 1}` / `{alert(1)}` store source and do not evaluate
- [ ] Confirm `{...cardProps}` is a spread-source list
- [ ] Confirm hostile `</script>` / quotes / `<` cannot break out of the payload
- [ ] Confirm `mdx=false` HTML is unchanged (no islands)


Made with [Cursor](https://cursor.com)