### PR TITLE
feat(mdx): render markdown children inside JSX islands

### DIFF
--- a/crates/ox_content_parser/tests/mdx_jsx.rs
+++ b/crates/ox_content_parser/tests/mdx_jsx.rs
@@ -34,6 +34,15 @@ fn mdx_false_does_not_emit_jsx_for_pascal_case() {
 }
 
 #[test]
+fn disabled_mdx_does_not_parse_jsx_children() {
+    let source = "<Callout>\n\n# Title\n\nHello **world**.\n\n</Callout>\n";
+    let tree = pretty_ast(source, ParserOptions::default());
+    assert!(!tree.contains("MdxJsx"), "mdx=false must not wrap children in JSX:\n{tree}");
+    assert!(tree.contains("Heading"), "markdown after the opener still parses:\n{tree}");
+    assert!(tree.contains("Strong"), "phrasing is not swallowed:\n{tree}");
+}
+
+#[test]
 fn flow_self_closing_literal_attr() {
     let tree = mdx_tree("<Alert title=\"hi\" />\n");
     assert!(
@@ -89,6 +98,14 @@ fn unclosed_tag_does_not_panic_or_emit_jsx() {
 }
 
 #[test]
+fn unclosed_component_does_not_swallow_file() {
+    let tree = mdx_tree("<Callout>\n\n# Still here\n\nAfter the unclosed tag.\n");
+    assert!(!tree.contains("MdxJsx"), "unclosed opener is not JSX:\n{tree}");
+    assert!(tree.contains("Heading"), "heading after the opener still parses:\n{tree}");
+    assert!(tree.contains("After the unclosed tag."), "trailing prose is not swallowed:\n{tree}");
+}
+
+#[test]
 fn fenced_and_inline_code_are_not_components() {
     let fenced = mdx_tree("```js\nconst x = <div />;\n```\n");
     assert!(fenced.contains("Code"), "expected a fence:\n{fenced}");
@@ -119,6 +136,17 @@ fn flow_open_close_parses_markdown_children() {
     );
     assert!(tree.contains("Strong"), "markdown children should parse:\n{tree}");
     assert!(!tree.contains("MdxFlowExpression"), "this fixture has no child expression:\n{tree}");
+}
+
+#[test]
+fn fence_inside_component_is_code_not_island() {
+    let tree = mdx_tree("<Callout>\n\n```js\nconst x = <Alert />;\n```\n\n</Callout>\n");
+    assert!(
+        tree.contains("MdxJsxFlowElement name=Some(\"Callout\")"),
+        "wrapper still parses:\n{tree}"
+    );
+    assert!(tree.contains("Code"), "inner fence is a code node:\n{tree}");
+    assert!(!tree.contains("name=Some(\"Alert\")"), "fence JSX is not a component:\n{tree}");
 }
 
 #[test]

--- a/crates/ox_content_renderer/src/html/renderer.rs
+++ b/crates/ox_content_renderer/src/html/renderer.rs
@@ -69,6 +69,10 @@ pub struct HtmlRenderer {
     /// (paragraphs, headings, emphasis, …) and only the link case needs
     /// to mask it out.
     in_link: bool,
+    /// Named MDX island children run the GFM tagfilter on raw HTML so a
+    /// `<script>` in component children cannot execute. Cleared while the
+    /// island writes its own non-executing JSON payload.
+    in_mdx_island_children: bool,
     /// First-byte skip index for the autolink scanner. It depends only on
     /// `options.autolink_patterns`, which is immutable for the duration of a
     /// render, so it is built once at `render()` entry and reused for every
@@ -107,6 +111,7 @@ impl HtmlRenderer {
             heading_text_scratch: String::with_capacity(64),
             heading_slug_scratch: String::with_capacity(64),
             in_link: false,
+            in_mdx_island_children: false,
             autolink_index: None,
         }
     }
@@ -136,6 +141,7 @@ impl HtmlRenderer {
     fn render_into_output(&mut self, document: &Document<'_>) {
         crate::profile_span!("renderer::render");
         self.output.clear();
+        self.in_mdx_island_children = false;
         // Renderer setup is intentionally split into a cheap structural scan
         // and the expensive optional work. TOC collection walks every heading
         // and allocates a slug per entry, which used to fire on every render

--- a/crates/ox_content_renderer/src/html/renderer/mdx.rs
+++ b/crates/ox_content_renderer/src/html/renderer/mdx.rs
@@ -1,8 +1,10 @@
 //! Render MDX JSX elements as island placeholders with serialized props.
 //!
 //! Named PascalCase / member-name tags become `data-ox-island` wrappers.
-//! Fragments render children only. Document-level `{expression}` and ESM
-//! stay silent. Pages without named components emit no `<script>`.
+//! Markdown children render as HTML *inside* that wrapper. Fragments render
+//! children only. Document-level `{expression}` and ESM stay silent. Pages
+//! without named components emit no `<script>`. Raw HTML under a named
+//! island is tagfiltered so `<script>` in children cannot execute.
 
 use ox_content_ast::{MdxJsxAttributeEntry, MdxJsxFlowElement, MdxJsxTextElement, Node};
 
@@ -38,6 +40,9 @@ impl HtmlRenderer {
             return;
         };
 
+        let previous_child_html = self.in_mdx_island_children;
+        self.in_mdx_island_children = false;
+
         self.output.push('<');
         self.output.push_str(tag);
         self.output.push_str(" class=\"ox-island\" data-ox-island=\"");
@@ -58,10 +63,12 @@ impl HtmlRenderer {
             self.output.push_str(json);
             self.output.push_str("</script>");
         }
+        self.in_mdx_island_children = true;
         self.render_mdx_children(children, block);
         self.output.push_str("</");
         self.output.push_str(tag);
         self.output.push('>');
+        self.in_mdx_island_children = previous_child_html;
         if block {
             self.output.push('\n');
         }

--- a/crates/ox_content_renderer/src/html/renderer/write.rs
+++ b/crates/ox_content_renderer/src/html/renderer/write.rs
@@ -148,7 +148,9 @@ impl HtmlRenderer {
         };
         let value = rewritten.as_deref().unwrap_or(value);
 
-        if self.options.disallow_raw_html && crate::html::tagfilter::needs_filtering(value) {
+        if (self.options.disallow_raw_html || self.in_mdx_island_children)
+            && crate::html::tagfilter::needs_filtering(value)
+        {
             crate::html::tagfilter::write_filtered_into(&mut self.output, value);
         } else {
             self.write(value);

--- a/crates/ox_content_renderer/src/html/tests/mdx_islands.rs
+++ b/crates/ox_content_renderer/src/html/tests/mdx_islands.rs
@@ -2,13 +2,16 @@
 //!
 //! Named components become `data-ox-island` placeholders. Literal props are
 //! JSON values; `{expression}` and `{...spread}` store source and are never
-//! evaluated. Pages without components stay JS-free. `mdx=false` is unchanged.
+//! evaluated. Markdown children render as HTML inside the island. Pages
+//! without components stay JS-free. `mdx=false` is unchanged.
 
 use ox_content_allocator::Allocator;
 use ox_content_parser::{Parser, ParserOptions};
 use serde_json::Value;
 
 use crate::html::HtmlRenderer;
+
+const ISLAND_JSON_SCRIPT: &str = "<script type=\"application/json\">";
 
 fn render_with(source: &str, options: ParserOptions) -> String {
     let allocator = Allocator::new();
@@ -45,13 +48,31 @@ fn json_attr(html: &str, name: &str) -> Option<Value> {
 }
 
 fn script_payload(html: &str) -> Option<Value> {
-    const OPEN: &str = "<script type=\"application/json\">";
-    let start = html.find(OPEN)? + OPEN.len();
+    let start = html.find(ISLAND_JSON_SCRIPT)? + ISLAND_JSON_SCRIPT.len();
     let rest = &html[start..];
     let end = rest.find("</script>")?;
     Some(serde_json::from_str(&rest[..end]).unwrap_or_else(|error| {
         panic!("island script is not JSON ({error}): {:?}\n{html}", &rest[..end])
     }))
+}
+
+/// Markdown children of a named island, after the optional JSON payload.
+fn island_inner<'a>(html: &'a str, name: &str) -> &'a str {
+    let marker = format!("data-ox-island=\"{name}\"");
+    let start = html.find(&marker).unwrap_or_else(|| panic!("missing island {name}:\n{html}"));
+    let after_gt =
+        html[start..].find('>').unwrap_or_else(|| panic!("unclosed island tag {name}:\n{html}"));
+    let mut body = start + after_gt + 1;
+    if let Some(rest) = html[body..].strip_prefix(ISLAND_JSON_SCRIPT)
+        && let Some(end) = rest.find("</script>")
+    {
+        body += ISLAND_JSON_SCRIPT.len() + end + "</script>".len();
+    }
+    let close_rel = html[body..]
+        .rfind("</div>")
+        .or_else(|| html[body..].rfind("</span>"))
+        .unwrap_or_else(|| panic!("missing island close for {name}:\n{html}"));
+    &html[body..body + close_rel]
 }
 
 fn island_payload(html: &str) -> Value {
@@ -150,4 +171,119 @@ fn mdx_false_does_not_emit_islands() {
     assert!(!html.contains("data-ox-island"), "mdx=false must not emit islands:\n{html}");
     assert!(!html.contains("data-ox-props"), "mdx=false must not emit a payload:\n{html}");
     assert!(!html.contains("type=\"application/json\""), "mdx=false stays JS-free:\n{html}");
+}
+
+#[test]
+fn disabled_mdx_does_not_parse_jsx_children() {
+    let html = render_with(
+        "<Callout>\n\n# Title\n\nHello **world**.\n\n</Callout>\n",
+        ParserOptions::default(),
+    );
+    assert!(!html.contains("data-ox-island"), "mdx=false must not wrap children:\n{html}");
+    assert!(!html.contains("ox-island"), "mdx=false has no island chrome:\n{html}");
+    assert!(html.contains("<h1"), "heading still renders as document HTML:\n{html}");
+    assert!(html.contains("<strong>world</strong>"), "strong is not dropped:\n{html}");
+}
+
+#[test]
+fn flow_component_renders_heading_and_strong_inside_island() {
+    let html = render_mdx("<Callout>\n\n# Title\n\nHello **world**.\n\n</Callout>\n");
+    assert!(html.contains("data-ox-island=\"Callout\""), "expected a Callout island:\n{html}");
+    let inner = island_inner(&html, "Callout");
+    assert!(inner.contains("<h1"), "heading must render inside the island:\n{html}");
+    assert!(inner.contains("id=\"title\""), "heading id is preserved:\n{html}");
+    assert!(
+        inner.contains("<strong>world</strong>"),
+        "strong must be real HTML, not escaped:\n{html}"
+    );
+    assert!(inner.contains("Hello"), "prose must not be dropped:\n{html}");
+    let after = html.rsplit_once("</div>").map_or("", |(_, rest)| rest);
+    assert!(!after.contains("<h1"), "heading must not leak after the island:\n{html}");
+    assert!(!after.contains("<strong>"), "strong must not leak after the island:\n{html}");
+}
+
+#[test]
+fn nested_list_inside_component() {
+    let html = render_mdx("<Callout>\n\n- parent\n  - child\n- sibling\n\n</Callout>\n");
+    let inner = island_inner(&html, "Callout");
+    assert!(inner.contains("<ul>"), "list must render inside the island:\n{html}");
+    assert!(inner.contains("<li>parent"), "parent item is inside the island:\n{html}");
+    assert!(inner.contains("<li>child"), "nested item is inside the island:\n{html}");
+    assert!(inner.contains("<li>sibling"), "sibling item is inside the island:\n{html}");
+    let nested_lists = inner.matches("<ul>").count();
+    assert!(nested_lists >= 2, "nested list must stay nested:\n{html}");
+}
+
+#[test]
+fn fence_inside_component_is_code_not_island() {
+    let html = render_mdx("<Callout>\n\n```js\nconst x = <Alert />;\n```\n\n</Callout>\n");
+    let inner = island_inner(&html, "Callout");
+    assert!(inner.contains("<pre>"), "fence must become a code block:\n{html}");
+    assert!(inner.contains("language-js"), "fence language is preserved:\n{html}");
+    assert!(inner.contains("const x"), "fence text is not dropped:\n{html}");
+    assert!(!inner.contains("data-ox-island=\"Alert\""), "fence JSX is not an island:\n{html}");
+    assert!(
+        inner.contains("&lt;Alert") || inner.contains("&lt;Alert /&gt;"),
+        "fence contents are escaped code, not a component:\n{html}"
+    );
+}
+
+#[test]
+fn nested_jsx_inside_markdown_children() {
+    let html = render_mdx("<Callout>\n\n# Title\n\n<Badge title=\"hi\" />\n\n</Callout>\n");
+    let inner = island_inner(&html, "Callout");
+    assert!(inner.contains("<h1"), "markdown heading stays inside Callout:\n{html}");
+    assert!(inner.contains("data-ox-island=\"Badge\""), "nested PascalCase is an island:\n{html}");
+    assert!(
+        html.contains("data-ox-island=\"Callout\""),
+        "outer component is still an island:\n{html}"
+    );
+    assert!(
+        inner.contains("<script type=\"application/json\">"),
+        "nested island payload is not tagfiltered:\n{html}"
+    );
+    assert_eq!(island_payload(&html)["props"]["title"], "hi", "nested props still parse:\n{html}");
+}
+
+#[test]
+fn hostile_child_text_escaped() {
+    let html = render_mdx("<Callout>\n<script>alert(1)</script>\n</Callout>\n");
+    assert!(html.contains("data-ox-island=\"Callout\""), "wrapper still emits:\n{html}");
+    assert!(!html.contains("<script>"), "raw script must not appear:\n{html}");
+    assert!(!html.contains("<script "), "raw script tag must not appear:\n{html}");
+    let inner = island_inner(&html, "Callout");
+    assert!(inner.contains("alert(1)"), "hostile child text is not dropped:\n{html}");
+    assert!(inner.contains("&lt;script"), "script tag is escaped:\n{html}");
+
+    let nested = render_mdx("<Callout>\n\n- <script>alert(1)</script>\n\n</Callout>\n");
+    assert!(!nested.contains("<script>"), "list child script is not raw:\n{nested}");
+    assert!(
+        island_inner(&nested, "Callout").contains("<ul>"),
+        "list still renders around escaped HTML:\n{nested}"
+    );
+}
+
+#[test]
+fn unclosed_component_does_not_swallow_file() {
+    let html = render_mdx("<Callout>\n\n# Still here\n\nAfter the unclosed tag.\n");
+    assert!(!html.contains("data-ox-island"), "unclosed opener is not an island:\n{html}");
+    assert!(html.contains("<h1"), "heading after the opener still renders:\n{html}");
+    assert!(html.contains("Still here"), "heading text is not swallowed:\n{html}");
+    assert!(html.contains("After the unclosed tag."), "trailing prose is not swallowed:\n{html}");
+}
+
+#[test]
+fn page_without_components_still_js_free() {
+    let prose = render_mdx("# Hello\n\nJust prose with **bold**.\n\n- a\n- b\n");
+    assert!(!prose.contains("<script"), "prose pages stay JS-free:\n{prose}");
+    assert!(!prose.contains("data-ox-island"), "prose is not an island:\n{prose}");
+
+    let fragment = render_mdx("<>\n\n# Title\n\nHello **world**.\n\n</>\n");
+    assert!(!fragment.contains("<script"), "fragments are not islands:\n{fragment}");
+    assert!(!fragment.contains("data-ox-island"), "nameless wrappers emit no island:\n{fragment}");
+    assert!(fragment.contains("<h1"), "fragment markdown children still render:\n{fragment}");
+    assert!(
+        fragment.contains("<strong>world</strong>"),
+        "fragment phrasing is real HTML:\n{fragment}"
+    );
 }

--- a/crates/ox_content_renderer/tests/stress_mutations.rs
+++ b/crates/ox_content_renderer/tests/stress_mutations.rs
@@ -31,7 +31,7 @@ const SPEC: &str = include_str!("spec_fixtures/commonmark-0.31.2-spec.txt");
 /// Generous enough that a slow debug-build machine never trips it, tight
 /// enough that an infinite loop is caught in one test run. The batch
 /// takes low single-digit seconds in practice.
-const BUDGET: Duration = Duration::from_secs(120);
+const BUDGET: Duration = Duration::from_mins(2);
 
 /// Syntax markers spliced into the seeds. Each opens a construct whose
 /// scanner has to cope with the closer being absent or misplaced.

--- a/docs/content/mdx.md
+++ b/docs/content/mdx.md
@@ -76,7 +76,16 @@ Regular **Markdown** prose. Hello {name}.
 <Counter initial={5} />
 
 <Callout type="tip">
-  This child content is passed to the component.
+
+# Title
+
+Hello **world**.
+
+- nested
+  - list
+
+<Badge />
+
 </Callout>
 
 <>
@@ -112,6 +121,15 @@ not a JavaScript parser — so regex literals may confuse boundaries.
 Unclosed `{` stays ordinary text. Fences and inline code never become
 expressions. Hostile source such as `{ "<script>" }` is stored and is not
 emitted as HTML.
+
+When MDX is on, Markdown between a component's tags is parsed as Markdown
+and rendered as HTML **inside** the island wrapper (`<h1>`, `<strong>`,
+lists, fences). Fenced and inline code stay code — a `<Alert />` inside a
+fence is not an island. Nested PascalCase tags become nested islands.
+Unclosed tags do not swallow the rest of the file. Hostile raw HTML in
+children such as `<script>alert(1)</script>` is neutralized (the leading
+`<` is escaped) so it cannot execute. Fragments (`<>...</>`) render their
+markdown children with no island wrapper.
 
 When MDX is on, a named JSX component becomes an island placeholder in the
 HTML (`data-ox-island="Name"`). Its attributes are serialized onto that


### PR DESCRIPTION
## Summary
- Prove and complete Markdown-as-children of MDX JSX in the HTML path: headings, emphasis, nested lists, fences, and nested PascalCase tags render *inside* the island wrapper.
- Neutralize hostile raw HTML under named islands (`<script>` in children is tagfiltered) without evaluating expressions or shipping JS on pages with no named components.
- Document a live-looking fenced example of markdown children in `docs/content/mdx.md`. `mdx=false` / `.md` stay unchanged.

Refs #701. Parent #699.

This does **not** close #701: framework-plugin import resolution / hydration, expression evaluation, a full JS parser, and Code Play remain.

## Test plan
- [x] `rustup run 1.95.0 cargo test -p ox_content_renderer -p ox_content_parser`
- [x] `rustup run 1.95.0 cargo clippy -p ox_content_renderer -p ox_content_parser --all-targets -- -D warnings`
- [ ] Confirm CI is green


Made with [Cursor](https://cursor.com)