### PR TITLE
fix(test): split locale-switcher Vite tests under the file line limit

### DIFF
--- a/npm/vite-plugin-ox-content/src/locale-switcher.test.ts
+++ b/npm/vite-plugin-ox-content/src/locale-switcher.test.ts
@@ -5,6 +5,7 @@ import {
   remainderPath,
   resolveLocaleSwitcherOption,
 } from "./locale-switcher";
+import { resolveSsgOptions } from "./ssg";
 
 describe("resolveLocaleSwitcherOption", () => {
   it("treats omitted as false", () => {
@@ -17,6 +18,20 @@ describe("resolveLocaleSwitcherOption", () => {
 
   it("treats an empty object as true", () => {
     expect(resolveLocaleSwitcherOption({})).toBe(true);
+  });
+});
+
+describe("resolveSsgOptions localeSwitcher", () => {
+  it("disables localeSwitcher by default", () => {
+    expect(resolveSsgOptions(undefined).localeSwitcher).toBe(false);
+  });
+
+  it("enables localeSwitcher when requested", () => {
+    expect(resolveSsgOptions({ localeSwitcher: true }).localeSwitcher).toBe(true);
+  });
+
+  it("enables localeSwitcher when an object is passed", () => {
+    expect(resolveSsgOptions({ localeSwitcher: {} }).localeSwitcher).toBe(true);
   });
 });
 

--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -70,18 +70,6 @@ describe("resolveSsgOptions", () => {
     });
   });
 
-  it("disables localeSwitcher by default", () => {
-    expect(resolveSsgOptions(undefined).localeSwitcher).toBe(false);
-  });
-
-  it("enables localeSwitcher when requested", () => {
-    expect(resolveSsgOptions({ localeSwitcher: true }).localeSwitcher).toBe(true);
-  });
-
-  it("enables localeSwitcher when an object is passed", () => {
-    expect(resolveSsgOptions({ localeSwitcher: {} }).localeSwitcher).toBe(true);
-  });
-
   it("disables notFound by default", () => {
     expect(resolveSsgOptions(undefined).notFound?.enabled).toBe(false);
   });

--- a/npm/vite-plugin-ox-content/src/transform.test.ts
+++ b/npm/vite-plugin-ox-content/src/transform.test.ts
@@ -1,6 +1,7 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vite-plus/test";
+import { createDocsResolvedOptions } from "../test/fixtures/docs-fixture";
 import { transformMarkdown } from "./transform";
 import type { ResolvedOptions } from "./types";
 
@@ -253,99 +254,5 @@ describe("transformMarkdown", () => {
 });
 
 function createResolvedOptions(overrides: Partial<ResolvedOptions> = {}): ResolvedOptions {
-  return {
-    srcDir: "content",
-    outDir: "dist",
-    base: "/",
-    extensions: [".md", ".markdown", ".mdx"],
-    ssg: {
-      enabled: true,
-      extension: ".html",
-      clean: false,
-      bare: false,
-      generateOgImage: false,
-      lastUpdated: false,
-      pagination: false,
-      breadcrumbs: false,
-      readerChrome: false,
-      localeSwitcher: false,
-    },
-    gfm: true,
-    footnotes: true,
-    tables: true,
-    taskLists: true,
-    strikethrough: true,
-    autolinks: true,
-    highlight: false,
-    codeAnnotations: {
-      enabled: false,
-      notation: "attribute",
-      metaKey: "annotate",
-      defaultLineNumbers: false,
-    },
-    wikiLinks: { enabled: false, baseUrl: "/" },
-    emojiShortcodes: { enabled: false, custom: {} },
-    attrs: { enabled: false },
-    badges: { enabled: false },
-    containers: { enabled: false, types: {} },
-    images: { enabled: false, lazy: true },
-    codeImports: { enabled: false },
-    includes: { enabled: false },
-    cards: { enabled: false },
-    steps: { enabled: false },
-    fileTree: { enabled: false },
-    sanitize: { enabled: false },
-    editThisPage: { enabled: false, branch: "main", label: "Edit this page" },
-    cjkEmphasis: false,
-    codeBlockLint: {
-      enabled: false,
-      requireLanguage: false,
-      trailingSpaces: true,
-      mode: "warn",
-    },
-    codeBlockTypecheck: {
-      enabled: false,
-      languages: ["ts", "tsx"],
-      requireMeta: true,
-      tsgoCommand: "tsgo",
-      mode: "warn",
-    },
-    docsTests: { enabled: false, languages: ["js", "jsx", "ts", "tsx"], requireMeta: true },
-    mermaid: false,
-    math: { enabled: false },
-    frontmatter: true,
-    toc: true,
-    tocMaxDepth: 3,
-    ogImage: false,
-    ogImageOptions: {
-      width: 1200,
-      height: 630,
-      cache: true,
-      concurrency: 1,
-      vuePlugin: "vitejs",
-    },
-    transformers: [],
-    docs: false,
-    search: {
-      enabled: true,
-      limit: 10,
-      prefix: true,
-      placeholder: "Search documentation...",
-      hotkey: "/",
-    },
-    collections: { enabled: false, collections: {} },
-    ogViewer: false,
-    embeds: {
-      github: {},
-      openGraph: {},
-      pm: false,
-      spotify: false,
-      stackBlitz: false,
-      twitter: false,
-      bluesky: false,
-      webContainer: false,
-    },
-    i18n: false,
-    ...overrides,
-  };
+  return createDocsResolvedOptions({ highlight: false, ...overrides });
 }


### PR DESCRIPTION
## Summary
- Move `resolveSsgOptions` localeSwitcher cases out of `ssg.test.ts` into `locale-switcher.test.ts` so `ssg.test.ts` stays at 339 lines.
- Reuse `createDocsResolvedOptions` in `transform.test.ts` so that file stays under 350 after `localeSwitcher` was added.

## Test plan
- [x] `node scripts/check-file-lines.ts --base prod/main`
- [x] `vp exec --filter @ox-content/vite-plugin -- vp test src/locale-switcher.test.ts src/ssg.test.ts src/transform.test.ts`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790162803&installation_model_id=422833&pr_number=751&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F751&signature=54c709ab57ba5e6c6eb5f1c02d70bd7a1241f809ddae400eff445f3f0029952b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->