### PR TITLE
fix(ssg): skip landing-page chrome and honor announcement dismiss

### DIFF
--- a/crates/ox_content_ssg/src/html/breadcrumbs.rs
+++ b/crates/ox_content_ssg/src/html/breadcrumbs.rs
@@ -35,7 +35,7 @@ pub(super) fn resolve_breadcrumbs(
 }
 
 fn breadcrumbs_enabled(page: &PageData, config: &SsgConfig) -> bool {
-    if page.breadcrumbs == Some(false) {
+    if page.entry_page.is_some() || page.breadcrumbs == Some(false) {
         return false;
     }
     config.breadcrumbs || config.theme.as_ref().and_then(|theme| theme.breadcrumbs) == Some(true)

--- a/crates/ox_content_ssg/src/html/breadcrumbs/tests.rs
+++ b/crates/ox_content_ssg/src/html/breadcrumbs/tests.rs
@@ -255,10 +255,11 @@ fn generate_bare_html_is_unchanged() {
 }
 
 #[test]
-fn entry_page_still_renders_trail_when_enabled() {
+fn entry_page_skips_trail_when_enabled() {
     let mut page_data = page("features/breadcrumbs");
     page_data.entry_page = Some(EntryPageConfig::default());
+    page_data.title = "Docs".to_string();
 
     let html = generate_html(&page_data, &nested_nav(), &config(true));
-    assert!(breadcrumbs_html(&html).is_some(), "entry pages keep the visible trail: {html}");
+    assert!(breadcrumbs_html(&html).is_none(), "entry pages must not emit a trail: {html}");
 }

--- a/crates/ox_content_ssg/src/html/header_chrome.css
+++ b/crates/ox_content_ssg/src/html/header_chrome.css
@@ -74,6 +74,9 @@
   color: #fff;
   font-size: 0.875rem;
 }
+.ox-announce[hidden] {
+  display: none;
+}
 .ox-announce-text {
   margin: 0;
 }

--- a/crates/ox_content_ssg/src/html/header_chrome/tests.rs
+++ b/crates/ox_content_ssg/src/html/header_chrome/tests.rs
@@ -173,6 +173,7 @@ fn announcement_escaped() {
     assert!(html.contains(r#"<div class="ox-announce""#), "{html}");
     assert!(body_class(&html).contains("ox-has-announce"), "{html}");
     assert!(html.contains(r#"data-ox-announce="welcome""#), "{html}");
+    assert!(html.contains(".ox-announce[hidden]"), "{html}");
     assert!(html.contains("parentElement"), "{html}");
     assert!(html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"), "{html}");
     assert!(!html.contains("<script>alert(1)</script>"), "{html}");

--- a/crates/ox_content_ssg/src/html/header_chrome/tests.rs
+++ b/crates/ox_content_ssg/src/html/header_chrome/tests.rs
@@ -173,8 +173,7 @@ fn announcement_escaped() {
     assert!(html.contains(r#"<div class="ox-announce""#), "{html}");
     assert!(body_class(&html).contains("ox-has-announce"), "{html}");
     assert!(html.contains(r#"data-ox-announce="welcome""#), "{html}");
-    assert!(html.contains(".ox-announce[hidden]"), "{html}");
-    assert!(html.contains("parentElement"), "{html}");
+    assert!(html.contains(".ox-announce[hidden]") && html.contains("parentElement"), "{html}");
     assert!(html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"), "{html}");
     assert!(!html.contains("<script>alert(1)</script>"), "{html}");
     assert!(html.contains(r#"href="https://example.com/news""#), "{html}");

--- a/crates/ox_content_ssg/src/html/reader_chrome.css
+++ b/crates/ox_content_ssg/src/html/reader_chrome.css
@@ -55,7 +55,6 @@
   color: var(--octc-color-text);
   font: inherit;
   font-size: 0.75rem;
-  box-shadow: 0 8px 24px color-mix(in srgb, var(--octc-color-text) 12%, transparent);
   cursor: pointer;
   transition:
     opacity 0.2s ease,

--- a/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
+++ b/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
@@ -1,6 +1,6 @@
 use super::super::{
-    NavGroup, NavItem, PageChromeFlags, PageData, ReaderChrome, SsgConfig, generate_bare_html,
-    generate_html,
+    EntryPageConfig, NavGroup, NavItem, PageChromeFlags, PageData, ReaderChrome, SsgConfig,
+    generate_bare_html, generate_html,
 };
 use super::{READER_CHROME_CSS, READER_CHROME_JS, apply_reader_chrome};
 
@@ -258,4 +258,13 @@ fn encoded_javascript_href_is_not_a_live_action() {
     assert!(!html.contains("javascript:"), "{html}");
     assert!(!html.contains("javascript&#58;"), "{html}");
     assert!(html.contains(r#"class="ox-external-inert""#), "{html}");
+}
+
+#[test]
+fn entry_page_skips_back_to_top_when_enabled() {
+    let mut page_data = page(ARTICLE);
+    page_data.entry_page = Some(EntryPageConfig::default());
+    let html = generate_html(&page_data, &nav(), &config(ReaderChrome::enabled()));
+    assert!(!html.contains(r#"<button type="button" class="ox-back-to-top""#), "{html}");
+    assert!(!html_open_tag(&html).contains("data-ox-back-to-top"), "{}", html_open_tag(&html));
 }

--- a/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
+++ b/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
@@ -215,6 +215,10 @@ fn reduced_motion_class_and_css_are_present() {
 
     assert!(READER_CHROME_CSS.contains("prefers-reduced-motion"), "{READER_CHROME_CSS}");
     assert!(READER_CHROME_CSS.contains("ox-reader-chrome--reduced-motion"), "{READER_CHROME_CSS}");
+    assert!(
+        !READER_CHROME_CSS.contains("box-shadow"),
+        "back-to-top must stay flat like the rest of the chrome: {READER_CHROME_CSS}"
+    );
     assert!(html.contains("prefers-reduced-motion"), "{html}");
     assert!(html.contains("ox-reader-chrome--reduced-motion"), "{html}");
     assert!(READER_CHROME_JS.contains("ox-reader-chrome--reduced-motion"), "{READER_CHROME_JS}");

--- a/crates/ox_content_ssg/src/html/render.rs
+++ b/crates/ox_content_ssg/src/html/render.rs
@@ -58,6 +58,10 @@ pub fn generate_html(page_data: &PageData, nav_groups: &[NavGroup], config: &Ssg
 
     // Check if this is an entry page
     let is_entry_page = page_data.entry_page.is_some();
+    let mut reader_chrome = config.reader_chrome;
+    if is_entry_page {
+        reader_chrome.back_to_top = false;
+    }
     // Build CSS as named sections instead of one anonymous blob. Shared,
     // content-addressed extraction can then pull out only the sections that are
     // globally cacheable and keep page-specific or relative-url CSS inline.
@@ -99,7 +103,7 @@ pub fn generate_html(page_data: &PageData, nav_groups: &[NavGroup], config: &Ssg
     if has_footer {
         css_sections.push(wrap_css_section("footer", footer_css));
     }
-    if config.reader_chrome.is_enabled() {
+    if reader_chrome.is_enabled() {
         css_sections.push(wrap_css_section("reader-chrome", READER_CHROME_CSS));
     }
     if header_chrome_needs_css(&header_nav_html, &announcement_html, chrome) {
@@ -114,7 +118,7 @@ pub fn generate_html(page_data: &PageData, nav_groups: &[NavGroup], config: &Ssg
 
     let all_css = css_sections.join("");
     let toc_html = generate_toc_html(&page_data.toc);
-    let has_toc = super::aside::has_toc(chrome.show_outline, &toc_html);
+    let has_toc = !is_entry_page && super::aside::has_toc(chrome.show_outline, &toc_html);
     let pager = resolve_pager(page_data, nav_groups, config.pagination);
     let breadcrumbs = resolve_breadcrumbs(page_data, nav_groups, config);
     let last_updated = chrome
@@ -170,7 +174,7 @@ pub fn generate_html(page_data: &PageData, nav_groups: &[NavGroup], config: &Ssg
     let custom_js = theme.and_then(|t| t.js.as_deref()).unwrap_or("");
     let mut all_js =
         format!("{}\n{}\n{}", SSG_JS.replace("{{base}}", &config.base), TABS_JS, custom_js);
-    if config.reader_chrome.needs_js() {
+    if reader_chrome.needs_js() {
         all_js.push('\n');
         all_js.push_str(READER_CHROME_JS);
     }
@@ -191,8 +195,8 @@ pub fn generate_html(page_data: &PageData, nav_groups: &[NavGroup], config: &Ssg
         .map_or(String::new(), generate_mobile_social_links_html);
 
     let enhanced_content;
-    let article_html = if config.reader_chrome.copy || config.reader_chrome.external_links {
-        enhanced_content = apply_reader_chrome(&page_data.content, config.reader_chrome);
+    let article_html = if reader_chrome.copy || reader_chrome.external_links {
+        enhanced_content = apply_reader_chrome(&page_data.content, reader_chrome);
         enhanced_content.as_str()
     } else {
         page_data.content.as_str()
@@ -270,7 +274,7 @@ pub fn generate_html(page_data: &PageData, nav_groups: &[NavGroup], config: &Ssg
         has_toc,
         toc_html: &toc_html,
         pager: pager.as_ref(),
-        reader_chrome: config.reader_chrome.is_enabled().then_some(&config.reader_chrome),
+        reader_chrome: reader_chrome.is_enabled().then_some(&reader_chrome),
         last_updated: last_updated.as_ref(),
         embed_content_after,
         embed_footer_before,

--- a/crates/ox_content_ssg/src/html/tests/aside.rs
+++ b/crates/ox_content_ssg/src/html/tests/aside.rs
@@ -114,6 +114,15 @@ fn aside_true_with_empty_toc_emits_nothing() {
 }
 
 #[test]
+fn entry_page_skips_outline_even_when_aside_enabled() {
+    let mut page_data = page(hello_toc());
+    page_data.entry_page = Some(EntryPageConfig::default());
+    let html = generate_html(&page_data, &[], &config(Some(theme_with_aside(true))));
+    assert_outline_absent(&html);
+    assert!(html.contains(r#"<main class="main">"#), "{html}");
+}
+
+#[test]
 fn aside_false_explicitly_hides_outline() {
     let html = render(hello_toc(), Some(theme_with_aside(false)));
     assert_outline_absent(&html);

--- a/docs/content/built-in/breadcrumbs.md
+++ b/docs/content/built-in/breadcrumbs.md
@@ -41,7 +41,7 @@ oxContent({
 ```
 
 The visible trail is independent of structured data. Enabling breadcrumbs does
-not emit JSON-LD.
+not emit JSON-LD. Entry pages skip the trail.
 
 ## Frontmatter
 

--- a/docs/content/built-in/header-chrome.md
+++ b/docs/content/built-in/header-chrome.md
@@ -66,11 +66,11 @@ oxContent({
 });
 ```
 
-| Field        | Required | Effect                                                                  |
-| ------------ | -------- | ----------------------------------------------------------------------- |
-| `text`       | yes      | Escaped. There is no raw HTML slot.                                     |
-| `link`       | no       | `https:` or same-origin only. Other schemes are dropped.                |
-| `dismissKey` | no       | Best-effort `localStorage` key. Invalid keys still render a static bar. |
+| Field        | Required | Effect                                                                                                                                     |
+| ------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `text`       | yes      | Escaped. There is no raw HTML slot.                                                                                                        |
+| `link`       | no       | `https:` or same-origin only. Other schemes are dropped.                                                                                   |
+| `dismissKey` | no       | Best-effort `localStorage` key. Invalid keys still render a static bar. Dismiss sets `hidden` on the bar; the theme CSS honors `[hidden]`. |
 
 ## Per-page chrome
 

--- a/docs/content/built-in/reader-chrome.md
+++ b/docs/content/built-in/reader-chrome.md
@@ -53,5 +53,5 @@ Outbound icons skip relative, hash, `mailto:`, and `tel:` links. Links inside
 fenced blocks or inline code spans are left alone. `javascript:`, `data:`, and
 `vbscript:` hrefs are not given a live action.
 
-The back-to-top control respects `prefers-reduced-motion`. Bare mode never
-emits reader chrome.
+The back-to-top control respects `prefers-reduced-motion`. Entry pages skip
+it. Bare mode never emits reader chrome.

--- a/docs/content/ja/built-in/reader-chrome.md
+++ b/docs/content/ja/built-in/reader-chrome.md
@@ -31,6 +31,8 @@ oxContent({
 });
 ```
 
+先頭へ戻るは `prefers-reduced-motion` を尊重します。エントリページでは出しません。
+
 ## 関連
 
 - [英語版ガイド](/built-in/reader-chrome.md)

--- a/docs/content/theming.md
+++ b/docs/content/theming.md
@@ -186,7 +186,7 @@ defineTheme({
 
 The default theme can render a right-hand "On this page" outline from the page
 headings. It is **off by default**. Set `aside: true` to enable it; the outline
-still appears only on pages that have TOC entries.
+still appears only on pages that have TOC entries. Entry pages skip the outline.
 
 ```ts
 defineTheme({

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -54,7 +54,6 @@ export default defineConfig(({ mode }) => {
               id: "3.0.0-alpha",
               label: "3.0.0-alpha",
               prefix: "",
-              banner: "unreleased",
             },
             {
               id: "2.90.0",
@@ -85,7 +84,7 @@ export default defineConfig(({ mode }) => {
           siteUrl,
           pagination: true,
           breadcrumbs: true,
-          readerChrome: true,
+          readerChrome: { backToTop: false },
           a11y: true,
           pageChrome: true,
           localeSwitcher: true,
@@ -99,11 +98,6 @@ export default defineConfig(({ mode }) => {
               { text: { en: "Guide", ja: "ガイド" }, link: `${base}getting-started/` },
               { text: "API", link: `${base}api/` },
             ],
-            announcement: {
-              text: "Header nav, announcement, and per-page chrome are now opt-in.",
-              link: `${base}built-in/header-chrome/`,
-              dismissKey: "header-chrome-681",
-            },
             header: {
               logo: "oxcontent-dark.svg",
               logoLight: "oxcontent-dark.svg",


### PR DESCRIPTION
## Summary
- Entry pages (`layout: entry`) no longer emit the outline, breadcrumb trail, or back-to-top control, so the docs home page does not show a TOC or `Ox Content / Ox Content`.
- Announcement dismiss now honors `[hidden]` (`display: flex` was keeping the bar visible).
- This docs site turns off the version banner, announcement bar, and back-to-top. The features themselves stay available.

Follow-up to #754.

## Test plan
- [ ] Open `/` and `/ja/`: no outline, no breadcrumbs, no back-to-top
- [ ] Open a guide page: outline and breadcrumbs still appear
- [ ] With `theme.announcement.dismissKey` enabled on a sample site, Dismiss hides the bar and stays hidden after reload
- [ ] Docs header still has the version switcher; no unreleased banner


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Entry pages no longer display breadcrumbs, table-of-contents outlines, or back-to-top controls.
  * Dismissed announcement banners now remain hidden correctly.

* **Style**
  * Removed the back-to-top button’s drop shadow.

* **Documentation**
  * Updated documentation to describe entry-page navigation behavior, announcement dismissal, and reduced-motion support.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->