### PR TITLE
fix(theme): align nested sidebar hierarchy

### DIFF
--- a/crates/ox_content_ssg/src/html/tests/rendering.rs
+++ b/crates/ox_content_ssg/src/html/tests/rendering.rs
@@ -152,6 +152,27 @@ fn test_generate_nav_html_with_nested_collapsed_items() {
 }
 
 #[test]
+fn test_nested_nav_css_keeps_disclosure_and_hierarchy_visible() {
+    assert!(
+        SSG_CSS.contains(".nav-details > .nav-summary"),
+        "linked sidebar groups need an explicit disclosure row"
+    );
+    assert!(
+        SSG_CSS.contains(".nav-summary::-webkit-details-marker"),
+        "the browser marker must not occupy a separate layout row"
+    );
+    assert!(
+        SSG_CSS.contains(".nav-list--nested {\n  margin-inline-start:"),
+        "nested navigation must use RTL-safe visual indentation"
+    );
+    assert!(
+        SSG_CSS.contains(".nav-list--nested {\n  margin-inline-start:")
+            && SSG_CSS.contains("border-inline-start:"),
+        "nested navigation needs both an indentation step and a hierarchy rail"
+    );
+}
+
+#[test]
 fn test_generate_html_without_toc_omits_outline() {
     let page_data = PageData {
         title: "No TOC".to_string(),

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -649,11 +649,64 @@ a:hover {
   margin-bottom: 0.4rem;
   padding: 0 0.625rem;
 }
+.nav-title--summary,
+.nav-details > .nav-summary {
+  display: flex;
+  align-items: flex-start;
+  min-width: 0;
+  list-style: none;
+  cursor: pointer;
+}
+.nav-title--summary::-webkit-details-marker,
+.nav-summary::-webkit-details-marker {
+  display: none;
+}
+.nav-title--summary::before,
+.nav-details > .nav-summary::before {
+  content: "";
+  flex: 0 0 auto;
+  width: 0.4rem;
+  height: 0.4rem;
+  margin-block-start: 0.32rem;
+  margin-inline-end: 0.45rem;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  color: var(--octc-color-text-muted);
+  transform: rotate(-45deg);
+  transform-origin: center;
+  transition: transform 150ms ease;
+}
+.nav-details > .nav-summary::before {
+  margin-block-start: 0.8rem;
+  margin-inline-start: 0.45rem;
+}
+.nav-section--collapsible[open] > .nav-title--summary::before,
+.nav-details[open] > .nav-summary::before {
+  transform: rotate(45deg);
+}
+[dir="rtl"] .nav-section--collapsible:not([open]) > .nav-title--summary::before,
+[dir="rtl"] .nav-details:not([open]) > .nav-summary::before {
+  transform: rotate(135deg);
+}
+.nav-title--summary:focus-visible,
+.nav-details > .nav-summary:focus-visible {
+  outline: 2px solid var(--octc-color-primary);
+  outline-offset: 2px;
+}
 .nav-list {
   list-style: none;
   display: flex;
   flex-direction: column;
   gap: 0.125rem;
+}
+.nav-list--nested {
+  margin-inline-start: 0.65rem;
+  padding-inline-start: 0.75rem;
+  border-inline-start: 1px solid color-mix(in srgb, var(--octc-color-border) 64%, transparent);
+}
+.nav-list--nested .nav-list--nested {
+  margin-inline-start: 0.4rem;
+  padding-inline-start: 0.65rem;
 }
 .nav-item {
   margin: 0;
@@ -687,6 +740,18 @@ a:hover {
 .nav-link.active:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
   color: var(--octc-color-text);
+}
+.nav-link--summary {
+  flex: 1;
+  min-width: 0;
+  padding-inline-start: 0.25rem;
+  overflow-wrap: anywhere;
+}
+@media (prefers-reduced-motion: reduce) {
+  .nav-title--summary::before,
+  .nav-details > .nav-summary::before {
+    transition: none;
+  }
 }
 .main {
   flex: 1;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -645,11 +645,64 @@ a:hover {
   margin-bottom: 0.4rem;
   padding: 0 0.625rem;
 }
+.nav-title--summary,
+.nav-details > .nav-summary {
+  display: flex;
+  align-items: flex-start;
+  min-width: 0;
+  list-style: none;
+  cursor: pointer;
+}
+.nav-title--summary::-webkit-details-marker,
+.nav-summary::-webkit-details-marker {
+  display: none;
+}
+.nav-title--summary::before,
+.nav-details > .nav-summary::before {
+  content: "";
+  flex: 0 0 auto;
+  width: 0.4rem;
+  height: 0.4rem;
+  margin-block-start: 0.32rem;
+  margin-inline-end: 0.45rem;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  color: var(--octc-color-text-muted);
+  transform: rotate(-45deg);
+  transform-origin: center;
+  transition: transform 150ms ease;
+}
+.nav-details > .nav-summary::before {
+  margin-block-start: 0.8rem;
+  margin-inline-start: 0.45rem;
+}
+.nav-section--collapsible[open] > .nav-title--summary::before,
+.nav-details[open] > .nav-summary::before {
+  transform: rotate(45deg);
+}
+[dir="rtl"] .nav-section--collapsible:not([open]) > .nav-title--summary::before,
+[dir="rtl"] .nav-details:not([open]) > .nav-summary::before {
+  transform: rotate(135deg);
+}
+.nav-title--summary:focus-visible,
+.nav-details > .nav-summary:focus-visible {
+  outline: 2px solid var(--octc-color-primary);
+  outline-offset: 2px;
+}
 .nav-list {
   list-style: none;
   display: flex;
   flex-direction: column;
   gap: 0.125rem;
+}
+.nav-list--nested {
+  margin-inline-start: 0.65rem;
+  padding-inline-start: 0.75rem;
+  border-inline-start: 1px solid color-mix(in srgb, var(--octc-color-border) 64%, transparent);
+}
+.nav-list--nested .nav-list--nested {
+  margin-inline-start: 0.4rem;
+  padding-inline-start: 0.65rem;
 }
 .nav-item {
   margin: 0;
@@ -683,6 +736,18 @@ a:hover {
 .nav-link.active:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
   color: var(--octc-color-text);
+}
+.nav-link--summary {
+  flex: 1;
+  min-width: 0;
+  padding-inline-start: 0.25rem;
+  overflow-wrap: anywhere;
+}
+@media (prefers-reduced-motion: reduce) {
+  .nav-title--summary::before,
+  .nav-details > .nav-summary::before {
+    transition: none;
+  }
 }
 .main {
   flex: 1;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -645,11 +645,64 @@ a:hover {
   margin-bottom: 0.4rem;
   padding: 0 0.625rem;
 }
+.nav-title--summary,
+.nav-details > .nav-summary {
+  display: flex;
+  align-items: flex-start;
+  min-width: 0;
+  list-style: none;
+  cursor: pointer;
+}
+.nav-title--summary::-webkit-details-marker,
+.nav-summary::-webkit-details-marker {
+  display: none;
+}
+.nav-title--summary::before,
+.nav-details > .nav-summary::before {
+  content: "";
+  flex: 0 0 auto;
+  width: 0.4rem;
+  height: 0.4rem;
+  margin-block-start: 0.32rem;
+  margin-inline-end: 0.45rem;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  color: var(--octc-color-text-muted);
+  transform: rotate(-45deg);
+  transform-origin: center;
+  transition: transform 150ms ease;
+}
+.nav-details > .nav-summary::before {
+  margin-block-start: 0.8rem;
+  margin-inline-start: 0.45rem;
+}
+.nav-section--collapsible[open] > .nav-title--summary::before,
+.nav-details[open] > .nav-summary::before {
+  transform: rotate(45deg);
+}
+[dir="rtl"] .nav-section--collapsible:not([open]) > .nav-title--summary::before,
+[dir="rtl"] .nav-details:not([open]) > .nav-summary::before {
+  transform: rotate(135deg);
+}
+.nav-title--summary:focus-visible,
+.nav-details > .nav-summary:focus-visible {
+  outline: 2px solid var(--octc-color-primary);
+  outline-offset: 2px;
+}
 .nav-list {
   list-style: none;
   display: flex;
   flex-direction: column;
   gap: 0.125rem;
+}
+.nav-list--nested {
+  margin-inline-start: 0.65rem;
+  padding-inline-start: 0.75rem;
+  border-inline-start: 1px solid color-mix(in srgb, var(--octc-color-border) 64%, transparent);
+}
+.nav-list--nested .nav-list--nested {
+  margin-inline-start: 0.4rem;
+  padding-inline-start: 0.65rem;
 }
 .nav-item {
   margin: 0;
@@ -683,6 +736,18 @@ a:hover {
 .nav-link.active:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
   color: var(--octc-color-text);
+}
+.nav-link--summary {
+  flex: 1;
+  min-width: 0;
+  padding-inline-start: 0.25rem;
+  overflow-wrap: anywhere;
+}
+@media (prefers-reduced-motion: reduce) {
+  .nav-title--summary::before,
+  .nav-details > .nav-summary::before {
+    transition: none;
+  }
 }
 .main {
   flex: 1;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -645,11 +645,64 @@ a:hover {
   margin-bottom: 0.4rem;
   padding: 0 0.625rem;
 }
+.nav-title--summary,
+.nav-details > .nav-summary {
+  display: flex;
+  align-items: flex-start;
+  min-width: 0;
+  list-style: none;
+  cursor: pointer;
+}
+.nav-title--summary::-webkit-details-marker,
+.nav-summary::-webkit-details-marker {
+  display: none;
+}
+.nav-title--summary::before,
+.nav-details > .nav-summary::before {
+  content: "";
+  flex: 0 0 auto;
+  width: 0.4rem;
+  height: 0.4rem;
+  margin-block-start: 0.32rem;
+  margin-inline-end: 0.45rem;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  color: var(--octc-color-text-muted);
+  transform: rotate(-45deg);
+  transform-origin: center;
+  transition: transform 150ms ease;
+}
+.nav-details > .nav-summary::before {
+  margin-block-start: 0.8rem;
+  margin-inline-start: 0.45rem;
+}
+.nav-section--collapsible[open] > .nav-title--summary::before,
+.nav-details[open] > .nav-summary::before {
+  transform: rotate(45deg);
+}
+[dir="rtl"] .nav-section--collapsible:not([open]) > .nav-title--summary::before,
+[dir="rtl"] .nav-details:not([open]) > .nav-summary::before {
+  transform: rotate(135deg);
+}
+.nav-title--summary:focus-visible,
+.nav-details > .nav-summary:focus-visible {
+  outline: 2px solid var(--octc-color-primary);
+  outline-offset: 2px;
+}
 .nav-list {
   list-style: none;
   display: flex;
   flex-direction: column;
   gap: 0.125rem;
+}
+.nav-list--nested {
+  margin-inline-start: 0.65rem;
+  padding-inline-start: 0.75rem;
+  border-inline-start: 1px solid color-mix(in srgb, var(--octc-color-border) 64%, transparent);
+}
+.nav-list--nested .nav-list--nested {
+  margin-inline-start: 0.4rem;
+  padding-inline-start: 0.65rem;
 }
 .nav-item {
   margin: 0;
@@ -683,6 +736,18 @@ a:hover {
 .nav-link.active:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
   color: var(--octc-color-text);
+}
+.nav-link--summary {
+  flex: 1;
+  min-width: 0;
+  padding-inline-start: 0.25rem;
+  overflow-wrap: anywhere;
+}
+@media (prefers-reduced-motion: reduce) {
+  .nav-title--summary::before,
+  .nav-details > .nav-summary::before {
+    transition: none;
+  }
 }
 .main {
   flex: 1;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -645,11 +645,64 @@ a:hover {
   margin-bottom: 0.4rem;
   padding: 0 0.625rem;
 }
+.nav-title--summary,
+.nav-details > .nav-summary {
+  display: flex;
+  align-items: flex-start;
+  min-width: 0;
+  list-style: none;
+  cursor: pointer;
+}
+.nav-title--summary::-webkit-details-marker,
+.nav-summary::-webkit-details-marker {
+  display: none;
+}
+.nav-title--summary::before,
+.nav-details > .nav-summary::before {
+  content: "";
+  flex: 0 0 auto;
+  width: 0.4rem;
+  height: 0.4rem;
+  margin-block-start: 0.32rem;
+  margin-inline-end: 0.45rem;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  color: var(--octc-color-text-muted);
+  transform: rotate(-45deg);
+  transform-origin: center;
+  transition: transform 150ms ease;
+}
+.nav-details > .nav-summary::before {
+  margin-block-start: 0.8rem;
+  margin-inline-start: 0.45rem;
+}
+.nav-section--collapsible[open] > .nav-title--summary::before,
+.nav-details[open] > .nav-summary::before {
+  transform: rotate(45deg);
+}
+[dir="rtl"] .nav-section--collapsible:not([open]) > .nav-title--summary::before,
+[dir="rtl"] .nav-details:not([open]) > .nav-summary::before {
+  transform: rotate(135deg);
+}
+.nav-title--summary:focus-visible,
+.nav-details > .nav-summary:focus-visible {
+  outline: 2px solid var(--octc-color-primary);
+  outline-offset: 2px;
+}
 .nav-list {
   list-style: none;
   display: flex;
   flex-direction: column;
   gap: 0.125rem;
+}
+.nav-list--nested {
+  margin-inline-start: 0.65rem;
+  padding-inline-start: 0.75rem;
+  border-inline-start: 1px solid color-mix(in srgb, var(--octc-color-border) 64%, transparent);
+}
+.nav-list--nested .nav-list--nested {
+  margin-inline-start: 0.4rem;
+  padding-inline-start: 0.65rem;
 }
 .nav-item {
   margin: 0;
@@ -683,6 +736,18 @@ a:hover {
 .nav-link.active:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
   color: var(--octc-color-text);
+}
+.nav-link--summary {
+  flex: 1;
+  min-width: 0;
+  padding-inline-start: 0.25rem;
+  overflow-wrap: anywhere;
+}
+@media (prefers-reduced-motion: reduce) {
+  .nav-title--summary::before,
+  .nav-details > .nav-summary::before {
+    transition: none;
+  }
 }
 .main {
   flex: 1;

--- a/crates/ox_content_ssg/src/ssg.css
+++ b/crates/ox_content_ssg/src/ssg.css
@@ -627,11 +627,64 @@ a:hover {
   margin-bottom: 0.4rem;
   padding: 0 0.625rem;
 }
+.nav-title--summary,
+.nav-details > .nav-summary {
+  display: flex;
+  align-items: flex-start;
+  min-width: 0;
+  list-style: none;
+  cursor: pointer;
+}
+.nav-title--summary::-webkit-details-marker,
+.nav-summary::-webkit-details-marker {
+  display: none;
+}
+.nav-title--summary::before,
+.nav-details > .nav-summary::before {
+  content: "";
+  flex: 0 0 auto;
+  width: 0.4rem;
+  height: 0.4rem;
+  margin-block-start: 0.32rem;
+  margin-inline-end: 0.45rem;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  color: var(--octc-color-text-muted);
+  transform: rotate(-45deg);
+  transform-origin: center;
+  transition: transform 150ms ease;
+}
+.nav-details > .nav-summary::before {
+  margin-block-start: 0.8rem;
+  margin-inline-start: 0.45rem;
+}
+.nav-section--collapsible[open] > .nav-title--summary::before,
+.nav-details[open] > .nav-summary::before {
+  transform: rotate(45deg);
+}
+[dir="rtl"] .nav-section--collapsible:not([open]) > .nav-title--summary::before,
+[dir="rtl"] .nav-details:not([open]) > .nav-summary::before {
+  transform: rotate(135deg);
+}
+.nav-title--summary:focus-visible,
+.nav-details > .nav-summary:focus-visible {
+  outline: 2px solid var(--octc-color-primary);
+  outline-offset: 2px;
+}
 .nav-list {
   list-style: none;
   display: flex;
   flex-direction: column;
   gap: 0.125rem;
+}
+.nav-list--nested {
+  margin-inline-start: 0.65rem;
+  padding-inline-start: 0.75rem;
+  border-inline-start: 1px solid color-mix(in srgb, var(--octc-color-border) 64%, transparent);
+}
+.nav-list--nested .nav-list--nested {
+  margin-inline-start: 0.4rem;
+  padding-inline-start: 0.65rem;
 }
 .nav-item {
   margin: 0;
@@ -665,6 +718,18 @@ a:hover {
 .nav-link.active:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
   color: var(--octc-color-text);
+}
+.nav-link--summary {
+  flex: 1;
+  min-width: 0;
+  padding-inline-start: 0.25rem;
+  overflow-wrap: anywhere;
+}
+@media (prefers-reduced-motion: reduce) {
+  .nav-title--summary::before,
+  .nav-details > .nav-summary::before {
+    transition: none;
+  }
 }
 .main {
   flex: 1;


### PR DESCRIPTION
## Summary

- keep linked sidebar disclosure controls on the same row as their labels
- add logical nested indentation and a hierarchy rail for LTR and RTL layouts
- preserve keyboard focus and reduced-motion behavior
- update embedded theme snapshots and add a CSS contract regression test

## Browser verification

Verified the Built-in Features sidebar at 1280x720 and 390x844 after rebuilding the native package.

- disclosure label and arrow render on one row
- nested list begins 10.4px after the parent row
- nested content adds 12px logical padding and a single 1px hierarchy rail
- desktop and mobile menu screenshots were captured for comparison

## Tests

- cargo test -p ox_content_ssg
- cargo clippy -p ox_content_ssg --all-targets -- -D warnings
- cargo fmt --all -- --check
- node scripts/check-file-lines.ts
- git diff --check

Closes #762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added collapsible navigation sections for easier browsing of nested content.
  - Added directional indicators that rotate when sections are expanded.
  - Improved support for right-to-left layouts and nested navigation indentation.
  - Added visual hierarchy rails and separators to clarify navigation structure.

- **Accessibility**
  - Added clear keyboard focus outlines.
  - Improved support for reduced-motion preferences.
  - Hidden browser-generated disclosure markers for a cleaner, consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->