### PR TITLE
fix(theme): keep copy control clear of code

### DIFF
--- a/crates/ox_content_ssg/src/html/reader_chrome.css
+++ b/crates/ox_content_ssg/src/html/reader_chrome.css
@@ -1,14 +1,21 @@
 .ox-code {
+  --ox-copy-reserved-inline-size: 4.75rem;
   position: relative;
   margin: 1.25rem 0;
 }
 .content .ox-code > pre {
   margin: 0;
 }
+.content .ox-code > pre:not([data-code-title]) {
+  padding-block-start: 3rem;
+}
+.content .ox-code > pre[data-code-title]::before {
+  padding-inline-end: var(--ox-copy-reserved-inline-size);
+}
 .ox-copy {
   position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
+  inset-block-start: 0.5rem;
+  inset-inline-end: 0.5rem;
   z-index: 1;
   padding: 0.2rem 0.55rem;
   border: 1px solid color-mix(in srgb, var(--octc-color-border) 80%, transparent);

--- a/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
+++ b/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
@@ -144,6 +144,27 @@ fn enabled_defaults_emit_copy_external_and_back_to_top() {
 }
 
 #[test]
+fn copy_control_reserves_space_in_plain_and_titled_code_blocks() {
+    assert!(
+        READER_CHROME_CSS.contains("inset-block-start: 0.5rem;")
+            && READER_CHROME_CSS.contains("inset-inline-end: 0.5rem;"),
+        "copy positioning must follow the document writing direction: {READER_CHROME_CSS}"
+    );
+    assert!(
+        READER_CHROME_CSS.contains(
+            ".content .ox-code > pre:not([data-code-title]) {\n  padding-block-start: 3rem;"
+        ),
+        "plain code needs a toolbar strip above its first line: {READER_CHROME_CSS}"
+    );
+    assert!(
+        READER_CHROME_CSS.contains(
+            ".content .ox-code > pre[data-code-title]::before {\n  padding-inline-end: var(--ox-copy-reserved-inline-size);"
+        ),
+        "a code title must reserve inline space for Copy and Copied: {READER_CHROME_CSS}"
+    );
+}
+
+#[test]
 fn object_can_disable_copy() {
     let html =
         render(ARTICLE, ReaderChrome { copy: false, external_links: true, back_to_top: true });


### PR DESCRIPTION
## Summary

- reserve a dedicated toolbar strip above untitled code so Copy never covers the first line
- reserve logical inline-end title space for both Copy and Copied labels
- switch control positioning to logical inset properties for RTL documents
- add a regression contract for plain and titled code blocks

## Browser verification

Verified the Code Blocks guide at 390x844 and 1280x720 after rebuilding the native package.

- before: the Copy control overlapped the end of the first source line
- after: the mobile control ends about 17px before the first source line begins
- titled blocks reserve 76px on the logical end side
- long and horizontally scrollable lines remain readable below the control

## Tests

- cargo test -p ox_content_ssg
- cargo clippy -p ox_content_ssg --all-targets -- -D warnings
- cargo fmt --all -- --check
- node scripts/check-file-lines.ts
- git diff --check

Closes #763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code block spacing so copy controls no longer overlap code or headers.
  * Corrected copy-button positioning across different reading directions and code block layouts.

* **Tests**
  * Added regression coverage for copy controls in titled and untitled code blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->