### PR TITLE
fix(theme): eliminate doubled table borders

### DIFF
--- a/crates/ox_content_ssg/src/html/tests/rendering.rs
+++ b/crates/ox_content_ssg/src/html/tests/rendering.rs
@@ -173,6 +173,35 @@ fn test_nested_nav_css_keeps_disclosure_and_hierarchy_visible() {
 }
 
 #[test]
+fn test_table_css_draws_each_separator_once() {
+    assert!(
+        SSG_CSS.contains(".content table {\n  width: 100%;")
+            && SSG_CSS.contains("border: 1px solid var(--octc-color-border);")
+            && SSG_CSS.contains("border-collapse: separate;"),
+        "tables need one shared separated-border model at every breakpoint"
+    );
+    assert!(
+        SSG_CSS.contains("border-inline-end: 1px solid var(--octc-color-border);")
+            && SSG_CSS.contains("border-block-end: 1px solid var(--octc-color-border);"),
+        "cells must paint only one logical edge per internal seam"
+    );
+    assert!(
+        SSG_CSS.contains(".content tr > :last-child")
+            && SSG_CSS.contains(".content table > :last-child > tr:last-child > *"),
+        "the table border must own the outer inline and block edges"
+    );
+    assert_eq!(
+        SSG_CSS.matches("border-collapse: separate;").count(),
+        1,
+        "mobile must not install a second border model"
+    );
+    assert!(
+        !SSG_CSS.contains("border-collapse: collapse;"),
+        "collapsed cell borders conflict with the scrollable mobile table"
+    );
+}
+
+#[test]
 fn test_generate_html_without_toc_omits_outline() {
     let page_data = PageData {
         title: "No TOC".to_string(),

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -1229,15 +1229,26 @@ a:hover {
 }
 .content table {
   width: 100%;
-  border-collapse: collapse;
+  box-sizing: border-box;
+  border: 1px solid var(--octc-color-border);
+  border-collapse: separate;
+  border-spacing: 0;
   margin: 1.25rem 0;
   font-size: 0.875rem;
 }
 .content th,
 .content td {
-  border: 1px solid var(--octc-color-border);
+  border: 0;
+  border-inline-end: 1px solid var(--octc-color-border);
+  border-block-end: 1px solid var(--octc-color-border);
   padding: 0.75rem 1rem;
-  text-align: left;
+  text-align: start;
+}
+.content tr > :last-child {
+  border-inline-end: 0;
+}
+.content table > :last-child > tr:last-child > * {
+  border-block-end: 0;
 }
 .content th {
   background: var(--octc-color-bg-alt);
@@ -2062,8 +2073,6 @@ a:hover {
     -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
     font-size: 0.8125rem;
-    border-collapse: separate;
-    border-spacing: 0;
   }
   .content th,
   .content td {

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -1225,15 +1225,26 @@ a:hover {
 }
 .content table {
   width: 100%;
-  border-collapse: collapse;
+  box-sizing: border-box;
+  border: 1px solid var(--octc-color-border);
+  border-collapse: separate;
+  border-spacing: 0;
   margin: 1.25rem 0;
   font-size: 0.875rem;
 }
 .content th,
 .content td {
-  border: 1px solid var(--octc-color-border);
+  border: 0;
+  border-inline-end: 1px solid var(--octc-color-border);
+  border-block-end: 1px solid var(--octc-color-border);
   padding: 0.75rem 1rem;
-  text-align: left;
+  text-align: start;
+}
+.content tr > :last-child {
+  border-inline-end: 0;
+}
+.content table > :last-child > tr:last-child > * {
+  border-block-end: 0;
 }
 .content th {
   background: var(--octc-color-bg-alt);
@@ -2058,8 +2069,6 @@ a:hover {
     -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
     font-size: 0.8125rem;
-    border-collapse: separate;
-    border-spacing: 0;
   }
   .content th,
   .content td {

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -1225,15 +1225,26 @@ a:hover {
 }
 .content table {
   width: 100%;
-  border-collapse: collapse;
+  box-sizing: border-box;
+  border: 1px solid var(--octc-color-border);
+  border-collapse: separate;
+  border-spacing: 0;
   margin: 1.25rem 0;
   font-size: 0.875rem;
 }
 .content th,
 .content td {
-  border: 1px solid var(--octc-color-border);
+  border: 0;
+  border-inline-end: 1px solid var(--octc-color-border);
+  border-block-end: 1px solid var(--octc-color-border);
   padding: 0.75rem 1rem;
-  text-align: left;
+  text-align: start;
+}
+.content tr > :last-child {
+  border-inline-end: 0;
+}
+.content table > :last-child > tr:last-child > * {
+  border-block-end: 0;
 }
 .content th {
   background: var(--octc-color-bg-alt);
@@ -2058,8 +2069,6 @@ a:hover {
     -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
     font-size: 0.8125rem;
-    border-collapse: separate;
-    border-spacing: 0;
   }
   .content th,
   .content td {

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -1225,15 +1225,26 @@ a:hover {
 }
 .content table {
   width: 100%;
-  border-collapse: collapse;
+  box-sizing: border-box;
+  border: 1px solid var(--octc-color-border);
+  border-collapse: separate;
+  border-spacing: 0;
   margin: 1.25rem 0;
   font-size: 0.875rem;
 }
 .content th,
 .content td {
-  border: 1px solid var(--octc-color-border);
+  border: 0;
+  border-inline-end: 1px solid var(--octc-color-border);
+  border-block-end: 1px solid var(--octc-color-border);
   padding: 0.75rem 1rem;
-  text-align: left;
+  text-align: start;
+}
+.content tr > :last-child {
+  border-inline-end: 0;
+}
+.content table > :last-child > tr:last-child > * {
+  border-block-end: 0;
 }
 .content th {
   background: var(--octc-color-bg-alt);
@@ -2058,8 +2069,6 @@ a:hover {
     -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
     font-size: 0.8125rem;
-    border-collapse: separate;
-    border-spacing: 0;
   }
   .content th,
   .content td {

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -1225,15 +1225,26 @@ a:hover {
 }
 .content table {
   width: 100%;
-  border-collapse: collapse;
+  box-sizing: border-box;
+  border: 1px solid var(--octc-color-border);
+  border-collapse: separate;
+  border-spacing: 0;
   margin: 1.25rem 0;
   font-size: 0.875rem;
 }
 .content th,
 .content td {
-  border: 1px solid var(--octc-color-border);
+  border: 0;
+  border-inline-end: 1px solid var(--octc-color-border);
+  border-block-end: 1px solid var(--octc-color-border);
   padding: 0.75rem 1rem;
-  text-align: left;
+  text-align: start;
+}
+.content tr > :last-child {
+  border-inline-end: 0;
+}
+.content table > :last-child > tr:last-child > * {
+  border-block-end: 0;
 }
 .content th {
   background: var(--octc-color-bg-alt);
@@ -2058,8 +2069,6 @@ a:hover {
     -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
     font-size: 0.8125rem;
-    border-collapse: separate;
-    border-spacing: 0;
   }
   .content th,
   .content td {

--- a/crates/ox_content_ssg/src/ssg.css
+++ b/crates/ox_content_ssg/src/ssg.css
@@ -1207,15 +1207,26 @@ a:hover {
 }
 .content table {
   width: 100%;
-  border-collapse: collapse;
+  box-sizing: border-box;
+  border: 1px solid var(--octc-color-border);
+  border-collapse: separate;
+  border-spacing: 0;
   margin: 1.25rem 0;
   font-size: 0.875rem;
 }
 .content th,
 .content td {
-  border: 1px solid var(--octc-color-border);
+  border: 0;
+  border-inline-end: 1px solid var(--octc-color-border);
+  border-block-end: 1px solid var(--octc-color-border);
   padding: 0.75rem 1rem;
-  text-align: left;
+  text-align: start;
+}
+.content tr > :last-child {
+  border-inline-end: 0;
+}
+.content table > :last-child > tr:last-child > * {
+  border-block-end: 0;
 }
 .content th {
   background: var(--octc-color-bg-alt);
@@ -2040,8 +2051,6 @@ a:hover {
     -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
     font-size: 0.8125rem;
-    border-collapse: separate;
-    border-spacing: 0;
   }
   .content th,
   .content td {


### PR DESCRIPTION
## Summary

- use one separated-border model for documentation tables at every viewport
- draw each inner separator from one cell edge only
- keep one outer border on the table and logical alignment for RTL layouts
- lock the contract with CSS regression coverage and rendered snapshots

## Browser verification

- 390px mobile: table border is 1px and border-spacing is 0
- first cell owns the 1px inner edge; the final cell and final row own no duplicate edge
- desktop light and dark themes were inspected after the change

## Verification

- cargo test -p ox_content_ssg
- cargo clippy -p ox_content_ssg --all-targets -- -D warnings
- cargo fmt --all -- --check
- node scripts/check-file-lines.ts
- git diff --check

Closes #765

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790184418&installation_model_id=422833&pr_number=773&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F773&signature=fc6c2d0197a32c099e526df565dd72b8629ad9046db7e241c1de64aa12c66c65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->