### PR TITLE
fix(theme): restore mobile content gutters

### DIFF
--- a/crates/ox_content_ssg/src/html/tests/rendering.rs
+++ b/crates/ox_content_ssg/src/html/tests/rendering.rs
@@ -202,6 +202,31 @@ fn test_table_css_draws_each_separator_once() {
 }
 
 #[test]
+fn test_mobile_content_css_preserves_safe_reading_gutters() {
+    assert!(
+        SSG_CSS.contains("--octc-mobile-gutter: clamp(1rem, 4vw, 1.25rem);"),
+        "mobile layouts need a shared readable gutter token"
+    );
+    assert!(
+        SSG_CSS.contains(
+            "padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));"
+        ) && SSG_CSS.contains(
+            "padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));"
+        ),
+        "content gutters must include each physical display safe area"
+    );
+    assert!(
+        SSG_CSS.contains(".content table {\n    display: block;")
+            && SSG_CSS.contains("max-width: 100%;"),
+        "wide tables must scroll inside the safe content gutter"
+    );
+    assert!(
+        !SSG_CSS.contains("padding: 0.75rem 0.4rem;"),
+        "the narrow breakpoint must not collapse back to a 6.4px gutter"
+    );
+}
+
+#[test]
 fn test_generate_html_without_toc_omits_outline() {
     let page_data = PageData {
         title: "No TOC".to_string(),

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -24,6 +24,7 @@ expression: "super::snapshot_text(&html)"
   --octc-sidebar-width: 260px;
   --octc-header-height: 60px;
   --octc-max-content-width: 960px;
+  --octc-mobile-gutter: clamp(1rem, 4vw, 1.25rem);
   --octc-font-sans: "IBM Plex Sans", "Avenir Next", "Segoe UI Variable", "Segoe UI", sans-serif;
   --octc-font-mono: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
   --octc-color-bg: #ffffff;
@@ -1822,7 +1823,8 @@ a:hover {
     border-top: 1px solid var(--octc-color-border);
     justify-content: space-around;
     align-items: center;
-    padding: 0 1rem;
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     z-index: 100;
   }
   .mobile-footer-btn {
@@ -1870,6 +1872,8 @@ a:hover {
     z-index: 99;
     border-radius: 4px 4px 0 0;
     padding: 1.5rem 1rem calc(56px + 1.5rem);
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-color-bg));
   }
   .entry-page .sidebar--entry {
@@ -1899,11 +1903,10 @@ a:hover {
   }
   .main {
     margin-left: 0;
-    padding: 0.9rem 0.5rem;
+    padding: 0.9rem var(--octc-mobile-gutter);
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     padding-bottom: calc(56px + 0.9rem);
-  }
-  .main--with-toc {
-    padding-right: 0.5rem;
   }
   .content {
     padding: 0;
@@ -2068,7 +2071,7 @@ a:hover {
     display: block;
     width: max-content;
     min-width: 100%;
-    max-width: calc(100vw - 1rem);
+    max-width: 100%;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
@@ -2081,7 +2084,8 @@ a:hover {
     vertical-align: top;
   }
   .header {
-    padding: 0 1rem;
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
   }
   .header-title {
     font-size: 1rem;
@@ -2104,7 +2108,7 @@ a:hover {
 
 @media (max-width: 480px) {
   .main {
-    padding: 0.75rem 0.4rem;
+    padding-block-start: 0.75rem;
     padding-bottom: calc(56px + 0.75rem);
   }
   .content h1 {
@@ -2141,7 +2145,6 @@ a:hover {
     left: 0.85rem;
   }
   .content table {
-    max-width: calc(100vw - 0.8rem);
     font-size: 0.75rem;
   }
   .content th,

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -20,6 +20,7 @@ expression: "super::snapshot_text(&html)"
   --octc-sidebar-width: 260px;
   --octc-header-height: 60px;
   --octc-max-content-width: 960px;
+  --octc-mobile-gutter: clamp(1rem, 4vw, 1.25rem);
   --octc-font-sans: "IBM Plex Sans", "Avenir Next", "Segoe UI Variable", "Segoe UI", sans-serif;
   --octc-font-mono: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
   --octc-color-bg: #ffffff;
@@ -1818,7 +1819,8 @@ a:hover {
     border-top: 1px solid var(--octc-color-border);
     justify-content: space-around;
     align-items: center;
-    padding: 0 1rem;
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     z-index: 100;
   }
   .mobile-footer-btn {
@@ -1866,6 +1868,8 @@ a:hover {
     z-index: 99;
     border-radius: 4px 4px 0 0;
     padding: 1.5rem 1rem calc(56px + 1.5rem);
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-color-bg));
   }
   .entry-page .sidebar--entry {
@@ -1895,11 +1899,10 @@ a:hover {
   }
   .main {
     margin-left: 0;
-    padding: 0.9rem 0.5rem;
+    padding: 0.9rem var(--octc-mobile-gutter);
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     padding-bottom: calc(56px + 0.9rem);
-  }
-  .main--with-toc {
-    padding-right: 0.5rem;
   }
   .content {
     padding: 0;
@@ -2064,7 +2067,7 @@ a:hover {
     display: block;
     width: max-content;
     min-width: 100%;
-    max-width: calc(100vw - 1rem);
+    max-width: 100%;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
@@ -2077,7 +2080,8 @@ a:hover {
     vertical-align: top;
   }
   .header {
-    padding: 0 1rem;
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
   }
   .header-title {
     font-size: 1rem;
@@ -2100,7 +2104,7 @@ a:hover {
 
 @media (max-width: 480px) {
   .main {
-    padding: 0.75rem 0.4rem;
+    padding-block-start: 0.75rem;
     padding-bottom: calc(56px + 0.75rem);
   }
   .content h1 {
@@ -2137,7 +2141,6 @@ a:hover {
     left: 0.85rem;
   }
   .content table {
-    max-width: calc(100vw - 0.8rem);
     font-size: 0.75rem;
   }
   .content th,

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -20,6 +20,7 @@ expression: "super::snapshot_text(&html)"
   --octc-sidebar-width: 260px;
   --octc-header-height: 60px;
   --octc-max-content-width: 960px;
+  --octc-mobile-gutter: clamp(1rem, 4vw, 1.25rem);
   --octc-font-sans: "IBM Plex Sans", "Avenir Next", "Segoe UI Variable", "Segoe UI", sans-serif;
   --octc-font-mono: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
   --octc-color-bg: #ffffff;
@@ -1818,7 +1819,8 @@ a:hover {
     border-top: 1px solid var(--octc-color-border);
     justify-content: space-around;
     align-items: center;
-    padding: 0 1rem;
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     z-index: 100;
   }
   .mobile-footer-btn {
@@ -1866,6 +1868,8 @@ a:hover {
     z-index: 99;
     border-radius: 4px 4px 0 0;
     padding: 1.5rem 1rem calc(56px + 1.5rem);
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-color-bg));
   }
   .entry-page .sidebar--entry {
@@ -1895,11 +1899,10 @@ a:hover {
   }
   .main {
     margin-left: 0;
-    padding: 0.9rem 0.5rem;
+    padding: 0.9rem var(--octc-mobile-gutter);
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     padding-bottom: calc(56px + 0.9rem);
-  }
-  .main--with-toc {
-    padding-right: 0.5rem;
   }
   .content {
     padding: 0;
@@ -2064,7 +2067,7 @@ a:hover {
     display: block;
     width: max-content;
     min-width: 100%;
-    max-width: calc(100vw - 1rem);
+    max-width: 100%;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
@@ -2077,7 +2080,8 @@ a:hover {
     vertical-align: top;
   }
   .header {
-    padding: 0 1rem;
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
   }
   .header-title {
     font-size: 1rem;
@@ -2100,7 +2104,7 @@ a:hover {
 
 @media (max-width: 480px) {
   .main {
-    padding: 0.75rem 0.4rem;
+    padding-block-start: 0.75rem;
     padding-bottom: calc(56px + 0.75rem);
   }
   .content h1 {
@@ -2137,7 +2141,6 @@ a:hover {
     left: 0.85rem;
   }
   .content table {
-    max-width: calc(100vw - 0.8rem);
     font-size: 0.75rem;
   }
   .content th,

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -20,6 +20,7 @@ expression: "super::snapshot_text(&html)"
   --octc-sidebar-width: 260px;
   --octc-header-height: 60px;
   --octc-max-content-width: 960px;
+  --octc-mobile-gutter: clamp(1rem, 4vw, 1.25rem);
   --octc-font-sans: "IBM Plex Sans", "Avenir Next", "Segoe UI Variable", "Segoe UI", sans-serif;
   --octc-font-mono: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
   --octc-color-bg: #ffffff;
@@ -1818,7 +1819,8 @@ a:hover {
     border-top: 1px solid var(--octc-color-border);
     justify-content: space-around;
     align-items: center;
-    padding: 0 1rem;
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     z-index: 100;
   }
   .mobile-footer-btn {
@@ -1866,6 +1868,8 @@ a:hover {
     z-index: 99;
     border-radius: 4px 4px 0 0;
     padding: 1.5rem 1rem calc(56px + 1.5rem);
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-color-bg));
   }
   .entry-page .sidebar--entry {
@@ -1895,11 +1899,10 @@ a:hover {
   }
   .main {
     margin-left: 0;
-    padding: 0.9rem 0.5rem;
+    padding: 0.9rem var(--octc-mobile-gutter);
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     padding-bottom: calc(56px + 0.9rem);
-  }
-  .main--with-toc {
-    padding-right: 0.5rem;
   }
   .content {
     padding: 0;
@@ -2064,7 +2067,7 @@ a:hover {
     display: block;
     width: max-content;
     min-width: 100%;
-    max-width: calc(100vw - 1rem);
+    max-width: 100%;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
@@ -2077,7 +2080,8 @@ a:hover {
     vertical-align: top;
   }
   .header {
-    padding: 0 1rem;
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
   }
   .header-title {
     font-size: 1rem;
@@ -2100,7 +2104,7 @@ a:hover {
 
 @media (max-width: 480px) {
   .main {
-    padding: 0.75rem 0.4rem;
+    padding-block-start: 0.75rem;
     padding-bottom: calc(56px + 0.75rem);
   }
   .content h1 {
@@ -2137,7 +2141,6 @@ a:hover {
     left: 0.85rem;
   }
   .content table {
-    max-width: calc(100vw - 0.8rem);
     font-size: 0.75rem;
   }
   .content th,

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -20,6 +20,7 @@ expression: "super::snapshot_text(&html)"
   --octc-sidebar-width: 260px;
   --octc-header-height: 60px;
   --octc-max-content-width: 960px;
+  --octc-mobile-gutter: clamp(1rem, 4vw, 1.25rem);
   --octc-font-sans: "IBM Plex Sans", "Avenir Next", "Segoe UI Variable", "Segoe UI", sans-serif;
   --octc-font-mono: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
   --octc-color-bg: #ffffff;
@@ -1818,7 +1819,8 @@ a:hover {
     border-top: 1px solid var(--octc-color-border);
     justify-content: space-around;
     align-items: center;
-    padding: 0 1rem;
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     z-index: 100;
   }
   .mobile-footer-btn {
@@ -1866,6 +1868,8 @@ a:hover {
     z-index: 99;
     border-radius: 4px 4px 0 0;
     padding: 1.5rem 1rem calc(56px + 1.5rem);
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-color-bg));
   }
   .entry-page .sidebar--entry {
@@ -1895,11 +1899,10 @@ a:hover {
   }
   .main {
     margin-left: 0;
-    padding: 0.9rem 0.5rem;
+    padding: 0.9rem var(--octc-mobile-gutter);
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     padding-bottom: calc(56px + 0.9rem);
-  }
-  .main--with-toc {
-    padding-right: 0.5rem;
   }
   .content {
     padding: 0;
@@ -2064,7 +2067,7 @@ a:hover {
     display: block;
     width: max-content;
     min-width: 100%;
-    max-width: calc(100vw - 1rem);
+    max-width: 100%;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
@@ -2077,7 +2080,8 @@ a:hover {
     vertical-align: top;
   }
   .header {
-    padding: 0 1rem;
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
   }
   .header-title {
     font-size: 1rem;
@@ -2100,7 +2104,7 @@ a:hover {
 
 @media (max-width: 480px) {
   .main {
-    padding: 0.75rem 0.4rem;
+    padding-block-start: 0.75rem;
     padding-bottom: calc(56px + 0.75rem);
   }
   .content h1 {
@@ -2137,7 +2141,6 @@ a:hover {
     left: 0.85rem;
   }
   .content table {
-    max-width: calc(100vw - 0.8rem);
     font-size: 0.75rem;
   }
   .content th,

--- a/crates/ox_content_ssg/src/ssg.css
+++ b/crates/ox_content_ssg/src/ssg.css
@@ -2,6 +2,7 @@
   --octc-sidebar-width: 260px;
   --octc-header-height: 60px;
   --octc-max-content-width: 960px;
+  --octc-mobile-gutter: clamp(1rem, 4vw, 1.25rem);
   --octc-font-sans: "IBM Plex Sans", "Avenir Next", "Segoe UI Variable", "Segoe UI", sans-serif;
   --octc-font-mono: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
   --octc-color-bg: #ffffff;
@@ -1800,7 +1801,8 @@ a:hover {
     border-top: 1px solid var(--octc-color-border);
     justify-content: space-around;
     align-items: center;
-    padding: 0 1rem;
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     z-index: 100;
   }
   .mobile-footer-btn {
@@ -1848,6 +1850,8 @@ a:hover {
     z-index: 99;
     border-radius: 4px 4px 0 0;
     padding: 1.5rem 1rem calc(56px + 1.5rem);
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-color-bg));
   }
   .entry-page .sidebar--entry {
@@ -1877,11 +1881,10 @@ a:hover {
   }
   .main {
     margin-left: 0;
-    padding: 0.9rem 0.5rem;
+    padding: 0.9rem var(--octc-mobile-gutter);
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
     padding-bottom: calc(56px + 0.9rem);
-  }
-  .main--with-toc {
-    padding-right: 0.5rem;
   }
   .content {
     padding: 0;
@@ -2046,7 +2049,7 @@ a:hover {
     display: block;
     width: max-content;
     min-width: 100%;
-    max-width: calc(100vw - 1rem);
+    max-width: 100%;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
@@ -2059,7 +2062,8 @@ a:hover {
     vertical-align: top;
   }
   .header {
-    padding: 0 1rem;
+    padding-left: max(var(--octc-mobile-gutter), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--octc-mobile-gutter), env(safe-area-inset-right, 0px));
   }
   .header-title {
     font-size: 1rem;
@@ -2082,7 +2086,7 @@ a:hover {
 
 @media (max-width: 480px) {
   .main {
-    padding: 0.75rem 0.4rem;
+    padding-block-start: 0.75rem;
     padding-bottom: calc(56px + 0.75rem);
   }
   .content h1 {
@@ -2119,7 +2123,6 @@ a:hover {
     left: 0.85rem;
   }
   .content table {
-    max-width: calc(100vw - 0.8rem);
     font-size: 0.75rem;
   }
   .content th,


### PR DESCRIPTION
## Summary

- guarantee a 16px minimum reading gutter on narrow viewports
- include safe-area insets for the header, sidebar, main content, and footer
- keep wide prose elements and tables inside the viewport

## Verification

- cargo test -p ox_content_ssg --lib
- cargo clippy -p ox_content_ssg --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- pnpm check:file-lines
- browser QA at 390px in light and dark themes; main, header, prose, and tables measured at 16px minimum inline gutters

Closes #764

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790185232&installation_model_id=422833&pr_number=776&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F776&signature=5597f2fd756cab74cdbd0e9b55492a7b6df1da5bad1dd2b6a2621d0d01e57d54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->