### PR TITLE
fix(theme): harden mobile menu interactions

### DIFF
--- a/crates/ox_content_ssg/src/html/header_chrome/tests/nav.rs
+++ b/crates/ox_content_ssg/src/html/header_chrome/tests/nav.rs
@@ -11,7 +11,7 @@ fn nav_disabled_by_default() {
     assert!(!html.contains(r#"class="ox-no-navbar""#), "{html}");
     assert!(!html.contains("data-ox-announce"), "{html}");
     assert!(html.contains(r#"<header class="header">"#), "{html}");
-    assert!(html.contains(r#"<aside class="sidebar">"#), "{html}");
+    assert!(html.contains(r#"<aside id="ox-sidebar" class="sidebar">"#), "{html}");
 }
 
 #[test]
@@ -24,7 +24,11 @@ fn nav_happy_path_links() {
         false,
         PageChromeFlags::default(),
     );
-    let nav = html.find(r#"<nav class="header-nav""#).map(|i| &html[i..]).expect("header nav");
+    let nav = html
+        .find(r#"<nav class="header-nav""#)
+        .map(|i| &html[i..])
+        .and_then(|tail| tail.find("</nav>").map(|end| &tail[..end]))
+        .expect("header nav");
 
     assert!(nav.contains(r#"aria-label="Header""#), "{nav}");
     assert!(nav.contains(r#"href="/guide/""#), "{nav}");

--- a/crates/ox_content_ssg/src/html/header_chrome/tests/page_chrome.rs
+++ b/crates/ox_content_ssg/src/html/header_chrome/tests/page_chrome.rs
@@ -7,7 +7,7 @@ fn frontmatter_hides_sidebar() {
     let html =
         render(None, true, PageChromeFlags { sidebar: Some(false), ..PageChromeFlags::default() });
 
-    assert!(!html.contains(r#"<aside class="sidebar""#), "{html}");
+    assert!(!html.contains(r#"class="sidebar""#), "{html}");
     assert!(html.contains(r#"<header class="header">"#), "{html}");
 }
 
@@ -18,7 +18,7 @@ fn frontmatter_hides_navbar() {
 
     assert!(!html.contains(r#"<header class="header">"#), "{html}");
     assert!(body_class(&html).contains("ox-no-navbar"), "{html}");
-    assert!(html.contains(r#"<aside class="sidebar">"#), "{html}");
+    assert!(html.contains(r#"<aside id="ox-sidebar" class="sidebar">"#), "{html}");
 }
 
 #[test]
@@ -29,7 +29,7 @@ fn page_chrome_off_ignores_hide_flags() {
         PageChromeFlags { sidebar: Some(false), navbar: Some(false), ..PageChromeFlags::default() },
     );
 
-    assert!(html.contains(r#"<aside class="sidebar">"#), "{html}");
+    assert!(html.contains(r#"<aside id="ox-sidebar" class="sidebar">"#), "{html}");
     assert!(html.contains(r#"<header class="header">"#), "{html}");
     assert!(!body_class(&html).contains("ox-no-navbar"), "{html}");
 }

--- a/crates/ox_content_ssg/src/html/tests.rs
+++ b/crates/ox_content_ssg/src/html/tests.rs
@@ -27,3 +27,23 @@ mod theme;
 fn search_keydown_ignores_ime_composition() {
     assert!(super::SSG_JS.contains("if (e.isComposing || e.keyCode === 229) return;"));
 }
+
+#[test]
+fn mobile_menu_script_keeps_state_and_focus_synchronized() {
+    assert!(
+        super::SSG_JS
+            .contains("const setMenuOpen = (open, trigger = null, restoreFocus = false) =>"),
+        "desktop and mobile menu controls need one state transition"
+    );
+    assert!(
+        super::SSG_JS.contains("document.body.classList.toggle(\"menu-open\", open);")
+            && super::SSG_JS.contains("setAttribute(\"aria-expanded\", String(open))"),
+        "scroll locking and expanded state must follow the visual sheet"
+    );
+    assert!(
+        super::SSG_JS.contains("e.key === \"Escape\"")
+            && super::SSG_JS.contains("setMenuOpen(false, null, true)")
+            && super::SSG_JS.contains("triggerToRestore?.focus()"),
+        "only keyboard dismissal should force focus back to the opener"
+    );
+}

--- a/crates/ox_content_ssg/src/html/tests/rendering.rs
+++ b/crates/ox_content_ssg/src/html/tests/rendering.rs
@@ -227,6 +227,40 @@ fn test_mobile_content_css_preserves_safe_reading_gutters() {
 }
 
 #[test]
+fn test_mobile_menu_css_stays_reachable_and_touch_safe() {
+    assert!(
+        SSG_CSS.contains("body.menu-open {\n  overflow: hidden;"),
+        "an open sheet must not scroll the page behind it"
+    );
+    assert!(
+        SSG_CSS.contains(".sidebar::before {\n    content: \"\";\n    position: sticky;")
+            && SSG_CSS.contains(
+                "background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-color-bg));\n    border-block-end: 1px solid var(--octc-color-border);"
+            ),
+        "the mobile sheet needs a flat sticky bar above long navigation"
+    );
+    assert!(
+        SSG_CSS.contains(".sidebar .nav-link {\n    min-height: 44px;")
+            && SSG_CSS.contains(".sidebar .nav-title--summary {\n    min-height: 44px;"),
+        "every mobile navigation control needs a reliable touch target"
+    );
+    assert!(
+        SSG_CSS
+            .contains("@media (any-hover: hover) and (any-pointer: fine) {\n  .nav-link:hover {")
+            && SSG_CSS.contains(
+                "@media (any-hover: hover) and (any-pointer: fine) {\n  .mobile-footer-btn:hover {"
+            ),
+        "touch input must not retain mouse-only hover treatments"
+    );
+    assert!(
+        SSG_CSS.contains(
+            "@media (any-hover: none) and (any-pointer: coarse) {\n  .mobile-footer-btn:focus {\n    outline: none;"
+        ),
+        "touch-only focus treatment must be selected with input media queries"
+    );
+}
+
+#[test]
 fn test_generate_html_without_toc_omits_outline() {
     let page_data = PageData {
         title: "No TOC".to_string(),

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -161,6 +161,9 @@ body {
 body.search-open {
   overflow: hidden;
 }
+body.menu-open {
+  overflow: hidden;
+}
 a {
   color: var(--octc-color-primary);
   text-decoration: none;
@@ -720,27 +723,29 @@ a:hover {
   color: color-mix(in srgb, var(--octc-color-text) 92%, var(--octc-color-text-muted));
   font-size: 0.875rem;
 }
-.nav-link:hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 58%, transparent);
-  text-decoration: none;
-  color: var(--octc-color-text);
-}
-[data-theme="dark"] .nav-link:not(.active):hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
-}
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .nav-link:not(.active):hover {
-    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
-  }
-}
 .nav-link.active {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
   color: var(--octc-color-text);
   font-weight: 600;
 }
-.nav-link.active:hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
-  color: var(--octc-color-text);
+@media (any-hover: hover) and (any-pointer: fine) {
+  .nav-link:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 58%, transparent);
+    text-decoration: none;
+    color: var(--octc-color-text);
+  }
+  [data-theme="dark"] .nav-link:not(.active):hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
+  }
+  .nav-link.active:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
+    color: var(--octc-color-text);
+  }
+}
+@media (any-hover: hover) and (any-pointer: fine) and (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .nav-link:not(.active):hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
+  }
 }
 .nav-link--summary {
   flex: 1;
@@ -1842,11 +1847,6 @@ a:hover {
     text-decoration: none;
     min-width: 48px;
   }
-  .mobile-footer-btn:hover {
-    background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-primary) 12%);
-    color: var(--octc-color-text);
-    text-decoration: none;
-  }
   .mobile-footer-btn svg {
     width: 22px;
     height: 22px;
@@ -1889,17 +1889,35 @@ a:hover {
   }
   .sidebar::before {
     content: "";
-    position: absolute;
-    top: 0.75rem;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 40px;
-    height: 4px;
-    background: var(--octc-color-border);
-    border-radius: 2px;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: block;
+    height: 2.5rem;
+    margin-block-start: -1.5rem;
+    margin-block-end: 0.5rem;
+    margin-inline: calc(0px - var(--octc-mobile-gutter));
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-color-bg));
+    border-block-end: 1px solid var(--octc-color-border);
+    border-radius: 4px 4px 0 0;
   }
   .sidebar.open {
     transform: translateY(0);
+  }
+  .sidebar .nav-link {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    padding-block: 0.625rem;
+    line-height: 1.35;
+  }
+  .sidebar .nav-title--summary {
+    min-height: 44px;
+    align-items: center;
+  }
+  .sidebar .nav-title--summary::before,
+  .sidebar .nav-details > .nav-summary::before {
+    margin-block-start: 0;
   }
   .main {
     margin-left: 0;
@@ -2106,6 +2124,20 @@ a:hover {
   }
 }
 
+@media (any-hover: hover) and (any-pointer: fine) {
+  .mobile-footer-btn:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-primary) 12%);
+    color: var(--octc-color-text);
+    text-decoration: none;
+  }
+}
+
+@media (any-hover: none) and (any-pointer: coarse) {
+  .mobile-footer-btn:focus {
+    outline: none;
+  }
+}
+
 @media (max-width: 480px) {
   .main {
     padding-block-start: 0.75rem;
@@ -2162,7 +2194,7 @@ a:hover {
 <body>
 
   <header class="header">
-    <button class="menu-toggle" aria-label="Toggle menu">
+    <button class="menu-toggle" aria-label="Toggle menu" aria-controls="ox-sidebar" aria-expanded="false">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round">
         <path d="M3 12h18M3 6h18M3 18h18"/>
       </svg>
@@ -2214,7 +2246,7 @@ a:hover {
   <div class="overlay"></div>
   <div class="layout">
 
-    <aside class="sidebar">
+    <aside id="ox-sidebar" class="sidebar">
 
       <nav>
 <div class="nav-section">
@@ -2245,7 +2277,7 @@ a:hover {
 
   </div>
   <footer class="mobile-footer">
-    <button class="mobile-footer-btn" aria-label="Menu" data-mobile-menu>
+    <button class="mobile-footer-btn" aria-label="Menu" aria-controls="ox-sidebar" aria-expanded="false" data-mobile-menu>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <path d="M3 12h18M3 6h18M3 18h18"/>
       </svg>
@@ -2269,21 +2301,46 @@ a:hover {
   </footer>
   <!-- ox-content:scripts:start -->
   <script>const toggle = document.querySelector(".menu-toggle"),
+  mobileMenuBtn = document.querySelector("[data-mobile-menu]"),
   sidebar = document.querySelector(".sidebar"),
   overlay = document.querySelector(".overlay");
 
-if (toggle && sidebar && overlay) {
-  const close = () => {
-    sidebar.classList.remove("open");
-    overlay.classList.remove("open");
-  };
+let lastMenuTrigger = null;
 
-  toggle.addEventListener("click", () => {
-    sidebar.classList.toggle("open");
-    overlay.classList.toggle("open");
+const setMenuOpen = (open, trigger = null, restoreFocus = false) => {
+  if (!sidebar || !overlay) return;
+
+  sidebar.classList.toggle("open", open);
+  overlay.classList.toggle("open", open);
+  document.body.classList.toggle("menu-open", open);
+  [toggle, mobileMenuBtn].forEach((button) => button?.setAttribute("aria-expanded", String(open)));
+
+  if (open && trigger instanceof HTMLElement) {
+    lastMenuTrigger = trigger;
+  } else if (!open) {
+    const triggerToRestore = lastMenuTrigger;
+    lastMenuTrigger = null;
+    if (restoreFocus) {
+      requestAnimationFrame(() => triggerToRestore?.focus());
+    }
+  }
+};
+
+const toggleMenu = (trigger) => setMenuOpen(!sidebar?.classList.contains("open"), trigger);
+
+if (sidebar && overlay) {
+  toggle?.addEventListener("click", () => toggleMenu(toggle));
+  mobileMenuBtn?.addEventListener("click", () => toggleMenu(mobileMenuBtn));
+  overlay.addEventListener("click", () => setMenuOpen(false));
+  sidebar
+    .querySelectorAll("a")
+    .forEach((a) => a.addEventListener("click", () => setMenuOpen(false)));
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && sidebar.classList.contains("open")) {
+      e.preventDefault();
+      setMenuOpen(false, null, true);
+    }
   });
-  overlay.addEventListener("click", close);
-  sidebar.querySelectorAll("a").forEach((a) => a.addEventListener("click", close));
 }
 
 if (sidebar) {
@@ -2414,16 +2471,8 @@ document.querySelectorAll('a[href^="#"]').forEach((a) =>
   }),
 );
 
-const mobileMenuBtn = document.querySelector("[data-mobile-menu]"),
-  mobileSearchBtn = document.querySelector("[data-mobile-search]"),
+const mobileSearchBtn = document.querySelector("[data-mobile-search]"),
   mobileThemeBtn = document.querySelector("[data-mobile-theme]");
-
-mobileMenuBtn?.addEventListener("click", () => {
-  if (sidebar && overlay) {
-    sidebar.classList.toggle("open");
-    overlay.classList.toggle("open");
-  }
-});
 
 mobileSearchBtn?.addEventListener("click", () => {
   void openSearch();

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -157,6 +157,9 @@ body {
 body.search-open {
   overflow: hidden;
 }
+body.menu-open {
+  overflow: hidden;
+}
 a {
   color: var(--octc-color-primary);
   text-decoration: none;
@@ -716,27 +719,29 @@ a:hover {
   color: color-mix(in srgb, var(--octc-color-text) 92%, var(--octc-color-text-muted));
   font-size: 0.875rem;
 }
-.nav-link:hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 58%, transparent);
-  text-decoration: none;
-  color: var(--octc-color-text);
-}
-[data-theme="dark"] .nav-link:not(.active):hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
-}
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .nav-link:not(.active):hover {
-    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
-  }
-}
 .nav-link.active {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
   color: var(--octc-color-text);
   font-weight: 600;
 }
-.nav-link.active:hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
-  color: var(--octc-color-text);
+@media (any-hover: hover) and (any-pointer: fine) {
+  .nav-link:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 58%, transparent);
+    text-decoration: none;
+    color: var(--octc-color-text);
+  }
+  [data-theme="dark"] .nav-link:not(.active):hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
+  }
+  .nav-link.active:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
+    color: var(--octc-color-text);
+  }
+}
+@media (any-hover: hover) and (any-pointer: fine) and (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .nav-link:not(.active):hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
+  }
 }
 .nav-link--summary {
   flex: 1;
@@ -1838,11 +1843,6 @@ a:hover {
     text-decoration: none;
     min-width: 48px;
   }
-  .mobile-footer-btn:hover {
-    background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-primary) 12%);
-    color: var(--octc-color-text);
-    text-decoration: none;
-  }
   .mobile-footer-btn svg {
     width: 22px;
     height: 22px;
@@ -1885,17 +1885,35 @@ a:hover {
   }
   .sidebar::before {
     content: "";
-    position: absolute;
-    top: 0.75rem;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 40px;
-    height: 4px;
-    background: var(--octc-color-border);
-    border-radius: 2px;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: block;
+    height: 2.5rem;
+    margin-block-start: -1.5rem;
+    margin-block-end: 0.5rem;
+    margin-inline: calc(0px - var(--octc-mobile-gutter));
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-color-bg));
+    border-block-end: 1px solid var(--octc-color-border);
+    border-radius: 4px 4px 0 0;
   }
   .sidebar.open {
     transform: translateY(0);
+  }
+  .sidebar .nav-link {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    padding-block: 0.625rem;
+    line-height: 1.35;
+  }
+  .sidebar .nav-title--summary {
+    min-height: 44px;
+    align-items: center;
+  }
+  .sidebar .nav-title--summary::before,
+  .sidebar .nav-details > .nav-summary::before {
+    margin-block-start: 0;
   }
   .main {
     margin-left: 0;
@@ -2102,6 +2120,20 @@ a:hover {
   }
 }
 
+@media (any-hover: hover) and (any-pointer: fine) {
+  .mobile-footer-btn:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-primary) 12%);
+    color: var(--octc-color-text);
+    text-decoration: none;
+  }
+}
+
+@media (any-hover: none) and (any-pointer: coarse) {
+  .mobile-footer-btn:focus {
+    outline: none;
+  }
+}
+
 @media (max-width: 480px) {
   .main {
     padding-block-start: 0.75rem;
@@ -2158,7 +2190,7 @@ a:hover {
 <body>
 
   <header class="header">
-    <button class="menu-toggle" aria-label="Toggle menu">
+    <button class="menu-toggle" aria-label="Toggle menu" aria-controls="ox-sidebar" aria-expanded="false">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round">
         <path d="M3 12h18M3 6h18M3 18h18"/>
       </svg>
@@ -2225,7 +2257,7 @@ a:hover {
 
   </div>
   <footer class="mobile-footer">
-    <button class="mobile-footer-btn" aria-label="Menu" data-mobile-menu>
+    <button class="mobile-footer-btn" aria-label="Menu" aria-controls="ox-sidebar" aria-expanded="false" data-mobile-menu>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <path d="M3 12h18M3 6h18M3 18h18"/>
       </svg>
@@ -2249,21 +2281,46 @@ a:hover {
   </footer>
   <!-- ox-content:scripts:start -->
   <script>const toggle = document.querySelector(".menu-toggle"),
+  mobileMenuBtn = document.querySelector("[data-mobile-menu]"),
   sidebar = document.querySelector(".sidebar"),
   overlay = document.querySelector(".overlay");
 
-if (toggle && sidebar && overlay) {
-  const close = () => {
-    sidebar.classList.remove("open");
-    overlay.classList.remove("open");
-  };
+let lastMenuTrigger = null;
 
-  toggle.addEventListener("click", () => {
-    sidebar.classList.toggle("open");
-    overlay.classList.toggle("open");
+const setMenuOpen = (open, trigger = null, restoreFocus = false) => {
+  if (!sidebar || !overlay) return;
+
+  sidebar.classList.toggle("open", open);
+  overlay.classList.toggle("open", open);
+  document.body.classList.toggle("menu-open", open);
+  [toggle, mobileMenuBtn].forEach((button) => button?.setAttribute("aria-expanded", String(open)));
+
+  if (open && trigger instanceof HTMLElement) {
+    lastMenuTrigger = trigger;
+  } else if (!open) {
+    const triggerToRestore = lastMenuTrigger;
+    lastMenuTrigger = null;
+    if (restoreFocus) {
+      requestAnimationFrame(() => triggerToRestore?.focus());
+    }
+  }
+};
+
+const toggleMenu = (trigger) => setMenuOpen(!sidebar?.classList.contains("open"), trigger);
+
+if (sidebar && overlay) {
+  toggle?.addEventListener("click", () => toggleMenu(toggle));
+  mobileMenuBtn?.addEventListener("click", () => toggleMenu(mobileMenuBtn));
+  overlay.addEventListener("click", () => setMenuOpen(false));
+  sidebar
+    .querySelectorAll("a")
+    .forEach((a) => a.addEventListener("click", () => setMenuOpen(false)));
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && sidebar.classList.contains("open")) {
+      e.preventDefault();
+      setMenuOpen(false, null, true);
+    }
   });
-  overlay.addEventListener("click", close);
-  sidebar.querySelectorAll("a").forEach((a) => a.addEventListener("click", close));
 }
 
 if (sidebar) {
@@ -2394,16 +2451,8 @@ document.querySelectorAll('a[href^="#"]').forEach((a) =>
   }),
 );
 
-const mobileMenuBtn = document.querySelector("[data-mobile-menu]"),
-  mobileSearchBtn = document.querySelector("[data-mobile-search]"),
+const mobileSearchBtn = document.querySelector("[data-mobile-search]"),
   mobileThemeBtn = document.querySelector("[data-mobile-theme]");
-
-mobileMenuBtn?.addEventListener("click", () => {
-  if (sidebar && overlay) {
-    sidebar.classList.toggle("open");
-    overlay.classList.toggle("open");
-  }
-});
 
 mobileSearchBtn?.addEventListener("click", () => {
   void openSearch();

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -157,6 +157,9 @@ body {
 body.search-open {
   overflow: hidden;
 }
+body.menu-open {
+  overflow: hidden;
+}
 a {
   color: var(--octc-color-primary);
   text-decoration: none;
@@ -716,27 +719,29 @@ a:hover {
   color: color-mix(in srgb, var(--octc-color-text) 92%, var(--octc-color-text-muted));
   font-size: 0.875rem;
 }
-.nav-link:hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 58%, transparent);
-  text-decoration: none;
-  color: var(--octc-color-text);
-}
-[data-theme="dark"] .nav-link:not(.active):hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
-}
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .nav-link:not(.active):hover {
-    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
-  }
-}
 .nav-link.active {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
   color: var(--octc-color-text);
   font-weight: 600;
 }
-.nav-link.active:hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
-  color: var(--octc-color-text);
+@media (any-hover: hover) and (any-pointer: fine) {
+  .nav-link:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 58%, transparent);
+    text-decoration: none;
+    color: var(--octc-color-text);
+  }
+  [data-theme="dark"] .nav-link:not(.active):hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
+  }
+  .nav-link.active:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
+    color: var(--octc-color-text);
+  }
+}
+@media (any-hover: hover) and (any-pointer: fine) and (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .nav-link:not(.active):hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
+  }
 }
 .nav-link--summary {
   flex: 1;
@@ -1838,11 +1843,6 @@ a:hover {
     text-decoration: none;
     min-width: 48px;
   }
-  .mobile-footer-btn:hover {
-    background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-primary) 12%);
-    color: var(--octc-color-text);
-    text-decoration: none;
-  }
   .mobile-footer-btn svg {
     width: 22px;
     height: 22px;
@@ -1885,17 +1885,35 @@ a:hover {
   }
   .sidebar::before {
     content: "";
-    position: absolute;
-    top: 0.75rem;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 40px;
-    height: 4px;
-    background: var(--octc-color-border);
-    border-radius: 2px;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: block;
+    height: 2.5rem;
+    margin-block-start: -1.5rem;
+    margin-block-end: 0.5rem;
+    margin-inline: calc(0px - var(--octc-mobile-gutter));
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-color-bg));
+    border-block-end: 1px solid var(--octc-color-border);
+    border-radius: 4px 4px 0 0;
   }
   .sidebar.open {
     transform: translateY(0);
+  }
+  .sidebar .nav-link {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    padding-block: 0.625rem;
+    line-height: 1.35;
+  }
+  .sidebar .nav-title--summary {
+    min-height: 44px;
+    align-items: center;
+  }
+  .sidebar .nav-title--summary::before,
+  .sidebar .nav-details > .nav-summary::before {
+    margin-block-start: 0;
   }
   .main {
     margin-left: 0;
@@ -2102,6 +2120,20 @@ a:hover {
   }
 }
 
+@media (any-hover: hover) and (any-pointer: fine) {
+  .mobile-footer-btn:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-primary) 12%);
+    color: var(--octc-color-text);
+    text-decoration: none;
+  }
+}
+
+@media (any-hover: none) and (any-pointer: coarse) {
+  .mobile-footer-btn:focus {
+    outline: none;
+  }
+}
+
 @media (max-width: 480px) {
   .main {
     padding-block-start: 0.75rem;
@@ -2158,7 +2190,7 @@ a:hover {
 <body>
 
   <header class="header">
-    <button class="menu-toggle" aria-label="Toggle menu">
+    <button class="menu-toggle" aria-label="Toggle menu" aria-controls="ox-sidebar" aria-expanded="false">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round">
         <path d="M3 12h18M3 6h18M3 18h18"/>
       </svg>
@@ -2225,7 +2257,7 @@ a:hover {
 
   </div>
   <footer class="mobile-footer">
-    <button class="mobile-footer-btn" aria-label="Menu" data-mobile-menu>
+    <button class="mobile-footer-btn" aria-label="Menu" aria-controls="ox-sidebar" aria-expanded="false" data-mobile-menu>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <path d="M3 12h18M3 6h18M3 18h18"/>
       </svg>
@@ -2249,21 +2281,46 @@ a:hover {
   </footer>
   <!-- ox-content:scripts:start -->
   <script>const toggle = document.querySelector(".menu-toggle"),
+  mobileMenuBtn = document.querySelector("[data-mobile-menu]"),
   sidebar = document.querySelector(".sidebar"),
   overlay = document.querySelector(".overlay");
 
-if (toggle && sidebar && overlay) {
-  const close = () => {
-    sidebar.classList.remove("open");
-    overlay.classList.remove("open");
-  };
+let lastMenuTrigger = null;
 
-  toggle.addEventListener("click", () => {
-    sidebar.classList.toggle("open");
-    overlay.classList.toggle("open");
+const setMenuOpen = (open, trigger = null, restoreFocus = false) => {
+  if (!sidebar || !overlay) return;
+
+  sidebar.classList.toggle("open", open);
+  overlay.classList.toggle("open", open);
+  document.body.classList.toggle("menu-open", open);
+  [toggle, mobileMenuBtn].forEach((button) => button?.setAttribute("aria-expanded", String(open)));
+
+  if (open && trigger instanceof HTMLElement) {
+    lastMenuTrigger = trigger;
+  } else if (!open) {
+    const triggerToRestore = lastMenuTrigger;
+    lastMenuTrigger = null;
+    if (restoreFocus) {
+      requestAnimationFrame(() => triggerToRestore?.focus());
+    }
+  }
+};
+
+const toggleMenu = (trigger) => setMenuOpen(!sidebar?.classList.contains("open"), trigger);
+
+if (sidebar && overlay) {
+  toggle?.addEventListener("click", () => toggleMenu(toggle));
+  mobileMenuBtn?.addEventListener("click", () => toggleMenu(mobileMenuBtn));
+  overlay.addEventListener("click", () => setMenuOpen(false));
+  sidebar
+    .querySelectorAll("a")
+    .forEach((a) => a.addEventListener("click", () => setMenuOpen(false)));
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && sidebar.classList.contains("open")) {
+      e.preventDefault();
+      setMenuOpen(false, null, true);
+    }
   });
-  overlay.addEventListener("click", close);
-  sidebar.querySelectorAll("a").forEach((a) => a.addEventListener("click", close));
 }
 
 if (sidebar) {
@@ -2394,16 +2451,8 @@ document.querySelectorAll('a[href^="#"]').forEach((a) =>
   }),
 );
 
-const mobileMenuBtn = document.querySelector("[data-mobile-menu]"),
-  mobileSearchBtn = document.querySelector("[data-mobile-search]"),
+const mobileSearchBtn = document.querySelector("[data-mobile-search]"),
   mobileThemeBtn = document.querySelector("[data-mobile-theme]");
-
-mobileMenuBtn?.addEventListener("click", () => {
-  if (sidebar && overlay) {
-    sidebar.classList.toggle("open");
-    overlay.classList.toggle("open");
-  }
-});
 
 mobileSearchBtn?.addEventListener("click", () => {
   void openSearch();

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -157,6 +157,9 @@ body {
 body.search-open {
   overflow: hidden;
 }
+body.menu-open {
+  overflow: hidden;
+}
 a {
   color: var(--octc-color-primary);
   text-decoration: none;
@@ -716,27 +719,29 @@ a:hover {
   color: color-mix(in srgb, var(--octc-color-text) 92%, var(--octc-color-text-muted));
   font-size: 0.875rem;
 }
-.nav-link:hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 58%, transparent);
-  text-decoration: none;
-  color: var(--octc-color-text);
-}
-[data-theme="dark"] .nav-link:not(.active):hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
-}
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .nav-link:not(.active):hover {
-    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
-  }
-}
 .nav-link.active {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
   color: var(--octc-color-text);
   font-weight: 600;
 }
-.nav-link.active:hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
-  color: var(--octc-color-text);
+@media (any-hover: hover) and (any-pointer: fine) {
+  .nav-link:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 58%, transparent);
+    text-decoration: none;
+    color: var(--octc-color-text);
+  }
+  [data-theme="dark"] .nav-link:not(.active):hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
+  }
+  .nav-link.active:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
+    color: var(--octc-color-text);
+  }
+}
+@media (any-hover: hover) and (any-pointer: fine) and (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .nav-link:not(.active):hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
+  }
 }
 .nav-link--summary {
   flex: 1;
@@ -1838,11 +1843,6 @@ a:hover {
     text-decoration: none;
     min-width: 48px;
   }
-  .mobile-footer-btn:hover {
-    background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-primary) 12%);
-    color: var(--octc-color-text);
-    text-decoration: none;
-  }
   .mobile-footer-btn svg {
     width: 22px;
     height: 22px;
@@ -1885,17 +1885,35 @@ a:hover {
   }
   .sidebar::before {
     content: "";
-    position: absolute;
-    top: 0.75rem;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 40px;
-    height: 4px;
-    background: var(--octc-color-border);
-    border-radius: 2px;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: block;
+    height: 2.5rem;
+    margin-block-start: -1.5rem;
+    margin-block-end: 0.5rem;
+    margin-inline: calc(0px - var(--octc-mobile-gutter));
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-color-bg));
+    border-block-end: 1px solid var(--octc-color-border);
+    border-radius: 4px 4px 0 0;
   }
   .sidebar.open {
     transform: translateY(0);
+  }
+  .sidebar .nav-link {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    padding-block: 0.625rem;
+    line-height: 1.35;
+  }
+  .sidebar .nav-title--summary {
+    min-height: 44px;
+    align-items: center;
+  }
+  .sidebar .nav-title--summary::before,
+  .sidebar .nav-details > .nav-summary::before {
+    margin-block-start: 0;
   }
   .main {
     margin-left: 0;
@@ -2102,6 +2120,20 @@ a:hover {
   }
 }
 
+@media (any-hover: hover) and (any-pointer: fine) {
+  .mobile-footer-btn:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-primary) 12%);
+    color: var(--octc-color-text);
+    text-decoration: none;
+  }
+}
+
+@media (any-hover: none) and (any-pointer: coarse) {
+  .mobile-footer-btn:focus {
+    outline: none;
+  }
+}
+
 @media (max-width: 480px) {
   .main {
     padding-block-start: 0.75rem;
@@ -2158,7 +2190,7 @@ a:hover {
 <body>
 
   <header class="header">
-    <button class="menu-toggle" aria-label="Toggle menu">
+    <button class="menu-toggle" aria-label="Toggle menu" aria-controls="ox-sidebar" aria-expanded="false">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round">
         <path d="M3 12h18M3 6h18M3 18h18"/>
       </svg>
@@ -2226,7 +2258,7 @@ a:hover {
 
   </div>
   <footer class="mobile-footer">
-    <button class="mobile-footer-btn" aria-label="Menu" data-mobile-menu>
+    <button class="mobile-footer-btn" aria-label="Menu" aria-controls="ox-sidebar" aria-expanded="false" data-mobile-menu>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <path d="M3 12h18M3 6h18M3 18h18"/>
       </svg>
@@ -2251,21 +2283,46 @@ a:hover {
   </footer>
   <!-- ox-content:scripts:start -->
   <script>const toggle = document.querySelector(".menu-toggle"),
+  mobileMenuBtn = document.querySelector("[data-mobile-menu]"),
   sidebar = document.querySelector(".sidebar"),
   overlay = document.querySelector(".overlay");
 
-if (toggle && sidebar && overlay) {
-  const close = () => {
-    sidebar.classList.remove("open");
-    overlay.classList.remove("open");
-  };
+let lastMenuTrigger = null;
 
-  toggle.addEventListener("click", () => {
-    sidebar.classList.toggle("open");
-    overlay.classList.toggle("open");
+const setMenuOpen = (open, trigger = null, restoreFocus = false) => {
+  if (!sidebar || !overlay) return;
+
+  sidebar.classList.toggle("open", open);
+  overlay.classList.toggle("open", open);
+  document.body.classList.toggle("menu-open", open);
+  [toggle, mobileMenuBtn].forEach((button) => button?.setAttribute("aria-expanded", String(open)));
+
+  if (open && trigger instanceof HTMLElement) {
+    lastMenuTrigger = trigger;
+  } else if (!open) {
+    const triggerToRestore = lastMenuTrigger;
+    lastMenuTrigger = null;
+    if (restoreFocus) {
+      requestAnimationFrame(() => triggerToRestore?.focus());
+    }
+  }
+};
+
+const toggleMenu = (trigger) => setMenuOpen(!sidebar?.classList.contains("open"), trigger);
+
+if (sidebar && overlay) {
+  toggle?.addEventListener("click", () => toggleMenu(toggle));
+  mobileMenuBtn?.addEventListener("click", () => toggleMenu(mobileMenuBtn));
+  overlay.addEventListener("click", () => setMenuOpen(false));
+  sidebar
+    .querySelectorAll("a")
+    .forEach((a) => a.addEventListener("click", () => setMenuOpen(false)));
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && sidebar.classList.contains("open")) {
+      e.preventDefault();
+      setMenuOpen(false, null, true);
+    }
   });
-  overlay.addEventListener("click", close);
-  sidebar.querySelectorAll("a").forEach((a) => a.addEventListener("click", close));
 }
 
 if (sidebar) {
@@ -2396,16 +2453,8 @@ document.querySelectorAll('a[href^="#"]').forEach((a) =>
   }),
 );
 
-const mobileMenuBtn = document.querySelector("[data-mobile-menu]"),
-  mobileSearchBtn = document.querySelector("[data-mobile-search]"),
+const mobileSearchBtn = document.querySelector("[data-mobile-search]"),
   mobileThemeBtn = document.querySelector("[data-mobile-theme]");
-
-mobileMenuBtn?.addEventListener("click", () => {
-  if (sidebar && overlay) {
-    sidebar.classList.toggle("open");
-    overlay.classList.toggle("open");
-  }
-});
 
 mobileSearchBtn?.addEventListener("click", () => {
   void openSearch();

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -157,6 +157,9 @@ body {
 body.search-open {
   overflow: hidden;
 }
+body.menu-open {
+  overflow: hidden;
+}
 a {
   color: var(--octc-color-primary);
   text-decoration: none;
@@ -716,27 +719,29 @@ a:hover {
   color: color-mix(in srgb, var(--octc-color-text) 92%, var(--octc-color-text-muted));
   font-size: 0.875rem;
 }
-.nav-link:hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 58%, transparent);
-  text-decoration: none;
-  color: var(--octc-color-text);
-}
-[data-theme="dark"] .nav-link:not(.active):hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
-}
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .nav-link:not(.active):hover {
-    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
-  }
-}
 .nav-link.active {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
   color: var(--octc-color-text);
   font-weight: 600;
 }
-.nav-link.active:hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
-  color: var(--octc-color-text);
+@media (any-hover: hover) and (any-pointer: fine) {
+  .nav-link:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 58%, transparent);
+    text-decoration: none;
+    color: var(--octc-color-text);
+  }
+  [data-theme="dark"] .nav-link:not(.active):hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
+  }
+  .nav-link.active:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
+    color: var(--octc-color-text);
+  }
+}
+@media (any-hover: hover) and (any-pointer: fine) and (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .nav-link:not(.active):hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
+  }
 }
 .nav-link--summary {
   flex: 1;
@@ -1838,11 +1843,6 @@ a:hover {
     text-decoration: none;
     min-width: 48px;
   }
-  .mobile-footer-btn:hover {
-    background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-primary) 12%);
-    color: var(--octc-color-text);
-    text-decoration: none;
-  }
   .mobile-footer-btn svg {
     width: 22px;
     height: 22px;
@@ -1885,17 +1885,35 @@ a:hover {
   }
   .sidebar::before {
     content: "";
-    position: absolute;
-    top: 0.75rem;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 40px;
-    height: 4px;
-    background: var(--octc-color-border);
-    border-radius: 2px;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: block;
+    height: 2.5rem;
+    margin-block-start: -1.5rem;
+    margin-block-end: 0.5rem;
+    margin-inline: calc(0px - var(--octc-mobile-gutter));
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-color-bg));
+    border-block-end: 1px solid var(--octc-color-border);
+    border-radius: 4px 4px 0 0;
   }
   .sidebar.open {
     transform: translateY(0);
+  }
+  .sidebar .nav-link {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    padding-block: 0.625rem;
+    line-height: 1.35;
+  }
+  .sidebar .nav-title--summary {
+    min-height: 44px;
+    align-items: center;
+  }
+  .sidebar .nav-title--summary::before,
+  .sidebar .nav-details > .nav-summary::before {
+    margin-block-start: 0;
   }
   .main {
     margin-left: 0;
@@ -2102,6 +2120,20 @@ a:hover {
   }
 }
 
+@media (any-hover: hover) and (any-pointer: fine) {
+  .mobile-footer-btn:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-primary) 12%);
+    color: var(--octc-color-text);
+    text-decoration: none;
+  }
+}
+
+@media (any-hover: none) and (any-pointer: coarse) {
+  .mobile-footer-btn:focus {
+    outline: none;
+  }
+}
+
 @media (max-width: 480px) {
   .main {
     padding-block-start: 0.75rem;
@@ -2185,7 +2217,7 @@ a:hover {
 <body>
 
   <header class="header">
-    <button class="menu-toggle" aria-label="Toggle menu">
+    <button class="menu-toggle" aria-label="Toggle menu" aria-controls="ox-sidebar" aria-expanded="false">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round">
         <path d="M3 12h18M3 6h18M3 18h18"/>
       </svg>
@@ -2260,7 +2292,7 @@ a:hover {
 
   </div>
   <footer class="mobile-footer">
-    <button class="mobile-footer-btn" aria-label="Menu" data-mobile-menu>
+    <button class="mobile-footer-btn" aria-label="Menu" aria-controls="ox-sidebar" aria-expanded="false" data-mobile-menu>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <path d="M3 12h18M3 6h18M3 18h18"/>
       </svg>
@@ -2284,21 +2316,46 @@ a:hover {
   </footer>
   <!-- ox-content:scripts:start -->
   <script>const toggle = document.querySelector(".menu-toggle"),
+  mobileMenuBtn = document.querySelector("[data-mobile-menu]"),
   sidebar = document.querySelector(".sidebar"),
   overlay = document.querySelector(".overlay");
 
-if (toggle && sidebar && overlay) {
-  const close = () => {
-    sidebar.classList.remove("open");
-    overlay.classList.remove("open");
-  };
+let lastMenuTrigger = null;
 
-  toggle.addEventListener("click", () => {
-    sidebar.classList.toggle("open");
-    overlay.classList.toggle("open");
+const setMenuOpen = (open, trigger = null, restoreFocus = false) => {
+  if (!sidebar || !overlay) return;
+
+  sidebar.classList.toggle("open", open);
+  overlay.classList.toggle("open", open);
+  document.body.classList.toggle("menu-open", open);
+  [toggle, mobileMenuBtn].forEach((button) => button?.setAttribute("aria-expanded", String(open)));
+
+  if (open && trigger instanceof HTMLElement) {
+    lastMenuTrigger = trigger;
+  } else if (!open) {
+    const triggerToRestore = lastMenuTrigger;
+    lastMenuTrigger = null;
+    if (restoreFocus) {
+      requestAnimationFrame(() => triggerToRestore?.focus());
+    }
+  }
+};
+
+const toggleMenu = (trigger) => setMenuOpen(!sidebar?.classList.contains("open"), trigger);
+
+if (sidebar && overlay) {
+  toggle?.addEventListener("click", () => toggleMenu(toggle));
+  mobileMenuBtn?.addEventListener("click", () => toggleMenu(mobileMenuBtn));
+  overlay.addEventListener("click", () => setMenuOpen(false));
+  sidebar
+    .querySelectorAll("a")
+    .forEach((a) => a.addEventListener("click", () => setMenuOpen(false)));
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && sidebar.classList.contains("open")) {
+      e.preventDefault();
+      setMenuOpen(false, null, true);
+    }
   });
-  overlay.addEventListener("click", close);
-  sidebar.querySelectorAll("a").forEach((a) => a.addEventListener("click", close));
 }
 
 if (sidebar) {
@@ -2429,16 +2486,8 @@ document.querySelectorAll('a[href^="#"]').forEach((a) =>
   }),
 );
 
-const mobileMenuBtn = document.querySelector("[data-mobile-menu]"),
-  mobileSearchBtn = document.querySelector("[data-mobile-search]"),
+const mobileSearchBtn = document.querySelector("[data-mobile-search]"),
   mobileThemeBtn = document.querySelector("[data-mobile-theme]");
-
-mobileMenuBtn?.addEventListener("click", () => {
-  if (sidebar && overlay) {
-    sidebar.classList.toggle("open");
-    overlay.classList.toggle("open");
-  }
-});
 
 mobileSearchBtn?.addEventListener("click", () => {
   void openSearch();

--- a/crates/ox_content_ssg/src/ssg.css
+++ b/crates/ox_content_ssg/src/ssg.css
@@ -139,6 +139,9 @@ body {
 body.search-open {
   overflow: hidden;
 }
+body.menu-open {
+  overflow: hidden;
+}
 a {
   color: var(--octc-color-primary);
   text-decoration: none;
@@ -698,27 +701,29 @@ a:hover {
   color: color-mix(in srgb, var(--octc-color-text) 92%, var(--octc-color-text-muted));
   font-size: 0.875rem;
 }
-.nav-link:hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 58%, transparent);
-  text-decoration: none;
-  color: var(--octc-color-text);
-}
-[data-theme="dark"] .nav-link:not(.active):hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
-}
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .nav-link:not(.active):hover {
-    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
-  }
-}
 .nav-link.active {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
   color: var(--octc-color-text);
   font-weight: 600;
 }
-.nav-link.active:hover {
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
-  color: var(--octc-color-text);
+@media (any-hover: hover) and (any-pointer: fine) {
+  .nav-link:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 58%, transparent);
+    text-decoration: none;
+    color: var(--octc-color-text);
+  }
+  [data-theme="dark"] .nav-link:not(.active):hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
+  }
+  .nav-link.active:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 72%, transparent);
+    color: var(--octc-color-text);
+  }
+}
+@media (any-hover: hover) and (any-pointer: fine) and (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .nav-link:not(.active):hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
+  }
 }
 .nav-link--summary {
   flex: 1;
@@ -1820,11 +1825,6 @@ a:hover {
     text-decoration: none;
     min-width: 48px;
   }
-  .mobile-footer-btn:hover {
-    background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-primary) 12%);
-    color: var(--octc-color-text);
-    text-decoration: none;
-  }
   .mobile-footer-btn svg {
     width: 22px;
     height: 22px;
@@ -1867,17 +1867,35 @@ a:hover {
   }
   .sidebar::before {
     content: "";
-    position: absolute;
-    top: 0.75rem;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 40px;
-    height: 4px;
-    background: var(--octc-color-border);
-    border-radius: 2px;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: block;
+    height: 2.5rem;
+    margin-block-start: -1.5rem;
+    margin-block-end: 0.5rem;
+    margin-inline: calc(0px - var(--octc-mobile-gutter));
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-color-bg));
+    border-block-end: 1px solid var(--octc-color-border);
+    border-radius: 4px 4px 0 0;
   }
   .sidebar.open {
     transform: translateY(0);
+  }
+  .sidebar .nav-link {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    padding-block: 0.625rem;
+    line-height: 1.35;
+  }
+  .sidebar .nav-title--summary {
+    min-height: 44px;
+    align-items: center;
+  }
+  .sidebar .nav-title--summary::before,
+  .sidebar .nav-details > .nav-summary::before {
+    margin-block-start: 0;
   }
   .main {
     margin-left: 0;
@@ -2081,6 +2099,20 @@ a:hover {
   }
   .overlay.open {
     display: block;
+  }
+}
+
+@media (any-hover: hover) and (any-pointer: fine) {
+  .mobile-footer-btn:hover {
+    background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-primary) 12%);
+    color: var(--octc-color-text);
+    text-decoration: none;
+  }
+}
+
+@media (any-hover: none) and (any-pointer: coarse) {
+  .mobile-footer-btn:focus {
+    outline: none;
   }
 }
 

--- a/crates/ox_content_ssg/src/ssg.js
+++ b/crates/ox_content_ssg/src/ssg.js
@@ -1,19 +1,44 @@
 const toggle = document.querySelector(".menu-toggle"),
+  mobileMenuBtn = document.querySelector("[data-mobile-menu]"),
   sidebar = document.querySelector(".sidebar"),
   overlay = document.querySelector(".overlay");
 
-if (toggle && sidebar && overlay) {
-  const close = () => {
-    sidebar.classList.remove("open");
-    overlay.classList.remove("open");
-  };
+let lastMenuTrigger = null;
 
-  toggle.addEventListener("click", () => {
-    sidebar.classList.toggle("open");
-    overlay.classList.toggle("open");
+const setMenuOpen = (open, trigger = null, restoreFocus = false) => {
+  if (!sidebar || !overlay) return;
+
+  sidebar.classList.toggle("open", open);
+  overlay.classList.toggle("open", open);
+  document.body.classList.toggle("menu-open", open);
+  [toggle, mobileMenuBtn].forEach((button) => button?.setAttribute("aria-expanded", String(open)));
+
+  if (open && trigger instanceof HTMLElement) {
+    lastMenuTrigger = trigger;
+  } else if (!open) {
+    const triggerToRestore = lastMenuTrigger;
+    lastMenuTrigger = null;
+    if (restoreFocus) {
+      requestAnimationFrame(() => triggerToRestore?.focus());
+    }
+  }
+};
+
+const toggleMenu = (trigger) => setMenuOpen(!sidebar?.classList.contains("open"), trigger);
+
+if (sidebar && overlay) {
+  toggle?.addEventListener("click", () => toggleMenu(toggle));
+  mobileMenuBtn?.addEventListener("click", () => toggleMenu(mobileMenuBtn));
+  overlay.addEventListener("click", () => setMenuOpen(false));
+  sidebar
+    .querySelectorAll("a")
+    .forEach((a) => a.addEventListener("click", () => setMenuOpen(false)));
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && sidebar.classList.contains("open")) {
+      e.preventDefault();
+      setMenuOpen(false, null, true);
+    }
   });
-  overlay.addEventListener("click", close);
-  sidebar.querySelectorAll("a").forEach((a) => a.addEventListener("click", close));
 }
 
 if (sidebar) {
@@ -144,16 +169,8 @@ document.querySelectorAll('a[href^="#"]').forEach((a) =>
   }),
 );
 
-const mobileMenuBtn = document.querySelector("[data-mobile-menu]"),
-  mobileSearchBtn = document.querySelector("[data-mobile-search]"),
+const mobileSearchBtn = document.querySelector("[data-mobile-search]"),
   mobileThemeBtn = document.querySelector("[data-mobile-theme]");
-
-mobileMenuBtn?.addEventListener("click", () => {
-  if (sidebar && overlay) {
-    sidebar.classList.toggle("open");
-    overlay.classList.toggle("open");
-  }
-});
 
 mobileSearchBtn?.addEventListener("click", () => {
   void openSearch();

--- a/crates/ox_content_ssg/templates/page.html
+++ b/crates/ox_content_ssg/templates/page.html
@@ -27,7 +27,7 @@
 {% if let Some(skip) = skip_link %}{{ skip|safe }}
 {% endif %}{{ embed_header_before|safe }}{{ announcement_html|safe }}{% if show_navbar %}
   <header class="header">
-    <button class="menu-toggle" aria-label="Toggle menu">
+    <button class="menu-toggle" aria-label="Toggle menu" aria-controls="ox-sidebar" aria-expanded="false">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round">
         <path d="M3 12h18M3 6h18M3 18h18"/>
       </svg>
@@ -86,7 +86,7 @@
   <div class="overlay"></div>
   <div class="layout">
 {% if !navigation.is_empty() %}
-    <aside class="sidebar{% if is_entry_page %} sidebar--entry{% endif %}">
+    <aside id="ox-sidebar" class="sidebar{% if is_entry_page %} sidebar--entry{% endif %}">
 {{ embed_sidebar_before|safe }}
       <nav>
 {{ navigation|safe }}
@@ -149,7 +149,7 @@
 {% endif %}
   </div>
   <footer class="mobile-footer">
-    <button class="mobile-footer-btn" aria-label="Menu" data-mobile-menu>
+    <button class="mobile-footer-btn" aria-label="Menu" aria-controls="ox-sidebar" aria-expanded="false" data-mobile-menu>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <path d="M3 12h18M3 6h18M3 18h18"/>
       </svg>


### PR DESCRIPTION
## Summary

- keep a flat sticky menu bar reachable while long mobile navigation scrolls independently
- gate hover styles with any-hover and any-pointer capability queries so touch taps do not retain desktop hover chrome
- make links and disclosure rows 44px tall, synchronize both menu triggers, lock background scroll, and restore focus on Escape
- keep the new chrome free of shadows and gradients

## Verification

- cargo test -p ox_content_ssg --lib
- cargo clippy -p ox_content_ssg --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- pnpm check:file-lines
- browser QA at 390px: 64 navigation targets measured at 44px; the sidebar scroll reached 1000px while the sticky bar remained at top 0 and the page stayed locked
- capability QA: any-hover none plus any-pointer coarse suppressed sticky focus styling; hover plus fine preserved keyboard focus and Escape restoration

Closes #766
Closes #767
Closes #768

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790185634&installation_model_id=422833&pr_number=777&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F777&signature=de94d26eeb5a8fe60c4a6d3e253bc58e9f030e5e07a17c6ca66cfe9e87630651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->