### PR TITLE
fix(theme): compact mobile breadcrumb spacing

### DIFF
--- a/crates/ox_content_ssg/src/html/breadcrumbs/tests.rs
+++ b/crates/ox_content_ssg/src/html/breadcrumbs/tests.rs
@@ -1,6 +1,6 @@
 use super::super::{
-    A11y, EntryPageConfig, NavGroup, NavItem, PageChromeFlags, PageData, ReaderChrome, SsgConfig,
-    ThemeConfig, generate_bare_html, generate_html,
+    A11y, EntryPageConfig, NavGroup, NavItem, PageChromeFlags, PageData, ReaderChrome, SSG_CSS,
+    SsgConfig, ThemeConfig, generate_bare_html, generate_html,
 };
 
 fn nav_item(title: &str, path: &str, href: &str) -> NavItem {
@@ -87,6 +87,16 @@ fn breadcrumbs_html(html: &str) -> Option<&str> {
 fn assert_no_json_ld(html: &str) {
     assert!(!html.contains("application/ld+json"), "breadcrumbs must not emit JSON-LD: {html}");
     assert!(!html.contains("BreadcrumbList"), "breadcrumbs must not emit BreadcrumbList: {html}");
+}
+
+#[test]
+fn mobile_separator_spacing_is_compact() {
+    assert!(
+        SSG_CSS.contains(
+            ".ox-breadcrumbs-item:not(:last-child)::after {\n    margin-inline: 0.25rem;"
+        ),
+        "mobile separators must not inherit the wide desktop spacing"
+    );
 }
 
 #[test]

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -1929,6 +1929,9 @@ a:hover {
   .content {
     padding: 0;
   }
+  .ox-breadcrumbs-item:not(:last-child)::after {
+    margin-inline: 0.25rem;
+  }
   .content h1 {
     font-size: 1.5rem;
   }

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -1925,6 +1925,9 @@ a:hover {
   .content {
     padding: 0;
   }
+  .ox-breadcrumbs-item:not(:last-child)::after {
+    margin-inline: 0.25rem;
+  }
   .content h1 {
     font-size: 1.5rem;
   }

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -1925,6 +1925,9 @@ a:hover {
   .content {
     padding: 0;
   }
+  .ox-breadcrumbs-item:not(:last-child)::after {
+    margin-inline: 0.25rem;
+  }
   .content h1 {
     font-size: 1.5rem;
   }

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -1925,6 +1925,9 @@ a:hover {
   .content {
     padding: 0;
   }
+  .ox-breadcrumbs-item:not(:last-child)::after {
+    margin-inline: 0.25rem;
+  }
   .content h1 {
     font-size: 1.5rem;
   }

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -1925,6 +1925,9 @@ a:hover {
   .content {
     padding: 0;
   }
+  .ox-breadcrumbs-item:not(:last-child)::after {
+    margin-inline: 0.25rem;
+  }
   .content h1 {
     font-size: 1.5rem;
   }

--- a/crates/ox_content_ssg/src/ssg.css
+++ b/crates/ox_content_ssg/src/ssg.css
@@ -1907,6 +1907,9 @@ a:hover {
   .content {
     padding: 0;
   }
+  .ox-breadcrumbs-item:not(:last-child)::after {
+    margin-inline: 0.25rem;
+  }
   .content h1 {
     font-size: 1.5rem;
   }


### PR DESCRIPTION
## Summary
- reduce mobile breadcrumb separator gaps without changing desktop rhythm
- keep breadcrumbs on one line at narrow widths
- add a reader chrome regression test for the responsive spacing contract

## Validation
- cargo test -p ox_content_ssg
- cargo clippy -p ox_content_ssg --all-targets -- -D warnings
- browser QA at 390px and desktop widths

Closes #769

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790186080&installation_model_id=422833&pr_number=779&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F779&signature=5e4bb03369fa90e7c45737f65014004e2337aeda684b2ef815dd763e52a19252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->