### PR TITLE
fix(theme): make code copy an interaction icon

### DIFF
--- a/crates/ox_content_ssg/src/html/reader_chrome.css
+++ b/crates/ox_content_ssg/src/html/reader_chrome.css
@@ -1,13 +1,11 @@
 .ox-code {
-  --ox-copy-reserved-inline-size: 4.75rem;
+  --ox-copy-reserved-inline-size: 2.5rem;
   position: relative;
   margin: 1.25rem 0;
 }
 .content .ox-code > pre {
   margin: 0;
-}
-.content .ox-code > pre:not([data-code-title]) {
-  padding-block-start: 3rem;
+  padding-inline-end: calc(var(--ox-copy-reserved-inline-size) + 0.5rem);
 }
 .content .ox-code > pre[data-code-title]::before {
   padding-inline-end: var(--ox-copy-reserved-inline-size);
@@ -17,23 +15,65 @@
   inset-block-start: 0.5rem;
   inset-inline-end: 0.5rem;
   z-index: 1;
-  padding: 0.2rem 0.55rem;
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  place-items: center;
   border: 1px solid color-mix(in srgb, var(--octc-color-border) 80%, transparent);
   border-radius: 4px;
-  background: color-mix(in srgb, var(--octc-color-bg) 88%, transparent);
+  background: var(--octc-color-bg);
   color: var(--octc-color-text-muted);
-  font: inherit;
-  font-size: 0.75rem;
-  line-height: 1.4;
   cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+.ox-copy::before {
+  content: "";
+  width: 1rem;
+  height: 1rem;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><rect x='9' y='9' width='11' height='11' rx='2'/><path d='M15 9V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h3'/></svg>")
+    center / contain no-repeat;
+  mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><rect x='9' y='9' width='11' height='11' rx='2'/><path d='M15 9V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h3'/></svg>")
+    center / contain no-repeat;
 }
 .ox-copy:hover,
 .ox-copy:focus-visible {
   color: var(--octc-color-text);
   border-color: var(--octc-color-primary);
 }
-.ox-copy[data-copied] {
+.ox-copy[data-copy-state="copied"] {
   color: var(--octc-color-primary);
+}
+.ox-copy[data-copy-state="copied"]::before {
+  -webkit-mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'><path d='m5 12 4 4L19 6'/></svg>");
+  mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'><path d='m5 12 4 4L19 6'/></svg>");
+}
+.ox-copy[data-copy-state="failed"] {
+  color: var(--octc-color-code-line-error-border);
+}
+.ox-copy-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+@media (any-hover: hover) and (any-pointer: fine) {
+  .ox-copy {
+    opacity: 0;
+    pointer-events: none;
+  }
+  .ox-code:hover > .ox-copy,
+  .ox-code:focus-within > .ox-copy {
+    opacity: 1;
+    pointer-events: auto;
+  }
 }
 .ox-external {
   text-decoration-thickness: from-font;

--- a/crates/ox_content_ssg/src/html/reader_chrome.js
+++ b/crates/ox_content_ssg/src/html/reader_chrome.js
@@ -6,24 +6,45 @@
   if (reduced) root.classList.add("ox-reader-chrome--reduced-motion");
 
   if (root.hasAttribute("data-ox-copy")) {
+    const resetTimers = new WeakMap();
+    const setCopyState = (button, status, state) => {
+      const previousTimer = resetTimers.get(button);
+      if (previousTimer) clearTimeout(previousTimer);
+
+      const label =
+        state === "copied" ? "Copied" : state === "failed" ? "Copy failed" : "Copy code";
+      if (state) button.dataset.copyState = state;
+      else delete button.dataset.copyState;
+      button.setAttribute("aria-label", label);
+      button.setAttribute("title", label);
+      if (status) status.textContent = state ? label : "";
+
+      if (state) {
+        resetTimers.set(
+          button,
+          setTimeout(() => setCopyState(button, status, null), 1500),
+        );
+      } else {
+        resetTimers.delete(button);
+      }
+    };
+
     document.addEventListener("click", (event) => {
       const button =
         event.target instanceof Element ? event.target.closest("[data-ox-copy]") : null;
       if (!(button instanceof HTMLButtonElement)) return;
-      const pre = button.closest(".ox-code")?.querySelector("pre");
+      const container = button.closest(".ox-code");
+      const pre = container?.querySelector("pre");
+      const status = container?.querySelector("[data-ox-copy-status]");
       const text = pre ? pre.textContent || "" : "";
-      if (!navigator.clipboard?.writeText) return;
+      if (!navigator.clipboard?.writeText) {
+        setCopyState(button, status, "failed");
+        return;
+      }
       navigator.clipboard
         .writeText(text)
-        .then(() => {
-          button.dataset.copied = "true";
-          button.setAttribute("aria-label", "Copied");
-          setTimeout(() => {
-            delete button.dataset.copied;
-            button.setAttribute("aria-label", "Copy code");
-          }, 1500);
-        })
-        .catch(() => {});
+        .then(() => setCopyState(button, status, "copied"))
+        .catch(() => setCopyState(button, status, "failed"));
     });
   }
 

--- a/crates/ox_content_ssg/src/html/reader_chrome.rs
+++ b/crates/ox_content_ssg/src/html/reader_chrome.rs
@@ -40,9 +40,12 @@ impl ReaderChrome {
 
 pub(super) const READER_CHROME_CSS: &str = include_str!("reader_chrome.css");
 pub(super) const READER_CHROME_JS: &str = include_str!("reader_chrome.js");
-
-const COPY_BUTTON: &str =
-    "<button type=\"button\" class=\"ox-copy\" data-ox-copy aria-label=\"Copy code\">Copy</button>";
+const COPY_BUTTON: &str = concat!(
+    "<button type=\"button\" class=\"ox-copy\" data-ox-copy ",
+    "aria-label=\"Copy code\" title=\"Copy code\"></button>",
+    "<span class=\"ox-copy-status\" data-ox-copy-status role=\"status\" ",
+    "aria-live=\"polite\"></span>"
+);
 const EXTERNAL_ICON: &str = "<span class=\"ox-external-icon\" aria-hidden=\"true\"></span>";
 
 /// Rewrites article HTML. Fenced code is never treated as a link target.

--- a/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
+++ b/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
@@ -121,10 +121,17 @@ fn enabled_defaults_emit_copy_external_and_back_to_top() {
     assert!(html.contains(r#"<div class="ox-code">"#), "{html}");
     assert!(
         html.contains(
-            r#"<button type="button" class="ox-copy" data-ox-copy aria-label="Copy code">Copy</button>"#
+            r#"<button type="button" class="ox-copy" data-ox-copy aria-label="Copy code" title="Copy code"></button>"#
         ),
         "{html}"
     );
+    assert!(
+        html.contains(
+            r#"<span class="ox-copy-status" data-ox-copy-status role="status" aria-live="polite"></span>"#
+        ),
+        "{html}"
+    );
+    assert!(!html.contains(">Copy</button>"), "copy control must be icon-only: {html}");
     assert!(html.contains("<pre><code>curl https://example.com/api\n</code></pre>"), "{html}");
     assert!(
         !html.contains("data-ox-copy-text"),
@@ -144,7 +151,7 @@ fn enabled_defaults_emit_copy_external_and_back_to_top() {
 }
 
 #[test]
-fn copy_control_reserves_space_in_plain_and_titled_code_blocks() {
+fn copy_control_uses_inline_clearance_without_wasting_vertical_space() {
     assert!(
         READER_CHROME_CSS.contains("inset-block-start: 0.5rem;")
             && READER_CHROME_CSS.contains("inset-inline-end: 0.5rem;"),
@@ -152,15 +159,42 @@ fn copy_control_reserves_space_in_plain_and_titled_code_blocks() {
     );
     assert!(
         READER_CHROME_CSS.contains(
-            ".content .ox-code > pre:not([data-code-title]) {\n  padding-block-start: 3rem;"
+            ".content .ox-code > pre {\n  margin: 0;\n  padding-inline-end: calc(var(--ox-copy-reserved-inline-size) + 0.5rem);"
         ),
-        "plain code needs a toolbar strip above its first line: {READER_CHROME_CSS}"
+        "code only needs enough inline clearance for the icon: {READER_CHROME_CSS}"
+    );
+    assert!(
+        !READER_CHROME_CSS.contains("padding-block-start: 3rem"),
+        "copy must not push the first code line down: {READER_CHROME_CSS}"
     );
     assert!(
         READER_CHROME_CSS.contains(
             ".content .ox-code > pre[data-code-title]::before {\n  padding-inline-end: var(--ox-copy-reserved-inline-size);"
         ),
-        "a code title must reserve inline space for Copy and Copied: {READER_CHROME_CSS}"
+        "a code title must reserve inline space for the fixed-size icon: {READER_CHROME_CSS}"
+    );
+}
+
+#[test]
+fn copy_control_uses_capability_media_queries_and_stable_status_ui() {
+    assert!(
+        READER_CHROME_CSS.contains("(any-hover: hover) and (any-pointer: fine)"),
+        "hover reveal must be restricted to hover-capable devices: {READER_CHROME_CSS}"
+    );
+    assert!(
+        READER_CHROME_CSS.contains(".ox-code:focus-within > .ox-copy"),
+        "keyboard focus must reveal the control: {READER_CHROME_CSS}"
+    );
+    assert!(
+        READER_CHROME_CSS.contains(".ox-copy::before")
+            && READER_CHROME_CSS.contains(".ox-copy-status"),
+        "the control needs a visible icon and a non-visual status region: {READER_CHROME_CSS}"
+    );
+    assert!(
+        READER_CHROME_JS.contains("data-ox-copy-status")
+            && READER_CHROME_JS.contains("Copy failed")
+            && !READER_CHROME_JS.contains("textContent = \"Copy"),
+        "copy feedback must not replace the fixed-size icon: {READER_CHROME_JS}"
     );
 }
 
@@ -237,8 +271,8 @@ fn reduced_motion_class_and_css_are_present() {
     assert!(READER_CHROME_CSS.contains("prefers-reduced-motion"), "{READER_CHROME_CSS}");
     assert!(READER_CHROME_CSS.contains("ox-reader-chrome--reduced-motion"), "{READER_CHROME_CSS}");
     assert!(
-        !READER_CHROME_CSS.contains("box-shadow"),
-        "back-to-top must stay flat like the rest of the chrome: {READER_CHROME_CSS}"
+        !READER_CHROME_CSS.contains("box-shadow") && !READER_CHROME_CSS.contains("linear-gradient"),
+        "reader chrome must stay flat, without shadows or gradients: {READER_CHROME_CSS}"
     );
     assert!(html.contains("prefers-reduced-motion"), "{html}");
     assert!(html.contains("ox-reader-chrome--reduced-motion"), "{html}");


### PR DESCRIPTION
## Summary
- replace the text Copy control with a compact accessible icon
- reveal it on hover-capable fine-pointer devices while keeping it available on touch devices
- remove wasted top padding and reserve only the horizontal space needed to keep code readable
- announce copied and failed states without replacing button content
- keep the control flat, with no shadow or gradient

## Validation
- cargo test -p ox_content_ssg
- cargo clippy -p ox_content_ssg --all-targets -- -D warnings
- NAPI debug build
- focused reader-chrome interaction and CSS contract tests

Closes #775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the code-copy control as a compact icon button.
  * Added visual feedback for successful and failed copy attempts.
  * Improved keyboard and hover interactions for revealing the copy control.
  * Added accessible labels and live status updates for copy actions.

* **Bug Fixes**
  * Copy failures, including unsupported clipboard functionality, now provide clear feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->