### PR TITLE
fix(theme): keep default surfaces flat

### DIFF
--- a/crates/ox_content_ssg/src/html/header_chrome.css
+++ b/crates/ox_content_ssg/src/html/header_chrome.css
@@ -48,7 +48,6 @@
   background: var(--octc-color-bg);
   border: 1px solid var(--octc-color-border);
   border-radius: 6px;
-  box-shadow: 0 8px 24px color-mix(in srgb, var(--octc-color-text) 12%, transparent);
   z-index: 120;
 }
 .header-nav-dropdown > button[aria-expanded="true"] + .header-nav-menu {

--- a/crates/ox_content_ssg/src/html/tests.rs
+++ b/crates/ox_content_ssg/src/html/tests.rs
@@ -47,3 +47,20 @@ fn mobile_menu_script_keeps_state_and_focus_synchronized() {
         "only keyboard dismissal should force focus back to the opener"
     );
 }
+
+#[test]
+fn default_theme_surfaces_stay_flat() {
+    let default_css = [
+        super::SSG_CSS,
+        super::header_chrome::HEADER_CHROME_CSS,
+        super::reader_chrome::READER_CHROME_CSS,
+    ]
+    .join("\n");
+
+    for decorative_effect in ["box-shadow", "linear-gradient(", "radial-gradient("] {
+        assert!(
+            !default_css.contains(decorative_effect),
+            "default theme chrome must use flat surfaces instead of {decorative_effect}"
+        );
+    }
+}

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -297,7 +297,6 @@ a:hover {
   background: var(--octc-color-bg);
   border: 1px solid var(--octc-color-border);
   border-radius: 6px;
-  box-shadow: 0 8px 24px color-mix(in srgb, var(--octc-color-text) 12%, transparent);
   z-index: 120;
 }
 .ox-header-select > button[aria-expanded="true"] + .ox-header-select-menu {
@@ -425,7 +424,6 @@ a:hover {
   max-height: 70vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 24px 80px rgba(5, 8, 22, 0.32);
 }
 .search-header {
   display: flex;
@@ -1142,11 +1140,7 @@ a:hover {
   overflow-wrap: anywhere;
 }
 .content pre {
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 3.5rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
   color: var(--octc-color-code-text);
   padding: 1rem 1.25rem;
   border-radius: 4px;
@@ -1424,11 +1418,7 @@ a:hover {
   display: block;
   width: 100%;
   max-width: 100%;
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 2.75rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
   border: 1px solid var(--octc-color-code-frame-border) !important;
   padding: 0.55rem 0.7rem !important;
   border-radius: 4px !important;
@@ -1602,11 +1592,7 @@ a:hover {
   padding: 0.9rem 1rem;
   border: 1px solid var(--octc-color-code-frame-border);
   border-radius: 4px;
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 2.75rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
 }
 .content .ox-api-entry__section--signature pre code {
   font-size: 0.91rem;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -293,7 +293,6 @@ a:hover {
   background: var(--octc-color-bg);
   border: 1px solid var(--octc-color-border);
   border-radius: 6px;
-  box-shadow: 0 8px 24px color-mix(in srgb, var(--octc-color-text) 12%, transparent);
   z-index: 120;
 }
 .ox-header-select > button[aria-expanded="true"] + .ox-header-select-menu {
@@ -421,7 +420,6 @@ a:hover {
   max-height: 70vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 24px 80px rgba(5, 8, 22, 0.32);
 }
 .search-header {
   display: flex;
@@ -1138,11 +1136,7 @@ a:hover {
   overflow-wrap: anywhere;
 }
 .content pre {
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 3.5rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
   color: var(--octc-color-code-text);
   padding: 1rem 1.25rem;
   border-radius: 4px;
@@ -1420,11 +1414,7 @@ a:hover {
   display: block;
   width: 100%;
   max-width: 100%;
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 2.75rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
   border: 1px solid var(--octc-color-code-frame-border) !important;
   padding: 0.55rem 0.7rem !important;
   border-radius: 4px !important;
@@ -1598,11 +1588,7 @@ a:hover {
   padding: 0.9rem 1rem;
   border: 1px solid var(--octc-color-code-frame-border);
   border-radius: 4px;
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 2.75rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
 }
 .content .ox-api-entry__section--signature pre code {
   font-size: 0.91rem;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -293,7 +293,6 @@ a:hover {
   background: var(--octc-color-bg);
   border: 1px solid var(--octc-color-border);
   border-radius: 6px;
-  box-shadow: 0 8px 24px color-mix(in srgb, var(--octc-color-text) 12%, transparent);
   z-index: 120;
 }
 .ox-header-select > button[aria-expanded="true"] + .ox-header-select-menu {
@@ -421,7 +420,6 @@ a:hover {
   max-height: 70vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 24px 80px rgba(5, 8, 22, 0.32);
 }
 .search-header {
   display: flex;
@@ -1138,11 +1136,7 @@ a:hover {
   overflow-wrap: anywhere;
 }
 .content pre {
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 3.5rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
   color: var(--octc-color-code-text);
   padding: 1rem 1.25rem;
   border-radius: 4px;
@@ -1420,11 +1414,7 @@ a:hover {
   display: block;
   width: 100%;
   max-width: 100%;
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 2.75rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
   border: 1px solid var(--octc-color-code-frame-border) !important;
   padding: 0.55rem 0.7rem !important;
   border-radius: 4px !important;
@@ -1598,11 +1588,7 @@ a:hover {
   padding: 0.9rem 1rem;
   border: 1px solid var(--octc-color-code-frame-border);
   border-radius: 4px;
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 2.75rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
 }
 .content .ox-api-entry__section--signature pre code {
   font-size: 0.91rem;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -293,7 +293,6 @@ a:hover {
   background: var(--octc-color-bg);
   border: 1px solid var(--octc-color-border);
   border-radius: 6px;
-  box-shadow: 0 8px 24px color-mix(in srgb, var(--octc-color-text) 12%, transparent);
   z-index: 120;
 }
 .ox-header-select > button[aria-expanded="true"] + .ox-header-select-menu {
@@ -421,7 +420,6 @@ a:hover {
   max-height: 70vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 24px 80px rgba(5, 8, 22, 0.32);
 }
 .search-header {
   display: flex;
@@ -1138,11 +1136,7 @@ a:hover {
   overflow-wrap: anywhere;
 }
 .content pre {
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 3.5rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
   color: var(--octc-color-code-text);
   padding: 1rem 1.25rem;
   border-radius: 4px;
@@ -1420,11 +1414,7 @@ a:hover {
   display: block;
   width: 100%;
   max-width: 100%;
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 2.75rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
   border: 1px solid var(--octc-color-code-frame-border) !important;
   padding: 0.55rem 0.7rem !important;
   border-radius: 4px !important;
@@ -1598,11 +1588,7 @@ a:hover {
   padding: 0.9rem 1rem;
   border: 1px solid var(--octc-color-code-frame-border);
   border-radius: 4px;
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 2.75rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
 }
 .content .ox-api-entry__section--signature pre code {
   font-size: 0.91rem;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -293,7 +293,6 @@ a:hover {
   background: var(--octc-color-bg);
   border: 1px solid var(--octc-color-border);
   border-radius: 6px;
-  box-shadow: 0 8px 24px color-mix(in srgb, var(--octc-color-text) 12%, transparent);
   z-index: 120;
 }
 .ox-header-select > button[aria-expanded="true"] + .ox-header-select-menu {
@@ -421,7 +420,6 @@ a:hover {
   max-height: 70vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 24px 80px rgba(5, 8, 22, 0.32);
 }
 .search-header {
   display: flex;
@@ -1138,11 +1136,7 @@ a:hover {
   overflow-wrap: anywhere;
 }
 .content pre {
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 3.5rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
   color: var(--octc-color-code-text);
   padding: 1rem 1.25rem;
   border-radius: 4px;
@@ -1420,11 +1414,7 @@ a:hover {
   display: block;
   width: 100%;
   max-width: 100%;
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 2.75rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
   border: 1px solid var(--octc-color-code-frame-border) !important;
   padding: 0.55rem 0.7rem !important;
   border-radius: 4px !important;
@@ -1598,11 +1588,7 @@ a:hover {
   padding: 0.9rem 1rem;
   border: 1px solid var(--octc-color-code-frame-border);
   border-radius: 4px;
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 2.75rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
 }
 .content .ox-api-entry__section--signature pre code {
   font-size: 0.91rem;

--- a/crates/ox_content_ssg/src/ssg.css
+++ b/crates/ox_content_ssg/src/ssg.css
@@ -275,7 +275,6 @@ a:hover {
   background: var(--octc-color-bg);
   border: 1px solid var(--octc-color-border);
   border-radius: 6px;
-  box-shadow: 0 8px 24px color-mix(in srgb, var(--octc-color-text) 12%, transparent);
   z-index: 120;
 }
 .ox-header-select > button[aria-expanded="true"] + .ox-header-select-menu {
@@ -403,7 +402,6 @@ a:hover {
   max-height: 70vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 24px 80px rgba(5, 8, 22, 0.32);
 }
 .search-header {
   display: flex;
@@ -1120,11 +1118,7 @@ a:hover {
   overflow-wrap: anywhere;
 }
 .content pre {
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 3.5rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
   color: var(--octc-color-code-text);
   padding: 1rem 1.25rem;
   border-radius: 4px;
@@ -1402,11 +1396,7 @@ a:hover {
   display: block;
   width: 100%;
   max-width: 100%;
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 2.75rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
   border: 1px solid var(--octc-color-code-frame-border) !important;
   padding: 0.55rem 0.7rem !important;
   border-radius: 4px !important;
@@ -1580,11 +1570,7 @@ a:hover {
   padding: 0.9rem 1rem;
   border: 1px solid var(--octc-color-code-frame-border);
   border-radius: 4px;
-  background: linear-gradient(
-    180deg,
-    var(--octc-color-code-bg-top) 0,
-    var(--octc-color-code-bg) 2.75rem
-  ) !important;
+  background: var(--octc-color-code-bg) !important;
 }
 .content .ox-api-entry__section--signature pre code {
   font-size: 0.91rem;


### PR DESCRIPTION
## Summary
- remove decorative shadows from header menus, locale/version menus, and the search dialog
- replace code and API signature gradients with solid code surfaces
- preserve one-pixel borders and accessible focus indicators
- add a regression test that forbids shadows and gradients in the base and first-party chrome CSS
- refresh the generated SSG snapshots

## Validation
- cargo test -p ox_content_ssg (169 passed)
- cargo clippy -p ox_content_ssg --all-targets -- -D warnings
- cargo fmt --all -- --check

Closes #778