### PR TITLE
test(mdx): lock static rendering contract

### DIFF
--- a/crates/ox_content_renderer/src/html/tests/mdx.rs
+++ b/crates/ox_content_renderer/src/html/tests/mdx.rs
@@ -26,3 +26,18 @@ fn hostile_expression_does_not_emit_raw_markup() {
     assert!(!html.contains("<script"), "hostile source must not render as HTML:\n{html}");
     assert!(!html.contains("alert(1)"), "expression source is not evaluated or emitted:\n{html}");
 }
+
+#[test]
+fn esm_is_metadata_only_in_static_html() {
+    let html = render_mdx(
+        "import Chart from './Chart'\nexport const meta = { title: 'Report' }\n\n# Report\n",
+    );
+
+    assert!(!html.contains("import Chart"), "imports must not leak into HTML:\n{html}");
+    assert!(!html.contains("export const"), "exports must not leak into HTML:\n{html}");
+    assert!(!html.contains("<script"), "ESM must not become executable HTML:\n{html}");
+    assert!(
+        html.contains("<h1 id=\"report\">Report</h1>"),
+        "markdown after ESM must still render:\n{html}"
+    );
+}


### PR DESCRIPTION
## Summary

- Lock the static MDX rendering contract delivered across #741, #744, and #745.
- Assert that module imports and exports stay metadata-only, emit no executable HTML, and do not suppress following Markdown.
- Preserve the final safe fallback: prose expressions are silent, component props are non-executing XSS-safe JSON, fragments render children, and lowercase HTML continues through the normal sanitize and link-rewrite path.

Closes #656.

## Test plan

- [x] cargo test -p ox_content_renderer
- [x] cargo clippy -p ox_content_renderer --all-targets -- -D warnings
- [x] cargo fmt --all -- --check
- [x] git diff --check
- [ ] Required GitHub Actions checks are green

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790193370&installation_model_id=422833&pr_number=786&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F786&signature=56c555bcf7f4b9102686ce9434475eff992968adfe6bf1b26d0f3d7fc340efd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->