### PR TITLE
docs(mdx): add built-in MDX example and clarify defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 - **Blazing Fast** - Arena-allocated parser with zero-copy parsing
 - **mdast Compatible** - Run custom mdast plugins and existing remark/unified transforms
-- **MDX-ready Files** - Process `.mdx` alongside Markdown in Vite, SSG, and framework integrations
+- **Built-in MDX** - `.mdx` files parse JSX, ESM, and `{expression}` by default; `.md` stays GFM. Static HTML plus optional component islands
 - **GFM Support** - Tables, task lists, strikethrough, autolinks, footnotes
 - **Multi-Runtime** - Node.js (NAPI), WebAssembly, Native Rust
 - **Framework Agnostic** - Works with Vue, React, Svelte, and more

--- a/docs/content/examples/index.md
+++ b/docs/content/examples/index.md
@@ -163,6 +163,13 @@ Interactive web playground for testing Markdown parsing.
 
 Static Site Generation example using Vite.
 
+### [Built-in MDX](./mdx.md)
+
+Default-on MDX for `.mdx` files: static HTML, island placeholders, ESM that
+is not executed, and `{expression}` that is not evaluated. A sibling `.md`
+file stays GFM. Runnable app:
+[`examples/mdx`](https://github.com/ubugeeei-prod/ox-content/tree/main/examples/mdx).
+
 ## Running Examples
 
 ```bash

--- a/docs/content/examples/mdx.md
+++ b/docs/content/examples/mdx.md
@@ -22,11 +22,11 @@ corepack pnpm --filter ./examples/mdx build
 
 ## What the pages show
 
-| File | Shows |
-| ---- | ----- |
-| `src/content/index.mdx` | Lowercase tags as static HTML, PascalCase `data-ox-island`, ESM omitted, `{expression}` not evaluated |
-| `src/content/islands.mdx` | Static HTML vs island placeholders without a framework plugin |
-| `src/content/plain.md` | Sibling `.md` that does **not** parse JSX |
+| File                      | Shows                                                                                                 |
+| ------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `src/content/index.mdx`   | Lowercase tags as static HTML, PascalCase `data-ox-island`, ESM omitted, `{expression}` not evaluated |
+| `src/content/islands.mdx` | Static HTML vs island placeholders without a framework plugin                                         |
+| `src/content/plain.md`    | Sibling `.md` that does **not** parse JSX                                                             |
 
 There is no React / Vue / Svelte / Solid plugin. Named components stay
 `data-ox-island` placeholders. `import` / `export` do not appear in the HTML

--- a/docs/content/examples/mdx.md
+++ b/docs/content/examples/mdx.md
@@ -1,0 +1,35 @@
+---
+title: Built-in MDX
+description: Default-on MDX for .mdx files, with a runnable Vite SSG example.
+---
+
+# Built-in MDX
+
+A copy-paste Vite app lives at
+[`examples/mdx`](https://github.com/ubugeeei-prod/ox-content/tree/main/examples/mdx)
+in the repository.
+
+This example does **not** set `mdx: true`. `.mdx` files parse JSX, ESM, and
+`{expression}` by default. A sibling `.md` file stays CommonMark + GFM.
+
+## Run it
+
+```bash
+corepack pnpm --filter ./examples/mdx dev
+corepack pnpm --filter ./examples/mdx typecheck
+corepack pnpm --filter ./examples/mdx build
+```
+
+## What the pages show
+
+| File | Shows |
+| ---- | ----- |
+| `src/content/index.mdx` | Lowercase tags as static HTML, PascalCase `data-ox-island`, ESM omitted, `{expression}` not evaluated |
+| `src/content/islands.mdx` | Static HTML vs island placeholders without a framework plugin |
+| `src/content/plain.md` | Sibling `.md` that does **not** parse JSX |
+
+There is no React / Vue / Svelte / Solid plugin. Named components stay
+`data-ox-island` placeholders. `import` / `export` do not appear in the HTML
+and are not executed.
+
+See [MDX & Components](../mdx.md) for the language reference.

--- a/docs/content/ja/examples/index.md
+++ b/docs/content/ja/examples/index.md
@@ -163,6 +163,14 @@ Markdown パースを試す対話的な Web プレイグラウンドです。
 
 Vite を使った静的サイト生成の例です。
 
+### [組み込み MDX](/examples/mdx.md)
+
+`.mdx` では MDX が既定でオンです。静的 HTML、island プレースホルダー、
+実行されない ESM、評価されない `{expression}` を示します。隣の `.md` は
+GFM のままです。実行可能なアプリは
+[`examples/mdx`](https://github.com/ubugeeei-prod/ox-content/tree/main/examples/mdx)
+です。
+
 ## 事例を動かす
 
 ```bash

--- a/docs/content/ja/mdx.md
+++ b/docs/content/ja/mdx.md
@@ -32,10 +32,10 @@ Ox Content では、Markdown と `.mdx` ファイルの中にフレームワー�
 
 `mdx` を省略すると、Ox Content はソースの拡張子から推論します。
 
-| ソース | 既定 | `mdx: true` | `mdx: false` |
-| ------ | ---- | ----------- | ------------ |
-| `.mdx` | MDX オン（JSX、ESM、`{expression}`） | MDX オン | CommonMark + GFM |
-| `.md` / `.markdown` | CommonMark + GFM | MDX オン | CommonMark + GFM |
+| ソース              | 既定                                 | `mdx: true` | `mdx: false`     |
+| ------------------- | ------------------------------------ | ----------- | ---------------- |
+| `.mdx`              | MDX オン（JSX、ESM、`{expression}`） | MDX オン    | CommonMark + GFM |
+| `.md` / `.markdown` | CommonMark + GFM                     | MDX オン    | CommonMark + GFM |
 
 `.mdx` に `mdx: true` は**不要**です。`.md` でも同じ構文を使いたいときだけ
 `mdx: true` / `ParserOptions.mdx` を付けます。`.mdx` をプレーンな

--- a/docs/content/ja/mdx.md
+++ b/docs/content/ja/mdx.md
@@ -9,8 +9,9 @@ Ox Content では、Markdown と `.mdx` ファイルの中にフレームワー�
 動き方を理解しておく価値があります。いわゆる「クラシック」な MDX とは違います。
 
 - **JSX 要素、モジュールレベルの `import` / `export`、本文の `{expression}` は、
-  MDX が有効なときにパースされます。** `mdx: true` /
-  `ParserOptions.mdx` があると、Rust パーサーは PascalCase とメンバー名の
+  MDX が有効なときにパースされます。** `.mdx` ではそれが既定です。
+  `mdx: true` / `ParserOptions.mdx` を付けると、設定したすべての拡張子で
+  同じ経路を有効にできます。Rust パーサーは PascalCase とメンバー名の
   タグを `MdxJsxFlowElement` / `MdxJsxTextElement` ノードにします（自己閉じ
   または開閉、リテラル、真偽、`{expr}`、spread 属性付き）。
   ファイルレベルの `import` / `export` は `MdxjsEsm` ノードになり、
@@ -26,6 +27,39 @@ Ox Content では、Markdown と `.mdx` ファイルの中にフレームワー�
 
 そのため、本文は Markdown の速さのまま、必要なところだけ本物の対話コンポーネントを置けます。
 コンポーネントのないページには JavaScript バンドルを出しません。
+
+## 既定
+
+`mdx` を省略すると、Ox Content はソースの拡張子から推論します。
+
+| ソース | 既定 | `mdx: true` | `mdx: false` |
+| ------ | ---- | ----------- | ------------ |
+| `.mdx` | MDX オン（JSX、ESM、`{expression}`） | MDX オン | CommonMark + GFM |
+| `.md` / `.markdown` | CommonMark + GFM | MDX オン | CommonMark + GFM |
+
+`.mdx` に `mdx: true` は**不要**です。`.md` でも同じ構文を使いたいときだけ
+`mdx: true` / `ParserOptions.mdx` を付けます。`.mdx` をプレーンな
+Markdown 経路のままにするなら `mdx: false` です。
+
+## 静的 HTML と island
+
+フレームワークプラグインが無いとき、HTML レンダラーは静的経路のままです。
+
+- **小文字 / カスタム HTML タグ**（`<div>`、`<note>`）は HTML のままです。
+  island にはなりません。
+- **PascalCase / メンバー名のタグ**（`<NoteCard />`、`<Icons.Star />`）は
+  `data-ox-island` プレースホルダーになります。props は直列化されます。
+  React / Vue / Svelte / Solid プラグインが無いあいだはハイドレートしません。
+- **モジュールレベルの `import` / `export`** は `MdxjsEsm` ノードになります。
+  HTML には**出ません**し、**実行もされません**。
+- **本文の `{expression}`** は AST ソースとして保存され、**評価されません**。
+  静的 HTML レンダラーはいまのところこれらのノードには何も出しません。
+  ソースはテキストとしても JavaScript としても漏れません。
+
+本物の `.mdx` ページがある、実行可能な Vite + `@ox-content/vite-plugin`
+サイトは
+[`examples/mdx`](https://github.com/ubugeeei-prod/ox-content/tree/main/examples/mdx)
+です。
 
 ## セットアップ
 
@@ -203,6 +237,7 @@ React はなく、オプトインする開発専用の振る舞いもありま�
 
 ## 関連
 
+- [組み込み MDX の例](/examples/mdx.md)
 - [React 連携](/packages/vite-plugin-ox-content-react.md)
 - [Vue 連携](/packages/vite-plugin-ox-content-vue.md)
 - [Svelte 連携](/packages/vite-plugin-ox-content-svelte.md)

--- a/docs/content/mdx.md
+++ b/docs/content/mdx.md
@@ -33,10 +33,10 @@ need them — without shipping a JavaScript bundle for pages that have none.
 
 When `mdx` is omitted, Ox Content infers it from the source extension:
 
-| Source | Default | `mdx: true` | `mdx: false` |
-| ------ | ------- | ----------- | ------------ |
-| `.mdx` | MDX on (JSX, ESM, `{expression}`) | MDX on | CommonMark + GFM |
-| `.md` / `.markdown` | CommonMark + GFM | MDX on | CommonMark + GFM |
+| Source              | Default                           | `mdx: true` | `mdx: false`     |
+| ------------------- | --------------------------------- | ----------- | ---------------- |
+| `.mdx`              | MDX on (JSX, ESM, `{expression}`) | MDX on      | CommonMark + GFM |
+| `.md` / `.markdown` | CommonMark + GFM                  | MDX on      | CommonMark + GFM |
 
 You do **not** need `mdx: true` for `.mdx` files. Set `mdx: true` /
 `ParserOptions.mdx` only when you want the same syntax in `.md` files.

--- a/docs/content/mdx.md
+++ b/docs/content/mdx.md
@@ -9,15 +9,17 @@ Ox Content lets you embed framework components inside Markdown and `.mdx` files.
 It is worth understanding how this works, because it differs from "classic" MDX:
 
 - **JSX elements, module-level `import` / `export`, and prose
-  `{expression}` parse when MDX is enabled.** With `mdx: true` /
-  `ParserOptions.mdx`, the Rust parser turns PascalCase and member-name
-  tags into `MdxJsxFlowElement` / `MdxJsxTextElement` nodes (self-closing
-  or open/close, with literal, boolean, `{expr}`, and spread attributes),
-  turns file-level `import` / `export` into `MdxjsEsm` nodes, and turns
-  document-level `{foo}` / `Hello {name}` into `MdxFlowExpression` /
-  `MdxTextExpression`. Fragments (`<>...</>`), JSX comments, and
-  `{expression}` children are stored as AST source. Nothing is evaluated.
-  `.md` stays CommonMark + GFM unless that option is on.
+  `{expression}` parse when MDX is enabled.** That is the default for
+  `.mdx` files. With `mdx: true` / `ParserOptions.mdx`, you can enable
+  the same path for every configured extension. The Rust parser turns
+  PascalCase and member-name tags into `MdxJsxFlowElement` /
+  `MdxJsxTextElement` nodes (self-closing or open/close, with literal,
+  boolean, `{expr}`, and spread attributes), turns file-level `import` /
+  `export` into `MdxjsEsm` nodes, and turns document-level `{foo}` /
+  `Hello {name}` into `MdxFlowExpression` / `MdxTextExpression`.
+  Fragments (`<>...</>`), JSX comments, and `{expression}` children are
+  stored as AST source. Nothing is evaluated. `.md` stays CommonMark +
+  GFM unless that option is on.
 - **Components are resolved by a framework plugin**, not the renderer. The
   HTML renderer turns named MDX JSX into island placeholders and
   serializes props (literals as JSON, `{expression}` / spreads as source).
@@ -26,6 +28,37 @@ It is worth understanding how this works, because it differs from "classic" MDX:
 
 So you get Markdown's speed for prose plus real interactive components where you
 need them — without shipping a JavaScript bundle for pages that have none.
+
+## Defaults
+
+When `mdx` is omitted, Ox Content infers it from the source extension:
+
+| Source | Default | `mdx: true` | `mdx: false` |
+| ------ | ------- | ----------- | ------------ |
+| `.mdx` | MDX on (JSX, ESM, `{expression}`) | MDX on | CommonMark + GFM |
+| `.md` / `.markdown` | CommonMark + GFM | MDX on | CommonMark + GFM |
+
+You do **not** need `mdx: true` for `.mdx` files. Set `mdx: true` /
+`ParserOptions.mdx` only when you want the same syntax in `.md` files.
+Set `mdx: false` to keep `.mdx` on the plain Markdown path.
+
+## Static HTML vs islands
+
+Without a framework plugin, the HTML renderer stays on the static path:
+
+- **Lowercase / custom HTML tags** (`<div>`, `<note>`) stay HTML. They are
+  not islands.
+- **PascalCase / member-name tags** (`<NoteCard />`, `<Icons.Star />`)
+  become `data-ox-island` placeholders. Props are serialized; nothing is
+  hydrated until a React / Vue / Svelte / Solid plugin is present.
+- **Module-level `import` / `export`** become `MdxjsEsm` nodes. They do
+  **not** appear in the HTML and are **not** executed.
+- **Prose `{expression}`** is stored as AST source and is **not**
+  evaluated. The static HTML renderer currently emits nothing for those
+  nodes — the source is not leaked as text or as JavaScript.
+
+A runnable Vite + `@ox-content/vite-plugin` site with real `.mdx` pages is
+[`examples/mdx`](https://github.com/ubugeeei-prod/ox-content/tree/main/examples/mdx).
 
 ## Setup
 
@@ -211,6 +244,7 @@ See [Theming](./theming.md) for using it to build a custom layout.
 
 ## See also
 
+- [Built-in MDX example](./examples/mdx.md)
 - [React Integration](./packages/vite-plugin-ox-content-react.md)
 - [Vue Integration](./packages/vite-plugin-ox-content-vue.md)
 - [Svelte Integration](./packages/vite-plugin-ox-content-svelte.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,15 +19,15 @@ This directory contains runnable projects and small source examples.
 
 ## Site and Tooling
 
-| Example                                      | Description               | Shows                                |
-| -------------------------------------------- | ------------------------- | ------------------------------------ |
-| [playground](./playground)                   | Browser playground        | Live Markdown preview                |
-| [code-play](./code-play)                     | `@ox-content/code-play`   | On-demand sample run / type-check    |
-| [ssg-vite](./ssg-vite)                       | Vite static site          | SSG output and generated routes      |
+| Example                                      | Description               | Shows                                 |
+| -------------------------------------------- | ------------------------- | ------------------------------------- |
+| [playground](./playground)                   | Browser playground        | Live Markdown preview                 |
+| [code-play](./code-play)                     | `@ox-content/code-play`   | On-demand sample run / type-check     |
+| [ssg-vite](./ssg-vite)                       | Vite static site          | SSG output and generated routes       |
 | [mdx](./mdx)                                 | Built-in MDX              | `.mdx` JSX, islands, ESM, expressions |
-| [gen-source-docs](./gen-source-docs)         | Source documentation      | API docs generated from TypeScript   |
-| [og-image-custom](./og-image-custom)         | Custom OG image templates | React, Svelte, Vue, and TS templates |
-| [incremental-html-js](./incremental-html-js) | Incremental rendering     | Plain Node.js, HTML, CSS, and SSE    |
+| [gen-source-docs](./gen-source-docs)         | Source documentation      | API docs generated from TypeScript    |
+| [og-image-custom](./og-image-custom)         | Custom OG image templates | React, Svelte, Vue, and TS templates  |
+| [incremental-html-js](./incremental-html-js) | Incremental rendering     | Plain Node.js, HTML, CSS, and SSE     |
 
 ## Parser and Pipeline Plugins
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,7 @@ This directory contains runnable projects and small source examples.
 | [playground](./playground)                   | Browser playground        | Live Markdown preview                |
 | [code-play](./code-play)                     | `@ox-content/code-play`   | On-demand sample run / type-check    |
 | [ssg-vite](./ssg-vite)                       | Vite static site          | SSG output and generated routes      |
+| [mdx](./mdx)                                 | Built-in MDX              | `.mdx` JSX, islands, ESM, expressions |
 | [gen-source-docs](./gen-source-docs)         | Source documentation      | API docs generated from TypeScript   |
 | [og-image-custom](./og-image-custom)         | Custom OG image templates | React, Svelte, Vue, and TS templates |
 | [incremental-html-js](./incremental-html-js) | Incremental rendering     | Plain Node.js, HTML, CSS, and SSE    |
@@ -49,6 +50,7 @@ Most examples are workspace packages. Run them from the repository root:
 ```bash
 corepack pnpm --filter ./examples/integ-vue dev
 corepack pnpm --filter ./examples/ssg-vite build
+corepack pnpm --filter ./examples/mdx dev
 corepack pnpm --filter ./examples/plugin-markdown-it start
 ```
 

--- a/examples/mdx/README.md
+++ b/examples/mdx/README.md
@@ -1,0 +1,33 @@
+# Built-in MDX example
+
+Vite + `@ox-content/vite-plugin` SSG app with real `.mdx` pages.
+
+`mdx` is omitted in `vite.config.ts` on purpose:
+
+- `.mdx` files parse JSX, module-level `import` / `export`, and `{expression}`
+- sibling `.md` files stay CommonMark + GFM
+- there is no framework plugin, so PascalCase tags stay static
+  `data-ox-island` placeholders
+
+From the repository root:
+
+```bash
+corepack pnpm --filter ./examples/mdx dev
+```
+
+```bash
+corepack pnpm --filter ./examples/mdx typecheck
+corepack pnpm --filter ./examples/mdx build
+corepack pnpm --filter ./examples/mdx preview
+```
+
+## Pages
+
+| File                     | Shows                                                                 |
+| ------------------------ | --------------------------------------------------------------------- |
+| `src/content/index.mdx`  | Static HTML, island placeholder, ESM omitted, expressions not evaluated |
+| `src/content/islands.mdx` | Lowercase tags as HTML vs PascalCase `data-ox-island`                  |
+| `src/content/plain.md`   | Sibling `.md` that does **not** parse JSX                             |
+
+After `build`, inspect `dist` for `data-ox-island="NoteCard"`, lowercase
+`<note>` markup, and the absence of `import` / `export` from the `.mdx` pages.

--- a/examples/mdx/README.md
+++ b/examples/mdx/README.md
@@ -23,11 +23,11 @@ corepack pnpm --filter ./examples/mdx preview
 
 ## Pages
 
-| File                     | Shows                                                                 |
-| ------------------------ | --------------------------------------------------------------------- |
-| `src/content/index.mdx`  | Static HTML, island placeholder, ESM omitted, expressions not evaluated |
-| `src/content/islands.mdx` | Lowercase tags as HTML vs PascalCase `data-ox-island`                  |
-| `src/content/plain.md`   | Sibling `.md` that does **not** parse JSX                             |
+| File                      | Shows                                                                   |
+| ------------------------- | ----------------------------------------------------------------------- |
+| `src/content/index.mdx`   | Static HTML, island placeholder, ESM omitted, expressions not evaluated |
+| `src/content/islands.mdx` | Lowercase tags as HTML vs PascalCase `data-ox-island`                   |
+| `src/content/plain.md`    | Sibling `.md` that does **not** parse JSX                               |
 
 After `build`, inspect `dist` for `data-ox-island="NoteCard"`, lowercase
 `<note>` markup, and the absence of `import` / `export` from the `.mdx` pages.

--- a/examples/mdx/index.html
+++ b/examples/mdx/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ox Content Built-in MDX Example</title>
+    <link rel="stylesheet" href="/src/style.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/mdx/package.json
+++ b/examples/mdx/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ox-content-mdx-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vp dev",
+    "build": "vp build",
+    "preview": "vp preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@ox-content/vite-plugin": "workspace:*",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
+  }
+}

--- a/examples/mdx/src/content/index.mdx
+++ b/examples/mdx/src/content/index.mdx
@@ -1,0 +1,54 @@
+---
+title: Built-in MDX
+description: Default-on MDX for .mdx files — static HTML, islands, ESM, and expressions
+---
+
+import NoteCard from './NoteCard'
+export const demo = true
+
+# Built-in MDX
+
+This page is a real `.mdx` file. MDX is **on by default** for this extension —
+`vite.config.ts` does not set `mdx: true`. Compare with the sibling
+[plain Markdown page](./plain.md), and see [static HTML vs islands](./islands.mdx)
+for a closer look at the generated markup.
+
+## Static HTML
+
+Lowercase and custom tags stay HTML. The `<note>` below is **not** an island:
+
+<note class="callout">
+This is static HTML from an unregistered lowercase tag.
+</note>
+
+## Island placeholder
+
+PascalCase tags become `data-ox-island` placeholders. This example has **no**
+framework plugin, so the island stays static HTML:
+
+<NoteCard title="Static island" count={3}></NoteCard>
+
+Inspect the generated markup for `class="ox-island"` and
+`data-ox-island="NoteCard"`. Props are serialized; nothing hydrates.
+
+## ESM is not executed
+
+The `import` / `export` at the top of this file are stored as `MdxjsEsm`.
+They do **not** appear in the HTML and are **not** run as JavaScript.
+
+## Expressions are not evaluated
+
+Hello {name}.
+
+{1 + 1}
+
+The `{name}` and `{1 + 1}` above are parsed as MDX expressions. They are
+**not** evaluated (you will not see `2`) and the static HTML renderer emits
+nothing for them — they do not become JavaScript. The source text of those
+expressions is omitted from the HTML rather than interpolated.
+
+```mdx
+Hello {name}.
+
+{1 + 1}
+```

--- a/examples/mdx/src/content/index.mdx
+++ b/examples/mdx/src/content/index.mdx
@@ -3,8 +3,8 @@ title: Built-in MDX
 description: Default-on MDX for .mdx files — static HTML, islands, ESM, and expressions
 ---
 
-import NoteCard from './NoteCard'
-export const demo = true
+import NoteCard from "./NoteCard";
+export const demo = true;
 
 # Built-in MDX
 
@@ -17,9 +17,7 @@ for a closer look at the generated markup.
 
 Lowercase and custom tags stay HTML. The `<note>` below is **not** an island:
 
-<note class="callout">
-This is static HTML from an unregistered lowercase tag.
-</note>
+<note class="callout">This is static HTML from an unregistered lowercase tag.</note>
 
 ## Island placeholder
 

--- a/examples/mdx/src/content/islands.mdx
+++ b/examples/mdx/src/content/islands.mdx
@@ -1,0 +1,29 @@
+---
+title: Static HTML vs islands
+description: Lowercase tags stay HTML; PascalCase tags become data-ox-island
+---
+
+# Static HTML vs islands
+
+This second `.mdx` page shows the two JSX paths without a framework plugin.
+
+## Unregistered lowercase tags
+
+A custom `<note>` and a normal `<div>` render as HTML:
+
+<note>custom lowercase tag</note>
+
+<div class="static-html">ordinary HTML div</div>
+
+## PascalCase becomes an island
+
+<NoteCard label="no hydrate"></NoteCard>
+
+There is no React / Vue / Svelte / Solid plugin in this example. The
+placeholder is still emitted so you can read `data-ox-island="NoteCard"` in
+the HTML. Hydration is a later step.
+
+## Back
+
+- [Built-in MDX](./index.mdx)
+- [Plain Markdown](./plain.md)

--- a/examples/mdx/src/content/plain.md
+++ b/examples/mdx/src/content/plain.md
@@ -1,0 +1,23 @@
+---
+title: Plain Markdown
+description: Sibling .md stays GFM — JSX, ESM, and expressions are not parsed
+---
+
+# Plain Markdown
+
+This sibling `.md` file stays CommonMark + GFM. MDX is **off** unless you set
+`mdx: true`. The following lines are **not** JSX, ESM, or expressions.
+
+<NoteCard title="not an island"></NoteCard>
+
+Hello {name}.
+
+import Chart from './Chart.js'
+
+You should **not** see `data-ox-island` on this page. `{name}` stays visible
+as source text, and the `import` line is ordinary prose.
+
+## Contrast
+
+- [Built-in MDX (`.mdx`)](./index.mdx)
+- [Static HTML vs islands](./islands.mdx)

--- a/examples/mdx/src/main.ts
+++ b/examples/mdx/src/main.ts
@@ -1,0 +1,58 @@
+/**
+ * Built-in MDX example — import `.mdx` and a sibling `.md` file.
+ */
+
+import mdx from "./content/index.mdx";
+import plain from "./content/plain.md";
+
+function tocList(entries: OxContentTocEntry[]): string {
+  return entries
+    .map(
+      (entry) => `
+        <li>
+          <a href="#${entry.slug}">${entry.text}</a>
+          ${entry.children.length > 0 ? `<ul>${tocList(entry.children)}</ul>` : ""}
+        </li>
+      `,
+    )
+    .join("");
+}
+
+function escapeHtml(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+const app = document.getElementById("app");
+if (app) {
+  app.innerHTML = `
+    <nav class="toc">
+      <h2>On this page</h2>
+      <ul>${tocList(mdx.toc)}</ul>
+      <p class="toc-note">Also see the sibling <a href="#plain-markdown">.md contrast</a>.</p>
+    </nav>
+    <div class="pages">
+      <main class="content">
+        ${mdx.html}
+        <section class="html-dump">
+          <h2>Generated HTML from <code>index.mdx</code></h2>
+          <p>
+            Look for <code>data-ox-island="NoteCard"</code>, the lowercase
+            <code>&lt;note&gt;</code> markup, and the absence of
+            <code>import</code> / <code>export</code> and <code>{name}</code>.
+          </p>
+          <pre><code>${escapeHtml(mdx.html)}</code></pre>
+        </section>
+        <section class="content" id="plain-markdown">
+          ${plain.html}
+        </section>
+      </main>
+    </div>
+  `;
+}
+
+if (import.meta.hot) {
+  import.meta.hot.on("ox-content:update", (data) => {
+    console.log("Content updated:", data.file);
+    import.meta.hot?.invalidate();
+  });
+}

--- a/examples/mdx/src/style.css
+++ b/examples/mdx/src/style.css
@@ -1,0 +1,187 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #1a1a2e;
+  color: #eee;
+  min-height: 100vh;
+  line-height: 1.6;
+}
+
+#app {
+  display: grid;
+  grid-template-columns: 250px 1fr;
+  max-width: 1200px;
+  margin: 0 auto;
+  gap: 40px;
+  padding: 40px 20px;
+}
+
+.toc {
+  position: sticky;
+  top: 20px;
+  height: fit-content;
+}
+
+.toc h2 {
+  color: #e94560;
+  font-size: 1rem;
+  margin-bottom: 16px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.toc ul {
+  list-style: none;
+}
+
+.toc li {
+  margin: 8px 0;
+}
+
+.toc a {
+  color: #888;
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: color 0.2s;
+}
+
+.toc a:hover {
+  color: #e94560;
+}
+
+.toc ul ul {
+  margin-left: 16px;
+  margin-top: 4px;
+}
+
+.toc-note {
+  margin-top: 16px;
+  color: #888;
+  font-size: 0.85rem;
+}
+
+.content {
+  max-width: 800px;
+}
+
+.content h1 {
+  font-size: 2.5rem;
+  color: #e94560;
+  margin-bottom: 24px;
+  border-bottom: 2px solid #0f3460;
+  padding-bottom: 16px;
+}
+
+.content h2 {
+  font-size: 1.8rem;
+  color: #e94560;
+  margin-top: 48px;
+  margin-bottom: 16px;
+}
+
+.content h3 {
+  font-size: 1.4rem;
+  color: #e94560;
+  margin-top: 32px;
+  margin-bottom: 12px;
+}
+
+.content p {
+  margin-bottom: 16px;
+}
+
+.content code {
+  background: #0f3460;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-family: "Fira Code", "Consolas", monospace;
+  font-size: 0.9em;
+}
+
+.content pre {
+  background: #0f3460;
+  padding: 20px;
+  border-radius: 8px;
+  overflow-x: auto;
+  margin: 16px 0;
+}
+
+.content pre code {
+  background: transparent;
+  padding: 0;
+}
+
+.content a {
+  color: #e94560;
+  text-decoration: none;
+}
+
+.content a:hover {
+  text-decoration: underline;
+}
+
+.content ul,
+.content ol {
+  margin-left: 24px;
+  margin-bottom: 16px;
+}
+
+.content li {
+  margin-bottom: 8px;
+}
+
+.content strong {
+  color: #fff;
+}
+
+note {
+  display: block;
+  border: 1px solid #0f3460;
+  background: #16213e;
+  padding: 16px;
+  border-radius: 8px;
+  margin: 16px 0;
+}
+
+.ox-island {
+  border: 1px dashed #e94560;
+  border-radius: 8px;
+  padding: 16px;
+  margin: 16px 0;
+}
+
+.ox-island::before {
+  content: "island: " attr(data-ox-island);
+  display: block;
+  color: #e94560;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.html-dump {
+  margin-top: 48px;
+}
+
+.html-dump pre {
+  max-height: 320px;
+}
+
+@media (max-width: 768px) {
+  #app {
+    grid-template-columns: 1fr;
+  }
+
+  .toc {
+    position: static;
+    margin-bottom: 32px;
+    padding-bottom: 32px;
+    border-bottom: 1px solid #0f3460;
+  }
+}

--- a/examples/mdx/src/vite-env.d.ts
+++ b/examples/mdx/src/vite-env.d.ts
@@ -1,0 +1,30 @@
+/// <reference types="vite-plus/client" />
+
+type OxContentTocEntry = {
+  depth: number;
+  text: string;
+  slug: string;
+  children: OxContentTocEntry[];
+};
+
+type OxContentModule = {
+  html: string;
+  frontmatter: Record<string, unknown>;
+  toc: OxContentTocEntry[];
+};
+
+declare module "*.md" {
+  const content: OxContentModule;
+  export default content;
+  export const html: string;
+  export const frontmatter: Record<string, unknown>;
+  export const toc: OxContentModule["toc"];
+}
+
+declare module "*.mdx" {
+  const content: OxContentModule;
+  export default content;
+  export const html: string;
+  export const frontmatter: Record<string, unknown>;
+  export const toc: OxContentModule["toc"];
+}

--- a/examples/mdx/tsconfig.json
+++ b/examples/mdx/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/examples/mdx/vite.config.ts
+++ b/examples/mdx/vite.config.ts
@@ -1,0 +1,31 @@
+/**
+ * Built-in MDX example.
+ *
+ * `mdx` is omitted on purpose: `.mdx` files enable JSX / ESM / expressions
+ * by default, while sibling `.md` files stay CommonMark + GFM.
+ */
+
+import { defineConfig } from "vite-plus";
+import { oxContent } from "@ox-content/vite-plugin";
+
+export default defineConfig({
+  plugins: [
+    oxContent({
+      srcDir: "src/content",
+      outDir: "dist",
+      gfm: true,
+      tables: true,
+      taskLists: true,
+      strikethrough: true,
+      footnotes: true,
+      highlight: true,
+      toc: true,
+      tocMaxDepth: 3,
+      docs: false,
+    }),
+  ],
+  build: {
+    ssr: false,
+    outDir: "dist",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,6 +417,21 @@ importers:
         specifier: 'catalog:'
         version: 0.2.9(@types/node@26.2.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(jiti@1.21.7)(svelte@5.56.10)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)
 
+  examples/mdx:
+    devDependencies:
+      '@ox-content/vite-plugin':
+        specifier: workspace:*
+        version: link:../../npm/vite-plugin-ox-content
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite:
+        specifier: npm:@voidzero-dev/vite-plus-core@0.2.8
+        version: '@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)'
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.2.9(@types/node@26.2.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(jiti@1.21.7)(svelte@5.56.10)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)
+
   examples/og-image-custom:
     devDependencies:
       '@ox-content/vite-plugin':

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -259,6 +259,7 @@ export default defineConfig({
       "integ-solid": uncachedTask("vp run --filter ./examples/integ-solid dev"),
       "integ-svelte": uncachedTask("vp run --filter ./examples/integ-svelte dev"),
       "ssg-vite": uncachedTask("vp run --filter ./examples/ssg-vite dev"),
+      mdx: uncachedTask("vp run --filter ./examples/mdx dev"),
       "plugin-markdown-it": uncachedTask("vp run --filter ./examples/plugin-markdown-it start"),
       "plugin-rehype": uncachedTask("vp run --filter ./examples/plugin-rehype start"),
       "gen-source-docs": uncachedTask("vp run --filter ./examples/gen-source-docs dev"),


### PR DESCRIPTION
## Summary
- Document default-on MDX for `.mdx` (`.md` stays GFM), static HTML vs islands, and ESM / `{expression}` that are not executed in HTML — English and Japanese `mdx.md` stay section-for-section.
- Add runnable `examples/mdx` (Vite + `@ox-content/vite-plugin`) with real `.mdx` pages plus a sibling `.md` contrast.
- Link the example from the root README, `examples/README.md`, and the docs example catalogs.

Closes #661

Parent: #651

## Test plan
- [ ] `corepack pnpm --filter ./examples/mdx typecheck`
- [ ] `corepack pnpm --filter ./examples/mdx build`
- [ ] After build, `dist/index.html` / `dist/islands/index.html` contain `data-ox-island="NoteCard"` and lowercase `<note>` HTML, and do not contain the file-level `import` / `export`
- [ ] `dist/plain/index.html` has no `data-ox-island` and keeps `{name}` as source text
- [ ] Docs pages `/mdx/` and `/ja/mdx/` show the new Defaults / Static HTML vs islands sections


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790223820&installation_model_id=422833&pr_number=796&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F796&signature=88bb8ff5b1869c35d2957c1ea6944b4961ff572a2feaa989d651e181d46ee2ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->