### PR TITLE
fix: first slice of input-triggered panic hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,17 @@ jobs:
       - name: Check Rust formatting
         run: cargo fmt --all -- --check
 
+  panic-constructs:
+    name: Panic constructs
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Reject new production panic-prone constructs
+        run: node scripts/check-panic-constructs.mjs
+
   clippy:
     name: Clippy
     runs-on: blacksmith-32vcpu-ubuntu-2404

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,7 @@ cargo test --workspace
 cargo check --workspace --all-targets
 cargo clippy --workspace --all-targets -- -D warnings
 cargo fmt --all -- --check
+node scripts/check-panic-constructs.mjs
 ```
 
 ## Branches, Commits, and Pull Requests

--- a/config/panic-allowlist.json
+++ b/config/panic-allowlist.json
@@ -1,0 +1,54 @@
+{
+  "version": 1,
+  "description": "Reviewed production panic-prone constructs. New hits fail CI. Lower counts when a site is removed. Follow-up PRs for #774 should shrink this list.",
+  "entries": [
+    {
+      "file": "crates/ox_content_docs/src/graph/docs.rs",
+      "kind": "expect",
+      "count": 1,
+      "reason": "Internal docs-cache lookup after insert. Follow-up: return a typed error."
+    },
+    {
+      "file": "crates/ox_content_docs/src/string_builder.rs",
+      "kind": "expect",
+      "count": 2,
+      "reason": "ASCII digit buffer is written by this crate; UTF-8 is an internal invariant."
+    },
+    {
+      "file": "crates/ox_content_link_checker/src/site.rs",
+      "kind": "expect",
+      "count": 1,
+      "reason": "Generated-page index lookup after the walker inserted the file. Follow-up: Result."
+    },
+    {
+      "file": "crates/ox_content_lsp/src/frontmatter/schema.rs",
+      "kind": "expect",
+      "count": 1,
+      "reason": "Compile-time builtin JSON schema. Follow-up: include_str parse once with documented fallback."
+    },
+    {
+      "file": "crates/ox_content_profile_cli/src/markdown.rs",
+      "kind": "unreachable",
+      "count": 1,
+      "reason": "CLI dispatch exhaustiveness after command routing. Not a user-content path."
+    },
+    {
+      "file": "crates/ox_content_profiler/src/alloc/histogram.rs",
+      "kind": "expect",
+      "count": 1,
+      "reason": "ASCII digit buffer written by this crate; UTF-8 is an internal invariant."
+    },
+    {
+      "file": "crates/ox_content_profiler/src/report/format.rs",
+      "kind": "expect",
+      "count": 1,
+      "reason": "ASCII digit buffer written by this crate; UTF-8 is an internal invariant."
+    },
+    {
+      "file": "crates/ox_content_transform/src/youtube.rs",
+      "kind": "expect",
+      "count": 3,
+      "reason": "Compile-time Regex::new literals. Invalid patterns fail at startup, not on user HTML."
+    }
+  ]
+}

--- a/crates/ox_content_napi/src/collection_bindings.rs
+++ b/crates/ox_content_napi/src/collection_bindings.rs
@@ -219,7 +219,9 @@ fn get_transformed_file<'a>(
         cache.insert(file.path_key.clone(), transformed);
     }
 
-    Ok(cache.get(&file.path_key).expect("transformed file should be cached"))
+    cache.get(&file.path_key).ok_or_else(|| {
+        Error::from_reason(format!("transformed file missing from cache: {}", file.path_key))
+    })
 }
 
 fn collect_source_files(src_dir: &Path, extensions: &[String]) -> Vec<SourceFile> {

--- a/crates/ox_content_napi/src/ffi.rs
+++ b/crates/ox_content_napi/src/ffi.rs
@@ -1,0 +1,16 @@
+//! Helpers that keep unexpected Rust panics from crossing the N-API boundary.
+//!
+//! Release artifacts use `panic = "abort"`, so `catch_unwind` only helps debug
+//! and test builds. Public bindings must still avoid input-triggered panics.
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+pub const UNEXPECTED_PANIC: &str =
+    "internal error: unexpected panic in native binding; the host process stayed alive";
+
+pub fn recover<T>(op: impl FnOnce() -> T, on_panic: impl FnOnce() -> T) -> T {
+    match catch_unwind(AssertUnwindSafe(op)) {
+        Ok(value) => value,
+        Err(_) => on_panic(),
+    }
+}

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -3,11 +3,23 @@
 //! This crate provides NAPI bindings for using Ox Content from Node.js,
 //! including raw-buffer AST transfer for JavaScript interoperability.
 
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::todo,
+        clippy::unimplemented
+    )
+)]
+
 mod collection_bindings;
 mod docs_bindings;
 mod docs_graph_types;
 mod docs_markdown_types;
 mod docs_source_types;
+mod ffi;
 mod framework_codegen;
 mod highlight_bindings;
 mod i18n_bindings;

--- a/crates/ox_content_napi/src/parse_bindings.rs
+++ b/crates/ox_content_napi/src/parse_bindings.rs
@@ -107,12 +107,19 @@ pub struct JsSourceOptions {
 /// Returns the AST as a JSON string for compatibility-oriented JavaScript consumers.
 #[napi]
 pub fn parse(source: String, options: Option<JsParserOptions>) -> ParseResult {
-    let parser_options = options.map(ParserOptions::from).unwrap_or_default();
-
-    match render_scratch::parse_to_mdast_json(&source, parser_options) {
-        Ok(ast) => ParseResult { ast, errors: vec![] },
-        Err(error) => ParseResult { ast: String::new(), errors: vec![error] },
-    }
+    crate::ffi::recover(
+        || {
+            let parser_options = options.map(ParserOptions::from).unwrap_or_default();
+            match render_scratch::parse_to_mdast_json(&source, parser_options) {
+                Ok(ast) => ParseResult { ast, errors: vec![] },
+                Err(error) => ParseResult { ast: String::new(), errors: vec![error] },
+            }
+        },
+        || ParseResult {
+            ast: String::new(),
+            errors: vec![crate::ffi::UNEXPECTED_PANIC.to_string()],
+        },
+    )
 }
 
 /// Parses Markdown source into a raw mdast memory block for JavaScript-side deserialization.
@@ -157,12 +164,19 @@ pub fn parse_transfer_raw(
 /// Parses Markdown and renders to HTML.
 #[napi]
 pub fn parse_and_render(source: String, options: Option<JsParserOptions>) -> RenderResult {
-    let parser_options = options.map(ParserOptions::from).unwrap_or_default();
-
-    match render_scratch::parse_and_render_html(&source, parser_options) {
-        Ok(html) => RenderResult { html, errors: vec![] },
-        Err(error) => RenderResult { html: String::new(), errors: vec![error] },
-    }
+    crate::ffi::recover(
+        || {
+            let parser_options = options.map(ParserOptions::from).unwrap_or_default();
+            match render_scratch::parse_and_render_html(&source, parser_options) {
+                Ok(html) => RenderResult { html, errors: vec![] },
+                Err(error) => RenderResult { html: String::new(), errors: vec![error] },
+            }
+        },
+        || RenderResult {
+            html: String::new(),
+            errors: vec![crate::ffi::UNEXPECTED_PANIC.to_string()],
+        },
+    )
 }
 
 /// Renders an AST (provided as JSON) to HTML.

--- a/crates/ox_content_napi/src/tests/render_scratch.rs
+++ b/crates/ox_content_napi/src/tests/render_scratch.rs
@@ -74,3 +74,28 @@ fn the_ast_entry_point_shares_the_arena_safely() {
     assert!(html.contains("Other"), "unexpected html: {html}");
     assert_eq!(ast, ast_again, "the same source parsed differently after an interleaved render");
 }
+
+#[test]
+fn hostile_markdown_returns_errors_or_html_without_aborting() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    use crate::{parse, parse_and_render, transform};
+
+    let cases = ["", "*", &"> ".repeat(120), "---\n[broken\n---\n# Body", "\u{1F600}***"];
+    for source in cases {
+        let parse_outcome = catch_unwind(AssertUnwindSafe(|| parse(source.to_string(), None)));
+        let parsed = parse_outcome.unwrap_or_else(|_| panic!("parse aborted on {source:?}"));
+        assert!(
+            parsed.errors.is_empty() || !parsed.errors.is_empty(),
+            "parse should return a result object for {source:?}"
+        );
+
+        let render_outcome =
+            catch_unwind(AssertUnwindSafe(|| parse_and_render(source.to_string(), None)));
+        render_outcome.unwrap_or_else(|_| panic!("parse_and_render aborted on {source:?}"));
+
+        let transform_outcome =
+            catch_unwind(AssertUnwindSafe(|| transform(source.to_string(), None)));
+        transform_outcome.unwrap_or_else(|_| panic!("transform aborted on {source:?}"));
+    }
+}

--- a/crates/ox_content_napi/src/transform_bindings.rs
+++ b/crates/ox_content_napi/src/transform_bindings.rs
@@ -121,9 +121,19 @@ pub fn transform_pm_embeds(
 /// This is the main entry point for @ox-content/unplugin.
 #[napi]
 pub fn transform(source: String, options: Option<JsTransformOptions>) -> TransformResult {
-    let opts = options.unwrap_or_default();
-    let core_options = opts.into();
-    MarkdownTransformer::from_options(&core_options).transform(&source).into()
+    crate::ffi::recover(
+        || {
+            let opts = options.unwrap_or_default();
+            let core_options = opts.into();
+            MarkdownTransformer::from_options(&core_options).transform(&source).into()
+        },
+        || TransformResult {
+            html: String::new(),
+            frontmatter: "{}".to_string(),
+            toc: vec![],
+            errors: vec![crate::ffi::UNEXPECTED_PANIC.to_string()],
+        },
+    )
 }
 
 /// Sanitize an HTML string with safe defaults or an explicit allow-list.

--- a/crates/ox_content_parser/src/lib.rs
+++ b/crates/ox_content_parser/src/lib.rs
@@ -22,6 +22,16 @@
 //! ```
 
 #![deny(clippy::disallowed_macros, clippy::disallowed_methods, clippy::disallowed_types)]
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::todo,
+        clippy::unimplemented
+    )
+)]
 
 /// Lightweight RAII span guard used internally by the parser modules.
 ///

--- a/crates/ox_content_parser/src/parser.rs
+++ b/crates/ox_content_parser/src/parser.rs
@@ -103,7 +103,8 @@ pub struct ParserOptions {
 
     /// Maximum nesting depth for block elements.
     ///
-    /// Default: `0`; [`ParserOptions::gfm`] sets this to `100`.
+    /// `0` means unlimited. [`ParserOptions::gfm`] and [`ParserOptions::mdx`]
+    /// set this to `100`.
     pub max_nesting_depth: usize,
 }
 
@@ -215,7 +216,7 @@ impl<'a> Parser<'a> {
             source,
             options: self.options.clone(),
             position: 0,
-            nesting_depth: 0,
+            nesting_depth: self.nesting_depth,
             definitions: self.definitions.clone(),
             footnote_labels: self.footnote_labels.clone(),
             // Most sub-sources are entered without any lazy continuation

--- a/crates/ox_content_parser/src/parser/block.rs
+++ b/crates/ox_content_parser/src/parser/block.rs
@@ -15,8 +15,10 @@ impl<'a> Parser<'a> {
             return Ok(None);
         }
 
-        // Check nesting depth
-        if self.nesting_depth > self.options.max_nesting_depth {
+        // `max_nesting_depth == 0` means unlimited. Sub-parsers inherit depth,
+        // so a positive cap actually applies to quotes and list items.
+        if self.options.max_nesting_depth > 0 && self.nesting_depth > self.options.max_nesting_depth
+        {
             return Err(ParseError::NestingTooDeep {
                 span: Span::new(self.position as u32, self.position as u32),
                 max_depth: self.options.max_nesting_depth,

--- a/crates/ox_content_parser/src/parser/inline/emphasis.rs
+++ b/crates/ox_content_parser/src/parser/inline/emphasis.rs
@@ -136,14 +136,16 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            let opener_pos = delimiters
-                .iter()
-                .position(|d| d.node_index == opener_node)
-                .expect("opener survives retain");
-            let closer_pos = delimiters
-                .iter()
-                .position(|d| d.node_index == closer_node_now)
-                .expect("closer survives retain");
+            let Some(opener_pos) = delimiters.iter().position(|d| d.node_index == opener_node)
+            else {
+                closer_idx += 1;
+                continue;
+            };
+            let Some(closer_pos) = delimiters.iter().position(|d| d.node_index == closer_node_now)
+            else {
+                closer_idx += 1;
+                continue;
+            };
             delimiters[opener_pos].remaining -= use_delims as usize;
             delimiters[closer_pos].remaining -= use_delims as usize;
 

--- a/crates/ox_content_parser/src/parser/line_scan.rs
+++ b/crates/ox_content_parser/src/parser/line_scan.rs
@@ -105,8 +105,7 @@ fn line_end_swar(bytes: &[u8], from: usize) -> usize {
     let mut i = from;
 
     while i + 8 <= end {
-        // `unwrap` is unreachable: the slice is exactly 8 bytes wide.
-        let word = u64::from_le_bytes(bytes[i..i + 8].try_into().unwrap());
+        let word = u64::from_le_bytes(copy_eight(bytes, i));
         let mask = has_zero(word ^ NEWLINES);
         if mask != 0 {
             return i + (mask.trailing_zeros() / 8) as usize;
@@ -126,6 +125,13 @@ fn line_end_swar(bytes: &[u8], from: usize) -> usize {
 pub(in crate::parser) fn next_line_start(bytes: &[u8], from: usize) -> usize {
     let end = line_end(bytes, from);
     if end < bytes.len() { end + 1 } else { end }
+}
+
+#[inline]
+fn copy_eight(bytes: &[u8], from: usize) -> [u8; 8] {
+    let mut chunk = [0u8; 8];
+    chunk.copy_from_slice(&bytes[from..from + 8]);
+    chunk
 }
 
 #[cfg(test)]

--- a/crates/ox_content_parser/src/parser/list.rs
+++ b/crates/ox_content_parser/src/parser/list.rs
@@ -165,11 +165,9 @@ impl<'a> Parser<'a> {
                 // blank line, but its list may (`* a\n*\n\n* c`).
                 if next_indent >= content_indent && !(item_is_empty && item_source.is_none()) {
                     // Interior blank line(s): the item continues below.
-                    if item_source.is_none() {
-                        item_source =
-                            Some(self.init_list_item_source(item.content, consumed_newline));
-                    }
-                    let item_source = item_source.as_mut().expect("item source initialized");
+                    let item_source = item_source.get_or_insert_with(|| {
+                        self.init_list_item_source(item.content, consumed_newline)
+                    });
                     for _ in 0..blank_count {
                         item_source.push('\n');
                     }
@@ -198,10 +196,9 @@ impl<'a> Parser<'a> {
             let current_indent = self.calc_indentation(continuation_start);
             if current_indent >= content_indent {
                 // Indented continuation content.
-                if item_source.is_none() {
-                    item_source = Some(self.init_list_item_source(item.content, consumed_newline));
-                }
-                let item_source = item_source.as_mut().expect("item source initialized");
+                let item_source = item_source.get_or_insert_with(|| {
+                    self.init_list_item_source(item.content, consumed_newline)
+                });
                 Self::push_line_without_indent(item_source, continuation_line, content_indent);
                 item_source.push('\n');
                 self.position = continuation_next;
@@ -236,10 +233,8 @@ impl<'a> Parser<'a> {
             if item_is_empty || after_blank || self.line_starts_block() {
                 break;
             }
-            if item_source.is_none() {
-                item_source = Some(self.init_list_item_source(item.content, consumed_newline));
-            }
-            let source = item_source.as_mut().expect("item source initialized");
+            let source = item_source
+                .get_or_insert_with(|| self.init_list_item_source(item.content, consumed_newline));
             // Keep the lazy line's own indentation: the sub-parse then
             // treats it as paragraph continuation even when it looks like
             // an (over-indented) marker, e.g. `- e` five columns deep.

--- a/crates/ox_content_parser/tests/input_panics.rs
+++ b/crates/ox_content_parser/tests/input_panics.rs
@@ -1,0 +1,52 @@
+//! Hostile inputs must return `Result` errors or a document, never abort.
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use ox_content_allocator::Allocator;
+use ox_content_parser::{ParseError, Parser, ParserOptions};
+
+fn parse_or_err(source: &str, options: ParserOptions) -> Result<(), String> {
+    let allocator = Allocator::new();
+    Parser::with_options(&allocator, source, options)
+        .parse()
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+}
+
+#[test]
+fn malformed_markdown_does_not_abort() {
+    let options = ParserOptions::gfm();
+    let cases = [
+        "",
+        "*",
+        "**",
+        "[",
+        "](",
+        "![",
+        "`",
+        "```",
+        "|",
+        "> ",
+        "- \n- \n- ",
+        "<script>",
+        "\\",
+        "\u{1F600}***\u{3042}",
+        &"> ".repeat(8),
+        &format!("{}emphasis*", "*".repeat(32)),
+    ];
+
+    for source in cases {
+        let outcome = catch_unwind(AssertUnwindSafe(|| parse_or_err(source, options.clone())));
+        assert!(outcome.is_ok(), "parser aborted on {source:?}");
+    }
+}
+
+#[test]
+fn nesting_limit_returns_an_error_instead_of_aborting() {
+    let source = "> ".repeat(120) + "too deep";
+    let allocator = Allocator::new();
+    let error = Parser::with_options(&allocator, &source, ParserOptions::gfm())
+        .parse()
+        .expect_err("deeply nested quotes should fail closed");
+    assert!(matches!(error, ParseError::NestingTooDeep { max_depth: 100, .. }));
+}

--- a/crates/ox_content_renderer/src/frameworks.rs
+++ b/crates/ox_content_renderer/src/frameworks.rs
@@ -146,6 +146,9 @@ pub fn render_framework_component_code(
     target: FrameworkCodegenTarget,
     islands: &[FrameworkComponentIsland],
 ) -> String {
+    if target == FrameworkCodegenTarget::Svelte {
+        return svelte::escape_markup(html);
+    }
     let nodes = parser::HtmlFragmentParser::new(html).parse();
     render::FrameworkCodegen { target, islands }.render_root(&nodes)
 }

--- a/crates/ox_content_renderer/src/frameworks/parser.rs
+++ b/crates/ox_content_renderer/src/frameworks/parser.rs
@@ -274,7 +274,9 @@ fn close_element(root: &mut HtmlNodes, stack: &mut OpenElements, tag_name: &str)
     };
 
     while stack.len() > position {
-        let open = stack.pop().expect("stack length checked above");
+        let Some(open) = stack.pop() else {
+            break;
+        };
         append_node(root, stack, open.into_node());
     }
 }

--- a/crates/ox_content_renderer/src/frameworks/render.rs
+++ b/crates/ox_content_renderer/src/frameworks/render.rs
@@ -19,9 +19,7 @@ impl FrameworkCodegen<'_> {
         match self.target {
             FrameworkCodegenTarget::React => react::render_root(&children),
             FrameworkCodegenTarget::Solid => solid::render_root(&children),
-            FrameworkCodegenTarget::Svelte => {
-                unreachable!("svelte component output does not use the VDOM renderer")
-            }
+            FrameworkCodegenTarget::Svelte => String::new(),
             FrameworkCodegenTarget::Vue => vue::render_root(&children),
         }
     }
@@ -54,9 +52,7 @@ impl FrameworkCodegen<'_> {
         match self.target {
             FrameworkCodegenTarget::React => react::render_element(element, &children),
             FrameworkCodegenTarget::Solid => solid::render_element(element, &children),
-            FrameworkCodegenTarget::Svelte => {
-                unreachable!("svelte component output does not use the VDOM renderer")
-            }
+            FrameworkCodegenTarget::Svelte => String::new(),
             FrameworkCodegenTarget::Vue => vue::render_element(element, &children),
         }
     }
@@ -65,9 +61,7 @@ impl FrameworkCodegen<'_> {
         match self.target {
             FrameworkCodegenTarget::React => react::render_island(island),
             FrameworkCodegenTarget::Solid => solid::render_island(island),
-            FrameworkCodegenTarget::Svelte => {
-                unreachable!("svelte component output does not use the VDOM renderer")
-            }
+            FrameworkCodegenTarget::Svelte => String::new(),
             FrameworkCodegenTarget::Vue => vue::render_island(island),
         }
     }

--- a/crates/ox_content_renderer/src/frameworks/tests.rs
+++ b/crates/ox_content_renderer/src/frameworks/tests.rs
@@ -323,3 +323,23 @@ fn parses_solid_target_aliases() {
     }
     assert_eq!(FrameworkCodegenTarget::Solid.as_str(), "solid");
 }
+
+#[test]
+fn svelte_public_codegen_does_not_abort_on_user_html() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let html = "<p>{count}</p><script>alert(1)</script>";
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        render_framework_component_code(html, FrameworkCodegenTarget::Svelte, &[])
+    }));
+    let code = outcome.expect("svelte component codegen aborted");
+    assert!(code.contains("{count}") || code.contains("&#123;count&#125;") || !code.is_empty());
+
+    let result = render_framework_code(
+        html,
+        FrameworkCodegenTarget::Svelte,
+        FrameworkCodegenMode::Expression,
+        &[],
+    );
+    assert!(matches!(result, Err(FrameworkCodegenError::UnsupportedModeForTarget { .. })));
+}

--- a/crates/ox_content_renderer/src/html/escape.rs
+++ b/crates/ox_content_renderer/src/html/escape.rs
@@ -135,8 +135,7 @@ fn first_flagged(
     let mut i = from;
 
     while i + 8 <= len {
-        // `unwrap` is unreachable: the slice is exactly 8 bytes wide.
-        let word = u64::from_le_bytes(bytes[i..i + 8].try_into().unwrap());
+        let word = u64::from_le_bytes(copy_eight(bytes, i));
         let mask = mask_of(word);
         if mask != 0 {
             return i + first_flagged_lane(mask);
@@ -148,7 +147,7 @@ fn first_flagged(
         // `base < i` here: the loop above only stops with bytes left when
         // fewer than eight remain, so the re-read always overlaps.
         let base = len - 8;
-        let word = u64::from_le_bytes(bytes[base..len].try_into().unwrap());
+        let word = u64::from_le_bytes(copy_eight(bytes, base));
         let mut mask = mask_of(word) & (u64::MAX << ((i - base) * 8));
         while mask != 0 {
             let lane = base + first_flagged_lane(mask);
@@ -164,6 +163,13 @@ fn first_flagged(
         i += 1;
     }
     i
+}
+
+#[inline]
+fn copy_eight(bytes: &[u8], from: usize) -> [u8; 8] {
+    let mut chunk = [0u8; 8];
+    chunk.copy_from_slice(&bytes[from..from + 8]);
+    chunk
 }
 
 /// Appends `src` to `out`, copying short runs inline instead of handing them

--- a/crates/ox_content_renderer/src/html/renderer/write.rs
+++ b/crates/ox_content_renderer/src/html/renderer/write.rs
@@ -20,7 +20,7 @@ impl HtmlRenderer {
     }
 
     pub(in crate::html::renderer) fn write_display(&mut self, value: impl Display) {
-        write!(self.output, "{value}").expect("writing to String should not fail");
+        let _ = write!(self.output, "{value}");
     }
 
     pub(in crate::html::renderer) fn write_escaped(&mut self, s: &str) {

--- a/crates/ox_content_renderer/src/lib.rs
+++ b/crates/ox_content_renderer/src/lib.rs
@@ -21,6 +21,16 @@
 
 #![deny(clippy::disallowed_macros)]
 #![cfg_attr(test, allow(clippy::disallowed_macros))]
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::todo,
+        clippy::unimplemented
+    )
+)]
 
 /// Lightweight RAII span guard used internally by the renderer modules.
 ///

--- a/crates/ox_content_ssg/src/html/entry.rs
+++ b/crates/ox_content_ssg/src/html/entry.rs
@@ -24,8 +24,8 @@ fn convert_entry_link(link: &str, base: &str) -> String {
         return link.to_string();
     }
 
-    // Remove .md extension
-    let stem = path[..path.len() - 3].trim_start_matches('/');
+    // Remove a trailing `.md` without slicing through a multibyte character.
+    let stem = strip_ascii_suffix_ignore_case(path, b".md").unwrap_or(path).trim_start_matches('/');
 
     // Entry page is always index.md, so plain relative: getting-started.md -> {base}getting-started/index.html
     let converted = if stem == "index" || stem.ends_with("/index") {
@@ -178,6 +178,12 @@ fn render_icon(icon: &str, base: &str) -> String {
     icon.to_string()
 }
 
+fn strip_ascii_suffix_ignore_case<'a>(value: &'a str, suffix: &[u8]) -> Option<&'a str> {
+    let bytes = value.as_bytes();
+    let start = bytes.len().checked_sub(suffix.len())?;
+    bytes[start..].eq_ignore_ascii_case(suffix).then(|| &value[..start])
+}
+
 #[cfg(test)]
 mod tests {
     use super::{convert_entry_asset, convert_entry_link};
@@ -188,6 +194,11 @@ mod tests {
             convert_entry_link("/ja/getting-started.md", "/ox-content/"),
             "/ox-content/ja/getting-started/index.html"
         );
+        assert_eq!(
+            convert_entry_link("/ja/\u{3042}.md", "/ox-content/"),
+            "/ox-content/ja/\u{3042}/index.html"
+        );
+        assert_eq!(convert_entry_link("\u{1F600}", "/ox-content/"), "\u{1F600}");
     }
 
     #[test]

--- a/crates/ox_content_ssg/src/lib.rs
+++ b/crates/ox_content_ssg/src/lib.rs
@@ -63,6 +63,17 @@
 //! let html = generate_html(&page_data, &nav_groups, &config);
 //! ```
 
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::todo,
+        clippy::unimplemented
+    )
+)]
+
 mod assets;
 mod feeds;
 mod html;

--- a/crates/ox_content_ssg/src/routes/path.rs
+++ b/crates/ox_content_ssg/src/routes/path.rs
@@ -141,16 +141,19 @@ fn join_path(left: &str, right: &str) -> String {
 }
 
 pub(super) fn strip_markdown_extension(path: &str) -> String {
-    if path.len() >= 3 && path[path.len() - 3..].eq_ignore_ascii_case(".md") {
-        return path[..path.len() - 3].to_string();
-    }
-    if path.len() >= 4 && path[path.len() - 4..].eq_ignore_ascii_case(".mdx") {
-        return path[..path.len() - 4].to_string();
-    }
-    if path.len() >= 9 && path[path.len() - 9..].eq_ignore_ascii_case(".markdown") {
-        return path[..path.len() - 9].to_string();
+    for suffix in [b".markdown".as_slice(), b".mdx", b".md"] {
+        if let Some(stem) = strip_ascii_suffix_ignore_case(path, suffix) {
+            return stem.to_string();
+        }
     }
     path.to_string()
+}
+
+/// Byte-wise ASCII suffix compare so multibyte paths never slice mid-character.
+fn strip_ascii_suffix_ignore_case<'a>(path: &'a str, suffix: &[u8]) -> Option<&'a str> {
+    let bytes = path.as_bytes();
+    let start = bytes.len().checked_sub(suffix.len())?;
+    bytes[start..].eq_ignore_ascii_case(suffix).then(|| &path[..start])
 }
 
 fn replace_markdown_extension(path: &str, extension: &str) -> String {
@@ -197,5 +200,20 @@ mod tests {
             ),
             "https://example.com/base/guide/og-image.png"
         );
+    }
+
+    #[test]
+    fn multibyte_paths_do_not_panic_and_keep_non_markdown_stems() {
+        let root = "/repo/docs";
+        let emoji = "/repo/docs/\u{1F600}";
+        let japanese = "/repo/docs/\u{3042}.md";
+        let mixed = "/repo/docs/guide/\u{1F600}.mdx";
+
+        let emoji_paths = resolve_route_paths(emoji, root, "/repo/dist", "/base/", ".html", None);
+        assert_eq!(emoji_paths.url_path, "\u{1F600}");
+        assert_eq!(get_url_path(japanese, root), "\u{3042}");
+        assert_eq!(get_url_path(mixed, root), "guide/\u{1F600}");
+        assert_eq!(strip_markdown_extension("\u{1F600}"), "\u{1F600}");
+        assert_eq!(strip_markdown_extension("\u{3042}.MD"), "\u{3042}");
     }
 }

--- a/crates/ox_content_transform/src/lib.rs
+++ b/crates/ox_content_transform/src/lib.rs
@@ -1,5 +1,16 @@
 //! Markdown transformation pipeline for Ox Content.
 
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::todo,
+        clippy::unimplemented
+    )
+)]
+
 pub mod features;
 pub mod highlight;
 pub(crate) mod html_scan;

--- a/crates/ox_content_transform/src/transformer/tests.rs
+++ b/crates/ox_content_transform/src/transformer/tests.rs
@@ -104,3 +104,32 @@ fn toc_entries_are_nested_in_rust() {
     assert_eq!(toc[0].children[0].children[0].slug, "cli");
     assert_eq!(toc[1].slug, "api");
 }
+
+#[test]
+fn hostile_user_content_returns_errors_or_html_without_aborting() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let transformer = MarkdownTransformer::from_options(&TransformOptions {
+        gfm: Some(true),
+        frontmatter: Some(true),
+        ..Default::default()
+    });
+    let cases = [
+        "---\ntitle: [broken\n---\nBody",
+        "---\n{not: yaml\n---\n# Hi",
+        &"> ".repeat(120),
+        "*[unterminated",
+        "```\nunclosed fence",
+        "<!-- @include: ../../etc/passwd -->\n",
+    ];
+
+    for source in cases {
+        let outcome = catch_unwind(AssertUnwindSafe(|| transformer.transform(source)));
+        let result = outcome.unwrap_or_else(|_| panic!("transform aborted on {source:?}"));
+        assert!(
+            result.errors.iter().all(|error| !error.contains("panic")),
+            "unexpected panic diagnostic for {source:?}: {:?}",
+            result.errors
+        );
+    }
+}

--- a/crates/ox_content_transform/src/youtube.rs
+++ b/crates/ox_content_transform/src/youtube.rs
@@ -43,15 +43,19 @@ impl Default for YouTubeEmbedOptions {
     }
 }
 
-static VIDEO_ID: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9_-]{11}$").expect("valid video id regex"));
+static VIDEO_ID: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::expect_used)]
+    Regex::new(r"^[a-zA-Z0-9_-]{11}$").expect("compile-time YouTube video id regex")
+});
 static URL_PATTERNS: LazyLock<[Regex; 2]> = LazyLock::new(|| {
+    #[allow(clippy::expect_used)]
     [
         Regex::new(
             r"(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/embed/|youtube\.com/v/)([a-zA-Z0-9_-]{11})",
         )
-        .expect("valid url regex"),
-        Regex::new(r"youtube\.com/shorts/([a-zA-Z0-9_-]{11})").expect("valid shorts regex"),
+        .expect("compile-time YouTube URL regex"),
+        Regex::new(r"youtube\.com/shorts/([a-zA-Z0-9_-]{11})")
+            .expect("compile-time YouTube shorts regex"),
     ]
 });
 

--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -245,3 +245,5 @@ go-to-definition, hover, inlay hints, and preview HTML.
 - [@ox-content/wasm](./packages/wasm.md) covers browser and WebAssembly usage.
 - [Development Setup](./development-setup.md) explains local builds,
   contributor commands, and test workflows.
+- [Panic Prevention](./panic-prevention.md) is the #774 evidence ledger for
+  input-triggered panics.

--- a/docs/content/development-setup.md
+++ b/docs/content/development-setup.md
@@ -64,6 +64,7 @@ vp run fmt
 vp run fmt:check
 vp run clippy
 vp run lint
+vp run check:panic-constructs
 vp run ready
 
 # Documentation

--- a/docs/content/ja/architecture.md
+++ b/docs/content/ja/architecture.md
@@ -241,3 +241,4 @@ LSP はサイトパイプラインと同じパーサーとレンダラーの概�
 - [@ox-content/wasm](./packages/wasm.md) はブラウザと WebAssembly の使い方を扱います。
 - [開発環境のセットアップ](./development-setup.md) はローカルビルド、
   コントリビューター向けコマンド、テストワークフローを説明します。
+- [Panic 防止](./panic-prevention.md) は入力起因 panic の #774 証拠台帳です。

--- a/docs/content/ja/development-setup.md
+++ b/docs/content/ja/development-setup.md
@@ -64,6 +64,7 @@ vp run fmt
 vp run fmt:check
 vp run clippy
 vp run lint
+vp run check:panic-constructs
 vp run ready
 
 # Documentation

--- a/docs/content/ja/panic-prevention.md
+++ b/docs/content/ja/panic-prevention.md
@@ -1,0 +1,64 @@
+# Panic 防止
+
+これは [issue #774](https://github.com/ubugeeei-prod/ox-content/issues/774) の最初の証拠台帳です。壊れた Markdown、設定、パス、プラグインデータは、ホストプロセスを abort するのではなく、エラーまたは診断を返さなければなりません。
+
+#774 は **完了していません**。このページは、最初にマージできるスライスを記録します。棚卸し、CI ゲート、公開面で最も危険な修正、残りの除外です。
+
+リリースバイナリは `panic = "abort"` です。公開 N-API 成果物の中で Rust が panic すると Node が落ちます。`catch_unwind` が効くのは debug / test ビルドだけです。根本対応は、ユーザー入力で panic しないことです。
+
+## コマンド
+
+```bash
+# 棚卸し + allowlist ゲート（crates/ 配下の非テスト Rust）
+node scripts/check-panic-constructs.mjs
+
+# このスライス向けの回帰テスト
+cargo test -p ox_content_parser --test input_panics
+cargo test -p ox_content_ssg --lib paths -- --nocapture
+cargo test -p ox_content_transform --lib hostile_user_content
+cargo test -p ox_content_renderer --lib svelte_public_codegen
+cargo test -p ox_content_napi hostile_markdown
+```
+
+CI は `.github/workflows/ci.yml` の `Panic constructs` ジョブでゲートを実行します。`vp run check:panic-constructs` と `vp run workspace:check` も同じスクリプトです。
+
+## 監査したサブシステム（このスライス）
+
+| サブシステム | Crate | 結果 |
+| --- | --- | --- |
+| Markdown パース | `ox_content_parser` | 公開 `parse` は `ParseResult` を返します。サブパーサーは入れ子深さを引き継ぐので、深い引用は際限なく伸びず `NestingTooDeep` を返します。delimiter / list ヘルパーは回復可能な不一致で `expect` しません。 |
+| HTML 描画 / フレームワーク codegen | `ox_content_renderer` | `String` への書き込みは `expect` しません。Svelte の公開 codegen は `unreachable!` に到達しません。 |
+| Transform / frontmatter | `ox_content_transform` | 壊れた YAML は空の frontmatter のままです。敵対的な Markdown は abort せず `errors` を返します。コンパイル時 YouTube 正規表現の `expect` は allowlist に残します。 |
+| SSG ルート / エントリリンク | `ox_content_ssg` | パス接尾辞の除去はバイト安全です。`😀` のようなマルチバイトパスで文字境界の途中をスライスしません。 |
+| N-API 公開 parse / transform | `ox_content_napi` | キャッシュミスは `napi::Error` です。unwind ビルドでは、想定外 panic を `errors` 配列に落とします。 |
+
+テスト専用の `unwrap` / `expect` / `panic!` は対象外です。
+
+## このスライスの修正
+
+- **SSG パス**: `strip_markdown_extension` は末尾 N バイトを `&str` スライスで比較していました。4 バイトの絵文字パス（`😀`）は、比較の前に文字境界以外で panic していました。ヘルパーは ASCII 接尾辞をバイト列で比較します。
+- **SSG エントリリンク**: `.md` の除去も同じバイト安全な接尾辞チェックです。
+- **パーサーの list / emphasis**: 初期化後や retain 後の局所 `expect` は `get_or_insert_with` / `if let` になりました。
+- **パーサーの入れ子**: 引用と list item のサブパーサーは `nesting_depth` を引き継ぐので、`max_nesting_depth` が実際に効きます。
+- **レンダラー / SWAR スキャン**: 長さ確認後の 8 バイト `try_into().unwrap()` はスタック配列へのコピーです。
+- **N-API キャッシュ**: 変換済みファイルの欠落は `expect` ではなく `Result` エラーです。
+- **N-API FFI**: `parse`、`parse_and_render`、`transform` は unwind ビルドで想定外 panic から回復します。
+
+## CI ゲートと allowlist
+
+`scripts/check-panic-constructs.mjs` は `crates/**/*.rs` を歩き、`tests/`、`benches/`、`examples/`、`tests.rs`、`#[cfg(test)]` モジュールを除いて次を数えます。
+
+`unwrap`、`unwrap_err`、`unwrap_unchecked`、`expect`、`panic!`、`unreachable!`、`todo!`、`unimplemented!`
+
+件数は `config/panic-allowlist.json` と比較します。新規ヒットは失敗です。実件数が下がった場合も、allowlist を減らすまで失敗します。ワークスペース全体の `allow(clippy::unwrap_used)` ではありません。
+
+対象 5 crate は、非テストビルドで `clippy::unwrap_used`、`expect_used`、`panic`、`todo`、`unimplemented` を `deny` します。これらの crate でレビュー済みの例外は、`ox_content_transform` のコンパイル時 YouTube 正規表現だけです。
+
+## 残作業（後続 PR）
+
+- 残りのワークスペースを終える: `ox_content_docs`、`ox_content_lsp`、`ox_content_i18n`、`ox_content_search`、`ox_content_highlight`、`ox_content_wasm`、Vite バインディング、エディタ crate。
+- CI に有界な fuzz / property レーンを追加する（既存の `fuzz/` ターゲットは nightly が必要で、必須 CI ジョブではありません）。
+- 公開成果物の FFI 境界で `panic = "abort"` ではなく unwind を使えるかを決める。
+- 残サイトを証明または書き換えるたびに `config/panic-allowlist.json` を縮める。
+
+これらが終わるまで #774 は閉じません。

--- a/docs/content/ja/panic-prevention.md
+++ b/docs/content/ja/panic-prevention.md
@@ -24,13 +24,13 @@ CI は `.github/workflows/ci.yml` の `Panic constructs` ジョブでゲート�
 
 ## 監査したサブシステム（このスライス）
 
-| サブシステム | Crate | 結果 |
-| --- | --- | --- |
-| Markdown パース | `ox_content_parser` | 公開 `parse` は `ParseResult` を返します。サブパーサーは入れ子深さを引き継ぐので、深い引用は際限なく伸びず `NestingTooDeep` を返します。delimiter / list ヘルパーは回復可能な不一致で `expect` しません。 |
-| HTML 描画 / フレームワーク codegen | `ox_content_renderer` | `String` への書き込みは `expect` しません。Svelte の公開 codegen は `unreachable!` に到達しません。 |
-| Transform / frontmatter | `ox_content_transform` | 壊れた YAML は空の frontmatter のままです。敵対的な Markdown は abort せず `errors` を返します。コンパイル時 YouTube 正規表現の `expect` は allowlist に残します。 |
-| SSG ルート / エントリリンク | `ox_content_ssg` | パス接尾辞の除去はバイト安全です。`😀` のようなマルチバイトパスで文字境界の途中をスライスしません。 |
-| N-API 公開 parse / transform | `ox_content_napi` | キャッシュミスは `napi::Error` です。unwind ビルドでは、想定外 panic を `errors` 配列に落とします。 |
+| サブシステム                       | Crate                  | 結果                                                                                                                                                                                                      |
+| ---------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Markdown パース                    | `ox_content_parser`    | 公開 `parse` は `ParseResult` を返します。サブパーサーは入れ子深さを引き継ぐので、深い引用は際限なく伸びず `NestingTooDeep` を返します。delimiter / list ヘルパーは回復可能な不一致で `expect` しません。 |
+| HTML 描画 / フレームワーク codegen | `ox_content_renderer`  | `String` への書き込みは `expect` しません。Svelte の公開 codegen は `unreachable!` に到達しません。                                                                                                       |
+| Transform / frontmatter            | `ox_content_transform` | 壊れた YAML は空の frontmatter のままです。敵対的な Markdown は abort せず `errors` を返します。コンパイル時 YouTube 正規表現の `expect` は allowlist に残します。                                        |
+| SSG ルート / エントリリンク        | `ox_content_ssg`       | パス接尾辞の除去はバイト安全です。`😀` のようなマルチバイトパスで文字境界の途中をスライスしません。                                                                                                       |
+| N-API 公開 parse / transform       | `ox_content_napi`      | キャッシュミスは `napi::Error` です。unwind ビルドでは、想定外 panic を `errors` 配列に落とします。                                                                                                       |
 
 テスト専用の `unwrap` / `expect` / `panic!` は対象外です。
 

--- a/docs/content/panic-prevention.md
+++ b/docs/content/panic-prevention.md
@@ -24,13 +24,13 @@ CI runs the gate as the `Panic constructs` job in `.github/workflows/ci.yml`. `v
 
 ## Audited subsystems (this slice)
 
-| Subsystem | Crate | Outcome |
-| --- | --- | --- |
-| Markdown parse | `ox_content_parser` | Public `parse` returns `ParseResult`. Sub-parsers inherit nesting depth so deeply nested quotes return `NestingTooDeep` instead of growing without bound. Delimiter and list helpers no longer `expect` on recoverable mismatch. |
-| HTML render / framework codegen | `ox_content_renderer` | String writes no longer `expect`. Svelte public codegen no longer hits `unreachable!`. |
-| Transform / frontmatter | `ox_content_transform` | Malformed YAML stays empty frontmatter. Hostile Markdown returns `errors` instead of aborting. Compile-time YouTube regex `expect`s remain allowlisted. |
-| SSG routes / entry links | `ox_content_ssg` | Path suffix stripping is byte-safe. Multibyte paths such as `😀` no longer slice mid-character. |
-| N-API public parse / transform | `ox_content_napi` | Cache misses return `napi::Error`. Parse/transform wrap unexpected panics into the `errors` array in unwind builds. |
+| Subsystem                       | Crate                  | Outcome                                                                                                                                                                                                                          |
+| ------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Markdown parse                  | `ox_content_parser`    | Public `parse` returns `ParseResult`. Sub-parsers inherit nesting depth so deeply nested quotes return `NestingTooDeep` instead of growing without bound. Delimiter and list helpers no longer `expect` on recoverable mismatch. |
+| HTML render / framework codegen | `ox_content_renderer`  | String writes no longer `expect`. Svelte public codegen no longer hits `unreachable!`.                                                                                                                                           |
+| Transform / frontmatter         | `ox_content_transform` | Malformed YAML stays empty frontmatter. Hostile Markdown returns `errors` instead of aborting. Compile-time YouTube regex `expect`s remain allowlisted.                                                                          |
+| SSG routes / entry links        | `ox_content_ssg`       | Path suffix stripping is byte-safe. Multibyte paths such as `😀` no longer slice mid-character.                                                                                                                                  |
+| N-API public parse / transform  | `ox_content_napi`      | Cache misses return `napi::Error`. Parse/transform wrap unexpected panics into the `errors` array in unwind builds.                                                                                                              |
 
 Test-only `unwrap` / `expect` / `panic!` are out of scope.
 

--- a/docs/content/panic-prevention.md
+++ b/docs/content/panic-prevention.md
@@ -1,0 +1,64 @@
+# Panic Prevention
+
+This is the first evidence ledger for [issue #774](https://github.com/ubugeeei-prod/ox-content/issues/774): malformed Markdown, config, paths, and plugin data must return errors or diagnostics instead of aborting the host process.
+
+#774 is **not complete**. This page records the first mergeable slice: inventory, a CI gate, the most dangerous public-surface fixes, and the remaining exclusions.
+
+Release binaries use `panic = "abort"`. A Rust panic in a published N-API artifact kills Node. `catch_unwind` only helps debug and test builds. The durable fix is to stop panicking on user input.
+
+## Commands
+
+```bash
+# Inventory + allowlist gate (non-test Rust under crates/)
+node scripts/check-panic-constructs.mjs
+
+# Targeted regression tests for this slice
+cargo test -p ox_content_parser --test input_panics
+cargo test -p ox_content_ssg --lib paths -- --nocapture
+cargo test -p ox_content_transform --lib hostile_user_content
+cargo test -p ox_content_renderer --lib svelte_public_codegen
+cargo test -p ox_content_napi hostile_markdown
+```
+
+CI runs the gate as the `Panic constructs` job in `.github/workflows/ci.yml`. `vp run check:panic-constructs` and `vp run workspace:check` run the same script.
+
+## Audited subsystems (this slice)
+
+| Subsystem | Crate | Outcome |
+| --- | --- | --- |
+| Markdown parse | `ox_content_parser` | Public `parse` returns `ParseResult`. Sub-parsers inherit nesting depth so deeply nested quotes return `NestingTooDeep` instead of growing without bound. Delimiter and list helpers no longer `expect` on recoverable mismatch. |
+| HTML render / framework codegen | `ox_content_renderer` | String writes no longer `expect`. Svelte public codegen no longer hits `unreachable!`. |
+| Transform / frontmatter | `ox_content_transform` | Malformed YAML stays empty frontmatter. Hostile Markdown returns `errors` instead of aborting. Compile-time YouTube regex `expect`s remain allowlisted. |
+| SSG routes / entry links | `ox_content_ssg` | Path suffix stripping is byte-safe. Multibyte paths such as `😀` no longer slice mid-character. |
+| N-API public parse / transform | `ox_content_napi` | Cache misses return `napi::Error`. Parse/transform wrap unexpected panics into the `errors` array in unwind builds. |
+
+Test-only `unwrap` / `expect` / `panic!` are out of scope.
+
+## Fixes in this slice
+
+- **SSG paths**: `strip_markdown_extension` compared the last N bytes with a `&str` slice. A 4-byte emoji path (`😀`) panicked at a non-character boundary before the comparison ran. The helper now compares ASCII suffixes on bytes.
+- **SSG entry links**: `.md` stripping uses the same byte-safe suffix check.
+- **Parser lists / emphasis**: local `expect`s after initialization or retain are now `get_or_insert_with` / `if let`.
+- **Parser nesting**: quote and list item sub-parsers inherit `nesting_depth`, so `max_nesting_depth` is actually enforced.
+- **Renderer / SWAR scans**: 8-byte `try_into().unwrap()` copies into a stack array after a length check.
+- **N-API cache**: a missing transformed file is a `Result` error, not `expect`.
+- **N-API FFI**: `parse`, `parse_and_render`, and `transform` recover from unexpected panics in unwind builds.
+
+## CI gate and allowlist
+
+`scripts/check-panic-constructs.mjs` walks `crates/**/*.rs`, skips `tests/`, `benches/`, `examples/`, `tests.rs`, and `#[cfg(test)]` modules, then counts:
+
+`unwrap`, `unwrap_err`, `unwrap_unchecked`, `expect`, `panic!`, `unreachable!`, `todo!`, `unimplemented!`
+
+Counts are compared to `config/panic-allowlist.json`. New hits fail. Lower actual counts also fail until the allowlist is reduced. This is not a workspace-wide `allow(clippy::unwrap_used)`.
+
+The five focus crates also `deny` `clippy::unwrap_used`, `expect_used`, `panic`, `todo`, and `unimplemented` for non-test builds. The only reviewed exception in those crates is the compile-time YouTube regex in `ox_content_transform`.
+
+## Remaining work (follow-up PRs)
+
+- Finish the rest of the workspace: `ox_content_docs`, `ox_content_lsp`, `ox_content_i18n`, `ox_content_search`, `ox_content_highlight`, `ox_content_wasm`, Vite bindings, and editor crates.
+- Add bounded fuzz / property lanes in CI (the existing `fuzz/` targets still need nightly and are not a required CI job).
+- Decide whether published artifacts can use unwind at FFI boundaries instead of `panic = "abort"`.
+- Keep shrinking `config/panic-allowlist.json` as each remaining site is proven or rewritten.
+
+Do not close #774 until those items are done.

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -180,6 +180,7 @@ export default defineConfig(({ mode }) => {
                 text: "Advanced",
                 items: [
                   { text: "Architecture", link: "/architecture.md" },
+                  { text: "Panic Prevention", link: "/panic-prevention.md" },
                   { text: "Performance", link: "/performance.md" },
                   { text: "Profiling Mode", link: "/profiling.md" },
                   { text: "mdast Bridge Example", link: "/examples/unplugin-mdast-bridge.md" },

--- a/scripts/check-panic-constructs.mjs
+++ b/scripts/check-panic-constructs.mjs
@@ -75,7 +75,9 @@ for (const [entryKey, entry] of allowed) {
 
 if (extras.length > 0 || stale.length > 0) {
   if (extras.length > 0) {
-    console.error("New panic-prone production constructs (update the allowlist only after review):");
+    console.error(
+      "New panic-prone production constructs (update the allowlist only after review):",
+    );
     for (const extra of extras) {
       console.error(`  - ${extra.file} ${extra.kind} x${extra.count} (${extra.reason})`);
     }

--- a/scripts/check-panic-constructs.mjs
+++ b/scripts/check-panic-constructs.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+
+import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const allowlistPath = join(root, "config/panic-allowlist.json");
+const cratesRoot = join(root, "crates");
+const writeAllowlist = process.argv.includes("--write-allowlist");
+const dump = process.argv.includes("--dump");
+
+const KIND_PATTERNS = [
+  { kind: "unwrap_unchecked", regex: /\.unwrap_unchecked\s*\(/g },
+  { kind: "unwrap_err", regex: /\.unwrap_err\s*\(/g },
+  { kind: "unwrap", regex: /\.unwrap\s*\(/g },
+  { kind: "expect", regex: /\.expect\s*\(\s*"/g },
+  { kind: "panic", regex: /\bpanic!\s*\(/g },
+  { kind: "unreachable", regex: /\bunreachable!\s*\(/g },
+  { kind: "todo", regex: /\btodo!\s*\(/g },
+  { kind: "unimplemented", regex: /\bunimplemented!\s*\(/g },
+];
+
+const SKIP_DIR_NAMES = new Set(["tests", "benches", "examples", "target"]);
+
+const findings = scanCrates(cratesRoot);
+const counts = countByFileKind(findings);
+
+if (writeAllowlist) {
+  writeFileSync(allowlistPath, `${JSON.stringify(buildAllowlist(counts), null, 2)}\n`);
+  console.log(`Wrote ${counts.length} allowlist entries to ${relative(root, allowlistPath)}`);
+  process.exit(0);
+}
+
+if (dump) {
+  for (const finding of findings) {
+    console.log(`${finding.file}:${finding.line}:${finding.kind}: ${finding.text}`);
+  }
+  console.log(`\n${findings.length} production hits in ${counts.length} file/kind groups`);
+  process.exit(0);
+}
+
+const allowlist = JSON.parse(readFileSync(allowlistPath, "utf8"));
+const allowed = new Map(
+  (allowlist.entries ?? []).map((entry) => [key(entry.file, entry.kind), entry]),
+);
+const extras = [];
+const stale = [];
+
+for (const group of counts) {
+  const allow = allowed.get(key(group.file, group.kind));
+  if (!allow) {
+    extras.push({ ...group, reason: "not in allowlist" });
+    continue;
+  }
+  if (group.count > allow.count) {
+    extras.push({
+      ...group,
+      reason: `count ${group.count} exceeds allowlist ${allow.count}`,
+    });
+  }
+}
+
+for (const [entryKey, entry] of allowed) {
+  const actual = counts.find((group) => key(group.file, group.kind) === entryKey);
+  if (!actual) {
+    stale.push({ ...entry, reason: "no remaining production hits" });
+  } else if (actual.count < entry.count) {
+    stale.push({
+      ...entry,
+      reason: `allowlist count ${entry.count} is higher than actual ${actual.count}`,
+    });
+  }
+}
+
+if (extras.length > 0 || stale.length > 0) {
+  if (extras.length > 0) {
+    console.error("New panic-prone production constructs (update the allowlist only after review):");
+    for (const extra of extras) {
+      console.error(`  - ${extra.file} ${extra.kind} x${extra.count} (${extra.reason})`);
+    }
+  }
+  if (stale.length > 0) {
+    console.error("Stale panic-allowlist entries (lower the count or remove the row):");
+    for (const entry of stale) {
+      console.error(`  - ${entry.file} ${entry.kind} x${entry.count} (${entry.reason})`);
+    }
+  }
+  process.exit(1);
+}
+
+console.log(
+  `Panic-construct gate passed: ${findings.length} reviewed production hits, ${allowed.size} allowlist entries.`,
+);
+
+function scanCrates(dir) {
+  const files = [];
+  walk(dir, files);
+  const hits = [];
+  for (const file of files) {
+    hits.push(...scanFile(file));
+  }
+  return hits;
+}
+
+function walk(dir, files) {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      if (!SKIP_DIR_NAMES.has(entry)) {
+        walk(path, files);
+      }
+      continue;
+    }
+    if (entry.endsWith(".rs") && !/(^|_)tests\.rs$/.test(entry)) {
+      files.push(path);
+    }
+  }
+}
+
+function scanFile(absPath) {
+  const rel = relative(root, absPath).replaceAll("\\", "/");
+  const text = readFileSync(absPath, "utf8");
+  const lines = text.split(/\r?\n/);
+  const hits = [];
+  let testDepth = 0;
+  let pendingTestMod = false;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const trimmed = line.trim();
+
+    if (testDepth === 0 && /#\[cfg\(test\)\]/.test(trimmed)) {
+      pendingTestMod = true;
+    }
+    if (pendingTestMod && /\bmod\s+\w+/.test(trimmed)) {
+      pendingTestMod = false;
+      if (trimmed.includes("{")) {
+        testDepth = 1;
+        testDepth += braceDelta(trimmed);
+        continue;
+      }
+      continue;
+    }
+    if (pendingTestMod && trimmed === "") {
+      continue;
+    }
+    if (pendingTestMod && !trimmed.startsWith("#[")) {
+      pendingTestMod = false;
+    }
+    if (testDepth > 0) {
+      testDepth += braceDelta(line);
+      continue;
+    }
+
+    if (trimmed.startsWith("//") || trimmed.startsWith("///") || trimmed.startsWith("//!")) {
+      continue;
+    }
+
+    for (const { kind, regex } of KIND_PATTERNS) {
+      regex.lastIndex = 0;
+      if (!regex.test(line)) {
+        continue;
+      }
+      if (kind === "unwrap" && /\.unwrap_(or|or_else|or_default)\s*\(/.test(line)) {
+        continue;
+      }
+      hits.push({ file: rel, line: index + 1, kind, text: trimmed });
+      break;
+    }
+  }
+
+  return hits;
+}
+
+function braceDelta(line) {
+  let delta = 0;
+  for (const char of line) {
+    if (char === "{") {
+      delta += 1;
+    } else if (char === "}") {
+      delta -= 1;
+    }
+  }
+  return delta;
+}
+
+function countByFileKind(items) {
+  const map = new Map();
+  for (const item of items) {
+    const entryKey = key(item.file, item.kind);
+    const current = map.get(entryKey) ?? { file: item.file, kind: item.kind, count: 0 };
+    current.count += 1;
+    map.set(entryKey, current);
+  }
+  return [...map.values()].sort((left, right) =>
+    left.file === right.file
+      ? left.kind.localeCompare(right.kind)
+      : left.file.localeCompare(right.file),
+  );
+}
+
+function buildAllowlist(groups) {
+  return {
+    version: 1,
+    description:
+      "Reviewed production panic-prone constructs. New hits fail CI. Lower counts when a site is removed.",
+    entries: groups.map((group) => ({
+      file: group.file,
+      kind: group.kind,
+      count: group.count,
+      reason: "reviewed; not an input-triggered abort on the current public surfaces",
+    })),
+  };
+}
+
+function key(file, kind) {
+  return `${file}\0${kind}`;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -191,7 +191,13 @@ export default defineConfig({
         },
       ),
 
-      "workspace:check": noopTask(["fmt:rust-check", "lint:rust", "check:ts"]),
+      "check:panic-constructs": task("node scripts/check-panic-constructs.mjs"),
+      "workspace:check": noopTask([
+        "fmt:rust-check",
+        "lint:rust",
+        "check:panic-constructs",
+        "check:ts",
+      ]),
       "check:rust": task("cargo check --workspace --all-targets"),
 
       clippy: task("cargo clippy --workspace --all-targets -- -D warnings", {
@@ -233,7 +239,13 @@ export default defineConfig({
         cwd: "crates/ox_content_napi",
       }),
 
-      "workspace:ci": noopTask(["fmt:rust-check", "lint:rust", "check:ts", "workspace:test"]),
+      "workspace:ci": noopTask([
+        "fmt:rust-check",
+        "lint:rust",
+        "check:panic-constructs",
+        "check:ts",
+        "workspace:test",
+      ]),
       actrun: uncachedTask("actrun workflow run .github/workflows/ci.yml --trust"),
       "testbox:warmup": uncachedTask(
         "blacksmith testbox warmup .github/workflows/testbox.yml --job testbox --idle-timeout 60",


### PR DESCRIPTION
## Summary
- Inventory production `unwrap`/`expect`/`panic!`/`todo!`/`unreachable!` in non-test Rust and add a CI allowlist gate (`scripts/check-panic-constructs.mjs`, `config/panic-allowlist.json`).
- Stop the most dangerous public-surface panics: multibyte SSG paths, inherited parser nesting depth, N-API cache misses, and Svelte codegen `unreachable!`.
- Add regression tests plus EN/JA evidence ledgers. **Does not close #774.**

Refs #774

## Test plan
- [x] `node scripts/check-panic-constructs.mjs`
- [x] `cargo +1.95.0 test -p ox_content_parser --test input_panics`
- [x] `cargo +1.95.0 test -p ox_content_ssg --lib multibyte_paths`
- [x] `cargo +1.95.0 test -p ox_content_ssg --lib entry_links_join`
- [x] `cargo +1.95.0 test -p ox_content_transform --lib hostile_user_content`
- [x] `cargo +1.95.0 test -p ox_content_renderer --lib --features frameworks svelte_public`
- [x] `cargo +1.95.0 test -p ox_content_napi hostile_markdown`
- [x] `cargo +1.95.0 clippy -p ox_content_parser -p ox_content_renderer -p ox_content_transform -p ox_content_ssg -p ox_content_napi --all-targets --features frameworks -- -D warnings`
- [ ] GitHub CI (`Panic constructs`, Clippy, Test)


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790224045&installation_model_id=422833&pr_number=799&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F799&signature=904345d00f55c8be9e044d6f7ff7df2fe2761e858e69ed8296da4dcb85993dfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->