### PR TITLE
docs: mark shipped 3.0 built-ins and align theme peers

### DIFF
--- a/docs/content/docs-site-feature-roadmap.md
+++ b/docs/content/docs-site-feature-roadmap.md
@@ -22,13 +22,13 @@ Already tracked elsewhere:
 
 | Feature                             | Issue                                                          | Status  |
 | ----------------------------------- | -------------------------------------------------------------- | ------- |
-| Custom containers (`::: tip`)       | [#665](https://github.com/ubugeeei-prod/ox-content/issues/665) | planned |
+| Custom containers (`::: tip`)       | [#665](https://github.com/ubugeeei-prod/ox-content/issues/665) | shipped |
 | Math (inline `$` / block `$$`)      | [#666](https://github.com/ubugeeei-prod/ox-content/issues/666) | shipped |
 | Markdown file includes              | [#667](https://github.com/ubugeeei-prod/ox-content/issues/667) | shipped |
-| Figures, captions, and lazy images  | [#668](https://github.com/ubugeeei-prod/ox-content/issues/668) | planned |
-| Inline badges                       | [#669](https://github.com/ubugeeei-prod/ox-content/issues/669) | planned |
+| Figures, captions, and lazy images  | [#668](https://github.com/ubugeeei-prod/ox-content/issues/668) | shipped |
+| Inline badges                       | [#669](https://github.com/ubugeeei-prod/ox-content/issues/669) | shipped |
 | File tree blocks                    | [#670](https://github.com/ubugeeei-prod/ox-content/issues/670) | shipped |
-| Step lists                          | [#671](https://github.com/ubugeeei-prod/ox-content/issues/671) | planned |
+| Step lists                          | [#671](https://github.com/ubugeeei-prod/ox-content/issues/671) | shipped |
 | Card / link-card / card-grid blocks | [#672](https://github.com/ubugeeei-prod/ox-content/issues/672) | shipped |
 
 ## Phase B — Site outputs
@@ -40,25 +40,25 @@ Already tracked elsewhere:
 | Redirects, aliases, and path rewrites   | [#675](https://github.com/ubugeeei-prod/ox-content/issues/675) | shipped |
 | Draft, unlisted, and scheduled pages    | [#676](https://github.com/ubugeeei-prod/ox-content/issues/676) | shipped |
 | Custom 404 page                         | [#677](https://github.com/ubugeeei-prod/ox-content/issues/677) | shipped |
-| Permalinks and frontmatter cascade      | [#678](https://github.com/ubugeeei-prod/ox-content/issues/678) | planned |
+| Permalinks and frontmatter cascade      | [#678](https://github.com/ubugeeei-prod/ox-content/issues/678) | shipped |
 
 ## Phase C — Theme chrome
 
 | Feature                                       | Issue                                                          | Status  |
 | --------------------------------------------- | -------------------------------------------------------------- | ------- |
-| Previous / next page links                    | [#679](https://github.com/ubugeeei-prod/ox-content/issues/679) | planned |
-| Code copy, external-link icons, back-to-top   | [#680](https://github.com/ubugeeei-prod/ox-content/issues/680) | planned |
+| Previous / next page links                    | [#679](https://github.com/ubugeeei-prod/ox-content/issues/679) | shipped |
+| Code copy, external-link icons, back-to-top   | [#680](https://github.com/ubugeeei-prod/ox-content/issues/680) | shipped |
 | Header nav, announcement bar, per-page chrome | [#681](https://github.com/ubugeeei-prod/ox-content/issues/681) | shipped |
 | Breadcrumbs                                   | [#682](https://github.com/ubugeeei-prod/ox-content/issues/682) | shipped |
 | Team / members page                           | [#683](https://github.com/ubugeeei-prod/ox-content/issues/683) | shipped |
 | Locale switcher                               | [#684](https://github.com/ubugeeei-prod/ox-content/issues/684) | shipped |
-| Skip link and print styles                    | [#685](https://github.com/ubugeeei-prod/ox-content/issues/685) | planned |
+| Skip link and print styles                    | [#685](https://github.com/ubugeeei-prod/ox-content/issues/685) | shipped |
 
 ## Phase D — Content model
 
 | Feature                                            | Issue                                                          | Status  |
 | -------------------------------------------------- | -------------------------------------------------------------- | ------- |
-| Taxonomies and related pages                       | [#687](https://github.com/ubugeeei-prod/ox-content/issues/687) | planned |
+| Taxonomies and related pages                       | [#687](https://github.com/ubugeeei-prod/ox-content/issues/687) | shipped |
 | Blog (index, authors, tags, reading time, archive) | [#688](https://github.com/ubugeeei-prod/ox-content/issues/688) | shipped |
 | Documentation versioning                           | [#689](https://github.com/ubugeeei-prod/ox-content/issues/689) | shipped |
 | Generated section index pages                      | [#690](https://github.com/ubugeeei-prod/ox-content/issues/690) | shipped |
@@ -70,6 +70,6 @@ Already tracked elsewhere:
 | ------------------------------------------ | -------------------------------------------------------------- | ------- |
 | Git contributors                           | [#692](https://github.com/ubugeeei-prod/ox-content/issues/692) | shipped |
 | Typed hover overlays for TypeScript fences | [#693](https://github.com/ubugeeei-prod/ox-content/issues/693) | shipped |
-| Hosted search provider adapter             | [#694](https://github.com/ubugeeei-prod/ox-content/issues/694) | planned |
+| Hosted search provider adapter             | [#694](https://github.com/ubugeeei-prod/ox-content/issues/694) | shipped |
 | PWA manifest and service worker            | [#695](https://github.com/ubugeeei-prod/ox-content/issues/695) | shipped |
 | Structured data (JSON-LD)                  | [#696](https://github.com/ubugeeei-prod/ox-content/issues/696) | shipped |

--- a/docs/content/ja/docs-site-feature-roadmap.md
+++ b/docs/content/ja/docs-site-feature-roadmap.md
@@ -21,13 +21,13 @@ Ox Content は、非標準の Markdown と追加のサイト振る舞いは **�
 
 | 機能                                   | Issue                                                          | 状態    |
 | -------------------------------------- | -------------------------------------------------------------- | ------- |
-| カスタムコンテナ（`::: tip`）          | [#665](https://github.com/ubugeeei-prod/ox-content/issues/665) | planned |
+| カスタムコンテナ（`::: tip`）          | [#665](https://github.com/ubugeeei-prod/ox-content/issues/665) | shipped |
 | 数式（インライン `$` / ブロック `$$`） | [#666](https://github.com/ubugeeei-prod/ox-content/issues/666) | shipped |
 | Markdown ファイルインクルード          | [#667](https://github.com/ubugeeei-prod/ox-content/issues/667) | shipped |
-| 図、キャプション、遅延読み込み画像     | [#668](https://github.com/ubugeeei-prod/ox-content/issues/668) | planned |
-| インラインバッジ                       | [#669](https://github.com/ubugeeei-prod/ox-content/issues/669) | planned |
+| 図、キャプション、遅延読み込み画像     | [#668](https://github.com/ubugeeei-prod/ox-content/issues/668) | shipped |
+| インラインバッジ                       | [#669](https://github.com/ubugeeei-prod/ox-content/issues/669) | shipped |
 | ファイルツリーブロック                 | [#670](https://github.com/ubugeeei-prod/ox-content/issues/670) | shipped |
-| ステップリスト                         | [#671](https://github.com/ubugeeei-prod/ox-content/issues/671) | planned |
+| ステップリスト                         | [#671](https://github.com/ubugeeei-prod/ox-content/issues/671) | shipped |
 | card / link-card / card-grid ブロック  | [#672](https://github.com/ubugeeei-prod/ox-content/issues/672) | shipped |
 
 ## Phase B — サイト出力
@@ -39,27 +39,27 @@ Ox Content は、非標準の Markdown と追加のサイト振る舞いは **�
 | リダイレクト、エイリアス、パス書き換え  | [#675](https://github.com/ubugeeei-prod/ox-content/issues/675) | shipped |
 | 下書き、非公開、予約公開ページ          | [#676](https://github.com/ubugeeei-prod/ox-content/issues/676) | shipped |
 | カスタム 404 ページ                     | [#677](https://github.com/ubugeeei-prod/ox-content/issues/677) | shipped |
-| パーマリンクと frontmatter カスケード   | [#678](https://github.com/ubugeeei-prod/ox-content/issues/678) | planned |
+| パーマリンクと frontmatter カスケード   | [#678](https://github.com/ubugeeei-prod/ox-content/issues/678) | shipped |
 
 ## Phase C — テーマクロム
 
 | 機能                                         | Issue                                                          | 状態    |
 | -------------------------------------------- | -------------------------------------------------------------- | ------- |
-| 前へ / 次へページリンク                      | [#679](https://github.com/ubugeeei-prod/ox-content/issues/679) | planned |
-| コードコピー、外部リンクアイコン、先頭へ戻る | [#680](https://github.com/ubugeeei-prod/ox-content/issues/680) | planned |
+| 前へ / 次へページリンク                      | [#679](https://github.com/ubugeeei-prod/ox-content/issues/679) | shipped |
+| コードコピー、外部リンクアイコン、先頭へ戻る | [#680](https://github.com/ubugeeei-prod/ox-content/issues/680) | shipped |
 | ヘッダーナビ、告知バー、ページ単位のクロム   | [#681](https://github.com/ubugeeei-prod/ox-content/issues/681) | shipped |
 | パンくずリスト                               | [#682](https://github.com/ubugeeei-prod/ox-content/issues/682) | shipped |
 | チーム / メンバーページ                      | [#683](https://github.com/ubugeeei-prod/ox-content/issues/683) | shipped |
 | ロケールスイッチャー                         | [#684](https://github.com/ubugeeei-prod/ox-content/issues/684) | shipped |
-| スキップリンクと印刷スタイル                 | [#685](https://github.com/ubugeeei-prod/ox-content/issues/685) | planned |
+| スキップリンクと印刷スタイル                 | [#685](https://github.com/ubugeeei-prod/ox-content/issues/685) | shipped |
 
 ## Phase D — コンテンツモデル
 
 | 機能                                             | Issue                                                          | 状態    |
 | ------------------------------------------------ | -------------------------------------------------------------- | ------- |
-| タクソノミーと関連ページ                         | [#687](https://github.com/ubugeeei-prod/ox-content/issues/687) | planned |
+| タクソノミーと関連ページ                         | [#687](https://github.com/ubugeeei-prod/ox-content/issues/687) | shipped |
 | ブログ（索引、著者、タグ、読了時間、アーカイブ） | [#688](https://github.com/ubugeeei-prod/ox-content/issues/688) | shipped |
-| ドキュメントのバージョニング                     | [#689](https://github.com/ubugeeei-prod/ox-content/issues/689) | planned |
+| ドキュメントのバージョニング                     | [#689](https://github.com/ubugeeei-prod/ox-content/issues/689) | shipped |
 | 生成されるセクション索引ページ                   | [#690](https://github.com/ubugeeei-prod/ox-content/issues/690) | shipped |
 | ページリソースと画像処理                         | [#691](https://github.com/ubugeeei-prod/ox-content/issues/691) | shipped |
 
@@ -69,6 +69,6 @@ Ox Content は、非標準の Markdown と追加のサイト振る舞いは **�
 | ----------------------------------------- | -------------------------------------------------------------- | ------- |
 | Git コントリビューター                    | [#692](https://github.com/ubugeeei-prod/ox-content/issues/692) | shipped |
 | TypeScript フェンスの型ホバーオーバーレイ | [#693](https://github.com/ubugeeei-prod/ox-content/issues/693) | shipped |
-| ホスト型検索プロバイダーアダプター        | [#694](https://github.com/ubugeeei-prod/ox-content/issues/694) | planned |
+| ホスト型検索プロバイダーアダプター        | [#694](https://github.com/ubugeeei-prod/ox-content/issues/694) | shipped |
 | PWA マニフェストとサービスワーカー        | [#695](https://github.com/ubugeeei-prod/ox-content/issues/695) | shipped |
 | 構造化データ（JSON-LD）                   | [#696](https://github.com/ubugeeei-prod/ox-content/issues/696) | shipped |

--- a/npm/theme-color/arctic/package.json
+++ b/npm/theme-color/arctic/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/ayu/package.json
+++ b/npm/theme-color/ayu/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/cacao/package.json
+++ b/npm/theme-color/cacao/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/catppuccin/package.json
+++ b/npm/theme-color/catppuccin/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/commander/package.json
+++ b/npm/theme-color/commander/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/coral/package.json
+++ b/npm/theme-color/coral/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/dracula/package.json
+++ b/npm/theme-color/dracula/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/emerald/package.json
+++ b/npm/theme-color/emerald/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/everforest/package.json
+++ b/npm/theme-color/everforest/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/flexoki/package.json
+++ b/npm/theme-color/flexoki/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/fuji/package.json
+++ b/npm/theme-color/fuji/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/github/package.json
+++ b/npm/theme-color/github/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/graphite/package.json
+++ b/npm/theme-color/graphite/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/gruvbox/package.json
+++ b/npm/theme-color/gruvbox/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/high-contrast/package.json
+++ b/npm/theme-color/high-contrast/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/horizon/package.json
+++ b/npm/theme-color/horizon/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/iceberg/package.json
+++ b/npm/theme-color/iceberg/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/ink/package.json
+++ b/npm/theme-color/ink/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/kanagawa/package.json
+++ b/npm/theme-color/kanagawa/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/melange/package.json
+++ b/npm/theme-color/melange/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/modus/package.json
+++ b/npm/theme-color/modus/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/mono/package.json
+++ b/npm/theme-color/mono/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/monokai/package.json
+++ b/npm/theme-color/monokai/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/moss/package.json
+++ b/npm/theme-color/moss/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/night-owl/package.json
+++ b/npm/theme-color/night-owl/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/nord/package.json
+++ b/npm/theme-color/nord/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/oceanic/package.json
+++ b/npm/theme-color/oceanic/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/one-dark/package.json
+++ b/npm/theme-color/one-dark/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/palenight/package.json
+++ b/npm/theme-color/palenight/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/plum/package.json
+++ b/npm/theme-color/plum/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/poimandres/package.json
+++ b/npm/theme-color/poimandres/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/porcelain/package.json
+++ b/npm/theme-color/porcelain/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/retro/package.json
+++ b/npm/theme-color/retro/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/rose-pine/package.json
+++ b/npm/theme-color/rose-pine/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/sand/package.json
+++ b/npm/theme-color/sand/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/sepia/package.json
+++ b/npm/theme-color/sepia/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/slate/package.json
+++ b/npm/theme-color/slate/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/snow/package.json
+++ b/npm/theme-color/snow/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/solarized/package.json
+++ b/npm/theme-color/solarized/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/stage/package.json
+++ b/npm/theme-color/stage/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/synthwave/package.json
+++ b/npm/theme-color/synthwave/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/tokyo-night/package.json
+++ b/npm/theme-color/tokyo-night/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/vitesse/package.json
+++ b/npm/theme-color/vitesse/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/voltage/package.json
+++ b/npm/theme-color/voltage/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme-color/zenburn/package.json
+++ b/npm/theme-color/zenburn/package.json
@@ -50,7 +50,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/analog-film/package.json
+++ b/npm/theme/analog-film/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/atlas/package.json
+++ b/npm/theme/atlas/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/aurora/package.json
+++ b/npm/theme/aurora/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/bauhaus/package.json
+++ b/npm/theme/bauhaus/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/blueprint/package.json
+++ b/npm/theme/blueprint/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/blur-glass/package.json
+++ b/npm/theme/blur-glass/package.json
@@ -52,7 +52,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/brutalist/package.json
+++ b/npm/theme/brutalist/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/clay/package.json
+++ b/npm/theme/clay/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/editorial/package.json
+++ b/npm/theme/editorial/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/fabric/package.json
+++ b/npm/theme/fabric/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/fluid/package.json
+++ b/npm/theme/fluid/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/holo/package.json
+++ b/npm/theme/holo/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/kiosk/package.json
+++ b/npm/theme/kiosk/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/leather/package.json
+++ b/npm/theme/leather/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/ledger/package.json
+++ b/npm/theme/ledger/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/liquid-glass/package.json
+++ b/npm/theme/liquid-glass/package.json
@@ -52,7 +52,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/manuscript/package.json
+++ b/npm/theme/manuscript/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/neon/package.json
+++ b/npm/theme/neon/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/noir/package.json
+++ b/npm/theme/noir/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/paper/package.json
+++ b/npm/theme/paper/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/pixel/package.json
+++ b/npm/theme/pixel/package.json
@@ -52,7 +52,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/receipt/package.json
+++ b/npm/theme/receipt/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/risograph/package.json
+++ b/npm/theme/risograph/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/swiss/package.json
+++ b/npm/theme/swiss/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/terminal/package.json
+++ b/npm/theme/terminal/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/voltage/package.json
+++ b/npm/theme/voltage/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {

--- a/npm/theme/zine/package.json
+++ b/npm/theme/zine/package.json
@@ -53,7 +53,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@ox-content/vite-plugin": ">=2.84.0"
+    "@ox-content/vite-plugin": ">=3.0.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "@ox-content/vite-plugin": {


### PR DESCRIPTION
## Summary
- Mark every Phase A–E docs-site built-in on the EN/JA in-repo roadmap as `shipped` now that #665–#696 are CLOSED.
- Bump `@ox-content/theme-*` and `@ox-content/theme-color-*` peer ranges from `>=2.84.0` to `>=3.0.0-alpha.1` (#699). `peerDependenciesMeta.optional` is unchanged.
- Tracker close-out: #650 and #651 are CLOSED; #699 stays open as the 3.0.0 release tracker.

## Test plan
- [ ] Confirm EN/JA `docs-site-feature-roadmap.md` have no remaining `planned` rows for #665–#696
- [ ] Confirm theme / theme-color `package.json` peers are `>=3.0.0-alpha.1` and still optional
- [ ] Confirm #650 / #651 are CLOSED and #699 remains OPEN with grammar expansion still unchecked


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790232690&installation_model_id=422833&pr_number=803&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F803&signature=324858239ff3541bcc57208487087f9f7b32d50908e0b4431ed688225139464d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the feature roadmap to mark numerous documentation capabilities as shipped, including custom containers, navigation links, search, taxonomies, and accessibility enhancements.
  * Synchronized roadmap status updates in English and Japanese documentation.

* **Chores**
  * Updated all themes and color themes to require `@ox-content/vite-plugin` version `3.0.0-alpha.1` or newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->