### PR TITLE
feat(mdx): resolve per-document component imports for islands

### DIFF
--- a/docs/content/ja/mdx.md
+++ b/docs/content/ja/mdx.md
@@ -24,11 +24,12 @@ Ox Content では、Markdown と `.mdx` ファイルの中にフレームワー�
   props を直列化します（リテラルは JSON、`{expression}` / spread はソース）。
   `.mdx` ファイル（または `mdx: true`）では、React / Vue / Svelte / Solid
   プラグインは MDX AST を歩きます。AST が使えないときは、描画済みの
-  `data-ox-island` 名を使います。グローバルな `components` マップにある名前だけ
-  ハイドレーション用モジュールを import します。入れ子の JSX、式属性、
-  フラグメントもその走査に入ります。未登録の JSX は静的 HTML のままです。
-  素の `.md` は既存ページのためソース走査のままです。式は保存され、
-  評価は後です。
+  `data-ox-island` 名を使います。グローバルな `components` マップにある名前、
+  またはその文書から解決した相対 `import` の名前だけ、ハイドレーション用
+  モジュールを import します。入れ子の JSX、式属性、フラグメントもその走査に
+  入ります。一致する import のない未登録 JSX は静的 HTML のままです。
+  素の `.md` は既存ページのためグローバルマップのソース走査のままです。
+  式は保存され、評価は後です。
 
 そのため、本文は Markdown の速さのまま、必要なところだけ本物の対話コンポーネントを置けます。
 コンポーネントのないページには JavaScript バンドルを出しません。
@@ -99,6 +100,39 @@ Vue、Svelte、Solid も同じように `@ox-content/vite-plugin-vue`
 Solid 連携は加えて `vite-plugin-solid` より前に動かす必要があり、
 そちらには Markdown 拡張子を渡す必要があります。
 [そのリファレンスページ](/packages/vite-plugin-ox-content-solid.md#plugin-order-and-extensions) を見てください。
+
+## 文書ローカルな import
+
+`.mdx`（または `mdx: true`）では、サイト全体の `components` マップに登録せず、
+文書自身からの相対 import でコンポーネントを使えます。
+
+```md
+import GtvChart from './gtv-chart/GtvChart.tsx'
+
+<GtvChart title="ok" />
+```
+
+specifier はそのファイルのディレクトリから解決されます。束縛はその文書だけに
+効きます。2 つのページが同じ名前 `Chart` を別ファイルから import しても、
+グローバル名は衝突しません。そのページが実際に使うコンポーネントだけが、
+静的な `import` として生成モジュールに入ります。コンポーネントファイルを
+変えると、Vite HMR がその Markdown モジュールを無効化します。
+
+| 形                                           | island として解決するか            |
+| -------------------------------------------- | ---------------------------------- |
+| `import Name from './file.tsx'`              | `<Name />` を使っていればする      |
+| `import { Chart as Plot } from './file.tsx'` | `<Plot />` を使っていればする      |
+| bare / npm / `https:` specifier              | しない。報告するだけで解決しない   |
+| `srcDir` を出る `../`                        | しない。診断を出し、import しない  |
+| 文書 import とグローバルマップに同じ名前     | そのファイルでは文書 import が勝つ |
+| `mdx: true` のない `.md`                     | しない。ESM は文書 import ではない |
+
+グローバルな `components` マップは、ローカル import を書かないページ向けの
+後方互換フォールバックのままです。フレームワークプラグインは任意で
+`renderIsland(name, props, filePath)` フックを渡し、transform 時に island の
+内側 HTML を差し替えられます。そのフックはアダプタ側に置きます。コア
+レンダラーは `react-dom/server`、`svelte/server`、`solid-js/web` を
+import しません。
 
 ## Markdown でコンポーネントを書く
 
@@ -239,8 +273,9 @@ MDX がオンのとき、名前付き JSX コンポーネントは HTML の isla
 `<script type="application/json">` に置かれます。
 `{"</script><script>"}` や `{alert(1)}` のような敵対的なソースはペイロードから抜けられず、
 評価もされません。コンポーネントのないページは `<script>` も island ランタイムも出しません。
-フレームワークプラグインは MDX AST から登録済みの名前を解決し、それらの island を後で
-ハイドレートします。未登録の名前は、レンダラーがすでに出した静的 HTML のままです。
+フレームワークプラグインは MDX AST から登録済みの名前と文書ローカルな
+import を解決し、それらの island を後でハイドレートします。未登録の名前は、
+レンダラーがすでに出した静的 HTML のままです。
 
 ### Props
 
@@ -278,8 +313,9 @@ Props は JSX 風の構文です。次の形を認識します。
 
 サーバー出力はプレーン HTML なので、ハイドレーションの前（またはなし）でもページは描画され読めます。
 island の JavaScript は、そのページが実際に使うコンポーネント分だけ読み込まれます。
-`.mdx` ではその一覧は AST とグローバルなコンポーネントマップの交差です。
-入れ子やフラグメント内のタグも、登録されていればハイドレートされます。
+`.mdx` ではその一覧は AST と、グローバルなコンポーネントマップおよび
+解決済みの文書ローカル import の交差です。入れ子やフラグメント内のタグも、
+登録されているか、そのページが import していればハイドレートされます。
 
 ## テーマ内の静的 JSX
 

--- a/docs/content/mdx.md
+++ b/docs/content/mdx.md
@@ -25,11 +25,12 @@ It is worth understanding how this works, because it differs from "classic" MDX:
   serializes props (literals as JSON, `{expression}` / spreads as source).
   For `.mdx` files (or when `mdx: true`), the React/Vue/Svelte/Solid
   plugins walk the MDX AST — or the rendered `data-ox-island` names —
-  and import hydration modules only for names in the global `components`
-  map. Nested JSX, expression attributes, and fragments are visible to
-  that walk. Unregistered JSX stays static HTML. Plain `.md` still uses a
-  source scan so existing pages keep working. Expressions are stored and
-  evaluated later.
+  and import hydration modules for names in the global `components` map
+  **or** a relative `import` resolved from that document. Nested JSX,
+  expression attributes, and fragments are visible to that walk.
+  Unregistered JSX without a matching import stays static HTML. Plain
+  `.md` still uses a source scan of the global map so existing pages keep
+  working. Expressions are stored and evaluated later.
 
 So you get Markdown's speed for prose plus real interactive components where you
 need them — without shipping a JavaScript bundle for pages that have none.
@@ -98,6 +99,38 @@ the component name is the PascalCased file name.
 The Solid integration additionally has to run before `vite-plugin-solid`, which
 must be given the Markdown extensions — see
 [its reference page](./packages/vite-plugin-ox-content-solid.md#plugin-order-and-extensions).
+
+## Document-local imports
+
+On `.mdx` (or when `mdx: true`), a document can import a component relative to
+itself instead of registering it in the site-wide `components` map:
+
+```md
+import GtvChart from './gtv-chart/GtvChart.tsx'
+
+<GtvChart title="ok" />
+```
+
+The specifier is resolved from that file's directory. The binding is local to
+the document: two pages may both import `Chart` from different files without
+sharing one global name. Only the components that page actually uses are
+imported into the generated module, as static `import`s, so changing the
+component file invalidates the Markdown module through Vite HMR.
+
+| Form                                                | Resolved as an island?             |
+| --------------------------------------------------- | ---------------------------------- |
+| `import Name from './file.tsx'`                     | Yes, if `<Name />` is used         |
+| `import { Chart as Plot } from './file.tsx'`        | Yes, if `<Plot />` is used         |
+| Bare / npm / `https:` specifier                     | No. Reported, not resolved         |
+| `../` that leaves `srcDir`                          | No. Diagnostic, no import          |
+| Same name in the document import and the global map | Document import wins for that file |
+| `.md` without `mdx: true`                           | No. ESM is not a document import   |
+
+The global `components` map remains the backwards-compatible fallback for pages
+that do not declare a local import. Framework plugins may also pass an optional
+`renderIsland(name, props, filePath)` hook to replace island inner HTML at
+transform time. That hook lives on the adapter; the core renderer does not
+import `react-dom/server`, `svelte/server`, or `solid-js/web`.
 
 ## Authoring components in Markdown
 
@@ -243,9 +276,9 @@ The payload is JSON that unicode-escapes `<`, `>`, and `&`, then sits in
 that the browser does not execute. Hostile source such as
 `{"</script><script>"}` or `{alert(1)}` cannot break out of the payload
 and is not evaluated. Pages with no components emit no `<script>` and no
-island runtime. Framework plugins resolve registered names from the MDX
-AST and hydrate those islands later. Unregistered names keep the static
-HTML the renderer already emitted.
+island runtime. Framework plugins resolve registered names and document-local imports from
+the MDX AST and hydrate those islands later. Unregistered names keep the
+static HTML the renderer already emitted.
 
 ### Props
 
@@ -285,8 +318,9 @@ Hydration timing is controlled by a load strategy (see
 Because the server output is plain HTML, pages render and are readable before
 (or entirely without) hydration; the island JavaScript is only loaded for the
 components a page actually uses. On `.mdx`, that list comes from the AST
-intersected with the global component map, so a nested or fragmented tag
-still hydrates when it is registered.
+intersected with the global component map and any resolved document-local
+imports, so a nested or fragmented tag still hydrates when it is
+registered or imported by that page.
 
 ## Static JSX in themes
 

--- a/docs/content/packages/vite-plugin-ox-content-solid.md
+++ b/docs/content/packages/vite-plugin-ox-content-solid.md
@@ -96,6 +96,9 @@ Turn it off when Solid's JSX is compiled by something other than
 
 ## Using Components in Markdown
 
+Register shared components in the global `components` map, or import a
+component from the document that uses it.
+
 ```markdown
 # My Page
 
@@ -109,6 +112,19 @@ And an alert:
   This is a warning message!
 </Alert>
 ```
+
+On `.mdx`, a relative import is local to that file and overrides the global
+map when the names match:
+
+```md
+import GtvChart from './gtv-chart/GtvChart.tsx'
+
+<GtvChart title="ok" />
+```
+
+Optional `renderIsland(name, props, filePath)` can replace island inner HTML
+at transform time. The hook belongs on the Solid adapter; `@ox-content/vite-plugin`
+does not import `solid-js/web` for SSR.
 
 ## Example Component
 
@@ -147,13 +163,13 @@ generated modules import directly.
 
 ## Islands
 
-Markdown that uses a registered component is emitted with island markers and
-hydrated through `@ox-content/islands`, the same runtime the other framework
-integrations use. Each island is mounted with `render` from `solid-js/web` and
-disposed when the Markdown component unmounts.
+Markdown that uses a registered or document-imported component is emitted with
+island markers and hydrated through `@ox-content/islands`, the same runtime the
+other framework integrations use. Each island is mounted with `render` from
+`solid-js/web` and disposed when the Markdown component unmounts.
 
-Markdown without any registered component skips the island runtime entirely and
-compiles to a single `innerHTML` binding.
+Markdown without any registered or document-imported component skips the island
+runtime entirely and compiles to a single `innerHTML` binding.
 
 ## HMR
 

--- a/docs/content/packages/vite-plugin-ox-content-svelte.md
+++ b/docs/content/packages/vite-plugin-ox-content-svelte.md
@@ -69,6 +69,9 @@ Enable Svelte 5 Runes mode.
 
 ## Using Components in Markdown
 
+Register shared components in the global `components` map, or import a
+component from the document that uses it.
+
 ```markdown
 # My Page
 
@@ -82,6 +85,19 @@ And an alert:
   This is a warning message!
 </Alert>
 ```
+
+On `.mdx`, a relative import is local to that file and overrides the global
+map when the names match:
+
+```md
+import GtvChart from './gtv-chart/GtvChart.svelte'
+
+<GtvChart title="ok" />
+```
+
+Optional `renderIsland(name, props, filePath)` can replace island inner HTML
+at transform time. The hook belongs on the Svelte adapter; `@ox-content/vite-plugin`
+does not import `svelte/server`.
 
 ## Example Component (Svelte 5 Runes)
 

--- a/npm/vite-plugin-ox-content-react/src/document-imports.test.ts
+++ b/npm/vite-plugin-ox-content-react/src/document-imports.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vite-plus/test";
+import { transformMarkdownWithReact } from "./transform";
+import type { ResolvedReactOptions } from "./types";
+
+describe("document-local React islands", () => {
+  it("hydrates a relative default import and emits a static import of that file", async () => {
+    const result = await transformMarkdownWithReact(
+      "import GtvChart from './gtv-chart/GtvChart.tsx'\n\n<GtvChart title=\"ok\" />\n",
+      "/repo/docs/guide.mdx",
+      createOptions({ components: {} }),
+    );
+
+    expect(result.usedComponents).toEqual(["GtvChart"]);
+    expect(result.code).toContain("import GtvChart from './gtv-chart/GtvChart.tsx'");
+    expect(result.code).toContain('data-ox-island=\\"GtvChart\\"');
+    expect(result.code).toContain("ok");
+  });
+
+  it("keeps the same local name on two documents as distinct imports", async () => {
+    const first = await transformMarkdownWithReact(
+      "import Chart from './a/Chart.tsx'\n\n<Chart />\n",
+      "/repo/docs/a.mdx",
+      createOptions({ components: {} }),
+    );
+    const second = await transformMarkdownWithReact(
+      "import Chart from './b/Chart.tsx'\n\n<Chart />\n",
+      "/repo/docs/b.mdx",
+      createOptions({ components: {} }),
+    );
+
+    expect(first.code).toContain("import Chart from './a/Chart.tsx'");
+    expect(second.code).toContain("import Chart from './b/Chart.tsx'");
+  });
+
+  it("rejects an import that escapes the content root", async () => {
+    const result = await transformMarkdownWithReact(
+      "import Outside from '../../Outside.tsx'\n\n<Outside />\n",
+      "/repo/docs/nested/page.mdx",
+      createOptions({ components: {} }),
+    );
+
+    expect(result.usedComponents).toEqual([]);
+    expect(result.code).not.toContain("import Outside");
+  });
+
+  it("still hydrates the global map and leaves plain .md unchanged", async () => {
+    const globalMap = await transformMarkdownWithReact(
+      '<Alert tone="info" />\n',
+      "/repo/docs/guide.mdx",
+      createOptions(),
+    );
+    expect(globalMap.code).toContain("import Alert from '../src/components/Alert.tsx'");
+
+    const plain = await transformMarkdownWithReact(
+      "import Chart from './Chart.tsx'\n\n<Chart />\n",
+      "/repo/docs/page.md",
+      createOptions({ components: {} }),
+    );
+    expect(plain.usedComponents).toEqual([]);
+    expect(plain.code).not.toContain("import Chart from './Chart.tsx'");
+  });
+});
+
+function createOptions(overrides: Partial<ResolvedReactOptions> = {}): ResolvedReactOptions {
+  return {
+    srcDir: "docs",
+    outDir: "dist",
+    base: "/",
+    extensions: [".md", ".markdown", ".mdx"],
+    gfm: true,
+    autolinks: true,
+    frontmatter: true,
+    toc: true,
+    tocMaxDepth: 3,
+    codeAnnotations: { enabled: false, metaKey: "annotate" },
+    components: { Alert: "./src/components/Alert.tsx" },
+    jsxRuntime: "automatic",
+    embeds: { github: false, openGraph: false },
+    root: "/repo",
+    ...overrides,
+  };
+}

--- a/npm/vite-plugin-ox-content-react/src/index.ts
+++ b/npm/vite-plugin-ox-content-react/src/index.ts
@@ -121,6 +121,7 @@ export function oxContentReact(options: ReactIntegrationOptions = {}): PluginOpt
         ...resolved,
         components: Object.fromEntries(componentMap),
         root: config.root,
+        renderIsland: options.renderIsland,
       });
 
       return {

--- a/npm/vite-plugin-ox-content-react/src/transform.ts
+++ b/npm/vite-plugin-ox-content-react/src/transform.ts
@@ -1,8 +1,11 @@
-import * as path from "path";
 import {
-  discoverRegisteredMdxComponents,
+  applyIslandSsrHtml,
+  discoverDocumentMdxIslands,
+  renderIslandComponentImports,
+  resolveContentRootPath,
   resolveMdxForFilePath,
   transformMarkdown as baseTransformMarkdown,
+  type ResolvedDocumentComponentImport,
 } from "@ox-content/vite-plugin";
 import type {
   ResolvedReactOptions,
@@ -90,22 +93,35 @@ export async function transformMarkdownWithReact(
 
   if (mdx) {
     const transformed = await baseTransformMarkdown(markdownContent, id, baseOptions);
-    const usedComponents = await discoverRegisteredMdxComponents({
+    const discovered = await discoverDocumentMdxIslands({
       source: markdownContent,
       html: transformed.html,
       components,
+      imports: transformed.imports,
+      documentPath: id,
+      contentRoot: resolveContentRootPath({ srcDir: options.srcDir, root: options.root }),
+      srcDir: options.srcDir,
     });
+    const html = options.renderIsland
+      ? await applyIslandSsrHtml(
+          transformed.html,
+          options.renderIsland,
+          id,
+          discovered.usedComponents,
+        )
+      : transformed.html;
     return {
       code: generateReactModule(
-        transformed.html,
-        usedComponents,
-        usedComponents,
+        html,
+        discovered.usedComponents,
+        discovered.usedComponents,
         frontmatter,
         options,
         id,
+        discovered.localBindings,
       ),
       map: null,
-      usedComponents,
+      usedComponents: discovered.usedComponents,
       frontmatter,
     };
   }
@@ -321,21 +337,14 @@ function generateReactModule(
   frontmatter: Record<string, unknown>,
   options: ResolvedReactOptions & { root?: string },
   id: string,
+  localBindings?: ReadonlyMap<string, ResolvedDocumentComponentImport>,
 ): string {
-  const mdDir = path.dirname(id);
-  const root = options.root || process.cwd();
-
-  const imports = usedComponents
-    .map((name) => {
-      const componentPath = options.components[name];
-      if (!componentPath) return "";
-      const absolutePath = path.resolve(root, componentPath.replace(/^\.\//, ""));
-      const relativePath = path.relative(mdDir, absolutePath).replace(/\\/g, "/");
-      const importPath = relativePath.startsWith(".") ? relativePath : "./" + relativePath;
-      return `import ${name} from '${importPath}';`;
-    })
-    .filter(Boolean)
-    .join("\n");
+  const imports = renderIslandComponentImports(usedComponents, {
+    globalComponents: options.components,
+    localBindings,
+    documentPath: id,
+    root: options.root,
+  });
 
   const componentMap = usedComponents.map((name) => `  ${name},`).join("\n");
 

--- a/npm/vite-plugin-ox-content-react/src/types.ts
+++ b/npm/vite-plugin-ox-content-react/src/types.ts
@@ -1,4 +1,4 @@
-import type { OxContentOptions } from "@ox-content/vite-plugin";
+import type { OxContentOptions, RenderIslandFn } from "@ox-content/vite-plugin";
 
 /**
  * Code annotation options for the React integration.
@@ -100,6 +100,13 @@ export interface ReactIntegrationOptions extends OxContentOptions {
    * @default { github: true, openGraph: true }
    */
   embeds?: BuiltinEmbedOptions | false;
+
+  /**
+   * Optional adapter hook that replaces island inner HTML at transform time.
+   * The core renderer stays framework-neutral; do not import a framework SSR
+   * runtime from `@ox-content/vite-plugin`.
+   */
+  renderIsland?: RenderIslandFn;
 }
 
 /**
@@ -204,6 +211,7 @@ export interface ResolvedReactOptions {
   embeds: ResolvedBuiltinEmbedOptions;
   mdx?: boolean;
   root?: string;
+  renderIsland?: RenderIslandFn;
 }
 
 export interface ReactTransformResult {

--- a/npm/vite-plugin-ox-content-solid/src/codegen.ts
+++ b/npm/vite-plugin-ox-content-solid/src/codegen.ts
@@ -6,7 +6,10 @@
  * the React and Vue integrations there is no factory-call form to emit.
  */
 
-import * as path from "path";
+import {
+  renderIslandComponentImports,
+  type ResolvedDocumentComponentImport,
+} from "@ox-content/vite-plugin";
 import type { ComponentIsland, ResolvedSolidOptions } from "./types";
 
 export function generateSolidModule(
@@ -16,6 +19,7 @@ export function generateSolidModule(
   frontmatter: Record<string, unknown>,
   options: ResolvedSolidOptions & { root?: string },
   id: string,
+  localBindings?: ReadonlyMap<string, ResolvedDocumentComponentImport>,
 ): string {
   const rawHtml = JSON.stringify(content);
   const frontmatterLiteral = JSON.stringify(frontmatter);
@@ -35,7 +39,12 @@ export default function MarkdownContent() {
 `;
   }
 
-  const imports = renderComponentImports(usedComponents, options, id);
+  const imports = renderIslandComponentImports(usedComponents, {
+    globalComponents: options.components,
+    localBindings,
+    documentPath: id,
+    root: options.root,
+  });
   const componentMap = usedComponents.map((name) => `  ${name},`).join("\n");
 
   return `
@@ -88,26 +97,4 @@ export default function MarkdownContent() {
   return <div class="ox-content" ref={container} innerHTML={rawHtml} />;
 }
 `;
-}
-
-/** Rewrites registered component paths as imports relative to the Markdown file. */
-function renderComponentImports(
-  usedComponents: string[],
-  options: ResolvedSolidOptions & { root?: string },
-  id: string,
-): string {
-  const mdDir = path.dirname(id);
-  const root = options.root || process.cwd();
-
-  return usedComponents
-    .map((name) => {
-      const componentPath = options.components[name];
-      if (!componentPath) return "";
-      const absolutePath = path.resolve(root, componentPath.replace(/^\.\//, ""));
-      const relativePath = path.relative(mdDir, absolutePath).replace(/\\/g, "/");
-      const importPath = relativePath.startsWith(".") ? relativePath : "./" + relativePath;
-      return `import ${name} from '${importPath}';`;
-    })
-    .filter(Boolean)
-    .join("\n");
 }

--- a/npm/vite-plugin-ox-content-solid/src/document-imports.test.ts
+++ b/npm/vite-plugin-ox-content-solid/src/document-imports.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vite-plus/test";
+import { transformMarkdownWithSolid } from "./transform";
+import type { ResolvedSolidOptions } from "./types";
+
+describe("document-local Solid islands", () => {
+  it("hydrates a relative default import and emits a static import of that file", async () => {
+    const result = await transformMarkdownWithSolid(
+      "import GtvChart from './gtv-chart/GtvChart.tsx'\n\n<GtvChart title=\"ok\" />\n",
+      "/repo/docs/guide.mdx",
+      createOptions({ components: {} }),
+    );
+
+    expect(result.usedComponents).toEqual(["GtvChart"]);
+    expect(result.code).toContain("import GtvChart from './gtv-chart/GtvChart.tsx'");
+    expect(result.code).toContain('data-ox-island=\\"GtvChart\\"');
+    expect(result.code).toContain("ok");
+    expect(result.code).toContain("initIslands");
+  });
+
+  it("keeps the same local name on two documents as distinct imports", async () => {
+    const first = await transformMarkdownWithSolid(
+      "import Chart from './a/Chart.tsx'\n\n<Chart />\n",
+      "/repo/docs/a.mdx",
+      createOptions({ components: {} }),
+    );
+    const second = await transformMarkdownWithSolid(
+      "import Chart from './b/Chart.tsx'\n\n<Chart />\n",
+      "/repo/docs/b.mdx",
+      createOptions({ components: {} }),
+    );
+
+    expect(first.code).toContain("import Chart from './a/Chart.tsx'");
+    expect(second.code).toContain("import Chart from './b/Chart.tsx'");
+    expect(first.code).not.toContain("./b/Chart.tsx");
+    expect(second.code).not.toContain("./a/Chart.tsx");
+  });
+
+  it("rejects an import that escapes the content root", async () => {
+    const result = await transformMarkdownWithSolid(
+      "import Outside from '../../Outside.tsx'\n\n<Outside />\n",
+      "/repo/docs/nested/page.mdx",
+      createOptions({ components: {} }),
+    );
+
+    expect(result.usedComponents).toEqual([]);
+    expect(result.code).not.toContain("import Outside");
+    expect(result.code).not.toContain("initIslands");
+  });
+
+  it("resolves a nested relative path", async () => {
+    const result = await transformMarkdownWithSolid(
+      "import Foo from './widgets/Foo.tsx'\n\n<Foo />\n",
+      "/repo/docs/guide.mdx",
+      createOptions({ components: {} }),
+    );
+
+    expect(result.usedComponents).toEqual(["Foo"]);
+    expect(result.code).toContain("import Foo from './widgets/Foo.tsx'");
+  });
+
+  it("keeps serialized literal props on the island payload", async () => {
+    const result = await transformMarkdownWithSolid(
+      "import GtvChart from './gtv-chart/GtvChart.tsx'\n\n<GtvChart title=\"ok\" count={3} />\n",
+      "/repo/docs/guide.mdx",
+      createOptions({ components: {} }),
+    );
+
+    expect(result.code).toContain("data-ox-island");
+    expect(result.code).toContain("title");
+    expect(result.code).toContain("ok");
+    expect(result.code).toMatch(/data-ox-props|application\\\/json/);
+  });
+
+  it("still hydrates the global components map when the document has no import", async () => {
+    const result = await transformMarkdownWithSolid(
+      '<Alert tone="info" />\n',
+      "/repo/docs/guide.mdx",
+      createOptions(),
+    );
+
+    expect(result.usedComponents).toEqual(["Alert"]);
+    expect(result.code).toContain("import Alert from '../src/components/Alert.tsx'");
+  });
+
+  it("lets a document-local binding override a global name", async () => {
+    const result = await transformMarkdownWithSolid(
+      "import Alert from './local/Alert.tsx'\n\n<Alert />\n",
+      "/repo/docs/guide.mdx",
+      createOptions(),
+    );
+
+    expect(result.code).toContain("import Alert from './local/Alert.tsx'");
+    expect(result.code).not.toContain("../src/components/Alert.tsx");
+  });
+
+  it("leaves unregistered JSX without a matching import static", async () => {
+    const result = await transformMarkdownWithSolid(
+      "# Plain\n\n<Unknown />\n",
+      "/repo/docs/unknown.mdx",
+      createOptions({ components: {} }),
+    );
+
+    expect(result.usedComponents).toEqual([]);
+    expect(result.code).not.toContain("import Unknown");
+    expect(result.code).not.toContain("initIslands");
+    expect(result.code).toContain('data-ox-island=\\"Unknown\\"');
+  });
+
+  it("does not create document-import islands from ESM in plain .md", async () => {
+    const result = await transformMarkdownWithSolid(
+      "import Chart from './Chart.tsx'\n\n<Chart />\n",
+      "/repo/docs/page.md",
+      createOptions({ components: {} }),
+    );
+
+    expect(result.usedComponents).toEqual([]);
+    expect(result.code).not.toContain("import Chart from './Chart.tsx'");
+    expect(result.code).not.toContain("initIslands");
+  });
+
+  it("applies an optional SSR hook without a framework SSR runtime in core", async () => {
+    const result = await transformMarkdownWithSolid(
+      "import GtvChart from './gtv-chart/GtvChart.tsx'\n\n<GtvChart title=\"ok\" />\n",
+      "/repo/docs/guide.mdx",
+      createOptions({
+        components: {},
+        renderIsland: (name, props) => `<span class="ssr">${name}:${String(props.title)}</span>`,
+      }),
+    );
+
+    expect(result.code).toContain("GtvChart:ok");
+    expect(result.code).toContain("import GtvChart from './gtv-chart/GtvChart.tsx'");
+    expect(result.code).not.toContain("svelte/server");
+    expect(result.code).not.toContain("react-dom/server");
+  });
+});
+
+function createOptions(overrides: Partial<ResolvedSolidOptions> = {}): ResolvedSolidOptions {
+  return {
+    srcDir: "docs",
+    outDir: "dist",
+    base: "/",
+    extensions: [".md", ".markdown", ".mdx"],
+    gfm: true,
+    autolinks: true,
+    frontmatter: true,
+    toc: true,
+    tocMaxDepth: 3,
+    codeAnnotations: { enabled: false, metaKey: "annotate" },
+    components: { Alert: "./src/components/Alert.tsx" },
+    verifySolidPlugin: true,
+    embeds: { github: false, openGraph: false },
+    root: "/repo",
+    ...overrides,
+  };
+}

--- a/npm/vite-plugin-ox-content-solid/src/index.ts
+++ b/npm/vite-plugin-ox-content-solid/src/index.ts
@@ -96,6 +96,7 @@ export function oxContentSolid(options: SolidIntegrationOptions = {}): PluginOpt
         ...resolved,
         components: Object.fromEntries(componentMap),
         root: config.root,
+        renderIsland: options.renderIsland,
       });
 
       return {

--- a/npm/vite-plugin-ox-content-solid/src/transform.ts
+++ b/npm/vite-plugin-ox-content-solid/src/transform.ts
@@ -1,5 +1,7 @@
 import {
-  discoverRegisteredMdxComponents,
+  applyIslandSsrHtml,
+  discoverDocumentMdxIslands,
+  resolveContentRootPath,
   resolveMdxForFilePath,
   transformMarkdown as baseTransformMarkdown,
 } from "@ox-content/vite-plugin";
@@ -22,22 +24,38 @@ export async function transformMarkdownWithSolid(
 
   if (mdx) {
     const transformed = await baseTransformMarkdown(markdownContent, id, baseOptions);
-    const usedComponents = await discoverRegisteredMdxComponents({
+    const discovered = await discoverDocumentMdxIslands({
       source: markdownContent,
       html: transformed.html,
       components: options.components,
+      imports: transformed.imports,
+      documentPath: id,
+      contentRoot: resolveContentRootPath({
+        srcDir: options.srcDir,
+        root: options.root,
+      }),
+      srcDir: options.srcDir,
     });
+    const html = options.renderIsland
+      ? await applyIslandSsrHtml(
+          transformed.html,
+          options.renderIsland,
+          id,
+          discovered.usedComponents,
+        )
+      : transformed.html;
     return {
       code: generateSolidModule(
-        transformed.html,
-        usedComponents,
-        usedComponents,
+        html,
+        discovered.usedComponents,
+        discovered.usedComponents,
         frontmatter,
         options,
         id,
+        discovered.localBindings,
       ),
       map: null,
-      usedComponents,
+      usedComponents: discovered.usedComponents,
       frontmatter,
     };
   }

--- a/npm/vite-plugin-ox-content-solid/src/types.ts
+++ b/npm/vite-plugin-ox-content-solid/src/types.ts
@@ -1,4 +1,4 @@
-import type { OxContentOptions } from "@ox-content/vite-plugin";
+import type { OxContentOptions, RenderIslandFn } from "@ox-content/vite-plugin";
 
 /**
  * Code annotation options for the Solid integration.
@@ -117,6 +117,13 @@ export interface SolidIntegrationOptions extends OxContentOptions {
    * @default { github: true, openGraph: true }
    */
   embeds?: BuiltinEmbedOptions | false;
+
+  /**
+   * Optional adapter hook that replaces island inner HTML at transform time.
+   * The core renderer stays framework-neutral; do not import a framework SSR
+   * runtime from `@ox-content/vite-plugin`.
+   */
+  renderIsland?: RenderIslandFn;
 }
 
 /**
@@ -221,6 +228,7 @@ export interface ResolvedSolidOptions {
   embeds: ResolvedBuiltinEmbedOptions;
   mdx?: boolean;
   root?: string;
+  renderIsland?: RenderIslandFn;
 }
 
 export interface SolidTransformResult {

--- a/npm/vite-plugin-ox-content-svelte/src/document-imports.test.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/document-imports.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vite-plus/test";
+import { transformMarkdownWithSvelte } from "./transform";
+import type { ResolvedSvelteOptions } from "./types";
+
+describe("document-local Svelte islands", () => {
+  it("hydrates a relative default import and emits a static import of that file", async () => {
+    const result = await transformMarkdownWithSvelte(
+      "import GtvChart from './gtv-chart/GtvChart.svelte'\n\n<GtvChart title=\"ok\" />\n",
+      "/repo/docs/guide.mdx",
+      createOptions({ components: {} }),
+    );
+
+    expect(result.usedComponents).toEqual(["GtvChart"]);
+    expect(result.code).toContain("import GtvChart from './gtv-chart/GtvChart.svelte'");
+    expect(result.code).toContain("initIslands");
+  });
+
+  it("keeps the same local name on two documents as distinct imports", async () => {
+    const first = await transformMarkdownWithSvelte(
+      "import Chart from './a/Chart.svelte'\n\n<Chart />\n",
+      "/repo/docs/a.mdx",
+      createOptions({ components: {} }),
+    );
+    const second = await transformMarkdownWithSvelte(
+      "import Chart from './b/Chart.svelte'\n\n<Chart />\n",
+      "/repo/docs/b.mdx",
+      createOptions({ components: {} }),
+    );
+
+    expect(first.code).toContain("import Chart from './a/Chart.svelte'");
+    expect(second.code).toContain("import Chart from './b/Chart.svelte'");
+    expect(first.code).not.toContain("./b/Chart.svelte");
+    expect(second.code).not.toContain("./a/Chart.svelte");
+  });
+
+  it("rejects an import that escapes the content root", async () => {
+    const result = await transformMarkdownWithSvelte(
+      "import Outside from '../../Outside.svelte'\n\n<Outside />\n",
+      "/repo/docs/nested/page.mdx",
+      createOptions({ components: {} }),
+    );
+
+    expect(result.usedComponents).toEqual([]);
+    expect(result.code).not.toContain("import Outside");
+    expect(result.code).not.toContain("initIslands");
+  });
+
+  it("resolves a nested relative path and keeps literal props", async () => {
+    const result = await transformMarkdownWithSvelte(
+      "import Foo from './widgets/Foo.svelte'\n\n<Foo title=\"ok\" />\n",
+      "/repo/docs/guide.mdx",
+      createOptions({ components: {} }),
+    );
+
+    expect(result.usedComponents).toEqual(["Foo"]);
+    expect(result.code).toContain("import Foo from './widgets/Foo.svelte'");
+    expect(result.code).toContain("ok");
+  });
+
+  it("still hydrates the global components map when the document has no import", async () => {
+    const result = await transformMarkdownWithSvelte(
+      '<Alert tone="info" />\n',
+      "/repo/docs/guide.mdx",
+      createOptions(),
+    );
+
+    expect(result.usedComponents).toEqual(["Alert"]);
+    expect(result.code).toContain("import Alert from '../src/components/Alert.svelte'");
+  });
+
+  it("lets a document-local binding override a global name", async () => {
+    const result = await transformMarkdownWithSvelte(
+      "import Alert from './local/Alert.svelte'\n\n<Alert />\n",
+      "/repo/docs/guide.mdx",
+      createOptions(),
+    );
+
+    expect(result.code).toContain("import Alert from './local/Alert.svelte'");
+    expect(result.code).not.toContain("../src/components/Alert.svelte");
+  });
+
+  it("leaves unregistered JSX without a matching import static", async () => {
+    const result = await transformMarkdownWithSvelte(
+      "# Plain\n\n<Unknown />\n",
+      "/repo/docs/unknown.mdx",
+      createOptions({ components: {} }),
+    );
+
+    expect(result.usedComponents).toEqual([]);
+    expect(result.code).not.toContain("import Unknown");
+    expect(result.code).not.toContain("initIslands");
+  });
+
+  it("does not create document-import islands from ESM in plain .md", async () => {
+    const result = await transformMarkdownWithSvelte(
+      "import Chart from './Chart.svelte'\n\n<Chart />\n",
+      "/repo/docs/page.md",
+      createOptions({ components: {} }),
+    );
+
+    expect(result.usedComponents).toEqual([]);
+    expect(result.code).not.toContain("import Chart from './Chart.svelte'");
+    expect(result.code).not.toContain("initIslands");
+  });
+
+  it("applies an optional SSR hook without importing svelte/server", async () => {
+    const result = await transformMarkdownWithSvelte(
+      "import GtvChart from './gtv-chart/GtvChart.svelte'\n\n<GtvChart title=\"ok\" />\n",
+      "/repo/docs/guide.mdx",
+      createOptions({
+        components: {},
+        renderIsland: (name, props) => `<span class="ssr">${name}:${String(props.title)}</span>`,
+      }),
+    );
+
+    expect(result.code).toContain("GtvChart:ok");
+    expect(result.code).toContain("import GtvChart from './gtv-chart/GtvChart.svelte'");
+    expect(result.code).not.toContain("svelte/server");
+  });
+});
+
+function createOptions(overrides: Partial<ResolvedSvelteOptions> = {}): ResolvedSvelteOptions {
+  return {
+    srcDir: "docs",
+    outDir: "dist",
+    base: "/",
+    extensions: [".md", ".markdown", ".mdx"],
+    gfm: true,
+    frontmatter: true,
+    toc: true,
+    tocMaxDepth: 3,
+    codeAnnotations: { enabled: false, metaKey: "annotate" },
+    components: { Alert: "./src/components/Alert.svelte" },
+    runes: true,
+    embeds: { github: false, openGraph: false },
+    root: "/repo",
+    ...overrides,
+  };
+}

--- a/npm/vite-plugin-ox-content-svelte/src/index.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/index.ts
@@ -121,6 +121,7 @@ export function oxContentSvelte(options: SvelteIntegrationOptions = {}): PluginO
         ...resolved,
         components: Object.fromEntries(componentMap),
         root: config.root,
+        renderIsland: options.renderIsland,
       });
 
       return {

--- a/npm/vite-plugin-ox-content-svelte/src/transform.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/transform.ts
@@ -1,8 +1,11 @@
-import * as path from "path";
 import {
-  discoverRegisteredMdxComponents,
+  applyIslandSsrHtml,
+  discoverDocumentMdxIslands,
+  renderIslandComponentImports,
+  resolveContentRootPath,
   resolveMdxForFilePath,
   transformMarkdown as baseTransformMarkdown,
+  type ResolvedDocumentComponentImport,
 } from "@ox-content/vite-plugin";
 import { compile } from "svelte/compiler";
 import type {
@@ -91,22 +94,35 @@ export async function transformMarkdownWithSvelte(
 
   if (mdx) {
     const transformed = await baseTransformMarkdown(markdownContent, id, baseOptions);
-    const usedComponents = await discoverRegisteredMdxComponents({
+    const discovered = await discoverDocumentMdxIslands({
       source: markdownContent,
       html: transformed.html,
       components,
+      imports: transformed.imports,
+      documentPath: id,
+      contentRoot: resolveContentRootPath({ srcDir: options.srcDir, root: options.root }),
+      srcDir: options.srcDir,
     });
+    const html = options.renderIsland
+      ? await applyIslandSsrHtml(
+          transformed.html,
+          options.renderIsland,
+          id,
+          discovered.usedComponents,
+        )
+      : transformed.html;
     return compileSvelteResult(
       generateSvelteModule(
-        transformed.html,
-        usedComponents,
-        usedComponents,
+        html,
+        discovered.usedComponents,
+        discovered.usedComponents,
         frontmatter,
         options,
         id,
+        discovered.localBindings,
       ),
       id,
-      usedComponents,
+      discovered.usedComponents,
       frontmatter,
     );
   }
@@ -332,23 +348,17 @@ function generateSvelteModule(
   frontmatter: Record<string, unknown>,
   options: ResolvedSvelteOptions & { root?: string },
   id: string,
+  localBindings?: ReadonlyMap<string, ResolvedDocumentComponentImport>,
 ): string {
-  const mdDir = path.dirname(id);
-  const root = options.root || process.cwd();
   // Rust island payloads include `</script>`; that must not close this SFC block.
   const rawHtmlLiteral = JSON.stringify(content).replaceAll("</script", "<\\/script");
 
-  const imports = usedComponents
-    .map((name) => {
-      const componentPath = options.components[name];
-      if (!componentPath) return "";
-      const absolutePath = path.resolve(root, componentPath.replace(/^\.\//, ""));
-      const relativePath = path.relative(mdDir, absolutePath).replace(/\\/g, "/");
-      const importPath = relativePath.startsWith(".") ? relativePath : "./" + relativePath;
-      return `import ${name} from '${importPath}';`;
-    })
-    .filter(Boolean)
-    .join("\n");
+  const imports = renderIslandComponentImports(usedComponents, {
+    globalComponents: options.components,
+    localBindings,
+    documentPath: id,
+    root: options.root,
+  });
 
   // If no registered islands, generate simpler code without island runtime
   if (usedComponents.length === 0) {

--- a/npm/vite-plugin-ox-content-svelte/src/types.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/types.ts
@@ -1,4 +1,4 @@
-import type { OxContentOptions } from "@ox-content/vite-plugin";
+import type { OxContentOptions, RenderIslandFn } from "@ox-content/vite-plugin";
 
 /**
  * Code annotation options for the Svelte integration.
@@ -98,6 +98,13 @@ export interface SvelteIntegrationOptions extends OxContentOptions {
    * @default { github: true, openGraph: true }
    */
   embeds?: BuiltinEmbedOptions | false;
+
+  /**
+   * Optional adapter hook that replaces island inner HTML at transform time.
+   * The core renderer stays framework-neutral; do not import a framework SSR
+   * runtime from `@ox-content/vite-plugin`.
+   */
+  renderIsland?: RenderIslandFn;
 }
 
 /**
@@ -202,6 +209,7 @@ export interface ResolvedSvelteOptions {
   embeds: ResolvedBuiltinEmbedOptions;
   mdx?: boolean;
   root?: string;
+  renderIsland?: RenderIslandFn;
 }
 
 export interface SvelteTransformResult {

--- a/npm/vite-plugin-ox-content-vue/src/document-imports.test.ts
+++ b/npm/vite-plugin-ox-content-vue/src/document-imports.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vite-plus/test";
+import { transformMarkdownWithVue } from "./transform";
+import type { ResolvedVueOptions } from "./types";
+
+describe("document-local Vue islands", () => {
+  it("hydrates a relative default import and emits a static import of that file", async () => {
+    const result = await transformMarkdownWithVue(
+      "import GtvChart from './gtv-chart/GtvChart.vue'\n\n<GtvChart title=\"ok\" />\n",
+      "/repo/docs/guide.mdx",
+      createOptions({ components: new Map() }),
+    );
+
+    expect(result.usedComponents).toEqual(["GtvChart"]);
+    expect(result.code).toContain("import GtvChart from './gtv-chart/GtvChart.vue'");
+    expect(result.code).toContain('data-ox-island=\\"GtvChart\\"');
+    expect(result.code).toContain("ok");
+  });
+
+  it("keeps the same local name on two documents as distinct imports", async () => {
+    const first = await transformMarkdownWithVue(
+      "import Chart from './a/Chart.vue'\n\n<Chart />\n",
+      "/repo/docs/a.mdx",
+      createOptions({ components: new Map() }),
+    );
+    const second = await transformMarkdownWithVue(
+      "import Chart from './b/Chart.vue'\n\n<Chart />\n",
+      "/repo/docs/b.mdx",
+      createOptions({ components: new Map() }),
+    );
+
+    expect(first.code).toContain("import Chart from './a/Chart.vue'");
+    expect(second.code).toContain("import Chart from './b/Chart.vue'");
+  });
+
+  it("rejects an import that escapes the content root", async () => {
+    const result = await transformMarkdownWithVue(
+      "import Outside from '../../Outside.vue'\n\n<Outside />\n",
+      "/repo/docs/nested/page.mdx",
+      createOptions({ components: new Map() }),
+    );
+
+    expect(result.usedComponents).toEqual([]);
+    expect(result.code).not.toContain("import Outside");
+  });
+
+  it("still hydrates the global map and leaves plain .md unchanged", async () => {
+    const globalMap = await transformMarkdownWithVue(
+      '<Alert tone="info" />\n',
+      "/repo/docs/guide.mdx",
+      createOptions(),
+    );
+    expect(globalMap.code).toContain("import Alert from '../src/components/Alert.vue'");
+
+    const plain = await transformMarkdownWithVue(
+      "import Chart from './Chart.vue'\n\n<Chart />\n",
+      "/repo/docs/page.md",
+      createOptions({ components: new Map() }),
+    );
+    expect(plain.usedComponents).toEqual([]);
+    expect(plain.code).not.toContain("import Chart from './Chart.vue'");
+  });
+});
+
+function createOptions(
+  overrides: Partial<
+    Omit<ResolvedVueOptions, "components"> & { components: Map<string, string>; root: string }
+  > = {},
+): Omit<ResolvedVueOptions, "components"> & { components: Map<string, string>; root: string } {
+  return {
+    srcDir: "docs",
+    outDir: "dist",
+    base: "/",
+    extensions: [".md", ".markdown", ".mdx"],
+    gfm: true,
+    autolinks: true,
+    frontmatter: true,
+    toc: true,
+    tocMaxDepth: 3,
+    codeAnnotations: { enabled: false, metaKey: "annotate" },
+    components: new Map([["Alert", "./src/components/Alert.vue"]]),
+    reactivityTransform: false,
+    customBlocks: true,
+    embeds: { github: false, openGraph: false },
+    root: "/repo",
+    ...overrides,
+  };
+}

--- a/npm/vite-plugin-ox-content-vue/src/index.ts
+++ b/npm/vite-plugin-ox-content-vue/src/index.ts
@@ -127,6 +127,7 @@ export function oxContentVue(options: VueIntegrationOptions = {}): PluginOption[
         ...resolved,
         components: componentMap,
         root: config.root,
+        renderIsland: options.renderIsland,
       });
 
       return {

--- a/npm/vite-plugin-ox-content-vue/src/transform.ts
+++ b/npm/vite-plugin-ox-content-vue/src/transform.ts
@@ -2,11 +2,14 @@
  * Markdown to Vue SFC transformation.
  */
 
-import * as path from "path";
 import {
-  discoverRegisteredMdxComponents,
+  applyIslandSsrHtml,
+  discoverDocumentMdxIslands,
+  renderIslandComponentImports,
+  resolveContentRootPath,
   resolveMdxForFilePath,
   transformMarkdown as baseTransformMarkdown,
+  type ResolvedDocumentComponentImport,
 } from "@ox-content/vite-plugin";
 import type { ResolvedVueOptions, VueTransformResult, ComponentIsland } from "./types";
 
@@ -104,22 +107,35 @@ export async function transformMarkdownWithVue(
 
   if (mdx) {
     const transformed = await baseTransformMarkdown(markdownContent, id, baseOptions);
-    const usedComponents = await discoverRegisteredMdxComponents({
+    const discovered = await discoverDocumentMdxIslands({
       source: markdownContent,
       html: transformed.html,
       components,
+      imports: transformed.imports,
+      documentPath: id,
+      contentRoot: resolveContentRootPath({ srcDir: options.srcDir, root: options.root }),
+      srcDir: options.srcDir,
     });
+    const html = options.renderIsland
+      ? await applyIslandSsrHtml(
+          transformed.html,
+          options.renderIsland,
+          id,
+          discovered.usedComponents,
+        )
+      : transformed.html;
     return {
       code: generateVueSFC(
-        transformed.html,
-        usedComponents,
-        usedComponents,
+        html,
+        discovered.usedComponents,
+        discovered.usedComponents,
         frontmatter,
         options,
         id,
+        discovered.localBindings,
       ),
       map: null,
-      usedComponents,
+      usedComponents: discovered.usedComponents,
       frontmatter,
     };
   }
@@ -363,23 +379,14 @@ function generateVueSFC(
   frontmatter: Record<string, unknown>,
   options: TransformOptions,
   id: string,
+  localBindings?: ReadonlyMap<string, ResolvedDocumentComponentImport>,
 ): string {
-  const mdDir = path.dirname(id);
-  const root = options.root || process.cwd();
-
-  const componentImports = usedComponents
-    .map((name) => {
-      const componentPath = options.components.get(name);
-      if (!componentPath) return "";
-      // Convert relative-to-root path to relative-to-md-file path
-      const absolutePath = path.resolve(root, componentPath.replace(/^\.\//, ""));
-      const relativePath = path.relative(mdDir, absolutePath).replace(/\\/g, "/");
-      // Ensure the path starts with ./ or ../
-      const importPath = relativePath.startsWith(".") ? relativePath : "./" + relativePath;
-      return `import ${name} from '${importPath}';`;
-    })
-    .filter(Boolean)
-    .join("\n");
+  const componentImports = renderIslandComponentImports(usedComponents, {
+    globalComponents: options.components,
+    localBindings,
+    documentPath: id,
+    root: options.root,
+  });
 
   const componentMap = usedComponents.map((name) => `  ${name},`).join("\n");
 

--- a/npm/vite-plugin-ox-content-vue/src/types.ts
+++ b/npm/vite-plugin-ox-content-vue/src/types.ts
@@ -2,7 +2,7 @@
  * Type definitions for Vue integration plugin.
  */
 
-import type { OxContentOptions } from "@ox-content/vite-plugin";
+import type { OxContentOptions, RenderIslandFn } from "@ox-content/vite-plugin";
 
 /**
  * Code annotation options for the Vue integration.
@@ -129,6 +129,13 @@ export interface VueIntegrationOptions extends OxContentOptions {
    * @default { github: true, openGraph: true }
    */
   embeds?: BuiltinEmbedOptions | false;
+
+  /**
+   * Optional adapter hook that replaces island inner HTML at transform time.
+   * The core renderer stays framework-neutral; do not import a framework SSR
+   * runtime from `@ox-content/vite-plugin`.
+   */
+  renderIsland?: RenderIslandFn;
 }
 
 /**
@@ -236,6 +243,7 @@ export interface ResolvedVueOptions {
   customBlocks: boolean;
   embeds: ResolvedBuiltinEmbedOptions;
   mdx?: boolean;
+  renderIsland?: RenderIslandFn;
 }
 
 /**

--- a/npm/vite-plugin-ox-content/src/document-imports.test.ts
+++ b/npm/vite-plugin-ox-content/src/document-imports.test.ts
@@ -1,0 +1,133 @@
+import path from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+import { resolveDocumentComponentImports } from "./document-imports";
+import type { MdxImport } from "./types";
+
+const contentRoot = "/repo/docs";
+
+describe("resolveDocumentComponentImports", () => {
+  it("resolves a relative default import against the document directory", () => {
+    const result = resolveDocumentComponentImports({
+      imports: [defaultImport("GtvChart", "./gtv-chart/GtvChart.tsx")],
+      documentPath: "/repo/docs/guide.mdx",
+      contentRoot,
+      srcDir: "docs",
+    });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.bindings).toEqual([
+      {
+        localName: "GtvChart",
+        specifier: "./gtv-chart/GtvChart.tsx",
+        resolvedPath: path.normalize("/repo/docs/gtv-chart/GtvChart.tsx"),
+        importPathRelativeToDocument: "./gtv-chart/GtvChart.tsx",
+        imported: "default",
+        kind: "default",
+      },
+    ]);
+  });
+
+  it("resolves a named import alias", () => {
+    const result = resolveDocumentComponentImports({
+      imports: [
+        {
+          source: "./Chart.tsx",
+          specifiers: [{ imported: "Chart", local: "Plot", kind: "named" }],
+        },
+      ],
+      documentPath: "/repo/docs/guide.mdx",
+      contentRoot,
+    });
+
+    expect(result.bindings).toEqual([
+      expect.objectContaining({
+        localName: "Plot",
+        imported: "Chart",
+        kind: "named",
+        importPathRelativeToDocument: "./Chart.tsx",
+      }),
+    ]);
+  });
+
+  it("keeps two documents with the same local name on distinct paths", () => {
+    const first = resolveDocumentComponentImports({
+      imports: [defaultImport("Chart", "./a/Chart.tsx")],
+      documentPath: "/repo/docs/a.mdx",
+      contentRoot,
+    });
+    const second = resolveDocumentComponentImports({
+      imports: [defaultImport("Chart", "./b/Chart.tsx")],
+      documentPath: "/repo/docs/b.mdx",
+      contentRoot,
+    });
+
+    expect(first.bindings[0]?.importPathRelativeToDocument).toBe("./a/Chart.tsx");
+    expect(second.bindings[0]?.importPathRelativeToDocument).toBe("./b/Chart.tsx");
+    expect(first.bindings[0]?.resolvedPath).not.toBe(second.bindings[0]?.resolvedPath);
+  });
+
+  it("rejects a specifier that escapes the content root", () => {
+    const result = resolveDocumentComponentImports({
+      imports: [defaultImport("Outside", "../../Outside.tsx")],
+      documentPath: "/repo/docs/nested/page.mdx",
+      contentRoot,
+      srcDir: "docs",
+    });
+
+    expect(result.bindings).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "escapes-root",
+        specifier: "../../Outside.tsx",
+        localName: "Outside",
+      }),
+    ]);
+  });
+
+  it("ignores bare, package, and remote specifiers", () => {
+    const result = resolveDocumentComponentImports({
+      imports: [
+        defaultImport("Chart", "chart-pkg"),
+        defaultImport("Remote", "https://example.com/Chart.js"),
+      ],
+      documentPath: "/repo/docs/guide.mdx",
+      contentRoot,
+    });
+
+    expect(result.bindings).toEqual([]);
+    expect(result.diagnostics.map((item) => item.code)).toEqual(["not-relative", "not-relative"]);
+  });
+
+  it("skips namespace imports", () => {
+    const result = resolveDocumentComponentImports({
+      imports: [
+        {
+          source: "./icons.tsx",
+          specifiers: [{ imported: "*", local: "Icons", kind: "namespace" }],
+        },
+      ],
+      documentPath: "/repo/docs/guide.mdx",
+      contentRoot,
+    });
+
+    expect(result.bindings).toEqual([]);
+  });
+
+  it("drops a name bound twice in the same document", () => {
+    const result = resolveDocumentComponentImports({
+      imports: [defaultImport("Chart", "./A.tsx"), defaultImport("Chart", "./B.tsx")],
+      documentPath: "/repo/docs/guide.mdx",
+      contentRoot,
+    });
+
+    expect(result.bindings).toEqual([]);
+    expect(result.diagnostics.some((item) => item.code === "duplicate-binding")).toBe(true);
+  });
+});
+
+function defaultImport(local: string, source: string): MdxImport {
+  return {
+    source,
+    specifiers: [{ imported: "default", local, kind: "default" }],
+  };
+}

--- a/npm/vite-plugin-ox-content/src/document-imports.ts
+++ b/npm/vite-plugin-ox-content/src/document-imports.ts
@@ -1,0 +1,155 @@
+/**
+ * Resolve MDX component imports relative to the document that declared them.
+ *
+ * Only `./` and `../` specifiers become island bindings. Bare, package, and
+ * remote specifiers are reported and ignored. A specifier that leaves the
+ * configured content root is rejected with a diagnostic.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type { MdxImport, MdxImportSpecifierKind } from "./types";
+
+export interface ResolveDocumentComponentImportsInput {
+  imports: readonly MdxImport[];
+  documentPath: string;
+  contentRoot?: string;
+  srcDir?: string;
+}
+
+export interface ResolvedDocumentComponentImport {
+  localName: string;
+  specifier: string;
+  resolvedPath: string;
+  importPathRelativeToDocument: string;
+  imported: string;
+  kind: Exclude<MdxImportSpecifierKind, "namespace">;
+}
+
+export type DocumentImportDiagnosticCode = "not-relative" | "escapes-root" | "duplicate-binding";
+
+export interface DocumentImportDiagnostic {
+  code: DocumentImportDiagnosticCode;
+  message: string;
+  specifier: string;
+  localName?: string;
+}
+
+export interface ResolveDocumentComponentImportsResult {
+  bindings: ResolvedDocumentComponentImport[];
+  diagnostics: DocumentImportDiagnostic[];
+}
+
+export function resolveContentRootPath(input: {
+  contentRoot?: string;
+  srcDir?: string;
+  root?: string;
+}): string {
+  if (input.contentRoot) {
+    return path.resolve(input.contentRoot);
+  }
+  const root = input.root ?? process.cwd();
+  return path.resolve(root, input.srcDir ?? ".");
+}
+
+export function stripViteQuery(id: string): string {
+  return id.split("?")[0].split("#")[0];
+}
+
+export function resolveDocumentComponentImports(
+  input: ResolveDocumentComponentImportsInput,
+): ResolveDocumentComponentImportsResult {
+  const documentPath = stripViteQuery(input.documentPath);
+  const documentDir = path.dirname(documentPath);
+  const contentRoot = resolveContentRootPath(input);
+  const diagnostics: DocumentImportDiagnostic[] = [];
+  const candidates: ResolvedDocumentComponentImport[] = [];
+
+  for (const statement of input.imports) {
+    const specifier = statement.source;
+    if (!isRelativeSpecifier(specifier)) {
+      diagnostics.push({
+        code: "not-relative",
+        message: `Document component import "${specifier}" is not relative and was ignored.`,
+        specifier,
+      });
+      continue;
+    }
+
+    for (const spec of statement.specifiers) {
+      if (spec.kind === "namespace") {
+        continue;
+      }
+
+      const resolvedPath = resolveExistingPath(path.resolve(documentDir, specifier));
+      if (!isInsideRoot(resolvedPath, contentRoot)) {
+        diagnostics.push({
+          code: "escapes-root",
+          message: `Document component import "${specifier}" escapes the content root.`,
+          specifier,
+          localName: spec.local,
+        });
+        continue;
+      }
+
+      candidates.push({
+        localName: spec.local,
+        specifier,
+        resolvedPath,
+        importPathRelativeToDocument: toDocumentRelativeImport(documentDir, resolvedPath),
+        imported: spec.imported,
+        kind: spec.kind,
+      });
+    }
+  }
+
+  const counts = new Map<string, number>();
+  for (const binding of candidates) {
+    counts.set(binding.localName, (counts.get(binding.localName) ?? 0) + 1);
+  }
+
+  const bindings: ResolvedDocumentComponentImport[] = [];
+  const reportedDuplicates = new Set<string>();
+  for (const binding of candidates) {
+    if ((counts.get(binding.localName) ?? 0) > 1) {
+      if (!reportedDuplicates.has(binding.localName)) {
+        reportedDuplicates.add(binding.localName);
+        diagnostics.push({
+          code: "duplicate-binding",
+          message: `Document component name "${binding.localName}" is imported more than once.`,
+          specifier: binding.specifier,
+          localName: binding.localName,
+        });
+      }
+      continue;
+    }
+    bindings.push(binding);
+  }
+
+  return { bindings, diagnostics };
+}
+
+function isRelativeSpecifier(source: string): boolean {
+  return source.startsWith("./") || source.startsWith("../");
+}
+
+function resolveExistingPath(filePath: string): string {
+  try {
+    return fs.realpathSync(filePath);
+  } catch {
+    return path.normalize(filePath);
+  }
+}
+
+function isInsideRoot(resolvedPath: string, root: string): boolean {
+  const relative = path.relative(resolveExistingPath(root), resolvedPath);
+  return (
+    relative === "" ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative))
+  );
+}
+
+function toDocumentRelativeImport(documentDir: string, resolvedPath: string): string {
+  const relative = path.relative(documentDir, resolvedPath).replace(/\\/g, "/");
+  return relative.startsWith(".") ? relative : `./${relative}`;
+}

--- a/npm/vite-plugin-ox-content/src/document-islands.ts
+++ b/npm/vite-plugin-ox-content/src/document-islands.ts
@@ -1,0 +1,55 @@
+/**
+ * Combine document-local import resolution with MDX island discovery.
+ */
+
+import {
+  resolveContentRootPath,
+  resolveDocumentComponentImports,
+  type DocumentImportDiagnostic,
+  type ResolvedDocumentComponentImport,
+  type ResolveDocumentComponentImportsInput,
+} from "./document-imports";
+import { discoverRegisteredMdxComponents, type ComponentRegistry } from "./mdx-islands";
+import type { MdxImport } from "./types";
+
+export interface DiscoverDocumentMdxIslandsInput {
+  source: string;
+  html?: string;
+  components: ComponentRegistry;
+  imports: readonly MdxImport[];
+  documentPath: string;
+  contentRoot?: string;
+  srcDir?: string;
+  root?: string;
+}
+
+export interface DiscoverDocumentMdxIslandsResult {
+  usedComponents: string[];
+  localBindings: Map<string, ResolvedDocumentComponentImport>;
+  diagnostics: DocumentImportDiagnostic[];
+}
+
+export async function discoverDocumentMdxIslands(
+  input: DiscoverDocumentMdxIslandsInput,
+): Promise<DiscoverDocumentMdxIslandsResult> {
+  const resolved = resolveDocumentComponentImports({
+    imports: input.imports,
+    documentPath: input.documentPath,
+    contentRoot: input.contentRoot ?? resolveContentRootPath(input),
+    srcDir: input.srcDir,
+  } satisfies ResolveDocumentComponentImportsInput);
+  const localBindings = new Map(
+    resolved.bindings.map((binding) => [binding.localName, binding] as const),
+  );
+  const usedComponents = await discoverRegisteredMdxComponents({
+    source: input.source,
+    html: input.html,
+    components: input.components,
+    localNames: localBindings.keys(),
+  });
+  return {
+    usedComponents,
+    localBindings,
+    diagnostics: resolved.diagnostics,
+  };
+}

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -1000,11 +1000,33 @@ export {
   collectMdxIslandNamesFromHtml,
   collectMdxJsxNamesFromAst,
   discoverRegisteredMdxComponents,
+  intersectHydratableComponentNames,
   intersectRegisteredComponentNames,
   isRegisteredComponent,
   type ComponentRegistry,
   type DiscoverRegisteredMdxComponentsInput,
 } from "./mdx-islands";
+export {
+  resolveContentRootPath,
+  resolveDocumentComponentImports,
+  stripViteQuery,
+  type DocumentImportDiagnostic,
+  type DocumentImportDiagnosticCode,
+  type ResolveDocumentComponentImportsInput,
+  type ResolveDocumentComponentImportsResult,
+  type ResolvedDocumentComponentImport,
+} from "./document-imports";
+export {
+  discoverDocumentMdxIslands,
+  type DiscoverDocumentMdxIslandsInput,
+  type DiscoverDocumentMdxIslandsResult,
+} from "./document-islands";
+export {
+  renderIslandComponentImports,
+  type GlobalComponentMap,
+  type RenderIslandComponentImportsInput,
+} from "./island-codegen";
+export { applyIslandSsrHtml, type RenderIslandFn } from "./island-ssr";
 export { resolveImageOptions } from "./resolve-image-options";
 export {
   createFrameworkMarkdownOptions,

--- a/npm/vite-plugin-ox-content/src/island-codegen.ts
+++ b/npm/vite-plugin-ox-content/src/island-codegen.ts
@@ -1,0 +1,80 @@
+/**
+ * Emit static component imports for framework Markdown modules.
+ *
+ * Document-local bindings win over the global `components` map for that file
+ * only. Two documents that bind the same local name therefore emit different
+ * specifiers and do not share one module id.
+ */
+
+import path from "node:path";
+import type { ResolvedDocumentComponentImport } from "./document-imports";
+import { stripViteQuery } from "./document-imports";
+
+export type GlobalComponentMap = Readonly<Record<string, string>> | ReadonlyMap<string, string>;
+
+export interface RenderIslandComponentImportsInput {
+  globalComponents: GlobalComponentMap;
+  localBindings?: ReadonlyMap<string, ResolvedDocumentComponentImport>;
+  documentPath: string;
+  root?: string;
+}
+
+export function renderIslandComponentImports(
+  usedComponents: readonly string[],
+  input: RenderIslandComponentImportsInput,
+): string {
+  const documentDir = path.dirname(stripViteQuery(input.documentPath));
+  const root = input.root || process.cwd();
+
+  return usedComponents
+    .map((name) => {
+      const local = input.localBindings?.get(name);
+      if (local) {
+        return renderLocalImport(local);
+      }
+      const componentPath = getGlobalComponentPath(input.globalComponents, name);
+      if (!componentPath) return "";
+      return renderGlobalImport(name, componentPath, documentDir, root);
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function renderLocalImport(binding: ResolvedDocumentComponentImport): string {
+  const specifier = binding.importPathRelativeToDocument.replace(/\\/g, "/");
+  if (binding.kind === "default") {
+    return `import ${binding.localName} from '${specifier}';`;
+  }
+  if (binding.imported === binding.localName) {
+    return `import { ${binding.imported} } from '${specifier}';`;
+  }
+  return `import { ${binding.imported} as ${binding.localName} } from '${specifier}';`;
+}
+
+function renderGlobalImport(
+  name: string,
+  componentPath: string,
+  documentDir: string,
+  root: string,
+): string {
+  const absolutePath = path.resolve(root, componentPath.replace(/^\.\//, ""));
+  const relativePath = path.relative(documentDir, absolutePath).replace(/\\/g, "/");
+  const importPath = relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+  return `import ${name} from '${importPath}';`;
+}
+
+function getGlobalComponentPath(components: GlobalComponentMap, name: string): string | undefined {
+  if (isMapRegistry(components)) {
+    return components.get(name);
+  }
+  return Object.prototype.hasOwnProperty.call(components, name) ? components[name] : undefined;
+}
+
+function isMapRegistry(value: GlobalComponentMap): value is ReadonlyMap<string, string> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as ReadonlyMap<string, string>).has === "function" &&
+    typeof (value as ReadonlyMap<string, string>).get === "function"
+  );
+}

--- a/npm/vite-plugin-ox-content/src/island-ssr.test.ts
+++ b/npm/vite-plugin-ox-content/src/island-ssr.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vite-plus/test";
+import { applyIslandSsrHtml } from "./island-ssr";
+
+describe("applyIslandSsrHtml", () => {
+  it("injects adapter HTML without importing a framework SSR package", async () => {
+    const html = [
+      '<div class="ox-island" data-ox-island="GtvChart" data-ox-props="{&quot;props&quot;:{&quot;title&quot;:&quot;ok&quot;}}">',
+      '<script type="application/json">{"props":{"title":"ok"}}</script>',
+      "</div>",
+    ].join("");
+
+    const rendered = await applyIslandSsrHtml(
+      html,
+      (name, props, filePath) =>
+        `<span class="ssr">${name}:${String(props.title)}:${filePath}</span>`,
+      "/repo/docs/guide.mdx",
+    );
+
+    expect(rendered).toContain('<span class="ssr">GtvChart:ok:/repo/docs/guide.mdx</span>');
+    expect(rendered).toContain('data-ox-island="GtvChart"');
+    expect(rendered).toContain('<script type="application/json">');
+    expect(rendered).not.toContain("svelte/server");
+    expect(rendered).not.toContain("react-dom/server");
+    expect(rendered).not.toContain("solid-js/web");
+  });
+});

--- a/npm/vite-plugin-ox-content/src/island-ssr.ts
+++ b/npm/vite-plugin-ox-content/src/island-ssr.ts
@@ -1,0 +1,151 @@
+/**
+ * Optional adapter-side island SSR.
+ *
+ * Framework plugins may supply `renderIsland` to replace island inner HTML at
+ * transform time. This helper stays framework-neutral and does not import a
+ * framework SSR runtime.
+ */
+
+export type RenderIslandFn = (
+  name: string,
+  props: Record<string, unknown>,
+  filePath: string,
+) => string | Promise<string>;
+
+const RUST_PAYLOAD_KEYS = new Set(["props", "expressions", "spreads"]);
+const PAYLOAD_SCRIPT = /^\s*<script type="application\/json">[\s\S]*?<\/script>/;
+
+export async function applyIslandSsrHtml(
+  html: string,
+  renderIsland: RenderIslandFn,
+  filePath: string,
+  names?: Iterable<string>,
+): Promise<string> {
+  const allowed = names ? new Set(names) : null;
+  const islands = findIslandRanges(html);
+  let output = html;
+
+  for (const island of islands.toReversed()) {
+    if (allowed && !allowed.has(island.name)) {
+      continue;
+    }
+    const inner = output.slice(island.innerStart, island.closeStart);
+    const scriptMatch = inner.match(PAYLOAD_SCRIPT);
+    const script = scriptMatch?.[0] ?? "";
+    const props = parseIslandProps(island.propsAttr, script);
+    const ssrHtml = await renderIsland(island.name, props, filePath);
+    output =
+      output.slice(0, island.innerStart) + script + ssrHtml + output.slice(island.closeStart);
+  }
+
+  return output;
+}
+
+interface IslandRange {
+  name: string;
+  innerStart: number;
+  closeStart: number;
+  propsAttr?: string;
+}
+
+function findIslandRanges(html: string): IslandRange[] {
+  const ranges: IslandRange[] = [];
+  const openRe = /<(div|span)\b([^>]*\bdata-ox-island="([^"]+)"[^>]*)>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = openRe.exec(html)) !== null) {
+    const tag = match[1];
+    const name = decodeHtmlAttr(match[3] ?? "");
+    if (!tag || !name) continue;
+    const innerStart = match.index + match[0].length;
+    const closeStart = findMatchingClose(html, innerStart, tag);
+    ranges.push({
+      name,
+      innerStart,
+      closeStart,
+      propsAttr: matchAttr(match[2] ?? "", "data-ox-props"),
+    });
+  }
+  return ranges;
+}
+
+function findMatchingClose(html: string, from: number, tag: string): number {
+  const openNeedle = `<${tag}`;
+  const closeNeedle = `</${tag}>`;
+  let depth = 1;
+  let cursor = from;
+  while (cursor < html.length) {
+    const nextOpen = indexOfTagOpen(html, openNeedle, cursor);
+    const nextClose = html.indexOf(closeNeedle, cursor);
+    if (nextClose === -1) return html.length;
+    if (nextOpen !== -1 && nextOpen < nextClose) {
+      depth += 1;
+      cursor = nextOpen + openNeedle.length;
+    } else {
+      depth -= 1;
+      if (depth === 0) return nextClose;
+      cursor = nextClose + closeNeedle.length;
+    }
+  }
+  return html.length;
+}
+
+function indexOfTagOpen(html: string, openNeedle: string, from: number): number {
+  let cursor = from;
+  while (cursor < html.length) {
+    const index = html.indexOf(openNeedle, cursor);
+    if (index === -1) return -1;
+    const next = html[index + openNeedle.length];
+    if (next === " " || next === ">" || next === "\t" || next === "\n" || next === "/") {
+      return index;
+    }
+    cursor = index + openNeedle.length;
+  }
+  return -1;
+}
+
+function matchAttr(attrs: string, name: string): string | undefined {
+  const match = new RegExp(`\\b${name}="([^"]*)"`, "i").exec(attrs);
+  return match?.[1] === undefined ? undefined : decodeHtmlAttr(match[1]);
+}
+
+function parseIslandProps(propsAttr: string | undefined, script: string): Record<string, unknown> {
+  const fromAttr = propsAttr ? tryParseJson(propsAttr) : undefined;
+  if (fromAttr) return unwrapIslandProps(fromAttr);
+  const scriptBody = script.match(/<script type="application\/json">([\s\S]*?)<\/script>/i)?.[1];
+  return scriptBody ? unwrapIslandProps(tryParseJson(scriptBody) ?? {}) : {};
+}
+
+function tryParseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function unwrapIslandProps(parsed: unknown): Record<string, unknown> {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {};
+  }
+  const record = parsed as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (
+    keys.length > 0 &&
+    keys.every((key) => RUST_PAYLOAD_KEYS.has(key)) &&
+    record.props &&
+    typeof record.props === "object" &&
+    !Array.isArray(record.props)
+  ) {
+    return record.props as Record<string, unknown>;
+  }
+  return record;
+}
+
+function decodeHtmlAttr(value: string): string {
+  return value
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
+}

--- a/npm/vite-plugin-ox-content/src/mdx-islands.test.ts
+++ b/npm/vite-plugin-ox-content/src/mdx-islands.test.ts
@@ -80,4 +80,20 @@ describe("discoverRegisteredMdxComponents", () => {
     });
     expect(used).toEqual(["Alert"]);
   });
+
+  it("treats document-local bindings as hydratable and lets them override globals", async () => {
+    const localOnly = await discoverRegisteredMdxComponents({
+      source: '<GtvChart title="ok" />\n',
+      components: {},
+      localNames: ["GtvChart"],
+    });
+    expect(localOnly).toEqual(["GtvChart"]);
+
+    const override = await discoverRegisteredMdxComponents({
+      source: "<Chart />\n<Alert />\n",
+      components: { Chart: "./GlobalChart.tsx", Alert: "./Alert.tsx" },
+      localNames: ["Chart"],
+    });
+    expect(override).toEqual(["Chart", "Alert"]);
+  });
 });

--- a/npm/vite-plugin-ox-content/src/mdx-islands.ts
+++ b/npm/vite-plugin-ox-content/src/mdx-islands.ts
@@ -3,7 +3,8 @@
  *
  * Framework plugins use this instead of a source regex when MDX is on, so
  * nested JSX, expression attributes, and fragments stay visible. Names that
- * are not in the global `components` map are left as static HTML.
+ * are not in the global `components` map and are not document-local import
+ * bindings are left as static HTML.
  */
 
 import { importNapiModule } from "./napi";
@@ -47,9 +48,21 @@ export function intersectRegisteredComponentNames(
   names: Iterable<string>,
   components: ComponentRegistry,
 ): string[] {
+  return intersectHydratableComponentNames(names, components);
+}
+
+/**
+ * Keep names that are either globally registered or document-local bindings.
+ */
+export function intersectHydratableComponentNames(
+  names: Iterable<string>,
+  components: ComponentRegistry,
+  localNames?: Iterable<string>,
+): string[] {
+  const local = localNames ? new Set(localNames) : null;
   const used: string[] = [];
   for (const name of names) {
-    if (isRegisteredComponent(name, components) && !used.includes(name)) {
+    if ((local?.has(name) || isRegisteredComponent(name, components)) && !used.includes(name)) {
       used.push(name);
     }
   }
@@ -62,6 +75,8 @@ export interface DiscoverRegisteredMdxComponentsInput {
   /** Rendered HTML, used when `parse()` is missing or the AST walk fails. */
   html?: string;
   components: ComponentRegistry;
+  /** Document-local import bindings. These override the global map for this file. */
+  localNames?: Iterable<string>;
 }
 
 /**
@@ -76,7 +91,7 @@ export async function discoverRegisteredMdxComponents(
   const astNames = await tryCollectNamesFromParse(input.source);
   const names =
     astNames ?? (input.html !== undefined ? collectMdxIslandNamesFromHtml(input.html) : []);
-  return intersectRegisteredComponentNames(names, input.components);
+  return intersectHydratableComponentNames(names, input.components, input.localNames);
 }
 
 export function isRegisteredComponent(name: string, components: ComponentRegistry): boolean {


### PR DESCRIPTION
## Summary
- Resolve relative MDX `import`s from `TransformResult.imports` against the document directory, keep bindings local to that file, and reject paths that escape the content root.
- Hydrate a JSX name when it is either in the global `components` map or a resolved document-local default/named import (local wins). Generated modules emit static `import`s for HMR.
- Optional adapter `renderIsland(name, props, filePath)` can replace island inner HTML at transform time without putting a framework SSR runtime in `@ox-content/vite-plugin`.

## Test plan
- [ ] Solid/Svelte (and React/Vue) unit tests: relative default import becomes an island and the generated module imports that file
- [ ] Two documents with the same local name import different files (no collision)
- [ ] `../` escape of `srcDir` produces a diagnostic and no island import
- [ ] Nested `./widgets/Foo.tsx`, serialized literal props on `data-ox-island`, unused/unregistered JSX stays static
- [ ] Global `components` map still works without a document import; `.md` without `mdx: true` is unchanged
- [ ] Optional `renderIsland` fixture injects server HTML without importing `svelte/server` / `react-dom/server` in core

Closes #789

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790233058&installation_model_id=422833&pr_number=804&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F804&signature=2daea857bc501b08b29c45168e1ba1c8378ea8a580f2f2d6f1779977865c7ff6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->