### PR TITLE
fix(docs): handle optional and rest tuple types

### DIFF
--- a/crates/ox_content_docs/src/extractor/tests/type_aliases.rs
+++ b/crates/ox_content_docs/src/extractor/tests/type_aliases.rs
@@ -114,3 +114,46 @@ export type PluginFunction<G> = (ctx: Readonly<PluginContext<G>>) => Awaitable<v
     assert_eq!(alias.params[0].type_annotation.as_deref(), Some("Readonly<PluginContext<G>>"));
     assert_eq!(alias.return_type.as_deref(), Some("Awaitable<void>"));
 }
+
+#[test]
+fn tuple_type_aliases_format_optional_rest_and_named_elements() {
+    let source = r"
+/** Optional trailing element. */
+export type Pair = [number, string?];
+
+/** Optional-only tuple. */
+export type OptionalOnly = [number?];
+
+/** Rest tuple element. */
+export type Variadic = [number, ...string[]];
+
+/** Named optional tuple element. */
+export type NamedPair = [value: number, label?: string];
+
+/** Named rest tuple element. */
+export type NamedVariadic = [head: number, ...tail: string[]];
+
+/** Nested optional tuple. */
+export type ReadonlyPair = readonly [number, string?];
+";
+
+    let extractor = DocExtractor::new();
+    let items = extractor.extract_source(source, "tuples.ts", SourceType::ts()).unwrap();
+    let signature = |name: &str| {
+        items
+            .iter()
+            .find(|item| item.name == name)
+            .and_then(|item| item.signature.as_deref())
+            .unwrap()
+    };
+
+    assert_eq!(signature("Pair"), "export type Pair = [number, string?]");
+    assert_eq!(signature("OptionalOnly"), "export type OptionalOnly = [number?]");
+    assert_eq!(signature("Variadic"), "export type Variadic = [number, ...string[]]");
+    assert_eq!(signature("NamedPair"), "export type NamedPair = [value: number, label?: string]");
+    assert_eq!(
+        signature("NamedVariadic"),
+        "export type NamedVariadic = [head: number, ...tail: string[]]"
+    );
+    assert_eq!(signature("ReadonlyPair"), "export type ReadonlyPair = readonly [number, string?]");
+}

--- a/crates/ox_content_docs/src/extractor/types.rs
+++ b/crates/ox_content_docs/src/extractor/types.rs
@@ -1,4 +1,4 @@
-use oxc_ast::ast::{TSSignature, TSType, TSTypeLiteral, TSTypeName};
+use oxc_ast::ast::{TSSignature, TSTupleElement, TSType, TSTypeLiteral, TSTypeName};
 use oxc_span::GetSpan;
 
 use crate::string_builder::{StringBuilder, join2, join3};
@@ -61,7 +61,7 @@ impl<'a> DocVisitor<'a> {
                 let types: Vec<String> = tuple
                     .element_types
                     .iter()
-                    .map(|t| self.format_ts_type(t.to_ts_type()))
+                    .map(|element| self.format_ts_tuple_element(element))
                     .collect();
                 join3("[", &types.join(", "), "]")
             }
@@ -75,6 +75,21 @@ impl<'a> DocVisitor<'a> {
                 _ => "literal".to_string(),
             },
             _ => self.format_type_from_span(ts_type),
+        }
+    }
+
+    fn format_ts_tuple_element(&self, element: &TSTupleElement<'a>) -> String {
+        match element {
+            TSTupleElement::TSOptionalType(optional) => {
+                join2(&self.format_ts_type(&optional.type_annotation), "?")
+            }
+            TSTupleElement::TSRestType(rest) => {
+                join2("...", &self.format_ts_type(&rest.type_annotation))
+            }
+            _ => element.as_ts_type().map_or_else(
+                || self.format_type_span(element.span().start, element.span().end),
+                |ts_type| self.format_ts_type(ts_type),
+            ),
         }
     }
 

--- a/crates/ox_content_docs/src/graph/tests/entrypoints.rs
+++ b/crates/ox_content_docs/src/graph/tests/entrypoints.rs
@@ -138,6 +138,54 @@ export const CLI_OPTIONS_DEFAULT: CliOptions<DefaultGunshiParams> = {
 }
 
 #[test]
+fn entrypoint_docs_handle_internal_optional_tuple_alias() {
+    let root = temp_root();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/resolver.ts"),
+        r"
+const enum Actions {
+  APPEND,
+  PUSH,
+}
+
+const enum States {
+  BEFORE_PATH,
+  ERROR,
+}
+
+type StateAction = [States, Actions?]
+type PathState = StateAction | States.ERROR
+
+export type Path = string
+",
+    )
+    .unwrap();
+
+    let entrypoints = [EntryPointSpec {
+        path: PathBuf::from("src/resolver.ts"),
+        name: Some("default".to_string()),
+    }];
+    let docs = extract_docs_from_entry_points(
+        &entrypoints,
+        &EntryPointDocsOptions {
+            graph: GraphOptions { root: Some(root.clone()), ..GraphOptions::default() },
+            include_private: false,
+            include_internal: false,
+            type_parameters: false,
+        },
+    )
+    .unwrap();
+
+    assert!(docs[0].diagnostics.is_empty());
+    assert_eq!(docs[0].entries.len(), 1);
+    assert_eq!(docs[0].entries[0].name, "Path");
+    assert_eq!(docs[0].entries[0].signature.as_deref(), Some("export type Path = string"));
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn entrypoint_docs_diagnose_internal_type_filtered_by_visibility() {
     let root = temp_root();
     fs::create_dir_all(root.join("src")).unwrap();


### PR DESCRIPTION
## Summary

Fix docs extraction for TypeScript tuples with optional or rest elements. A tuple formatter preserves `?` and `...`, reuses regular type formatting, and falls back safely for future OXC variants.

## Background

`to_ts_type()` was called for every `TSTupleElement`; optional/rest variants cannot become `TSType`, aborting release NAPI builds. Tests cover aliases and the vue-i18n state-machine shape.

## Verification

Formatting, checks, 1,518 Rust tests, 449 TypeScript tests, 13 CI-mode VRTs, and five NAPI fixtures pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed documentation extraction for TypeScript tuples containing optional (`?`) and rest (`...`) elements.
  * Prevented extraction failures when tuple aliases include named elements, readonly tuples, or enum-based references.
  * Ensured public entrypoint documentation is generated without unexpected diagnostics.

* **Tests**
  * Added coverage for optional, rest, named, and readonly tuple type aliases.
  * Added regression coverage for entrypoint extraction involving internal tuple aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->