### PR TITLE
fix(code-play): decode numeric HTML entities in play fences

### DIFF
--- a/npm/ox-content-code-play/src/escape.ts
+++ b/npm/ox-content-code-play/src/escape.ts
@@ -21,7 +21,14 @@ export function decodeHtml(value: string): string {
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex: string) => decodeCodePoint(hex, 16))
+    .replace(/&#(\d+);/g, (_, dec: string) => decodeCodePoint(dec, 10))
     .replace(/&amp;/g, "&");
+}
+
+function decodeCodePoint(digits: string, radix: number): string {
+  const code = Number.parseInt(digits, radix);
+  return Number.isFinite(code) ? String.fromCodePoint(code) : "";
 }
 
 export function escapeAttribute(value: string): string {

--- a/npm/ox-content-code-play/src/markdown.test.ts
+++ b/npm/ox-content-code-play/src/markdown.test.ts
@@ -78,6 +78,30 @@ describe("markdown and viewers", () => {
     });
     expect(matched).toContain("data-ox-code-play");
 
+    const rustPayload = encodePayload(
+      payloadFromFence(
+        {
+          language: "rust",
+          meta: "play",
+          code: "let v: Vec<u8> = vec![];",
+          raw: "",
+          start: 0,
+          end: 0,
+          typecheck: false,
+        },
+        resolveCodePlayOptions({ languages: { rust: true } }),
+      ),
+    );
+    const numeric = enhancePlayHtml(
+      `<pre><code class="language-rust">let v: Vec&#x3C;u8> = vec![];</code></pre>`,
+      {
+        decodePayload,
+        encodePayload,
+        matchFences: [{ language: "rust", code: "let v: Vec<u8> = vec![];", payload: rustPayload }],
+      },
+    );
+    expect(numeric).toContain("data-ox-code-play");
+
     const moduleSource = `export const html = ${JSON.stringify(`<!--ox-code-play:${payload}--><pre><code>x</code></pre>`)};`;
     expect(enhanceGeneratedModule(moduleSource, { decodePayload, encodePayload })).toContain(
       "ox-code-play",


### PR DESCRIPTION
## Summary
- `#807`: SSG-highlighted fences emit `&#x3C;` for `<`, so play matching skipped those widgets.
- Decode hex and decimal character references in `decodeHtml` before comparing source.

## Test plan
- [ ] `vp test` in `npm/ox-content-code-play` (`src/markdown.test.ts`)
- [ ] A Rust play fence whose code contains `<` (e.g. `Vec<u8>`) still becomes a play widget


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790245750&installation_model_id=422833&pr_number=812&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F812&signature=c9a7ca3fa4e14974bb6974fe7563264f43d65e31c4c510c121af6348e28dc58e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTML decoding to support hexadecimal and decimal numeric character references.
  - Handles invalid numeric values safely without producing unexpected output.

- **Tests**
  - Added coverage for enhanced Rust code blocks containing encoded payloads and escaped angle brackets.
  - Verified matching Rust fences receive the expected interactive attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->