### PR TITLE
fix(code-play): keep successful Rust runs on the stdio tab

### DIFF
--- a/npm/ox-content-code-play/src/hydrate-action.test.ts
+++ b/npm/ox-content-code-play/src/hydrate-action.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import { readPlayPayload, runPlayAction } from "./hydrate-action";
+import { resultPanelToShow } from "./hydrate";
 import { encodePayload } from "./payload";
 import { DEFAULT_VIEWERS } from "./config";
 import { errorResult } from "./result";
+import { emptyTiming } from "./timing";
 
 describe("readPlayPayload", () => {
   it("returns undefined for malformed widgets instead of throwing", () => {
@@ -55,5 +57,62 @@ describe("runPlayAction", () => {
     expect(setBusy.mock.calls.map((call) => call[0])).toEqual([true, false]);
     expect(errors).toHaveLength(1);
     expect(errors[0]).toBeInstanceOf(Error);
+  });
+});
+
+describe("resultPanelToShow", () => {
+  const cargoProgress = [
+    "   Compiling playground v0.0.1 (/playground)",
+    "    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.77s",
+    "     Running `target/debug/playground`",
+  ].join("\n");
+
+  it("keeps successful runs on stdio even when cargo wrote progress to stderr", () => {
+    expect(
+      resultPanelToShow(
+        {
+          status: "ok",
+          stdio: [
+            { stream: "stdout", text: "hello\n", timestampMs: 0 },
+            { stream: "stderr", text: cargoProgress, timestampMs: 0 },
+          ],
+          diagnostics: [],
+          provenance: {},
+          timing: emptyTiming(),
+          stdout: "hello\n",
+          stderr: cargoProgress,
+        },
+        true,
+      ),
+    ).toBe("stdio");
+  });
+
+  it("opens stderr when the run failed or reported an error diagnostic", () => {
+    expect(
+      resultPanelToShow(
+        {
+          status: "error",
+          stdio: [{ stream: "stderr", text: "error: expected `;`", timestampMs: 0 }],
+          diagnostics: [],
+          provenance: {},
+          timing: emptyTiming(),
+          stderr: "error: expected `;`",
+        },
+        true,
+      ),
+    ).toBe("stderr");
+    expect(
+      resultPanelToShow(
+        {
+          status: "ok",
+          stdio: [],
+          diagnostics: [{ message: "unused", severity: "error", source: "rustc" }],
+          provenance: {},
+          timing: emptyTiming(),
+          stderr: cargoProgress,
+        },
+        true,
+      ),
+    ).toBe("stderr");
   });
 });

--- a/npm/ox-content-code-play/src/hydrate.ts
+++ b/npm/ox-content-code-play/src/hydrate.ts
@@ -135,11 +135,23 @@ function paintResult(element: HTMLElement, _payload: PlayPayload, result: RunRes
   if (stderr) {
     stderr.innerHTML = renderStderrHtml(result);
   }
-  const focusStderr =
-    Boolean(stderr) &&
-    (Boolean(result.stderr) ||
-      result.diagnostics.some((diagnostic) => diagnostic.severity === "error"));
-  showPanel(element, focusStderr ? "stderr" : "stdio");
+  showPanel(element, resultPanelToShow(result, Boolean(stderr)));
+}
+
+export function resultPanelToShow(
+  result: RunResult,
+  hasStderrPanel: boolean,
+): "stderr" | "stdio" {
+  if (!hasStderrPanel) {
+    return "stdio";
+  }
+  const hasErrorDiagnostics = result.diagnostics.some(
+    (diagnostic) => diagnostic.severity === "error",
+  );
+  if (hasErrorDiagnostics || (result.status !== "ok" && Boolean(result.stderr))) {
+    return "stderr";
+  }
+  return "stdio";
 }
 
 function showPanel(element: HTMLElement, panel: string): void {

--- a/npm/ox-content-code-play/src/hydrate.ts
+++ b/npm/ox-content-code-play/src/hydrate.ts
@@ -138,10 +138,7 @@ function paintResult(element: HTMLElement, _payload: PlayPayload, result: RunRes
   showPanel(element, resultPanelToShow(result, Boolean(stderr)));
 }
 
-export function resultPanelToShow(
-  result: RunResult,
-  hasStderrPanel: boolean,
-): "stderr" | "stdio" {
+export function resultPanelToShow(result: RunResult, hasStderrPanel: boolean): "stderr" | "stdio" {
   if (!hasStderrPanel) {
     return "stdio";
   }


### PR DESCRIPTION
## Summary
- `#808`: cargo writes progress to stderr even on success, so the widget opened the stderr tab.
- Focus stderr only for failed runs or error diagnostics.

## Test plan
- [ ] `vp test` in `npm/ox-content-code-play` (`src/hydrate-action.test.ts`)
- [ ] Successful Rust play run stays on stdio; a compile error still opens stderr


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790245751&installation_model_id=422833&pr_number=813&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F813&signature=943d9dab879f8a58b13422be44965b47d76f5dbc186114aeb3b3cb5d78a33238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved result-panel selection after Rust playground runs.
  - Successful runs with cargo progress continue to show the standard output panel.
  - Failed runs and runs with error diagnostics now correctly open the error output panel.

- **Tests**
  - Added coverage for successful, failed, and diagnostic-error run scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->