### PR TITLE
fix(ssg): keep Code Play Run clear of the copy control

### DIFF
--- a/crates/ox_content_ssg/src/html/reader_chrome.css
+++ b/crates/ox_content_ssg/src/html/reader_chrome.css
@@ -3,9 +3,13 @@
   position: relative;
   margin: 1.25rem 0;
 }
-.content .ox-code > pre {
+.content .ox-code > pre,
+.content .ox-code:has(ox-code-play) pre {
   margin: 0;
   padding-inline-end: calc(var(--ox-copy-reserved-inline-size) + 0.5rem);
+}
+.ox-code:has(> ox-code-play) .ox-code-play__toolbar {
+  padding-inline-end: calc(var(--ox-copy-reserved-inline-size) + 0.8rem);
 }
 .content .ox-code > pre[data-code-title]::before {
   padding-inline-end: var(--ox-copy-reserved-inline-size);

--- a/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
+++ b/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
@@ -162,9 +162,15 @@ fn copy_control_uses_inline_clearance_without_wasting_vertical_space() {
     );
     assert!(
         READER_CHROME_CSS.contains(
-            ".content .ox-code > pre {\n  margin: 0;\n  padding-inline-end: calc(var(--ox-copy-reserved-inline-size) + 0.5rem);"
+            ".content .ox-code > pre,\n.content .ox-code:has(ox-code-play) pre {\n  margin: 0;\n  padding-inline-end: calc(var(--ox-copy-reserved-inline-size) + 0.5rem);"
         ),
         "code only needs enough inline clearance for the icon: {READER_CHROME_CSS}"
+    );
+    assert!(
+        READER_CHROME_CSS.contains(
+            ".ox-code:has(> ox-code-play) .ox-code-play__toolbar {\n  padding-inline-end: calc(var(--ox-copy-reserved-inline-size) + 0.8rem);"
+        ),
+        "Code Play Run must sit left of the copy icon: {READER_CHROME_CSS}"
     );
     assert!(
         !READER_CHROME_CSS.contains("padding-block-start: 3rem"),


### PR DESCRIPTION
## Summary
- Copy is absolutely positioned on `.ox-code`; Code Play Run sat under it.
- Reserve inline space on the play toolbar when a copy control is present.

## Test plan
- [ ] `cargo test -p ox_content_ssg --lib html::reader_chrome`
- [ ] A play fence with copy enabled: Run and Copy do not overlap


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790245753&installation_model_id=422833&pr_number=814&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F814&signature=47ce2b914a1708d54c3fc1ea9710c0865341831568b5868c802f8d0432188e18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->