### PR TITLE
fix(math): typeset multiline display math blocks

### DIFF
--- a/crates/ox_content_transform/src/features/math.rs
+++ b/crates/ox_content_transform/src/features/math.rs
@@ -6,7 +6,7 @@ mod tests;
 use std::borrow::Cow;
 
 use super::escape_html_attr;
-use super::segments::transform_markdown_text_segments;
+use super::segments::transform_markdown_prose_segments;
 use crate::MathOptions;
 
 pub(super) fn resolve(options: Option<&MathOptions>) -> bool {
@@ -16,7 +16,7 @@ pub(super) fn resolve(options: Option<&MathOptions>) -> bool {
 pub(super) fn apply(current: &mut Cow<'_, str>, enabled: bool) {
     if enabled
         && current.contains('$')
-        && let Some(replaced) = transform_markdown_text_segments(current, replace_math)
+        && let Some(replaced) = transform_markdown_prose_segments(current, replace_math)
     {
         *current = Cow::Owned(replaced);
     }
@@ -128,8 +128,17 @@ fn find_inline_close(bytes: &[u8], from: usize) -> Option<usize> {
 }
 
 fn is_block_math_context(bytes: &[u8], open: usize, close: usize) -> bool {
-    bytes[..open].iter().all(u8::is_ascii_whitespace)
-        && bytes.get(close + 2..).is_none_or(|after| after.iter().all(u8::is_ascii_whitespace))
+    is_line_start(bytes, open) && is_line_end(bytes, close + 2)
+}
+
+fn is_line_start(bytes: &[u8], index: usize) -> bool {
+    index == 0
+        || bytes[..index].iter().rev().take_while(|byte| **byte != b'\n').all(u8::is_ascii_whitespace)
+}
+
+fn is_line_end(bytes: &[u8], index: usize) -> bool {
+    index >= bytes.len()
+        || bytes[index..].iter().take_while(|byte| **byte != b'\n').all(u8::is_ascii_whitespace)
 }
 
 fn can_open_inline(bytes: &[u8], index: usize) -> bool {

--- a/crates/ox_content_transform/src/features/math.rs
+++ b/crates/ox_content_transform/src/features/math.rs
@@ -133,7 +133,11 @@ fn is_block_math_context(bytes: &[u8], open: usize, close: usize) -> bool {
 
 fn is_line_start(bytes: &[u8], index: usize) -> bool {
     index == 0
-        || bytes[..index].iter().rev().take_while(|byte| **byte != b'\n').all(u8::is_ascii_whitespace)
+        || bytes[..index]
+            .iter()
+            .rev()
+            .take_while(|byte| **byte != b'\n')
+            .all(u8::is_ascii_whitespace)
 }
 
 fn is_line_end(bytes: &[u8], index: usize) -> bool {

--- a/crates/ox_content_transform/src/features/math/tests.rs
+++ b/crates/ox_content_transform/src/features/math/tests.rs
@@ -38,6 +38,17 @@ fn block_happy_path() {
 }
 
 #[test]
+fn multiline_block_math() {
+    let html = transform_html("Intro\n\n$$\n\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx\n$$\n\nOutro\n", math_on());
+    assert!(html.contains(r#"class="ox-math ox-math-block""#), "{html}");
+    assert!(html.contains(r#"data-ox-tex=""#), "{html}");
+    assert!(html.contains("\\int"), "{html}");
+    assert!(!html.contains("$$\n"), "{html}");
+    assert!(html.contains("Intro"), "{html}");
+    assert!(html.contains("Outro"), "{html}");
+}
+
+#[test]
 fn skips_fenced_code() {
     let html = transform_html("```\n$E=mc^2$\n```\n", math_on());
     assert!(!html.contains("ox-math"), "{html}");

--- a/crates/ox_content_transform/src/features/math/tests.rs
+++ b/crates/ox_content_transform/src/features/math/tests.rs
@@ -39,7 +39,10 @@ fn block_happy_path() {
 
 #[test]
 fn multiline_block_math() {
-    let html = transform_html("Intro\n\n$$\n\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx\n$$\n\nOutro\n", math_on());
+    let html = transform_html(
+        "Intro\n\n$$\n\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx\n$$\n\nOutro\n",
+        math_on(),
+    );
     assert!(html.contains(r#"class="ox-math ox-math-block""#), "{html}");
     assert!(html.contains(r#"data-ox-tex=""#), "{html}");
     assert!(html.contains("\\int"), "{html}");

--- a/crates/ox_content_transform/src/features/segments.rs
+++ b/crates/ox_content_transform/src/features/segments.rs
@@ -54,6 +54,78 @@ pub(crate) fn transform_markdown_text_segments(
     changed.then_some(out)
 }
 
+/// Like [`transform_markdown_text_segments`], but feeds consecutive prose
+/// (including newlines) to `transform` as one chunk so delimiters can span
+/// lines. Fenced and indented code still pass through unchanged.
+pub(crate) fn transform_markdown_prose_segments(
+    source: &str,
+    mut transform: impl FnMut(&str, &mut String),
+) -> Option<String> {
+    let mut out = String::with_capacity(source.len());
+    let mut prose = String::new();
+    let mut changed = false;
+    let mut in_fence = false;
+    let mut fence_char = b'\0';
+    let mut fence_len = 0usize;
+
+    for line_with_end in source.split_inclusive('\n') {
+        let (line, ending) = match line_with_end.strip_suffix('\n') {
+            Some(line) => (line, "\n"),
+            None => (line_with_end, ""),
+        };
+
+        if in_fence {
+            changed |= flush_prose(&mut prose, &mut out, &mut transform);
+            out.push_str(line);
+            out.push_str(ending);
+            if is_closing_fence(line, fence_char, fence_len) {
+                in_fence = false;
+                fence_char = b'\0';
+                fence_len = 0;
+            }
+            continue;
+        }
+
+        if let Some(open) = parse_opening_fence(line) {
+            changed |= flush_prose(&mut prose, &mut out, &mut transform);
+            in_fence = true;
+            fence_char = open.fence_char;
+            fence_len = open.fence_len;
+            out.push_str(line);
+            out.push_str(ending);
+            continue;
+        }
+
+        if is_indented_code_line(line) {
+            changed |= flush_prose(&mut prose, &mut out, &mut transform);
+            out.push_str(line);
+            out.push_str(ending);
+            continue;
+        }
+
+        prose.push_str(line);
+        prose.push_str(ending);
+    }
+
+    changed |= flush_prose(&mut prose, &mut out, &mut transform);
+    changed.then_some(out)
+}
+
+fn flush_prose(
+    prose: &mut String,
+    out: &mut String,
+    transform: &mut impl FnMut(&str, &mut String),
+) -> bool {
+    if prose.is_empty() {
+        return false;
+    }
+    let before_len = out.len();
+    transform_inline_code_segments(prose, out, transform);
+    let changed = &out[before_len..] != prose.as_str();
+    prose.clear();
+    changed
+}
+
 pub(super) fn transform_inline_code_segments(
     line: &str,
     out: &mut String,


### PR DESCRIPTION
## Summary
- Line-wise math scanning could not close a `$$` that started on a later line.
- Scan prose across newlines and treat line-bounded `$$` as display math.

## Test plan
- [ ] `cargo test -p ox_content_transform --lib features::math`
- [ ] A multiline `$$ ... $$` block on the docs site renders as KaTeX, not raw dollars


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790245763&installation_model_id=422833&pr_number=816&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F816&signature=fef92fec52323d4badc7a9f93ec0a91fef21e09df1dec207909788aa24d74431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->