### PR TITLE
feat(ssg): add build-time page-head API and built-in SEO

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -196,7 +196,7 @@ export declare function generateSsgBareHtml(content: string, title: string): str
 export declare function generateSsgBarePage(page: JsSsgBarePage): string
 
 /** Generates SSG HTML page with navigation and search. */
-export declare function generateSsgHtml(pageData: JsSsgPageData, navGroups: Array<JsSsgNavGroup>, config: JsSsgConfig): string
+export declare function generateSsgHtml(pageData: JsSsgPageData, navGroups: Array<JsSsgNavGroup>, config: JsSsgConfig): JsSsgHtmlResult
 
 /** Returns unique git authors for a file. Empty when git is missing or fails. */
 export declare function getGitContributors(filePath: string, root?: string | undefined | null): Array<JsGitContributor>
@@ -922,6 +922,12 @@ export interface JsGraphOptions {
   externalPackageSources?: Array<JsExternalPackageSource>
 }
 
+/** One page-head validation finding. */
+export interface JsHeadDiagnostic {
+  strict: boolean
+  message: string
+}
+
 /** Header nav link or dropdown. */
 export interface JsHeaderNavItem {
   /** Display label. */
@@ -1080,6 +1086,10 @@ export interface JsJsonLd {
   publisher?: JsJsonLdPublisher
   /** Site origin used for `@id` / `url`. */
   siteUrl?: string
+  /** Page `@type`. Defaults to `TechArticle`. */
+  pageType?: string
+  /** Extra `@graph` nodes as JSON object strings. */
+  graph?: Array<string>
 }
 
 /** Optional JSON-LD publisher. Only configured fields are emitted. */
@@ -1608,6 +1618,10 @@ export interface JsSsgConfig {
   breadcrumbRootHref?: string
   /** OG image URL. */
   ogImage?: string
+  /** Site origin used for canonical / `og:url` / hreflang. */
+  siteUrl?: string
+  /** `off` / `warn` / `strict`. Omitted is off. */
+  headValidation?: string
   /** Theme configuration. */
   theme?: JsThemeConfig
   /** Current locale for this page. */
@@ -1658,6 +1672,12 @@ export interface JsSsgGeneratedHtmlPage {
   outputPath: string
   /** HTML content. */
   html: string
+}
+
+/** Themed SSG HTML plus page-head diagnostics. */
+export interface JsSsgHtmlResult {
+  html: string
+  diagnostics: Array<JsHeadDiagnostic>
 }
 
 /** Navigation group for SSG. */
@@ -1724,6 +1744,10 @@ export interface JsSsgPageData {
   layout?: string
   /** Per-page chrome flags. Honored only when page chrome is enabled. */
   chrome?: JsPageChromeFlags
+  /** Frontmatter `robots`. */
+  robots?: string
+  /** Frontmatter `canonical`. */
+  canonical?: string
 }
 
 /** Resolved SSG output and public route paths. */
@@ -2370,6 +2394,9 @@ export declare function render(astJson: string): RenderResult
  * `mode` defaults to `"expression"` for backward compatibility.
  */
 export declare function renderFrameworkComponentCode(html: string, target: string, islands?: Array<JsFrameworkComponentIsland> | undefined | null, mode?: string | undefined | null): string
+
+/** Resolve Unhead-compatible page-head descriptors to HTML. */
+export declare function renderHead(inputJson: string): JsSsgHtmlResult
 
 /** Render result containing the HTML output. */
 export interface RenderResult {

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -1086,9 +1086,7 @@ export interface JsJsonLd {
   publisher?: JsJsonLdPublisher
   /** Site origin used for `@id` / `url`. */
   siteUrl?: string
-  /** Page `@type`. Defaults to `TechArticle`. */
   pageType?: string
-  /** Extra `@graph` nodes as JSON object strings. */
   graph?: Array<string>
 }
 
@@ -1610,17 +1608,11 @@ export interface JsSsgBarePage {
 
 /** SSG configuration. */
 export interface JsSsgConfig {
-  /** Site name. */
   siteName: string
-  /** Base URL path. */
   base: string
-  /** Optional site-root href for breadcrumbs. */
   breadcrumbRootHref?: string
-  /** OG image URL. */
   ogImage?: string
-  /** Site origin used for canonical / `og:url` / hreflang. */
   siteUrl?: string
-  /** `off` / `warn` / `strict`. Omitted is off. */
   headValidation?: string
   /** Theme configuration. */
   theme?: JsThemeConfig

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -209,6 +209,7 @@ module.exports.generateSearchModuleFromOptions = binding.generateSearchModuleFro
 module.exports.collectSearchMarkdownFiles = binding.collectSearchMarkdownFiles;
 module.exports.normalizeVitePressFrontmatter = binding.normalizeVitePressFrontmatter;
 module.exports.generateSsgHtml = binding.generateSsgHtml;
+module.exports.renderHead = binding.renderHead;
 module.exports.generateSsgBareHtml = binding.generateSsgBareHtml;
 module.exports.highlightCodeBlock = binding.highlightCodeBlock;
 module.exports.applyPendingHighlights = binding.applyPendingHighlights;

--- a/crates/ox_content_napi/src/ssg_bindings.rs
+++ b/crates/ox_content_napi/src/ssg_bindings.rs
@@ -1,22 +1,26 @@
 use napi_derive::napi;
 
 use crate::{
-    JsA11y, JsReaderChrome, JsSsgBarePage, JsSsgConfig, JsSsgExternalizedAssets,
-    JsSsgGeneratedHtmlPage, JsSsgNavGroup, JsSsgNavigationGroup, JsSsgPageData, JsSsgRoutePaths,
-    JsSsgSidebarItem, JsTeamOptions,
+    JsHeadDiagnostic, JsReaderChrome, JsSsgBarePage, JsSsgConfig, JsSsgExternalizedAssets,
+    JsSsgGeneratedHtmlPage, JsSsgHtmlResult, JsSsgNavGroup, JsSsgNavigationGroup, JsSsgPageData,
+    JsSsgRoutePaths, JsSsgSidebarItem, JsTeamOptions,
 };
 
 mod converters;
 mod git;
 pub use git::*;
+mod head;
+pub use head::render_head;
 mod section_index;
 pub use section_index::*;
 
 use converters::{
-    convert_entry_page_config, convert_generated_html_page, convert_json_ld, convert_nav_item,
-    convert_navigation_group, convert_pager_override, convert_sidebar_item, convert_theme_config,
-    flatten_toc_entries, map_generated_html_page, map_nav_group, map_route_paths, map_shared_asset,
+    convert_a11y, convert_entry_page_config, convert_generated_html_page, convert_json_ld,
+    convert_nav_item, convert_navigation_group, convert_pager_override, convert_sidebar_item,
+    convert_theme_config, flatten_toc_entries, map_generated_html_page, map_nav_group,
+    map_route_paths, map_shared_asset,
 };
+use head::convert_head_validation;
 
 /// Resolves all output and public route paths for an SSG page.
 #[napi(js_name = "resolveSsgRoutePaths")]
@@ -150,7 +154,7 @@ pub fn generate_ssg_html(
     page_data: JsSsgPageData,
     nav_groups: Vec<JsSsgNavGroup>,
     config: JsSsgConfig,
-) -> String {
+) -> JsSsgHtmlResult {
     // Convert NAPI types to ox_content_ssg types
     let layout = page_data.layout.unwrap_or_default();
     let content =
@@ -179,6 +183,8 @@ pub fn generate_ssg_html(
         next: convert_pager_override(page_data.next),
         breadcrumbs: page_data.breadcrumbs,
         chrome: convert_page_chrome_flags(page_data.chrome),
+        robots: page_data.robots,
+        canonical: page_data.canonical,
     };
 
     let ssg_nav_groups: Vec<ox_content_ssg::NavGroup> = nav_groups
@@ -196,6 +202,11 @@ pub fn generate_ssg_html(
         base: config.base,
         breadcrumb_root_href: config.breadcrumb_root_href,
         og_image: config.og_image,
+        site_url: config.site_url.and_then(|url| {
+            let trimmed = url.trim().to_string();
+            (!trimmed.is_empty()).then_some(trimmed)
+        }),
+        head_validation: convert_head_validation(config.head_validation),
         theme: convert_theme_config(config.theme),
         locale: config.locale,
         available_locales: config.available_locales.map(|locales| {
@@ -223,15 +234,15 @@ pub fn generate_ssg_html(
         json_ld: convert_json_ld(config.json_ld),
     };
 
-    ox_content_ssg::generate_html(&ssg_page_data, &ssg_nav_groups, &ssg_config)
-}
-
-fn convert_a11y(a11y: Option<JsA11y>) -> ox_content_ssg::A11y {
-    match a11y {
-        None => ox_content_ssg::A11y::disabled(),
-        Some(a11y) => {
-            ox_content_ssg::A11y { skip_link_label: Some(a11y.skip_link_label.unwrap_or_default()) }
-        }
+    let generated =
+        ox_content_ssg::generate_html_result(&ssg_page_data, &ssg_nav_groups, &ssg_config);
+    JsSsgHtmlResult {
+        html: generated.html,
+        diagnostics: generated
+            .diagnostics
+            .into_iter()
+            .map(|d| JsHeadDiagnostic { strict: d.strict, message: d.message })
+            .collect(),
     }
 }
 

--- a/crates/ox_content_napi/src/ssg_bindings/converters.rs
+++ b/crates/ox_content_napi/src/ssg_bindings/converters.rs
@@ -1,5 +1,5 @@
 use crate::{
-    JsEntryPageConfig, JsHeaderNavItem, JsJsonLd, JsPagerOverride, JsSsgGeneratedHtmlPage,
+    JsA11y, JsEntryPageConfig, JsHeaderNavItem, JsJsonLd, JsPagerOverride, JsSsgGeneratedHtmlPage,
     JsSsgNavGroup, JsSsgNavItem, JsSsgNavigationGroup, JsSsgNavigationItem, JsSsgRoutePaths,
     JsSsgSharedAsset, JsSsgSidebarItem, JsThemeColors, JsThemeConfig, TocEntry,
 };
@@ -270,6 +270,17 @@ pub(super) fn convert_json_ld(json_ld: Option<JsJsonLd>) -> ox_content_ssg::Json
                     let trimmed = url.trim().to_string();
                     (!trimmed.is_empty()).then_some(trimmed)
                 }),
+                page_type: opts.page_type.and_then(|value| {
+                    let trimmed = value.trim().to_string();
+                    (!trimmed.is_empty()).then_some(trimmed)
+                }),
+                graph: opts
+                    .graph
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|node| serde_json::from_str(&node).ok())
+                    .filter(|node: &serde_json::Value| node.is_object())
+                    .collect(),
             }
         }
     }
@@ -286,4 +297,13 @@ pub(super) fn flatten_toc_entries(entries: Vec<TocEntry>) -> Vec<ox_content_ssg:
         flat.extend(flatten_toc_entries(entry.children));
     }
     flat
+}
+
+pub(super) fn convert_a11y(a11y: Option<JsA11y>) -> ox_content_ssg::A11y {
+    match a11y {
+        None => ox_content_ssg::A11y::disabled(),
+        Some(a11y) => {
+            ox_content_ssg::A11y { skip_link_label: Some(a11y.skip_link_label.unwrap_or_default()) }
+        }
+    }
 }

--- a/crates/ox_content_napi/src/ssg_bindings/head.rs
+++ b/crates/ox_content_napi/src/ssg_bindings/head.rs
@@ -1,0 +1,29 @@
+use napi_derive::napi;
+
+use crate::{JsHeadDiagnostic, JsSsgHtmlResult};
+
+pub(super) fn convert_head_validation(value: Option<String>) -> ox_content_ssg::HeadValidation {
+    match value.as_deref().map(str::trim) {
+        Some(value) if value.eq_ignore_ascii_case("warn") => ox_content_ssg::HeadValidation::Warn,
+        Some(value) if value.eq_ignore_ascii_case("strict") => {
+            ox_content_ssg::HeadValidation::Strict
+        }
+        _ => ox_content_ssg::HeadValidation::Off,
+    }
+}
+
+/// Resolve Unhead-compatible page-head descriptors to HTML.
+#[napi(js_name = "renderHead")]
+pub fn render_head(input_json: String) -> napi::Result<JsSsgHtmlResult> {
+    let input: ox_content_ssg::HeadInput = serde_json::from_str(&input_json)
+        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+    let rendered = ox_content_ssg::render_head(&input);
+    Ok(JsSsgHtmlResult {
+        html: rendered.html,
+        diagnostics: rendered
+            .diagnostics
+            .into_iter()
+            .map(|d| JsHeadDiagnostic { strict: d.strict, message: d.message })
+            .collect(),
+    })
+}

--- a/crates/ox_content_napi/src/ssg_page_types.rs
+++ b/crates/ox_content_napi/src/ssg_page_types.rs
@@ -29,6 +29,21 @@ pub struct JsSsgNavGroup {
     pub sticky_collapsed: Option<bool>,
 }
 
+/// Themed SSG HTML plus page-head diagnostics.
+#[napi(object)]
+pub struct JsSsgHtmlResult {
+    pub html: String,
+    pub diagnostics: Vec<JsHeadDiagnostic>,
+}
+
+/// One page-head validation finding.
+#[napi(object)]
+#[derive(Clone)]
+pub struct JsHeadDiagnostic {
+    pub strict: bool,
+    pub message: String,
+}
+
 /// Head metadata and injected markup for a bare SSG page.
 ///
 /// Every field is optional. A value with none of them set renders the same
@@ -287,6 +302,10 @@ pub struct JsSsgPageData {
     pub layout: Option<String>,
     /// Per-page chrome flags. Honored only when page chrome is enabled.
     pub chrome: Option<JsPageChromeFlags>,
+    /// Frontmatter `robots`.
+    pub robots: Option<String>,
+    /// Frontmatter `canonical`.
+    pub canonical: Option<String>,
 }
 
 /// Per-page frontmatter chrome flags.

--- a/crates/ox_content_napi/src/ssg_theme_types.rs
+++ b/crates/ox_content_napi/src/ssg_theme_types.rs
@@ -178,14 +178,12 @@ pub struct JsThemeConfig {
 #[napi(object)]
 #[derive(Clone)]
 pub struct JsSsgConfig {
-    /// Site name.
     pub site_name: String,
-    /// Base URL path.
     pub base: String,
-    /// Optional site-root href for breadcrumbs.
     pub breadcrumb_root_href: Option<String>,
-    /// OG image URL.
     pub og_image: Option<String>,
+    pub site_url: Option<String>,
+    pub head_validation: Option<String>,
     /// Theme configuration.
     pub theme: Option<JsThemeConfig>,
     /// Current locale for this page.
@@ -223,6 +221,8 @@ pub struct JsJsonLd {
     pub publisher: Option<JsJsonLdPublisher>,
     /// Site origin used for `@id` / `url`.
     pub site_url: Option<String>,
+    pub page_type: Option<String>,
+    pub graph: Option<Vec<String>>,
 }
 
 /// Optional JSON-LD publisher. Only configured fields are emitted.

--- a/crates/ox_content_napi/src/tests/runtime_features.rs
+++ b/crates/ox_content_napi/src/tests/runtime_features.rs
@@ -86,6 +86,7 @@ fn javascript_wrapper_and_declarations_cover_expected_exports() {
         "prepareSourceRaw",
         "render",
         "renderFrameworkComponentCode",
+        "renderHead",
         "renderSsgSectionIndex",
         "resolveSsgNavigationGroups",
         "resolveSsgRoutePaths",

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -1090,9 +1090,7 @@ export interface JsJsonLd {
   publisher?: JsJsonLdPublisher
   /** Site origin used for `@id` / `url`. */
   siteUrl?: string
-  /** Page `@type`. Defaults to `TechArticle`. */
   pageType?: string
-  /** Extra `@graph` nodes as JSON object strings. */
   graph?: Array<string>
 }
 
@@ -1614,17 +1612,11 @@ export interface JsSsgBarePage {
 
 /** SSG configuration. */
 export interface JsSsgConfig {
-  /** Site name. */
   siteName: string
-  /** Base URL path. */
   base: string
-  /** Optional site-root href for breadcrumbs. */
   breadcrumbRootHref?: string
-  /** OG image URL. */
   ogImage?: string
-  /** Site origin used for canonical / `og:url` / hreflang. */
   siteUrl?: string
-  /** `off` / `warn` / `strict`. Omitted is off. */
   headValidation?: string
   /** Theme configuration. */
   theme?: JsThemeConfig

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -200,7 +200,7 @@ export declare function generateSsgBareHtml(content: string, title: string): str
 export declare function generateSsgBarePage(page: JsSsgBarePage): string
 
 /** Generates SSG HTML page with navigation and search. */
-export declare function generateSsgHtml(pageData: JsSsgPageData, navGroups: Array<JsSsgNavGroup>, config: JsSsgConfig): string
+export declare function generateSsgHtml(pageData: JsSsgPageData, navGroups: Array<JsSsgNavGroup>, config: JsSsgConfig): JsSsgHtmlResult
 
 /** Returns unique git authors for a file. Empty when git is missing or fails. */
 export declare function getGitContributors(filePath: string, root?: string | undefined | null): Array<JsGitContributor>
@@ -926,6 +926,12 @@ export interface JsGraphOptions {
   externalPackageSources?: Array<JsExternalPackageSource>
 }
 
+/** One page-head validation finding. */
+export interface JsHeadDiagnostic {
+  strict: boolean
+  message: string
+}
+
 /** Header nav link or dropdown. */
 export interface JsHeaderNavItem {
   /** Display label. */
@@ -1084,6 +1090,10 @@ export interface JsJsonLd {
   publisher?: JsJsonLdPublisher
   /** Site origin used for `@id` / `url`. */
   siteUrl?: string
+  /** Page `@type`. Defaults to `TechArticle`. */
+  pageType?: string
+  /** Extra `@graph` nodes as JSON object strings. */
+  graph?: Array<string>
 }
 
 /** Optional JSON-LD publisher. Only configured fields are emitted. */
@@ -1612,6 +1622,10 @@ export interface JsSsgConfig {
   breadcrumbRootHref?: string
   /** OG image URL. */
   ogImage?: string
+  /** Site origin used for canonical / `og:url` / hreflang. */
+  siteUrl?: string
+  /** `off` / `warn` / `strict`. Omitted is off. */
+  headValidation?: string
   /** Theme configuration. */
   theme?: JsThemeConfig
   /** Current locale for this page. */
@@ -1662,6 +1676,12 @@ export interface JsSsgGeneratedHtmlPage {
   outputPath: string
   /** HTML content. */
   html: string
+}
+
+/** Themed SSG HTML plus page-head diagnostics. */
+export interface JsSsgHtmlResult {
+  html: string
+  diagnostics: Array<JsHeadDiagnostic>
 }
 
 /** Navigation group for SSG. */
@@ -1728,6 +1748,10 @@ export interface JsSsgPageData {
   layout?: string
   /** Per-page chrome flags. Honored only when page chrome is enabled. */
   chrome?: JsPageChromeFlags
+  /** Frontmatter `robots`. */
+  robots?: string
+  /** Frontmatter `canonical`. */
+  canonical?: string
 }
 
 /** Resolved SSG output and public route paths. */
@@ -2374,6 +2398,9 @@ export declare function render(astJson: string): RenderResult
  * `mode` defaults to `"expression"` for backward compatibility.
  */
 export declare function renderFrameworkComponentCode(html: string, target: string, islands?: Array<JsFrameworkComponentIsland> | undefined | null, mode?: string | undefined | null): string
+
+/** Resolve Unhead-compatible page-head descriptors to HTML. */
+export declare function renderHead(inputJson: string): JsSsgHtmlResult
 
 /** Render result containing the HTML output. */
 export interface RenderResult {

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
@@ -68,6 +68,7 @@ prepareSource
 prepareSourceRaw
 render
 renderFrameworkComponentCode
+renderHead
 renderSsgSectionIndex
 resolveSsgNavigationGroups
 resolveSsgRoutePaths

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
@@ -213,6 +213,7 @@ module.exports.generateSearchModuleFromOptions = binding.generateSearchModuleFro
 module.exports.collectSearchMarkdownFiles = binding.collectSearchMarkdownFiles;
 module.exports.normalizeVitePressFrontmatter = binding.normalizeVitePressFrontmatter;
 module.exports.generateSsgHtml = binding.generateSsgHtml;
+module.exports.renderHead = binding.renderHead;
 module.exports.generateSsgBareHtml = binding.generateSsgBareHtml;
 module.exports.highlightCodeBlock = binding.highlightCodeBlock;
 module.exports.applyPendingHighlights = binding.applyPendingHighlights;

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
@@ -213,6 +213,7 @@ module.exports.generateSearchModuleFromOptions = binding.generateSearchModuleFro
 module.exports.collectSearchMarkdownFiles = binding.collectSearchMarkdownFiles;
 module.exports.normalizeVitePressFrontmatter = binding.normalizeVitePressFrontmatter;
 module.exports.generateSsgHtml = binding.generateSsgHtml;
+module.exports.renderHead = binding.renderHead;
 module.exports.generateSsgBareHtml = binding.generateSsgBareHtml;
 module.exports.highlightCodeBlock = binding.highlightCodeBlock;
 module.exports.applyPendingHighlights = binding.applyPendingHighlights;

--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -8,6 +8,7 @@ mod bare;
 mod breadcrumbs;
 mod entry;
 mod footer;
+mod head;
 mod header_chrome;
 mod json_ld;
 mod locale_switcher;
@@ -22,10 +23,15 @@ mod social;
 mod team;
 mod theme;
 mod theme_css;
+mod urls;
 mod utils;
 
 pub use a11y::A11y;
 use breadcrumbs::BreadcrumbsView;
+pub use head::{
+    HeadAlternate, HeadDiagnostic, HeadInput, HeadJsonLd, HeadLink, HeadMeta, RenderedHead,
+    ResolvedHead, ResolvedTag, SiteHead, render_head, resolve_head, serialize_head,
+};
 pub use header_chrome::{HeaderNavItem, PageChromeFlags, ThemeAnnouncement};
 pub use json_ld::{JsonLd, JsonLdPublisher};
 use pagination::PagerView;
@@ -37,11 +43,11 @@ pub use team::{TeamLink, TeamMember, TeamOptions, render_team_page};
 
 pub use bare::{BarePageData, generate_bare_html, generate_bare_page};
 pub use page::{
-    Contributor, EntryPageConfig, FeatureConfig, HeroAction, HeroConfig, HeroImage,
+    Contributor, EntryPageConfig, FeatureConfig, HeadValidation, HeroAction, HeroConfig, HeroImage,
     HeroNoticeConfig, LocaleInfo, LocalePath, NavGroup, NavItem, PageData, PagerOverride,
     SsgConfig, TocEntry,
 };
-pub use render::generate_html;
+pub use render::{GeneratedHtml, generate_html, generate_html_result};
 pub use theme::{
     SocialLink, SocialLinks, ThemeColors, ThemeConfig, ThemeEmbed, ThemeEntryPage, ThemeFonts,
     ThemeFooter, ThemeHeader, ThemeLayout,
@@ -129,10 +135,7 @@ struct PageTemplate<'a> {
     html_lang: &'a str,
     html_dir: &'a str,
     site_name: &'a str,
-    document_title: &'a str,
-    description: Option<&'a str>,
-    og_image: Option<&'a str>,
-    json_ld: Option<&'a str>,
+    page_head: &'a str,
     theme_bootstrap_js: &'a str,
     css: &'a str,
     embed_head: &'a str,
@@ -178,13 +181,8 @@ struct PageTemplate<'a> {
 struct BarePageTemplate<'a> {
     lang: &'a str,
     dir: &'a str,
-    title: &'a str,
+    page_head: &'a str,
     content: &'a str,
-    has_metadata: bool,
-    description: Option<&'a str>,
-    canonical_url: Option<&'a str>,
-    site_name: Option<&'a str>,
-    og_image: Option<&'a str>,
     head: &'a str,
     body_start: &'a str,
     body_end: &'a str,

--- a/crates/ox_content_ssg/src/html/a11y/tests.rs
+++ b/crates/ox_content_ssg/src/html/a11y/tests.rs
@@ -17,6 +17,8 @@ fn page(content: &str) -> PageData {
         next: None,
         breadcrumbs: None,
         chrome: crate::PageChromeFlags::default(),
+        robots: None,
+        canonical: None,
     }
 }
 
@@ -37,6 +39,8 @@ fn config(a11y: A11y) -> SsgConfig {
         a11y,
         page_chrome: false,
         json_ld: crate::JsonLd::default(),
+        site_url: None,
+        head_validation: Default::default(),
     }
 }
 

--- a/crates/ox_content_ssg/src/html/a11y/tests.rs
+++ b/crates/ox_content_ssg/src/html/a11y/tests.rs
@@ -1,5 +1,6 @@
 use super::super::{
-    A11y, NavGroup, NavItem, PageData, ReaderChrome, SsgConfig, generate_bare_html, generate_html,
+    A11y, HeadValidation, NavGroup, NavItem, PageData, ReaderChrome, SsgConfig, generate_bare_html,
+    generate_html,
 };
 use super::A11Y_CSS;
 
@@ -40,7 +41,7 @@ fn config(a11y: A11y) -> SsgConfig {
         page_chrome: false,
         json_ld: crate::JsonLd::default(),
         site_url: None,
-        head_validation: Default::default(),
+        head_validation: HeadValidation::Off,
     }
 }
 

--- a/crates/ox_content_ssg/src/html/bare.rs
+++ b/crates/ox_content_ssg/src/html/bare.rs
@@ -1,6 +1,7 @@
 use askama::Template;
 
 use super::BarePageTemplate;
+use super::head::render_bare_head;
 
 /// Everything the bare template can put around a rendered page body.
 ///
@@ -47,21 +48,12 @@ pub fn generate_bare_html(content: &str, title: &str) -> String {
 /// Generates a bare HTML page with whatever head metadata and injected markup
 /// the caller has.
 pub fn generate_bare_page(data: &BarePageData<'_>) -> String {
-    let has_metadata = data.description.is_some()
-        || data.canonical_url.is_some()
-        || data.site_name.is_some()
-        || data.og_image.is_some();
-
+    let page_head = render_bare_head(data);
     BarePageTemplate {
         lang: if data.lang.is_empty() { "en" } else { data.lang },
         dir: data.dir,
-        title: data.title,
+        page_head: &page_head.html,
         content: data.content,
-        has_metadata,
-        description: data.description,
-        canonical_url: data.canonical_url,
-        site_name: data.site_name,
-        og_image: data.og_image,
         head: data.head,
         body_start: data.body_start,
         body_end: data.body_end,

--- a/crates/ox_content_ssg/src/html/breadcrumbs/tests.rs
+++ b/crates/ox_content_ssg/src/html/breadcrumbs/tests.rs
@@ -57,6 +57,8 @@ fn page(path: &str) -> PageData {
         next: None,
         breadcrumbs: None,
         chrome: PageChromeFlags::default(),
+        robots: None,
+        canonical: None,
     }
 }
 
@@ -77,6 +79,8 @@ fn config(breadcrumbs: bool) -> SsgConfig {
         a11y: A11y::default(),
         page_chrome: false,
         json_ld: JsonLd::default(),
+        site_url: None,
+        head_validation: Default::default(),
     }
 }
 

--- a/crates/ox_content_ssg/src/html/breadcrumbs/tests.rs
+++ b/crates/ox_content_ssg/src/html/breadcrumbs/tests.rs
@@ -1,6 +1,6 @@
 use super::super::{
-    A11y, EntryPageConfig, JsonLd, NavGroup, NavItem, PageChromeFlags, PageData, ReaderChrome,
-    SSG_CSS, SsgConfig, ThemeConfig, generate_bare_html, generate_html,
+    A11y, EntryPageConfig, HeadValidation, JsonLd, NavGroup, NavItem, PageChromeFlags, PageData,
+    ReaderChrome, SSG_CSS, SsgConfig, ThemeConfig, generate_bare_html, generate_html,
 };
 
 fn nav_item(title: &str, path: &str, href: &str) -> NavItem {
@@ -80,7 +80,7 @@ fn config(breadcrumbs: bool) -> SsgConfig {
         page_chrome: false,
         json_ld: JsonLd::default(),
         site_url: None,
-        head_validation: Default::default(),
+        head_validation: HeadValidation::Off,
     }
 }
 

--- a/crates/ox_content_ssg/src/html/head.rs
+++ b/crates/ox_content_ssg/src/html/head.rs
@@ -1,0 +1,43 @@
+//! Build-time page-head resolver shared by themed, bare, and custom SSG hosts.
+
+mod from_page;
+mod input;
+mod resolve;
+mod serialize;
+
+#[cfg(test)]
+mod tests;
+
+pub use input::{HeadAlternate, HeadInput, HeadJsonLd, HeadLink, HeadMeta, SiteHead};
+pub use resolve::{HeadDiagnostic, ResolvedHead, ResolvedTag, resolve_head};
+pub use serialize::serialize_head;
+
+use from_page::{bare_head_input, themed_head_input};
+
+use crate::html::BarePageData;
+use crate::html::page::{PageData, SsgConfig};
+
+/// HTML plus diagnostics from [`render_head`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RenderedHead {
+    pub html: String,
+    pub diagnostics: Vec<HeadDiagnostic>,
+}
+
+/// Resolve and serialize descriptors. Invalid values are dropped.
+pub fn render_head(input: &HeadInput) -> RenderedHead {
+    let resolved = resolve_head(input);
+    RenderedHead { html: serialize_head(&resolved.tags), diagnostics: resolved.diagnostics }
+}
+
+pub(super) fn render_themed_head(
+    page: &PageData,
+    config: &SsgConfig,
+    json_ld: Option<&str>,
+) -> RenderedHead {
+    render_head(&themed_head_input(page, config, json_ld))
+}
+
+pub(super) fn render_bare_head(data: &BarePageData<'_>) -> RenderedHead {
+    render_head(&bare_head_input(data))
+}

--- a/crates/ox_content_ssg/src/html/head/from_page.rs
+++ b/crates/ox_content_ssg/src/html/head/from_page.rs
@@ -1,0 +1,89 @@
+//! Build [`HeadInput`] from themed pages and bare metadata.
+
+use super::input::{HeadAlternate, HeadInput, HeadJsonLd, SiteHead};
+use crate::html::BarePageData;
+use crate::html::page::{PageData, SsgConfig};
+use crate::html::urls::{absolute_href, page_absolute_url};
+
+/// Themed default: OG/Twitter always, no canonical unless SEO fields are set.
+pub fn themed_head_input(page: &PageData, config: &SsgConfig, json_ld: Option<&str>) -> HeadInput {
+    let mut input = HeadInput {
+        site: SiteHead {
+            name: Some(config.site_name.clone()),
+            url: config.site_url.clone(),
+            locale: config.locale.clone(),
+            title_template: None,
+        },
+        title: Some(page.title.clone()),
+        title_suffix: true,
+        description: page.description.clone(),
+        og_image: config.og_image.clone(),
+        social: true,
+        emit_site_name: false,
+        trusted: true,
+        validation: config.head_validation,
+        ..HeadInput::default()
+    };
+    apply_seo(&mut input, page, config);
+    if let Some(json) = json_ld.map(str::trim).filter(|json| !json.is_empty()) {
+        input.json_ld.push(HeadJsonLd { key: Some("ox:json-ld".into()), json: json.to_string() });
+    }
+    input
+}
+
+/// Bare metadata: social tags only when there is something to say.
+pub fn bare_head_input(data: &BarePageData<'_>) -> HeadInput {
+    let has_metadata = data.description.is_some()
+        || data.canonical_url.is_some()
+        || data.site_name.is_some()
+        || data.og_image.is_some();
+    HeadInput {
+        site: SiteHead { name: data.site_name.map(str::to_string), ..SiteHead::default() },
+        title: Some(data.title.to_string()),
+        title_suffix: false,
+        description: data.description.map(str::to_string),
+        canonical: data.canonical_url.map(str::to_string),
+        og_image: data.og_image.map(str::to_string),
+        social: has_metadata,
+        emit_site_name: has_metadata,
+        trusted: true,
+        ..HeadInput::default()
+    }
+}
+
+fn apply_seo(input: &mut HeadInput, page: &PageData, config: &SsgConfig) {
+    input.robots = page.robots.clone();
+    input.canonical = page.canonical.clone().or_else(|| {
+        config
+            .site_url
+            .as_deref()
+            .and_then(|site| page_absolute_url(site, &config.base, &page.path))
+    });
+    input.alternates = locale_alternates(config);
+}
+
+fn locale_alternates(config: &SsgConfig) -> Vec<HeadAlternate> {
+    let Some(site) = config.site_url.as_deref() else {
+        return config
+            .locale_paths
+            .iter()
+            .filter_map(|path| {
+                let href = path.href.as_deref().or(path.root.as_deref())?.trim();
+                if href.starts_with("http://") || href.starts_with("https://") {
+                    Some(HeadAlternate { lang: path.code.clone(), href: href.to_string() })
+                } else {
+                    None
+                }
+            })
+            .collect();
+    };
+    config
+        .locale_paths
+        .iter()
+        .filter_map(|path| {
+            let href = path.href.as_deref().or(path.root.as_deref())?;
+            let href = absolute_href(site, href)?;
+            Some(HeadAlternate { lang: path.code.clone(), href })
+        })
+        .collect()
+}

--- a/crates/ox_content_ssg/src/html/head/from_page.rs
+++ b/crates/ox_content_ssg/src/html/head/from_page.rs
@@ -52,7 +52,7 @@ pub fn bare_head_input(data: &BarePageData<'_>) -> HeadInput {
 }
 
 fn apply_seo(input: &mut HeadInput, page: &PageData, config: &SsgConfig) {
-    input.robots = page.robots.clone();
+    input.robots.clone_from(&page.robots);
     input.canonical = page.canonical.clone().or_else(|| {
         config
             .site_url

--- a/crates/ox_content_ssg/src/html/head/input.rs
+++ b/crates/ox_content_ssg/src/html/head/input.rs
@@ -1,0 +1,165 @@
+//! Unhead-compatible head descriptors. Build-time only; no client runtime.
+
+use serde::{Deserialize, Serialize};
+
+pub use crate::html::page::HeadValidation;
+
+/// One `meta` descriptor.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct HeadMeta {
+    /// Stable identity. Wins over name/property when set.
+    #[serde(default)]
+    pub key: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub property: Option<String>,
+    #[serde(default, rename = "httpEquiv")]
+    pub http_equiv: Option<String>,
+    #[serde(default)]
+    pub content: String,
+}
+
+/// One `link` descriptor.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct HeadLink {
+    #[serde(default)]
+    pub key: Option<String>,
+    #[serde(default)]
+    pub rel: String,
+    #[serde(default)]
+    pub href: String,
+    #[serde(default)]
+    pub hreflang: Option<String>,
+    #[serde(default, rename = "type")]
+    pub r#type: Option<String>,
+    #[serde(default)]
+    pub sizes: Option<String>,
+}
+
+/// Extra JSON-LD graph node. Serialized into a script element.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct HeadJsonLd {
+    #[serde(default)]
+    pub key: Option<String>,
+    /// Serialized JSON object (not a full `@graph` document).
+    pub json: String,
+}
+
+/// `hreflang` alternate.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct HeadAlternate {
+    pub lang: String,
+    pub href: String,
+}
+
+/// Site-level defaults that pages inherit.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct SiteHead {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub locale: Option<String>,
+    /// `%s` is the page title. `%siteName` comes from [`Self::name`].
+    #[serde(default, rename = "titleTemplate")]
+    pub title_template: Option<String>,
+}
+
+/// Typed page-head input shared by themed, bare, custom, and `ssg: false` hosts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HeadInput {
+    #[serde(default)]
+    pub site: SiteHead,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default, rename = "titleTemplate")]
+    pub title_template: Option<String>,
+    /// When true, suffix `site.name` as `{title} - {site}` when they differ.
+    #[serde(default = "default_true", rename = "titleSuffix")]
+    pub title_suffix: bool,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub canonical: Option<String>,
+    #[serde(default)]
+    pub robots: Option<String>,
+    #[serde(default, rename = "ogImage")]
+    pub og_image: Option<String>,
+    #[serde(default, rename = "ogType")]
+    pub og_type: Option<String>,
+    #[serde(default, rename = "twitterCard")]
+    pub twitter_card: Option<String>,
+    /// When true, emit the built-in OG/Twitter pair for title/description/image.
+    #[serde(default = "default_true")]
+    pub social: bool,
+    /// When true, emit `og:site_name` from [`SiteHead::name`].
+    #[serde(default, rename = "emitSiteName")]
+    pub emit_site_name: bool,
+    /// When true, emit built-in URL fields without scheme checks.
+    #[serde(default)]
+    pub trusted: bool,
+    #[serde(default)]
+    pub metas: Vec<HeadMeta>,
+    #[serde(default)]
+    pub links: Vec<HeadLink>,
+    #[serde(default)]
+    pub alternates: Vec<HeadAlternate>,
+    #[serde(default, rename = "jsonLd")]
+    pub json_ld: Vec<HeadJsonLd>,
+    #[serde(default)]
+    pub validation: HeadValidation,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for HeadInput {
+    fn default() -> Self {
+        Self {
+            site: SiteHead::default(),
+            title: None,
+            title_template: None,
+            title_suffix: true,
+            description: None,
+            canonical: None,
+            robots: None,
+            og_image: None,
+            og_type: None,
+            twitter_card: None,
+            social: true,
+            emit_site_name: false,
+            trusted: false,
+            metas: Vec::new(),
+            links: Vec::new(),
+            alternates: Vec::new(),
+            json_ld: Vec::new(),
+            validation: HeadValidation::Off,
+        }
+    }
+}
+
+impl HeadInput {
+    pub(super) fn document_title(&self) -> String {
+        let page = self.title.as_deref().unwrap_or("").trim();
+        let site = self.site.name.as_deref().unwrap_or("").trim();
+        let template = self
+            .title_template
+            .as_deref()
+            .or(self.site.title_template.as_deref())
+            .map(str::trim)
+            .filter(|template| !template.is_empty());
+        if let Some(template) = template {
+            return template.replace("%s", page).replace("%siteName", site);
+        }
+        if page.is_empty() {
+            return site.to_string();
+        }
+        if !self.title_suffix || site.is_empty() || page == site {
+            return page.to_string();
+        }
+        format!("{page} - {site}")
+    }
+}

--- a/crates/ox_content_ssg/src/html/head/resolve.rs
+++ b/crates/ox_content_ssg/src/html/head/resolve.rs
@@ -1,0 +1,304 @@
+//! Resolve, deduplicate, and validate head descriptors.
+
+use super::input::{HeadAlternate, HeadInput, HeadJsonLd, HeadLink, HeadMeta, HeadValidation};
+use crate::html::urls::{is_safe_href, safe_http_url};
+use crate::html::utils::escape_json_for_script;
+
+/// One resolved tag ready to serialize.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedTag {
+    Title(String),
+    Meta(HeadMeta),
+    Link(HeadLink),
+    JsonLd { key: Option<String>, json: String },
+}
+
+/// A validation finding. `strict` findings are errors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeadDiagnostic {
+    pub strict: bool,
+    pub message: String,
+}
+
+/// Resolved tags plus diagnostics.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResolvedHead {
+    pub tags: Vec<ResolvedTag>,
+    pub diagnostics: Vec<HeadDiagnostic>,
+}
+
+pub fn resolve_head(input: &HeadInput) -> ResolvedHead {
+    let mut diagnostics = Vec::new();
+    let title = input.document_title();
+    let mut tags = Vec::new();
+    if !title.is_empty() {
+        tags.push(ResolvedTag::Title(title.clone()));
+    }
+
+    push_meta(&mut tags, name_meta("description", input.description.as_deref()));
+    if input.social {
+        push_meta(&mut tags, property_meta("og:description", input.description.as_deref()));
+        push_meta(&mut tags, name_meta("twitter:description", input.description.as_deref()));
+    }
+    push_meta(&mut tags, name_meta("robots", input.robots.as_deref()));
+
+    if let Some(canonical) =
+        resolve_url(input.canonical.as_deref(), "canonical", input.trusted, &mut diagnostics)
+    {
+        upsert_link(
+            &mut tags,
+            HeadLink {
+                key: Some("canonical".into()),
+                rel: "canonical".into(),
+                href: canonical.clone(),
+                ..HeadLink::default()
+            },
+        );
+        if input.social {
+            push_meta(&mut tags, property_meta("og:url", Some(canonical.as_str())));
+        }
+    }
+    if input.social {
+        if input.emit_site_name {
+            push_meta(&mut tags, property_meta("og:site_name", input.site.name.as_deref()));
+        }
+        push_meta(
+            &mut tags,
+            property_meta("og:type", input.og_type.as_deref().or(Some("website"))),
+        );
+        push_meta(&mut tags, property_meta("og:title", Some(title.as_str())));
+        let image =
+            resolve_url(input.og_image.as_deref(), "og:image", input.trusted, &mut diagnostics);
+        push_meta(&mut tags, property_meta("og:image", image.as_deref()));
+        push_meta(&mut tags, name_meta("twitter:image", image.as_deref()));
+        push_meta(
+            &mut tags,
+            name_meta(
+                "twitter:card",
+                input.twitter_card.as_deref().or(Some("summary_large_image")),
+            ),
+        );
+        push_meta(&mut tags, name_meta("twitter:title", Some(title.as_str())));
+    }
+
+    for meta in &input.metas {
+        if let Some(meta) = sanitize_meta(meta, &mut diagnostics) {
+            upsert_meta(&mut tags, meta);
+        }
+    }
+    for alternate in &input.alternates {
+        if let Some(link) = sanitize_alternate(alternate, &mut diagnostics) {
+            upsert_link(&mut tags, link);
+        }
+    }
+    for link in &input.links {
+        if let Some(link) = sanitize_link(link, &mut diagnostics) {
+            upsert_link(&mut tags, link);
+        }
+    }
+    for node in &input.json_ld {
+        if let Some(tag) = sanitize_json_ld(node, &mut diagnostics) {
+            upsert_json_ld(&mut tags, tag);
+        }
+    }
+
+    if input.validation == HeadValidation::Off {
+        diagnostics.clear();
+    }
+    ResolvedHead { tags, diagnostics }
+}
+
+fn name_meta(name: &str, content: Option<&str>) -> Option<HeadMeta> {
+    let content = content.map(str::trim).filter(|value| !value.is_empty())?;
+    Some(HeadMeta {
+        key: Some(format!("name:{name}")),
+        name: Some(name.into()),
+        content: content.to_string(),
+        ..HeadMeta::default()
+    })
+}
+
+fn property_meta(property: &str, content: Option<&str>) -> Option<HeadMeta> {
+    let content = content.map(str::trim).filter(|value| !value.is_empty())?;
+    Some(HeadMeta {
+        key: Some(format!("property:{property}")),
+        property: Some(property.into()),
+        content: content.to_string(),
+        ..HeadMeta::default()
+    })
+}
+
+fn push_meta(tags: &mut Vec<ResolvedTag>, meta: Option<HeadMeta>) {
+    if let Some(meta) = meta {
+        upsert_meta(tags, meta);
+    }
+}
+
+fn upsert_meta(tags: &mut Vec<ResolvedTag>, meta: HeadMeta) {
+    let identity = meta_identity(&meta);
+    if let Some(existing) = tags.iter_mut().find(|tag| match tag {
+        ResolvedTag::Meta(current) => meta_identity(current) == identity,
+        _ => false,
+    }) {
+        *existing = ResolvedTag::Meta(meta);
+        return;
+    }
+    tags.push(ResolvedTag::Meta(meta));
+}
+
+fn upsert_link(tags: &mut Vec<ResolvedTag>, link: HeadLink) {
+    let identity = link_identity(&link);
+    if let Some(existing) = tags.iter_mut().find(|tag| match tag {
+        ResolvedTag::Link(current) => link_identity(current) == identity,
+        _ => false,
+    }) {
+        *existing = ResolvedTag::Link(link);
+        return;
+    }
+    tags.push(ResolvedTag::Link(link));
+}
+
+fn upsert_json_ld(tags: &mut Vec<ResolvedTag>, tag: ResolvedTag) {
+    let identity = json_ld_identity(&tag);
+    if let Some(existing) =
+        tags.iter_mut().find(|current| json_ld_identity(current) == identity && identity.is_some())
+    {
+        *existing = tag;
+        return;
+    }
+    tags.push(tag);
+}
+
+fn meta_identity(meta: &HeadMeta) -> String {
+    if let Some(key) = meta.key.as_deref().map(str::trim).filter(|key| !key.is_empty()) {
+        return format!("key:{key}");
+    }
+    if let Some(name) = meta.name.as_deref() {
+        return format!("name:{name}");
+    }
+    if let Some(property) = meta.property.as_deref() {
+        return format!("property:{property}");
+    }
+    format!("http-equiv:{}", meta.http_equiv.as_deref().unwrap_or(""))
+}
+
+fn link_identity(link: &HeadLink) -> String {
+    if let Some(key) = link.key.as_deref().map(str::trim).filter(|key| !key.is_empty()) {
+        return format!("key:{key}");
+    }
+    if link.rel == "alternate" {
+        return format!("alternate:{}", link.hreflang.as_deref().unwrap_or(""));
+    }
+    link.rel.clone()
+}
+
+fn json_ld_identity(tag: &ResolvedTag) -> Option<String> {
+    match tag {
+        ResolvedTag::JsonLd { key, .. } => key.clone(),
+        _ => None,
+    }
+}
+
+fn resolve_url(
+    value: Option<&str>,
+    label: &str,
+    trusted: bool,
+    diagnostics: &mut Vec<HeadDiagnostic>,
+) -> Option<String> {
+    let raw = value.map(str::trim).filter(|value| !value.is_empty())?;
+    if trusted {
+        return Some(raw.to_string());
+    }
+    if let Some(url) = safe_http_url(raw) {
+        return Some(url.to_string());
+    }
+    diagnostics.push(HeadDiagnostic {
+        strict: true,
+        message: format!("{label} is not a safe http(s) URL"),
+    });
+    None
+}
+
+fn sanitize_meta(meta: &HeadMeta, diagnostics: &mut Vec<HeadDiagnostic>) -> Option<HeadMeta> {
+    let has_attr = meta.name.is_some() || meta.property.is_some() || meta.http_equiv.is_some();
+    if !has_attr || meta.content.trim().is_empty() {
+        diagnostics.push(HeadDiagnostic {
+            strict: false,
+            message: "meta descriptor needs a name, property, or http-equiv and non-empty content"
+                .into(),
+        });
+        return None;
+    }
+    Some(meta.clone())
+}
+
+fn sanitize_link(link: &HeadLink, diagnostics: &mut Vec<HeadDiagnostic>) -> Option<HeadLink> {
+    if link.rel.trim().is_empty() || !is_safe_href(&link.href) {
+        diagnostics.push(HeadDiagnostic {
+            strict: true,
+            message: format!("link rel=\"{}\" has an empty rel or unsafe href", link.rel),
+        });
+        return None;
+    }
+    Some(link.clone())
+}
+
+fn sanitize_alternate(
+    alternate: &HeadAlternate,
+    diagnostics: &mut Vec<HeadDiagnostic>,
+) -> Option<HeadLink> {
+    let lang = alternate.lang.trim();
+    if !is_valid_hreflang(lang) {
+        diagnostics.push(HeadDiagnostic {
+            strict: true,
+            message: format!("invalid hreflang \"{}\"", alternate.lang),
+        });
+        return None;
+    }
+    if !is_safe_href(&alternate.href) {
+        diagnostics.push(HeadDiagnostic {
+            strict: true,
+            message: format!("alternate hreflang=\"{lang}\" has an unsafe href"),
+        });
+        return None;
+    }
+    Some(HeadLink {
+        key: Some(format!("alternate:{lang}")),
+        rel: "alternate".into(),
+        href: alternate.href.trim().to_string(),
+        hreflang: Some(lang.to_string()),
+        ..HeadLink::default()
+    })
+}
+
+fn is_valid_hreflang(lang: &str) -> bool {
+    if lang.eq_ignore_ascii_case("x-default") {
+        return true;
+    }
+    let mut parts = lang.split('-');
+    let primary = parts.next().unwrap_or("");
+    if primary.len() < 2 || primary.len() > 8 || !primary.bytes().all(|b| b.is_ascii_alphabetic()) {
+        return false;
+    }
+    parts.all(|part| {
+        (1..=8).contains(&part.len()) && part.bytes().all(|b| b.is_ascii_alphanumeric())
+    })
+}
+
+fn sanitize_json_ld(
+    node: &HeadJsonLd,
+    diagnostics: &mut Vec<HeadDiagnostic>,
+) -> Option<ResolvedTag> {
+    let json = node.json.trim();
+    if json.is_empty() {
+        diagnostics
+            .push(HeadDiagnostic { strict: false, message: "empty jsonLd node dropped".into() });
+        return None;
+    }
+    if serde_json::from_str::<serde_json::Value>(json).is_err() {
+        diagnostics
+            .push(HeadDiagnostic { strict: true, message: "jsonLd node is not valid JSON".into() });
+        return None;
+    }
+    Some(ResolvedTag::JsonLd { key: node.key.clone(), json: escape_json_for_script(json) })
+}

--- a/crates/ox_content_ssg/src/html/head/serialize.rs
+++ b/crates/ox_content_ssg/src/html/head/serialize.rs
@@ -1,0 +1,59 @@
+//! Serialize resolved head tags to HTML.
+
+use super::input::{HeadLink, HeadMeta};
+use super::resolve::ResolvedTag;
+use crate::html::utils::escape_html;
+
+pub fn serialize_head(tags: &[ResolvedTag]) -> String {
+    let mut out = String::new();
+    for tag in tags {
+        match tag {
+            ResolvedTag::Title(title) => {
+                out.push_str("  <title>");
+                out.push_str(&escape_html(title));
+                out.push_str("</title>\n");
+            }
+            ResolvedTag::Meta(meta) => push_meta(&mut out, meta),
+            ResolvedTag::Link(link) => push_link(&mut out, link),
+            ResolvedTag::JsonLd { json, .. } => {
+                out.push_str("  <script type=\"application/ld+json\">");
+                out.push_str(json);
+                out.push_str("</script>\n");
+            }
+        }
+    }
+    if out.ends_with('\n') {
+        out.pop();
+    }
+    out
+}
+
+fn push_meta(out: &mut String, meta: &HeadMeta) {
+    out.push_str("  <meta");
+    push_attr(out, "name", meta.name.as_deref());
+    push_attr(out, "property", meta.property.as_deref());
+    push_attr(out, "http-equiv", meta.http_equiv.as_deref());
+    push_attr(out, "content", Some(meta.content.as_str()));
+    out.push_str(">\n");
+}
+
+fn push_link(out: &mut String, link: &HeadLink) {
+    out.push_str("  <link");
+    push_attr(out, "rel", Some(link.rel.as_str()));
+    push_attr(out, "hreflang", link.hreflang.as_deref());
+    push_attr(out, "href", Some(link.href.as_str()));
+    push_attr(out, "type", link.r#type.as_deref());
+    push_attr(out, "sizes", link.sizes.as_deref());
+    out.push_str(">\n");
+}
+
+fn push_attr(out: &mut String, name: &str, value: Option<&str>) {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return;
+    };
+    out.push(' ');
+    out.push_str(name);
+    out.push_str("=\"");
+    out.push_str(&escape_html(value));
+    out.push('"');
+}

--- a/crates/ox_content_ssg/src/html/head/tests.rs
+++ b/crates/ox_content_ssg/src/html/head/tests.rs
@@ -1,0 +1,105 @@
+use super::{HeadInput, HeadJsonLd, HeadLink, HeadMeta, SiteHead, render_head};
+use crate::html::page::HeadValidation;
+use crate::html::urls::{is_safe_href, page_absolute_url, safe_http_url};
+
+#[test]
+fn disabled_social_emits_only_title() {
+    let html = render_head(&HeadInput {
+        title: Some("Guide".into()),
+        social: false,
+        ..HeadInput::default()
+    })
+    .html;
+    assert_eq!(html, "  <title>Guide</title>");
+}
+
+#[test]
+fn default_themed_social_matches_built_in_order() {
+    let rendered = render_head(&HeadInput {
+        site: SiteHead { name: Some("Docs".into()), ..SiteHead::default() },
+        title: Some("Guide".into()),
+        description: Some("How it works".into()),
+        trusted: true,
+        ..HeadInput::default()
+    });
+    assert!(rendered.diagnostics.is_empty());
+    assert_eq!(
+        rendered.html,
+        concat!(
+            "  <title>Guide - Docs</title>\n",
+            "  <meta name=\"description\" content=\"How it works\">\n",
+            "  <meta property=\"og:description\" content=\"How it works\">\n",
+            "  <meta name=\"twitter:description\" content=\"How it works\">\n",
+            "  <meta property=\"og:type\" content=\"website\">\n",
+            "  <meta property=\"og:title\" content=\"Guide - Docs\">\n",
+            "  <meta name=\"twitter:card\" content=\"summary_large_image\">\n",
+            "  <meta name=\"twitter:title\" content=\"Guide - Docs\">",
+        )
+    );
+}
+
+#[test]
+fn later_descriptor_wins_and_keeps_first_position() {
+    let html = render_head(&HeadInput {
+        title: Some("Guide".into()),
+        social: false,
+        metas: vec![
+            HeadMeta {
+                name: Some("description".into()),
+                content: "first".into(),
+                ..HeadMeta::default()
+            },
+            HeadMeta {
+                name: Some("description".into()),
+                content: "second".into(),
+                ..HeadMeta::default()
+            },
+        ],
+        ..HeadInput::default()
+    })
+    .html;
+    assert!(html.contains("content=\"second\""));
+    assert!(!html.contains("content=\"first\""));
+    assert_eq!(html.matches("name=\"description\"").count(), 1);
+}
+
+#[test]
+fn unsafe_urls_are_dropped_and_escaped_text_cannot_break_out() {
+    let rendered = render_head(&HeadInput {
+        title: Some("<script>alert(1)</script>".into()),
+        canonical: Some("javascript:alert(1)".into()),
+        social: false,
+        validation: HeadValidation::Strict,
+        links: vec![HeadLink {
+            rel: "stylesheet".into(),
+            href: "data:text/css,body{}".into(),
+            ..HeadLink::default()
+        }],
+        json_ld: vec![HeadJsonLd {
+            key: Some("extra".into()),
+            json: r#"{"@type":"BlogPosting","headline":"</script><script>"}"#.into(),
+        }],
+        ..HeadInput::default()
+    });
+    assert!(rendered.html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"));
+    assert!(!rendered.html.contains("javascript:"));
+    assert!(!rendered.html.contains("data:text/css"));
+    assert!(rendered.html.contains(r"\u003c/script\u003e"));
+    assert!(rendered.diagnostics.iter().any(|d| d.strict && d.message.contains("canonical")));
+}
+
+#[test]
+fn page_url_and_href_safety() {
+    assert_eq!(
+        page_absolute_url("https://example.com", "/docs/", "guide").as_deref(),
+        Some("https://example.com/docs/guide/")
+    );
+    assert_eq!(
+        page_absolute_url("https://example.com", "/docs/", "index").as_deref(),
+        Some("https://example.com/docs/")
+    );
+    assert!(safe_http_url("https://example.com/x").is_some());
+    assert!(safe_http_url("javascript:alert(1)").is_none());
+    assert!(!is_safe_href("//evil.example"));
+    assert!(!is_safe_href("vbscript:x"));
+}

--- a/crates/ox_content_ssg/src/html/header_chrome/tests.rs
+++ b/crates/ox_content_ssg/src/html/header_chrome/tests.rs
@@ -30,6 +30,8 @@ fn page() -> PageData {
         next: None,
         breadcrumbs: None,
         chrome: PageChromeFlags::default(),
+        robots: None,
+        canonical: None,
     }
 }
 
@@ -66,6 +68,8 @@ fn config(theme: Option<ThemeConfig>, page_chrome: bool) -> SsgConfig {
         a11y: crate::A11y::default(),
         page_chrome,
         json_ld: crate::JsonLd::default(),
+        site_url: None,
+        head_validation: Default::default(),
     }
 }
 

--- a/crates/ox_content_ssg/src/html/header_chrome/tests.rs
+++ b/crates/ox_content_ssg/src/html/header_chrome/tests.rs
@@ -1,6 +1,6 @@
 use super::super::{
-    HeaderNavItem, NavGroup, NavItem, PageChromeFlags, PageData, ReaderChrome, SsgConfig,
-    ThemeConfig, TocEntry, generate_html,
+    HeadValidation, HeaderNavItem, NavGroup, NavItem, PageChromeFlags, PageData, ReaderChrome,
+    SsgConfig, ThemeConfig, TocEntry, generate_html,
 };
 
 mod announcement;
@@ -69,7 +69,7 @@ fn config(theme: Option<ThemeConfig>, page_chrome: bool) -> SsgConfig {
         page_chrome,
         json_ld: crate::JsonLd::default(),
         site_url: None,
-        head_validation: Default::default(),
+        head_validation: HeadValidation::Off,
     }
 }
 

--- a/crates/ox_content_ssg/src/html/json_ld.rs
+++ b/crates/ox_content_ssg/src/html/json_ld.rs
@@ -5,6 +5,8 @@ use serde_json::{Map, Value, json};
 
 use super::breadcrumbs::BreadcrumbsView;
 use super::page::{PageData, SsgConfig};
+use super::urls::{absolute_href, page_absolute_url, safe_http_url};
+use super::utils::escape_json_for_script;
 
 /// Optional publisher written only from site configuration.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -32,6 +34,12 @@ pub struct JsonLd {
     /// Site origin used for `@id` / `url`. Absolute URLs are omitted when missing.
     #[serde(default, rename = "siteUrl")]
     pub site_url: Option<String>,
+    /// Page `@type`. Defaults to `TechArticle`.
+    #[serde(default, rename = "type")]
+    pub page_type: Option<String>,
+    /// Extra `@graph` nodes. Invalid JSON objects are dropped.
+    #[serde(default)]
+    pub graph: Vec<Value>,
 }
 
 impl JsonLd {
@@ -42,7 +50,14 @@ impl JsonLd {
 
     /// `true` or `{}` in JS: emit TechArticle / WebSite; BreadcrumbList follows the trail.
     pub fn enabled() -> Self {
-        Self { enabled: true, breadcrumbs: true, publisher: None, site_url: None }
+        Self {
+            enabled: true,
+            breadcrumbs: true,
+            publisher: None,
+            site_url: None,
+            page_type: None,
+            graph: Vec::new(),
+        }
     }
 
     pub(super) fn is_enabled(&self) -> bool {
@@ -60,13 +75,14 @@ pub(super) fn render_json_ld(
         return None;
     }
 
-    let mut graph = vec![website_node(config), tech_article_node(page, config)];
+    let mut graph = vec![website_node(config), page_node(page, config)];
     if config.json_ld.breadcrumbs
         && let Some(trail) = breadcrumbs
         && let Some(list) = breadcrumb_list_node(trail, config)
     {
         graph.push(list);
     }
+    graph.extend(config.json_ld.graph.iter().filter(|node| node.is_object()).cloned());
 
     let document = json!({
         "@context": "https://schema.org",
@@ -82,7 +98,7 @@ fn website_node(config: &SsgConfig) -> Value {
     if !name.is_empty() {
         node.insert("name".into(), json!(name));
     }
-    if let Some(url) = config.json_ld.site_url.as_deref().and_then(safe_http_url) {
+    if let Some(url) = json_ld_site_url(config) {
         let url = url.trim_end_matches('/');
         node.insert("url".into(), json!(url));
         node.insert("@id".into(), json!(format!("{url}#website")));
@@ -90,15 +106,15 @@ fn website_node(config: &SsgConfig) -> Value {
     Value::Object(node)
 }
 
-fn tech_article_node(page: &PageData, config: &SsgConfig) -> Value {
+fn page_node(page: &PageData, config: &SsgConfig) -> Value {
     let mut node = Map::new();
-    node.insert("@type".into(), json!("TechArticle"));
+    node.insert("@type".into(), json!(page_schema_type(config.json_ld.page_type.as_deref())));
     node.insert("headline".into(), json!(page.title.as_str()));
     if let Some(description) = page.description.as_deref().map(str::trim).filter(|d| !d.is_empty())
     {
         node.insert("description".into(), json!(description));
     }
-    if let Some(url) = page_absolute_url(config, &page.path) {
+    if let Some(url) = json_ld_page_url(config, &page.path) {
         node.insert("url".into(), json!(url));
         node.insert("@id".into(), json!(format!("{url}#article")));
         if let Some(website_id) = website_id(config) {
@@ -125,7 +141,7 @@ fn breadcrumb_list_node(trail: &BreadcrumbsView, config: &SsgConfig) -> Option<V
             item.insert("position".into(), json!(index + 1));
             item.insert("name".into(), json!(crumb.title.as_str()));
             if let Some(href) = crumb.href.as_deref()
-                && let Some(url) = absolute_href(config, href)
+                && let Some(url) = json_ld_absolute_href(config, href)
             {
                 item.insert("item".into(), json!(url));
             }
@@ -157,110 +173,32 @@ fn publisher_node(publisher: Option<&JsonLdPublisher>) -> Option<Value> {
 }
 
 fn website_id(config: &SsgConfig) -> Option<String> {
-    config
-        .json_ld
-        .site_url
-        .as_deref()
-        .and_then(safe_http_url)
-        .map(|url| format!("{}#website", url.trim_end_matches('/')))
+    json_ld_site_url(config).map(|url| format!("{}#website", url.trim_end_matches('/')))
 }
 
-fn page_absolute_url(config: &SsgConfig, path: &str) -> Option<String> {
-    let site = config.json_ld.site_url.as_deref().and_then(safe_http_url)?.trim_end_matches('/');
-    let path = path.trim().trim_matches('/');
-    if path.is_empty() || path.eq_ignore_ascii_case("index") {
-        Some(format!("{site}{}", config.base))
-    } else {
-        Some(format!("{site}{}{path}/", config.base))
-    }
+fn json_ld_site_url(config: &SsgConfig) -> Option<&str> {
+    config.json_ld.site_url.as_deref().or(config.site_url.as_deref()).and_then(safe_http_url)
 }
 
-fn absolute_href(config: &SsgConfig, href: &str) -> Option<String> {
-    let href = href.trim();
-    if let Some(url) = safe_http_url(href) {
-        return Some(url.to_string());
-    }
-    if !is_safe_relative_href(href) {
-        return None;
-    }
-    let site = config.json_ld.site_url.as_deref().and_then(safe_http_url)?;
-    if href.starts_with('/') {
-        return Some(format!("{}{href}", site_origin(site)?));
-    }
-    let site = site.trim_end_matches('/');
-    Some(format!("{site}/{href}"))
+fn json_ld_page_url(config: &SsgConfig, path: &str) -> Option<String> {
+    page_absolute_url(json_ld_site_url(config)?, &config.base, path)
 }
 
-fn site_origin(site_url: &str) -> Option<String> {
-    let (scheme, rest) = if let Some(rest) = site_url.strip_prefix("https://") {
-        ("https", rest)
-    } else {
-        let rest = site_url.strip_prefix("http://")?;
-        ("http", rest)
-    };
-    let host = rest.split('/').next()?.trim();
-    if host.is_empty() {
-        return None;
-    }
-    Some(format!("{scheme}://{host}"))
+fn json_ld_absolute_href(config: &SsgConfig, href: &str) -> Option<String> {
+    absolute_href(json_ld_site_url(config)?, href)
 }
 
-fn safe_http_url(value: &str) -> Option<&str> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() || !is_safe_absolute_http_url(trimmed) {
-        return None;
+fn page_schema_type(page_type: Option<&str>) -> &str {
+    match page_type.map(str::trim) {
+        Some("BlogPosting") => "BlogPosting",
+        Some("WebPage") => "WebPage",
+        _ => "TechArticle",
     }
-    Some(trimmed)
-}
-
-fn is_safe_absolute_http_url(value: &str) -> bool {
-    let lower = value.to_ascii_lowercase();
-    (lower.starts_with("https://") || lower.starts_with("http://"))
-        && !lower.starts_with("https:///")
-        && is_safe_href(value)
-}
-
-fn is_safe_relative_href(href: &str) -> bool {
-    !href.is_empty() && is_safe_href(href)
-}
-
-fn is_safe_href(href: &str) -> bool {
-    let trimmed = href.trim();
-    if trimmed.is_empty() || trimmed.starts_with("//") {
-        return false;
-    }
-    let lower = trimmed.to_ascii_lowercase();
-    if lower.starts_with("javascript:")
-        || lower.starts_with("data:")
-        || lower.starts_with("vbscript:")
-    {
-        return false;
-    }
-    if let Some(scheme_end) = trimmed.find(':') {
-        let scheme = &lower[..scheme_end];
-        return matches!(scheme, "http" | "https");
-    }
-    true
 }
 
 fn serialize_for_script(value: &Value) -> String {
     let json = serde_json::to_string(value).unwrap_or_else(|_| "{}".to_string());
     escape_json_for_script(&json)
-}
-
-fn escape_json_for_script(json: &str) -> String {
-    let mut out = String::with_capacity(json.len());
-    for ch in json.chars() {
-        match ch {
-            '<' => out.push_str("\\u003c"),
-            '>' => out.push_str("\\u003e"),
-            '&' => out.push_str("\\u0026"),
-            '\u{2028}' => out.push_str("\\u2028"),
-            '\u{2029}' => out.push_str("\\u2029"),
-            _ => out.push(ch),
-        }
-    }
-    out
 }
 
 #[cfg(test)]

--- a/crates/ox_content_ssg/src/html/json_ld/tests.rs
+++ b/crates/ox_content_ssg/src/html/json_ld/tests.rs
@@ -1,6 +1,6 @@
 use super::super::{
-    A11y, JsonLd, JsonLdPublisher, NavGroup, NavItem, PageChromeFlags, PageData, ReaderChrome,
-    SsgConfig, generate_html,
+    A11y, HeadValidation, JsonLd, JsonLdPublisher, NavGroup, NavItem, PageChromeFlags, PageData,
+    ReaderChrome, SsgConfig, generate_html,
 };
 
 fn nav_item(title: &str, path: &str, href: &str) -> NavItem {
@@ -76,7 +76,7 @@ fn config(json_ld: JsonLd, breadcrumbs: bool) -> SsgConfig {
         page_chrome: false,
         json_ld,
         site_url: None,
-        head_validation: Default::default(),
+        head_validation: HeadValidation::Off,
     }
 }
 

--- a/crates/ox_content_ssg/src/html/json_ld/tests.rs
+++ b/crates/ox_content_ssg/src/html/json_ld/tests.rs
@@ -53,6 +53,8 @@ fn page(title: &str) -> PageData {
         next: None,
         breadcrumbs: None,
         chrome: PageChromeFlags::default(),
+        robots: None,
+        canonical: None,
     }
 }
 
@@ -73,6 +75,8 @@ fn config(json_ld: JsonLd, breadcrumbs: bool) -> SsgConfig {
         a11y: A11y::default(),
         page_chrome: false,
         json_ld,
+        site_url: None,
+        head_validation: Default::default(),
     }
 }
 
@@ -236,6 +240,36 @@ fn no_publisher_invented() {
     assert!(value["@graph"][0].get("@id").is_none(), "{raw}");
     assert!(value["@graph"][1].get("@id").is_none(), "{raw}");
     assert!(value["@graph"][1].get("isPartOf").is_none(), "{raw}");
+}
+
+#[test]
+fn themed_canonical_only_when_site_url_is_set() {
+    let html =
+        generate_html(&page("Getting Started"), &nested_nav(), &config(JsonLd::default(), false));
+    assert!(!html.contains("rel=\"canonical\""), "{html}");
+
+    let mut with_url = config(JsonLd::default(), false);
+    with_url.site_url = Some("https://docs.example".into());
+    let html = generate_html(&page("Getting Started"), &nested_nav(), &with_url);
+    assert!(
+        html.contains("<link rel=\"canonical\" href=\"https://docs.example/docs/guide/\">"),
+        "{html}"
+    );
+    assert!(
+        html.contains("<meta property=\"og:url\" content=\"https://docs.example/docs/guide/\">"),
+        "{html}"
+    );
+}
+
+#[test]
+fn page_type_and_extra_graph_nodes() {
+    let mut json_ld = JsonLd::enabled();
+    json_ld.page_type = Some("BlogPosting".into());
+    json_ld.graph = vec![serde_json::json!({"@type": "Person", "name": "Ada"})];
+    let html = generate_html(&page("Getting Started"), &nested_nav(), &config(json_ld, false));
+    let value = parse_json_ld(&html);
+    let types = graph_types(&value);
+    assert_eq!(types, ["WebSite", "BlogPosting", "Person"], "{html}");
 }
 
 #[test]

--- a/crates/ox_content_ssg/src/html/locale_switcher/tests.rs
+++ b/crates/ox_content_ssg/src/html/locale_switcher/tests.rs
@@ -1,6 +1,6 @@
 use super::super::{
-    A11y, JsonLd, LocaleInfo, LocalePath, NavGroup, NavItem, PageChromeFlags, PageData,
-    ReaderChrome, SsgConfig, generate_bare_html, generate_html,
+    A11y, HeadValidation, JsonLd, LocaleInfo, LocalePath, NavGroup, NavItem, PageChromeFlags,
+    PageData, ReaderChrome, SsgConfig, generate_bare_html, generate_html,
 };
 
 fn page(path: &str) -> PageData {
@@ -77,7 +77,7 @@ fn config(
         page_chrome: false,
         json_ld: JsonLd::default(),
         site_url: None,
-        head_validation: Default::default(),
+        head_validation: HeadValidation::Off,
     }
 }
 

--- a/crates/ox_content_ssg/src/html/locale_switcher/tests.rs
+++ b/crates/ox_content_ssg/src/html/locale_switcher/tests.rs
@@ -17,6 +17,8 @@ fn page(path: &str) -> PageData {
         next: None,
         breadcrumbs: None,
         chrome: PageChromeFlags::default(),
+        robots: None,
+        canonical: None,
     }
 }
 
@@ -74,6 +76,8 @@ fn config(
         a11y: A11y::default(),
         page_chrome: false,
         json_ld: JsonLd::default(),
+        site_url: None,
+        head_validation: Default::default(),
     }
 }
 

--- a/crates/ox_content_ssg/src/html/page.rs
+++ b/crates/ox_content_ssg/src/html/page.rs
@@ -6,6 +6,19 @@ use super::header_chrome::PageChromeFlags;
 use super::json_ld::JsonLd;
 use super::reader_chrome::ReaderChrome;
 
+/// How invalid page-head descriptors are reported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HeadValidation {
+    /// Drop invalid values silently.
+    #[default]
+    Off,
+    /// Keep valid tags and record warnings.
+    Warn,
+    /// Record errors that a caller can treat as fatal.
+    Strict,
+}
+
 /// Hero action button.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct HeroAction {
@@ -183,6 +196,12 @@ pub struct PageData {
     /// Per-page chrome flags. Honored only when `SsgConfig::page_chrome` is on.
     #[serde(default)]
     pub chrome: PageChromeFlags,
+    /// Frontmatter `robots`. Omitted when empty.
+    #[serde(default)]
+    pub robots: Option<String>,
+    /// Frontmatter `canonical`. Overrides the `siteUrl` + path URL.
+    #[serde(default)]
+    pub canonical: Option<String>,
 }
 
 /// SSG configuration.
@@ -197,6 +216,12 @@ pub struct SsgConfig {
     pub breadcrumb_root_href: Option<String>,
     /// OG image URL.
     pub og_image: Option<String>,
+    /// Site origin used for canonical / `og:url` / hreflang. Not invented.
+    #[serde(default)]
+    pub site_url: Option<String>,
+    /// How invalid head descriptors are reported.
+    #[serde(default)]
+    pub head_validation: HeadValidation,
     /// Theme configuration.
     pub theme: Option<ThemeConfig>,
     /// Current locale (BCP 47 tag) for this page, if i18n is enabled.

--- a/crates/ox_content_ssg/src/html/pagination/tests.rs
+++ b/crates/ox_content_ssg/src/html/pagination/tests.rs
@@ -1,6 +1,6 @@
 use super::super::{
-    EntryPageConfig, NavGroup, NavItem, PageChromeFlags, PageData, PagerOverride, ReaderChrome,
-    SsgConfig, generate_bare_html, generate_html,
+    EntryPageConfig, HeadValidation, NavGroup, NavItem, PageChromeFlags, PageData, PagerOverride,
+    ReaderChrome, SsgConfig, generate_bare_html, generate_html,
 };
 
 fn nav_item(title: &str, path: &str, href: &str) -> NavItem {
@@ -74,7 +74,7 @@ fn config(pagination: bool) -> SsgConfig {
         page_chrome: false,
         json_ld: crate::JsonLd::default(),
         site_url: None,
-        head_validation: Default::default(),
+        head_validation: HeadValidation::Off,
     }
 }
 

--- a/crates/ox_content_ssg/src/html/pagination/tests.rs
+++ b/crates/ox_content_ssg/src/html/pagination/tests.rs
@@ -51,6 +51,8 @@ fn page(path: &str) -> PageData {
         next: None,
         breadcrumbs: None,
         chrome: PageChromeFlags::default(),
+        robots: None,
+        canonical: None,
     }
 }
 
@@ -71,6 +73,8 @@ fn config(pagination: bool) -> SsgConfig {
         a11y: crate::A11y::default(),
         page_chrome: false,
         json_ld: crate::JsonLd::default(),
+        site_url: None,
+        head_validation: Default::default(),
     }
 }
 

--- a/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
+++ b/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
@@ -18,6 +18,8 @@ fn page(content: &str) -> PageData {
         next: None,
         breadcrumbs: None,
         chrome: PageChromeFlags::default(),
+        robots: None,
+        canonical: None,
     }
 }
 
@@ -38,6 +40,8 @@ fn config(reader_chrome: ReaderChrome) -> SsgConfig {
         a11y: crate::A11y::default(),
         page_chrome: false,
         json_ld: crate::JsonLd::default(),
+        site_url: None,
+        head_validation: Default::default(),
     }
 }
 

--- a/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
+++ b/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
@@ -1,6 +1,6 @@
 use super::super::{
-    EntryPageConfig, NavGroup, NavItem, PageChromeFlags, PageData, ReaderChrome, SsgConfig,
-    generate_bare_html, generate_html,
+    EntryPageConfig, HeadValidation, NavGroup, NavItem, PageChromeFlags, PageData, ReaderChrome,
+    SsgConfig, generate_bare_html, generate_html,
 };
 use super::{READER_CHROME_CSS, READER_CHROME_JS, apply_reader_chrome};
 
@@ -41,7 +41,7 @@ fn config(reader_chrome: ReaderChrome) -> SsgConfig {
         page_chrome: false,
         json_ld: crate::JsonLd::default(),
         site_url: None,
-        head_validation: Default::default(),
+        head_validation: HeadValidation::Off,
     }
 }
 

--- a/crates/ox_content_ssg/src/html/render.rs
+++ b/crates/ox_content_ssg/src/html/render.rs
@@ -4,6 +4,7 @@ use super::a11y::A11Y_CSS;
 use super::breadcrumbs::resolve_breadcrumbs;
 use super::entry::generate_entry_html;
 use super::footer::{FOOTER_CSS, generate_footer_html};
+use super::head::{HeadDiagnostic, RenderedHead, render_themed_head};
 use super::header_chrome::{
     HEADER_CHROME_CSS, HEADER_CHROME_JS, header_chrome_needs_css, header_chrome_needs_js,
     push_header_chrome_body_classes, render_announcement, render_header_nav, resolve_page_chrome,
@@ -28,11 +29,40 @@ use super::{
     YOUTUBE_CSS,
 };
 
+/// Themed HTML plus page-head diagnostics.
+pub struct GeneratedHtml {
+    pub html: String,
+    pub diagnostics: Vec<HeadDiagnostic>,
+}
+
+struct GeneratedPage {
+    html: String,
+    head: RenderedHead,
+}
+
 /// Generates a complete HTML page for SSG.
 ///
 /// This function creates a full HTML document with navigation sidebar,
 /// content area, table of contents, search functionality, and theme toggle.
 pub fn generate_html(page_data: &PageData, nav_groups: &[NavGroup], config: &SsgConfig) -> String {
+    generate_html_result(page_data, nav_groups, config).html
+}
+
+/// Same as [`generate_html`], with head-validation findings.
+pub fn generate_html_result(
+    page_data: &PageData,
+    nav_groups: &[NavGroup],
+    config: &SsgConfig,
+) -> GeneratedHtml {
+    let generated = generate_html_inner(page_data, nav_groups, config);
+    GeneratedHtml { html: generated.html, diagnostics: generated.head.diagnostics }
+}
+
+fn generate_html_inner(
+    page_data: &PageData,
+    nav_groups: &[NavGroup],
+    config: &SsgConfig,
+) -> GeneratedPage {
     let theme = config.theme.as_ref();
     let chrome = resolve_page_chrome(
         config.page_chrome,
@@ -262,11 +292,7 @@ pub fn generate_html(page_data: &PageData, nav_groups: &[NavGroup], config: &Ssg
     push_header_chrome_body_classes(&mut body_classes, &announcement_html, chrome);
     let body_class = body_classes.join(" ");
 
-    let document_title = if page_data.title.trim() == config.site_name.trim() {
-        config.site_name.clone()
-    } else {
-        format!("{} - {}", page_data.title, config.site_name)
-    };
+    let page_head = render_themed_head(page_data, config, json_ld.as_deref());
     let (html_lang, html_dir) = html_locale_attrs(config);
 
     let skip_link = config.a11y.skip_link_html();
@@ -274,10 +300,7 @@ pub fn generate_html(page_data: &PageData, nav_groups: &[NavGroup], config: &Ssg
         html_lang,
         html_dir,
         site_name: &config.site_name,
-        document_title: &document_title,
-        description: page_data.description.as_deref(),
-        og_image: config.og_image.as_deref(),
-        json_ld: json_ld.as_deref(),
+        page_head: &page_head.html,
         theme_bootstrap_js: THEME_BOOTSTRAP_JS,
         css: &all_css,
         embed_head: &embed_head,
@@ -317,5 +340,5 @@ pub fn generate_html(page_data: &PageData, nav_groups: &[NavGroup], config: &Ssg
         js: &all_js,
     };
 
-    template.render().unwrap_or_default()
+    GeneratedPage { html: template.render().unwrap_or_default(), head: page_head }
 }

--- a/crates/ox_content_ssg/src/html/section_index/tests.rs
+++ b/crates/ox_content_ssg/src/html/section_index/tests.rs
@@ -26,6 +26,8 @@ fn page(content: &str) -> PageData {
         next: None,
         breadcrumbs: None,
         chrome: crate::PageChromeFlags::default(),
+        robots: None,
+        canonical: None,
     }
 }
 
@@ -46,6 +48,8 @@ fn config() -> SsgConfig {
         a11y: crate::A11y::default(),
         page_chrome: false,
         json_ld: crate::JsonLd::default(),
+        site_url: None,
+        head_validation: Default::default(),
     }
 }
 

--- a/crates/ox_content_ssg/src/html/section_index/tests.rs
+++ b/crates/ox_content_ssg/src/html/section_index/tests.rs
@@ -1,6 +1,6 @@
 use super::{SectionIndexItem, SectionIndexStyle, is_safe_section_href, render_section_index};
 use crate::html::{
-    NavGroup, NavItem, PageData, ReaderChrome, SsgConfig, generate_html,
+    HeadValidation, NavGroup, NavItem, PageData, ReaderChrome, SsgConfig, generate_html,
     section_index::SECTION_INDEX_CSS,
 };
 
@@ -49,7 +49,7 @@ fn config() -> SsgConfig {
         page_chrome: false,
         json_ld: crate::JsonLd::default(),
         site_url: None,
-        head_validation: Default::default(),
+        head_validation: HeadValidation::Off,
     }
 }
 

--- a/crates/ox_content_ssg/src/html/team/tests.rs
+++ b/crates/ox_content_ssg/src/html/team/tests.rs
@@ -39,6 +39,8 @@ fn page(content: &str) -> PageData {
         next: None,
         breadcrumbs: None,
         chrome: crate::PageChromeFlags::default(),
+        robots: None,
+        canonical: None,
     }
 }
 
@@ -59,6 +61,8 @@ fn config() -> SsgConfig {
         a11y: crate::A11y::default(),
         page_chrome: false,
         json_ld: crate::JsonLd::default(),
+        site_url: None,
+        head_validation: Default::default(),
     }
 }
 

--- a/crates/ox_content_ssg/src/html/team/tests.rs
+++ b/crates/ox_content_ssg/src/html/team/tests.rs
@@ -1,6 +1,7 @@
 use super::{TeamLink, TeamMember, TeamOptions, render_team_page};
 use crate::html::{
-    NavGroup, NavItem, PageData, ReaderChrome, SsgConfig, generate_html, team::TEAM_CSS,
+    HeadValidation, NavGroup, NavItem, PageData, ReaderChrome, SsgConfig, generate_html,
+    team::TEAM_CSS,
 };
 
 fn member(
@@ -62,7 +63,7 @@ fn config() -> SsgConfig {
         page_chrome: false,
         json_ld: crate::JsonLd::default(),
         site_url: None,
-        head_validation: Default::default(),
+        head_validation: HeadValidation::Off,
     }
 }
 

--- a/crates/ox_content_ssg/src/html/tests/aside.rs
+++ b/crates/ox_content_ssg/src/html/tests/aside.rs
@@ -18,6 +18,8 @@ fn page(toc: Vec<TocEntry>) -> PageData {
         next: None,
         breadcrumbs: None,
         chrome: PageChromeFlags::default(),
+        robots: None,
+        canonical: None,
     }
 }
 
@@ -38,6 +40,8 @@ fn config(theme: Option<ThemeConfig>) -> SsgConfig {
         a11y: A11y::default(),
         page_chrome: false,
         json_ld: JsonLd::default(),
+        site_url: None,
+        head_validation: Default::default(),
     }
 }
 

--- a/crates/ox_content_ssg/src/html/tests/aside.rs
+++ b/crates/ox_content_ssg/src/html/tests/aside.rs
@@ -41,7 +41,7 @@ fn config(theme: Option<ThemeConfig>) -> SsgConfig {
         page_chrome: false,
         json_ld: JsonLd::default(),
         site_url: None,
-        head_validation: Default::default(),
+        head_validation: HeadValidation::Off,
     }
 }
 

--- a/crates/ox_content_ssg/src/html/tests/contributors.rs
+++ b/crates/ox_content_ssg/src/html/tests/contributors.rs
@@ -14,6 +14,8 @@ fn page(contributors: Vec<Contributor>) -> PageData {
         next: None,
         breadcrumbs: None,
         chrome: PageChromeFlags::default(),
+        robots: None,
+        canonical: None,
     }
 }
 
@@ -34,6 +36,8 @@ fn config() -> SsgConfig {
         a11y: A11y::default(),
         page_chrome: false,
         json_ld: JsonLd::default(),
+        site_url: None,
+        head_validation: Default::default(),
     }
 }
 

--- a/crates/ox_content_ssg/src/html/tests/contributors.rs
+++ b/crates/ox_content_ssg/src/html/tests/contributors.rs
@@ -37,7 +37,7 @@ fn config() -> SsgConfig {
         page_chrome: false,
         json_ld: JsonLd::default(),
         site_url: None,
-        head_validation: Default::default(),
+        head_validation: HeadValidation::Off,
     }
 }
 

--- a/crates/ox_content_ssg/src/html/tests/mpa_navigation.rs
+++ b/crates/ox_content_ssg/src/html/tests/mpa_navigation.rs
@@ -37,7 +37,7 @@ fn config(theme: Option<ThemeConfig>) -> SsgConfig {
         page_chrome: false,
         json_ld: JsonLd::default(),
         site_url: None,
-        head_validation: Default::default(),
+        head_validation: HeadValidation::Off,
     }
 }
 

--- a/crates/ox_content_ssg/src/html/tests/mpa_navigation.rs
+++ b/crates/ox_content_ssg/src/html/tests/mpa_navigation.rs
@@ -14,6 +14,8 @@ fn page() -> PageData {
         next: None,
         breadcrumbs: None,
         chrome: PageChromeFlags::default(),
+        robots: None,
+        canonical: None,
     }
 }
 
@@ -34,6 +36,8 @@ fn config(theme: Option<ThemeConfig>) -> SsgConfig {
         a11y: A11y::default(),
         page_chrome: false,
         json_ld: JsonLd::default(),
+        site_url: None,
+        head_validation: Default::default(),
     }
 }
 

--- a/crates/ox_content_ssg/src/html/tests/rendering.rs
+++ b/crates/ox_content_ssg/src/html/tests/rendering.rs
@@ -23,6 +23,30 @@ fn page(
         next: None,
         breadcrumbs: None,
         chrome: PageChromeFlags::default(),
+        robots: None,
+        canonical: None,
+    }
+}
+
+fn config(site_name: &str, base: &str, locale: Option<&str>) -> SsgConfig {
+    SsgConfig {
+        site_name: site_name.to_string(),
+        base: base.to_string(),
+        breadcrumb_root_href: None,
+        og_image: None,
+        theme: None,
+        locale: locale.map(str::to_string),
+        available_locales: None,
+        pagination: false,
+        breadcrumbs: false,
+        reader_chrome: ReaderChrome::default(),
+        locale_switcher: false,
+        locale_paths: vec![],
+        a11y: A11y::default(),
+        page_chrome: false,
+        json_ld: JsonLd::default(),
+        site_url: None,
+        head_validation: Default::default(),
     }
 }
 
@@ -49,23 +73,7 @@ fn test_generate_html() {
         collapsed: None,
         sticky_collapsed: None,
     }];
-    let config = SsgConfig {
-        site_name: "Test Site".to_string(),
-        base: "/docs/".to_string(),
-        breadcrumb_root_href: None,
-        og_image: None,
-        theme: None,
-        locale: None,
-        available_locales: None,
-        pagination: false,
-        breadcrumbs: false,
-        reader_chrome: ReaderChrome::default(),
-        locale_switcher: false,
-        locale_paths: vec![],
-        a11y: A11y::default(),
-        page_chrome: false,
-        json_ld: JsonLd::default(),
-    };
+    let config = config("Test Site", "/docs/", None);
     let html = generate_html(&page_data, &nav_groups, &config);
 
     insta::assert_snapshot!(super::snapshot_text(&html));
@@ -281,24 +289,7 @@ fn test_mobile_menu_css_stays_reachable_and_touch_safe() {
 #[test]
 fn test_generate_html_without_toc_omits_outline() {
     let page_data = page("No TOC", None, "<p>Content</p>", vec![], None, "no-toc");
-    let config = SsgConfig {
-        site_name: "Test Site".to_string(),
-        base: "/".to_string(),
-        breadcrumb_root_href: None,
-        og_image: None,
-        theme: None,
-        locale: None,
-        available_locales: None,
-        pagination: false,
-        breadcrumbs: false,
-        reader_chrome: ReaderChrome::default(),
-        locale_switcher: false,
-        locale_paths: vec![],
-        a11y: A11y::default(),
-        page_chrome: false,
-        json_ld: JsonLd::default(),
-    };
-
+    let config = config("Test Site", "/", None);
     let html = generate_html(&page_data, &[], &config);
     insta::assert_snapshot!(super::snapshot_text(&html));
 }
@@ -310,23 +301,7 @@ fn test_format_last_updated_rejects_invalid_timestamps() {
 
 #[test]
 fn test_html_locale_attrs_use_current_locale_and_direction() {
-    let config = SsgConfig {
-        site_name: "Localized".to_string(),
-        base: "/".to_string(),
-        breadcrumb_root_href: None,
-        og_image: None,
-        theme: None,
-        locale: Some("ar".to_string()),
-        available_locales: None,
-        pagination: false,
-        breadcrumbs: false,
-        reader_chrome: ReaderChrome::default(),
-        locale_switcher: false,
-        locale_paths: vec![],
-        a11y: A11y::default(),
-        page_chrome: false,
-        json_ld: JsonLd::default(),
-    };
+    let config = config("Localized", "/", Some("ar"));
 
     assert_eq!(html_locale_attrs(&config), ("ar", "rtl"));
 

--- a/crates/ox_content_ssg/src/html/tests/rendering.rs
+++ b/crates/ox_content_ssg/src/html/tests/rendering.rs
@@ -46,7 +46,7 @@ fn config(site_name: &str, base: &str, locale: Option<&str>) -> SsgConfig {
         page_chrome: false,
         json_ld: JsonLd::default(),
         site_url: None,
-        head_validation: Default::default(),
+        head_validation: HeadValidation::Off,
     }
 }
 

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_bare_html_escapes_title_but_keeps_content_raw.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_bare_html_escapes_title_but_keeps_content_raw.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/ox_content_ssg/src/html/tests/rendering.rs
-expression: html
+expression: "super::snapshot_text(&html)"
 ---
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>&#60;script&#62;alert(1)&#60;/script&#62;</title>
+  <title>&lt;script&gt;alert(1)&lt;/script&gt;</title>
 </head>
 <body>
 <h1>Raw & ready</h1>

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_bare_page_escapes_metadata_but_keeps_injected_markup_raw.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_bare_page_escapes_metadata_but_keeps_injected_markup_raw.snap
@@ -8,10 +8,10 @@ expression: "super::snapshot_text(&generate_bare_page(&data))"
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Guide</title>
-  <meta name="description" content="a &#34;quoted&#34; &#38; &#60;angled&#62; value">
-  <meta property="og:description" content="a &#34;quoted&#34; &#38; &#60;angled&#62; value">
-  <meta name="twitter:description" content="a &#34;quoted&#34; &#38; &#60;angled&#62; value">
-  <meta property="og:site_name" content="Docs &#38; More">
+  <meta name="description" content="a &quot;quoted&quot; &amp; &lt;angled&gt; value">
+  <meta property="og:description" content="a &quot;quoted&quot; &amp; &lt;angled&gt; value">
+  <meta name="twitter:description" content="a &quot;quoted&quot; &amp; &lt;angled&gt; value">
+  <meta property="og:site_name" content="Docs &amp; More">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Guide">
   <meta name="twitter:card" content="summary_large_image">

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -26,14 +26,11 @@ expression: "super::snapshot_text(&html)"
 })();
 </script>
   <title>Test Page - Test Site</title>
-<sp><sp>
   <meta name="description" content="Test description">
   <meta property="og:description" content="Test description">
   <meta name="twitter:description" content="Test description">
-<sp><sp>
   <meta property="og:type" content="website">
   <meta property="og:title" content="Test Page - Test Site">
-<sp><sp>
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Test Page - Test Site">
   <!-- ox-content:styles:start -->

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -26,10 +26,8 @@ expression: "super::snapshot_text(&html)"
 })();
 </script>
   <title>No TOC - Test Site</title>
-<sp><sp>
   <meta property="og:type" content="website">
   <meta property="og:title" content="No TOC - Test Site">
-<sp><sp>
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="No TOC - Test Site">
   <!-- ox-content:styles:start -->

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -26,10 +26,8 @@ expression: "super::snapshot_text(&html)"
 })();
 </script>
   <title>مرحبا - Localized</title>
-<sp><sp>
   <meta property="og:type" content="website">
   <meta property="og:title" content="مرحبا - Localized">
-<sp><sp>
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="مرحبا - Localized">
   <!-- ox-content:styles:start -->

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -26,10 +26,8 @@ expression: "super::snapshot_text(&html)"
 })();
 </script>
   <title>Social Page - Social Site</title>
-<sp><sp>
   <meta property="og:type" content="website">
   <meta property="og:title" content="Social Page - Social Site">
-<sp><sp>
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Social Page - Social Site">
   <!-- ox-content:styles:start -->

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -26,10 +26,8 @@ expression: "super::snapshot_text(&html)"
 })();
 </script>
   <title>Themed Page - Themed Site</title>
-<sp><sp>
   <meta property="og:type" content="website">
   <meta property="og:title" content="Themed Page - Themed Site">
-<sp><sp>
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Themed Page - Themed Site">
   <!-- ox-content:styles:start -->

--- a/crates/ox_content_ssg/src/html/tests/theme.rs
+++ b/crates/ox_content_ssg/src/html/tests/theme.rs
@@ -17,6 +17,8 @@ fn test_generate_html_with_theme() {
         next: None,
         breadcrumbs: None,
         chrome: PageChromeFlags::default(),
+        robots: None,
+        canonical: None,
     };
 
     let nav_groups = vec![];
@@ -47,6 +49,8 @@ fn test_generate_html_with_theme() {
         a11y: A11y::default(),
         page_chrome: false,
         json_ld: JsonLd::default(),
+        site_url: None,
+        head_validation: Default::default(),
     };
 
     let html = generate_html(&page_data, &nav_groups, &config);
@@ -69,6 +73,8 @@ fn test_generate_html_with_custom_social_link() {
         next: None,
         breadcrumbs: None,
         chrome: PageChromeFlags::default(),
+        robots: None,
+        canonical: None,
     };
     let config = SsgConfig {
         site_name: "Social Site".to_string(),
@@ -85,6 +91,8 @@ fn test_generate_html_with_custom_social_link() {
         a11y: A11y::default(),
         page_chrome: false,
         json_ld: JsonLd::default(),
+        site_url: None,
+        head_validation: Default::default(),
         theme: Some(ThemeConfig {
             social_links: Some(SocialLinks {
                 links: Some(vec![SocialLink {

--- a/crates/ox_content_ssg/src/html/tests/theme.rs
+++ b/crates/ox_content_ssg/src/html/tests/theme.rs
@@ -50,7 +50,7 @@ fn test_generate_html_with_theme() {
         page_chrome: false,
         json_ld: JsonLd::default(),
         site_url: None,
-        head_validation: Default::default(),
+        head_validation: HeadValidation::Off,
     };
 
     let html = generate_html(&page_data, &nav_groups, &config);
@@ -92,7 +92,7 @@ fn test_generate_html_with_custom_social_link() {
         page_chrome: false,
         json_ld: JsonLd::default(),
         site_url: None,
-        head_validation: Default::default(),
+        head_validation: HeadValidation::Off,
         theme: Some(ThemeConfig {
             social_links: Some(SocialLinks {
                 links: Some(vec![SocialLink {

--- a/crates/ox_content_ssg/src/html/urls.rs
+++ b/crates/ox_content_ssg/src/html/urls.rs
@@ -1,0 +1,82 @@
+//! Shared URL safety for JSON-LD, page-head, and SEO metadata.
+
+/// Absolute `http:` / `https:` URL, or `None` when empty or unsafe.
+pub(super) fn safe_http_url(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || !is_safe_absolute_http_url(trimmed) {
+        return None;
+    }
+    Some(trimmed)
+}
+
+pub(super) fn is_safe_absolute_http_url(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    (lower.starts_with("https://") || lower.starts_with("http://"))
+        && !lower.starts_with("https:///")
+        && is_safe_href(value)
+}
+
+pub(super) fn is_safe_relative_href(href: &str) -> bool {
+    !href.is_empty() && is_safe_href(href)
+}
+
+/// Rejects `javascript:`, `data:`, `vbscript:`, and protocol-relative URLs.
+pub(super) fn is_safe_href(href: &str) -> bool {
+    let trimmed = href.trim();
+    if trimmed.is_empty() || trimmed.starts_with("//") {
+        return false;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    if lower.starts_with("javascript:")
+        || lower.starts_with("data:")
+        || lower.starts_with("vbscript:")
+    {
+        return false;
+    }
+    if let Some(scheme_end) = trimmed.find(':') {
+        let scheme = &lower[..scheme_end];
+        return matches!(scheme, "http" | "https");
+    }
+    true
+}
+
+pub(super) fn site_origin(site_url: &str) -> Option<String> {
+    let (scheme, rest) = if let Some(rest) = site_url.strip_prefix("https://") {
+        ("https", rest)
+    } else {
+        let rest = site_url.strip_prefix("http://")?;
+        ("http", rest)
+    };
+    let host = rest.split('/').next()?.trim();
+    if host.is_empty() {
+        return None;
+    }
+    Some(format!("{scheme}://{host}"))
+}
+
+/// Joins `site_url` + `base` + page path, applying trailing slashes.
+pub(super) fn page_absolute_url(site_url: &str, base: &str, path: &str) -> Option<String> {
+    let site = safe_http_url(site_url)?.trim_end_matches('/');
+    let path = path.trim().trim_matches('/');
+    if path.is_empty() || path.eq_ignore_ascii_case("index") {
+        Some(format!("{site}{base}"))
+    } else {
+        Some(format!("{site}{base}{path}/"))
+    }
+}
+
+pub(super) fn absolute_href(site_url: &str, href: &str) -> Option<String> {
+    let href = href.trim();
+    if let Some(url) = safe_http_url(href) {
+        return Some(url.to_string());
+    }
+    if !is_safe_relative_href(href) {
+        return None;
+    }
+    let site = safe_http_url(site_url)?;
+    if href.starts_with('/') {
+        return Some(format!("{}{href}", site_origin(site)?));
+    }
+    let site = site.trim_end_matches('/');
+    Some(format!("{site}/{href}"))
+}

--- a/crates/ox_content_ssg/src/html/utils.rs
+++ b/crates/ox_content_ssg/src/html/utils.rs
@@ -22,6 +22,21 @@ pub(super) fn page_content_contains_any(content: &str, needles: &[&str]) -> bool
     needles.iter().any(|needle| memmem::find(haystack, needle.as_bytes()).is_some())
 }
 
+pub(super) fn escape_json_for_script(json: &str) -> String {
+    let mut out = String::with_capacity(json.len());
+    for ch in json.chars() {
+        match ch {
+            '<' => out.push_str("\\u003c"),
+            '>' => out.push_str("\\u003e"),
+            '&' => out.push_str("\\u0026"),
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
 pub(super) fn escape_html(value: &str) -> String {
     // SSG escaping favors predictable allocation over chained `replace()`:
     // allocate once at the input length, stream characters into the output,

--- a/crates/ox_content_ssg/src/lib.rs
+++ b/crates/ox_content_ssg/src/lib.rs
@@ -32,6 +32,8 @@
 //!     next: None,
 //!     breadcrumbs: None,
 //!     chrome: PageChromeFlags::default(),
+//!     robots: None,
+//!     canonical: None,
 //! };
 //!
 //! let nav_groups = vec![NavGroup {
@@ -90,13 +92,16 @@ pub use assets::{
 };
 pub use feeds::{FeedFormat, FeedItem, FeedsOptions, FeedsOutput, generate_feeds};
 pub use html::{
-    A11y, BarePageData, Contributor, EntryPageConfig, FeatureConfig, HeaderNavItem, HeroAction,
-    HeroConfig, HeroImage, HeroNoticeConfig, JsonLd, JsonLdPublisher, LocaleInfo, LocalePath,
-    NavGroup, NavItem, PageChromeFlags, PageData, PagerOverride, ReaderChrome, SectionIndexItem,
-    SectionIndexStyle, SocialLink, SocialLinks, SsgConfig, TeamLink, TeamMember, TeamOptions,
-    ThemeAnnouncement, ThemeColors, ThemeConfig, ThemeEmbed, ThemeEntryPage, ThemeFonts,
-    ThemeFooter, ThemeHeader, ThemeLayout, TocEntry, generate_bare_html, generate_bare_page,
-    generate_html, is_safe_section_href, render_section_index, render_team_page,
+    A11y, BarePageData, Contributor, EntryPageConfig, FeatureConfig, GeneratedHtml, HeadAlternate,
+    HeadDiagnostic, HeadInput, HeadJsonLd, HeadLink, HeadMeta, HeadValidation, HeaderNavItem,
+    HeroAction, HeroConfig, HeroImage, HeroNoticeConfig, JsonLd, JsonLdPublisher, LocaleInfo,
+    LocalePath, NavGroup, NavItem, PageChromeFlags, PageData, PagerOverride, ReaderChrome,
+    RenderedHead, ResolvedHead, ResolvedTag, SectionIndexItem, SectionIndexStyle, SiteHead,
+    SocialLink, SocialLinks, SsgConfig, TeamLink, TeamMember, TeamOptions, ThemeAnnouncement,
+    ThemeColors, ThemeConfig, ThemeEmbed, ThemeEntryPage, ThemeFonts, ThemeFooter, ThemeHeader,
+    ThemeLayout, TocEntry, generate_bare_html, generate_bare_page, generate_html,
+    generate_html_result, is_safe_section_href, render_head, render_section_index,
+    render_team_page, resolve_head, serialize_head,
 };
 pub use permalinks::{
     CascadeOptions, PermalinksOptions, ResolvedRoutePage, RoutePage, RouteResolveOutput,

--- a/crates/ox_content_ssg/templates/bare_page.html
+++ b/crates/ox_content_ssg/templates/bare_page.html
@@ -3,29 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{{ title }}</title>
-{%- if has_metadata %}
-{%- if let Some(desc) = description %}
-  <meta name="description" content="{{ desc }}">
-  <meta property="og:description" content="{{ desc }}">
-  <meta name="twitter:description" content="{{ desc }}">
-{%- endif %}
-{%- if let Some(url) = canonical_url %}
-  <link rel="canonical" href="{{ url }}">
-  <meta property="og:url" content="{{ url }}">
-{%- endif %}
-{%- if let Some(name) = site_name %}
-  <meta property="og:site_name" content="{{ name }}">
-{%- endif %}
-  <meta property="og:type" content="website">
-  <meta property="og:title" content="{{ title }}">
-{%- if let Some(img) = og_image %}
-  <meta property="og:image" content="{{ img }}">
-  <meta name="twitter:image" content="{{ img }}">
-{%- endif %}
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="{{ title }}">
-{%- endif %}
+{{ page_head|safe }}
 {%- if !head.is_empty() %}
 {{ head|safe }}
 {%- endif %}

--- a/crates/ox_content_ssg/templates/page.html
+++ b/crates/ox_content_ssg/templates/page.html
@@ -5,23 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="color-scheme" content="light dark">
   <script>{{ theme_bootstrap_js|safe }}</script>
-  <title>{{ document_title }}</title>
-  {% if let Some(desc) = description %}
-  <meta name="description" content="{{ desc }}">
-  <meta property="og:description" content="{{ desc }}">
-  <meta name="twitter:description" content="{{ desc }}">
-  {% endif %}
-  <meta property="og:type" content="website">
-  <meta property="og:title" content="{{ document_title }}">
-  {% if let Some(img) = og_image %}
-  <meta property="og:image" content="{{ img }}">
-  <meta name="twitter:image" content="{{ img }}">
-  {% endif %}
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="{{ document_title }}">
-{%- if let Some(json_ld) = json_ld %}
-  <script type="application/ld+json">{{ json_ld|safe }}</script>
-{%- endif %}
+{{ page_head|safe }}
   <!-- ox-content:styles:start -->
   <style>{{ css|safe }}</style>
   <!-- ox-content:styles:end -->

--- a/docs/content/built-in-features.md
+++ b/docs/content/built-in-features.md
@@ -40,6 +40,8 @@ inline**.
 | [Quality Checks](./built-in/quality-checks.md)         | Code block lint, type checking, docs tests, HTML sanitizer                |
 | [Typed Hover](./built-in/typed-hover.md)               | Opt-in build-time TypeScript hover overlays for `twoslash` fences         |
 | [Site Generation](./built-in/site-generation.md)       | SSG, OG images, edit links, collections, API docs, transformers           |
+| [Page head](./built-in/page-head.md)                   | Build-time Unhead-compatible title / meta / link / JSON-LD API            |
+| [SEO](./built-in/seo.md)                               | Canonical, robots, hreflang, and head validation on that API              |
 | [Previous / Next](./built-in/pagination.md)            | Opt-in previous and next page links                                       |
 | [Breadcrumbs](./built-in/breadcrumbs.md)               | Opt-in trail from the site root through sidebar ancestors                 |
 | [JSON-LD](./built-in/json-ld.md)                       | Opt-in TechArticle / WebSite / BreadcrumbList structured data             |
@@ -90,6 +92,9 @@ inline**.
 | Editing links    | `editThisPage`                                                                                                | `false`              | [Site Generation](./built-in/site-generation.md)       |
 | Page pager       | `ssg.pagination`                                                                                              | `false`              | [Previous / Next](./built-in/pagination.md)            |
 | Breadcrumbs      | `ssg.breadcrumbs` / `theme.breadcrumbs`                                                                       | `false`              | [Breadcrumbs](./built-in/breadcrumbs.md)               |
+| Page head        | `renderHead`                                                                                                  | build-time           | [Page head](./built-in/page-head.md)                   |
+| SEO tags         | `ssg.siteUrl`, frontmatter `robots` / `canonical`                                                             | off unless set       | [SEO](./built-in/seo.md)                               |
+| Head validation  | `ssg.headValidation`                                                                                          | `false`              | [SEO](./built-in/seo.md)                               |
 | Structured data  | `ssg.jsonLd`                                                                                                  | `false`              | [JSON-LD](./built-in/json-ld.md)                       |
 | Reader chrome    | `ssg.readerChrome`                                                                                            | `false`              | [Reader Chrome](./built-in/reader-chrome.md)           |
 | Locale switcher  | `ssg.localeSwitcher`                                                                                          | `false`              | [Locale Switcher](./built-in/locale-switcher.md)       |

--- a/docs/content/built-in/json-ld.md
+++ b/docs/content/built-in/json-ld.md
@@ -51,10 +51,12 @@ oxContent({
 });
 ```
 
-| Field         | Default | Effect                                                                          |
-| ------------- | ------- | ------------------------------------------------------------------------------- |
-| `breadcrumbs` | `true`  | Emit `BreadcrumbList` only when a visible trail exists. Set `false` to hide it. |
-| `publisher`   | omitted | Optional `{ name?, url? }`. Missing fields are not invented.                    |
+| Field         | Default       | Effect                                                                          |
+| ------------- | ------------- | ------------------------------------------------------------------------------- |
+| `breadcrumbs` | `true`        | Emit `BreadcrumbList` only when a visible trail exists. Set `false` to hide it. |
+| `publisher`   | omitted       | Optional `{ name?, url? }`. Missing fields are not invented.                    |
+| `type`        | `TechArticle` | Page `@type`: `TechArticle`, `BlogPosting`, or `WebPage`.                       |
+| `graph`       | omitted       | Extra `@graph` objects. Invalid JSON is dropped.                                |
 
 ## What is emitted
 
@@ -99,6 +101,8 @@ Bare mode never emits JSON-LD.
 ## Related
 
 - [Breadcrumbs](./breadcrumbs.md)
+- [Page head](./page-head.md)
+- [SEO](./seo.md)
 - [Site Generation](./site-generation.md)
 - [Built-in Features overview](../built-in-features.md)
 - Tracking issue: [#696](https://github.com/ubugeeei-prod/ox-content/issues/696)

--- a/docs/content/built-in/page-head.md
+++ b/docs/content/built-in/page-head.md
@@ -1,0 +1,81 @@
+---
+title: Page head
+description: Build-time Unhead-compatible page-head API shared by themed, bare, custom, and ssg: false hosts.
+---
+
+# Page head
+
+Ox Content resolves `<title>`, `meta`, `link`, and JSON-LD at **build time**.
+There is no Unhead runtime, no client head manager, and no extra browser JS.
+
+Themed pages, bare pages, `ssg.render` hosts, and `ssg: false` apps share the
+same typed resolver. Call it yourself when you own the document:
+
+```ts
+import { renderHead } from "@ox-content/vite-plugin";
+
+const { html, diagnostics } = renderHead({
+  site: { name: "Docs", url: "https://example.com" },
+  title: "Guide",
+  description: "How it works",
+  canonical: "https://example.com/guide/",
+});
+```
+
+`html` is already escaped. Inject it into `<head>` — for example with `raw()`
+in a custom `ssg.render` layout. `@ox-content/vite-plugin-svelte` re-exports
+the same `renderHead`.
+
+| Host                        | What emits head tags                                                                        |
+| --------------------------- | ------------------------------------------------------------------------------------------- |
+| Default theme               | Built-in resolver. Same OG/Twitter tags as before.                                          |
+| `bare: true`                | Same resolver. Social tags only when description, `siteUrl`, site name, or OG image is set. |
+| `ssg.render` / `ssg: false` | Nothing is injected. Call `renderHead` and write the tags yourself.                         |
+
+Existing sites keep the same tags unless they opt into
+[SEO](./seo.md) (`ssg.siteUrl`, `robots`, locale alternates) or
+[JSON-LD](./json-ld.md).
+
+## Descriptors
+
+`renderHead` accepts Unhead-shaped input. Later descriptors with the same
+identity win and keep the first position.
+
+| Field    | Identity                                       |
+| -------- | ---------------------------------------------- |
+| `title`  | one title                                      |
+| `metas`  | `key`, else `name`, `property`, or `httpEquiv` |
+| `links`  | `key`, else `rel`, or `alternate` + `hreflang` |
+| `jsonLd` | `key`                                          |
+
+```ts
+renderHead({
+  title: "Guide",
+  titleTemplate: "%s · %siteName",
+  site: { name: "Docs" },
+  metas: [{ name: "theme-color", content: "#111" }],
+  links: [{ rel: "icon", href: "https://example.com/favicon.ico" }],
+  jsonLd: [{ key: "blog", json: JSON.stringify({ "@type": "BlogPosting" }) }],
+});
+```
+
+Unknown keys such as `twitter.imggg` are a TypeScript error. Put extra tags in
+`metas` or `links`.
+
+## Safety
+
+Attribute values are HTML-escaped. JSON-LD script bodies escape `<`, `>`, `&`,
+and U+2028 / U+2029 as `\uXXXX`.
+
+`javascript:`, `data:`, `vbscript:`, and protocol-relative `//` URLs are
+dropped. Custom hosts validate by default. Built-in themed/bare paths keep
+emitting the OG image and canonical strings they already computed.
+
+See [SEO](./seo.md) for `ssg.headValidation`.
+
+## Related
+
+- [SEO](./seo.md)
+- [JSON-LD](./json-ld.md)
+- [Site Generation](./site-generation.md)
+- Tracking: [#819](https://github.com/ubugeeei-prod/ox-content/issues/819)

--- a/docs/content/built-in/seo.md
+++ b/docs/content/built-in/seo.md
@@ -1,0 +1,79 @@
+---
+title: SEO
+description: Built-in canonical, robots, hreflang, Open Graph, and head validation on the page-head API.
+---
+
+# SEO
+
+The [page-head](./page-head.md) resolver can emit documented SEO tags. Nothing
+is invented: no author, publisher, URL, or indexability unless you set it.
+
+## What turns a tag on
+
+| Tag                          | When                                                                                           |
+| ---------------------------- | ---------------------------------------------------------------------------------------------- |
+| `<title>`, OG/Twitter title  | Always on themed pages. Bare pages always have `<title>`.                                      |
+| `description` + OG/Twitter   | Page `description` frontmatter.                                                                |
+| `og:image` / `twitter:image` | `ssg.ogImage` or a generated OG image.                                                         |
+| `canonical` / `og:url`       | `ssg.siteUrl` (themed) or the computed bare `canonicalUrl`. Frontmatter `canonical` overrides. |
+| `og:site_name`               | Bare pages when `siteName` is set. Themed pages do not add it unless you pass a custom meta.   |
+| `robots`                     | Frontmatter `robots` only.                                                                     |
+| `hreflang` alternates        | `locale_paths` from i18n, when an absolute URL can be built.                                   |
+
+Themed pages without `ssg.siteUrl` stay as they were: no canonical, no
+`og:url`, no `hreflang`. Setting `siteUrl` for sitemaps or JSON-LD also
+enables those tags. Relative locale hrefs need `siteUrl` to become absolute.
+
+```yaml
+---
+title: Guide
+description: How it works
+robots: noindex, nofollow
+canonical: https://example.com/guide/
+---
+```
+
+```ts
+oxContent({
+  ssg: {
+    siteName: "Docs",
+    siteUrl: "https://example.com",
+    headValidation: "warn",
+  },
+  i18n: {
+    locales: [
+      { code: "en", name: "English" },
+      { code: "ja", name: "日本語" },
+    ],
+  },
+});
+```
+
+## Validation
+
+`ssg.headValidation`:
+
+| Value             | Effect                                               |
+| ----------------- | ---------------------------------------------------- |
+| omitted / `false` | Drop invalid values silently. Default.               |
+| `warn`            | Keep valid tags and log findings.                    |
+| `strict`          | Fail the build on unsafe URLs or invalid `hreflang`. |
+
+Invalid custom descriptors are dropped in every mode. `strict` is for CI.
+
+`renderHead({ validation: "strict", ... })` returns the same findings in
+`diagnostics` for custom hosts.
+
+## JSON-LD variants
+
+`ssg.jsonLd.type` can be `TechArticle` (default), `BlogPosting`, or `WebPage`.
+`ssg.jsonLd.graph` appends extra `@graph` nodes. Unknown types fall back to
+`TechArticle`. See [JSON-LD](./json-ld.md).
+
+## Related
+
+- [Page head](./page-head.md)
+- [JSON-LD](./json-ld.md)
+- [Locale Switcher](./locale-switcher.md)
+- [Site Generation](./site-generation.md)
+- Tracking: [#820](https://github.com/ubugeeei-prod/ox-content/issues/820)

--- a/docs/content/built-in/site-generation.md
+++ b/docs/content/built-in/site-generation.md
@@ -66,7 +66,8 @@ export default defineConfig({
 | `bodyStart`       | —              | Raw markup after `<body>` (bare mode).                                                                |
 | `bodyEnd`         | —              | Raw markup before `</body>` (bare mode).                                                              |
 | `siteName`        | —              | Suffix for `<title>` and OG site name.                                                                |
-| `siteUrl`         | —              | Origin used for absolute OG URLs.                                                                     |
+| `siteUrl`         | —              | Origin used for absolute OG URLs, canonical, and hreflang. See [SEO](./seo.md).                       |
+| `headValidation`  | `false`        | `warn` or `strict` for invalid head descriptors. See [SEO](./seo.md).                                 |
 | `ogImage`         | —              | Static fallback OG image URL.                                                                         |
 | `generateOgImage` | `false`        | Per-page OG images (see below).                                                                       |
 | `lastUpdated`     | `false`        | Show the git last-commit time per page.                                                               |
@@ -305,6 +306,8 @@ array order.
 
 - [Previous / Next](./pagination.md) — opt-in previous and next page links.
 - [Breadcrumbs](./breadcrumbs.md) — opt-in trail from the site root through sidebar ancestors.
+- [Page head](./page-head.md) — build-time title / meta / link / JSON-LD API.
+- [SEO](./seo.md) — canonical, robots, hreflang, and validation.
 - [JSON-LD](./json-ld.md) — opt-in TechArticle / WebSite / BreadcrumbList structured data.
 - [Reader Chrome](./reader-chrome.md) — opt-in copy, outbound icons, and back-to-top.
 - [Locale Switcher](./locale-switcher.md) — opt-in header locale list.

--- a/docs/content/ja/built-in-features.md
+++ b/docs/content/ja/built-in-features.md
@@ -36,6 +36,8 @@ Ox Content は、よく使うドキュメントの挙動を既定で載せ、非
 | [品質チェック](./built-in/quality-checks.md)             | lint、型チェック、docs テスト、HTML サニタイズ                                 |
 | [型ホバー](./built-in/typed-hover.md)                    | `twoslash` フェンスのビルド時 TypeScript 型オーバーレイ                        |
 | [サイト生成](./built-in/site-generation.md)              | SSG、OG 画像、編集リンク、API ドキュメント                                     |
+| [ページ head](./built-in/page-head.md)                   | ビルド時の Unhead 互換 title / meta / link / JSON-LD API                       |
+| [SEO](./built-in/seo.md)                                 | その API 上の canonical、robots、hreflang、検証                                |
 | [前へ / 次へ](./built-in/pagination.md)                  | サイドバー順の前後リンク                                                       |
 | [パンくず](./built-in/breadcrumbs.md)                    | ルートからサイドバー祖先までの道筋                                             |
 | [JSON-LD](./built-in/json-ld.md)                         | オプトインの TechArticle / WebSite / BreadcrumbList                            |
@@ -86,6 +88,9 @@ Ox Content は、よく使うドキュメントの挙動を既定で載せ、非
 | 編集リンク           | `editThisPage`                                                                                                | `false`       | [サイト生成](./built-in/site-generation.md)              |
 | ページ送り           | `ssg.pagination`                                                                                              | `false`       | [前へ / 次へ](./built-in/pagination.md)                  |
 | パンくず             | `ssg.breadcrumbs` / `theme.breadcrumbs`                                                                       | `false`       | [パンくず](./built-in/breadcrumbs.md)                    |
+| ページ head          | `renderHead`                                                                                                  | ビルド時      | [ページ head](./built-in/page-head.md)                   |
+| SEO タグ             | `ssg.siteUrl`、frontmatter `robots` / `canonical`                                                             | 設定時のみ    | [SEO](./built-in/seo.md)                                 |
+| head 検証            | `ssg.headValidation`                                                                                          | `false`       | [SEO](./built-in/seo.md)                                 |
 | 構造化データ         | `ssg.jsonLd`                                                                                                  | `false`       | [JSON-LD](./built-in/json-ld.md)                         |
 | リーダー chrome      | `ssg.readerChrome`                                                                                            | `false`       | [リーダー chrome](./built-in/reader-chrome.md)           |
 | ロケールスイッチャー | `ssg.localeSwitcher`                                                                                          | `false`       | [ロケールスイッチャー](./built-in/locale-switcher.md)    |

--- a/docs/content/ja/built-in/json-ld.md
+++ b/docs/content/ja/built-in/json-ld.md
@@ -49,10 +49,12 @@ oxContent({
 });
 ```
 
-| フィールド    | 既定   | 効果                                                                 |
-| ------------- | ------ | -------------------------------------------------------------------- |
-| `breadcrumbs` | `true` | 表示用の道筋があるときだけ `BreadcrumbList` を出す。`false` で隠す。 |
-| `publisher`   | 省略   | 任意の `{ name?, url? }`。未設定のフィールドは捏造しない。           |
+| フィールド    | 既定          | 効果                                                                 |
+| ------------- | ------------- | -------------------------------------------------------------------- |
+| `breadcrumbs` | `true`        | 表示用の道筋があるときだけ `BreadcrumbList` を出す。`false` で隠す。 |
+| `publisher`   | 省略          | 任意の `{ name?, url? }`。未設定のフィールドは捏造しない。           |
+| `type`        | `TechArticle` | ページの `@type`。`TechArticle` / `BlogPosting` / `WebPage`。        |
+| `graph`       | 省略          | 追加の `@graph` オブジェクト。不正な JSON は落とす。                 |
 
 ## 何が出力されるか
 
@@ -93,6 +95,8 @@ bare モードでは JSON-LD を出しません。
 
 ## 関連
 
+- [ページ head](./page-head.md)
+- [SEO](./seo.md)
 - [パンくず](./breadcrumbs.md)
 - [サイト生成](./site-generation.md)
 - [組み込み機能の概要](../built-in-features.md)

--- a/docs/content/ja/built-in/page-head.md
+++ b/docs/content/ja/built-in/page-head.md
@@ -1,0 +1,79 @@
+---
+title: ページ head
+description: テーマ付き・bare・独自ホスト・ssg: false で共有する、ビルド時の Unhead 互換 page-head API。
+---
+
+# ページ head
+
+Ox Content は `<title>`、`meta`、`link`、JSON-LD を **ビルド時** に解決します。
+Unhead ランタイムも、クライアントの head マネージャも、追加のブラウザ JS もありません。
+
+テーマ付きページ、bare、`ssg.render`、`ssg: false` は同じ型付きリゾルバを使います。
+文書を自分で持つときは、こう呼びます。
+
+```ts
+import { renderHead } from "@ox-content/vite-plugin";
+
+const { html, diagnostics } = renderHead({
+  site: { name: "Docs", url: "https://example.com" },
+  title: "Guide",
+  description: "How it works",
+  canonical: "https://example.com/guide/",
+});
+```
+
+`html` はすでにエスケープ済みです。`<head>` に差し込みます。独自の
+`ssg.render` レイアウトなら `raw()` が使えます。
+`@ox-content/vite-plugin-svelte` も同じ `renderHead` を再エクスポートします。
+
+| ホスト                      | head タグの出し方                                                                    |
+| --------------------------- | ------------------------------------------------------------------------------------ |
+| 既定テーマ                  | 組み込みリゾルバ。従来どおりの OG / Twitter。                                        |
+| `bare: true`                | 同じリゾルバ。説明、`siteUrl`、サイト名、OG 画像があるときだけソーシャルタグを出す。 |
+| `ssg.render` / `ssg: false` | 何も注入しない。`renderHead` を呼んで自分で書く。                                    |
+
+既存サイトのタグは、[SEO](./seo.md)（`ssg.siteUrl`、`robots`、ロケール alternate）
+や [JSON-LD](./json-ld.md) をオプトインしない限り変わりません。
+
+## デスクリプタ
+
+`renderHead` は Unhead 形の入力を受けます。同じ identity の後勝ちで、位置は最初のままです。
+
+| フィールド | Identity                                               |
+| ---------- | ------------------------------------------------------ |
+| `title`    | title は一つ                                           |
+| `metas`    | `key`、なければ `name` / `property` / `httpEquiv`      |
+| `links`    | `key`、なければ `rel`、または `alternate` + `hreflang` |
+| `jsonLd`   | `key`                                                  |
+
+```ts
+renderHead({
+  title: "Guide",
+  titleTemplate: "%s · %siteName",
+  site: { name: "Docs" },
+  metas: [{ name: "theme-color", content: "#111" }],
+  links: [{ rel: "icon", href: "https://example.com/favicon.ico" }],
+  jsonLd: [{ key: "blog", json: JSON.stringify({ "@type": "BlogPosting" }) }],
+});
+```
+
+`twitter.imggg` のような未知キーは TypeScript エラーです。追加タグは `metas` /
+`links` に入れてください。
+
+## 安全性
+
+属性値は HTML エスケープします。JSON-LD の script 本文は `<`、`>`、`&`、
+U+2028 / U+2029 を `\uXXXX` にします。
+
+`javascript:`、`data:`、`vbscript:`、プロトコル相対の `//` は落とします。
+独自ホストは既定で検証します。組み込みの themed / bare は、これまで計算していた
+OG 画像と canonical の文字列をそのまま出します。
+
+`ssg.headValidation` は [SEO](./seo.md) を見てください。
+
+## 関連
+
+- [SEO](./seo.md)
+- [JSON-LD](./json-ld.md)
+- [サイト生成](./site-generation.md)
+- 追跡: [#819](https://github.com/ubugeeei-prod/ox-content/issues/819)

--- a/docs/content/ja/built-in/seo.md
+++ b/docs/content/ja/built-in/seo.md
@@ -1,0 +1,79 @@
+---
+title: SEO
+description: page-head API 上の組み込み canonical、robots、hreflang、Open Graph、head 検証。
+---
+
+# SEO
+
+[ページ head](./page-head.md) のリゾルバは、文書化した SEO タグを出せます。
+設定していない author / publisher / URL / インデックス可否は**発明しません**。
+
+## タグが乗る条件
+
+| タグ                          | いつ                                                                                           |
+| ----------------------------- | ---------------------------------------------------------------------------------------------- |
+| `<title>`、OG / Twitter title | テーマ付きでは常時。bare も `<title>` は常時。                                                 |
+| `description` と OG / Twitter | ページ frontmatter の `description`。                                                          |
+| `og:image` / `twitter:image`  | `ssg.ogImage` または生成 OG 画像。                                                             |
+| `canonical` / `og:url`        | テーマ付きは `ssg.siteUrl`。bare は計算済み `canonicalUrl`。frontmatter `canonical` が上書き。 |
+| `og:site_name`                | bare で `siteName` があるとき。テーマ付きは、独自 meta を足さない限り出さない。                |
+| `robots`                      | frontmatter `robots` があるときだけ。                                                          |
+| `hreflang` alternate          | i18n の `locale_paths` から、絶対 URL を組み立てられるとき。                                   |
+
+`ssg.siteUrl` が無いテーマ付きページは従来どおりです。canonical も `og:url` も
+`hreflang` も出しません。サイトマップや JSON-LD 用に `siteUrl` を置いていると、
+これらのタグもオンになります。相対のロケール href を絶対にするにも `siteUrl` が要ります。
+
+```yaml
+---
+title: Guide
+description: How it works
+robots: noindex, nofollow
+canonical: https://example.com/guide/
+---
+```
+
+```ts
+oxContent({
+  ssg: {
+    siteName: "Docs",
+    siteUrl: "https://example.com",
+    headValidation: "warn",
+  },
+  i18n: {
+    locales: [
+      { code: "en", name: "English" },
+      { code: "ja", name: "日本語" },
+    ],
+  },
+});
+```
+
+## 検証
+
+`ssg.headValidation`:
+
+| 値             | 効果                                              |
+| -------------- | ------------------------------------------------- |
+| 省略 / `false` | 不正値は黙って落とす。既定。                      |
+| `warn`         | 正しいタグは残し、指摘をログする。                |
+| `strict`       | 危険な URL や不正な `hreflang` でビルドを落とす。 |
+
+不正な独自デスクリプタはどのモードでも落とします。`strict` は CI 向けです。
+
+独自ホストは `renderHead({ validation: "strict", ... })` の `diagnostics` で
+同じ指摘を受け取れます。
+
+## JSON-LD の型
+
+`ssg.jsonLd.type` は `TechArticle`（既定）、`BlogPosting`、`WebPage` です。
+`ssg.jsonLd.graph` は追加の `@graph` ノードです。未知の型は `TechArticle` に戻します。
+[JSON-LD](./json-ld.md) を見てください。
+
+## 関連
+
+- [ページ head](./page-head.md)
+- [JSON-LD](./json-ld.md)
+- [ロケールスイッチャー](./locale-switcher.md)
+- [サイト生成](./site-generation.md)
+- 追跡: [#820](https://github.com/ubugeeei-prod/ox-content/issues/820)

--- a/docs/content/ja/built-in/site-generation.md
+++ b/docs/content/ja/built-in/site-generation.md
@@ -62,7 +62,8 @@ export default defineConfig({
 | `bodyStart`       | —              | `<body>` の直後に足す生マークアップ（bare モード）。                                                     |
 | `bodyEnd`         | —              | `</body>` の直前に足す生マークアップ（bare モード）。                                                    |
 | `siteName`        | —              | `<title>` の接尾辞と OG サイト名。                                                                       |
-| `siteUrl`         | —              | 絶対 OG URL に使うオリジン。                                                                             |
+| `siteUrl`         | —              | 絶対 OG URL、canonical、hreflang に使うオリジン。[SEO](./seo.md)。                                       |
+| `headValidation`  | `false`        | 不正な head デスクリプタの `warn` / `strict`。[SEO](./seo.md)。                                          |
 | `ogImage`         | —              | 静的フォールバックの OG 画像 URL。                                                                       |
 | `generateOgImage` | `false`        | ページごとの OG 画像（後述）。                                                                           |
 | `lastUpdated`     | `false`        | ページごとの git 最終コミット時刻を出す。                                                                |

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -152,6 +152,8 @@ export default defineConfig(({ mode }) => {
                       { text: "Quality Checks", link: "/built-in/quality-checks.md" },
                       { text: "Typed Hover", link: "/built-in/typed-hover.md" },
                       { text: "Site Generation", link: "/built-in/site-generation.md" },
+                      { text: "Page head", link: "/built-in/page-head.md" },
+                      { text: "SEO", link: "/built-in/seo.md" },
                       { text: "Previous / Next", link: "/built-in/pagination.md" },
                       { text: "Breadcrumbs", link: "/built-in/breadcrumbs.md" },
                       { text: "Reader Chrome", link: "/built-in/reader-chrome.md" },

--- a/npm/vite-plugin-ox-content-svelte/src/index.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/index.ts
@@ -358,4 +358,5 @@ function toPascalCase(str: string): string {
   return str.replace(/[-_](\w)/g, (_, c) => c.toUpperCase()).replace(/^\w/, (c) => c.toUpperCase());
 }
 
-export { oxContent } from "@ox-content/vite-plugin";
+export { oxContent, renderHead } from "@ox-content/vite-plugin";
+export type { HeadInput, RenderedHead } from "@ox-content/vite-plugin";

--- a/npm/vite-plugin-ox-content/src/__snapshots__/ssg.test.ts.snap
+++ b/npm/vite-plugin-ox-content/src/__snapshots__/ssg.test.ts.snap
@@ -6,7 +6,7 @@ exports[`SSG route helpers > generates bare HTML through the NAPI-backed wrapper
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bare &#60;Page&#62;</title>
+  <title>Bare &lt;Page&gt;</title>
 </head>
 <body>
 <main>Body</main>

--- a/npm/vite-plugin-ox-content/src/dev-server.ts
+++ b/npm/vite-plugin-ox-content/src/dev-server.ts
@@ -419,6 +419,7 @@ async function renderPage(
     undefined,
     options.ssg.jsonLd,
     options.ssg.siteUrl,
+    options.ssg.headValidation,
   );
 
   // Inject Vite HMR client for live reload

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -1095,6 +1095,18 @@ export type {
   MarkdownLintFileOptions as MarkdownLintProjectOptions,
 } from "./lint-files";
 export { buildSsg, resolveSsgOptions, DEFAULT_HTML_TEMPLATE } from "./ssg";
+export { renderHead, resolveHeadValidation } from "./page-head";
+export type {
+  HeadAlternate,
+  HeadDiagnostic,
+  HeadInput,
+  HeadJsonLd,
+  HeadLink,
+  HeadMeta,
+  HeadValidationMode,
+  RenderedHead,
+  SiteHead,
+} from "./page-head";
 export { resolveNotFoundOptions } from "./not-found";
 export { resolveSiteMapsOptions } from "./site-maps";
 export {

--- a/npm/vite-plugin-ox-content/src/page-head.test.ts
+++ b/npm/vite-plugin-ox-content/src/page-head.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { reportHeadDiagnostics, resolveHeadValidation } from "./page-head";
+
+describe("resolveHeadValidation", () => {
+  it("stays off unless warn or strict is set", () => {
+    expect(resolveHeadValidation(undefined)).toBe(false);
+    expect(resolveHeadValidation(false)).toBe(false);
+    expect(resolveHeadValidation("off")).toBe(false);
+    expect(resolveHeadValidation("warn")).toBe("warn");
+    expect(resolveHeadValidation("strict")).toBe("strict");
+  });
+});
+
+describe("reportHeadDiagnostics", () => {
+  it("throws the first strict finding in strict mode", () => {
+    expect(() =>
+      reportHeadDiagnostics(
+        [
+          { strict: false, message: "empty" },
+          { strict: true, message: "canonical is not a safe http(s) URL" },
+        ],
+        "strict",
+      ),
+    ).toThrow("canonical is not a safe http(s) URL");
+  });
+
+  it("warns in warn mode", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    reportHeadDiagnostics([{ strict: true, message: "bad href" }], "warn");
+    expect(warn).toHaveBeenCalledWith("[ox-content] bad href");
+    warn.mockRestore();
+  });
+});

--- a/npm/vite-plugin-ox-content/src/page-head.ts
+++ b/npm/vite-plugin-ox-content/src/page-head.ts
@@ -1,0 +1,107 @@
+import { importNapiModuleSync } from "./napi";
+
+/** How invalid head descriptors are reported. */
+export type HeadValidationMode = false | "off" | "warn" | "strict";
+
+export interface SiteHead {
+  name?: string;
+  url?: string;
+  locale?: string;
+  titleTemplate?: string;
+}
+
+export interface HeadMeta {
+  key?: string;
+  name?: string;
+  property?: string;
+  httpEquiv?: string;
+  content: string;
+}
+
+export interface HeadLink {
+  key?: string;
+  rel: string;
+  href: string;
+  hreflang?: string;
+  type?: string;
+  sizes?: string;
+}
+
+export interface HeadAlternate {
+  lang: string;
+  href: string;
+}
+
+export interface HeadJsonLd {
+  key?: string;
+  json: string;
+}
+
+/**
+ * Build-time page-head input. Unhead-shaped, no client runtime.
+ *
+ * Unknown keys such as `twitter.imggg` are a TypeScript error here. Use
+ * `metas` / `links` for extra tags.
+ */
+export interface HeadInput {
+  site?: SiteHead;
+  title?: string;
+  titleTemplate?: string;
+  titleSuffix?: boolean;
+  description?: string;
+  canonical?: string;
+  robots?: string;
+  ogImage?: string;
+  ogType?: string;
+  twitterCard?: "summary" | "summary_large_image" | (string & {});
+  social?: boolean;
+  emitSiteName?: boolean;
+  trusted?: boolean;
+  metas?: HeadMeta[];
+  links?: HeadLink[];
+  alternates?: HeadAlternate[];
+  jsonLd?: HeadJsonLd[];
+  validation?: "off" | "warn" | "strict";
+}
+
+export interface HeadDiagnostic {
+  strict: boolean;
+  message: string;
+}
+
+export interface RenderedHead {
+  html: string;
+  diagnostics: HeadDiagnostic[];
+}
+
+/** Resolve descriptors to escaped `<head>` markup. Build-time only. */
+export function renderHead(input: HeadInput): RenderedHead {
+  return importNapiModuleSync().renderHead(JSON.stringify(input));
+}
+
+export function resolveHeadValidation(
+  value: HeadValidationMode | undefined,
+): false | "warn" | "strict" {
+  if (value === "warn" || value === "strict") {
+    return value;
+  }
+  return false;
+}
+
+export function reportHeadDiagnostics(
+  diagnostics: HeadDiagnostic[],
+  validation: false | "warn" | "strict",
+): void {
+  if (!validation || diagnostics.length === 0) {
+    return;
+  }
+  const fatal = diagnostics.filter((item) => item.strict);
+  if (validation === "strict" && fatal.length > 0) {
+    throw new Error(`[ox-content] ${fatal[0].message}`);
+  }
+  if (validation === "warn") {
+    for (const item of diagnostics) {
+      console.warn(`[ox-content] ${item.message}`);
+    }
+  }
+}

--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -95,6 +95,24 @@ describe("resolveSsgOptions", () => {
     });
   });
 
+  it("disables headValidation when omitted", () => {
+    expect(resolveSsgOptions(undefined).headValidation).toBe(false);
+    expect(resolveSsgOptions({ headValidation: "warn" }).headValidation).toBe("warn");
+    expect(resolveSsgOptions({ headValidation: "strict" }).headValidation).toBe("strict");
+  });
+
+  it("carries jsonLd type and graph through", () => {
+    expect(
+      resolveSsgOptions({
+        jsonLd: { type: "BlogPosting", graph: [{ "@type": "Person", name: "Ada" }] },
+      }).jsonLd,
+    ).toEqual({
+      breadcrumbs: true,
+      type: "BlogPosting",
+      graph: [{ "@type": "Person", name: "Ada" }],
+    });
+  });
+
   it("carries a configured jsonLd publisher through", () => {
     expect(
       resolveSsgOptions({

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -45,6 +45,7 @@ import {
   resolvePageChromeOption,
   type PageChromeFlags,
 } from "./header-chrome";
+import { reportHeadDiagnostics, resolveHeadValidation } from "./page-head";
 import { resolveTheme, themeToNapi } from "./theme";
 import type { ResolvedThemeConfig, SidebarItem } from "./theme";
 import { normalizeVitePressFrontmatter } from "./vitepress";
@@ -181,6 +182,7 @@ export function resolveSsgOptions(ssg: SsgOptions | boolean | undefined): Resolv
       pagination: false,
       breadcrumbs: false,
       jsonLd: false,
+      headValidation: false,
       readerChrome: false,
       localeSwitcher: false,
       a11y: false,
@@ -204,6 +206,7 @@ export function resolveSsgOptions(ssg: SsgOptions | boolean | undefined): Resolv
       pagination: false,
       breadcrumbs: false,
       jsonLd: false,
+      headValidation: false,
       readerChrome: false,
       localeSwitcher: false,
       a11y: false,
@@ -234,6 +237,7 @@ export function resolveSsgOptions(ssg: SsgOptions | boolean | undefined): Resolv
     pagination: resolvePaginationOption(ssg.pagination),
     breadcrumbs: resolvePaginationOption(ssg.breadcrumbs),
     jsonLd: resolveJsonLdOption(ssg.jsonLd),
+    headValidation: resolveHeadValidation(ssg.headValidation),
     readerChrome: resolveReaderChromeOption(ssg.readerChrome),
     localeSwitcher: resolveLocaleSwitcherOption(ssg.localeSwitcher),
     a11y: resolveA11yOption(ssg.a11y),
@@ -277,6 +281,8 @@ function resolveJsonLdOption(value: boolean | JsonLdOptions | undefined): Resolv
     return {
       breadcrumbs: value.breadcrumbs !== false,
       ...(publisher ? { publisher } : {}),
+      ...(value.type ? { type: value.type } : {}),
+      ...(value.graph ? { graph: value.graph } : {}),
     };
   }
   return false;
@@ -526,6 +532,7 @@ export async function generateHtmlPage(
   breadcrumbRootHref?: string,
   jsonLd: ResolvedJsonLd = false,
   siteUrl?: string,
+  headValidation: false | "warn" | "strict" = false,
 ): Promise<string> {
   const mod = await importNapiModule();
 
@@ -579,7 +586,7 @@ export async function generateHtmlPage(
       }
     : undefined;
 
-  return mod.generateSsgHtml(
+  const result = mod.generateSsgHtml(
     {
       title: pageData.title,
       description: pageData.description,
@@ -595,6 +602,12 @@ export async function generateHtmlPage(
       layout:
         typeof pageData.frontmatter.layout === "string" ? pageData.frontmatter.layout : undefined,
       chrome: pageData.chrome,
+      robots:
+        typeof pageData.frontmatter.robots === "string" ? pageData.frontmatter.robots : undefined,
+      canonical:
+        typeof pageData.frontmatter.canonical === "string"
+          ? pageData.frontmatter.canonical
+          : undefined,
     },
     navGroupsForRust,
     {
@@ -602,6 +615,8 @@ export async function generateHtmlPage(
       base,
       breadcrumbRootHref,
       ogImage,
+      siteUrl,
+      headValidation: headValidation || undefined,
       theme: themeForRust,
       locale,
       availableLocales: availableLocales ? toRustLocales(availableLocales) : undefined,
@@ -624,10 +639,16 @@ export async function generateHtmlPage(
             breadcrumbs: jsonLd.breadcrumbs,
             publisher: jsonLd.publisher,
             siteUrl,
+            pageType: jsonLd.type,
+            graph: jsonLd.graph?.map((node) => JSON.stringify(node)),
           }
         : undefined,
     },
   );
+  const html = typeof result === "string" ? result : result.html;
+  const diagnostics = typeof result === "string" ? [] : (result.diagnostics ?? []);
+  reportHeadDiagnostics(diagnostics, headValidation);
+  return html;
 }
 
 interface GeneratedHtmlPage {
@@ -1484,6 +1505,7 @@ async function renderSsgPage(
     versionNavigation?.root.href,
     context.ssgOptions.jsonLd,
     context.ssgOptions.siteUrl,
+    context.ssgOptions.headValidation,
   );
 }
 

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -337,6 +337,16 @@ export interface SsgOptions {
   jsonLd?: boolean | JsonLdOptions;
 
   /**
+   * Validate custom page-head descriptors during SSG.
+   *
+   * `false` / omitted drops invalid values silently. `warn` logs them.
+   * `strict` fails the build on unsafe URLs or invalid hreflang.
+   *
+   * @default false
+   */
+  headValidation?: false | "warn" | "strict";
+
+  /**
    * Opt-in copy buttons, outbound-link icons, and a back-to-top control.
    *
    * Disabled when omitted or `false`. `true` enables all three with defaults.
@@ -552,7 +562,21 @@ export interface JsonLdOptions {
    * Logo and other Organization fields are never invented.
    */
   publisher?: JsonLdPublisherOptions;
+
+  /**
+   * Page `@type`. Defaults to `TechArticle`.
+   */
+  type?: JsonLdPageType;
+
+  /**
+   * Extra `@graph` nodes. Only objects are kept. The build does not invent
+   * fields inside them.
+   */
+  graph?: Record<string, unknown>[];
 }
+
+/** JSON-LD page node `@type`. Unknown values fall back to `TechArticle`. */
+export type JsonLdPageType = "TechArticle" | "BlogPosting" | "WebPage";
 
 /**
  * Optional JSON-LD publisher. Empty or omitted fields are left out.
@@ -575,6 +599,8 @@ export type ResolvedJsonLd =
         name?: string;
         url?: string;
       };
+      type?: JsonLdPageType;
+      graph?: Record<string, unknown>[];
     };
 
 /**
@@ -601,6 +627,10 @@ export interface ResolvedSsgOptions {
   pagination: boolean;
   breadcrumbs: boolean;
   jsonLd: ResolvedJsonLd;
+  /**
+   * Present after `resolveSsgOptions`. Omitted / `false` means off.
+   */
+  headValidation?: false | "warn" | "strict";
   readerChrome: ResolvedReaderChrome;
   localeSwitcher: boolean;
   a11y: ResolvedA11y;


### PR DESCRIPTION
## Summary
- Shared build-time `renderHead` for themed, bare, `ssg.render`, and `ssg: false` hosts. Unhead-shaped input, no client runtime, no Unhead dependency.
- Built-in SEO on that resolver: canonical / `og:url` when `ssg.siteUrl` is set, frontmatter `robots` / `canonical`, hreflang from locale paths, `ssg.headValidation`, and JSON-LD `type` / `graph`.
- Invalid `javascript:` / `data:` / `vbscript:` / `//` URLs are dropped. Existing themed output without `siteUrl` stays the same.

Closes #819
Closes #820

## Test plan
- [x] `cargo test -p ox_content_ssg --lib`
- [x] `vp test src/page-head.test.ts src/ssg.test.ts`
- [ ] Default theme page: title / description / OG tags, no unexpected canonical
- [ ] `ssg.siteUrl` + i18n: canonical, `og:url`, hreflang
- [ ] Frontmatter `robots` / `canonical`
- [ ] `ssg.headValidation: "strict"` fails on unsafe custom URLs
- [ ] Custom `ssg.render` / `ssg: false` can call `renderHead` and get escaped HTML


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790249359&installation_model_id=422833&pr_number=821&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F821&signature=3c83e0c72aee0cba8f20d10e5a913f2bba41665ee11f6ea7a4f863e4ef433afe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added build-time page-head rendering for titles, metadata, links, social tags, and JSON-LD.
  * Added SEO support for canonical URLs, robots directives, site URLs, and alternate language links.
  * Added configurable head validation with silent, warning, and strict modes.
  * Added JSON-LD page types and custom graph support.
  * Rendering now returns HTML with optional validation diagnostics.

* **Documentation**
  * Added Page Head and SEO guides, including Japanese translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->