### PR TITLE
fix: hide SIMD nibble tables on non-vector targets

### DIFF
--- a/crates/ox_content_parser/src/parser/inline/scan.rs
+++ b/crates/ox_content_parser/src/parser/inline/scan.rs
@@ -56,8 +56,10 @@ const SHORT_RUN_PREFIX: usize = 8;
 /// A 16-entry table is what a vector shuffle can hold, which is the whole
 /// point: `vqtbl1q_u8` / `pshufb` look up all sixteen lanes in one
 /// instruction, where the flag table needs sixteen loads.
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 const LOW_NIBBLE: [u8; 16] =
     [0x10, 0x02, 0, 0, 0, 0, 0x02, 0, 0, 0, 0x03, 0x08, 0x0C, 0, 0x20, 0x08];
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 const HIGH_NIBBLE: [u8; 16] = [0x01, 0, 0x02, 0x04, 0, 0x08, 0x10, 0x20, 0, 0, 0, 0, 0, 0, 0, 0];
 
 /// Walks at most [`SHORT_RUN_PREFIX`] bytes. Returns the first marker, or

--- a/crates/ox_content_renderer/src/html/escape/nibble.rs
+++ b/crates/ox_content_renderer/src/html/escape/nibble.rs
@@ -152,7 +152,7 @@ pub(super) fn first_flagged_simd(
     }
     #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
     {
-        let _ = (bytes, from, tables);
+        let _ = (bytes, from, &tables.low, &tables.high);
         None
     }
 }


### PR DESCRIPTION
## Summary
- `LOW_NIBBLE` / `HIGH_NIBBLE` and `NibbleTables` fields are only read by the aarch64 / x86-64 vector paths.
- wasm (and other hosts) no longer warn that those tables are unused.

## Test plan
- [x] `cargo check -p ox_content_parser -p ox_content_renderer --target wasm32-unknown-unknown` (no `dead_code` warnings)
- [x] native `cargo check --tests` for the same crates


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790251339&installation_model_id=422833&pr_number=830&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F830&signature=50cef7e5cfa553065e38bb5e62582b4121ecde1271b750a9aeee09c35acbe133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->