### PR TITLE
feat(twitter): render quoted posts and reply metadata

### DIFF
--- a/crates/ox_content_ssg/src/plugins/social.css
+++ b/crates/ox_content_ssg/src/plugins/social.css
@@ -134,6 +134,51 @@
   white-space: nowrap;
 }
 
+.ox-tweet__reply {
+  margin: 0 0 0.5rem;
+  font-size: 0.8125rem;
+}
+
+.ox-tweet__reply-link {
+  color: var(--octc-color-text-muted);
+  text-decoration: none;
+}
+
+.ox-tweet__reply-link:hover {
+  text-decoration: underline;
+}
+
+.ox-tweet__quote {
+  margin: 0 0 0.625rem;
+  padding: 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--octc-color-border) 74%, transparent);
+  border-radius: 8px;
+}
+
+.ox-tweet__quote-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.ox-tweet__quote .ox-tweet__avatar {
+  width: 28px;
+  height: 28px;
+}
+
+.ox-tweet__quote-body {
+  margin: 0 0 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--octc-color-text);
+  white-space: pre-wrap;
+}
+
+.ox-tweet__quote .ox-tweet__media {
+  margin-bottom: 0;
+}
+
 /* WebContainer lazy placeholder */
 .ox-webcontainer {
   margin: 1.5rem 0;

--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -192,7 +192,9 @@ card:
 <XPost url="https://x.com/jack/status/20" />
 
 Use the object form to fetch the post body, author, avatar, and photos at
-build time and serve them from your own origin:
+build time and serve them from your own origin. Fetched cards include a
+nested quoted-post card and a “Replying to @…” link when the syndication
+response has that metadata:
 
 ```ts
 oxContent({
@@ -219,7 +221,8 @@ oxContent({
 
 Downloaded media is served from your site, so a strict `img-src 'self'` CSP
 keeps working. Deleted or private posts fall back to the link-only card
-instead of failing the build. See
+instead of failing the build. A missing quoted post is omitted without
+discarding the root card. See
 [Twitter/X Embed](../examples/twitter-embed.md) for details.
 
 ## Bluesky

--- a/docs/content/examples/twitter-embed.md
+++ b/docs/content/examples/twitter-embed.md
@@ -7,7 +7,9 @@ description: Render X posts as privacy-conscious static cards.
 
 Twitter/X embeds are opt-in and never load a third-party widget script.
 `twitter: true` renders the privacy-conscious link card. Use the object form to
-fetch the post body, author, avatar, and photos at build time:
+fetch the post body, author, avatar, and photos at build time. Fetched cards
+also render a nested quoted-post card and a “Replying to @…” link when that
+metadata is present:
 
 ```ts
 import { oxContent } from "@ox-content/vite-plugin";
@@ -33,10 +35,11 @@ export default {
 ```
 
 Fetched metadata is cached in memory and under `.cache/ox-content/twitter` by
-default. Avatars and photos are copied into the configured output directory, so
-the generated page can use a strict `img-src 'self'` policy. If the post is
-deleted, private, or unavailable during a build, Ox Content falls back to the
-link-only card instead of failing the build.
+default. Avatars and photos — including those on a quoted post — are copied
+into the configured output directory, so the generated page can use a strict
+`img-src 'self'` policy. If the post is deleted, private, or unavailable
+during a build, Ox Content falls back to the link-only card instead of failing
+the build. A missing quoted post is omitted without discarding the root card.
 
 | Option            | Default                     | Purpose                                      |
 | ----------------- | --------------------------- | -------------------------------------------- |

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -161,7 +161,7 @@ YouTube 埋め込みは SSG ビルドと dev preview で常に処理されます
 
 <XPost url="https://x.com/jack/status/20" />
 
-オブジェクト形式を使うと、ビルド時に本文、著者、アバター、写真を取り、自分のオリジンから配信します。
+オブジェクト形式を使うと、ビルド時に本文、著者、アバター、写真を取り、自分のオリジンから配信します。取ってきたカードには、syndication にそのメタデータがあるとき、引用投稿の入れ子カードと「Replying to @…」リンクも含まれます。
 
 ```ts
 oxContent({
@@ -186,7 +186,7 @@ oxContent({
 | `mediaOutputDir`  | `public/ox-content/twitter` | アバターと写真のローカルディレクトリ。              |
 | `mediaPublicPath` | `/ox-content/twitter`       | ダウンロードしたメディアに出す URL プレフィックス。 |
 
-ダウンロードしたメディアは自分のサイトから出すので、厳しい `img-src 'self'` CSP も動き続けます。削除済みや非公開の投稿は、ビルドを落とさずリンクのみのカードに落ちます。詳細は [Twitter/X Embed](/examples/twitter-embed.md) を見てください。
+ダウンロードしたメディアは自分のサイトから出すので、厳しい `img-src 'self'` CSP も動き続けます。削除済みや非公開の投稿は、ビルドを落とさずリンクのみのカードに落ちます。引用投稿が欠けていても、元の投稿カードは残します。詳細は [Twitter/X Embed](/examples/twitter-embed.md) を見てください。
 
 ## Bluesky
 

--- a/npm/vite-plugin-ox-content/src/plugins/twitter.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter.test.ts
@@ -131,4 +131,187 @@ describe("fetched Twitter embeds", () => {
     const input = '<Tweet id="987654">fallback summary</Tweet>';
     await expect(transformFetchedTweets(input, { fetch: true, cache: false })).resolves.toBe(input);
   });
+
+  it("renders a plain quoted post and omits the trailing quote URL", async () => {
+    const quoteLink = "https://t.co/quote";
+    const text = `See this ${quoteLink}`;
+    const html = await renderFetched({
+      text,
+      display_text_range: [0, text.length],
+      entities: {
+        urls: [
+          {
+            url: quoteLink,
+            expanded_url: "https://x.com/other/status/99",
+            display_url: "x.com/other/status/99",
+            indices: [text.indexOf(quoteLink), text.indexOf(quoteLink) + quoteLink.length],
+          },
+        ],
+      },
+      user: tweetUser(),
+      quoted_tweet: { id_str: "99", text: "Quoted body", user: tweetUser("Other User", "other") },
+    });
+    expect(html).toContain('class="ox-tweet__quote"');
+    expect(html).toContain("See this");
+    expect(html).toContain("Quoted body");
+    expect(html).toContain("Other User");
+    expect(html).toContain(">@other<");
+    expect(html).toContain('href="https://x.com/other/status/99"');
+    expect(html).not.toContain("https://t.co/quote");
+    expect(html).not.toContain(">x.com/other/status/99<");
+  });
+
+  it("materializes quoted avatars and photos with a distinct basename", async () => {
+    const html = await renderFetched({
+      text: "Quote with photos",
+      user: tweetUser(),
+      quoted_tweet: {
+        id_str: "99",
+        text: "Photo quote",
+        user: {
+          name: "Other",
+          screen_name: "other",
+          profile_image_url_https: "https://pbs.twimg.com/profile_images/q_normal.jpg",
+        },
+        mediaDetails: [
+          {
+            type: "photo",
+            media_url_https: "https://pbs.twimg.com/media/quoted.jpg",
+            ext_alt_text: "Quoted chart",
+            original_info: { width: 800, height: 400 },
+          },
+        ],
+      },
+    });
+    expect(html).toContain("Photo quote");
+    expect(html).toContain('src="/tweets/555-quoted-avatar.jpg"');
+    expect(html).toContain('src="/tweets/555-quoted-media-1.jpg"');
+    expect(html).toContain('alt="Quoted chart"');
+  });
+
+  it("renders reply metadata and ignores unsafe handles", async () => {
+    const html = await renderFetched({
+      text: "Thanks",
+      user: tweetUser(),
+      in_reply_to_screen_name: "alice",
+      in_reply_to_status_id_str: "42",
+    });
+    expect(html).toContain("Replying to @alice");
+    expect(html).toContain('href="https://x.com/alice/status/42"');
+
+    const unsafe = await renderFetched({
+      text: "Thanks",
+      user: tweetUser(),
+      in_reply_to_screen_name: '"><script>',
+      in_reply_to_status_id_str: "42",
+    });
+    expect(unsafe).toContain("Thanks");
+    expect(unsafe).not.toContain("Replying to");
+    expect(unsafe).not.toContain("<script>");
+  });
+
+  it("keeps the root post when the quoted post is missing or deleted", async () => {
+    const html = await renderFetched({
+      text: "Root still here",
+      user: tweetUser(),
+      quoted_tweet: { text: "This Post was deleted." },
+    });
+    expect(html).toContain('class="ox-tweet ox-tweet--fetched"');
+    expect(html).toContain("Root still here");
+    expect(html).not.toContain("ox-tweet__quote");
+    expect(html).not.toContain("was deleted");
+  });
+
+  it("drops malformed quotes and ignores nested quoted_tweet", async () => {
+    const malformed = await renderFetched({
+      text: "Root body",
+      user: tweetUser(),
+      quoted_tweet: { text: 1, user: { name: "x", screen_name: "x" } },
+    });
+    expect(malformed).toContain("Root body");
+    expect(malformed).not.toContain("ox-tweet__quote");
+
+    const nested = await renderFetched({
+      text: "Root body",
+      user: tweetUser(),
+      quoted_tweet: {
+        id_str: "99",
+        text: "Level one",
+        user: tweetUser("One", "one"),
+        quoted_tweet: {
+          id_str: "88",
+          text: "Level two should hide",
+          user: tweetUser("Two", "two"),
+        },
+      },
+    });
+    expect(nested).toContain("Level one");
+    expect(nested).not.toContain("Level two should hide");
+    expect(nested.match(/class="ox-tweet__quote"/g)).toHaveLength(1);
+  });
+
+  it("escapes entities and uses UTF-16 display_text_range indices", async () => {
+    const quoteLink = "https://t.co/quote";
+    const docs = "https://example.com/docs";
+    const text = `👍See ${docs} <this> ${quoteLink}`;
+    const html = await renderFetched({
+      text,
+      display_text_range: [2, text.length],
+      entities: {
+        urls: [
+          {
+            url: docs,
+            expanded_url: docs,
+            display_url: "example.com/docs",
+            indices: [text.indexOf(docs), text.indexOf(docs) + docs.length],
+          },
+          {
+            url: quoteLink,
+            expanded_url: "https://x.com/other/status/99",
+            display_url: "x.com/other/status/99",
+            indices: [text.indexOf(quoteLink), text.indexOf(quoteLink) + quoteLink.length],
+          },
+        ],
+      },
+      user: tweetUser("Ox <Content>"),
+      quoted_tweet: {
+        id_str: "99",
+        text: 'alert("xss")',
+        user: tweetUser("Evil <img>", "other"),
+      },
+    });
+    expect(html).toContain("See ");
+    expect(html).toContain('href="https://example.com/docs"');
+    expect(html).toContain("&lt;this&gt;");
+    expect(html).toContain("Ox &lt;Content&gt;");
+    expect(html).toContain("Evil &lt;img&gt;");
+    expect(html).toContain("alert(&quot;xss&quot;)");
+    expect(html).not.toContain("👍");
+    expect(html).not.toContain("https://t.co/quote");
+  });
 });
+
+function tweetUser(name = "Ox Content", screenName = "ox_content") {
+  return { name, screen_name: screenName };
+}
+
+async function renderFetched(data: unknown, id = "555"): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "ox-tweet-q-"));
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.startsWith("https://cdn.syndication.twimg.com/")) {
+      return { ok: true, json: async () => data } as Response;
+    }
+    return { ok: true, arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer } as Response;
+  };
+  try {
+    return await transformFetchedTweets(`<XPost id="${id}" />`, {
+      fetch: true,
+      cache: false,
+      mediaOutputDir: path.join(root, "media"),
+      mediaPublicPath: "/tweets",
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/fetch.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/fetch.ts
@@ -1,7 +1,8 @@
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import type { ResolvedTwitterEmbedOptions, TweetAssets, TweetBodyData, TweetData, TweetMedia } from "./types";
 import { createSyndicationToken } from "./url";
-import type { ResolvedTwitterEmbedOptions, TweetAssets, TweetData, TweetMedia } from "./types";
+import { parseTweetData } from "./validate";
 
 const tweetCache = new Map<string, TweetData>();
 
@@ -37,8 +38,8 @@ export async function fetchTweetData(
       signal: controller.signal,
     });
     if (!response.ok) return null;
-    const data: unknown = await response.json();
-    if (!isTweetData(data)) return null;
+    const data = parseTweetData(await response.json());
+    if (!data) return null;
     if (options.cache) {
       tweetCache.set(key, data);
       await writeCachedTweet(key, data, options.cacheDir);
@@ -54,6 +55,18 @@ export async function fetchTweetData(
 export async function materializeTweetAssets(
   id: string,
   data: TweetData,
+  options: ResolvedTwitterEmbedOptions,
+): Promise<TweetAssets> {
+  const assets = await materializeBodyAssets(id, data, options);
+  if (data.quoted_tweet) {
+    assets.quoted = await materializeBodyAssets(`${id}-quoted`, data.quoted_tweet, options);
+  }
+  return assets;
+}
+
+async function materializeBodyAssets(
+  id: string,
+  data: TweetBodyData,
   options: ResolvedTwitterEmbedOptions,
 ): Promise<TweetAssets> {
   const assets: TweetAssets = { media: [] };
@@ -110,8 +123,7 @@ async function downloadAsset(
 
 async function readCachedTweet(key: string, directory: string): Promise<TweetData | null> {
   try {
-    const data: unknown = JSON.parse(await readFile(path.join(directory, `${key}.json`), "utf8"));
-    return isTweetData(data) ? data : null;
+    return parseTweetData(JSON.parse(await readFile(path.join(directory, `${key}.json`), "utf8")));
   } catch {
     return null;
   }
@@ -124,17 +136,6 @@ async function writeCachedTweet(key: string, data: TweetData, directory: string)
   } catch {
     // A read-only cache directory must not fail the build.
   }
-}
-
-function isTweetData(data: unknown): data is TweetData {
-  if (!data || typeof data !== "object") return false;
-  const value = data as Partial<TweetData>;
-  return (
-    typeof value.text === "string" &&
-    Boolean(value.user) &&
-    typeof value.user?.name === "string" &&
-    typeof value.user.screen_name === "string"
-  );
 }
 
 function extensionFromUrl(url: URL): string {

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/fetch.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/fetch.ts
@@ -1,6 +1,12 @@
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import type { ResolvedTwitterEmbedOptions, TweetAssets, TweetBodyData, TweetData, TweetMedia } from "./types";
+import type {
+  ResolvedTwitterEmbedOptions,
+  TweetAssets,
+  TweetBodyData,
+  TweetData,
+  TweetMedia,
+} from "./types";
 import { createSyndicationToken } from "./url";
 import { parseTweetData } from "./validate";
 

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/html.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/html.ts
@@ -1,0 +1,16 @@
+export function escapeText(value: string): string {
+  return escapeHtml(value).replaceAll("\n", "<br>");
+}
+
+export function escapeAttribute(value: string): string {
+  return escapeHtml(value).replaceAll("`", "&#96;");
+}
+
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/index.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/index.ts
@@ -4,6 +4,7 @@ export { resolveTwitterEmbedOptions, transformFetchedTweets } from "./transform"
 export { createSyndicationToken, parseTweetReference } from "./url";
 export type {
   ResolvedTwitterEmbedOptions,
+  TweetBodyData,
   TweetData,
   TweetEntity,
   TweetMedia,

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/render.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/render.ts
@@ -1,4 +1,9 @@
-import type { ResolvedTwitterEmbedOptions, TweetAssets, TweetData, TweetEntity } from "./types";
+import { escapeAttribute, escapeHtml } from "./html";
+import { renderTweetText } from "./text";
+import type { ResolvedTwitterEmbedOptions, TweetAssets, TweetBodyData, TweetData } from "./types";
+import { quotedPermalink, replyPermalink, sanitizeScreenName } from "./validate";
+
+export { renderTweetText } from "./text";
 
 export function renderFetchedTweet(
   permalink: string,
@@ -6,66 +11,57 @@ export function renderFetchedTweet(
   assets: TweetAssets,
   options: ResolvedTwitterEmbedOptions,
 ): string {
-  const profile = `https://x.com/${encodeURIComponent(data.user.screen_name)}`;
-  const author = escapeHtml(data.user.name);
-  const handle = escapeHtml(data.user.screen_name);
-  const avatar = assets.avatar
-    ? `<img class="ox-tweet__avatar" src="${escapeAttribute(assets.avatar)}" alt="" width="48" height="48" loading="lazy" decoding="async">`
-    : "";
-  const media = renderMedia(assets);
-  const footer = renderFooter(permalink, data.created_at, options.lang);
-
+  const quote = data.quoted_tweet ? renderQuotedTweet(data.quoted_tweet, assets.quoted) : "";
   return [
     '<figure class="ox-tweet ox-tweet--fetched">',
-    '<header class="ox-tweet__header">',
-    `<a class="ox-tweet__profile" href="${escapeAttribute(profile)}" target="_blank" rel="noopener noreferrer">`,
-    avatar,
-    `<span class="ox-tweet__author-name">${author}</span>`,
-    `<span class="ox-tweet__author-handle">@${handle}</span>`,
-    "</a></header>",
-    `<div class="ox-tweet__body">${renderTweetText(data)}</div>`,
-    media,
-    footer,
+    renderHeader(data.user, assets.avatar),
+    renderReply(data),
+    `<div class="ox-tweet__body">${renderTweetText(data, { omitTrailingQuoteUrl: Boolean(quote) })}</div>`,
+    renderMedia(assets),
+    quote,
+    renderFooter(permalink, data.created_at, options.lang),
     "</figure>",
   ].join("");
 }
 
-export function renderTweetText(data: TweetData): string {
-  const [start, end] = data.display_text_range ?? [0, data.text.length];
-  const entities = collectEntities(data)
-    .filter((entity) => validRange(entity.indices, start, end))
-    .sort((left, right) => left.indices![0] - right.indices![0]);
-
-  let cursor = start;
-  let output = "";
-  for (const entity of entities) {
-    const [entityStart, entityEnd] = entity.indices!;
-    if (entityStart < cursor) continue;
-    output += escapeText(data.text.slice(cursor, entityStart));
-    if (entity.kind === "url") {
-      const href = entity.expanded_url ?? entity.url;
-      const label = entity.display_url ?? href;
-      output += `<a href="${escapeAttribute(href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a>`;
-    }
-    cursor = entityEnd;
-  }
-  output += escapeText(data.text.slice(cursor, end));
-  return output.trim();
-}
-
-function collectEntities(data: TweetData): Array<TweetEntity & { kind: "url" | "media" }> {
+function renderQuotedTweet(data: TweetBodyData, assets: TweetAssets | undefined): string {
+  const permalink = quotedPermalink(data);
+  const media = renderMedia(assets ?? { media: [] });
   return [
-    ...(data.entities?.urls ?? []).map((entity) => ({ ...entity, kind: "url" as const })),
-    ...(data.entities?.media ?? []).map((entity) => ({ ...entity, kind: "media" as const })),
-  ];
+    '<blockquote class="ox-tweet__quote">',
+    renderHeader(data.user, assets?.avatar, permalink, "ox-tweet__quote-header"),
+    `<div class="ox-tweet__quote-body">${renderTweetText(data)}</div>`,
+    media,
+    "</blockquote>",
+  ].join("");
 }
 
-function validRange(
-  indices: [number, number] | undefined,
-  start: number,
-  end: number,
-): indices is [number, number] {
-  return Boolean(indices && indices[0] >= start && indices[1] <= end && indices[0] < indices[1]);
+function renderHeader(
+  user: TweetBodyData["user"],
+  avatarSrc: string | undefined,
+  href?: string,
+  headerClass = "ox-tweet__header",
+): string {
+  const screen = sanitizeScreenName(user.screen_name) ?? user.screen_name;
+  const profile = href ?? `https://x.com/${encodeURIComponent(screen)}`;
+  const avatar = avatarSrc
+    ? `<img class="ox-tweet__avatar" src="${escapeAttribute(avatarSrc)}" alt="" width="48" height="48" loading="lazy" decoding="async">`
+    : "";
+  return [
+    `<header class="${headerClass}">`,
+    `<a class="ox-tweet__profile" href="${escapeAttribute(profile)}" target="_blank" rel="noopener noreferrer">`,
+    avatar,
+    `<span class="ox-tweet__author-name">${escapeHtml(user.name)}</span>`,
+    `<span class="ox-tweet__author-handle">@${escapeHtml(user.screen_name)}</span>`,
+    "</a></header>",
+  ].join("");
+}
+
+function renderReply(data: TweetData): string {
+  const href = replyPermalink(data);
+  const handle = data.in_reply_to_screen_name;
+  if (!href || !handle) return "";
+  return `<p class="ox-tweet__reply"><a class="ox-tweet__reply-link" href="${escapeAttribute(href)}" target="_blank" rel="noopener noreferrer">Replying to @${escapeHtml(handle)}</a></p>`;
 }
 
 function renderMedia(assets: TweetAssets): string {
@@ -96,21 +92,4 @@ function renderFooter(permalink: string, createdAt: string | undefined, lang: st
     label = new Intl.DateTimeFormat("en", { dateStyle: "medium", timeZone: "UTC" }).format(date);
   }
   return `<footer class="ox-tweet__footer"><a class="ox-tweet__permalink" href="${escapeAttribute(permalink)}" target="_blank" rel="noopener noreferrer"><time datetime="${iso}">${escapeHtml(label)}</time></a></footer>`;
-}
-
-function escapeText(value: string): string {
-  return escapeHtml(value).replaceAll("\n", "<br>");
-}
-
-function escapeAttribute(value: string): string {
-  return escapeHtml(value).replaceAll("`", "&#96;");
-}
-
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
 }

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/text.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/text.ts
@@ -1,0 +1,44 @@
+import { escapeAttribute, escapeHtml, escapeText } from "./html";
+import type { TweetBodyData, TweetEntity } from "./types";
+import { visibleTextRange } from "./validate";
+
+export function renderTweetText(
+  data: TweetBodyData,
+  options?: { omitTrailingQuoteUrl?: boolean },
+): string {
+  const [start, end] = visibleTextRange(data, options?.omitTrailingQuoteUrl === true);
+  const entities = collectEntities(data)
+    .filter((entity) => validRange(entity.indices, start, end))
+    .sort((left, right) => left.indices![0] - right.indices![0]);
+
+  let cursor = start;
+  let output = "";
+  for (const entity of entities) {
+    const [entityStart, entityEnd] = entity.indices!;
+    if (entityStart < cursor) continue;
+    output += escapeText(data.text.slice(cursor, entityStart));
+    if (entity.kind === "url") {
+      const href = entity.expanded_url ?? entity.url;
+      const label = entity.display_url ?? href;
+      output += `<a href="${escapeAttribute(href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a>`;
+    }
+    cursor = entityEnd;
+  }
+  output += escapeText(data.text.slice(cursor, end));
+  return output.trim();
+}
+
+function collectEntities(data: TweetBodyData): Array<TweetEntity & { kind: "url" | "media" }> {
+  return [
+    ...(data.entities?.urls ?? []).map((entity) => ({ ...entity, kind: "url" as const })),
+    ...(data.entities?.media ?? []).map((entity) => ({ ...entity, kind: "media" as const })),
+  ];
+}
+
+function validRange(
+  indices: [number, number] | undefined,
+  start: number,
+  end: number,
+): indices is [number, number] {
+  return Boolean(indices && indices[0] >= start && indices[1] <= end && indices[0] < indices[1]);
+}

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/types.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/types.ts
@@ -39,17 +39,27 @@ export interface TweetMedia extends TweetEntity {
   original_info?: { width?: number; height?: number };
 }
 
-export interface TweetData {
+export interface TweetUser {
+  name: string;
+  screen_name: string;
+  profile_image_url_https?: string;
+}
+
+/** Root or quoted post body. Nested `quoted_tweet` is stripped during normalize. */
+export interface TweetBodyData {
   text: string;
+  id_str?: string;
   display_text_range?: [number, number];
   entities?: { urls?: TweetEntity[]; media?: TweetMedia[] };
   mediaDetails?: TweetMedia[];
-  user: {
-    name: string;
-    screen_name: string;
-    profile_image_url_https?: string;
-  };
+  user: TweetUser;
   created_at?: string;
+}
+
+export interface TweetData extends TweetBodyData {
+  quoted_tweet?: TweetBodyData;
+  in_reply_to_screen_name?: string;
+  in_reply_to_status_id_str?: string;
 }
 
 export interface TweetReference {
@@ -60,4 +70,5 @@ export interface TweetReference {
 export interface TweetAssets {
   avatar?: string;
   media: Array<{ src: string; alt?: string; width?: number; height?: number }>;
+  quoted?: TweetAssets;
 }

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/validate.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/validate.ts
@@ -1,0 +1,102 @@
+import type { TweetBodyData, TweetData, TweetEntity, TweetUser } from "./types";
+
+const SCREEN_NAME = /^[A-Za-z0-9_]{1,15}$/;
+const STATUS_ID = /^\d+$/;
+const STATUS_PATH = /(?:x\.com|twitter\.com)\/(?:[^/]+|i\/web)\/status\/(\d+)/i;
+const TCO = /^https?:\/\/t\.co\/[A-Za-z0-9]+$/i;
+
+export function isTweetData(data: unknown): data is TweetData {
+  return isTweetBodyData(data);
+}
+
+export function parseTweetData(data: unknown): TweetData | null {
+  return isTweetData(data) ? normalizeTweetData(data) : null;
+}
+
+export function isTweetBodyData(data: unknown): data is TweetBodyData {
+  if (!data || typeof data !== "object") return false;
+  const value = data as Partial<TweetBodyData>;
+  return typeof value.text === "string" && isTweetUser(value.user);
+}
+
+function isTweetUser(value: unknown): value is TweetUser {
+  if (!value || typeof value !== "object") return false;
+  const user = value as Partial<TweetUser>;
+  return typeof user.name === "string" && typeof user.screen_name === "string";
+}
+
+export function normalizeTweetData(data: TweetData): TweetData {
+  const handle = sanitizeScreenName(data.in_reply_to_screen_name);
+  return {
+    ...data,
+    quoted_tweet: isTweetBodyData(data.quoted_tweet) ? stripNestedQuote(data.quoted_tweet) : undefined,
+    in_reply_to_screen_name: handle,
+    in_reply_to_status_id_str: handle ? sanitizeStatusId(data.in_reply_to_status_id_str) : undefined,
+  };
+}
+
+function stripNestedQuote(data: TweetBodyData): TweetBodyData {
+  const { quoted_tweet: _nested, ...quoted } = data as TweetBodyData & { quoted_tweet?: unknown };
+  return quoted;
+}
+
+export function sanitizeScreenName(value: string | undefined): string | undefined {
+  return value && SCREEN_NAME.test(value) ? value : undefined;
+}
+
+export function sanitizeStatusId(value: string | undefined): string | undefined {
+  return value && STATUS_ID.test(value) ? value : undefined;
+}
+
+export function quotedPermalink(quoted: TweetBodyData): string | undefined {
+  const id = sanitizeStatusId(quoted.id_str);
+  if (!id) return undefined;
+  const screen = sanitizeScreenName(quoted.user.screen_name);
+  return `https://x.com/${screen ?? "i/web"}/status/${id}`;
+}
+
+export function replyPermalink(data: TweetData): string | undefined {
+  const handle = sanitizeScreenName(data.in_reply_to_screen_name);
+  if (!handle) return undefined;
+  const id = sanitizeStatusId(data.in_reply_to_status_id_str);
+  return id ? `https://x.com/${handle}/status/${id}` : `https://x.com/${handle}`;
+}
+
+export function visibleTextRange(data: TweetBodyData, omitTrailingQuoteUrl = false): [number, number] {
+  const start = Math.max(0, data.display_text_range?.[0] ?? 0);
+  let end = Math.min(data.text.length, data.display_text_range?.[1] ?? data.text.length);
+  if (!omitTrailingQuoteUrl || start >= end) return [start, end];
+
+  const quoted = "quoted_tweet" in data ? (data as TweetData).quoted_tweet : undefined;
+  for (const entity of data.entities?.urls ?? []) {
+    const indices = entity.indices;
+    if (!indices || !isQuoteUrlEntity(entity, quoted)) continue;
+    const [entityStart, entityEnd] = indices;
+    if (entityStart >= start && isTrailingEntity(entityEnd, end, data.text)) {
+      end = Math.min(end, entityStart);
+    }
+  }
+
+  while (end > start && isUtf16Space(data.text, end - 1)) end -= 1;
+  return [start, end];
+}
+
+function isQuoteUrlEntity(entity: TweetEntity, quoted?: TweetBodyData): boolean {
+  for (const href of [entity.expanded_url, entity.url, entity.display_url]) {
+    if (!href) continue;
+    const match = href.match(STATUS_PATH);
+    if (match) return !quoted?.id_str || match[1] === quoted.id_str;
+    if (TCO.test(href)) return true;
+  }
+  return false;
+}
+
+function isTrailingEntity(entityEnd: number, rangeEnd: number, text: string): boolean {
+  if (entityEnd >= rangeEnd || entityEnd === text.length) return true;
+  return entityEnd > 0 && /^[\t\n\r ]*$/.test(text.slice(entityEnd, rangeEnd));
+}
+
+function isUtf16Space(text: string, index: number): boolean {
+  const char = text[index];
+  return char === " " || char === "\n" || char === "\t" || char === "\r";
+}

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/validate.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/validate.ts
@@ -29,9 +29,13 @@ export function normalizeTweetData(data: TweetData): TweetData {
   const handle = sanitizeScreenName(data.in_reply_to_screen_name);
   return {
     ...data,
-    quoted_tweet: isTweetBodyData(data.quoted_tweet) ? stripNestedQuote(data.quoted_tweet) : undefined,
+    quoted_tweet: isTweetBodyData(data.quoted_tweet)
+      ? stripNestedQuote(data.quoted_tweet)
+      : undefined,
     in_reply_to_screen_name: handle,
-    in_reply_to_status_id_str: handle ? sanitizeStatusId(data.in_reply_to_status_id_str) : undefined,
+    in_reply_to_status_id_str: handle
+      ? sanitizeStatusId(data.in_reply_to_status_id_str)
+      : undefined,
   };
 }
 
@@ -62,7 +66,10 @@ export function replyPermalink(data: TweetData): string | undefined {
   return id ? `https://x.com/${handle}/status/${id}` : `https://x.com/${handle}`;
 }
 
-export function visibleTextRange(data: TweetBodyData, omitTrailingQuoteUrl = false): [number, number] {
+export function visibleTextRange(
+  data: TweetBodyData,
+  omitTrailingQuoteUrl = false,
+): [number, number] {
   const start = Math.max(0, data.display_text_range?.[0] ?? 0);
   let end = Math.min(data.text.length, data.display_text_range?.[1] ?? data.text.length);
   if (!omitTrailingQuoteUrl || start >= end) return [start, end];


### PR DESCRIPTION
## Summary
- Fetched Twitter/X cards now render one nested quoted-post card (author, body, optional photos, permalink) and a “Replying to @…” link when syndication metadata is present.
- Invalid, deleted, or recursively nested quotes no longer discard the root post; trailing quote `t.co` / status URLs are omitted from the root body when a quote card is shown.
- Quoted avatars/photos are materialized as `{id}-quoted-…`; handles are sanitized; all author/body/attribute text is escaped. No widget script, no client JS, no video/`appearance` work.

Closes #831

## Test plan
- [x] `vp test src/plugins/twitter.test.ts` (existing fetched-tweet case plus quote, quoted photos, reply, deleted/malformed/nested quote, escaping + UTF-16 ranges)
- [ ] Required CI: TypeScript check, Test, Clippy, Rustfmt, Build, Dependency policy, Package dry-run, Changed source files


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790252389&installation_model_id=422833&pr_number=835&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F835&signature=5cea1b82fba53b558a67de8cd032eeb62d12e75c742cb8633c29e4ff97ff6942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Twitter/X embeds now support nested quoted posts, quoted media, and “Replying to @…” links.
  * Missing quoted posts no longer prevent the original post from rendering.
  * Tweet content, profile handles, links, and metadata are safely escaped.
  * Unavailable root posts can fall back to a link-only display.

* **Bug Fixes**
  * Improved handling of malformed, deleted, or nested quoted-post data.
  * Corrected entity rendering for tweets containing UTF-16 text ranges.

* **Documentation**
  * Updated English and Japanese embed documentation with the new Twitter/X behavior and media limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->