### PR TITLE
feat(twitter): render video and animated GIF media

### DIFF
--- a/crates/ox_content_ssg/src/plugins/social.css
+++ b/crates/ox_content_ssg/src/plugins/social.css
@@ -120,6 +120,23 @@
   background: var(--octc-color-bg-alt);
 }
 
+.ox-tweet__media-fallback {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.ox-tweet__media-fallback > img {
+  width: 100%;
+  height: auto;
+  border-radius: inherit;
+}
+
+.ox-tweet__watch {
+  margin-top: 0.375rem;
+  font-size: 0.8125rem;
+}
+
 .ox-tweet__footer {
   display: flex;
   align-items: center;

--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -191,8 +191,8 @@ card:
 
 <XPost url="https://x.com/jack/status/20" />
 
-Use the object form to fetch the post body, author, avatar, and photos at
-build time and serve them from your own origin:
+Use the object form to fetch the post body, author, avatar, photos, and video
+posters at build time and serve them from your own origin:
 
 ```ts
 oxContent({
@@ -207,19 +207,23 @@ oxContent({
 });
 ```
 
-| Option            | Default                     | Purpose                                   |
-| ----------------- | --------------------------- | ----------------------------------------- |
-| `fetch`           | `false`                     | Fetch post content at build time.         |
-| `lang`            | `"en"`                      | Syndication language and displayed date.  |
-| `timeout`         | `10000`                     | Metadata request timeout in milliseconds. |
-| `cache`           | `true`                      | In-memory and persistent JSON caches.     |
-| `cacheDir`        | `.cache/ox-content/twitter` | Persistent metadata cache directory.      |
-| `mediaOutputDir`  | `public/ox-content/twitter` | Local directory for avatars and photos.   |
-| `mediaPublicPath` | `/ox-content/twitter`       | URL prefix emitted for downloaded media.  |
+| Option            | Default                     | Purpose                                          |
+| ----------------- | --------------------------- | ------------------------------------------------ |
+| `fetch`           | `false`                     | Fetch post content at build time.                |
+| `lang`            | `"en"`                      | Syndication language and displayed date.         |
+| `timeout`         | `10000`                     | Metadata request timeout in milliseconds.        |
+| `cache`           | `true`                      | In-memory and persistent JSON caches.            |
+| `cacheDir`        | `.cache/ox-content/twitter` | Persistent metadata cache directory.             |
+| `mediaOutputDir`  | `public/ox-content/twitter` | Local directory for avatars, photos, and videos. |
+| `mediaPublicPath` | `/ox-content/twitter`       | URL prefix emitted for downloaded media.         |
+| `downloadVideo`   | `false`                     | Download MP4 video and animated GIF assets.      |
+| `maxVideoBytes`   | `8388608`                   | Skip videos larger than this (8 MiB).            |
 
 Downloaded media is served from your site, so a strict `img-src 'self'` CSP
-keeps working. Deleted or private posts fall back to the link-only card
-instead of failing the build. See
+keeps working. Video and animated GIF posts use a self-hosted poster and a
+Watch on X permalink unless `downloadVideo` is enabled, and the generated HTML
+never includes `video.twimg.com`. Deleted or private posts fall back to the
+link-only card instead of failing the build. See
 [Twitter/X Embed](../examples/twitter-embed.md) for details.
 
 ## Bluesky

--- a/docs/content/examples/twitter-embed.md
+++ b/docs/content/examples/twitter-embed.md
@@ -7,7 +7,7 @@ description: Render X posts as privacy-conscious static cards.
 
 Twitter/X embeds are opt-in and never load a third-party widget script.
 `twitter: true` renders the privacy-conscious link card. Use the object form to
-fetch the post body, author, avatar, and photos at build time:
+fetch the post body, author, avatar, photos, and video posters at build time:
 
 ```ts
 import { oxContent } from "@ox-content/vite-plugin";
@@ -33,17 +33,22 @@ export default {
 ```
 
 Fetched metadata is cached in memory and under `.cache/ox-content/twitter` by
-default. Avatars and photos are copied into the configured output directory, so
-the generated page can use a strict `img-src 'self'` policy. If the post is
-deleted, private, or unavailable during a build, Ox Content falls back to the
-link-only card instead of failing the build.
+default. Avatars, photos, and video posters are copied into the configured
+output directory, so the generated page can use a strict `img-src 'self'`
+policy. Video and animated GIF files are downloaded only when `downloadVideo`
+is true, stay within `maxVideoBytes`, and are never hotlinked from
+`video.twimg.com`. If the post is deleted, private, or unavailable during a
+build, Ox Content falls back to the link-only card instead of failing the
+build.
 
-| Option            | Default                     | Purpose                                      |
-| ----------------- | --------------------------- | -------------------------------------------- |
-| `fetch`           | `false`                     | Fetch post content from X at build time.     |
-| `lang`            | `"en"`                      | Syndication language and displayed date.     |
-| `timeout`         | `10000`                     | Metadata request timeout in milliseconds.    |
-| `cache`           | `true`                      | Enable in-memory and persistent JSON caches. |
-| `cacheDir`        | `.cache/ox-content/twitter` | Persistent metadata cache directory.         |
-| `mediaOutputDir`  | `public/ox-content/twitter` | Local directory for avatars and photos.      |
-| `mediaPublicPath` | `/ox-content/twitter`       | URL prefix emitted for downloaded media.     |
+| Option            | Default                     | Purpose                                          |
+| ----------------- | --------------------------- | ------------------------------------------------ |
+| `fetch`           | `false`                     | Fetch post content from X at build time.         |
+| `lang`            | `"en"`                      | Syndication language and displayed date.         |
+| `timeout`         | `10000`                     | Metadata request timeout in milliseconds.        |
+| `cache`           | `true`                      | Enable in-memory and persistent JSON caches.     |
+| `cacheDir`        | `.cache/ox-content/twitter` | Persistent metadata cache directory.             |
+| `mediaOutputDir`  | `public/ox-content/twitter` | Local directory for avatars, photos, and videos. |
+| `mediaPublicPath` | `/ox-content/twitter`       | URL prefix emitted for downloaded media.         |
+| `downloadVideo`   | `false`                     | Download MP4 video and animated GIF assets.      |
+| `maxVideoBytes`   | `8388608`                   | Skip videos larger than this (8 MiB).            |

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -161,7 +161,7 @@ YouTube 埋め込みは SSG ビルドと dev preview で常に処理されます
 
 <XPost url="https://x.com/jack/status/20" />
 
-オブジェクト形式を使うと、ビルド時に本文、著者、アバター、写真を取り、自分のオリジンから配信します。
+オブジェクト形式を使うと、ビルド時に本文、著者、アバター、写真、動画ポスターを取り、自分のオリジンから配信します。
 
 ```ts
 oxContent({
@@ -183,10 +183,12 @@ oxContent({
 | `timeout`         | `10000`                     | メタデータ要求のタイムアウト（ミリ秒）。            |
 | `cache`           | `true`                      | メモリと永続 JSON キャッシュ。                      |
 | `cacheDir`        | `.cache/ox-content/twitter` | 永続メタデータキャッシュディレクトリ。              |
-| `mediaOutputDir`  | `public/ox-content/twitter` | アバターと写真のローカルディレクトリ。              |
+| `mediaOutputDir`  | `public/ox-content/twitter` | アバター、写真、動画のローカルディレクトリ。        |
 | `mediaPublicPath` | `/ox-content/twitter`       | ダウンロードしたメディアに出す URL プレフィックス。 |
+| `downloadVideo`   | `false`                     | ビルド時に MP4 動画とアニメーション GIF を取る。    |
+| `maxVideoBytes`   | `8388608`                   | これより大きい動画はスキップする（8 MiB）。         |
 
-ダウンロードしたメディアは自分のサイトから出すので、厳しい `img-src 'self'` CSP も動き続けます。削除済みや非公開の投稿は、ビルドを落とさずリンクのみのカードに落ちます。詳細は [Twitter/X Embed](/examples/twitter-embed.md) を見てください。
+ダウンロードしたメディアは自分のサイトから出すので、厳しい `img-src 'self'` CSP も動き続けます。動画とアニメーション GIF は、`downloadVideo` をオンにしない限り自前のポスターと Watch on X パーマリンクを使い、生成 HTML に `video.twimg.com` は出しません。削除済みや非公開の投稿は、ビルドを落とさずリンクのみのカードに落ちます。詳細は [Twitter/X Embed](/examples/twitter-embed.md) を見てください。
 
 ## Bluesky
 

--- a/npm/vite-plugin-ox-content/src/plugins/twitter-video.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter-video.test.ts
@@ -1,0 +1,282 @@
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { clearTweetCache } from "./twitter/fetch";
+import { transformFetchedTweets } from "./twitter/transform";
+import { selectBestMp4Url } from "./twitter/video";
+import type { TwitterEmbedOptions } from "./twitter/types";
+
+const originalFetch = globalThis.fetch;
+const LOW = "https://video.twimg.com/amplify_video/1/vid/low.mp4";
+const MID = "https://video.twimg.com/amplify_video/1/vid/mid.mp4";
+const HIGH = "https://video.twimg.com/amplify_video/1/vid/high.mp4";
+const HLS = "https://video.twimg.com/amplify_video/1/pl/stream.m3u8";
+const POSTER = "https://pbs.twimg.com/amplify_video_thumb/1/img/poster.jpg";
+const GIF = "https://video.twimg.com/tweet_video/cat.mp4";
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  clearTweetCache();
+});
+
+describe("selectBestMp4Url", () => {
+  it("picks the highest-bitrate video/mp4 deterministically", () => {
+    expect(
+      selectBestMp4Url([
+        { content_type: "application/x-mpegURL", url: HLS },
+        { content_type: "video/mp4", url: LOW, bitrate: 256000 },
+        { content_type: "video/mp4", url: HIGH, bitrate: 2176000 },
+        { content_type: "video/mp4", url: MID, bitrate: 832000 },
+      ]),
+    ).toBe(HIGH);
+  });
+
+  it("skips empty, non-mp4, and disallowed hosts", () => {
+    expect(selectBestMp4Url([])).toBeUndefined();
+    expect(selectBestMp4Url([{ content_type: "application/x-mpegURL", url: HLS }])).toBeUndefined();
+    expect(
+      selectBestMp4Url([
+        { content_type: "video/mp4", url: "https://example.com/clip.mp4", bitrate: 1 },
+      ]),
+    ).toBeUndefined();
+  });
+});
+
+describe("fetched Twitter video media", () => {
+  it("downloads the highest-bitrate mp4 and renders native video", async () => {
+    await withTweet(
+      [videoDetails()],
+      { downloadVideo: true },
+      async ({ html, requested, mediaDir }) => {
+        expect(requested).toContain(HIGH);
+        expect(requested).not.toContain(LOW);
+        expect(requested).not.toContain(MID);
+        expect(html).toContain(
+          '<video class="ox-tweet__media-item" src="/tweets/555-media-1.mp4" poster="/tweets/555-media-1-poster.jpg" width="1604" height="1252" controls playsinline preload="none">',
+        );
+        expect(html).toContain(">Watch on X</a></video>");
+        expect(html).toContain('data-count="1"');
+        expect(html).not.toContain("video.twimg.com");
+        expect(html).not.toContain(" muted loop");
+        await expect(readFile(path.join(mediaDir, "555-media-1.mp4"))).resolves.toHaveLength(3);
+      },
+    );
+  });
+
+  it("renders animated GIFs as muted looping video", async () => {
+    await withTweet(
+      [
+        {
+          type: "animated_gif",
+          media_url_https: POSTER,
+          video_info: { variants: [{ content_type: "video/mp4", url: GIF, bitrate: 0 }] },
+        },
+      ],
+      { downloadVideo: true },
+      ({ html }) => {
+        expect(html).toContain('src="/tweets/555-media-1.mp4"');
+        expect(html).toContain(' controls playsinline preload="none" muted loop>');
+        expect(html).toContain("Watch on X");
+        expect(html).not.toContain("video.twimg.com");
+      },
+    );
+  });
+
+  it("keeps a poster and permalink when downloadVideo is false", async () => {
+    await withTweet([videoDetails()], {}, ({ html, requested }) => {
+      expect(requested.some((url) => url.includes("video.twimg.com"))).toBe(false);
+      expect(html).not.toContain("<video");
+      expect(html).toContain('src="/tweets/555-media-1-poster.jpg"');
+      expect(html).toContain("ox-tweet__media-fallback");
+      expect(html).toContain("Watch on X");
+      expect(html).not.toContain("video.twimg.com");
+    });
+  });
+
+  it("falls back when variants are empty or invalid", async () => {
+    await withTweet(
+      [{ type: "video", media_url_https: POSTER, video_info: { variants: [] } }],
+      { downloadVideo: true },
+      ({ html, requested }) => {
+        expect(requested.some((url) => url.includes("video.twimg.com"))).toBe(false);
+        expect(html).not.toContain("<video");
+        expect(html).toContain('src="/tweets/555-media-1-poster.jpg"');
+        expect(html).toContain("Watch on X");
+      },
+    );
+    await withTweet(
+      [
+        {
+          type: "video",
+          media_url_https: POSTER,
+          video_info: { variants: [{ content_type: "application/x-mpegURL", url: HLS }] },
+        },
+      ],
+      { downloadVideo: true },
+      ({ html }) => {
+        expect(html).not.toContain("<video");
+        expect(html).toContain("Watch on X");
+      },
+    );
+  });
+
+  it("rejects oversized videos without failing the build", async () => {
+    await withTweet(
+      [videoDetails()],
+      { downloadVideo: true, maxVideoBytes: 2 },
+      async ({ html, mediaDir }) => {
+        expect(html).not.toContain("<video");
+        expect(html).toContain("Watch on X");
+        await expect(access(path.join(mediaDir, "555-media-1.mp4"))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      },
+      (url) =>
+        url.startsWith("https://video.twimg.com/")
+          ? ({
+              ok: true,
+              headers: headerMap({ "content-type": "video/mp4", "content-length": "99" }),
+              arrayBuffer: async () => {
+                throw new Error("should not read an oversized body");
+              },
+            } as Response)
+          : undefined,
+    );
+    await withTweet(
+      [videoDetails()],
+      { downloadVideo: true, maxVideoBytes: 2 },
+      ({ html }) => {
+        expect(html).not.toContain("<video");
+        expect(html).toContain("Watch on X");
+      },
+      (url) =>
+        url.startsWith("https://video.twimg.com/")
+          ? ({
+              ok: true,
+              headers: headerMap({ "content-type": "video/mp4" }),
+              arrayBuffer: async () => Uint8Array.from([1, 2, 3]).buffer,
+            } as Response)
+          : undefined,
+    );
+  });
+
+  it("falls back on wrong MIME types and failed downloads", async () => {
+    await withTweet(
+      [videoDetails()],
+      { downloadVideo: true },
+      ({ html }) => {
+        expect(html).not.toContain("<video");
+        expect(html).toContain("Watch on X");
+        expect(html).not.toContain("video.twimg.com");
+      },
+      (url) =>
+        url.startsWith("https://video.twimg.com/")
+          ? ({
+              ok: true,
+              headers: headerMap({ "content-type": "video/webm" }),
+              arrayBuffer: async () => Uint8Array.from([1, 2, 3]).buffer,
+            } as Response)
+          : undefined,
+    );
+    await withTweet(
+      [videoDetails()],
+      { downloadVideo: true },
+      ({ html }) => {
+        expect(html).not.toContain("<video");
+        expect(html).toContain("Watch on X");
+      },
+      (url) =>
+        url.startsWith("https://video.twimg.com/")
+          ? ({ ok: false, status: 500 } as Response)
+          : undefined,
+    );
+    await withTweet(
+      [videoDetails()],
+      { downloadVideo: true },
+      ({ html }) => {
+        expect(html).not.toContain("<video");
+        expect(html).toContain("Watch on X");
+      },
+      (url) => {
+        if (url.startsWith("https://video.twimg.com/")) throw new Error("network down");
+        return undefined;
+      },
+    );
+  });
+});
+
+function videoDetails(): Record<string, unknown> {
+  return {
+    type: "video",
+    media_url_https: POSTER,
+    original_info: { width: 1604, height: 1252 },
+    video_info: {
+      variants: [
+        { content_type: "application/x-mpegURL", url: HLS },
+        { content_type: "video/mp4", url: LOW, bitrate: 256000 },
+        { content_type: "video/mp4", url: MID, bitrate: 832000 },
+        { content_type: "video/mp4", url: HIGH, bitrate: 2176000 },
+      ],
+    },
+  };
+}
+
+function headerMap(values: Record<string, string>): { get: (name: string) => string | null } {
+  const map = new Map(Object.entries(values).map(([key, value]) => [key.toLowerCase(), value]));
+  return { get: (name: string) => map.get(name.toLowerCase()) ?? null };
+}
+
+function videoBytes(): Response {
+  return {
+    ok: true,
+    headers: headerMap({ "content-type": "video/mp4", "content-length": "3" }),
+    arrayBuffer: async () => Uint8Array.from([1, 2, 3]).buffer,
+  } as Response;
+}
+
+async function withTweet(
+  mediaDetails: unknown[],
+  twitter: TwitterEmbedOptions,
+  assert: (ctx: { html: string; requested: string[]; mediaDir: string }) => Promise<void> | void,
+  respond?: (url: string) => Response | undefined,
+): Promise<void> {
+  const root = await mkdtemp(path.join(tmpdir(), "ox-content-twitter-video-"));
+  const mediaDir = path.join(root, "media");
+  const requested: string[] = [];
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    requested.push(url);
+    if (url.startsWith("https://cdn.syndication.twimg.com/")) {
+      return {
+        ok: true,
+        json: async () => ({
+          text: "Watch this",
+          display_text_range: [0, 10],
+          mediaDetails,
+          user: { name: "Ox", screen_name: "ox_content" },
+        }),
+      } as Response;
+    }
+    const custom = respond?.(url);
+    if (custom) return custom;
+    if (url.startsWith("https://video.twimg.com/")) return videoBytes();
+    return { ok: true, arrayBuffer: async () => Uint8Array.from([1, 2, 3]).buffer } as Response;
+  };
+
+  try {
+    const html = await transformFetchedTweets(
+      '<XPost url="https://x.com/ox_content/status/555" />',
+      {
+        fetch: true,
+        cache: false,
+        mediaOutputDir: mediaDir,
+        mediaPublicPath: "/tweets",
+        ...twitter,
+      },
+    );
+    await assert({ html, requested, mediaDir });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/fetch.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/fetch.ts
@@ -1,7 +1,15 @@
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { createSyndicationToken } from "./url";
-import type { ResolvedTwitterEmbedOptions, TweetAssets, TweetData, TweetMedia } from "./types";
+import type {
+  ResolvedTwitterEmbedOptions,
+  TweetAssets,
+  TweetData,
+  TweetMedia,
+  TweetMediaAsset,
+  TweetMediaKind,
+} from "./types";
+import { downloadVideoAsset, selectBestMp4Url } from "./video";
 
 const tweetCache = new Map<string, TweetData>();
 
@@ -64,10 +72,25 @@ export async function materializeTweetAssets(
 
   const media = data.mediaDetails ?? data.entities?.media ?? [];
   for (const [index, item] of media.entries()) {
-    if (item.type && item.type !== "photo") continue;
-    if (!item.media_url_https) continue;
-    const src = await downloadAsset(item.media_url_https, `${id}-media-${index + 1}`, options);
-    if (src) assets.media.push(assetRecord(src, item));
+    const kind: TweetMediaKind =
+      item.type === "video" || item.type === "animated_gif" ? item.type : "photo";
+    const basename = `${id}-media-${index + 1}`;
+    if (kind === "photo") {
+      if (item.type && item.type !== "photo") continue;
+      if (!item.media_url_https) continue;
+      const src = await downloadAsset(item.media_url_https, basename, options);
+      if (src) assets.media.push(assetRecord("photo", src, item));
+      continue;
+    }
+
+    const poster = item.media_url_https
+      ? await downloadAsset(item.media_url_https, `${basename}-poster`, options)
+      : undefined;
+    const videoUrl = options.downloadVideo
+      ? selectBestMp4Url(item.video_info?.variants)
+      : undefined;
+    const src = videoUrl ? await downloadVideoAsset(videoUrl, basename, options) : undefined;
+    assets.media.push(assetRecord(kind, src, item, poster));
   }
   return assets;
 }
@@ -150,9 +173,16 @@ function sanitizeSegment(value: string): string {
   return value.replaceAll(/[^a-zA-Z0-9_-]/g, "-");
 }
 
-function assetRecord(src: string, media: TweetMedia): TweetAssets["media"][number] {
+function assetRecord(
+  kind: TweetMediaKind,
+  src: string | undefined,
+  media: TweetMedia,
+  poster?: string,
+): TweetMediaAsset {
   return {
+    kind,
     src,
+    poster,
     alt: media.ext_alt_text,
     width: media.original_info?.width,
     height: media.original_info?.height,

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/render.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/render.ts
@@ -1,4 +1,10 @@
-import type { ResolvedTwitterEmbedOptions, TweetAssets, TweetData, TweetEntity } from "./types";
+import type {
+  ResolvedTwitterEmbedOptions,
+  TweetAssets,
+  TweetData,
+  TweetEntity,
+  TweetMediaAsset,
+} from "./types";
 
 export function renderFetchedTweet(
   permalink: string,
@@ -12,7 +18,7 @@ export function renderFetchedTweet(
   const avatar = assets.avatar
     ? `<img class="ox-tweet__avatar" src="${escapeAttribute(assets.avatar)}" alt="" width="48" height="48" loading="lazy" decoding="async">`
     : "";
-  const media = renderMedia(assets);
+  const media = renderMedia(assets, permalink);
   const footer = renderFooter(permalink, data.created_at, options.lang);
 
   return [
@@ -68,18 +74,48 @@ function validRange(
   return Boolean(indices && indices[0] >= start && indices[1] <= end && indices[0] < indices[1]);
 }
 
-function renderMedia(assets: TweetAssets): string {
+function renderMedia(assets: TweetAssets, permalink: string): string {
   if (assets.media.length === 0) return "";
-  const images = assets.media
-    .map((item) => {
-      const size = [
-        item.width ? ` width="${item.width}"` : "",
-        item.height ? ` height="${item.height}"` : "",
-      ].join("");
-      return `<img class="ox-tweet__media-item" src="${escapeAttribute(item.src)}" alt="${escapeAttribute(item.alt ?? "")}"${size} loading="lazy" decoding="async">`;
-    })
-    .join("");
-  return `<div class="ox-tweet__media" data-count="${assets.media.length}">${images}</div>`;
+  const items = assets.media.map((item) => renderMediaItem(item, permalink)).join("");
+  return `<div class="ox-tweet__media" data-count="${assets.media.length}">${items}</div>`;
+}
+
+function renderMediaItem(item: TweetMediaAsset, permalink: string): string {
+  if (item.kind === "video" || item.kind === "animated_gif") {
+    return renderVideoItem(item, permalink);
+  }
+  const size = sizeAttributes(item);
+  return `<img class="ox-tweet__media-item" src="${escapeAttribute(item.src ?? "")}" alt="${escapeAttribute(item.alt ?? "")}"${size} loading="lazy" decoding="async">`;
+}
+
+function renderVideoItem(item: TweetMediaAsset, permalink: string): string {
+  const watch = watchOnX(permalink);
+  const size = sizeAttributes(item);
+  const src = selfHostedMediaSrc(item.src);
+  if (src) {
+    const poster = item.poster ? ` poster="${escapeAttribute(item.poster)}"` : "";
+    const gif = item.kind === "animated_gif" ? " muted loop" : "";
+    return `<video class="ox-tweet__media-item" src="${escapeAttribute(src)}"${poster}${size} controls playsinline preload="none"${gif}>${watch}</video>`;
+  }
+  const poster = item.poster
+    ? `<img src="${escapeAttribute(item.poster)}" alt="${escapeAttribute(item.alt ?? "")}"${size} loading="lazy" decoding="async">`
+    : "";
+  return `<div class="ox-tweet__media-item ox-tweet__media-fallback">${poster}${watch}</div>`;
+}
+
+function selfHostedMediaSrc(src: string | undefined): string | undefined {
+  return src && !src.includes("video.twimg.com") ? src : undefined;
+}
+
+function sizeAttributes(item: Pick<TweetMediaAsset, "width" | "height">): string {
+  return [
+    item.width ? ` width="${item.width}"` : "",
+    item.height ? ` height="${item.height}"` : "",
+  ].join("");
+}
+
+function watchOnX(permalink: string): string {
+  return `<a class="ox-tweet__watch" href="${escapeAttribute(permalink)}" target="_blank" rel="noopener noreferrer">Watch on X</a>`;
 }
 
 function renderFooter(permalink: string, createdAt: string | undefined, lang: string): string {

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/transform.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/transform.ts
@@ -17,6 +17,8 @@ export function resolveTwitterEmbedOptions(
     cacheDir: path.resolve(options.cacheDir ?? ".cache/ox-content/twitter"),
     mediaOutputDir: path.resolve(options.mediaOutputDir ?? "public/ox-content/twitter"),
     mediaPublicPath: options.mediaPublicPath ?? "/ox-content/twitter",
+    downloadVideo: options.downloadVideo ?? false,
+    maxVideoBytes: options.maxVideoBytes ?? 8_388_608,
   };
 }
 

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/types.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/types.ts
@@ -9,10 +9,14 @@ export interface TwitterEmbedOptions {
   cache?: boolean;
   /** Directory used for the persistent metadata cache. @default ".cache/ox-content/twitter" */
   cacheDir?: string;
-  /** Directory where avatars and photos are written. @default "public/ox-content/twitter" */
+  /** Directory where avatars, photos, and videos are written. @default "public/ox-content/twitter" */
   mediaOutputDir?: string;
   /** Public URL prefix for downloaded media. @default "/ox-content/twitter" */
   mediaPublicPath?: string;
+  /** Download MP4 video and animated GIF assets at build time. @default false */
+  downloadVideo?: boolean;
+  /** Maximum video size in bytes. Oversized assets are skipped. @default 8388608 */
+  maxVideoBytes?: number;
 }
 
 export interface ResolvedTwitterEmbedOptions {
@@ -23,6 +27,8 @@ export interface ResolvedTwitterEmbedOptions {
   cacheDir: string;
   mediaOutputDir: string;
   mediaPublicPath: string;
+  downloadVideo: boolean;
+  maxVideoBytes: number;
 }
 
 export interface TweetEntity {
@@ -32,11 +38,18 @@ export interface TweetEntity {
   indices?: [number, number];
 }
 
+export interface TweetVideoVariant {
+  content_type?: string;
+  url?: string;
+  bitrate?: number;
+}
+
 export interface TweetMedia extends TweetEntity {
   media_url_https?: string;
   ext_alt_text?: string;
   type?: string;
   original_info?: { width?: number; height?: number };
+  video_info?: { variants?: TweetVideoVariant[] };
 }
 
 export interface TweetData {
@@ -57,7 +70,18 @@ export interface TweetReference {
   url: string;
 }
 
+export type TweetMediaKind = "photo" | "video" | "animated_gif";
+
+export interface TweetMediaAsset {
+  kind: TweetMediaKind;
+  src?: string;
+  poster?: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+}
+
 export interface TweetAssets {
   avatar?: string;
-  media: Array<{ src: string; alt?: string; width?: number; height?: number }>;
+  media: TweetMediaAsset[];
 }

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/video.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/video.ts
@@ -1,0 +1,88 @@
+import { access, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { ResolvedTwitterEmbedOptions, TweetVideoVariant } from "./types";
+
+const VIDEO_HOSTS = new Set(["pbs.twimg.com", "video.twimg.com"]);
+
+export function selectBestMp4Url(
+  variants: readonly TweetVideoVariant[] | undefined,
+): string | undefined {
+  const candidates = (variants ?? []).filter(
+    (variant): variant is TweetVideoVariant & { url: string } =>
+      isVideoMp4Type(variant.content_type) && isAllowedVideoUrl(variant.url),
+  );
+  if (candidates.length === 0) return undefined;
+
+  return candidates.reduce((best, variant) => {
+    const bestBitrate = best.bitrate ?? Number.NEGATIVE_INFINITY;
+    const nextBitrate = variant.bitrate ?? Number.NEGATIVE_INFINITY;
+    if (nextBitrate > bestBitrate) return variant;
+    if (nextBitrate === bestBitrate && variant.url < best.url) return variant;
+    return best;
+  }).url;
+}
+
+export function isVideoMp4Type(value: string | null | undefined): boolean {
+  return (value ?? "").split(";", 1)[0].trim().toLowerCase() === "video/mp4";
+}
+
+export function isAllowedVideoUrl(value: string | null | undefined): value is string {
+  if (!value) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" && VIDEO_HOSTS.has(url.hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+export async function downloadVideoAsset(
+  source: string,
+  basename: string,
+  options: ResolvedTwitterEmbedOptions,
+): Promise<string | undefined> {
+  if (!isAllowedVideoUrl(source)) return undefined;
+
+  const filename = `${sanitizeFilename(basename)}.mp4`;
+  const output = path.join(options.mediaOutputDir, filename);
+  const publicPath = joinPublicPath(options.mediaPublicPath, filename);
+  try {
+    await access(output);
+    return publicPath;
+  } catch {
+    // Download the missing asset below.
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeout);
+  try {
+    const response = await fetch(source, {
+      headers: { Accept: "video/mp4" },
+      signal: controller.signal,
+    });
+    if (!response.ok) return undefined;
+    if (!isVideoMp4Type(response.headers?.get("content-type"))) return undefined;
+
+    const declared = Number(response.headers?.get("content-length"));
+    if (Number.isFinite(declared) && declared > options.maxVideoBytes) return undefined;
+
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength > options.maxVideoBytes) return undefined;
+
+    await mkdir(options.mediaOutputDir, { recursive: true });
+    await writeFile(output, bytes);
+    return publicPath;
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function sanitizeFilename(value: string): string {
+  return value.replaceAll(/[^a-zA-Z0-9_-]/g, "-") || "video";
+}
+
+function joinPublicPath(prefix: string, filename: string): string {
+  return `${prefix.replace(/\/$/, "")}/${filename}`;
+}


### PR DESCRIPTION
## Summary
- Fetched Tweet cards now materialize `video` and `animated_gif` media. The highest-bitrate `video/mp4` variant is selected deterministically from `video_info.variants`.
- Default `downloadVideo: false` never hotlinks X video URLs. The card uses a self-hosted poster (when available) plus a Watch on X permalink, and generated HTML never includes `video.twimg.com`.
- Opt-in `downloadVideo: true` downloads an MP4 into `mediaOutputDir` (default `maxVideoBytes` 8 MiB), validates `Content-Type: video/mp4`, and renders native `<video controls playsinline preload="none">` with a permalink fallback. Animated GIFs also get `muted loop`. Failed, oversized, or invalid media falls back without failing the build.

Closes #832

## Test plan
- [x] `vp test src/plugins/twitter.test.ts src/plugins/twitter-video.test.ts` from `npm/vite-plugin-ox-content`
- [ ] Confirm CI: TypeScript check, Test, Clippy, Rustfmt, Build, Dependency policy, Package dry-run, Changed source files
- [ ] Photo embeds still render from the existing fetched-tweet path
- [ ] Video with multiple bitrates uses the highest `video/mp4`
- [ ] Animated GIF markup includes `muted loop`
- [ ] `downloadVideo: false` shows poster + Watch on X only
- [ ] Empty/invalid variants, oversized assets, wrong MIME, and failed downloads fall back


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790252471&installation_model_id=422833&pr_number=836&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F836&signature=e2db9e220915d4fed9193291dc1ae6f4c75b20629f1a18952407870a504ad1c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->