### PR TITLE
feat(twitter): add a full-fidelity static card with sveltweet visual parity

### DIFF
--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -209,6 +209,12 @@ const OGP_CSS: &str = include_str!("plugins/ogp.css");
 /// CSS styles for social embeds (Twitter/X, Bluesky, WebContainer, media iframes).
 const SOCIAL_CSS: &str = include_str!("plugins/social.css");
 
+/// CSS for opt-in full-fidelity Tweet cards (`.ox-tweet--full`).
+const SOCIAL_TWEET_FULL_CSS: &str = concat!(
+    include_str!("plugins/social-tweet-full.css"),
+    include_str!("plugins/social-tweet-full-media.css"),
+);
+
 /// CSS styles for Mermaid plugin.
 const MERMAID_CSS: &str = include_str!("plugins/mermaid.css");
 

--- a/crates/ox_content_ssg/src/html/render.rs
+++ b/crates/ox_content_ssg/src/html/render.rs
@@ -25,8 +25,8 @@ use super::utils::{
 };
 use super::{
     CONTRIBUTORS_CSS, ENTRY_CSS, FILE_TREE_CSS, GITHUB_CSS, ISLAND_CSS, MERMAID_CSS, NavGroup,
-    OGP_CSS, PageData, PageTemplate, SOCIAL_CSS, SSG_CSS, SSG_JS, SsgConfig, TABS_CSS, TABS_JS,
-    YOUTUBE_CSS,
+    OGP_CSS, PageData, PageTemplate, SOCIAL_CSS, SOCIAL_TWEET_FULL_CSS, SSG_CSS, SSG_JS, SsgConfig,
+    TABS_CSS, TABS_JS, YOUTUBE_CSS,
 };
 
 /// Themed HTML plus page-head diagnostics.
@@ -129,6 +129,9 @@ fn generate_html_inner(
         &["ox-tweet", "ox-bluesky", "ox-webcontainer", "ox-spotify", "ox-stackblitz"],
     ) {
         css_sections.push(wrap_css_section("plugin-social", SOCIAL_CSS));
+    }
+    if page_content_contains_any(&page_data.content, &["ox-tweet--full"]) {
+        css_sections.push(wrap_css_section("plugin-social-tweet-full", SOCIAL_TWEET_FULL_CSS));
     }
     if page_content_contains_any(&page_data.content, &["ox-mermaid"]) {
         css_sections.push(wrap_css_section("plugin-mermaid", MERMAID_CSS));

--- a/crates/ox_content_ssg/src/html/tests.rs
+++ b/crates/ox_content_ssg/src/html/tests.rs
@@ -24,6 +24,7 @@ mod contributors;
 mod mpa_navigation;
 mod navigation_state;
 mod rendering;
+mod social;
 mod theme;
 
 #[test]

--- a/crates/ox_content_ssg/src/html/tests/social.rs
+++ b/crates/ox_content_ssg/src/html/tests/social.rs
@@ -1,0 +1,66 @@
+use super::super::*;
+
+fn page(content: &str) -> PageData {
+    PageData {
+        title: "Social".to_string(),
+        description: None,
+        content: content.to_string(),
+        toc: vec![],
+        last_updated: None,
+        contributors: vec![],
+        path: "social".to_string(),
+        entry_page: None,
+        prev: None,
+        next: None,
+        breadcrumbs: None,
+        chrome: PageChromeFlags::default(),
+        robots: None,
+        canonical: None,
+    }
+}
+
+fn config() -> SsgConfig {
+    SsgConfig {
+        site_name: "Test".to_string(),
+        base: "/".to_string(),
+        breadcrumb_root_href: None,
+        og_image: None,
+        theme: None,
+        locale: None,
+        available_locales: None,
+        pagination: false,
+        breadcrumbs: false,
+        reader_chrome: ReaderChrome::default(),
+        locale_switcher: false,
+        locale_paths: vec![],
+        a11y: A11y::default(),
+        page_chrome: false,
+        json_ld: JsonLd::default(),
+        site_url: None,
+        head_validation: HeadValidation::Off,
+    }
+}
+
+#[test]
+fn compact_tweet_pages_do_not_ship_full_card_css() {
+    let html = generate_html(
+        &page(r#"<figure class="ox-tweet ox-tweet--fetched"></figure>"#),
+        &[],
+        &config(),
+    );
+    assert!(html.contains("ox-content:css:plugin-social:start"));
+    assert!(!html.contains("ox-content:css:plugin-social-tweet-full:start"));
+    assert!(!html.contains("--ox-tweet-color-blue"));
+}
+
+#[test]
+fn full_tweet_pages_ship_gated_full_card_css() {
+    let html = generate_html(
+        &page(r#"<figure class="ox-tweet ox-tweet--fetched ox-tweet--full"></figure>"#),
+        &[],
+        &config(),
+    );
+    assert!(html.contains("ox-content:css:plugin-social:start"));
+    assert!(html.contains("ox-content:css:plugin-social-tweet-full:start"));
+    assert!(html.contains("--ox-tweet-color-blue"));
+}

--- a/crates/ox_content_ssg/src/plugins/social-tweet-full-media.css
+++ b/crates/ox_content_ssg/src/plugins/social-tweet-full-media.css
@@ -1,0 +1,170 @@
+.ox-tweet--full .ox-tweet__media {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2px;
+  margin: 0.75rem 0 0;
+  overflow: hidden;
+  border: var(--ox-tweet-border);
+  border-radius: 12px;
+}
+
+.ox-tweet--full .ox-tweet__media[data-count="2"],
+.ox-tweet--full .ox-tweet__media[data-count="3"],
+.ox-tweet--full .ox-tweet__media[data-count="4"] {
+  grid-template-columns: 1fr 1fr;
+  aspect-ratio: 16 / 9;
+}
+
+.ox-tweet--full .ox-tweet__media[data-count="3"],
+.ox-tweet--full .ox-tweet__media[data-count="4"] {
+  grid-template-rows: 1fr 1fr;
+}
+
+.ox-tweet--full .ox-tweet__media[data-count="3"] > :first-child {
+  grid-row: span 2;
+}
+
+.ox-tweet--full .ox-tweet__media-item {
+  width: 100%;
+  height: auto;
+  border: 0;
+  border-radius: 0;
+}
+
+.ox-tweet--full .ox-tweet__media[data-count="2"] .ox-tweet__media-item,
+.ox-tweet--full .ox-tweet__media[data-count="3"] .ox-tweet__media-item,
+.ox-tweet--full .ox-tweet__media[data-count="4"] .ox-tweet__media-item {
+  height: 100%;
+  object-fit: cover;
+}
+
+.ox-tweet--full .ox-tweet__media-fallback {
+  position: relative;
+}
+
+.ox-tweet--full .ox-tweet__watch {
+  margin-top: 0.375rem;
+  font-size: 0.8125rem;
+}
+
+.ox-tweet--full .ox-tweet__quote {
+  margin: 0.75rem 0 0;
+  padding: 0.75rem;
+  overflow: hidden;
+  border: var(--ox-tweet-border);
+  border-radius: 12px;
+}
+
+.ox-tweet--full .ox-tweet__quote-header {
+  margin: 0;
+}
+
+.ox-tweet--full .ox-tweet__quote .ox-tweet__avatar {
+  width: 20px;
+  height: 20px;
+}
+
+.ox-tweet--full .ox-tweet__quote-body {
+  margin: 0.25rem 0 0;
+  font-size: var(--ox-tweet-quoted-body-font-size);
+  line-height: 1.25rem;
+}
+
+.ox-tweet--full .ox-tweet__quote .ox-tweet__media {
+  margin-top: 0.75rem;
+}
+
+.ox-tweet--full .ox-tweet__info,
+.ox-tweet--full .ox-tweet__actions {
+  display: flex;
+  align-items: center;
+  margin-top: 0.125rem;
+  overflow: hidden;
+  color: var(--ox-tweet-font-color-secondary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.ox-tweet--full .ox-tweet__actions {
+  padding-top: 0.25rem;
+  margin-top: 0.25rem;
+  border-top: var(--ox-tweet-border);
+}
+
+.ox-tweet--full .ox-tweet__permalink,
+.ox-tweet--full .ox-tweet__info-help,
+.ox-tweet--full .ox-tweet__action,
+.ox-tweet--full .ox-tweet__replies-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.ox-tweet--full .ox-tweet__permalink {
+  font-size: var(--ox-tweet-info-font-size);
+  line-height: 1.25rem;
+}
+
+.ox-tweet--full .ox-tweet__permalink:hover {
+  text-decoration: underline;
+}
+
+.ox-tweet--full .ox-tweet__info-help {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2em;
+  height: 2em;
+  margin-left: auto;
+  border-radius: 9999px;
+}
+
+.ox-tweet--full .ox-tweet__action {
+  display: flex;
+  align-items: center;
+  margin-right: 1.25rem;
+  font-size: var(--ox-tweet-actions-font-size);
+  font-weight: 700;
+  line-height: 1rem;
+}
+
+.ox-tweet--full .ox-tweet__action .ox-tweet__icon {
+  margin-right: 0.25rem;
+}
+
+.ox-tweet--full .ox-tweet__action--like:hover {
+  color: var(--ox-tweet-color-red);
+}
+
+.ox-tweet--full .ox-tweet__action--reply:hover {
+  color: var(--ox-tweet-color-blue-text);
+}
+
+.ox-tweet--full .ox-tweet__replies {
+  padding: 0.25rem 0 0;
+  margin: 0.5rem 0 0;
+  text-align: center;
+}
+
+.ox-tweet--full .ox-tweet__replies-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  padding: 0 1rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--ox-tweet-color-blue-text);
+  border: var(--ox-tweet-border);
+  border-radius: 9999px;
+}
+
+@media (max-width: 400px) {
+  .ox-tweet--full {
+    padding: 0.625rem 0.75rem;
+  }
+
+  .ox-tweet--full .ox-tweet__follow,
+  .ox-tweet--full .ox-tweet__sep {
+    display: none;
+  }
+}

--- a/crates/ox_content_ssg/src/plugins/social-tweet-full.css
+++ b/crates/ox_content_ssg/src/plugins/social-tweet-full.css
@@ -1,0 +1,210 @@
+/* Opt-in sveltweet / react-tweet chrome. Loaded only when a page has .ox-tweet--full. */
+
+.ox-tweet--full {
+  --ox-tweet-container-margin: 1.5rem 0;
+  --ox-tweet-header-font-size: 0.9375rem;
+  --ox-tweet-body-font-size: 1.25rem;
+  --ox-tweet-body-line-height: 1.5rem;
+  --ox-tweet-quoted-body-font-size: 0.938rem;
+  --ox-tweet-info-font-size: 0.9375rem;
+  --ox-tweet-actions-font-size: 0.875rem;
+  --ox-tweet-icon-size: 1.25em;
+  --ox-tweet-border: 1px solid rgb(207, 217, 222);
+  --ox-tweet-font-color: rgb(15, 20, 25);
+  --ox-tweet-font-color-secondary: rgb(83, 100, 113);
+  --ox-tweet-bg: #fff;
+  --ox-tweet-bg-hover: rgb(247, 249, 249);
+  --ox-tweet-quote-hover: rgba(0, 0, 0, 0.03);
+  --ox-tweet-color-blue: rgb(29, 155, 240);
+  --ox-tweet-color-blue-text: rgb(0, 111, 214);
+  --ox-tweet-color-blue-hover: rgba(0, 111, 214, 0.1);
+  --ox-tweet-color-red: rgb(249, 24, 128);
+  --ox-tweet-color-red-hover: rgba(249, 24, 128, 0.1);
+  --ox-tweet-verified-blue: var(--ox-tweet-color-blue);
+  --ox-tweet-verified-gold: rgb(226, 179, 64);
+  --ox-tweet-verified-gray: rgb(130, 154, 171);
+  --ox-tweet-icon-x: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.727-8.83L1.254 2.25H8.08l4.257 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117z'/%3E%3C/svg%3E");
+  --ox-tweet-icon-like: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M12 21.638h-.014C9.403 21.59 1.95 14.856 1.95 8.478c0-3.064 2.525-5.754 5.403-5.754 2.29 0 3.83 1.58 4.646 2.73.814-1.148 2.354-2.73 4.645-2.73 2.88 0 5.404 2.69 5.404 5.755 0 6.376-7.454 13.11-10.037 13.157H12z'/%3E%3C/svg%3E");
+  --ox-tweet-icon-reply: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81C17.04 14.42 18.25 12.37 18.25 10.14c0-3.39-2.744-6.13-6.129-6.13H9.756z'/%3E%3C/svg%3E");
+  --ox-tweet-icon-info: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M13.5 8.5c0 .83-.67 1.5-1.5 1.5s-1.5-.67-1.5-1.5S11.17 7 12 7s1.5.67 1.5 1.5zM13 17v-5h-2v5h2zm-1 5.25c5.66 0 10.25-4.59 10.25-10.25S17.66 1.75 12 1.75 1.75 6.34 1.75 12 6.34 22.25 12 22.25zM20.25 12c0 4.56-3.69 8.25-8.25 8.25S3.75 16.56 3.75 12 7.44 3.75 12 3.75s8.25 3.69 8.25 8.25z'/%3E%3C/svg%3E");
+  --ox-tweet-icon-badge: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M22.25 12c0-1.43-.88-2.67-2.19-3.34.46-1.39.2-2.9-.81-3.91s-2.52-1.27-3.91-.81c-.66-1.31-1.91-2.19-3.34-2.19s-2.67.88-3.34 2.19c-1.4-.46-2.91-.2-3.91.81s-1.27 2.52-.81 3.91c-1.31.67-2.19 1.91-2.19 3.34s.88 2.67 2.19 3.34c-.46 1.39-.2 2.9.81 3.91s2.52 1.27 3.91.81c.67 1.31 1.91 2.19 3.34 2.19s2.67-.88 3.34-2.19c1.4.46 2.91.2 3.91-.81s1.27-2.52.81-3.91c1.31-.67 2.19-1.91 2.19-3.34zm-11.71 4.2L6.8 12.46l1.41-1.42 2.26 2.26 4.8-5.23 1.47 1.36-6.2 6.77z'/%3E%3C/svg%3E");
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 550px;
+  min-width: 0;
+  margin: var(--ox-tweet-container-margin);
+  padding: 0.75rem 1rem;
+  overflow: hidden;
+  color: var(--ox-tweet-font-color);
+  border: var(--ox-tweet-border);
+  border-radius: 12px;
+  background: var(--ox-tweet-bg);
+}
+
+[data-theme="dark"] .ox-tweet--full {
+  --ox-tweet-border: 1px solid rgb(66, 83, 100);
+  --ox-tweet-font-color: rgb(247, 249, 249);
+  --ox-tweet-font-color-secondary: rgb(139, 152, 165);
+  --ox-tweet-bg: rgb(21, 32, 43);
+  --ox-tweet-bg-hover: rgb(30, 39, 50);
+  --ox-tweet-quote-hover: rgba(255, 255, 255, 0.03);
+  --ox-tweet-color-blue-text: rgb(107, 201, 251);
+  --ox-tweet-color-blue-hover: rgba(107, 201, 251, 0.1);
+  --ox-tweet-verified-blue: #fff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .ox-tweet--full {
+    --ox-tweet-border: 1px solid rgb(66, 83, 100);
+    --ox-tweet-font-color: rgb(247, 249, 249);
+    --ox-tweet-font-color-secondary: rgb(139, 152, 165);
+    --ox-tweet-bg: rgb(21, 32, 43);
+    --ox-tweet-bg-hover: rgb(30, 39, 50);
+    --ox-tweet-quote-hover: rgba(255, 255, 255, 0.03);
+    --ox-tweet-color-blue-text: rgb(107, 201, 251);
+    --ox-tweet-color-blue-hover: rgba(107, 201, 251, 0.1);
+    --ox-tweet-verified-blue: #fff;
+  }
+}
+
+.ox-tweet--full .ox-tweet__header {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  margin: 0 0 0.75rem;
+  overflow: hidden;
+  font-size: var(--ox-tweet-header-font-size);
+  line-height: 1.25rem;
+  white-space: nowrap;
+}
+
+.ox-tweet--full .ox-tweet__avatar-link {
+  flex: 0 0 48px;
+}
+
+.ox-tweet--full .ox-tweet__avatar {
+  width: 48px;
+  height: 48px;
+}
+
+.ox-tweet--full .ox-tweet__author {
+  min-width: 0;
+  margin: 0 0.5rem;
+}
+
+.ox-tweet--full .ox-tweet__author-name,
+.ox-tweet--full .ox-tweet__author-handle,
+.ox-tweet--full .ox-tweet__follow {
+  text-decoration: none;
+}
+
+.ox-tweet--full .ox-tweet__author-name {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  overflow: hidden;
+  font-weight: 700;
+  color: inherit;
+  text-overflow: ellipsis;
+}
+
+.ox-tweet--full .ox-tweet__author-name:hover,
+.ox-tweet--full .ox-tweet__follow:hover {
+  text-decoration: underline;
+}
+
+.ox-tweet--full .ox-tweet__author-meta {
+  display: flex;
+  min-width: 0;
+}
+
+.ox-tweet--full .ox-tweet__author-handle {
+  overflow: hidden;
+  color: var(--ox-tweet-font-color-secondary);
+  text-overflow: ellipsis;
+}
+
+.ox-tweet--full .ox-tweet__sep {
+  padding: 0 0.25rem;
+  color: var(--ox-tweet-font-color-secondary);
+}
+
+.ox-tweet--full .ox-tweet__follow {
+  font-weight: 700;
+  color: var(--ox-tweet-color-blue-text);
+}
+
+.ox-tweet--full .ox-tweet__brand {
+  margin-inline-start: auto;
+  color: inherit;
+}
+
+.ox-tweet--full .ox-tweet__badge,
+.ox-tweet--full .ox-tweet__icon {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 1.125em;
+  height: 1.125em;
+  background: currentColor;
+  -webkit-mask: var(--ox-tweet-icon-badge) center / contain no-repeat;
+  mask: var(--ox-tweet-icon-badge) center / contain no-repeat;
+}
+
+.ox-tweet--full .ox-tweet__icon {
+  width: var(--ox-tweet-icon-size);
+  height: var(--ox-tweet-icon-size);
+}
+
+.ox-tweet--full .ox-tweet__badge--blue {
+  color: var(--ox-tweet-verified-blue);
+}
+
+.ox-tweet--full .ox-tweet__badge--gold {
+  color: var(--ox-tweet-verified-gold);
+}
+
+.ox-tweet--full .ox-tweet__badge--gray {
+  color: var(--ox-tweet-verified-gray);
+}
+
+.ox-tweet--full .ox-tweet__icon--x {
+  -webkit-mask-image: var(--ox-tweet-icon-x);
+  mask-image: var(--ox-tweet-icon-x);
+}
+
+.ox-tweet--full .ox-tweet__icon--like {
+  color: var(--ox-tweet-color-red);
+  -webkit-mask-image: var(--ox-tweet-icon-like);
+  mask-image: var(--ox-tweet-icon-like);
+}
+
+.ox-tweet--full .ox-tweet__icon--reply {
+  color: var(--ox-tweet-color-blue);
+  -webkit-mask-image: var(--ox-tweet-icon-reply);
+  mask-image: var(--ox-tweet-icon-reply);
+}
+
+.ox-tweet--full .ox-tweet__icon--info {
+  -webkit-mask-image: var(--ox-tweet-icon-info);
+  mask-image: var(--ox-tweet-icon-info);
+}
+
+.ox-tweet--full .ox-tweet__reply {
+  margin: 0 0 0.25rem;
+  font-size: var(--ox-tweet-header-font-size);
+  line-height: 1.25rem;
+}
+
+.ox-tweet--full .ox-tweet__body {
+  margin: 0;
+  font-size: var(--ox-tweet-body-font-size);
+  font-weight: 400;
+  line-height: var(--ox-tweet-body-line-height);
+  overflow-wrap: break-word;
+}
+
+.ox-tweet--full .ox-tweet__body a,
+.ox-tweet--full .ox-tweet__quote-body a {
+  color: var(--ox-tweet-color-blue-text);
+  text-decoration: none;
+}

--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -194,7 +194,8 @@ card:
 Use the object form to fetch the post body, author, avatar, photos, and video
 posters at build time and serve them from your own origin. Fetched cards include
 a nested quoted-post card and a “Replying to @…” link when the syndication
-response has that metadata:
+response has that metadata. `appearance: "full"` opts into a sveltweet /
+react-tweet-shaped static card; the default `"compact"` card is unchanged:
 
 ```ts
 oxContent({
@@ -202,6 +203,7 @@ oxContent({
     twitter: {
       fetch: true,
       lang: "en",
+      appearance: "compact",
       mediaOutputDir: "public/ox-content/twitter",
       mediaPublicPath: "/ox-content/twitter",
     },
@@ -220,13 +222,15 @@ oxContent({
 | `mediaPublicPath` | `/ox-content/twitter`       | URL prefix emitted for downloaded media.         |
 | `downloadVideo`   | `false`                     | Download MP4 video and animated GIF assets.      |
 | `maxVideoBytes`   | `8388608`                   | Skip videos larger than this (8 MiB).            |
+| `appearance`      | `"compact"`                 | `"full"` for sveltweet-shaped static chrome.     |
 
 Downloaded media is served from your site, so a strict `img-src 'self'` CSP
 keeps working. Video and animated GIF posts use a self-hosted poster and a
 Watch on X permalink unless `downloadVideo` is enabled, and the generated HTML
 never includes `video.twimg.com`. Deleted or private posts fall back to the
 link-only card instead of failing the build. A missing quoted post is omitted
-without discarding the root card. See
+without discarding the root card. Full-card CSS ships only on pages that
+render `.ox-tweet--full`. See
 [Twitter/X Embed](../examples/twitter-embed.md) for details.
 
 ## Bluesky

--- a/docs/content/examples/twitter-embed.md
+++ b/docs/content/examples/twitter-embed.md
@@ -9,7 +9,9 @@ Twitter/X embeds are opt-in and never load a third-party widget script.
 `twitter: true` renders the privacy-conscious link card. Use the object form to
 fetch the post body, author, avatar, photos, and video posters at build time.
 Fetched cards also render a nested quoted-post card and a “Replying to @…” link
-when that metadata is present:
+when that metadata is present. Set `appearance: "full"` for a sveltweet /
+react-tweet-shaped static card, or override one embed with
+`appearance="full"`:
 
 ```ts
 import { oxContent } from "@ox-content/vite-plugin";
@@ -21,6 +23,7 @@ export default {
         twitter: {
           fetch: true,
           lang: "en",
+          appearance: "compact",
           mediaOutputDir: "public/ox-content/twitter",
           mediaPublicPath: "/ox-content/twitter",
         },
@@ -32,6 +35,7 @@ export default {
 
 ```html
 <XPost url="https://x.com/ox_content/status/1234567890" />
+<XPost url="https://x.com/ox_content/status/1234567890" appearance="full" />
 ```
 
 Fetched metadata is cached in memory and under `.cache/ox-content/twitter` by
@@ -55,3 +59,17 @@ root card.
 | `mediaPublicPath` | `/ox-content/twitter`       | URL prefix emitted for downloaded media.         |
 | `downloadVideo`   | `false`                     | Download MP4 video and animated GIF assets.      |
 | `maxVideoBytes`   | `8388608`                   | Skip videos larger than this (8 MiB).            |
+| `appearance`      | `"compact"`                 | `"full"` for sveltweet-shaped static chrome.     |
+
+Full appearance is static HTML/CSS: no hydration, widget iframe, or per-card
+listeners. It reuses the same materialized avatar/photo/video assets as compact.
+Pages that only render compact cards do not ship the full-card CSS.
+
+Intentional differences from `sveltweet@0.5.1` / `react-tweet`:
+
+- No copy control. It would need client JavaScript; the readable card does not.
+- No fonts or assets from the X/Twitter CDN. The card uses the page font stack.
+- Timestamps use UTC so build output does not depend on the viewer timezone.
+- Downloaded video uses native `<video controls>` instead of a custom player.
+- Government / legacy verified badges share the checkmark glyph and change color
+  only. Side-by-side sveltweet VRT is not in CI; HTML fixtures cover the states.

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -161,7 +161,7 @@ YouTube 埋め込みは SSG ビルドと dev preview で常に処理されます
 
 <XPost url="https://x.com/jack/status/20" />
 
-オブジェクト形式を使うと、ビルド時に本文、著者、アバター、写真、動画ポスターを取り、自分のオリジンから配信します。取ってきたカードには、syndication にそのメタデータがあるとき、引用投稿の入れ子カードと「Replying to @…」リンクも含まれます。
+オブジェクト形式を使うと、ビルド時に本文、著者、アバター、写真、動画ポスターを取り、自分のオリジンから配信します。取ってきたカードには、syndication にそのメタデータがあるとき、引用投稿の入れ子カードと「Replying to @…」リンクも含まれます。`appearance: "full"` は sveltweet / react-tweet 形の静的カードです。既定の `"compact"` カードは変わりません。
 
 ```ts
 oxContent({
@@ -169,6 +169,7 @@ oxContent({
     twitter: {
       fetch: true,
       lang: "en",
+      appearance: "compact",
       mediaOutputDir: "public/ox-content/twitter",
       mediaPublicPath: "/ox-content/twitter",
     },
@@ -187,8 +188,9 @@ oxContent({
 | `mediaPublicPath` | `/ox-content/twitter`       | ダウンロードしたメディアに出す URL プレフィックス。 |
 | `downloadVideo`   | `false`                     | ビルド時に MP4 動画とアニメーション GIF を取る。    |
 | `maxVideoBytes`   | `8388608`                   | これより大きい動画はスキップする（8 MiB）。         |
+| `appearance`      | `"compact"`                 | `"full"` で sveltweet 形の静的クロムを出す。        |
 
-ダウンロードしたメディアは自分のサイトから出すので、厳しい `img-src 'self'` CSP も動き続けます。動画とアニメーション GIF は、`downloadVideo` をオンにしない限り自前のポスターと Watch on X パーマリンクを使い、生成 HTML に `video.twimg.com` は出しません。削除済みや非公開の投稿は、ビルドを落とさずリンクのみのカードに落ちます。引用投稿が欠けていても、元の投稿カードは残します。詳細は [Twitter/X Embed](/examples/twitter-embed.md) を見てください。
+ダウンロードしたメディアは自分のサイトから出すので、厳しい `img-src 'self'` CSP も動き続けます。動画とアニメーション GIF は、`downloadVideo` をオンにしない限り自前のポスターと Watch on X パーマリンクを使い、生成 HTML に `video.twimg.com` は出しません。削除済みや非公開の投稿は、ビルドを落とさずリンクのみのカードに落ちます。引用投稿が欠けていても、元の投稿カードは残します。フルカード用 CSS は `.ox-tweet--full` を描画するページにだけ載ります。詳細は [Twitter/X Embed](/examples/twitter-embed.md) を見てください。
 
 ## Bluesky
 

--- a/npm/vite-plugin-ox-content/src/plugins/twitter-full.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter-full.test.ts
@@ -1,0 +1,259 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { clearTweetCache } from "./twitter/fetch";
+import { transformFetchedTweets } from "./twitter/transform";
+import { renderTweetText } from "./twitter/text";
+import type { TweetBodyData, TwitterEmbedOptions } from "./twitter/types";
+
+const originalFetch = globalThis.fetch;
+const POSTER = "https://pbs.twimg.com/amplify_video_thumb/1/img/poster.jpg";
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  clearTweetCache();
+});
+
+describe("full-fidelity Tweet cards", () => {
+  it("keeps compact markup by default and gates full chrome behind appearance", async () => {
+    const compact = await renderCard({ text: "Hello", user: user() });
+    expect(compact).toContain('class="ox-tweet ox-tweet--fetched"');
+    expect(compact).not.toContain("ox-tweet--full");
+    expect(compact).not.toContain("ox-tweet__actions");
+    expect(compact).not.toContain("ox-tweet__badge");
+
+    const full = await renderCard(
+      { text: "Hello", id_str: "555", user: user() },
+      { appearance: "full" },
+    );
+    expect(full).toContain('class="ox-tweet ox-tweet--fetched ox-tweet--full"');
+    expect(full).toContain("ox-tweet__actions");
+    expect(full).toContain("ox-tweet__replies");
+    expect(full).not.toContain("<script");
+  });
+
+  it("lets a per-element appearance override the site default", async () => {
+    const full = await renderCard(
+      { text: "Hello", id_str: "555", user: user() },
+      {},
+      {
+        html: '<XPost id="555" appearance="full" />',
+      },
+    );
+    expect(full).toContain("ox-tweet--full");
+
+    const compact = await renderCard(
+      { text: "Hello", id_str: "555", user: user() },
+      { appearance: "full" },
+      {
+        html: '<XPost id="555" appearance="compact" />',
+      },
+    );
+    expect(compact).not.toContain("ox-tweet--full");
+  });
+
+  it("renders URL, hashtag, mention, and symbol entities in one UTF-16 pass", () => {
+    const docs = "https://example.com/docs";
+    const text = `👍See ${docs} #ox @ox_content $OX 日本語`;
+    const html = renderTweetText(
+      body(
+        text,
+        {
+          urls: [
+            {
+              url: docs,
+              expanded_url: docs,
+              display_url: "example.com/docs",
+              indices: span(text, docs),
+            },
+          ],
+          hashtags: [{ text: "ox", indices: span(text, "#ox") }],
+          user_mentions: [{ screen_name: "ox_content", indices: span(text, "@ox_content") }],
+          symbols: [{ text: "OX", indices: span(text, "$OX") }],
+        },
+        2,
+      ),
+    );
+    expect(html).toContain('href="https://example.com/docs"');
+    expect(html).toContain('href="https://x.com/hashtag/ox"');
+    expect(html).toContain('href="https://x.com/ox_content"');
+    expect(html).toContain('href="https://x.com/search?q=%24OX"');
+    expect(html).toContain("日本語");
+    expect(html).not.toContain("👍");
+  });
+
+  it("drops unsafe mention hrefs and keeps JA/EN body text", () => {
+    const text = "こんにちは <script> @bad";
+    const html = renderTweetText(
+      body(text, {
+        user_mentions: [{ screen_name: '"><script>', indices: span(text, "@bad") }],
+      }),
+    );
+    expect(html).toContain("こんにちは");
+    expect(html).toContain("@bad");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).not.toContain('href="https://x.com/');
+  });
+
+  it("renders 1–4 photo grids, reply, quote+media, and video fallback", async () => {
+    for (const count of [1, 2, 3, 4]) {
+      const photos = await renderCard(photoPost(count), { appearance: "full" });
+      expect(photos).toContain(`data-count="${count}"`);
+      expect(photos.match(/ox-tweet__media-item/g)).toHaveLength(count);
+    }
+
+    const reply = await renderCard(
+      {
+        text: "Thanks",
+        id_str: "555",
+        user: user(),
+        in_reply_to_screen_name: "alice",
+        in_reply_to_status_id_str: "42",
+      },
+      { appearance: "full" },
+    );
+    expect(reply).toContain("Replying to @alice");
+
+    const quoted = await renderCard(
+      {
+        text: "See this",
+        id_str: "555",
+        user: user(),
+        quoted_tweet: {
+          id_str: "99",
+          text: "Quoted 写真",
+          user: { name: "Other", screen_name: "other", is_blue_verified: true },
+          mediaDetails: [
+            { type: "photo", media_url_https: "https://pbs.twimg.com/media/quoted.jpg" },
+          ],
+        },
+      },
+      { appearance: "full" },
+    );
+    expect(quoted).toContain("Quoted 写真");
+    expect(quoted).toContain("ox-tweet__badge--blue");
+    expect(quoted).toContain("/tweets/555-quoted-media-1.jpg");
+
+    const video = await renderCard(
+      {
+        text: "Watch",
+        id_str: "555",
+        user: user(),
+        mediaDetails: [
+          { type: "video", media_url_https: POSTER, original_info: { width: 16, height: 9 } },
+        ],
+      },
+      { appearance: "full" },
+    );
+    expect(video).toContain("ox-tweet__media-fallback");
+    expect(video).toContain("Watch on X");
+    expect(video).not.toContain("video.twimg.com");
+  });
+
+  it("renders verified variants, like/reply intents, and reply counts", async () => {
+    const blue = await renderCard(
+      {
+        text: "Hi",
+        id_str: "555",
+        favorite_count: 1500,
+        conversation_count: 12,
+        user: { ...user(), is_blue_verified: true },
+      },
+      { appearance: "full" },
+    );
+    expect(blue).toContain("ox-tweet__badge--blue");
+    expect(blue).toContain('href="https://x.com/intent/like?tweet_id=555"');
+    expect(blue).toContain('href="https://x.com/intent/tweet?in_reply_to=555"');
+    expect(blue).toContain("1.5K");
+    expect(blue).toContain("Read 12 replies");
+    expect(blue).toContain("Follow");
+    expect(blue).not.toContain("ox-tweet__action--copy");
+
+    const gold = await renderCard(
+      {
+        text: "Hi",
+        id_str: "555",
+        conversation_count: 1,
+        user: { ...user(), verified_type: "Business" },
+      },
+      { appearance: "full" },
+    );
+    expect(gold).toContain("ox-tweet__badge--gold");
+    expect(gold).toContain("Read 1 reply");
+
+    const gov = await renderCard(
+      {
+        text: "Hi",
+        id_str: "555",
+        user: { ...user(), verified_type: "Government" },
+      },
+      { appearance: "full" },
+    );
+    expect(gov).toContain("ox-tweet__badge--gray");
+    expect(gov).toContain("Read more on X");
+  });
+
+  it("keeps a cheap link-only fallback when the post cannot be fetched", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 404 }) as Response;
+    const input = '<Tweet id="987654">fallback summary</Tweet>';
+    await expect(
+      transformFetchedTweets(input, { fetch: true, cache: false, appearance: "full" }),
+    ).resolves.toBe(input);
+  });
+});
+
+function user() {
+  return { name: "Ox Content", screen_name: "ox_content" };
+}
+
+function body(
+  text: string,
+  entities: NonNullable<TweetBodyData["entities"]>,
+  start = 0,
+): TweetBodyData {
+  return { text, display_text_range: [start, text.length], user: user(), entities };
+}
+
+function span(text: string, value: string): [number, number] {
+  const start = text.indexOf(value);
+  return [start, start + value.length];
+}
+
+function photoPost(count: number) {
+  return {
+    text: "Photos",
+    id_str: "555",
+    user: user(),
+    mediaDetails: Array.from({ length: count }, (_, index) => ({
+      type: "photo",
+      media_url_https: `https://pbs.twimg.com/media/p${index}.jpg`,
+    })),
+  };
+}
+
+async function renderCard(
+  data: unknown,
+  twitter: TwitterEmbedOptions = {},
+  options?: { html?: string },
+): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "ox-tweet-full-"));
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.startsWith("https://cdn.syndication.twimg.com/")) {
+      return { ok: true, json: async () => data } as Response;
+    }
+    return { ok: true, arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer } as Response;
+  };
+  try {
+    return await transformFetchedTweets(options?.html ?? '<XPost id="555" />', {
+      fetch: true,
+      cache: false,
+      mediaOutputDir: path.join(root, "media"),
+      mediaPublicPath: "/tweets",
+      ...twitter,
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/npm/vite-plugin-ox-content/src/plugins/twitter.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter.test.ts
@@ -100,6 +100,7 @@ describe("fetched Twitter embeds", () => {
     try {
       const html = await transformMediaEmbeds(input, { twitter: options });
       expect(html).toContain('class="ox-tweet ox-tweet--fetched"');
+      expect(html).not.toContain("ox-tweet--full");
       expect(html).toContain("Ox &lt;Content&gt;");
       expect(html).toContain('href="https://example.com/docs"');
       expect(html).toContain(">example.com/docs</a>");

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/full.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/full.ts
@@ -1,0 +1,180 @@
+import { escapeAttribute, escapeHtml } from "./html";
+import { renderMedia } from "./markup";
+import { renderTweetText } from "./text";
+import type { TweetAssets, TweetBodyData, TweetData, TweetUser } from "./types";
+import { quotedPermalink, replyPermalink, sanitizeScreenName, sanitizeStatusId } from "./validate";
+
+const HELP_HREF = "https://help.x.com/en/x-for-websites-ads-info-and-privacy";
+
+export function renderFullTweet(permalink: string, data: TweetData, assets: TweetAssets): string {
+  const quote = data.quoted_tweet ? renderFullQuote(data.quoted_tweet, assets.quoted) : "";
+  return [
+    '<figure class="ox-tweet ox-tweet--fetched ox-tweet--full">',
+    renderFullHeader(data.user, assets.avatar, permalink),
+    renderReply(data),
+    `<div class="ox-tweet__body">${renderTweetText(data, { omitTrailingQuoteUrl: Boolean(quote) })}</div>`,
+    renderMedia(assets, permalink),
+    quote,
+    renderInfo(permalink, data.created_at),
+    renderActions(permalink, data),
+    renderReplies(permalink, data.conversation_count),
+    "</figure>",
+  ].join("");
+}
+
+function renderFullQuote(data: TweetBodyData, assets: TweetAssets | undefined): string {
+  const permalink = quotedPermalink(data) ?? "";
+  return [
+    '<blockquote class="ox-tweet__quote">',
+    renderQuoteHeader(data.user, assets?.avatar, permalink),
+    `<div class="ox-tweet__quote-body">${renderTweetText(data)}</div>`,
+    renderMedia(assets ?? { media: [] }, permalink),
+    "</blockquote>",
+  ].join("");
+}
+
+function renderFullHeader(
+  user: TweetUser,
+  avatarSrc: string | undefined,
+  permalink: string,
+): string {
+  const profile = profileHref(user);
+  const follow = followHref(user);
+  return [
+    '<header class="ox-tweet__header">',
+    `<a class="ox-tweet__avatar-link" href="${escapeAttribute(profile)}" target="_blank" rel="noopener noreferrer">`,
+    avatar(avatarSrc, 48),
+    "</a>",
+    '<div class="ox-tweet__author">',
+    `<a class="ox-tweet__author-name" href="${escapeAttribute(profile)}" target="_blank" rel="noopener noreferrer">${escapeHtml(user.name)}${verifiedBadge(user)}</a>`,
+    '<div class="ox-tweet__author-meta">',
+    `<a class="ox-tweet__author-handle" href="${escapeAttribute(profile)}" target="_blank" rel="noopener noreferrer">@${escapeHtml(user.screen_name)}</a>`,
+    follow
+      ? `<span class="ox-tweet__sep" aria-hidden="true">·</span><a class="ox-tweet__follow" href="${escapeAttribute(follow)}" target="_blank" rel="noopener noreferrer">Follow</a>`
+      : "",
+    "</div></div>",
+    `<a class="ox-tweet__brand" href="${escapeAttribute(permalink)}" target="_blank" rel="noopener noreferrer" aria-label="View on X"><span class="ox-tweet__icon ox-tweet__icon--x"></span></a>`,
+    "</header>",
+  ].join("");
+}
+
+function renderQuoteHeader(
+  user: TweetUser,
+  avatarSrc: string | undefined,
+  permalink: string,
+): string {
+  const href = permalink || profileHref(user);
+  return [
+    '<header class="ox-tweet__quote-header">',
+    `<a class="ox-tweet__profile" href="${escapeAttribute(href)}" target="_blank" rel="noopener noreferrer">`,
+    avatar(avatarSrc, 20),
+    `<span class="ox-tweet__author-name">${escapeHtml(user.name)}${verifiedBadge(user)}</span>`,
+    `<span class="ox-tweet__author-handle">@${escapeHtml(user.screen_name)}</span>`,
+    "</a></header>",
+  ].join("");
+}
+
+function renderReply(data: TweetData): string {
+  const href = replyPermalink(data);
+  const handle = data.in_reply_to_screen_name;
+  if (!href || !handle) return "";
+  return `<p class="ox-tweet__reply"><a class="ox-tweet__reply-link" href="${escapeAttribute(href)}" target="_blank" rel="noopener noreferrer">Replying to @${escapeHtml(handle)}</a></p>`;
+}
+
+function renderInfo(permalink: string, createdAt: string | undefined): string {
+  const formatted = formatFullDate(createdAt);
+  const time = formatted
+    ? `<a class="ox-tweet__permalink" href="${escapeAttribute(permalink)}" target="_blank" rel="noopener noreferrer"><time datetime="${formatted.iso}">${escapeHtml(formatted.label)}</time></a>`
+    : `<a class="ox-tweet__permalink" href="${escapeAttribute(permalink)}" target="_blank" rel="noopener noreferrer">View on X</a>`;
+  return `<div class="ox-tweet__info">${time}<a class="ox-tweet__info-help" href="${HELP_HREF}" target="_blank" rel="noopener noreferrer" aria-label="X for Websites, Ads Information and Privacy"><span class="ox-tweet__icon ox-tweet__icon--info"></span></a></div>`;
+}
+
+function renderActions(permalink: string, data: TweetData): string {
+  const id = statusId(data, permalink);
+  if (!id) return "";
+  const likes = formatCount(data.favorite_count);
+  return [
+    '<div class="ox-tweet__actions">',
+    `<a class="ox-tweet__action ox-tweet__action--like" href="https://x.com/intent/like?tweet_id=${id}" target="_blank" rel="noopener noreferrer"><span class="ox-tweet__icon ox-tweet__icon--like"></span><span>${likes}</span></a>`,
+    `<a class="ox-tweet__action ox-tweet__action--reply" href="https://x.com/intent/tweet?in_reply_to=${id}" target="_blank" rel="noopener noreferrer"><span class="ox-tweet__icon ox-tweet__icon--reply"></span>Reply</a>`,
+    "</div>",
+  ].join("");
+}
+
+function renderReplies(permalink: string, conversationCount: unknown): string {
+  return `<p class="ox-tweet__replies"><a class="ox-tweet__replies-link" href="${escapeAttribute(permalink)}" target="_blank" rel="noopener noreferrer">${escapeHtml(repliesLabel(conversationCount))}</a></p>`;
+}
+
+function avatar(src: string | undefined, size: number): string {
+  return src
+    ? `<img class="ox-tweet__avatar" src="${escapeAttribute(src)}" alt="" width="${size}" height="${size}" loading="lazy" decoding="async">`
+    : "";
+}
+
+function verifiedBadge(user: TweetUser): string {
+  const kind = verifiedKind(user);
+  return kind
+    ? `<span class="ox-tweet__badge ox-tweet__badge--${kind}" title="Verified"></span>`
+    : "";
+}
+
+function verifiedKind(user: TweetUser): "blue" | "gold" | "gray" | undefined {
+  if (user.verified_type === "Government") return "gray";
+  if (user.verified_type === "Business") return "gold";
+  if (user.is_blue_verified) return "blue";
+  if (user.verified) return "gray";
+  return undefined;
+}
+
+function profileHref(user: TweetUser): string {
+  const screen = sanitizeScreenName(user.screen_name) ?? user.screen_name;
+  return `https://x.com/${encodeURIComponent(screen)}`;
+}
+
+function followHref(user: TweetUser): string | undefined {
+  const screen = sanitizeScreenName(user.screen_name);
+  return screen
+    ? `https://x.com/intent/follow?screen_name=${encodeURIComponent(screen)}`
+    : undefined;
+}
+
+function statusId(data: TweetData, permalink: string): string | undefined {
+  return sanitizeStatusId(data.id_str) ?? permalink.match(/\/status\/(\d+)/)?.[1];
+}
+
+function formatCount(value: unknown): string {
+  const n =
+    typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0;
+  if (n > 999_999) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n > 999) return `${(n / 1000).toFixed(1)}K`;
+  return String(n);
+}
+
+function repliesLabel(value: unknown): string {
+  const n =
+    typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+  if (n === 0) return "Read more on X";
+  if (n === 1) return "Read 1 reply";
+  return `Read ${formatCount(n)} replies`;
+}
+
+function formatFullDate(createdAt: string | undefined): { iso: string; label: string } | undefined {
+  if (!createdAt) return undefined;
+  const date = new Date(createdAt);
+  if (Number.isNaN(date.valueOf())) return undefined;
+  const parts = new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).formatToParts(date);
+  const get = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((part) => part.type === type)?.value ?? "";
+  return {
+    iso: date.toISOString(),
+    label: `${get("hour")}:${get("minute")} ${get("dayPeriod")} · ${get("month")} ${get("day")}, ${get("year")}`,
+  };
+}

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/index.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/index.ts
@@ -4,6 +4,7 @@ export { resolveTwitterEmbedOptions, transformFetchedTweets } from "./transform"
 export { createSyndicationToken, parseTweetReference } from "./url";
 export type {
   ResolvedTwitterEmbedOptions,
+  TweetAppearance,
   TweetBodyData,
   TweetData,
   TweetEntity,

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/markup.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/markup.ts
@@ -1,0 +1,47 @@
+import { escapeAttribute } from "./html";
+import type { TweetAssets, TweetMediaAsset } from "./types";
+
+export function renderMedia(assets: TweetAssets, permalink: string): string {
+  if (assets.media.length === 0) return "";
+  const items = assets.media.map((item) => renderMediaItem(item, permalink)).join("");
+  return `<div class="ox-tweet__media" data-count="${assets.media.length}">${items}</div>`;
+}
+
+function renderMediaItem(item: TweetMediaAsset, permalink: string): string {
+  if (item.kind === "video" || item.kind === "animated_gif") {
+    return renderVideoItem(item, permalink);
+  }
+  const size = sizeAttributes(item);
+  return `<img class="ox-tweet__media-item" src="${escapeAttribute(item.src ?? "")}" alt="${escapeAttribute(item.alt ?? "")}"${size} loading="lazy" decoding="async">`;
+}
+
+function renderVideoItem(item: TweetMediaAsset, permalink: string): string {
+  const watch = watchOnX(permalink);
+  const size = sizeAttributes(item);
+  const src = selfHostedMediaSrc(item.src);
+  if (src) {
+    const poster = item.poster ? ` poster="${escapeAttribute(item.poster)}"` : "";
+    const gif = item.kind === "animated_gif" ? " muted loop" : "";
+    return `<video class="ox-tweet__media-item" src="${escapeAttribute(src)}"${poster}${size} controls playsinline preload="none"${gif}>${watch}</video>`;
+  }
+  const poster = item.poster
+    ? `<img src="${escapeAttribute(item.poster)}" alt="${escapeAttribute(item.alt ?? "")}"${size} loading="lazy" decoding="async">`
+    : "";
+  return `<div class="ox-tweet__media-item ox-tweet__media-fallback">${poster}${watch}</div>`;
+}
+
+function selfHostedMediaSrc(src: string | undefined): string | undefined {
+  return src && !src.includes("video.twimg.com") ? src : undefined;
+}
+
+function sizeAttributes(item: Pick<TweetMediaAsset, "width" | "height">): string {
+  return [
+    item.width ? ` width="${item.width}"` : "",
+    item.height ? ` height="${item.height}"` : "",
+  ].join("");
+}
+
+function watchOnX(permalink: string): string {
+  if (!permalink) return "";
+  return `<a class="ox-tweet__watch" href="${escapeAttribute(permalink)}" target="_blank" rel="noopener noreferrer">Watch on X</a>`;
+}

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/render.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/render.ts
@@ -1,12 +1,8 @@
+import { renderFullTweet } from "./full";
 import { escapeAttribute, escapeHtml } from "./html";
+import { renderMedia } from "./markup";
 import { renderTweetText } from "./text";
-import type {
-  ResolvedTwitterEmbedOptions,
-  TweetAssets,
-  TweetBodyData,
-  TweetData,
-  TweetMediaAsset,
-} from "./types";
+import type { ResolvedTwitterEmbedOptions, TweetAssets, TweetBodyData, TweetData } from "./types";
 import { quotedPermalink, replyPermalink, sanitizeScreenName } from "./validate";
 
 export { renderTweetText } from "./text";
@@ -17,6 +13,9 @@ export function renderFetchedTweet(
   assets: TweetAssets,
   options: ResolvedTwitterEmbedOptions,
 ): string {
+  if (options.appearance === "full") {
+    return renderFullTweet(permalink, data, assets);
+  }
   const quote = data.quoted_tweet ? renderQuotedTweet(data.quoted_tweet, assets.quoted) : "";
   return [
     '<figure class="ox-tweet ox-tweet--fetched">',
@@ -67,51 +66,6 @@ function renderReply(data: TweetData): string {
   const handle = data.in_reply_to_screen_name;
   if (!href || !handle) return "";
   return `<p class="ox-tweet__reply"><a class="ox-tweet__reply-link" href="${escapeAttribute(href)}" target="_blank" rel="noopener noreferrer">Replying to @${escapeHtml(handle)}</a></p>`;
-}
-
-function renderMedia(assets: TweetAssets, permalink: string): string {
-  if (assets.media.length === 0) return "";
-  const items = assets.media.map((item) => renderMediaItem(item, permalink)).join("");
-  return `<div class="ox-tweet__media" data-count="${assets.media.length}">${items}</div>`;
-}
-
-function renderMediaItem(item: TweetMediaAsset, permalink: string): string {
-  if (item.kind === "video" || item.kind === "animated_gif") {
-    return renderVideoItem(item, permalink);
-  }
-  const size = sizeAttributes(item);
-  return `<img class="ox-tweet__media-item" src="${escapeAttribute(item.src ?? "")}" alt="${escapeAttribute(item.alt ?? "")}"${size} loading="lazy" decoding="async">`;
-}
-
-function renderVideoItem(item: TweetMediaAsset, permalink: string): string {
-  const watch = watchOnX(permalink);
-  const size = sizeAttributes(item);
-  const src = selfHostedMediaSrc(item.src);
-  if (src) {
-    const poster = item.poster ? ` poster="${escapeAttribute(item.poster)}"` : "";
-    const gif = item.kind === "animated_gif" ? " muted loop" : "";
-    return `<video class="ox-tweet__media-item" src="${escapeAttribute(src)}"${poster}${size} controls playsinline preload="none"${gif}>${watch}</video>`;
-  }
-  const poster = item.poster
-    ? `<img src="${escapeAttribute(item.poster)}" alt="${escapeAttribute(item.alt ?? "")}"${size} loading="lazy" decoding="async">`
-    : "";
-  return `<div class="ox-tweet__media-item ox-tweet__media-fallback">${poster}${watch}</div>`;
-}
-
-function selfHostedMediaSrc(src: string | undefined): string | undefined {
-  return src && !src.includes("video.twimg.com") ? src : undefined;
-}
-
-function sizeAttributes(item: Pick<TweetMediaAsset, "width" | "height">): string {
-  return [
-    item.width ? ` width="${item.width}"` : "",
-    item.height ? ` height="${item.height}"` : "",
-  ].join("");
-}
-
-function watchOnX(permalink: string): string {
-  if (!permalink) return "";
-  return `<a class="ox-tweet__watch" href="${escapeAttribute(permalink)}" target="_blank" rel="noopener noreferrer">Watch on X</a>`;
 }
 
 function renderFooter(permalink: string, createdAt: string | undefined, lang: string): string {

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/text.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/text.ts
@@ -1,6 +1,14 @@
 import { escapeAttribute, escapeHtml, escapeText } from "./html";
-import type { TweetBodyData, TweetEntity } from "./types";
-import { visibleTextRange } from "./validate";
+import type { TweetBodyData, TweetIndexedEntity } from "./types";
+import { sanitizeScreenName, visibleTextRange } from "./validate";
+
+type EntityKind = "url" | "media" | "hashtag" | "mention" | "symbol";
+
+interface CollectedEntity extends TweetIndexedEntity {
+  kind: EntityKind;
+  href?: string;
+  label?: string;
+}
 
 export function renderTweetText(
   data: TweetBodyData,
@@ -17,10 +25,9 @@ export function renderTweetText(
     const [entityStart, entityEnd] = entity.indices!;
     if (entityStart < cursor) continue;
     output += escapeText(data.text.slice(cursor, entityStart));
-    if (entity.kind === "url") {
-      const href = entity.expanded_url ?? entity.url;
-      const label = entity.display_url ?? href;
-      output += `<a href="${escapeAttribute(href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a>`;
+    if (entity.href) {
+      const label = entity.label ?? data.text.slice(entityStart, entityEnd);
+      output += `<a href="${escapeAttribute(entity.href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a>`;
     }
     cursor = entityEnd;
   }
@@ -28,11 +35,45 @@ export function renderTweetText(
   return output.trim();
 }
 
-function collectEntities(data: TweetBodyData): Array<TweetEntity & { kind: "url" | "media" }> {
-  return [
-    ...(data.entities?.urls ?? []).map((entity) => ({ ...entity, kind: "url" as const })),
-    ...(data.entities?.media ?? []).map((entity) => ({ ...entity, kind: "media" as const })),
-  ];
+function collectEntities(data: TweetBodyData): CollectedEntity[] {
+  const collected: CollectedEntity[] = [];
+  for (const entity of data.entities?.urls ?? []) {
+    collected.push({
+      kind: "url",
+      indices: entity.indices,
+      href: entity.expanded_url ?? entity.url,
+      label: entity.display_url ?? entity.expanded_url ?? entity.url,
+    });
+  }
+  for (const entity of data.entities?.media ?? []) {
+    collected.push({ kind: "media", indices: entity.indices });
+  }
+  for (const entity of data.entities?.hashtags ?? []) {
+    if (!entity.text) continue;
+    collected.push({
+      kind: "hashtag",
+      indices: entity.indices,
+      href: `https://x.com/hashtag/${encodeURIComponent(entity.text)}`,
+    });
+  }
+  for (const entity of data.entities?.user_mentions ?? []) {
+    const screen = sanitizeScreenName(entity.screen_name);
+    if (!screen) continue;
+    collected.push({
+      kind: "mention",
+      indices: entity.indices,
+      href: `https://x.com/${encodeURIComponent(screen)}`,
+    });
+  }
+  for (const entity of data.entities?.symbols ?? []) {
+    if (!entity.text) continue;
+    collected.push({
+      kind: "symbol",
+      indices: entity.indices,
+      href: `https://x.com/search?q=%24${encodeURIComponent(entity.text)}`,
+    });
+  }
+  return collected;
 }
 
 function validRange(

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/transform.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/transform.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { fetchTweetData, materializeTweetAssets } from "./fetch";
 import { renderFetchedTweet } from "./render";
 import type { ResolvedTwitterEmbedOptions, TwitterEmbedOptions } from "./types";
-import { referenceFromAttributes } from "./url";
+import { tweetElementAttributes } from "./url";
 
 const TWEET_ELEMENT = /<(tweet|xpost)\b([^>]*?)(?:\/\s*>|>[\s\S]*?<\/\1\s*>)/gi;
 
@@ -19,6 +19,7 @@ export function resolveTwitterEmbedOptions(
     mediaPublicPath: options.mediaPublicPath ?? "/ox-content/twitter",
     downloadVideo: options.downloadVideo ?? false,
     maxVideoBytes: options.maxVideoBytes ?? 8_388_608,
+    appearance: options.appearance === "full" ? "full" : "compact",
   };
 }
 
@@ -34,22 +35,25 @@ export async function transformFetchedTweets(
   for (const match of html.matchAll(TWEET_ELEMENT)) {
     const index = match.index ?? 0;
     output += html.slice(cursor, index);
-    const reference = referenceFromAttributes(match[2]);
-    if (!reference) {
+    const attrs = tweetElementAttributes(match[2]);
+    if (!attrs.reference) {
       output += match[0];
       cursor = index + match[0].length;
       continue;
     }
 
-    const data = await fetchTweetData(reference.id, resolved);
+    const data = await fetchTweetData(attrs.reference.id, resolved);
     if (!data) {
       output += match[0];
       cursor = index + match[0].length;
       continue;
     }
 
-    const assets = await materializeTweetAssets(reference.id, data, resolved);
-    output += renderFetchedTweet(reference.url, data, assets, resolved);
+    const assets = await materializeTweetAssets(attrs.reference.id, data, resolved);
+    output += renderFetchedTweet(attrs.reference.url, data, assets, {
+      ...resolved,
+      appearance: attrs.appearance ?? resolved.appearance,
+    });
     cursor = index + match[0].length;
   }
   return output + html.slice(cursor);

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/types.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/types.ts
@@ -17,6 +17,8 @@ export interface TwitterEmbedOptions {
   downloadVideo?: boolean;
   /** Maximum video size in bytes. Oversized assets are skipped. @default 8388608 */
   maxVideoBytes?: number;
+  /** Fetched-card chrome. `"full"` matches sveltweet / react-tweet. @default "compact" */
+  appearance?: TweetAppearance;
 }
 
 export interface ResolvedTwitterEmbedOptions {
@@ -29,7 +31,10 @@ export interface ResolvedTwitterEmbedOptions {
   mediaPublicPath: string;
   downloadVideo: boolean;
   maxVideoBytes: number;
+  appearance: TweetAppearance;
 }
+
+export type TweetAppearance = "compact" | "full";
 
 export interface TweetEntity {
   url: string;
@@ -52,10 +57,29 @@ export interface TweetMedia extends TweetEntity {
   video_info?: { variants?: TweetVideoVariant[] };
 }
 
+export interface TweetIndexedEntity {
+  indices?: [number, number];
+}
+
+export interface TweetHashtagEntity extends TweetIndexedEntity {
+  text?: string;
+}
+
+export interface TweetMentionEntity extends TweetIndexedEntity {
+  screen_name?: string;
+}
+
+export interface TweetSymbolEntity extends TweetIndexedEntity {
+  text?: string;
+}
+
 export interface TweetUser {
   name: string;
   screen_name: string;
   profile_image_url_https?: string;
+  verified?: boolean;
+  is_blue_verified?: boolean;
+  verified_type?: string;
 }
 
 /** Root or quoted post body. Nested `quoted_tweet` is stripped during normalize. */
@@ -63,7 +87,13 @@ export interface TweetBodyData {
   text: string;
   id_str?: string;
   display_text_range?: [number, number];
-  entities?: { urls?: TweetEntity[]; media?: TweetMedia[] };
+  entities?: {
+    urls?: TweetEntity[];
+    media?: TweetMedia[];
+    hashtags?: TweetHashtagEntity[];
+    user_mentions?: TweetMentionEntity[];
+    symbols?: TweetSymbolEntity[];
+  };
   mediaDetails?: TweetMedia[];
   user: TweetUser;
   created_at?: string;
@@ -73,6 +103,8 @@ export interface TweetData extends TweetBodyData {
   quoted_tweet?: TweetBodyData;
   in_reply_to_screen_name?: string;
   in_reply_to_status_id_str?: string;
+  favorite_count?: number;
+  conversation_count?: number;
 }
 
 export interface TweetReference {

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/url.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/url.ts
@@ -1,4 +1,4 @@
-import type { TweetReference } from "./types";
+import type { TweetAppearance, TweetReference } from "./types";
 
 const STATUS_PATH = /^\/(?:[^/]+|i\/web)\/status\/(\d+)(?:\/.*)?$/;
 
@@ -33,11 +33,24 @@ export function parseTweetReference(value: string): TweetReference | null {
   }
 }
 
-export function referenceFromAttributes(attributes: string): TweetReference | null {
+export function tweetElementAttributes(attributes: string): {
+  reference: TweetReference | null;
+  appearance?: TweetAppearance;
+} {
   const values = new Map<string, string>();
-  const pattern = /\b(url|href|id)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/gi;
+  const pattern = /\b(url|href|id|appearance)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/gi;
   for (const match of attributes.matchAll(pattern)) {
     values.set(match[1].toLowerCase(), match[2] ?? match[3] ?? match[4] ?? "");
   }
-  return parseTweetReference(values.get("url") ?? values.get("href") ?? values.get("id") ?? "");
+  const appearance = values.get("appearance");
+  return {
+    reference: parseTweetReference(
+      values.get("url") ?? values.get("href") ?? values.get("id") ?? "",
+    ),
+    appearance: appearance === "full" || appearance === "compact" ? appearance : undefined,
+  };
+}
+
+export function referenceFromAttributes(attributes: string): TweetReference | null {
+  return tweetElementAttributes(attributes).reference;
 }


### PR DESCRIPTION
Closes #833


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790254898&installation_model_id=422833&pr_number=839&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F839&signature=439a198468587536b4dad2dfeaf30c061dc90ff9b511c68ee7dea9cadc57ea90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->