### PR TITLE
docs(twitter): add react-tweet and sveltweet license notices

### DIFF
--- a/crates/ox_content_ssg/src/plugins/social-tweet-full.css
+++ b/crates/ox_content_ssg/src/plugins/social-tweet-full.css
@@ -1,4 +1,40 @@
-/* Opt-in sveltweet / react-tweet chrome. Loaded only when a page has .ox-tweet--full. */
+/*
+ * Opt-in full-card chrome for Twitter/X embeds.
+ * Loaded only when a page has .ox-tweet--full.
+ *
+ * Visual tokens and control icons follow the theme contract of:
+ *
+ *   react-tweet — https://github.com/vercel/react-tweet
+ *   Copyright (c) 2023 Luis Alvarez
+ *
+ *   sveltweet — https://github.com/ryoppippi/sveltweet
+ *   Copyright (c) 2024 ryoppippi
+ *
+ * Both are MIT-licensed. The permission notice is included because this
+ * stylesheet is a substantial portion of that visual contract. Ox Content
+ * does not vendor their JavaScript, React, or Svelte components.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * X, Twitter, and related marks are trademarks of their respective owners.
+ */
 
 .ox-tweet--full {
   --ox-tweet-container-margin: 1.5rem 0;

--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -230,7 +230,10 @@ Watch on X permalink unless `downloadVideo` is enabled, and the generated HTML
 never includes `video.twimg.com`. Deleted or private posts fall back to the
 link-only card instead of failing the build. A missing quoted post is omitted
 without discarding the root card. Full-card CSS ships only on pages that
-render `.ox-tweet--full`. See
+render `.ox-tweet--full`. The full-card chrome follows the MIT-licensed
+[react-tweet](https://github.com/vercel/react-tweet) and
+[sveltweet](https://github.com/ryoppippi/sveltweet) visual contract; notices
+are in [Credits](../credits.md). See
 [Twitter/X Embed](../examples/twitter-embed.md) for details.
 
 ## Bluesky

--- a/docs/content/credits.md
+++ b/docs/content/credits.md
@@ -23,3 +23,19 @@ Contribution summary:
   documentation.
 - Improved documentation quality around generated API docs and user-facing
   docs.
+
+## Third-party attribution
+
+### react-tweet and sveltweet
+
+The opt-in Twitter/X `appearance: "full"` card is static HTML and CSS. Its
+visual contract — layout, color tokens, and control icons — follows
+[react-tweet](https://github.com/vercel/react-tweet) (MIT, Copyright (c) 2023
+Luis Alvarez) and [sveltweet](https://github.com/ryoppippi/sveltweet) (MIT,
+Copyright (c) 2024 ryoppippi). Ox Content does not depend on those packages at
+runtime.
+
+The MIT copyright notice and permission notice for both projects are
+reproduced in `crates/ox_content_ssg/src/plugins/social-tweet-full.css`.
+
+X, Twitter, and related marks are trademarks of their respective owners.

--- a/docs/content/examples/twitter-embed.md
+++ b/docs/content/examples/twitter-embed.md
@@ -65,6 +65,13 @@ Full appearance is static HTML/CSS: no hydration, widget iframe, or per-card
 listeners. It reuses the same materialized avatar/photo/video assets as compact.
 Pages that only render compact cards do not ship the full-card CSS.
 
+The full-card visual contract follows MIT-licensed
+[react-tweet](https://github.com/vercel/react-tweet) (Copyright (c) 2023 Luis
+Alvarez) and [sveltweet](https://github.com/ryoppippi/sveltweet) (Copyright (c)
+2024 ryoppippi). Notices are in [Credits](../credits.md) and
+`social-tweet-full.css`. X, Twitter, and related marks are trademarks of their
+respective owners.
+
 Intentional differences from `sveltweet@0.5.1` / `react-tweet`:
 
 - No copy control. It would need client JavaScript; the readable card does not.

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -190,7 +190,7 @@ oxContent({
 | `maxVideoBytes`   | `8388608`                   | これより大きい動画はスキップする（8 MiB）。         |
 | `appearance`      | `"compact"`                 | `"full"` で sveltweet 形の静的クロムを出す。        |
 
-ダウンロードしたメディアは自分のサイトから出すので、厳しい `img-src 'self'` CSP も動き続けます。動画とアニメーション GIF は、`downloadVideo` をオンにしない限り自前のポスターと Watch on X パーマリンクを使い、生成 HTML に `video.twimg.com` は出しません。削除済みや非公開の投稿は、ビルドを落とさずリンクのみのカードに落ちます。引用投稿が欠けていても、元の投稿カードは残します。フルカード用 CSS は `.ox-tweet--full` を描画するページにだけ載ります。詳細は [Twitter/X Embed](/examples/twitter-embed.md) を見てください。
+ダウンロードしたメディアは自分のサイトから出すので、厳しい `img-src 'self'` CSP も動き続けます。動画とアニメーション GIF は、`downloadVideo` をオンにしない限り自前のポスターと Watch on X パーマリンクを使い、生成 HTML に `video.twimg.com` は出しません。削除済みや非公開の投稿は、ビルドを落とさずリンクのみのカードに落ちます。引用投稿が欠けていても、元の投稿カードは残します。フルカード用 CSS は `.ox-tweet--full` を描画するページにだけ載ります。フルカードのクロムは MIT ライセンスの [react-tweet](https://github.com/vercel/react-tweet) と [sveltweet](https://github.com/ryoppippi/sveltweet) の見た目の契約に従います。帰属は [クレジット](../credits.md) にあります。詳細は [Twitter/X Embed](/examples/twitter-embed.md) を見てください。
 
 ## Bluesky
 

--- a/docs/content/ja/credits.md
+++ b/docs/content/ja/credits.md
@@ -21,3 +21,17 @@ JSDoc 対応とドキュメント品質まわりで、大きなコミュニテ�
 - JSDoc 対応を第一級の API ドキュメントワークフローとして形作るのに協力しました。
 - Ox Content 自身のドキュメントで使っている API ドキュメント生成パイプラインに貢献しました。
 - 生成 API ドキュメントとユーザー向けドキュメントの品質を改善しました。
+
+## 第三者の帰属
+
+### react-tweet と sveltweet
+
+Twitter / X の任意オプション `appearance: "full"` カードは静的 HTML / CSS です。見た目の契約（レイアウト、色トークン、操作アイコン）は
+[react-tweet](https://github.com/vercel/react-tweet)（MIT、Copyright (c) 2023
+Luis Alvarez）と [sveltweet](https://github.com/ryoppippi/sveltweet)（MIT、
+Copyright (c) 2024 ryoppippi）に従います。実行時にこれらのパッケージへ依存しません。
+
+両方のプロジェクトの MIT 著作権表示と許諾文は
+`crates/ox_content_ssg/src/plugins/social-tweet-full.css` に再掲しています。
+
+X、Twitter、および関連する標章は、それぞれの権利者の商標です。

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/full.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/full.ts
@@ -1,3 +1,6 @@
+// Static HTML for appearance: "full". Visual contract follows MIT-licensed
+// react-tweet (Copyright (c) 2023 Luis Alvarez) and sveltweet (Copyright (c)
+// 2024 ryoppippi). Notices live in social-tweet-full.css and docs/content/credits.md.
 import { escapeAttribute, escapeHtml } from "./html";
 import { renderMedia } from "./markup";
 import { renderTweetText } from "./text";


### PR DESCRIPTION
## Summary
- Reproduce the MIT copyright and permission notices for react-tweet and sveltweet next to the full-card CSS.
- Credit both projects on Credits (EN/JA) and in the Twitter embed docs.
- Note that X / Twitter marks are trademarks of their owners.

Closes #840

## Test plan
- [ ] Credits EN/JA show the third-party section with both copyright lines
- [ ] `social-tweet-full.css` header includes both MIT notices
- [ ] Embeds / twitter-embed docs mention the visual contract and Credits link
- [ ] File line limits stay under 350 for the touched CSS/TS sources


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790255524&installation_model_id=422833&pr_number=841&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F841&signature=0fa35232271c9a0b548d249e3bbe227ec0e059405d5ef0b7366796c3246463b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->