### PR TITLE
feat(embeds): honor YouTube start times

### DIFF
--- a/crates/ox_content_napi/src/transform_bindings.rs
+++ b/crates/ox_content_napi/src/transform_bindings.rs
@@ -253,3 +253,19 @@ pub fn transform_async(
     let opts = options.unwrap_or_default();
     AsyncTask::new(TransformTask { source, options: opts })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::transform_youtube_embeds;
+
+    #[test]
+    fn forwards_start_through_the_napi_wrapper() {
+        let html = transform_youtube_embeds(
+            r#"<youtube id="dQw4w9WgXcQ" start="4190"></youtube>"#.to_string(),
+            None,
+        );
+        assert!(
+            html.contains(r#"src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?start=4190""#)
+        );
+    }
+}

--- a/crates/ox_content_transform/src/youtube.rs
+++ b/crates/ox_content_transform/src/youtube.rs
@@ -96,7 +96,12 @@ pub fn transform_youtube(html: &str, options: &YouTubeEmbedOptions) -> String {
 
         match video_id {
             Some(video_id) => {
-                out.push_str(&render_embed(&video_id, options, element.title.as_deref()));
+                out.push_str(&render_embed(
+                    &video_id,
+                    options,
+                    element.title.as_deref(),
+                    element.start,
+                ));
             }
             // No usable id: leave the original element bytes in place.
             None => out.push_str(&html[start..end]),

--- a/crates/ox_content_transform/src/youtube/parser.rs
+++ b/crates/ox_content_transform/src/youtube/parser.rs
@@ -1,17 +1,14 @@
 use crate::html_scan::find_ci;
 
 /// A `<youtube ...>` element located in the source HTML.
-///
-/// Note: the `start` attribute is intentionally not read. The TS
-/// implementation this ports parsed HTML via hast, which coerces `start`
-/// (a known numeric attribute on `<ol>`) to a number and then dropped it in
-/// its string-only attribute reader, so `start` never reached the embed URL.
 pub(super) struct YouTubeElement {
     /// Byte range of the whole element (open tag through close tag or `/>`).
     pub(super) span: (usize, usize),
     pub(super) id: Option<String>,
     pub(super) url: Option<String>,
     pub(super) title: Option<String>,
+    /// First `start` attribute, if it is a non-negative integer of seconds.
+    pub(super) start: Option<u32>,
 }
 
 /// Find the next `<youtube ...>` element at or after `from`. Recognises both
@@ -57,12 +54,17 @@ pub(super) fn find_youtube_element(html: &str, from: usize) -> Option<YouTubeEle
         let self_closing = tag_end > after_name && bytes[tag_end - 1] == b'/';
 
         let inner_end = if self_closing { tag_end - 1 } else { tag_end };
-        let (mut id, mut url, mut title) = (None, None, None);
+        let (mut id, mut url, mut title, mut start) = (None, None, None, None);
+        let mut start_seen = false;
         for (name, value) in parse_attributes(&html[after_name..inner_end]) {
             match name.as_str() {
                 "id" if id.is_none() => id = Some(value),
                 "url" if url.is_none() => url = Some(value),
                 "title" if title.is_none() => title = Some(value),
+                "start" if !start_seen => {
+                    start_seen = true;
+                    start = parse_start_seconds(&value);
+                }
                 _ => {}
             }
         }
@@ -76,8 +78,17 @@ pub(super) fn find_youtube_element(html: &str, from: usize) -> Option<YouTubeEle
             }
         };
 
-        return Some(YouTubeElement { span: (tag_start, span_end), id, url, title });
+        return Some(YouTubeElement { span: (tag_start, span_end), id, url, title, start });
     }
+}
+
+/// Accept only a non-negative integer that fits in `u32`. Fractions, signs,
+/// whitespace, and overflow are ignored so hostile values never reach the URL.
+fn parse_start_seconds(value: &str) -> Option<u32> {
+    if value.is_empty() || !value.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    value.parse().ok()
 }
 
 /// Parse `name="value"` / `name='value'` / `name=value` / bare `name`

--- a/crates/ox_content_transform/src/youtube/render.rs
+++ b/crates/ox_content_transform/src/youtube/render.rs
@@ -16,21 +16,24 @@ fn escape_attribute(value: &str) -> String {
     out
 }
 
-fn build_embed_url(video_id: &str, options: &YouTubeEmbedOptions) -> String {
-    // Build directly from the validated id and option-selected host. Query
-    // string support is intentionally absent because the TS transform being
-    // ported dropped `start` before URL construction.
+fn build_embed_url(video_id: &str, options: &YouTubeEmbedOptions, start: Option<u32>) -> String {
+    // The video id is already restricted to `[A-Za-z0-9_-]{11}`, so it is
+    // safe to interpolate. `start` is digits-only `u32` from the parser.
     let domain =
         if options.privacy_enhanced { "www.youtube-nocookie.com" } else { "www.youtube.com" };
-    format!("https://{domain}/embed/{video_id}")
+    match start {
+        Some(seconds) => format!("https://{domain}/embed/{video_id}?start={seconds}"),
+        None => format!("https://{domain}/embed/{video_id}"),
+    }
 }
 
 pub(super) fn render_embed(
     video_id: &str,
     options: &YouTubeEmbedOptions,
     title: Option<&str>,
+    start: Option<u32>,
 ) -> String {
-    let embed_url = build_embed_url(video_id, options);
+    let embed_url = build_embed_url(video_id, options, start);
     // Escape the borrowed title directly instead of copying it into an owned
     // String first (`escape_attribute` already returns an owned String).
     let escaped_title = match title {

--- a/crates/ox_content_transform/src/youtube/tests.rs
+++ b/crates/ox_content_transform/src/youtube/tests.rs
@@ -14,15 +14,62 @@ fn wraps_bare_id_matching_characterization() {
 }
 
 #[test]
-fn extracts_from_url_and_title_ignoring_start() {
+fn extracts_from_url_and_honours_title_and_start() {
     let html = transform_youtube(
         r#"<youtube url="https://youtu.be/dQw4w9WgXcQ" title="Demo" start="30"></youtube>"#,
         &opts(),
     );
     assert_eq!(
         html,
-        r#"<div class="ox-youtube" style="aspect-ratio: 16/9;"><iframe src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ" title="Demo" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen loading="lazy"></iframe></div>"#
+        r#"<div class="ox-youtube" style="aspect-ratio: 16/9;"><iframe src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?start=30" title="Demo" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen loading="lazy"></iframe></div>"#
     );
+}
+
+#[test]
+fn honours_unquoted_zero_start() {
+    let html = transform_youtube(r#"<youtube id="dQw4w9WgXcQ" start=0></youtube>"#, &opts());
+    assert!(html.contains(r#"src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?start=0""#));
+}
+
+#[test]
+fn ignores_invalid_negative_fractional_overflow_and_hostile_start() {
+    for start in [
+        r#"start="-1""#,
+        r#"start="30.5""#,
+        r#"start="+30""#,
+        r#"start="4294967296""#,
+        r#"start="1e3""#,
+        r#"start="javascript:alert(1)""#,
+        r#"start="""#,
+    ] {
+        let input = format!(r#"<youtube id="dQw4w9WgXcQ" {start}></youtube>"#);
+        let html = transform_youtube(&input, &opts());
+        assert!(
+            html.contains(r#"src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ""#),
+            "{start} must drop the query string, got {html}"
+        );
+        assert!(!html.contains("start="), "{start} leaked into {html}");
+    }
+}
+
+#[test]
+fn first_start_wins_even_when_invalid() {
+    let html =
+        transform_youtube(r#"<youtube id="dQw4w9WgXcQ" start="-1" start="30"></youtube>"#, &opts());
+    assert!(html.contains(r#"src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ""#));
+    assert!(!html.contains("start="));
+}
+
+#[test]
+fn regular_host_keeps_start_query() {
+    let options = YouTubeEmbedOptions {
+        privacy_enhanced: false,
+        aspect_ratio: "16/9".to_string(),
+        allow_fullscreen: true,
+        lazy_load: true,
+    };
+    let html = transform_youtube(r#"<youtube id="dQw4w9WgXcQ" start="4190"></youtube>"#, &options);
+    assert!(html.contains(r#"src="https://www.youtube.com/embed/dQw4w9WgXcQ?start=4190""#));
 }
 
 #[test]

--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -177,7 +177,14 @@ default:
 <youtube id="aqz-KE-bpKQ" title="Big Buck Bunny" />
 
 `id`, `url`, and `href` attributes are accepted; `youtu.be`, `watch?v=`,
-`shorts`, and `embed` URL shapes are all recognized.
+`shorts`, and `embed` URL shapes are all recognized. `start` accepts a
+non-negative integer number of seconds and becomes `?start=` on the iframe
+URL. Invalid, negative, fractional, overflowing, or duplicated values are
+ignored. Omitting `start` leaves the previous URL unchanged.
+
+```md
+<youtube id="aqz-KE-bpKQ" title="Big Buck Bunny" start="4190" />
+```
 
 ## Twitter/X
 

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -149,7 +149,11 @@ YouTube 埋め込みは SSG ビルドと dev preview で常に処理されます
 
 <youtube id="aqz-KE-bpKQ" title="Big Buck Bunny" />
 
-`id`、`url`、`href` 属性を受け付けます。`youtu.be`、`watch?v=`、`shorts`、`embed` の URL 形はどれも認識します。
+`id`、`url`、`href` 属性を受け付けます。`youtu.be`、`watch?v=`、`shorts`、`embed` の URL 形はどれも認識します。`start` は非負整数の秒で、iframe URL に `?start=` を付けます。不正、負、小数、オーバーフロー、重複した値は無視します。`start` を省略すると、これまでの URL のままです。
+
+```md
+<youtube id="aqz-KE-bpKQ" title="Big Buck Bunny" start="4190" />
+```
 
 ## Twitter / X
 

--- a/npm/vite-plugin-ox-content/src/plugins/embed-transform.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/embed-transform.test.ts
@@ -31,12 +31,18 @@ describe("transformYouTube output", () => {
     );
     expect(html).toBe(
       `<div class="ox-youtube" style="aspect-ratio: 16/9;">` +
-        `<iframe src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ" ` +
+        `<iframe src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?start=30" ` +
         `title="Demo" ` +
         `allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" ` +
         `referrerpolicy="strict-origin-when-cross-origin" allowfullscreen loading="lazy">` +
         `</iframe></div>`,
     );
+  });
+
+  it("ignores an invalid start attribute", async () => {
+    const html = await transformYouTube(`<youtube id="dQw4w9WgXcQ" start="-1"></youtube>`);
+    expect(html).toContain(`src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"`);
+    expect(html).not.toContain("start=");
   });
 
   it("returns input unchanged when there is no <youtube> element", async () => {

--- a/npm/vite-plugin-ox-content/src/plugins/youtube.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/youtube.ts
@@ -2,7 +2,8 @@
  * YouTube Plugin - Privacy-enhanced iframe embedding
  *
  * Transforms <YouTube> components into responsive iframe embeds using
- * youtube-nocookie.com for enhanced privacy.
+ * youtube-nocookie.com for enhanced privacy. A digits-only `start` attribute
+ * becomes `?start=` on the iframe URL.
  *
  * The HTML rewrite is performed in Rust (`transformYoutubeEmbeds` in
  * @ox-content/napi), replacing the previous rehype parse/stringify


### PR DESCRIPTION
## Summary
- Honor a digits-only `start` attribute as `?start=` on the YouTube iframe URL.
- Ignore invalid, negative, fractional, overflowing, duplicated, or hostile values.
- Omitting `start` keeps the previous embed URL byte-for-byte.

Closes #822

## Test plan
- [ ] `<youtube id="…" start="4190" />` renders `?start=4190` on youtube-nocookie and youtube.com hosts
- [ ] `start="0"` and unquoted `start=0` emit `?start=0`
- [ ] Negative, fractional, overflow, empty, and hostile `start` values drop the query string
- [ ] A duplicated `start` uses the first attribute even when it is invalid
- [ ] No `start` matches the previous iframe HTML


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790255706&installation_model_id=422833&pr_number=842&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F842&signature=6367b0dae3bb73ae3854a00146f2924520d009c15f3fbb77bc8d86721efce12a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->