### PR TITLE
feat(ssg): include Git lastmod timestamps in sitemap.xml

### DIFF
--- a/crates/ox_content_ssg/src/site_maps.rs
+++ b/crates/ox_content_ssg/src/site_maps.rs
@@ -11,6 +11,8 @@ pub struct SiteMapPage {
     pub title: String,
     /// Optional page summary used by `llms.txt`.
     pub description: Option<String>,
+    /// Source-file git commit time in milliseconds. `None` omits `<lastmod>`.
+    pub last_updated: Option<i64>,
     /// When true, the page is omitted from every generated file.
     pub draft: bool,
     /// When true, the page is omitted from every generated file.
@@ -87,6 +89,31 @@ pub fn generate_site_maps(options: &SiteMapsOptions, pages: &[SiteMapPage]) -> S
     }
 }
 
+/// UTC `YYYY-MM-DD` for W3C lastmod. Negative timestamps are dropped.
+fn format_lastmod(timestamp_ms: Option<i64>) -> Option<String> {
+    let timestamp_ms = timestamp_ms.filter(|value| *value >= 0)?;
+    let days = (timestamp_ms / 1_000).div_euclid(86_400);
+    let (year, month, day) = civil_from_days(days);
+    if !(0..=9999).contains(&year) {
+        return None;
+    }
+    Some(format!("{year:04}-{month:02}-{day:02}"))
+}
+
+fn civil_from_days(days: i64) -> (i64, i64, i64) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let year = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = mp + if mp < 10 { 3 } else { -9 };
+    let year = year + i64::from(month <= 2);
+    (year, month, day)
+}
+
 fn has_site_url(site_url: Option<&str>) -> bool {
     site_url.is_some_and(|value| !value.trim().is_empty())
 }
@@ -99,7 +126,13 @@ fn generate_sitemap_xml(pages: &[&SiteMapPage]) -> String {
     for page in pages {
         xml.push_str("  <url>\n    <loc>");
         escape_xml(&page.loc, &mut xml);
-        xml.push_str("</loc>\n  </url>\n");
+        xml.push_str("</loc>\n");
+        if let Some(lastmod) = format_lastmod(page.last_updated) {
+            xml.push_str("    <lastmod>");
+            xml.push_str(&lastmod);
+            xml.push_str("</lastmod>\n");
+        }
+        xml.push_str("  </url>\n");
     }
     xml.push_str("</urlset>\n");
     xml

--- a/crates/ox_content_ssg/src/site_maps/tests.rs
+++ b/crates/ox_content_ssg/src/site_maps/tests.rs
@@ -5,6 +5,7 @@ fn page(loc: &str, title: &str, description: Option<&str>) -> SiteMapPage {
         loc: loc.to_string(),
         title: title.to_string(),
         description: description.map(str::to_string),
+        last_updated: None,
         draft: false,
         unlisted: false,
     }
@@ -183,4 +184,27 @@ fn sitemap_order_is_deterministic() {
     let m = sitemap.find("https://example.com/m/").expect("m");
     let z = sitemap.find("https://example.com/z/").expect("z");
     assert!(a < m && m < z, "{sitemap}");
+}
+
+#[test]
+fn writes_lastmod_from_git_timestamp_and_omits_invalid() {
+    let pages = vec![
+        SiteMapPage {
+            last_updated: Some(1_704_067_200_000),
+            ..page("https://example.com/fresh/", "Fresh", None)
+        },
+        SiteMapPage { last_updated: Some(-1), ..page("https://example.com/old/", "Old", None) },
+        page("https://example.com/plain/", "Plain", None),
+    ];
+    let sitemap = generate_site_maps(&enabled(Some("https://example.com")), &pages)
+        .sitemap_xml
+        .expect("pages should emit a sitemap");
+
+    assert!(
+        sitemap
+            .contains("<loc>https://example.com/fresh/</loc>\n    <lastmod>2024-01-01</lastmod>"),
+        "{sitemap}"
+    );
+    assert!(!sitemap.contains("https://example.com/old/</loc>\n    <lastmod>"), "{sitemap}");
+    assert!(!sitemap.contains("https://example.com/plain/</loc>\n    <lastmod>"), "{sitemap}");
 }

--- a/docs/content/built-in/site-maps.md
+++ b/docs/content/built-in/site-maps.md
@@ -8,7 +8,8 @@ description: Opt-in crawl manifests written next to generated HTML.
 When `siteMaps` is enabled and `ssg.siteUrl` is set, the SSG build writes
 crawl manifests next to the generated HTML:
 
-- `sitemap.xml` — every published page URL, sorted
+- `sitemap.xml` — every published page URL, sorted, with `<lastmod>` when Git
+  history is available
 - `robots.txt` — allow-all plus a Sitemap line
 - `llms.txt` — site title, description, and a page list
 
@@ -53,6 +54,12 @@ oxContent({
 `sitemap.xml` is always written when the feature is on. Pages with
 `draft: true` in frontmatter are omitted. When [`publishState`](./drafts.md)
 is also enabled, unlisted and not-yet-scheduled pages are omitted too.
+
+When Git history is available, each URL includes a W3C `<lastmod>` date. That
+value is the source file's latest Git commit time in UTC (`YYYY-MM-DD`), not
+the generated HTML mtime. Enabling `siteMaps` reuses the same Git lookup as
+`ssg.lastUpdated` and does not require the visible last-updated chrome. A
+shallow clone or missing history omits `<lastmod>` for that page.
 
 If `siteMaps` is enabled without `ssg.siteUrl`, no files are written. The build
 continues and emits a warning.

--- a/docs/content/ja/built-in/site-maps.md
+++ b/docs/content/ja/built-in/site-maps.md
@@ -7,7 +7,7 @@ description: 生成 HTML の横に書き出す、オプトインのクロール�
 
 `siteMaps` を有効にし、`ssg.siteUrl` を設定すると、SSG ビルドは生成 HTML の横にクロール用マニフェストを書き出します。
 
-- `sitemap.xml` — 公開ページの URL をソートして列挙
+- `sitemap.xml` — 公開ページの URL をソートして列挙。Git 履歴があれば `<lastmod>` も付ける
 - `robots.txt` — すべて許可し、Sitemap 行を付ける
 - `llms.txt` — サイトタイトル、説明、ページ一覧
 
@@ -49,6 +49,8 @@ oxContent({
 | `llms`     | `boolean`                     | `true`  |
 
 機能がオンなら `sitemap.xml` は必ず書き出します。frontmatter で `draft: true` のページは外れます。[`publishState`](./drafts.md) もオンなら、非公開（unlisted）とまだ公開時刻になっていないページも外れます。
+
+Git 履歴があるとき、各 URL に W3C の `<lastmod>` 日付が付きます。これはソースファイルの最新 Git コミット時刻（UTC の `YYYY-MM-DD`）であり、生成 HTML の mtime ではありません。`siteMaps` をオンにすると `ssg.lastUpdated` と同じ Git 参照を再利用し、表示用の last-updated クロムは不要です。浅い clone や履歴が無いページでは `<lastmod>` を省略します。
 
 `siteMaps` をオンにしても `ssg.siteUrl` がなければ、ファイルは書き出しません。ビルドは続き、警告を出します。
 

--- a/npm/vite-plugin-ox-content/src/site-maps.test.ts
+++ b/npm/vite-plugin-ox-content/src/site-maps.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, it } from "vite-plus/test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { generateSiteMaps, resolveSiteMapsOptions, writeSiteMapFiles } from "./site-maps";
+import {
+  formatLastmod,
+  generateSiteMaps,
+  resolveSiteMapsOptions,
+  writeSiteMapFiles,
+} from "./site-maps";
 
 const tempDirs: string[] = [];
 
@@ -251,5 +256,33 @@ describe("writeSiteMapFiles", () => {
       "Sitemap: https://example.com/docs/sitemap.xml",
     );
     expect(await fs.readFile(path.join(outDir, "llms.txt"), "utf8")).toContain("# Docs");
+  });
+});
+
+describe("sitemap lastmod", () => {
+  it("emits UTC lastmod from a git timestamp and omits invalid values", () => {
+    const output = generateSiteMaps({
+      options: { enabled: true, robots: false, llms: false },
+      siteUrl: "https://example.com",
+      pages: [
+        { loc: "https://example.com/fresh/", title: "Fresh", lastUpdated: 1_704_067_200_000 },
+        { loc: "https://example.com/old/", title: "Old", lastUpdated: -1 },
+        { loc: "https://example.com/plain/", title: "Plain" },
+      ],
+    });
+
+    expect(output.sitemapXml).toContain(
+      "<loc>https://example.com/fresh/</loc>\n    <lastmod>2024-01-01</lastmod>",
+    );
+    expect(output.sitemapXml).not.toContain("https://example.com/old/</loc>\n    <lastmod>");
+    expect(output.sitemapXml).not.toContain("https://example.com/plain/</loc>\n    <lastmod>");
+  });
+
+  it("formats only finite non-negative timestamps", () => {
+    expect(formatLastmod(1_704_067_200_000)).toBe("2024-01-01");
+    expect(formatLastmod(undefined)).toBeUndefined();
+    expect(formatLastmod(-1)).toBeUndefined();
+    expect(formatLastmod(Number.NaN)).toBeUndefined();
+    expect(formatLastmod(Number.POSITIVE_INFINITY)).toBeUndefined();
   });
 });

--- a/npm/vite-plugin-ox-content/src/site-maps.ts
+++ b/npm/vite-plugin-ox-content/src/site-maps.ts
@@ -17,6 +17,8 @@ export interface SiteMapPageInput {
   loc: string;
   title: string;
   description?: string;
+  /** Source-file git commit time in milliseconds. Omitted when Git has no history. */
+  lastUpdated?: number;
   draft?: boolean;
   unlisted?: boolean;
 }
@@ -133,6 +135,18 @@ export async function writeSiteMapFiles(
   return { files };
 }
 
+/** UTC `YYYY-MM-DD` for W3C lastmod. Invalid or negative timestamps are dropped. */
+export function formatLastmod(timestampMs: number | undefined): string | undefined {
+  if (timestampMs == null || !Number.isFinite(timestampMs) || timestampMs < 0) {
+    return undefined;
+  }
+  const date = new Date(timestampMs);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+  return date.toISOString().slice(0, 10);
+}
+
 function hasSiteUrl(siteUrl: string | undefined): boolean {
   return Boolean(siteUrl && siteUrl.trim());
 }
@@ -152,7 +166,14 @@ function generateSitemapXml(pages: readonly SiteMapPageInput[]): string {
   for (const page of pages) {
     xml += "  <url>\n    <loc>";
     xml += escapeXml(page.loc);
-    xml += "</loc>\n  </url>\n";
+    xml += "</loc>\n";
+    const lastmod = formatLastmod(page.lastUpdated);
+    if (lastmod) {
+      xml += "    <lastmod>";
+      xml += lastmod;
+      xml += "</lastmod>\n";
+    }
+    xml += "  </url>\n";
   }
   xml += "</urlset>\n";
   return xml;

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -1004,7 +1004,7 @@ async function createBuildSsgContext(
     siteName: await resolveSiteName(root, ssgOptions),
     shouldGenerateOgImages: shouldGenerateOgImages(options),
     napi:
-      ssgOptions.lastUpdated || ssgOptions.contributors || options.siteMaps.enabled
+      ssgOptions.lastUpdated || ssgOptions.contributors || options.siteMaps?.enabled
         ? await importNapiModule()
         : undefined,
   };
@@ -1217,7 +1217,7 @@ async function transformSsgPage(
     title,
     description: frontmatter.description as string | undefined,
     lastUpdated:
-      context.ssgOptions.lastUpdated || context.options.siteMaps.enabled
+      context.ssgOptions.lastUpdated || context.options.siteMaps?.enabled
         ? (context.napi?.getGitLastUpdated(inputPath, context.root) ?? undefined)
         : undefined,
     contributors: contributorsForPage(context, inputPath),

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -1003,7 +1003,10 @@ async function createBuildSsgContext(
     navItems,
     siteName: await resolveSiteName(root, ssgOptions),
     shouldGenerateOgImages: shouldGenerateOgImages(options),
-    napi: ssgOptions.lastUpdated || ssgOptions.contributors ? await importNapiModule() : undefined,
+    napi:
+      ssgOptions.lastUpdated || ssgOptions.contributors || options.siteMaps.enabled
+        ? await importNapiModule()
+        : undefined,
   };
 }
 
@@ -1213,9 +1216,10 @@ async function transformSsgPage(
     transformedHtml,
     title,
     description: frontmatter.description as string | undefined,
-    lastUpdated: context.ssgOptions.lastUpdated
-      ? (context.napi?.getGitLastUpdated(inputPath, context.root) ?? undefined)
-      : undefined,
+    lastUpdated:
+      context.ssgOptions.lastUpdated || context.options.siteMaps.enabled
+        ? (context.napi?.getGitLastUpdated(inputPath, context.root) ?? undefined)
+        : undefined,
     contributors: contributorsForPage(context, inputPath),
     frontmatter,
     toc: result.toc,
@@ -1850,13 +1854,21 @@ function sitemapPages(
   context: BuildSsgContext,
   listedPages: PageProcessResult[],
   outputPages: PageProcessResult[],
-): Array<{ loc: string; title: string; description?: string; draft: boolean; unlisted: boolean }> {
+): Array<{
+  loc: string;
+  title: string;
+  description?: string;
+  lastUpdated?: number;
+  draft: boolean;
+  unlisted: boolean;
+}> {
   const pages = context.options.publishState?.enabled ? listedPages : outputPages;
   const listedPaths = new Set(listedPages.map((page) => page.inputPath));
   return pages.map((page) => ({
     loc: canonicalPageUrl(context, page.routePaths.urlPath) ?? "",
     title: page.title,
     description: page.description,
+    lastUpdated: page.lastUpdated,
     draft: page.frontmatter.draft === true,
     unlisted: Boolean(context.options.publishState?.enabled) && !listedPaths.has(page.inputPath),
   }));


### PR DESCRIPTION
## Summary
- Propagate each page's existing Git last-updated timestamp into `sitemap.xml` as W3C `<lastmod>`.
- Enabling `siteMaps` reuses the same Git lookup as `ssg.lastUpdated` and does not require the visible last-updated chrome.
- Omit `<lastmod>` when Git history is missing or the timestamp is invalid.

Closes #834

## Test plan
- [ ] A page with a Git timestamp emits `<lastmod>YYYY-MM-DD</lastmod>` next to `<loc>`
- [ ] Negative, NaN, and missing timestamps omit `<lastmod>`
- [ ] Pages without Git history still emit `<loc>` only
- [ ] `siteMaps` without `ssg.lastUpdated` still resolves Git timestamps
- [ ] `ssg.lastUpdated: false` still hides the page chrome


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790255980&installation_model_id=422833&pr_number=843&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F843&signature=489e2759e69c01d6392080b24ab793196ea4e83fb4e459f9c5a1960f215fe8a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->