### PR TITLE
feat(blog): aggregate external feeds into the blog index (#827)

### DIFF
--- a/docs/content/built-in-features.md
+++ b/docs/content/built-in-features.md
@@ -19,49 +19,49 @@ inline**.
 
 ## Feature Guides
 
-| Guide                                                  | Covers                                                                    |
-| ------------------------------------------------------ | ------------------------------------------------------------------------- |
-| [Markdown Baseline](./built-in/markdown.md)            | GFM, tables, task lists, footnotes, autolinks, frontmatter, TOC           |
-| [Syntax Extensions](./built-in/syntax-extensions.md)   | Emoji shortcodes, wiki links, attribute syntax, CJK emphasis              |
-| [Custom Containers](./built-in/containers.md)          | Opt-in `::: tip` / `::: details` callout blocks                           |
-| [Cards](./built-in/cards.md)                           | Opt-in `::: card` / `::: link-card` / `::: card-grid` blocks              |
-| [Step Lists](./built-in/steps.md)                      | Opt-in `::: steps` tutorial lists                                         |
-| [File Includes](./built-in/includes.md)                | Opt-in `<!-- @include -->` Markdown fragments                             |
-| [File Tree](./built-in/file-tree.md)                   | Opt-in static `file-tree` directory diagrams                              |
-| [Inline Badges](./built-in/badges.md)                  | Opt-in `{badge:tip}` status labels in headings or prose                   |
-| [Images](./built-in/images.md)                         | Opt-in figures, captions, lazy loading, and safe dimensions               |
-| [Page resources](./built-in/resources.md)              | Opt-in page-bundle assets with resize, crop, and format transforms        |
-| [Code Blocks](./built-in/code-blocks.md)               | Syntax highlighting, code annotations, code imports                       |
-| [Embeds](./built-in/embeds.md)                         | GitHub cards, OG cards, package-manager tabs, tabs, YouTube, social cards |
-| [Mermaid Diagrams](./built-in/mermaid.md)              | Diagram fences rendered to static SVG                                     |
-| [Math](./built-in/math.md)                             | Opt-in `$…$` / `$$…$$` typeset with optional KaTeX                        |
-| [Search](./built-in/search.md)                         | The static BM25 index and client search API                               |
-| [Collections](./built-in/collections.md)               | Query Markdown files with a SQL-like builder                              |
-| [Quality Checks](./built-in/quality-checks.md)         | Code block lint, type checking, docs tests, HTML sanitizer                |
-| [Typed Hover](./built-in/typed-hover.md)               | Opt-in build-time TypeScript hover overlays for `twoslash` fences         |
-| [Site Generation](./built-in/site-generation.md)       | SSG, OG images, edit links, collections, API docs, transformers           |
-| [Page head](./built-in/page-head.md)                   | Build-time Unhead-compatible title / meta / link / JSON-LD API            |
-| [SEO](./built-in/seo.md)                               | Canonical, robots, hreflang, and head validation on that API              |
-| [Previous / Next](./built-in/pagination.md)            | Opt-in previous and next page links                                       |
-| [Breadcrumbs](./built-in/breadcrumbs.md)               | Opt-in trail from the site root through sidebar ancestors                 |
-| [JSON-LD](./built-in/json-ld.md)                       | Opt-in TechArticle / WebSite / BreadcrumbList structured data             |
-| [Reader Chrome](./built-in/reader-chrome.md)           | Opt-in copy, outbound-link icons, and back-to-top                         |
-| [Locale Switcher](./built-in/locale-switcher.md)       | Opt-in header control for configured locales                              |
-| [Accessibility](./built-in/a11y.md)                    | Opt-in skip link and print styles                                         |
-| [Header chrome](./built-in/header-chrome.md)           | Opt-in header nav, announcement bar, and per-page chrome                  |
-| [Sitemap / robots / llms.txt](./built-in/site-maps.md) | Opt-in crawl manifests written next to generated HTML                     |
-| [Draft / unlisted / scheduled](./built-in/drafts.md)   | Opt-in frontmatter publish states for production output                   |
-| [Permalinks and Cascade](./built-in/permalinks.md)     | Opt-in frontmatter URLs and directory-level default frontmatter           |
-| [Redirects and aliases](./built-in/redirects.md)       | Opt-in static HTML redirects from aliases and a rewrite map               |
-| [Custom 404](./built-in/not-found.md)                  | Opt-in themed 404 page with nav and search                                |
-| [RSS / Atom / JSON feeds](./built-in/feeds.md)         | Opt-in collection feeds written next to generated HTML                    |
-| [Blog](./built-in/blog.md)                             | Opt-in paginated index, authors, tags, reading time, and archive          |
-| [PWA manifest and service worker](./built-in/pwa.md)   | Opt-in web app manifest and conservative offline cache (adds client JS)   |
-| [Taxonomies](./built-in/taxonomies.md)                 | Opt-in tag/category term pages and related-page lists                     |
-| [Documentation versioning](./built-in/versioning.md)   | Opt-in prefixes, frozen snapshots, and a header version dropdown          |
-| [Team / members page](./built-in/team.md)              | Opt-in static member cards on `layout: team` pages                        |
-| [Git contributors](./built-in/contributors.md)         | Opt-in unique git authors under each article                              |
-| [Section index pages](./built-in/section-index.md)     | Opt-in generated listings for directories without `index.md`              |
+| Guide                                                  | Covers                                                                      |
+| ------------------------------------------------------ | --------------------------------------------------------------------------- |
+| [Markdown Baseline](./built-in/markdown.md)            | GFM, tables, task lists, footnotes, autolinks, frontmatter, TOC             |
+| [Syntax Extensions](./built-in/syntax-extensions.md)   | Emoji shortcodes, wiki links, attribute syntax, CJK emphasis                |
+| [Custom Containers](./built-in/containers.md)          | Opt-in `::: tip` / `::: details` callout blocks                             |
+| [Cards](./built-in/cards.md)                           | Opt-in `::: card` / `::: link-card` / `::: card-grid` blocks                |
+| [Step Lists](./built-in/steps.md)                      | Opt-in `::: steps` tutorial lists                                           |
+| [File Includes](./built-in/includes.md)                | Opt-in `<!-- @include -->` Markdown fragments                               |
+| [File Tree](./built-in/file-tree.md)                   | Opt-in static `file-tree` directory diagrams                                |
+| [Inline Badges](./built-in/badges.md)                  | Opt-in `{badge:tip}` status labels in headings or prose                     |
+| [Images](./built-in/images.md)                         | Opt-in figures, captions, lazy loading, and safe dimensions                 |
+| [Page resources](./built-in/resources.md)              | Opt-in page-bundle assets with resize, crop, and format transforms          |
+| [Code Blocks](./built-in/code-blocks.md)               | Syntax highlighting, code annotations, code imports                         |
+| [Embeds](./built-in/embeds.md)                         | GitHub cards, OG cards, package-manager tabs, tabs, YouTube, social cards   |
+| [Mermaid Diagrams](./built-in/mermaid.md)              | Diagram fences rendered to static SVG                                       |
+| [Math](./built-in/math.md)                             | Opt-in `$…$` / `$$…$$` typeset with optional KaTeX                          |
+| [Search](./built-in/search.md)                         | The static BM25 index and client search API                                 |
+| [Collections](./built-in/collections.md)               | Query Markdown files with a SQL-like builder                                |
+| [Quality Checks](./built-in/quality-checks.md)         | Code block lint, type checking, docs tests, HTML sanitizer                  |
+| [Typed Hover](./built-in/typed-hover.md)               | Opt-in build-time TypeScript hover overlays for `twoslash` fences           |
+| [Site Generation](./built-in/site-generation.md)       | SSG, OG images, edit links, collections, API docs, transformers             |
+| [Page head](./built-in/page-head.md)                   | Build-time Unhead-compatible title / meta / link / JSON-LD API              |
+| [SEO](./built-in/seo.md)                               | Canonical, robots, hreflang, and head validation on that API                |
+| [Previous / Next](./built-in/pagination.md)            | Opt-in previous and next page links                                         |
+| [Breadcrumbs](./built-in/breadcrumbs.md)               | Opt-in trail from the site root through sidebar ancestors                   |
+| [JSON-LD](./built-in/json-ld.md)                       | Opt-in TechArticle / WebSite / BreadcrumbList structured data               |
+| [Reader Chrome](./built-in/reader-chrome.md)           | Opt-in copy, outbound-link icons, and back-to-top                           |
+| [Locale Switcher](./built-in/locale-switcher.md)       | Opt-in header control for configured locales                                |
+| [Accessibility](./built-in/a11y.md)                    | Opt-in skip link and print styles                                           |
+| [Header chrome](./built-in/header-chrome.md)           | Opt-in header nav, announcement bar, and per-page chrome                    |
+| [Sitemap / robots / llms.txt](./built-in/site-maps.md) | Opt-in crawl manifests written next to generated HTML                       |
+| [Draft / unlisted / scheduled](./built-in/drafts.md)   | Opt-in frontmatter publish states for production output                     |
+| [Permalinks and Cascade](./built-in/permalinks.md)     | Opt-in frontmatter URLs and directory-level default frontmatter             |
+| [Redirects and aliases](./built-in/redirects.md)       | Opt-in static HTML redirects from aliases and a rewrite map                 |
+| [Custom 404](./built-in/not-found.md)                  | Opt-in themed 404 page with nav and search                                  |
+| [RSS / Atom / JSON feeds](./built-in/feeds.md)         | Opt-in collection feeds written next to generated HTML                      |
+| [Blog](./built-in/blog.md)                             | Opt-in paginated index, authors, tags, archive, and optional external feeds |
+| [PWA manifest and service worker](./built-in/pwa.md)   | Opt-in web app manifest and conservative offline cache (adds client JS)     |
+| [Taxonomies](./built-in/taxonomies.md)                 | Opt-in tag/category term pages and related-page lists                       |
+| [Documentation versioning](./built-in/versioning.md)   | Opt-in prefixes, frozen snapshots, and a header version dropdown            |
+| [Team / members page](./built-in/team.md)              | Opt-in static member cards on `layout: team` pages                          |
+| [Git contributors](./built-in/contributors.md)         | Opt-in unique git authors under each article                                |
+| [Section index pages](./built-in/section-index.md)     | Opt-in generated listings for directories without `index.md`                |
 
 ## Default vs Opt-in
 

--- a/docs/content/built-in/blog.md
+++ b/docs/content/built-in/blog.md
@@ -13,6 +13,7 @@ layout on top of collections:
 - Tag pages at `/blog/tags/{tag}/`
 - Yearly and monthly archive at `/blog/archive/`, `/blog/archive/{yyyy}/`, and
   `/blog/archive/{yyyy}/{mm}/`
+- Optional external RSS / Atom sources merged into that same index
 
 The feature is off unless you turn it on. Existing sites stay unchanged.
 Tags and archive are implemented here; they do not wait on taxonomies.
@@ -60,13 +61,14 @@ oxContent({
 });
 ```
 
-| Option       | Type                         | Default                                                      |
-| ------------ | ---------------------------- | ------------------------------------------------------------ |
-| `blog`       | `boolean` / `BlogOptions`    | `false`                                                      |
-| `ssg.blog`   | `boolean` / `BlogOptions`    | `false`                                                      |
-| `collection` | `string`                     | collection named `blog`, else the only configured collection |
-| `authors`    | `Record<string, BlogAuthor>` | `{}`                                                         |
-| `pageSize`   | `number`                     | `10`                                                         |
+| Option       | Type                           | Default                                                      |
+| ------------ | ------------------------------ | ------------------------------------------------------------ |
+| `blog`       | `boolean` / `BlogOptions`      | `false`                                                      |
+| `ssg.blog`   | `boolean` / `BlogOptions`      | `false`                                                      |
+| `collection` | `string`                       | collection named `blog`, else the only configured collection |
+| `authors`    | `Record<string, BlogAuthor>`   | `{}`                                                         |
+| `pageSize`   | `number`                       | `10`                                                         |
+| `feeds`      | `(string \| BlogFeedSource)[]` | `[]` (no fetch)                                              |
 
 ## Collection
 
@@ -159,6 +161,55 @@ maps to the same path:
 - `/blog/archive/{yyyy}/{mm}/` — posts in that month (`mm` is zero-padded)
 
 Posts without a parseable `date` stay on the index and tag pages only.
+
+## External feeds
+
+`feeds` is off unless you set a non-empty array. The build fetches only those
+configured URLs. Links inside Markdown or HTML are never requested.
+
+```ts
+oxContent({
+  blog: {
+    feeds: [
+      "https://example.com/rss.xml",
+      {
+        url: "https://example.com/atom.xml",
+        language: "ja",
+        author: "ada",
+        onError: "warn",
+      },
+    ],
+  },
+});
+```
+
+| Field      | Type               | Default | Role                                                          |
+| ---------- | ------------------ | ------- | ------------------------------------------------------------- |
+| `url`      | `string`           | —       | Absolute `https:` RSS or Atom URL                             |
+| `language` | `string`           | —       | Default language when an item omits one                       |
+| `author`   | `string`           | —       | Default author when an item omits one                         |
+| `onError`  | `"warn"`/`"error"` | `warn`  | Skip the source, or fail the build after other sources finish |
+
+A string entry is `{ url, onError: "warn" }`. Each unique URL is fetched once
+per build, not per page. The request uses a timeout, a redirect hop limit, a
+response size cap, and `https:`-only public hosts. Loopback, private, and
+link-local targets are rejected after DNS. HTML pages are not parsed.
+
+A failed source in `warn` mode is skipped; successful sources still merge. One
+bad source does not drop the rest of the blog. `onError: "error"` fails the
+build after the remaining sources finish.
+
+Items keep title, canonical `https:` link, publication date, stable id,
+language, and summary when present. They merge with local posts, newest first,
+then href. Duplicates match a canonical URL or an explicit stable id. The
+local post wins.
+
+External items carry an `external` marker (`class="ox-blog-external"`,
+`rel="external"`). Themes must keep the remote URL and must not rewrite the
+item to a local route.
+
+External items are **not** written to generated RSS, Atom, or JSON feeds.
+There is no include switch in this release.
 
 ## Drafts and unlisted posts
 

--- a/docs/content/built-in/feeds.md
+++ b/docs/content/built-in/feeds.md
@@ -67,9 +67,16 @@ continues and emits a warning.
 
 Titles and descriptions are escaped so they cannot break out of XML or JSON.
 
+## Blog index items
+
+External posts aggregated by [Blog](./blog.md) `blog.feeds` stay on the blog
+index only. They are omitted from these generated files. There is no include
+switch in this release.
+
 ## Related
 
 - [Collections](./collections.md)
+- [Blog](./blog.md)
 - [Sitemap / robots / llms.txt](./site-maps.md)
 - [Site Generation](./site-generation.md)
 - [Built-in Features overview](../built-in-features.md)

--- a/docs/content/built-in/site-generation.md
+++ b/docs/content/built-in/site-generation.md
@@ -80,7 +80,7 @@ export default defineConfig({
 | `a11y`            | `false`        | Skip link and print styles.                                                                           |
 | `notFound`        | `false`        | Themed 404 page. See [Custom 404](./not-found.md).                                                    |
 | `team`            | `false`        | Member cards on `layout: team`. See [Team](./team.md).                                                |
-| `blog`            | `false`        | Paginated index, authors, tags, archive. See [Blog](./blog.md).                                       |
+| `blog`            | `false`        | Paginated index, authors, tags, archive, optional external feeds. See [Blog](./blog.md).              |
 | `sectionIndex`    | `false`        | Generated listings for directories without `index.md`. See [Section index pages](./section-index.md). |
 | `pageChrome`      | `false`        | Honor per-page frontmatter chrome flags.                                                              |
 | `theme`           | `defaultTheme` | Theme configuration via `defineTheme()`.                                                              |

--- a/docs/content/ja/built-in-features.md
+++ b/docs/content/ja/built-in-features.md
@@ -51,7 +51,7 @@ Ox Content は、よく使うドキュメントの挙動を既定で載せ、非
 | [リダイレクトとエイリアス](./built-in/redirects.md)      | 静的 HTML リダイレクト                                                         |
 | [カスタム 404](./built-in/not-found.md)                  | テーマ付き 404                                                                 |
 | [RSS / Atom / JSON フィード](./built-in/feeds.md)        | コレクションからフィードを出力                                                 |
-| [ブログ](./built-in/blog.md)                             | ページ送り索引、著者、タグ、読了時間、アーカイブ                               |
+| [ブログ](./built-in/blog.md)                             | ページ送り索引、著者、タグ、アーカイブ、任意の外部フィード                     |
 | [PWA マニフェストとサービスワーカー](./built-in/pwa.md)  | Web アプリマニフェストと保守的なオフラインキャッシュ（クライアント JS を追加） |
 | [タクソノミー](./built-in/taxonomies.md)                 | タグ / カテゴリの用語ページと関連ページ                                        |
 | [ドキュメントのバージョン管理](./built-in/versioning.md) | プレフィックス、凍結スナップショット、切替 UI                                  |

--- a/docs/content/ja/built-in/blog.md
+++ b/docs/content/ja/built-in/blog.md
@@ -13,6 +13,7 @@ description: オプトインのページ送り索引、著者、タグ、読了�
 - `/blog/tags/{tag}/` のタグページ
 - `/blog/archive/`、`/blog/archive/{yyyy}/`、`/blog/archive/{yyyy}/{mm}/`
   の年次・月次アーカイブ
+- 同じ索引へマージする任意の外部 RSS / Atom ソース
 
 省略または `false` ではオフです。既存サイトの出力は変わりません。
 タグとアーカイブはこの機能の中で実装します。タクソノミー（#687）を待ちません。
@@ -58,13 +59,14 @@ oxContent({
 });
 ```
 
-| オプション   | 型                           | 既定                                                     |
-| ------------ | ---------------------------- | -------------------------------------------------------- |
-| `blog`       | `boolean` / `BlogOptions`    | `false`                                                  |
-| `ssg.blog`   | `boolean` / `BlogOptions`    | `false`                                                  |
-| `collection` | `string`                     | 名前が `blog` のコレクション、なければ唯一のコレクション |
-| `authors`    | `Record<string, BlogAuthor>` | `{}`                                                     |
-| `pageSize`   | `number`                     | `10`                                                     |
+| オプション   | 型                             | 既定                                                     |
+| ------------ | ------------------------------ | -------------------------------------------------------- |
+| `blog`       | `boolean` / `BlogOptions`      | `false`                                                  |
+| `ssg.blog`   | `boolean` / `BlogOptions`      | `false`                                                  |
+| `collection` | `string`                       | 名前が `blog` のコレクション、なければ唯一のコレクション |
+| `authors`    | `Record<string, BlogAuthor>`   | `{}`                                                     |
+| `pageSize`   | `number`                       | `10`                                                     |
+| `feeds`      | `(string \| BlogFeedSource)[]` | `[]`（取得しない）                                       |
 
 ## コレクション
 
@@ -155,6 +157,54 @@ tags:
 - `/blog/archive/{yyyy}/{mm}/` — その月の投稿（`mm` はゼロ埋め）
 
 パースできない `date` の投稿は索引とタグページにだけ載ります。
+
+## 外部フィード
+
+`feeds` は空でない配列を書いたときだけ動きます。ビルドが取るのはその
+設定 URL だけです。Markdown や HTML の中のリンクは取りに行きません。
+
+```ts
+oxContent({
+  blog: {
+    feeds: [
+      "https://example.com/rss.xml",
+      {
+        url: "https://example.com/atom.xml",
+        language: "ja",
+        author: "ada",
+        onError: "warn",
+      },
+    ],
+  },
+});
+```
+
+| フィールド | 型                 | 既定   | 役割                                                 |
+| ---------- | ------------------ | ------ | ---------------------------------------------------- |
+| `url`      | `string`           | —      | 絶対 `https:` の RSS または Atom URL                 |
+| `language` | `string`           | —      | 項目に言語が無いときの既定                           |
+| `author`   | `string`           | —      | 項目に著者が無いときの既定                           |
+| `onError`  | `"warn"`/`"error"` | `warn` | ソースを飛ばすか、他ソースのあとでビルドを失敗させる |
+
+文字列エントリは `{ url, onError: "warn" }` です。同じ URL はビルドあたり
+1 回だけ取ります。ページごとではありません。タイムアウト、リダイレクト回数、
+応答サイズ、`https:` の公開ホストだけ、が効きます。ループバック、プライベート、
+リンクローカルは DNS のあとで拒否します。HTML ページはパースしません。
+
+`warn` の失敗ソースは飛ばし、成功したソースはマージします。1 つの失敗で
+ブログ全体は落ちません。`onError: "error"` は残りのソースを終えたあとで
+ビルドを失敗させます。
+
+項目はタイトル、正規の `https:` リンク、公開日、安定 id、言語、要約がある
+ときそれを残します。ローカル投稿とマージし、新しい順、同じなら href です。
+重複は正規 URL か明示の安定 id で判定します。ローカル投稿が勝ちます。
+
+外部項目には `external` マーカー（`class="ox-blog-external"`、
+`rel="external"`）が付きます。テーマはリモート URL を残し、ローカル経路へ
+書き換えてはいけません。
+
+外部項目は生成する RSS / Atom / JSON フィードには**入りません**。
+このリリースに取り込みスイッチはありません。
 
 ## 下書きと非公開
 

--- a/docs/content/ja/built-in/feeds.md
+++ b/docs/content/ja/built-in/feeds.md
@@ -60,9 +60,15 @@ oxContent({
 
 タイトルと説明はエスケープされるので、XML や JSON の外へは出られません。
 
+## ブログ索引の項目
+
+[ブログ](./blog.md) の `blog.feeds` で集めた外部投稿は索引にだけ載ります。
+生成ファイルには入りません。このリリースに取り込みスイッチはありません。
+
 ## 関連
 
 - [コレクション](./collections.md)
+- [ブログ](./blog.md)
 - [Sitemap / robots / llms.txt](./site-maps.md)
 - [サイト生成](./site-generation.md)
 - [組み込み機能の一覧](../built-in-features.md)

--- a/docs/content/ja/built-in/site-generation.md
+++ b/docs/content/ja/built-in/site-generation.md
@@ -76,7 +76,7 @@ export default defineConfig({
 | `a11y`            | `false`        | スキップリンクと印刷スタイル。                                                                           |
 | `notFound`        | `false`        | テーマ付き 404。 [カスタム 404](./not-found.md) を見てください。                                         |
 | `team`            | `false`        | `layout: team` のメンバーカード。[チーム](./team.md) を見てください。                                    |
-| `blog`            | `false`        | ページ送り索引、著者、タグ、アーカイブ。[ブログ](./blog.md) を見てください。                             |
+| `blog`            | `false`        | ページ送り索引、著者、タグ、アーカイブ、任意の外部フィード。[ブログ](./blog.md) を見てください。         |
 | `sectionIndex`    | `false`        | `index.md` がないディレクトリ向けの生成一覧。[セクション索引ページ](./section-index.md) を見てください。 |
 | `pageChrome`      | `false`        | ページ単位の frontmatter chrome フラグを尊重する。                                                       |
 | `theme`           | `defaultTheme` | `defineTheme()` によるテーマ設定。                                                                       |

--- a/npm/vite-plugin-ox-content/src/blog-feed-date.ts
+++ b/npm/vite-plugin-ox-content/src/blog-feed-date.ts
@@ -1,0 +1,60 @@
+/**
+ * Publication dates from RSS / Atom items.
+ */
+
+import { parseDate, type ParsedDate } from "./feed-format";
+
+const MONTHS: Record<string, number> = {
+  jan: 1,
+  feb: 2,
+  mar: 3,
+  apr: 4,
+  may: 5,
+  jun: 6,
+  jul: 7,
+  aug: 8,
+  sep: 9,
+  oct: 10,
+  nov: 11,
+  dec: 12,
+};
+
+const RFC822 =
+  /^(?:[A-Za-z]{3},\s+)?(\d{1,2})\s+([A-Za-z]{3})\s+(\d{4})\s+(\d{2}):(\d{2})(?::(\d{2}))?\s+(?:GMT|UTC|UT|([+-]\d{4}))$/;
+
+export function parseFeedDate(value: string | undefined): ParsedDate | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return parseDate(trimmed) ?? parseRfc822(trimmed);
+}
+
+export function feedDateLabel(date: ParsedDate): string {
+  return `${String(date.year).padStart(4, "0")}-${String(date.month).padStart(2, "0")}-${String(date.day).padStart(2, "0")}`;
+}
+
+export function feedDateIso(date: ParsedDate): string {
+  return `${feedDateLabel(date)}T${String(date.hour).padStart(2, "0")}:${String(date.minute).padStart(2, "0")}:${String(date.second).padStart(2, "0")}Z`;
+}
+
+function parseRfc822(value: string): ParsedDate | undefined {
+  const match = value.match(RFC822);
+  if (!match) {
+    return undefined;
+  }
+  const month = MONTHS[match[2]?.toLowerCase() ?? ""];
+  if (!month) {
+    return undefined;
+  }
+  const day = match[1]?.padStart(2, "0");
+  const year = match[3];
+  const hour = match[4];
+  const minute = match[5];
+  const second = (match[6] ?? "00").padStart(2, "0");
+  const zone = match[7];
+  const tz = zone ? `${zone.slice(0, 3)}:${zone.slice(3)}` : "Z";
+  return parseDate(
+    `${year}-${String(month).padStart(2, "0")}-${day}T${hour}:${minute}:${second}${tz}`,
+  );
+}

--- a/npm/vite-plugin-ox-content/src/blog-feed-fetch.ts
+++ b/npm/vite-plugin-ox-content/src/blog-feed-fetch.ts
@@ -1,0 +1,195 @@
+/**
+ * Build-time fetch of configured blog feeds. Never used for document URLs.
+ */
+
+import { lookup as dnsLookup } from "node:dns/promises";
+import { isBlockedFeedAddress, isSafeFeedUrl } from "./blog-feed-url";
+
+export const BLOG_FEED_TIMEOUT_MS = 10_000;
+export const BLOG_FEED_MAX_BYTES = 1_048_576;
+export const BLOG_FEED_MAX_REDIRECTS = 5;
+
+export type BlogFeedLookup = (hostname: string) => Promise<string[]>;
+export type BlogFeedFetchFn = (input: string, init?: RequestInit) => Promise<Response>;
+
+export interface BlogFeedFetchLimits {
+  timeoutMs?: number;
+  maxBytes?: number;
+  maxRedirects?: number;
+}
+
+export interface BlogFeedNetwork {
+  fetch?: BlogFeedFetchFn;
+  lookup?: BlogFeedLookup;
+  limits?: BlogFeedFetchLimits;
+}
+
+let installedNetwork: BlogFeedNetwork = {};
+
+/** Test hook. Production builds leave this empty. */
+export function installBlogFeedNetwork(network: BlogFeedNetwork): void {
+  installedNetwork = network;
+}
+
+export function resetBlogFeedNetwork(): void {
+  installedNetwork = {};
+}
+
+export async function fetchBlogFeedBody(
+  url: string,
+  network: BlogFeedNetwork = {},
+): Promise<string> {
+  const timeoutMs =
+    network.limits?.timeoutMs ?? installedNetwork.limits?.timeoutMs ?? BLOG_FEED_TIMEOUT_MS;
+  const maxBytes =
+    network.limits?.maxBytes ?? installedNetwork.limits?.maxBytes ?? BLOG_FEED_MAX_BYTES;
+  const maxRedirects =
+    network.limits?.maxRedirects ??
+    installedNetwork.limits?.maxRedirects ??
+    BLOG_FEED_MAX_REDIRECTS;
+  const fetchFn = network.fetch ?? installedNetwork.fetch ?? defaultFetch;
+  const lookup = network.lookup ?? installedNetwork.lookup ?? defaultLookup;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await followFeed(url, fetchFn, lookup, controller.signal, maxBytes, maxRedirects);
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw new Error("timeout");
+    }
+    throw error instanceof Error ? error : new Error(String(error));
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function followFeed(
+  startUrl: string,
+  fetchFn: BlogFeedFetchFn,
+  lookup: BlogFeedLookup,
+  signal: AbortSignal,
+  maxBytes: number,
+  maxRedirects: number,
+): Promise<string> {
+  const seen = new Set<string>();
+  let current = startUrl;
+  for (let hops = 0; hops <= maxRedirects; hops += 1) {
+    await assertSafeFeedTarget(current, lookup);
+    if (seen.has(current)) {
+      throw new Error("too many redirects");
+    }
+    seen.add(current);
+    const response = await fetchFn(current, {
+      method: "GET",
+      redirect: "manual",
+      signal,
+      headers: {
+        Accept: "application/rss+xml, application/atom+xml, application/xml, text/xml;q=0.9",
+        "User-Agent": "ox-content-blog-feeds/1.0",
+      },
+    });
+    if (isRedirect(response.status)) {
+      const next = resolveRedirect(current, response.headers.get("location"));
+      current = next;
+      continue;
+    }
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    assertFeedContentType(response.headers.get("content-type"));
+    return readBoundedBody(response, maxBytes);
+  }
+  throw new Error("too many redirects");
+}
+
+export async function assertSafeFeedTarget(url: string, lookup: BlogFeedLookup): Promise<void> {
+  if (!isSafeFeedUrl(url)) {
+    throw new Error("unsafe URL");
+  }
+  const hostname = new URL(url).hostname;
+  const addresses = await lookup(hostname);
+  if (addresses.length === 0 || addresses.some((address) => isBlockedFeedAddress(address))) {
+    throw new Error("private network");
+  }
+}
+
+async function defaultLookup(hostname: string): Promise<string[]> {
+  const records = await dnsLookup(hostname, { all: true, verbatim: true });
+  return records.map((record) => record.address);
+}
+
+function defaultFetch(input: string, init?: RequestInit): Promise<Response> {
+  return fetch(input, init);
+}
+
+function isRedirect(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+function resolveRedirect(current: string, location: string | null): string {
+  if (!location?.trim()) {
+    throw new Error("too many redirects");
+  }
+  try {
+    return new URL(location, current).href;
+  } catch {
+    throw new Error("unsafe URL");
+  }
+}
+
+function assertFeedContentType(value: string | null): void {
+  if (!value) {
+    return;
+  }
+  const type = value.split(";")[0]?.trim().toLowerCase() ?? "";
+  if (type === "text/html" || type === "application/xhtml+xml" || type === "application/json") {
+    throw new Error("not a feed");
+  }
+}
+
+async function readBoundedBody(response: Response, maxBytes: number): Promise<string> {
+  const length = Number(response.headers.get("content-length"));
+  if (Number.isFinite(length) && length > maxBytes) {
+    throw new Error("oversized");
+  }
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const text = await response.text();
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
+      throw new Error("oversized");
+    }
+    return text;
+  }
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    if (!value) {
+      continue;
+    }
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      throw new Error("oversized");
+    }
+    chunks.push(value);
+  }
+  return new TextDecoder("utf-8").decode(concatBytes(chunks, total));
+}
+
+function concatBytes(chunks: readonly Uint8Array[], total: number): Uint8Array {
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === "AbortError" || error.message === "timeout");
+}

--- a/npm/vite-plugin-ox-content/src/blog-feed-parse.test.ts
+++ b/npm/vite-plugin-ox-content/src/blog-feed-parse.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vite-plus/test";
+import { parseBlogFeed } from "./blog-feed-parse";
+
+const RSS = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Notes</title>
+    <language>en</language>
+    <item>
+      <title>Older</title>
+      <link>https://example.com/older/</link>
+      <guid>https://example.com/older/</guid>
+      <pubDate>Wed, 01 Mar 2024 10:00:00 +0900</pubDate>
+      <description>Older summary</description>
+    </item>
+    <item>
+      <title>Newer</title>
+      <link>https://example.com/newer</link>
+      <guid isPermaLink="false">urn:uuid:newer</guid>
+      <pubDate>Wed, 01 Mar 2024 01:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title></title>
+      <link>https://example.com/missing</link>
+    </item>
+  </channel>
+</rss>
+`;
+
+const ATOM = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="ja">
+  <title>Atom</title>
+  <entry>
+    <title>Atom post</title>
+    <id>tag:example.com,2024:atom</id>
+    <link rel="related" href="https://example.com/related"/>
+    <link rel="alternate" href="https://example.com/atom-post"/>
+    <published>2024-02-01T00:00:00Z</published>
+    <summary>Atom summary</summary>
+  </entry>
+</feed>
+`;
+
+describe("parseBlogFeed", () => {
+  it("normalizes RSS items and skips entries without a title or https link", () => {
+    const items = parseBlogFeed(RSS);
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({
+      title: "Older",
+      link: "https://example.com/older",
+      id: "https://example.com/older/",
+      language: "en",
+      summary: "Older summary",
+    });
+    expect(items[0]?.date?.unix).toBe(items[1]?.date?.unix);
+    expect(items[1]).toMatchObject({
+      title: "Newer",
+      link: "https://example.com/newer",
+      id: "urn:uuid:newer",
+    });
+  });
+
+  it("prefers Atom alternate links and keeps a stable id", () => {
+    const items = parseBlogFeed(ATOM);
+    expect(items).toEqual([
+      expect.objectContaining({
+        title: "Atom post",
+        link: "https://example.com/atom-post",
+        id: "tag:example.com,2024:atom",
+        language: "ja",
+        summary: "Atom summary",
+      }),
+    ]);
+  });
+
+  it("rejects HTML pages and malformed XML", () => {
+    expect(() => parseBlogFeed("<!DOCTYPE html><html><body>not a feed</body></html>")).toThrow(
+      "not a feed",
+    );
+    expect(() => parseBlogFeed('{ "items": [] }')).toThrow("malformed XML");
+  });
+});

--- a/npm/vite-plugin-ox-content/src/blog-feed-parse.ts
+++ b/npm/vite-plugin-ox-content/src/blog-feed-parse.ts
@@ -1,0 +1,184 @@
+/**
+ * RSS 2.0 / Atom 1.0 item extraction. HTML documents are rejected.
+ */
+
+import { canonicalizeFeedItemUrl } from "./blog-feed-url";
+import { parseFeedDate } from "./blog-feed-date";
+import type { ParsedDate } from "./feed-format";
+
+const ITEM_BLOCK = /<(?:[\w.-]+:)?item\b[^>]*>([\s\S]*?)<\/(?:[\w.-]+:)?item>/gi;
+const ENTRY_BLOCK = /<(?:[\w.-]+:)?entry\b[^>]*>([\s\S]*?)<\/(?:[\w.-]+:)?entry>/gi;
+
+export interface ParsedFeedItem {
+  title: string;
+  link: string;
+  id: string;
+  date?: ParsedDate;
+  language?: string;
+  summary?: string;
+}
+
+export function parseBlogFeed(body: string, feedLanguage?: string): ParsedFeedItem[] {
+  const xml = stripBom(body);
+  if (looksLikeHtml(xml)) {
+    throw new Error("not a feed");
+  }
+  if (!looksLikeXmlFeed(xml)) {
+    throw new Error("malformed XML");
+  }
+  const channelLanguage =
+    textChild(xml, ["language", "dc:language"]) ?? xmlLang(xml) ?? feedLanguage;
+  const items = collectBlocks(xml, ITEM_BLOCK).map((block) =>
+    normalizeRssItem(block, channelLanguage),
+  );
+  if (items.length > 0 || /<(?:[\w.-]+:)?rss\b/i.test(xml)) {
+    return items.filter((item): item is ParsedFeedItem => item != null);
+  }
+  return collectBlocks(xml, ENTRY_BLOCK)
+    .map((block) => normalizeAtomEntry(block, channelLanguage))
+    .filter((item): item is ParsedFeedItem => item != null);
+}
+
+function normalizeRssItem(block: string, fallbackLanguage?: string): ParsedFeedItem | undefined {
+  const title = textChild(block, ["title"]);
+  const guid = guidChild(block);
+  const link =
+    canonicalizeFeedItemUrl(textChild(block, ["link"]) ?? "") ??
+    (guid?.permalink ? canonicalizeFeedItemUrl(guid.value) : undefined);
+  if (!title || !link) {
+    return undefined;
+  }
+  const id = guid?.value || link;
+  return {
+    title,
+    link,
+    id,
+    date: parseFeedDate(textChild(block, ["pubDate", "dc:date", "published", "updated"])),
+    language: textChild(block, ["language", "dc:language"]) ?? xmlLang(block) ?? fallbackLanguage,
+    summary: textChild(block, ["description", "summary", "content:encoded", "content"]),
+  };
+}
+
+function normalizeAtomEntry(block: string, fallbackLanguage?: string): ParsedFeedItem | undefined {
+  const title = textChild(block, ["title"]);
+  const link = canonicalizeFeedItemUrl(atomLink(block) ?? "");
+  if (!title || !link) {
+    return undefined;
+  }
+  const id = textChild(block, ["id"]) || link;
+  return {
+    title,
+    link,
+    id,
+    date: parseFeedDate(textChild(block, ["published", "updated", "dc:date"])),
+    language: xmlLang(block) ?? textChild(block, ["language", "dc:language"]) ?? fallbackLanguage,
+    summary: textChild(block, ["summary", "content", "description"]),
+  };
+}
+
+function collectBlocks(xml: string, pattern: RegExp): string[] {
+  return [...xml.matchAll(pattern)].flatMap((match) => (match[1] ? [match[1]] : []));
+}
+
+function textChild(block: string, names: readonly string[]): string | undefined {
+  for (const name of names) {
+    const pattern = new RegExp(
+      `<(?:[\\w.-]+:)?${escapeRegExp(localName(name))}(?:\\s[^>]*)?>([\\s\\S]*?)</(?:[\\w.-]+:)?${escapeRegExp(localName(name))}>`,
+      "i",
+    );
+    const match = block.match(pattern);
+    if (match?.[1] != null) {
+      const text = decodeXmlText(match[1]);
+      if (text) {
+        return text;
+      }
+    }
+  }
+  return undefined;
+}
+
+function guidChild(block: string): { value: string; permalink: boolean } | undefined {
+  const match = block.match(/<(?:[\w.-]+:)?guid\b([^>]*)>([\s\S]*?)<\/(?:[\w.-]+:)?guid>/i);
+  if (!match?.[2]) {
+    return undefined;
+  }
+  const value = decodeXmlText(match[2]);
+  if (!value) {
+    return undefined;
+  }
+  const attrs = match[1] ?? "";
+  const permalink = !/isPermaLink\s*=\s*(['"]?)false\1/i.test(attrs);
+  return { value, permalink };
+}
+
+function atomLink(block: string): string | undefined {
+  const links: Array<{ href: string; rel: string }> = [];
+  const pattern = /<(?:[\w.-]+:)?link\b([^>]*)\/?>/gi;
+  for (const match of block.matchAll(pattern)) {
+    const href = attrValue(match[1] ?? "", "href");
+    if (!href) {
+      continue;
+    }
+    links.push({ href, rel: (attrValue(match[1] ?? "", "rel") ?? "alternate").toLowerCase() });
+  }
+  return links.find((link) => link.rel === "alternate")?.href ?? links[0]?.href;
+}
+
+function xmlLang(block: string): string | undefined {
+  const match = block.match(/\bxml:lang\s*=\s*(['"])([^'"]+)\1/i);
+  const value = match?.[2]?.trim();
+  return value || undefined;
+}
+
+function attrValue(attrs: string, name: string): string | undefined {
+  const match = attrs.match(new RegExp(`(?:^|\\s)${name}\\s*=\\s*(['"])([\\s\\S]*?)\\1`, "i"));
+  return match?.[2]?.trim() || undefined;
+}
+
+function decodeXmlText(value: string): string {
+  const withoutCdata = value.replace(/<!\[CDATA\[([\s\S]*?)]]>/g, "$1");
+  const withoutTags = withoutCdata.replace(/<[^>]+>/g, " ");
+  return decodeEntities(withoutTags).replace(/\s+/g, " ").trim();
+}
+
+function decodeEntities(value: string): string {
+  return value.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (entity, name: string) => {
+    const lower = name.toLowerCase();
+    if (lower === "amp") return "&";
+    if (lower === "lt") return "<";
+    if (lower === "gt") return ">";
+    if (lower === "quot") return '"';
+    if (lower === "apos") return "'";
+    if (lower.startsWith("#x")) {
+      const code = Number.parseInt(lower.slice(2), 16);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : entity;
+    }
+    if (lower.startsWith("#")) {
+      const code = Number.parseInt(lower.slice(1), 10);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : entity;
+    }
+    return entity;
+  });
+}
+
+function looksLikeHtml(body: string): boolean {
+  const start = body.trim().slice(0, 256).toLowerCase();
+  return start.startsWith("<!doctype html") || start.startsWith("<html");
+}
+
+function looksLikeXmlFeed(body: string): boolean {
+  return /<(?:[\w.-]+:)?(?:rss|feed|rdf:RDF|item|entry)\b/i.test(body);
+}
+
+function stripBom(value: string): string {
+  return value.charCodeAt(0) === 0xfeff ? value.slice(1) : value;
+}
+
+function localName(name: string): string {
+  const index = name.indexOf(":");
+  return index === -1 ? name : name.slice(index + 1);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/npm/vite-plugin-ox-content/src/blog-feed-url.test.ts
+++ b/npm/vite-plugin-ox-content/src/blog-feed-url.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vite-plus/test";
+import { canonicalizeFeedItemUrl, isBlockedFeedAddress, isSafeFeedUrl } from "./blog-feed-url";
+
+describe("isSafeFeedUrl", () => {
+  it("accepts public https URLs", () => {
+    expect(isSafeFeedUrl("https://example.com/rss.xml")).toBe(true);
+    expect(isSafeFeedUrl("  https://feeds.example.com/atom.xml  ")).toBe(true);
+  });
+
+  it("rejects non-https, credentials, and control characters", () => {
+    expect(isSafeFeedUrl("http://example.com/rss.xml")).toBe(false);
+    expect(isSafeFeedUrl("file:///tmp/feed.xml")).toBe(false);
+    expect(isSafeFeedUrl("javascript:alert(1)")).toBe(false);
+    expect(isSafeFeedUrl("ftp://example.com/rss.xml")).toBe(false);
+    expect(isSafeFeedUrl("https://user:pass@example.com/rss.xml")).toBe(false);
+    expect(isSafeFeedUrl("https://example.com/rss.xml\nnext")).toBe(false);
+  });
+
+  it("rejects private and loopback hosts before DNS", () => {
+    expect(isSafeFeedUrl("https://localhost/rss.xml")).toBe(false);
+    expect(isSafeFeedUrl("https://127.0.0.1/rss.xml")).toBe(false);
+    expect(isSafeFeedUrl("https://10.0.0.4/rss.xml")).toBe(false);
+    expect(isSafeFeedUrl("https://192.168.1.9/rss.xml")).toBe(false);
+    expect(isSafeFeedUrl("https://172.16.1.4/rss.xml")).toBe(false);
+    expect(isSafeFeedUrl("https://169.254.1.1/rss.xml")).toBe(false);
+    expect(isSafeFeedUrl("https://[::1]/rss.xml")).toBe(false);
+    expect(isSafeFeedUrl("https://feed.local/rss.xml")).toBe(false);
+  });
+});
+
+describe("isBlockedFeedAddress", () => {
+  it("rejects private and loopback resolved addresses", () => {
+    expect(isBlockedFeedAddress("127.0.0.1")).toBe(true);
+    expect(isBlockedFeedAddress("10.1.2.3")).toBe(true);
+    expect(isBlockedFeedAddress("::1")).toBe(true);
+    expect(isBlockedFeedAddress("::ffff:127.0.0.1")).toBe(true);
+    expect(isBlockedFeedAddress("fd12::1")).toBe(true);
+    expect(isBlockedFeedAddress("fe80::1")).toBe(true);
+    expect(isBlockedFeedAddress("1.1.1.1")).toBe(false);
+  });
+});
+
+describe("canonicalizeFeedItemUrl", () => {
+  it("lowercases the host, drops hash and default port, and trims a trailing slash", () => {
+    expect(canonicalizeFeedItemUrl("https://Example.com:443/Post/#frag")).toBe(
+      "https://example.com/Post",
+    );
+    expect(canonicalizeFeedItemUrl("http://example.com/post")).toBeUndefined();
+  });
+});

--- a/npm/vite-plugin-ox-content/src/blog-feed-url.ts
+++ b/npm/vite-plugin-ox-content/src/blog-feed-url.ts
@@ -1,0 +1,104 @@
+/**
+ * Safe-URL checks for configured external blog feeds.
+ */
+
+const CONTROL_CHARS = /[\n\r\t\0]/;
+
+export function isSafeFeedUrl(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed || CONTROL_CHARS.test(trimmed)) {
+    return false;
+  }
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "https:") {
+      return false;
+    }
+    if (url.username || url.password) {
+      return false;
+    }
+    return !isBlockedFeedHost(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function canonicalizeFeedItemUrl(value: string): string | undefined {
+  if (!isSafeFeedUrl(value)) {
+    return undefined;
+  }
+  const url = new URL(value.trim());
+  url.hash = "";
+  url.username = "";
+  url.password = "";
+  if (url.port === "443") {
+    url.port = "";
+  }
+  url.hostname = url.hostname.toLowerCase();
+  let href = url.href;
+  if (url.pathname !== "/" && href.endsWith("/")) {
+    href = href.slice(0, -1);
+  }
+  return href;
+}
+
+export function isBlockedFeedHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (!host || host === "localhost" || host.endsWith(".localhost") || host.endsWith(".local")) {
+    return true;
+  }
+  if (host.includes(":")) {
+    return isBlockedIPv6(host);
+  }
+  return isIPv4(host) ? isBlockedIPv4(host) : false;
+}
+
+export function isBlockedFeedAddress(address: string): boolean {
+  const value = address.toLowerCase().replace(/^\[|\]$/g, "");
+  if (value.includes(":")) {
+    return isBlockedIPv6(value);
+  }
+  return isIPv4(value) ? isBlockedIPv4(value) : true;
+}
+
+function isIPv4(value: string): boolean {
+  const parts = value.split(".");
+  if (parts.length !== 4) {
+    return false;
+  }
+  return parts.every((part) => {
+    const n = Number(part);
+    return Number.isInteger(n) && n >= 0 && n <= 255 && String(n) === part;
+  });
+}
+
+function isBlockedIPv4(ip: string): boolean {
+  const parts = ip.split(".").map(Number);
+  const [a, b] = parts;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168)
+  );
+}
+
+function isBlockedIPv6(ip: string): boolean {
+  if (ip === "::" || ip === "::1") {
+    return true;
+  }
+  if (ip.startsWith("::ffff:")) {
+    const mapped = ip.slice("::ffff:".length);
+    return isIPv4(mapped) ? isBlockedIPv4(mapped) : true;
+  }
+  const first = Number.parseInt(ip.split(":")[0] ?? "", 16);
+  if (!Number.isFinite(first)) {
+    return true;
+  }
+  if (first >= 0xfe80 && first <= 0xfebf) {
+    return true;
+  }
+  return (first & 0xfe00) === 0xfc00;
+}

--- a/npm/vite-plugin-ox-content/src/blog-feeds.test.ts
+++ b/npm/vite-plugin-ox-content/src/blog-feeds.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vite-plus/test";
+import { generateFeeds } from "./feeds";
+import { loadExternalBlogPosts, mergeBlogPosts } from "./blog-feeds";
+import type { BlogSourcePage } from "./blog-html";
+import type { BlogFeedNetwork } from "./blog-feed-fetch";
+import type { ResolvedBlogFeedSource } from "./types";
+
+const RSS = `<?xml version="1.0"?><rss version="2.0"><channel>
+<item><title>Remote</title><link>https://news.example.com/remote</link>
+<guid>https://news.example.com/remote</guid>
+<pubDate>Thu, 01 Feb 2024 00:00:00 GMT</pubDate></item>
+</channel></rss>`;
+
+const ATOM = `<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom">
+<entry><title>Atom remote</title><id>urn:atom:1</id>
+<link href="https://news.example.com/atom"/><published>2024-03-01T00:00:00Z</published>
+</entry></feed>`;
+
+const DUP = `<?xml version="1.0"?><rss version="2.0"><channel>
+<item><title>First</title><link>https://news.example.com/same</link><guid>urn:same</guid>
+<pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate></item>
+<item><title>Second</title><link>https://news.example.com/same/</link><guid>urn:other</guid>
+<pubDate>Tue, 02 Jan 2024 00:00:00 GMT</pubDate></item>
+</channel></rss>`;
+
+function source(url: string, onError: "warn" | "error" = "warn"): ResolvedBlogFeedSource {
+  return { url, onError };
+}
+
+function xmlResponse(body: string, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "application/rss+xml", ...headers },
+  });
+}
+
+function network(
+  handler: (url: string) => Response | Promise<Response>,
+  lookup: (hostname: string) => Promise<string[]> = async () => ["1.1.1.1"],
+): BlogFeedNetwork {
+  return {
+    lookup,
+    limits: { timeoutMs: 40, maxBytes: 2048, maxRedirects: 2 },
+    fetch: async (url) => handler(url),
+  };
+}
+
+function localPage(title: string, href: string, date: string, id?: string): BlogSourcePage {
+  return {
+    title,
+    inputPath: `/${title}.md`,
+    transformedHtml: "",
+    routePaths: { href },
+    frontmatter: { date, ...(id ? { id } : {}) },
+  };
+}
+
+describe("loadExternalBlogPosts", () => {
+  it("does not fetch when no sources are configured", async () => {
+    let calls = 0;
+    const loaded = await loadExternalBlogPosts(
+      [],
+      network(() => {
+        calls += 1;
+        return xmlResponse(RSS);
+      }),
+    );
+    expect(calls).toBe(0);
+    expect(loaded).toEqual({ pages: [], warnings: [], fatals: [] });
+  });
+
+  it("fetches each unique URL once and marks items external", async () => {
+    const urls: string[] = [];
+    const loaded = await loadExternalBlogPosts(
+      [
+        {
+          url: "https://feeds.example.com/rss.xml",
+          language: "en",
+          author: "ada",
+          onError: "warn",
+        },
+        { url: "https://feeds.example.com/rss.xml", onError: "warn" },
+        { url: "https://feeds.example.com/atom.xml", onError: "warn" },
+      ],
+      network((url) => {
+        urls.push(url);
+        return xmlResponse(url.endsWith("atom.xml") ? ATOM : RSS);
+      }),
+    );
+    expect(urls).toEqual([
+      "https://feeds.example.com/rss.xml",
+      "https://feeds.example.com/atom.xml",
+    ]);
+    expect(loaded.pages.map((page) => page.title)).toEqual(["Remote", "Remote", "Atom remote"]);
+    expect(loaded.pages.every((page) => page.external === true)).toBe(true);
+    expect(loaded.pages[0]?.routePaths.href).toBe("https://news.example.com/remote");
+    expect(loaded.pages[0]?.frontmatter).toMatchObject({
+      external: true,
+      language: "en",
+      author: "ada",
+    });
+  });
+
+  it("keeps successful sources in warn mode and fails the source in error mode", async () => {
+    const warn = await loadExternalBlogPosts(
+      [source("https://feeds.example.com/ok.xml"), source("https://feeds.example.com/bad.xml")],
+      network((url) => {
+        if (url.endsWith("bad.xml")) {
+          return xmlResponse("<html><body>nope</body></html>", 200, {
+            "content-type": "text/html",
+          });
+        }
+        return xmlResponse(RSS);
+      }),
+    );
+    expect(warn.pages).toHaveLength(1);
+    expect(warn.fatals).toEqual([]);
+    expect(warn.warnings[0]).toContain("https://feeds.example.com/bad.xml");
+
+    const fatal = await loadExternalBlogPosts(
+      [
+        source("https://feeds.example.com/ok.xml"),
+        source("https://feeds.example.com/bad.xml", "error"),
+      ],
+      network((url) => {
+        if (url.endsWith("bad.xml")) {
+          throw new Error("boom");
+        }
+        return xmlResponse(RSS);
+      }),
+    );
+    expect(fatal.pages).toHaveLength(1);
+    expect(fatal.warnings).toEqual([]);
+    expect(fatal.fatals[0]).toContain("boom");
+  });
+
+  it("rejects timeouts, unsafe URLs, private DNS, and oversized bodies", async () => {
+    const timeout = await loadExternalBlogPosts([source("https://feeds.example.com/slow.xml")], {
+      lookup: async () => ["1.1.1.1"],
+      limits: { timeoutMs: 20, maxBytes: 64, maxRedirects: 1 },
+      fetch: async (_url, init) =>
+        new Promise<Response>((_, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            const error = new Error("aborted");
+            error.name = "AbortError";
+            reject(error);
+          });
+        }),
+    });
+    expect(timeout.warnings[0]).toContain("timeout");
+
+    const unsafe = await loadExternalBlogPosts(
+      [source("http://example.com/rss.xml"), source("https://127.0.0.1/rss.xml")],
+      network(() => xmlResponse(RSS)),
+    );
+    expect(unsafe.warnings.every((message) => message.includes("unsafe URL"))).toBe(true);
+
+    const privateNet = await loadExternalBlogPosts(
+      [source("https://feeds.example.com/rss.xml")],
+      network(
+        () => xmlResponse(RSS),
+        async () => ["10.0.0.1"],
+      ),
+    );
+    expect(privateNet.warnings[0]).toContain("private network");
+
+    const oversized = await loadExternalBlogPosts(
+      [source("https://feeds.example.com/big.xml")],
+      network(() => xmlResponse(RSS, 200, { "content-length": "999999" })),
+    );
+    expect(oversized.warnings[0]).toContain("oversized");
+
+    const redirects = await loadExternalBlogPosts(
+      [source("https://feeds.example.com/loop.xml")],
+      network(
+        (url) =>
+          new Response(null, {
+            status: 302,
+            headers: { location: url },
+          }),
+      ),
+    );
+    expect(redirects.warnings[0]).toContain("too many redirects");
+  });
+});
+
+describe("mergeBlogPosts", () => {
+  it("prefers local posts, dedupes by canonical URL or id, and sorts deterministically", () => {
+    const local = [
+      localPage("Local same url", "/local-remote/", "2024-01-15", undefined),
+      localPage("Local reprint", "/reprint/", "2024-01-10"),
+    ];
+    local[0]!.frontmatter.canonical = "https://news.example.com/remote";
+    local[1]!.frontmatter.id = "urn:atom:1";
+    const external: BlogSourcePage[] = [
+      {
+        title: "Remote",
+        inputPath: "external:remote",
+        transformedHtml: "",
+        external: true,
+        routePaths: { href: "https://news.example.com/remote" },
+        frontmatter: { external: true, id: "https://news.example.com/remote", date: "2024-02-01" },
+      },
+      {
+        title: "Atom remote",
+        inputPath: "external:atom",
+        transformedHtml: "",
+        external: true,
+        routePaths: { href: "https://news.example.com/atom" },
+        frontmatter: { external: true, id: "urn:atom:1", date: "2024-03-01" },
+      },
+      {
+        title: "Only remote",
+        inputPath: "external:only",
+        transformedHtml: "",
+        external: true,
+        routePaths: { href: "https://news.example.com/only" },
+        frontmatter: { external: true, id: "https://news.example.com/only", date: "2024-01-20" },
+      },
+    ];
+    expect(mergeBlogPosts(local, external).map((page) => page.title)).toEqual([
+      "Only remote",
+      "Local same url",
+      "Local reprint",
+    ]);
+  });
+
+  it("dedupes duplicate items inside one feed by canonical URL", async () => {
+    const loaded = await loadExternalBlogPosts(
+      [source("https://feeds.example.com/dup.xml")],
+      network(() => xmlResponse(DUP)),
+    );
+    expect(mergeBlogPosts([], loaded.pages).map((page) => page.title)).toEqual(["First"]);
+  });
+});
+
+describe("generated feeds exclude external items", () => {
+  it("omits frontmatter.external entries from outbound RSS and Atom", () => {
+    const output = generateFeeds({
+      options: { enabled: true, formats: ["rss", "atom"], limit: 20, path: "/" },
+      siteUrl: "https://site.example",
+      siteName: "Site",
+      items: [
+        { title: "Local", loc: "https://site.example/local/", date: "2024-02-01" },
+        {
+          title: "Remote",
+          loc: "https://news.example.com/remote",
+          date: "2024-03-01",
+          frontmatter: { external: true },
+        },
+      ],
+    });
+    expect(output.rssXml).toContain("Local");
+    expect(output.rssXml).not.toContain("Remote");
+    expect(output.atomXml).toContain("Local");
+    expect(output.atomXml).not.toContain("Remote");
+  });
+});

--- a/npm/vite-plugin-ox-content/src/blog-feeds.ts
+++ b/npm/vite-plugin-ox-content/src/blog-feeds.ts
@@ -1,0 +1,142 @@
+/**
+ * Load, normalize, and merge configured external blog feeds.
+ */
+
+import type { BlogSourcePage } from "./blog-html";
+import { feedDateIso } from "./blog-feed-date";
+import { fetchBlogFeedBody, type BlogFeedNetwork } from "./blog-feed-fetch";
+import { parseBlogFeed, type ParsedFeedItem } from "./blog-feed-parse";
+import { canonicalizeFeedItemUrl } from "./blog-feed-url";
+import { sortPosts } from "./blog-posts";
+import type { ResolvedBlogFeedSource } from "./types";
+
+export class BlogFeedError extends Error {
+  readonly issues: string[];
+
+  constructor(issues: string[]) {
+    super(issues.join("\n"));
+    this.name = "BlogFeedError";
+    this.issues = issues;
+  }
+}
+
+export interface LoadedBlogFeeds {
+  pages: BlogSourcePage[];
+  warnings: string[];
+  fatals: string[];
+}
+
+export async function loadExternalBlogPosts(
+  sources: readonly ResolvedBlogFeedSource[],
+  network: BlogFeedNetwork = {},
+): Promise<LoadedBlogFeeds> {
+  const pages: BlogSourcePage[] = [];
+  const warnings: string[] = [];
+  const fatals: string[] = [];
+  if (sources.length === 0) {
+    return { pages, warnings, fatals };
+  }
+
+  const bodies = new Map<string, Promise<string>>();
+  const results = await Promise.all(
+    sources.map(async (source) => {
+      try {
+        const body = await cachedBody(source.url, bodies, network);
+        const items = parseBlogFeed(body, source.language).map((item) =>
+          toExternalPage(item, source),
+        );
+        return { source, pages: items.filter((page): page is BlogSourcePage => page != null) };
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        const message = `[ox-content] blog feed ${source.url}: ${detail}`;
+        return { source, message };
+      }
+    }),
+  );
+
+  for (const result of results) {
+    if ("pages" in result) {
+      pages.push(...result.pages);
+      continue;
+    }
+    if (result.source.onError === "error") {
+      fatals.push(result.message);
+    } else {
+      warnings.push(result.message);
+    }
+  }
+  return { pages, warnings, fatals };
+}
+
+export function mergeBlogPosts(
+  local: readonly BlogSourcePage[],
+  external: readonly BlogSourcePage[],
+): BlogSourcePage[] {
+  const seenUrls = new Set<string>();
+  const seenIds = new Set<string>();
+  const merged: BlogSourcePage[] = [];
+  for (const page of [...local, ...external]) {
+    const keys = identityKeys(page);
+    if (seenUrls.has(keys.url) || seenIds.has(keys.id)) {
+      continue;
+    }
+    seenUrls.add(keys.url);
+    seenIds.add(keys.id);
+    merged.push(page);
+  }
+  return sortPosts(merged);
+}
+
+function cachedBody(
+  url: string,
+  cache: Map<string, Promise<string>>,
+  network: BlogFeedNetwork,
+): Promise<string> {
+  const existing = cache.get(url);
+  if (existing) {
+    return existing;
+  }
+  const pending = fetchBlogFeedBody(url, network);
+  cache.set(url, pending);
+  return pending;
+}
+
+function toExternalPage(
+  item: ParsedFeedItem,
+  source: ResolvedBlogFeedSource,
+): BlogSourcePage | undefined {
+  const link = canonicalizeFeedItemUrl(item.link);
+  if (!link) {
+    return undefined;
+  }
+  const id = item.id.trim() || link;
+  const language = item.language ?? source.language;
+  const author = source.author;
+  return {
+    title: item.title,
+    inputPath: `external:${id}`,
+    transformedHtml: "",
+    external: true,
+    routePaths: { href: link },
+    frontmatter: {
+      external: true,
+      id,
+      date: item.date ? feedDateIso(item.date) : undefined,
+      language,
+      author,
+      summary: item.summary,
+    },
+  };
+}
+
+function identityKeys(page: BlogSourcePage): { url: string; id: string } {
+  const explicitId = stringField(page.frontmatter.id);
+  const canonical = stringField(page.frontmatter.canonical);
+  const href = page.routePaths.href;
+  const url = canonicalizeFeedItemUrl(canonical ?? "") ?? canonicalizeFeedItemUrl(href) ?? href;
+  return { url, id: explicitId || url };
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/npm/vite-plugin-ox-content/src/blog-html.ts
+++ b/npm/vite-plugin-ox-content/src/blog-html.ts
@@ -12,6 +12,8 @@ export interface BlogSourcePage {
   transformedHtml: string;
   inputPath: string;
   routePaths: { href: string };
+  /** When true, href is a remote canonical URL and must not become a local route. */
+  external?: boolean;
 }
 
 export interface BlogPostMeta {
@@ -24,6 +26,7 @@ export interface BlogListItem {
   title: string;
   href: string;
   dateLabel?: string;
+  external?: boolean;
 }
 
 /** `https:` or a same-origin path starting with `/` but not `//`. */
@@ -149,5 +152,8 @@ function listItem(item: BlogListItem): string {
   const time = item.dateLabel
     ? ` <time datetime="${escapeHtml(item.dateLabel)}">${escapeHtml(item.dateLabel)}</time>`
     : "";
+  if (item.external) {
+    return `<li class="ox-blog-external" data-ox-blog-external="true"><a href="${escapeHtml(item.href)}" rel="external noopener noreferrer">${escapeHtml(item.title)}</a>${time}</li>`;
+  }
   return `<li><a href="${escapeHtml(item.href)}">${escapeHtml(item.title)}</a>${time}</li>`;
 }

--- a/npm/vite-plugin-ox-content/src/blog-options.ts
+++ b/npm/vite-plugin-ox-content/src/blog-options.ts
@@ -12,6 +12,7 @@ export function resolveBlogOptions(value: boolean | BlogOptions | undefined): Re
       enabled: false,
       authors: {},
       pageSize: DEFAULT_PAGE_SIZE,
+      feeds: [],
     };
   }
   if (value === true) {
@@ -19,6 +20,7 @@ export function resolveBlogOptions(value: boolean | BlogOptions | undefined): Re
       enabled: true,
       authors: {},
       pageSize: DEFAULT_PAGE_SIZE,
+      feeds: [],
     };
   }
   return {
@@ -26,6 +28,7 @@ export function resolveBlogOptions(value: boolean | BlogOptions | undefined): Re
     collection: value.collection,
     authors: normalizeAuthors(value.authors),
     pageSize: normalizePageSize(value.pageSize),
+    feeds: normalizeFeeds(value.feeds),
   };
 }
 
@@ -74,4 +77,40 @@ function normalizePageSize(value: number | undefined): number {
     return Math.floor(value);
   }
   return DEFAULT_PAGE_SIZE;
+}
+
+function normalizeFeeds(feeds: BlogOptions["feeds"]): ResolvedBlogOptions["feeds"] {
+  if (!Array.isArray(feeds)) {
+    return [];
+  }
+  const resolved: ResolvedBlogOptions["feeds"] = [];
+  for (const entry of feeds) {
+    if (typeof entry === "string") {
+      const url = entry.trim();
+      if (url) {
+        resolved.push({ url, onError: "warn" });
+      }
+      continue;
+    }
+    if (!entry || typeof entry !== "object" || typeof entry.url !== "string") {
+      continue;
+    }
+    const url = entry.url.trim();
+    if (!url) {
+      continue;
+    }
+    const language = trimOptional(entry.language);
+    const author = trimOptional(entry.author);
+    resolved.push({
+      url,
+      ...(language ? { language } : {}),
+      ...(author ? { author } : {}),
+      onError: entry.onError === "error" ? "error" : "warn",
+    });
+  }
+  return resolved;
+}
+
+function trimOptional(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }

--- a/npm/vite-plugin-ox-content/src/blog-pages-feeds.test.ts
+++ b/npm/vite-plugin-ox-content/src/blog-pages-feeds.test.ts
@@ -1,0 +1,105 @@
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+import { resolveBlogOptions } from "./blog-options";
+import { BlogFeedError } from "./blog-feeds";
+import { appendBlogPages } from "./blog-pages";
+import type { BlogSourcePage } from "./blog-html";
+import type { BlogFeedNetwork } from "./blog-feed-fetch";
+
+const RSS = `<?xml version="1.0"?><rss version="2.0"><channel>
+<item><title>Remote Essay</title><link>https://news.example.com/essay</link>
+<guid>https://news.example.com/essay</guid>
+<pubDate>Fri, 01 Mar 2024 00:00:00 GMT</pubDate></item>
+</channel></rss>`;
+
+function localPage(title: string, href: string, date: string): BlogSourcePage {
+  return {
+    title,
+    inputPath: `/src/${title}.md`,
+    transformedHtml: "",
+    routePaths: { href },
+    frontmatter: { date },
+  };
+}
+
+function network(handler: (url: string) => Response): BlogFeedNetwork {
+  return {
+    lookup: async () => ["1.1.1.1"],
+    fetch: async (url) => handler(url),
+  };
+}
+
+describe("appendBlogPages external feeds", () => {
+  it("does not fetch when feeds are empty", async () => {
+    let calls = 0;
+    const generated: Array<{ inputPath: string; outputPath: string; html: string }> = [];
+    await appendBlogPages({
+      generatedPages: generated,
+      listedPages: [localPage("Hello", "/hello/", "2024-01-15")],
+      options: resolveBlogOptions(true),
+      srcDir: "/src",
+      outDir: path.join(os.tmpdir(), "ox-blog-pages-off"),
+      base: "/",
+      errors: [],
+      feedNetwork: network(() => {
+        calls += 1;
+        return new Response(RSS);
+      }),
+      render: async (page) => page.content,
+    });
+    expect(calls).toBe(0);
+    expect(generated[0]?.html).toContain("Hello");
+    expect(generated[0]?.html).not.toContain("ox-blog-external");
+  });
+
+  it("merges remote items with an external marker and keeps the canonical href", async () => {
+    const urls: string[] = [];
+    const generated: Array<{ inputPath: string; outputPath: string; html: string }> = [];
+    await appendBlogPages({
+      generatedPages: generated,
+      listedPages: [localPage("Hello", "/hello/", "2024-01-15")],
+      options: resolveBlogOptions({ feeds: ["https://feeds.example.com/rss.xml"] }),
+      srcDir: "/src",
+      outDir: path.join(os.tmpdir(), "ox-blog-pages-on"),
+      base: "/",
+      errors: [],
+      feedNetwork: network((url) => {
+        urls.push(url);
+        return new Response(RSS, { headers: { "content-type": "application/rss+xml" } });
+      }),
+      render: async (page) => page.content,
+    });
+    expect(urls).toEqual(["https://feeds.example.com/rss.xml"]);
+    const html = generated[0]?.html ?? "";
+    expect(html).toContain("Remote Essay");
+    expect(html).toContain("Hello");
+    expect(html).toContain('href="https://news.example.com/essay"');
+    expect(html).toContain("ox-blog-external");
+    expect(html).toContain('rel="external noopener noreferrer"');
+    expect(html).not.toContain('href="/news.example.com/essay');
+  });
+
+  it("throws BlogFeedError when onError is error", async () => {
+    await expect(
+      appendBlogPages({
+        generatedPages: [],
+        listedPages: [localPage("Hello", "/hello/", "2024-01-15")],
+        options: resolveBlogOptions({
+          feeds: [{ url: "https://feeds.example.com/rss.xml", onError: "error" }],
+        }),
+        srcDir: "/src",
+        outDir: path.join(os.tmpdir(), "ox-blog-pages-err"),
+        base: "/",
+        errors: [],
+        feedNetwork: {
+          lookup: async () => ["1.1.1.1"],
+          fetch: async () => {
+            throw new Error("offline");
+          },
+        },
+        render: async (page) => page.content,
+      }),
+    ).rejects.toBeInstanceOf(BlogFeedError);
+  });
+});

--- a/npm/vite-plugin-ox-content/src/blog-pages.ts
+++ b/npm/vite-plugin-ox-content/src/blog-pages.ts
@@ -15,6 +15,8 @@ import {
   type BlogSourcePage,
 } from "./blog-html";
 import { readingTimeMinutes } from "./blog-reading";
+import { BlogFeedError, loadExternalBlogPosts, mergeBlogPosts } from "./blog-feeds";
+import type { BlogFeedNetwork } from "./blog-feed-fetch";
 import {
   collectTags,
   datedPosts,
@@ -58,7 +60,7 @@ export async function injectBlogPostMeta(input: {
   }
   const listedPaths = new Set(posts.map((page) => page.inputPath));
   for (const page of input.pages) {
-    if (!listedPaths.has(page.inputPath)) {
+    if (!listedPaths.has(page.inputPath) || page.external === true) {
       continue;
     }
     const markdown = await readMarkdown(page.inputPath);
@@ -113,6 +115,7 @@ export async function appendBlogPages(input: {
   base: string;
   render: (page: BlogGeneratedPage) => Promise<string>;
   errors: string[];
+  feedNetwork?: BlogFeedNetwork;
 }): Promise<void> {
   if (!input.options?.enabled) {
     return;
@@ -121,10 +124,11 @@ export async function appendBlogPages(input: {
     input.errors.push(AMBIGUOUS_COLLECTION);
     return;
   }
-  const posts = selectBlogPosts(input.listedPages, input.options, input.srcDir, input.collections);
-  if (posts === undefined) {
+  const local = selectBlogPosts(input.listedPages, input.options, input.srcDir, input.collections);
+  if (local === undefined) {
     return;
   }
+  const posts = await collectIndexPosts(local, input.options, input.errors, input.feedNetwork);
   for (const spec of blogPageSpecs(posts, input.options, input.outDir, input.base)) {
     try {
       input.generatedPages.push({
@@ -252,6 +256,26 @@ function blogPageSpecs(
   }
 
   return pages;
+}
+
+async function collectIndexPosts(
+  local: BlogSourcePage[],
+  options: ResolvedBlogOptions,
+  errors: string[],
+  network?: BlogFeedNetwork,
+): Promise<BlogSourcePage[]> {
+  if (options.feeds.length === 0) {
+    return local;
+  }
+  const loaded = await loadExternalBlogPosts(options.feeds, network);
+  errors.push(...loaded.warnings);
+  for (const warning of loaded.warnings) {
+    console.warn(warning);
+  }
+  if (loaded.fatals.length > 0) {
+    throw new BlogFeedError(loaded.fatals);
+  }
+  return mergeBlogPosts(local, loaded.pages);
 }
 
 async function readMarkdown(inputPath: string): Promise<string> {

--- a/npm/vite-plugin-ox-content/src/blog-posts.ts
+++ b/npm/vite-plugin-ox-content/src/blog-posts.ts
@@ -168,6 +168,7 @@ export function toListItem(page: BlogSourcePage): {
     dateLabel: parsed
       ? `${String(parsed.year).padStart(4, "0")}-${String(parsed.month).padStart(2, "0")}-${String(parsed.day).padStart(2, "0")}`
       : undefined,
+    ...(page.external || page.frontmatter.external === true ? { external: true } : {}),
   };
 }
 

--- a/npm/vite-plugin-ox-content/src/blog-ssg-feeds.test.ts
+++ b/npm/vite-plugin-ox-content/src/blog-ssg-feeds.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createDocsResolvedOptions } from "../test/fixtures/docs-fixture";
+import { BlogFeedError, resolveBlogOptions } from "./blog";
+import { installBlogFeedNetwork, resetBlogFeedNetwork } from "./blog-feed-fetch";
+import { resolveFeedsOptions } from "./feeds";
+import { buildSsg } from "./ssg";
+
+const RSS = `<?xml version="1.0"?><rss version="2.0"><channel>
+<item><title>Remote Essay</title><link>https://news.example.com/essay</link>
+<guid>https://news.example.com/essay</guid>
+<pubDate>Fri, 01 Mar 2024 00:00:00 GMT</pubDate></item>
+</channel></rss>`;
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  resetBlogFeedNetwork();
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+async function makeSite(files: Record<string, string>): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-blog-feeds-"));
+  tempDirs.push(root);
+  const srcDir = path.join(root, "content");
+  await fs.mkdir(srcDir, { recursive: true });
+  for (const [relative, body] of Object.entries(files)) {
+    const filePath = path.join(srcDir, relative);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, body, "utf8");
+  }
+  return root;
+}
+
+describe("buildSsg blog external feeds", () => {
+  it("does not fetch when blog feeds are omitted", async () => {
+    let calls = 0;
+    installBlogFeedNetwork({
+      lookup: async () => {
+        calls += 1;
+        return ["1.1.1.1"];
+      },
+      fetch: async () => {
+        calls += 1;
+        return new Response(RSS);
+      },
+    });
+    const root = await makeSite({
+      "hello.md": "---\ntitle: Hello\ndate: 2024-01-15\n---\n\n# Hello\n",
+    });
+    await buildSsg(createDocsResolvedOptions({ blog: resolveBlogOptions(true) }), root);
+    expect(calls).toBe(0);
+    const index = await fs.readFile(path.join(root, "dist", "blog", "index.html"), "utf8");
+    expect(index).toContain("Hello");
+    expect(index).not.toContain("ox-blog-external");
+  });
+
+  it("merges fixture items onto the index with an external marker and keeps them out of outbound feeds", async () => {
+    const urls: string[] = [];
+    installBlogFeedNetwork({
+      lookup: async () => ["1.1.1.1"],
+      fetch: async (url) => {
+        urls.push(url);
+        return new Response(RSS, { headers: { "content-type": "application/rss+xml" } });
+      },
+    });
+    const root = await makeSite({
+      "hello.md": "---\ntitle: Hello\ndate: 2024-01-15\n---\n\n# Hello\n",
+    });
+    await buildSsg(
+      createDocsResolvedOptions({
+        blog: resolveBlogOptions({
+          feeds: [{ url: "https://feeds.example.com/rss.xml", language: "en" }],
+        }),
+        feeds: resolveFeedsOptions({ formats: ["rss", "atom"], collection: "content" }),
+        ssg: { ...createDocsResolvedOptions().ssg, siteUrl: "https://site.example" },
+        collections: {
+          enabled: true,
+          collections: {
+            content: { name: "content", source: ["**/*.md"], include: [] },
+          },
+        },
+      }),
+      root,
+    );
+
+    expect(urls).toEqual(["https://feeds.example.com/rss.xml"]);
+    const index = await fs.readFile(path.join(root, "dist", "blog", "index.html"), "utf8");
+    expect(index).toContain("Remote Essay");
+    expect(index).toContain("Hello");
+    expect(index).toContain('href="https://news.example.com/essay"');
+    expect(index).toContain("ox-blog-external");
+    expect(index).toContain('rel="external noopener noreferrer"');
+    expect(index).not.toContain('href="/news.example.com/essay');
+
+    const feed = await fs.readFile(path.join(root, "dist", "feed.xml"), "utf8");
+    expect(feed).toContain("Hello");
+    expect(feed).not.toContain("Remote Essay");
+  });
+
+  it("fails the build when a source uses onError error", async () => {
+    installBlogFeedNetwork({
+      lookup: async () => ["1.1.1.1"],
+      fetch: async () => {
+        throw new Error("offline");
+      },
+    });
+    const root = await makeSite({
+      "hello.md": "---\ntitle: Hello\ndate: 2024-01-15\n---\n\n# Hello\n",
+    });
+    await expect(
+      buildSsg(
+        createDocsResolvedOptions({
+          blog: resolveBlogOptions({
+            feeds: [{ url: "https://feeds.example.com/rss.xml", onError: "error" }],
+          }),
+        }),
+        root,
+      ),
+    ).rejects.toBeInstanceOf(BlogFeedError);
+    await expect(fs.access(path.join(root, "dist", "blog", "index.html"))).rejects.toThrow();
+  });
+});

--- a/npm/vite-plugin-ox-content/src/blog.test.ts
+++ b/npm/vite-plugin-ox-content/src/blog.test.ts
@@ -9,11 +9,13 @@ describe("resolveBlogOptions", () => {
       enabled: false,
       authors: {},
       pageSize: 10,
+      feeds: [],
     });
     expect(resolveBlogOptions(false)).toEqual({
       enabled: false,
       authors: {},
       pageSize: 10,
+      feeds: [],
     });
     expect(createDocsResolvedOptions().blog).toBeUndefined();
     expect(resolveSsgOptions(undefined).blog?.enabled).toBe(false);
@@ -26,28 +28,49 @@ describe("resolveBlogOptions", () => {
       enabled: true,
       authors: {},
       pageSize: 10,
+      feeds: [],
     });
     expect(resolveSsgOptions({ blog: true }).blog).toEqual({
       enabled: true,
       authors: {},
       pageSize: 10,
+      feeds: [],
     });
     expect(
       resolveBlogOptions({
         collection: "posts",
         pageSize: 5,
         authors: { ada: { name: "Ada", bio: "Writer", url: "https://example.com/ada" } },
+        feeds: [
+          "https://example.com/rss.xml",
+          {
+            url: "https://example.com/atom.xml",
+            language: "ja",
+            author: "ada",
+            onError: "error",
+          },
+        ],
       }),
     ).toEqual({
       enabled: true,
       collection: "posts",
       pageSize: 5,
       authors: { ada: { name: "Ada", bio: "Writer", url: "https://example.com/ada" } },
+      feeds: [
+        { url: "https://example.com/rss.xml", onError: "warn" },
+        {
+          url: "https://example.com/atom.xml",
+          language: "ja",
+          author: "ada",
+          onError: "error",
+        },
+      ],
     });
     expect(resolveBlogOptions({})).toEqual({
       enabled: true,
       authors: {},
       pageSize: 10,
+      feeds: [],
     });
     expect(resolveBlogOptions({ pageSize: 0 }).pageSize).toBe(10);
     expect(resolveBlogOptions({ pageSize: -3 }).pageSize).toBe(10);

--- a/npm/vite-plugin-ox-content/src/blog.ts
+++ b/npm/vite-plugin-ox-content/src/blog.ts
@@ -4,6 +4,7 @@
 
 export type { BlogSourcePage } from "./blog-html";
 export { resolveBlogOptions, resolveBlogCollectionName } from "./blog-options";
+export { BlogFeedError, loadExternalBlogPosts, mergeBlogPosts } from "./blog-feeds";
 export { readingTimeMinutes } from "./blog-reading";
 export {
   appendBlogPages,

--- a/npm/vite-plugin-ox-content/src/feeds.ts
+++ b/npm/vite-plugin-ox-content/src/feeds.ts
@@ -243,6 +243,9 @@ function isExcludedFromFeed(
   if (item.unlisted === true || frontmatter.unlisted === true) {
     return true;
   }
+  if (frontmatter.external === true) {
+    return true;
+  }
   if (!publishState?.enabled) {
     return false;
   }

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -18,7 +18,7 @@ import { resolveCascadeOptions, resolvePermalinksOptions } from "./permalinks";
 import { resolveRedirectsOptions } from "./redirects";
 import { notFoundSearchExcludeIds } from "./not-found";
 import { resolveFeedsOptions } from "./feeds";
-import { resolveBlogOptions } from "./blog";
+import { BlogFeedError, resolveBlogOptions } from "./blog";
 import { resolvePwaOptions } from "./pwa";
 import { resolveTaxonomiesOptions } from "./taxonomies";
 import { resolveVersionsOptions } from "./versions";
@@ -131,7 +131,10 @@ export type {
   RedirectsOptions,
   ResolvedRedirectsOptions,
   BlogAuthor,
+  BlogFeedFailurePolicy,
+  BlogFeedSource,
   BlogOptions,
+  ResolvedBlogFeedSource,
   ResolvedBlogOptions,
   FeedFormat,
   FeedsOptions,
@@ -470,7 +473,7 @@ function createSsgPlugin(
         }
       } catch (err) {
         console.error("[ox-content] SSG build failed:", err);
-        if (err instanceof PageResourceError) {
+        if (err instanceof PageResourceError || err instanceof BlogFeedError) {
           throw err;
         }
       }
@@ -1117,7 +1120,12 @@ export {
 export { resolvePermalinksOptions, resolveCascadeOptions } from "./permalinks";
 export { resolveRedirectsOptions } from "./redirects";
 export { resolveFeedsOptions } from "./feeds";
-export { resolveBlogOptions, resolveBlogCollectionName, readingTimeMinutes } from "./blog";
+export {
+  BlogFeedError,
+  resolveBlogOptions,
+  resolveBlogCollectionName,
+  readingTimeMinutes,
+} from "./blog";
 export { resolvePwaOptions } from "./pwa";
 export { resolveTaxonomiesOptions } from "./taxonomies";
 export { resolveVersionsOptions } from "./versions";

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -1060,7 +1060,35 @@ export interface BlogOptions {
    * @default 10
    */
   pageSize?: number;
+
+  /**
+   * External RSS / Atom sources merged into the blog index at build time.
+   * Empty / omitted fetches nothing. Only these URLs are requested.
+   * @default []
+   */
+  feeds?: Array<string | BlogFeedSource>;
 }
+
+/**
+ * One configured external blog feed.
+ */
+export interface BlogFeedSource {
+  /** Absolute `https:` feed URL. */
+  url: string;
+  /** Default language applied when an item omits one. */
+  language?: string;
+  /** Default author applied when an item omits one. */
+  author?: string;
+  /**
+   * Failed fetch / parse handling for this source.
+   * `warn` skips the source. `error` fails the build after other sources run.
+   * @default "warn"
+   */
+  onError?: BlogFeedFailurePolicy;
+}
+
+/** How a failed external feed source is reported. */
+export type BlogFeedFailurePolicy = "warn" | "error";
 
 /**
  * Resolved blog options.
@@ -1070,6 +1098,17 @@ export interface ResolvedBlogOptions {
   collection?: string;
   authors: Record<string, BlogAuthor>;
   pageSize: number;
+  feeds: ResolvedBlogFeedSource[];
+}
+
+/**
+ * Resolved external blog feed source.
+ */
+export interface ResolvedBlogFeedSource {
+  url: string;
+  language?: string;
+  author?: string;
+  onError: BlogFeedFailurePolicy;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Opt-in `blog.feeds` aggregates configured RSS/Atom sources into the blog index at build time (disabled by default; only those URLs are fetched).
- Fetch is once per unique URL per build, with timeout, redirect, size, and `https:`-only public-host limits. `warn` skips a failed source; `error` fails the build after other sources finish.
- External items are marked so themes keep the remote URL. They are omitted from generated RSS/Atom/JSON feeds.

Closes #827

## Risk

- Risk level: low
- User or production impact: existing sites unchanged until `blog.feeds` is set. Generated outbound feeds still come from local collections only.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run: fixture RSS/Atom (no live network) for warn vs error, dedupe, external marker, timeout, unsafe URL, private DNS, oversized body, redirect loop, and outbound-feed exclusion
- [x] Manual verification completed: not needed beyond unit/SSG fixture tests
- [x] Edge cases or failure modes considered: one failed source does not drop successful sources; HTML pages are rejected; document links are never fetched

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

## Test plan

- [ ] Enable `blog` without `feeds` and confirm no network activity and unchanged index
- [ ] Add an RSS and an Atom URL with source defaults; confirm merge order and `ox-blog-external` hrefs
- [ ] Fail one source with `onError: "warn"` and confirm the rest still render
- [ ] Fail one source with `onError: "error"` and confirm the build fails
- [ ] Confirm generated `feed.xml` / `atom.xml` omit external titles


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790257261&installation_model_id=422833&pr_number=846&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F846&signature=dd2fa0a6084ff3fdf4dd03a3b0e658b39e0746a285fcea8008d70fc327538153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->