### PR TITLE
perf: report build and rendered output benchmarks

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -143,7 +143,9 @@ local command is:
 OX_CONTENT_BENCHMARK_RUNS=7 vp run bench:docs
 ```
 
-Pull requests use the same Blacksmith runner class for base/head runtime and
-bundle comparisons. The comment includes the regression gate, a head-commit
-competitive snapshot, and the captured runner/runtime metadata so result drift
-can be traced back to the environment.
+Pull requests use the same Blacksmith runner class for base/head runtime,
+fixture build-time, bundle, and rendered HTML output-size comparisons. The
+comment includes the regression gate, a head-commit competitive snapshot, and
+the captured runner/runtime metadata so result drift can be traced back to the
+environment. Build time is reported as an informational signal first; runtime,
+bundle gzip, and rendered HTML gzip are the gated values.

--- a/benchmarks/bundle-size/compare-pr-benchmark.mjs
+++ b/benchmarks/bundle-size/compare-pr-benchmark.mjs
@@ -214,25 +214,25 @@ function buildComment({ basePath, headPath, baseBundlePath, headBundlePath, base
 
   if (baseBundlePath && headBundlePath) {
     lines.push(
-      "### Bundle Size",
+      "### Build and Output Size",
       "",
-      "| App | Base gzip | Head gzip | Delta | Base requests | Head requests | Base files | Head files |",
-      "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+      "| App | Base gzip | Head gzip | Gzip delta | Base HTML gzip | Head HTML gzip | HTML delta | Base build | Head build | Build delta | Requests | Files |",
+      "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
     );
 
     if (bundleRows.length === 0) {
-      lines.push("| n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |");
+      lines.push("| n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |");
     } else {
       for (const row of bundleRows) {
         lines.push(
-          `| ${String(row.name)} | ${formatBytes(row.baseGzipped)} | ${formatBytes(row.headGzipped)} | ${formatDelta(row.deltaPercent)} | ${formatNumber(row.baseRequests)} | ${formatNumber(row.headRequests)} | ${formatNumber(row.baseFiles)} | ${formatNumber(row.headFiles)} |`,
+          `| ${String(row.name)} | ${formatBytes(row.baseGzipped)} | ${formatBytes(row.headGzipped)} | ${formatDelta(row.deltaPercent)} | ${formatBytes(row.baseHtmlGzipped)} | ${formatBytes(row.headHtmlGzipped)} | ${formatDelta(row.htmlDeltaPercent)} | ${formatDurationMs(row.baseBuildMs)} | ${formatDurationMs(row.headBuildMs)} | ${formatDelta(row.buildDeltaPercent)} | ${formatNumberTransition(row.baseRequests, row.headRequests)} | ${formatNumberTransition(row.baseFiles, row.headFiles)} |`,
         );
       }
     }
 
     lines.push(
       "",
-      "Bundle size uses gzipped JS/CSS/HTML/JSON assets. Requests estimate index.html plus referenced local initial assets. Lower is better.",
+      "Gzip uses JS/CSS/HTML/JSON assets. HTML gzip tracks rendered page output without JS/CSS assets. Requests estimate index.html plus referenced local initial assets. Build time is informational for now because runner variance is higher than the size gates.",
       "",
     );
   }
@@ -240,7 +240,7 @@ function buildComment({ basePath, headPath, baseBundlePath, headBundlePath, base
   lines.push(
     "### Regression Gate",
     "",
-    `Runtime regressions fail when head throughput is more than ${Math.abs(RUNTIME_REGRESSION_THRESHOLD_PERCENT)}% slower than base (async rows are informational only; their worker-scheduling variance exceeds the threshold on quiet PRs). Bundle regressions fail when gzipped size grows by more than ${BUNDLE_REGRESSION_THRESHOLD_PERCENT}%. Maintainers can intentionally override by applying the \`benchmark-regression-accepted\` PR label, which sets \`${BENCHMARK_OVERRIDE_ENV}=1\`.`,
+    `Runtime regressions fail when head throughput is more than ${Math.abs(RUNTIME_REGRESSION_THRESHOLD_PERCENT)}% slower than base (async rows are informational only; their worker-scheduling variance exceeds the threshold on quiet PRs). Bundle and rendered HTML regressions fail when gzipped size grows by more than ${BUNDLE_REGRESSION_THRESHOLD_PERCENT}%. Maintainers can intentionally override by applying the \`benchmark-regression-accepted\` PR label, which sets \`${BENCHMARK_OVERRIDE_ENV}=1\`.`,
     "",
   );
 
@@ -307,16 +307,26 @@ function compareBundleReports(base, head) {
     const headRow = headRows.get(name);
     const baseGzipped = baseRow?.gzipped ?? null;
     const headGzipped = headRow?.gzipped ?? null;
+    const baseHtmlGzipped = baseRow?.htmlGzipped ?? null;
+    const headHtmlGzipped = headRow?.htmlGzipped ?? null;
+    const baseBuildMs = baseRow?.buildMs ?? null;
+    const headBuildMs = headRow?.buildMs ?? null;
 
     return {
       name,
       baseGzipped,
       headGzipped,
+      baseHtmlGzipped,
+      headHtmlGzipped,
+      baseBuildMs,
+      headBuildMs,
       baseRequests: baseRow?.requests ?? null,
       headRequests: headRow?.requests ?? null,
       baseFiles: baseRow?.files ?? null,
       headFiles: headRow?.files ?? null,
       deltaPercent: percentChange(baseGzipped, headGzipped),
+      htmlDeltaPercent: percentChange(baseHtmlGzipped, headHtmlGzipped),
+      buildDeltaPercent: percentChange(baseBuildMs, headBuildMs),
     };
   });
 }
@@ -395,9 +405,11 @@ function collectBundleRows(report) {
     .filter((result) => !result.error)
     .map((result) => ({
       name: String(result.name),
-      gzipped: Number(result.gzipped),
-      requests: Number(result.requests),
-      files: Number(result.files),
+      gzipped: finiteNumber(result.gzipped),
+      htmlGzipped: finiteNumber(result.htmlGzipped),
+      requests: finiteNumber(result.requests),
+      files: finiteNumber(result.files),
+      buildMs: finiteNumber(result.buildMs),
     }));
 }
 
@@ -525,9 +537,24 @@ function collectRegressions(runtimeRows, bundleRows) {
         thresholdPercent: BUNDLE_REGRESSION_THRESHOLD_PERCENT,
       });
     }
+    if (
+      Number.isFinite(row.htmlDeltaPercent) &&
+      row.htmlDeltaPercent > BUNDLE_REGRESSION_THRESHOLD_PERCENT
+    ) {
+      regressions.push({
+        metric: "Rendered HTML gzip",
+        target: row.name,
+        deltaPercent: row.htmlDeltaPercent,
+        thresholdPercent: BUNDLE_REGRESSION_THRESHOLD_PERCENT,
+      });
+    }
   }
 
   return regressions;
+}
+
+function finiteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
 function formatNumber(value) {
@@ -536,6 +563,10 @@ function formatNumber(value) {
   }
 
   return Math.round(value).toLocaleString("en-US");
+}
+
+function formatNumberTransition(baseValue, headValue) {
+  return `${formatNumber(baseValue)} -> ${formatNumber(headValue)}`;
 }
 
 function formatOps(value) {
@@ -582,6 +613,17 @@ function formatBytes(value) {
   }
 
   return `${(value / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function formatDurationMs(value) {
+  if (!Number.isFinite(value)) {
+    return "n/a";
+  }
+  if (value < 1000) {
+    return `${value.toFixed(0)} ms`;
+  }
+
+  return `${(value / 1000).toFixed(2)} s`;
 }
 
 function formatDelta(value) {

--- a/benchmarks/bundle-size/compare-pr-benchmark.test.ts
+++ b/benchmarks/bundle-size/compare-pr-benchmark.test.ts
@@ -1,0 +1,101 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vite-plus/test";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const script = join(here, "compare-pr-benchmark.mjs");
+
+describe("compare-pr-benchmark", () => {
+  it("reports build time and gates rendered HTML gzip growth", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ox-benchmark-"));
+    const basePath = join(dir, "base.json");
+    const headPath = join(dir, "head.json");
+    writeJson(basePath, bundleReport({ gzipped: 1000, htmlGzipped: 100, buildMs: 1000 }));
+    writeJson(headPath, bundleReport({ gzipped: 1010, htmlGzipped: 120, buildMs: 1150 }));
+
+    const result = runCompare(
+      "--base",
+      basePath,
+      "--head",
+      headPath,
+      "--base-bundle",
+      basePath,
+      "--head-bundle",
+      headPath,
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("### Build and Output Size");
+    expect(result.stdout).toContain(
+      "| ox-content (bare) | 1000 B | 1010 B | +1.00% | 100 B | 120 B | +20.00% | 1.00 s | 1.15 s | +15.00% | 2 -> 2 | 3 -> 3 |",
+    );
+    expect(result.stdout).toContain("<!-- ox-content-benchmark-regression -->");
+    expect(result.stdout).toContain(
+      "| Rendered HTML gzip | ox-content (bare) | +20.00% | +5.00% |",
+    );
+  });
+
+  it("keeps older bundle reports comparable when new fields are absent", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ox-benchmark-"));
+    const basePath = join(dir, "base.json");
+    const headPath = join(dir, "head.json");
+    writeJson(basePath, bundleReport({ gzipped: 1000 }));
+    writeJson(headPath, bundleReport({ gzipped: 1000 }));
+
+    const result = runCompare(
+      "--base",
+      basePath,
+      "--head",
+      headPath,
+      "--base-bundle",
+      basePath,
+      "--head-bundle",
+      headPath,
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "| ox-content (bare) | 1000 B | 1000 B | 0.00% | n/a | n/a | n/a | n/a | n/a | n/a | 2 -> 2 | 3 -> 3 |",
+    );
+  });
+});
+
+function writeJson(path: string, value: unknown) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function bundleReport({
+  gzipped,
+  htmlGzipped,
+  buildMs,
+}: {
+  gzipped: number;
+  htmlGzipped?: number;
+  buildMs?: number;
+}) {
+  return {
+    name: "Bundle Size Benchmark",
+    generatedAt: "2026-08-26T00:00:00.000Z",
+    environment: { node: process.version },
+    results: [
+      {
+        name: "ox-content (bare)",
+        total: gzipped * 2,
+        gzipped,
+        ...(htmlGzipped === undefined ? {} : { htmlGzipped }),
+        files: 3,
+        requests: 2,
+        ...(buildMs === undefined ? {} : { buildMs }),
+      },
+    ],
+  };
+}
+
+function runCompare(...args: string[]) {
+  return spawnSync(process.execPath, [script, ...args], {
+    encoding: "utf8",
+  });
+}

--- a/benchmarks/bundle-size/measure.mjs
+++ b/benchmarks/bundle-size/measure.mjs
@@ -12,11 +12,13 @@ const options = parseOptions(process.argv.slice(2));
 /**
  * Get total size of a directory
  * @param {string} dir
- * @returns {{ total: number, gzipped: number, files: number }}
+ * @returns {{ total: number, gzipped: number, html: number, htmlGzipped: number, files: number }}
  */
 function getDirSize(dir) {
   let total = 0;
   let gzipped = 0;
+  let html = 0;
+  let htmlGzipped = 0;
   let files = 0;
 
   function walk(currentDir) {
@@ -35,6 +37,10 @@ function getDirSize(dir) {
           } else {
             gzipped += content.length;
           }
+          if (/\.html$/i.test(entry.name)) {
+            html += content.length;
+            htmlGzipped += gzipSizeSync(content);
+          }
           files++;
         }
       }
@@ -44,7 +50,7 @@ function getDirSize(dir) {
   }
 
   walk(dir);
-  return { total, gzipped, files };
+  return { total, gzipped, html, htmlGzipped, files };
 }
 
 /**
@@ -280,6 +286,12 @@ function formatBytes(bytes) {
   return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
 }
 
+function formatDuration(ms) {
+  if (!Number.isFinite(ms)) return "n/a";
+  if (ms < 1000) return `${ms.toFixed(0)} ms`;
+  return `${(ms / 1000).toFixed(2)} s`;
+}
+
 function collectEnvironment() {
   const cpuList = cpus();
   const firstCpu = cpuList[0];
@@ -457,18 +469,24 @@ async function main() {
 
   for (const app of apps) {
     console.log(`Building ${app.name}...`);
+    let buildMs = null;
 
     if (!options.skipBuild) {
       try {
+        const buildStart = performance.now();
         execSync(app.buildCmd, { cwd: app.dir, stdio: "pipe" });
+        buildMs = performance.now() - buildStart;
       } catch (e) {
         console.log(`  Build failed: ${e.message}\n`);
         results.push({
           name: app.name,
           total: -1,
           gzipped: -1,
+          html: -1,
+          htmlGzipped: -1,
           files: 0,
           requests: 0,
+          buildMs,
           error: true,
         });
         continue;
@@ -484,10 +502,15 @@ async function main() {
     results.push({
       name: app.name,
       ...size,
+      buildMs,
     });
 
+    if (Number.isFinite(buildMs)) {
+      console.log(`  Build: ${formatDuration(buildMs)}`);
+    }
     console.log(`  Total: ${formatBytes(size.total)}`);
     console.log(`  Gzipped: ${formatBytes(size.gzipped)}`);
+    console.log(`  HTML: ${formatBytes(size.html)} (${formatBytes(size.htmlGzipped)} gzip)`);
     console.log(`  Requests: ${size.requests}`);
     console.log(`  Files: ${size.files}\n`);
   }
@@ -511,38 +534,46 @@ async function main() {
 
   // Calculate dynamic column widths
   const nameWidth = Math.max(9, ...results.map((r) => r.name.length)); // min 9 for "Framework"
+  const buildWidth = 9;
   const totalWidth = 10;
   const gzippedWidth = 10;
+  const htmlWidth = 10;
   const ratioWidth = 9;
   const requestsWidth = 8;
   const filesWidth = 5;
 
   // Print markdown table
-  const header = `| ${"Framework".padEnd(nameWidth)} | ${"Total".padEnd(totalWidth)} | ${"Gzipped".padEnd(gzippedWidth)} | ${"Ratio".padEnd(ratioWidth)} | ${"Requests".padEnd(requestsWidth)} | ${"Files".padEnd(filesWidth)} |`;
-  const separator = `|${"-".repeat(nameWidth + 2)}|${"-".repeat(totalWidth + 2)}|${"-".repeat(gzippedWidth + 2)}|${"-".repeat(ratioWidth + 2)}|${"-".repeat(requestsWidth + 2)}|${"-".repeat(filesWidth + 2)}|`;
+  const header = `| ${"Framework".padEnd(nameWidth)} | ${"Build".padEnd(buildWidth)} | ${"Total".padEnd(totalWidth)} | ${"Gzipped".padEnd(gzippedWidth)} | ${"HTML gzip".padEnd(htmlWidth)} | ${"Ratio".padEnd(ratioWidth)} | ${"Requests".padEnd(requestsWidth)} | ${"Files".padEnd(filesWidth)} |`;
+  const separator = `|${"-".repeat(nameWidth + 2)}|${"-".repeat(buildWidth + 2)}|${"-".repeat(totalWidth + 2)}|${"-".repeat(gzippedWidth + 2)}|${"-".repeat(htmlWidth + 2)}|${"-".repeat(ratioWidth + 2)}|${"-".repeat(requestsWidth + 2)}|${"-".repeat(filesWidth + 2)}|`;
   console.log(header);
   console.log(separator);
 
   for (const result of results) {
     if (result.error) {
       console.log(
-        `| ${result.name.padEnd(nameWidth)} | ${"Error".padEnd(totalWidth)} | ${"-".padEnd(gzippedWidth)} | ${"-".padEnd(ratioWidth)} | ${"-".padEnd(requestsWidth)} | ${"-".padEnd(filesWidth)} |`,
+        `| ${result.name.padEnd(nameWidth)} | ${"Error".padEnd(buildWidth)} | ${"-".padEnd(totalWidth)} | ${"-".padEnd(gzippedWidth)} | ${"-".padEnd(htmlWidth)} | ${"-".padEnd(ratioWidth)} | ${"-".padEnd(requestsWidth)} | ${"-".padEnd(filesWidth)} |`,
       );
       continue;
     }
 
     const name = result.name.padEnd(nameWidth);
+    const build = formatDuration(result.buildMs).padEnd(buildWidth);
     const total = formatBytes(result.total).padEnd(totalWidth);
     const gzipped = formatBytes(result.gzipped).padEnd(gzippedWidth);
+    const html = formatBytes(result.htmlGzipped).padEnd(htmlWidth);
     const ratio = ((result.gzipped / baseline).toFixed(2) + "x").padEnd(ratioWidth);
     const requests = String(result.requests).padEnd(requestsWidth);
     const files = String(result.files).padEnd(filesWidth);
-    console.log(`| ${name} | ${total} | ${gzipped} | ${ratio} | ${requests} | ${files} |`);
+    console.log(
+      `| ${name} | ${build} | ${total} | ${gzipped} | ${html} | ${ratio} | ${requests} | ${files} |`,
+    );
   }
 
   console.log("\n\nNotes:");
   console.log("- All frameworks built with production settings");
   console.log("- Gzipped size calculated for JS/CSS/HTML files");
+  console.log("- HTML gzip tracks rendered page output, excluding JS and CSS assets");
+  console.log("- Build time is the production app build for this benchmark fixture");
   console.log("- Requests include index.html plus referenced local initial assets");
   console.log("- Same markdown content used across all frameworks");
   console.log("- Ratio is relative to the smallest bundle");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -138,12 +138,18 @@ export default defineConfig({
         "test:vscode-unit",
         "test:vrt",
       ]),
-      "test:ts-unit": noopTask(["test:vite-plugin", "test:code-play", "test:publish-targets"]),
+      "test:ts-unit": noopTask([
+        "test:vite-plugin",
+        "test:code-play",
+        "test:publish-targets",
+        "test:benchmark-scripts",
+      ]),
       "test:vite-plugin": task("vp exec --filter @ox-content/vite-plugin -- vp test src", {
         dependsOn: ["build:napi"],
       }),
       "test:code-play": task("vp exec --filter @ox-content/code-play -- vp test src"),
       "test:publish-targets": task("vp test scripts/verify-publish-targets.test.ts"),
+      "test:benchmark-scripts": task("vp test benchmarks/bundle-size/compare-pr-benchmark.test.ts"),
       "build:vite-plugin": task("vp run --filter @ox-content/vite-plugin build", {
         dependsOn: ["build:napi"],
       }),


### PR DESCRIPTION
## Summary

- report benchmark fixture build time from the existing bundle-size build pass
- add rendered HTML gzip size to benchmark JSON and PR comments
- gate rendered HTML gzip regressions with the existing benchmark override path
- cover the PR comment formatter with a focused test

Refs #851

## Risk

- Risk level: low
- User or production impact: benchmark/reporting only; build time is informational, while rendered HTML gzip joins the existing size gate
- Rollback plan: revert this PR to return the benchmark comment to runtime plus bundle-size reporting

## Validation

- [x] Automated tests or checks run: `vp test benchmarks/bundle-size/compare-pr-benchmark.test.ts`
- [x] Automated tests or checks run: `vp run test:benchmark-scripts`
- [x] Automated tests or checks run: `vp fmt --check benchmarks/bundle-size/measure.mjs benchmarks/bundle-size/compare-pr-benchmark.mjs benchmarks/bundle-size/compare-pr-benchmark.test.ts vite.config.ts benchmarks/README.md`
- [x] Automated tests or checks run: `vp check`
- [x] Manual verification completed: `node benchmarks/bundle-size/measure.mjs --skip-build --json /tmp/ox-content-bundle-measure.json`
- [x] Edge cases or failure modes considered: older bundle JSON without `htmlGzipped` or `buildMs` remains comparable as `n/a`

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790264848&installation_model_id=422833&pr_number=862&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F862&signature=0359cd819ccceb8521947980de69a6e5c22017ce7dcf3c421d5bcdfb0b6b3647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark reports now include build duration, rendered HTML gzip size, and base-to-head request/file changes.
  * Reports distinguish informational build-time results from gated runtime, bundle-size, and rendered HTML regressions.
  * Invalid benchmark values are displayed as unavailable instead of producing misleading results.

* **Tests**
  * Added coverage for new metrics, regression detection, and compatibility with reports missing optional fields.
  * Benchmark comparison tests now run as part of the TypeScript unit test task.

* **Documentation**
  * Updated benchmark documentation to describe runner consistency and regression gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->