### PR TITLE
fix(release): skip prerelease marketplace publish

### DIFF
--- a/scripts/publish-editor-extensions.test.ts
+++ b/scripts/publish-editor-extensions.test.ts
@@ -1,0 +1,91 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vite-plus/test";
+
+const scriptPath = resolve("scripts/publish-editor-extensions.ts");
+
+describe("publish editor extensions", () => {
+  it("skips VS Code Marketplace publish for prerelease extension versions", () => {
+    const fixture = createFixture();
+    const result = runPublisher(fixture, "vscode-marketplace", {
+      GITHUB_REF_NAME: "v3.0.0-alpha.7",
+      VSCE_PAT: "test-token",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Skipping VS Code Marketplace publish");
+    expect(result.stdout).toContain("3.0.0-alpha.7");
+    expect(existsSync(fixture.callLog)).toBe(false);
+  });
+
+  it("keeps Open VSX prerelease publishing and stable Marketplace publishing enabled", () => {
+    const openVsxFixture = createFixture();
+    const openVsx = runPublisher(openVsxFixture, "open-vsx", {
+      GITHUB_REF_NAME: "v3.0.0-alpha.7",
+      OVSX_PAT: "test-token",
+    });
+
+    expect(openVsx.status).toBe(0);
+    expect(readFileSync(openVsxFixture.callLog, "utf8")).toContain("ovsx");
+
+    const marketplaceFixture = createFixture();
+    const marketplace = runPublisher(marketplaceFixture, "vscode-marketplace", {
+      GITHUB_REF_NAME: "v3.0.0",
+      VSCE_PAT: "test-token",
+    });
+
+    expect(marketplace.status).toBe(0);
+    expect(readFileSync(marketplaceFixture.callLog, "utf8")).toContain("@vscode/vsce");
+  });
+});
+
+function createFixture() {
+  const root = mkdtempSync(join(tmpdir(), "ox-editor-publish-"));
+  const binDir = join(root, "bin");
+  const vsixDir = join(root, "dist", "vscode");
+  const callLog = join(root, "vp-calls.log");
+
+  mkdirSync(binDir);
+  mkdirSync(vsixDir, { recursive: true });
+  writeFileSync(join(vsixDir, "vscode-ox-content-linux-x64.vsix"), "");
+
+  const vpPath = join(binDir, "vp");
+  writeFileSync(
+    vpPath,
+    [
+      "#!/usr/bin/env node",
+      "const fs = require('node:fs');",
+      "fs.appendFileSync(process.env.VP_CALL_LOG, JSON.stringify(process.argv.slice(2)) + '\\n');",
+      "process.exit(0);",
+    ].join("\n"),
+  );
+  chmodSync(vpPath, 0o755);
+
+  return { root, binDir, callLog };
+}
+
+function runPublisher(
+  fixture: ReturnType<typeof createFixture>,
+  registry: "open-vsx" | "vscode-marketplace",
+  env: Record<string, string>,
+) {
+  return spawnSync(process.execPath, [scriptPath, registry], {
+    cwd: fixture.root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...env,
+      PATH: `${fixture.binDir}${process.platform === "win32" ? ";" : ":"}${process.env.PATH}`,
+      VP_CALL_LOG: fixture.callLog,
+    },
+  });
+}

--- a/scripts/publish-editor-extensions.ts
+++ b/scripts/publish-editor-extensions.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { readdirSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
@@ -69,6 +69,14 @@ if (
   process.exit(0);
 }
 
+const releaseVersion = getReleaseVersion();
+if (registry === registries["vscode-marketplace"] && isPrereleaseVersion(releaseVersion)) {
+  console.log(
+    `::notice::Skipping ${registry.label} publish for prerelease extension version ${releaseVersion}; VS Code Marketplace rejects prerelease semver strings.`,
+  );
+  process.exit(0);
+}
+
 const token = process.env[registry.tokenEnv];
 if (!token) {
   console.log(
@@ -108,6 +116,31 @@ function listVsixPackages(): string[] {
   }
 
   return found;
+}
+
+function getReleaseVersion(): string | null {
+  const input = process.env.VERSION_INPUT?.trim();
+  if (input) {
+    return input;
+  }
+
+  const refName = process.env.GITHUB_REF_NAME?.trim();
+  if (refName?.startsWith("v")) {
+    return refName.slice(1);
+  }
+
+  try {
+    const pkg = JSON.parse(readFileSync("npm/vscode-ox-content/package.json", "utf8")) as {
+      version?: unknown;
+    };
+    return typeof pkg.version === "string" ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
+function isPrereleaseVersion(version: string | null): boolean {
+  return version !== null && /^\d+\.\d+\.\d+-/.test(version);
 }
 
 async function publishWithRetry(target: Registry, vsix: string, pat: string): Promise<void> {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -143,6 +143,7 @@ export default defineConfig({
         "test:code-play",
         "test:publish-targets",
         "test:benchmark-scripts",
+        "test:editor-publish-scripts",
       ]),
       "test:vite-plugin": task("vp exec --filter @ox-content/vite-plugin -- vp test src", {
         dependsOn: ["build:napi"],
@@ -150,6 +151,7 @@ export default defineConfig({
       "test:code-play": task("vp exec --filter @ox-content/code-play -- vp test src"),
       "test:publish-targets": task("vp test scripts/verify-publish-targets.test.ts"),
       "test:benchmark-scripts": task("vp test benchmarks/bundle-size/compare-pr-benchmark.test.ts"),
+      "test:editor-publish-scripts": task("vp test scripts/publish-editor-extensions.test.ts"),
       "build:vite-plugin": task("vp run --filter @ox-content/vite-plugin build", {
         dependsOn: ["build:napi"],
       }),


### PR DESCRIPTION
## Summary

- Skip VS Code Marketplace publishing when the extension version is a prerelease semver string.
- Keep Open VSX prerelease publishing and stable Marketplace publishing paths unchanged.
- Add script coverage for the prerelease skip and active publish paths.

Fixes #864

## Validation

- `vp test scripts/publish-editor-extensions.test.ts`
- `vp run test:editor-publish-scripts`
- `vp fmt --check scripts/publish-editor-extensions.ts scripts/publish-editor-extensions.test.ts vite.config.ts`
- `vp check` (exit 0; existing warnings remain outside this change)

## Release impact

Prevents future alpha release tags from failing the editor publish workflow on deterministic VS Code Marketplace prerelease-version rejection.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790268055&installation_model_id=422833&pr_number=865&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F865&signature=1502f2064e4b242e17680681f5b43ddfa6a99b7dc8e67bbf9177449f098d1641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented prerelease versions from being published to the VS Code Marketplace, avoiding rejected releases.
  * Continued allowing prerelease releases on Open VSX.

* **Tests**
  * Added automated coverage for prerelease and stable publishing scenarios.
  * Included the new publishing tests in the TypeScript unit test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->