### PR TITLE
fix(docs): highlight WebContainer examples as MDX

### DIFF
--- a/crates/ox_content_highlight/src/languages.rs
+++ b/crates/ox_content_highlight/src/languages.rs
@@ -121,7 +121,7 @@ fn grammars() -> &'static [Grammar] {
         ),
         grammar!(
             "javascript",
-            ["javascript", "js", "cjs", "mjs", "jsx"],
+            ["javascript", "js", "cjs", "mjs", "jsx", "mdx"],
             tree_sitter_javascript::LANGUAGE,
             javascript_highlights(),
             tree_sitter_javascript::INJECTIONS_QUERY,

--- a/crates/ox_content_highlight/src/tests.rs
+++ b/crates/ox_content_highlight/src/tests.rs
@@ -14,6 +14,7 @@ fn aliases_resolve_to_the_same_grammar() {
     for alias in ["bash", "sh", "shell", "zsh"] {
         assert!(supports(alias), "{alias} should be supported");
     }
+    assert!(supports("mdx"));
     assert_eq!(
         highlight_to_html("const a = 1;", "ts"),
         highlight_to_html("const a = 1;", "typescript")
@@ -148,6 +149,20 @@ fn markdown_highlights_a_fenced_block_in_its_own_language() {
     let html = highlight_to_html("```ts\nconst a = 1;\n```\n", "md").expect("supported");
 
     assert!(html.contains("--octc-syntax-token-keyword"), "{html}");
+}
+
+#[test]
+fn mdx_highlights_custom_element_closing_tags() {
+    let html = highlight_to_html(
+        "<WebContainer entry=\"index.html\" title=\"Demo\">\n  npm install\n</WebContainer>\n",
+        "mdx",
+    )
+    .expect("supported");
+    let closing = html.split("&lt;/").nth(1).expect("closing tag should be present");
+
+    assert!(closing.contains("WebContainer"), "{html}");
+    assert!(closing.contains("--octc-syntax-token-function"), "{html}");
+    assert!(closing.contains("--octc-syntax-token-punctuation"), "{html}");
 }
 
 #[test]

--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -299,7 +299,8 @@ cross-origin isolation metadata, for sites that boot
 [WebContainers](https://webcontainers.io/) on interaction. The placeholder
 itself is fully static:
 
-```md
+<!-- prettier-ignore -->
+```mdx
 <WebContainer entry="index.html" title="Demo">
   npm install
   npm run dev

--- a/docs/content/examples/webcontainer-embed.md
+++ b/docs/content/examples/webcontainer-embed.md
@@ -22,6 +22,10 @@ export default {
 };
 ```
 
-```html
-<WebContainer entry="index.html" title="Demo"> npm install npm run dev </WebContainer>
+<!-- prettier-ignore -->
+```mdx
+<WebContainer entry="index.html" title="Demo">
+  npm install
+  npm run dev
+</WebContainer>
 ```

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -239,7 +239,8 @@ oxContent({
 
 `embeds.webContainer` は、操作時に [WebContainers](https://webcontainers.io/) を起動するサイト向けに、プロジェクトソースとクロスオリジン分離メタデータを持つ遅延プレースホルダを出します。プレースホルダ自体は完全に静的です。
 
-```md
+<!-- prettier-ignore -->
+```mdx
 <WebContainer entry="index.html" title="Demo">
   npm install
   npm run dev


### PR DESCRIPTION
## Summary
- teach the native highlighter to treat `mdx` fences as JSX-capable blocks
- switch WebContainer docs examples to `mdx` fences while preserving readable multiline samples
- add coverage for custom component closing tags in MDX-highlighted snippets

Fixes #876.
Refs #857.
Refs #859.

## Verification
- `vpr fmt:check`
- `cargo test -p ox_content_highlight`
- `node scripts/check-file-lines.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790274424&installation_model_id=422833&pr_number=914&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F914&signature=7a404fa378c7de1b78883102f953e79b5910f5c1e94756b9646b44387ebe5477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->