### PR TITLE
fix(vite-plugin): restore typed hover overlays

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@ox-content/code-play": "workspace:*",
     "@ox-content/vite-plugin": "workspace:*",
+    "@typescript/native-preview": "catalog:",
     "katex": "^0.16.22",
     "vite": "catalog:",
     "vite-plus": "catalog:"

--- a/npm/vite-plugin-ox-content/src/typed-hover.test.ts
+++ b/npm/vite-plugin-ox-content/src/typed-hover.test.ts
@@ -54,6 +54,22 @@ describe("typedHover transform", () => {
     expect(result.html).not.toContain("typescript/lib");
   });
 
+  it("keeps hover payloads after native syntax highlighting", async () => {
+    const result = await transformMarkdown(
+      TWOSLASH_SNIPPET,
+      "docs/typed-hover-highlighted.md",
+      createDocsResolvedOptions({
+        highlight: true,
+        typedHover: { enabled: true, languages: ["ts", "tsx"] },
+      }),
+    );
+
+    expect(result.html).toContain('class="ox-highlight css-variables ox-typed-hover"');
+    expect(result.html).toContain("ox-typed-hover-token");
+    expect(result.html).toContain("ox-typed-hover-data");
+    expect(result.html).toMatch(/number/);
+  });
+
   it("skips TypeScript fences that omit the twoslash meta", async () => {
     const result = await transformMarkdown(
       ["```ts", "const value = 1;", "```"].join("\n"),

--- a/npm/vite-plugin-ox-content/src/typed-hover.ts
+++ b/npm/vite-plugin-ox-content/src/typed-hover.ts
@@ -4,7 +4,7 @@ import {
   type TypedHoverAttachment,
   type TypedHoverRange,
 } from "./typed-hover-generate";
-import type { OxContentOptions, ResolvedOptions } from "./types";
+import type { OxContentOptions, ResolvedOptions, ResolvedTypedHoverOptions } from "./types";
 
 export type { TypedHoverAttachment, TypedHoverRange };
 
@@ -16,7 +16,7 @@ const DEFAULT_LANGUAGES = ["ts", "tsx"] as const;
 
 export function resolveTypedHoverOptions(
   options: OxContentOptions["typedHover"],
-): ResolvedOptions["typedHover"] {
+): ResolvedTypedHoverOptions {
   if (!options) {
     return { enabled: false, languages: [...DEFAULT_LANGUAGES] };
   }
@@ -218,4 +218,4 @@ function decodeHtmlEntities(value: string): string {
 
 const TYPED_HOVER_STYLE = `<style data-ox-typed-hover-style>.ox-typed-hover-token{cursor:help;text-decoration:underline dotted}.ox-typed-hover-overlay{position:fixed;z-index:50;max-width:36rem;padding:.35rem .55rem;border:1px solid #444;border-radius:4px;background:#1e1e1e;color:#d4d4d4;font:12px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace;white-space:pre-wrap;pointer-events:none}</style>`;
 
-const TYPED_HOVER_CLIENT = `<script data-ox-typed-hover-runtime>(function(){if(window.__oxTypedHover)return;window.__oxTypedHover=1;var tip=document.createElement("div");tip.className="ox-typed-hover-overlay";tip.setAttribute("role","tooltip");tip.hidden=true;document.body.appendChild(tip);function payload(token){var pre=token.closest(".ox-typed-hover");if(!pre)return null;var host=pre.closest(".ox-code")||pre;var data=host.nextElementSibling;if(!data||!data.classList.contains("ox-typed-hover-data"))return null;try{return JSON.parse(data.textContent||"")}catch(e){return null}}function show(token){var data=payload(token);var item=data&&data.hovers[Number(token.getAttribute("data-ox-typed-hover"))];if(!item)return;tip.textContent=item.type;tip.hidden=false;var box=token.getBoundingClientRect();tip.style.left=Math.max(8,box.left)+"px";tip.style.top=Math.max(8,box.top-tip.offsetHeight-8)+"px"}function hide(){tip.hidden=true}document.addEventListener("mouseover",function(e){var t=e.target.closest(".ox-typed-hover-token");if(t)show(t)});document.addEventListener("mouseout",function(e){var t=e.target.closest(".ox-typed-hover-token");if(t&&!t.contains(e.relatedTarget))hide()});document.addEventListener("focusin",function(e){var t=e.target.closest(".ox-typed-hover-token");if(t)show(t)});document.addEventListener("focusout",function(e){if(!e.relatedTarget||!e.relatedTarget.closest(".ox-typed-hover-token"))hide()});document.addEventListener("keydown",function(e){if(e.key==="Escape")hide()})})();</script>`;
+const TYPED_HOVER_CLIENT = `<script data-ox-typed-hover-runtime>(function(){if(window.__oxTypedHover)return;window.__oxTypedHover=1;var tip=document.createElement("div");tip.className="ox-typed-hover-overlay";tip.setAttribute("role","tooltip");tip.hidden=true;document.body.appendChild(tip);function closest(value,selector){return value instanceof Element?value.closest(selector):null}function nextData(host){var node=host.nextElementSibling;while(node&&node.tagName==="SCRIPT"&&!node.classList.contains("ox-typed-hover-data"))node=node.nextElementSibling;return node}function payload(token){var pre=token.closest(".ox-typed-hover");if(!pre)return null;var host=pre.closest(".ox-code")||pre;var data=nextData(host)||nextData(pre);if(!data||!data.classList.contains("ox-typed-hover-data"))return null;try{return JSON.parse(data.textContent||"")}catch(e){return null}}function show(token){var data=payload(token);var item=data&&data.hovers[Number(token.getAttribute("data-ox-typed-hover"))];if(!item)return;tip.textContent=item.type;tip.hidden=false;var box=token.getBoundingClientRect();tip.style.left=Math.max(8,box.left)+"px";tip.style.top=Math.max(8,box.top-tip.offsetHeight-8)+"px"}function hide(){tip.hidden=true}document.addEventListener("mouseover",function(e){var t=closest(e.target,".ox-typed-hover-token");if(t)show(t)});document.addEventListener("mouseout",function(e){var t=closest(e.target,".ox-typed-hover-token");if(t&&!t.contains(e.relatedTarget))hide()});document.addEventListener("focusin",function(e){var t=closest(e.target,".ox-typed-hover-token");if(t)show(t)});document.addEventListener("focusout",function(e){if(!closest(e.relatedTarget,".ox-typed-hover-token"))hide()});document.addEventListener("keydown",function(e){if(e.key==="Escape")hide()})})();</script>`;

--- a/npm/vite-plugin-ox-content/test/vrt/typed-hover.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/typed-hover.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+import { generateHtmlPage } from "../../src/ssg";
+import { transformMarkdown } from "../../src/transform";
+import { createDocsResolvedOptions } from "../fixtures/docs-fixture";
+
+test("typed hover remains interactive after syntax highlighting and reader chrome", async ({
+  page,
+}) => {
+  const markdown = ["# Typed Hover", "", "```ts twoslash", "const value = 1;", "```"].join("\n");
+  const result = await transformMarkdown(
+    markdown,
+    "docs/vrt-typed-hover.md",
+    createDocsResolvedOptions({
+      highlight: true,
+      typedHover: { enabled: true, languages: ["ts", "tsx"] },
+    }),
+  );
+  const html = await generateHtmlPage(
+    {
+      title: "Typed Hover",
+      content: result.html,
+      toc: result.toc,
+      frontmatter: {},
+      path: "/vrt-typed-hover",
+      href: "/vrt-typed-hover/index.html",
+    },
+    [],
+    "Ox Content",
+    "/",
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    false,
+    { copy: true, externalLinks: false, backToTop: false },
+  );
+
+  await page.setContent(html, { waitUntil: "load" });
+  const token = page.locator(".ox-typed-hover-token", { hasText: "value" }).first();
+
+  await expect(token).toBeVisible();
+  await expect(page.locator(".ox-code .ox-typed-hover-token")).toHaveCount(1);
+
+  await token.hover();
+  await expect(page.locator(".ox-typed-hover-overlay")).toContainText("number");
+
+  await token.focus();
+  await expect(page.locator(".ox-typed-hover-overlay")).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".ox-typed-hover-overlay")).toBeHidden();
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ importers:
       '@ox-content/vite-plugin':
         specifier: workspace:*
         version: link:../npm/vite-plugin-ox-content
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260707.2
       katex:
         specifier: ^0.16.22
         version: 0.16.47


### PR DESCRIPTION
## Summary
- keep typed hover payloads attached when native syntax highlighting is enabled
- make the browser runtime tolerant of reader chrome wrappers and non-Element event targets
- add a Playwright regression that hovers/focuses a highlighted `twoslash` fence after SSG reader chrome wraps it
- declare `@typescript/native-preview` in the docs app because docs enables `typedHover`

Closes #917

## Validation
- `vpr fmt:check`
- `vp test npm/vite-plugin-ox-content/src/typed-hover.test.ts`
- `vp exec --filter @ox-content/vite-plugin -- playwright test test/vrt/typed-hover.spec.ts`
- `node scripts/check-file-lines.ts`
- `git diff --check`

## Notes
- `vp exec --filter @ox-content/vite-plugin -- tsgo --noEmit` still fails on pre-existing package-wide issues in search fixtures, feeds tests, HAST version skew, missing `vitest` types, and related files; the typed-hover-specific strict errors are cleared by this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790275645&installation_model_id=422833&pr_number=918&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F918&signature=aed99fa0253310d57444204c57a90640828bf3c91193cec46f4adead31e7df90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved typed-hover behavior when native syntax highlighting is enabled.
  * Hover information now remains available in wrapped code layouts and documentation pages with reader controls.
  * Tooltips reliably appear when hovering or focusing supported code tokens and can be dismissed with Escape.

* **Tests**
  * Added coverage for typed-hover rendering, visibility, focus interactions, and dismissal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->