### PR TITLE
fix(theme): avoid empty table stretch columns

### DIFF
--- a/crates/ox_content_ssg/src/html/tests/rendering.rs
+++ b/crates/ox_content_ssg/src/html/tests/rendering.rs
@@ -201,10 +201,11 @@ fn test_nested_nav_css_keeps_disclosure_and_hierarchy_visible() {
 #[test]
 fn test_table_css_draws_each_separator_once() {
     assert!(
-        SSG_CSS.contains(".content table {\n  width: 100%;")
-            && SSG_CSS.contains("border: 1px solid var(--octc-color-border);")
+        SSG_CSS.contains(
+            ".content table {\n  display: block;\n  width: max-content;\n  max-width: 100%;"
+        ) && SSG_CSS.contains("border: 1px solid var(--octc-color-border);")
             && SSG_CSS.contains("border-collapse: separate;"),
-        "tables need one shared separated-border model at every breakpoint"
+        "tables need a shrink-to-content scroller and one shared separated-border model"
     );
     assert!(
         SSG_CSS.contains("border-inline-end: 1px solid var(--octc-color-border);")
@@ -246,8 +247,12 @@ fn test_mobile_content_css_preserves_safe_reading_gutters() {
         "content gutters must include each physical display safe area"
     );
     assert!(
-        SSG_CSS.contains(".content table {\n    display: block;")
-            && SSG_CSS.contains("max-width: 100%;"),
+        SSG_CSS.contains(".content table {\n  display: block;")
+            && SSG_CSS.contains("width: max-content;")
+            && SSG_CSS.contains("max-width: 100%;")
+            && SSG_CSS.contains("overflow-x: auto;")
+            && !SSG_CSS
+                .contains("  .content table {\n    display: block;\n    width: max-content;\n    min-width: 100%;"),
         "wide tables must scroll inside the safe content gutter"
     );
     assert!(

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -1251,11 +1251,15 @@ a:hover {
   background: var(--octc-color-code-line-focus);
 }
 .content table {
-  width: 100%;
+  display: block;
+  width: max-content;
+  max-width: 100%;
   box-sizing: border-box;
   border: 1px solid var(--octc-color-border);
   border-collapse: separate;
   border-spacing: 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   margin: 1.25rem 0;
   font-size: 0.875rem;
 }
@@ -2092,12 +2096,6 @@ a:hover {
     width: 1.75rem;
   }
   .content table {
-    display: block;
-    width: max-content;
-    min-width: 100%;
-    max-width: 100%;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
     font-size: 0.8125rem;
   }

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -1248,11 +1248,15 @@ a:hover {
   background: var(--octc-color-code-line-focus);
 }
 .content table {
-  width: 100%;
+  display: block;
+  width: max-content;
+  max-width: 100%;
   box-sizing: border-box;
   border: 1px solid var(--octc-color-border);
   border-collapse: separate;
   border-spacing: 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   margin: 1.25rem 0;
   font-size: 0.875rem;
 }
@@ -2089,12 +2093,6 @@ a:hover {
     width: 1.75rem;
   }
   .content table {
-    display: block;
-    width: max-content;
-    min-width: 100%;
-    max-width: 100%;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
     font-size: 0.8125rem;
   }

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -1248,11 +1248,15 @@ a:hover {
   background: var(--octc-color-code-line-focus);
 }
 .content table {
-  width: 100%;
+  display: block;
+  width: max-content;
+  max-width: 100%;
   box-sizing: border-box;
   border: 1px solid var(--octc-color-border);
   border-collapse: separate;
   border-spacing: 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   margin: 1.25rem 0;
   font-size: 0.875rem;
 }
@@ -2089,12 +2093,6 @@ a:hover {
     width: 1.75rem;
   }
   .content table {
-    display: block;
-    width: max-content;
-    min-width: 100%;
-    max-width: 100%;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
     font-size: 0.8125rem;
   }

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -1248,11 +1248,15 @@ a:hover {
   background: var(--octc-color-code-line-focus);
 }
 .content table {
-  width: 100%;
+  display: block;
+  width: max-content;
+  max-width: 100%;
   box-sizing: border-box;
   border: 1px solid var(--octc-color-border);
   border-collapse: separate;
   border-spacing: 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   margin: 1.25rem 0;
   font-size: 0.875rem;
 }
@@ -2089,12 +2093,6 @@ a:hover {
     width: 1.75rem;
   }
   .content table {
-    display: block;
-    width: max-content;
-    min-width: 100%;
-    max-width: 100%;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
     font-size: 0.8125rem;
   }

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -1248,11 +1248,15 @@ a:hover {
   background: var(--octc-color-code-line-focus);
 }
 .content table {
-  width: 100%;
+  display: block;
+  width: max-content;
+  max-width: 100%;
   box-sizing: border-box;
   border: 1px solid var(--octc-color-border);
   border-collapse: separate;
   border-spacing: 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   margin: 1.25rem 0;
   font-size: 0.875rem;
 }
@@ -2089,12 +2093,6 @@ a:hover {
     width: 1.75rem;
   }
   .content table {
-    display: block;
-    width: max-content;
-    min-width: 100%;
-    max-width: 100%;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
     font-size: 0.8125rem;
   }

--- a/crates/ox_content_ssg/src/ssg.css
+++ b/crates/ox_content_ssg/src/ssg.css
@@ -1214,11 +1214,15 @@ a:hover {
   background: var(--octc-color-code-line-focus);
 }
 .content table {
-  width: 100%;
+  display: block;
+  width: max-content;
+  max-width: 100%;
   box-sizing: border-box;
   border: 1px solid var(--octc-color-border);
   border-collapse: separate;
   border-spacing: 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   margin: 1.25rem 0;
   font-size: 0.875rem;
 }
@@ -2055,12 +2059,6 @@ a:hover {
     width: 1.75rem;
   }
   .content table {
-    display: block;
-    width: max-content;
-    min-width: 100%;
-    max-width: 100%;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
     font-size: 0.8125rem;
   }

--- a/npm/vite-plugin-ox-content/test/vrt/table-overflow.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/table-overflow.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "@playwright/test";
+import { generateHtmlPage } from "../../src/ssg";
+import { transformMarkdown } from "../../src/transform";
+import { createDocsResolvedOptions } from "../fixtures/docs-fixture";
+
+async function render(markdown: string) {
+  const result = await transformMarkdown(
+    markdown,
+    "docs/vrt-table-overflow.md",
+    createDocsResolvedOptions({ highlight: false }),
+  );
+  return generateHtmlPage(
+    {
+      title: "Tables",
+      content: result.html,
+      toc: result.toc,
+      frontmatter: {},
+      path: "/vrt-table-overflow",
+      href: "/vrt-table-overflow/index.html",
+    },
+    [],
+    "Ox Content",
+    "/",
+  );
+}
+
+test("narrow mobile tables do not draw an empty trailing column", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.setContent(
+    await render(
+      ["# Tables", "", "| A | B | C |", "| --- | --- | --- |", "| `x` | `y` | `z` |"].join("\n"),
+    ),
+    { waitUntil: "load" },
+  );
+
+  const metrics = await page.locator(".content table").evaluate((table) => {
+    const lastCell = table.querySelector("tr:first-child > :last-child");
+    const content = table.closest(".content");
+    if (!(lastCell instanceof HTMLElement) || !(content instanceof HTMLElement)) {
+      throw new Error("Missing table geometry targets");
+    }
+    const tableRect = table.getBoundingClientRect();
+    const cellRect = lastCell.getBoundingClientRect();
+    const contentRect = content.getBoundingClientRect();
+    return {
+      contentWidth: contentRect.width,
+      tableWidth: tableRect.width,
+      trailingGap: tableRect.right - cellRect.right,
+    };
+  });
+
+  expect(metrics.tableWidth).toBeLessThan(metrics.contentWidth);
+  expect(metrics.trailingGap).toBeLessThan(2);
+});
+
+test("wide mobile tables keep horizontal overflow inside the content gutter", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.setContent(
+    await render(
+      [
+        "# Tables",
+        "",
+        "| Option | Type | Default |",
+        "| --- | --- | --- |",
+        "| `veryLongOptionNameWithoutBreaks` | `ExtremelyLongTypeNameWithoutBreaks` | `false` |",
+      ].join("\n"),
+    ),
+    { waitUntil: "load" },
+  );
+
+  const metrics = await page.locator(".content table").evaluate((table) => {
+    const content = table.closest(".content");
+    if (!(table instanceof HTMLElement) || !(content instanceof HTMLElement)) {
+      throw new Error("Missing table geometry targets");
+    }
+    return {
+      clientWidth: table.clientWidth,
+      contentWidth: content.getBoundingClientRect().width,
+      scrollWidth: table.scrollWidth,
+      tableWidth: table.getBoundingClientRect().width,
+    };
+  });
+
+  expect(metrics.tableWidth).toBeLessThanOrEqual(metrics.contentWidth + 1);
+  expect(metrics.scrollWidth).toBeGreaterThan(metrics.clientWidth);
+});


### PR DESCRIPTION
## Summary
- make themed content tables shrink to their intrinsic width instead of forcing an empty full-width stretch area
- keep genuinely wide tables horizontally scrollable inside the content gutter
- refresh SSG CSS snapshots and add a browser regression for narrow and wide mobile tables

Closes #891

## Validation
- `vp exec --filter @ox-content/napi -- napi build`
- `cargo test -p ox_content_ssg`
- `vp exec --filter @ox-content/vite-plugin -- playwright test test/vrt/table-overflow.spec.ts`
- `vpr fmt:check`
- `node scripts/check-file-lines.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790276143&installation_model_id=422833&pr_number=919&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F919&signature=2dd0a7a181d2c6264344723e2a3db48f17362cd502cb6295d71dec58da95102e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->