### PR TITLE
fix(theme): tune magic link chips

### DIFF
--- a/crates/ox_content_ssg/src/html/reader_chrome.css
+++ b/crates/ox_content_ssg/src/html/reader_chrome.css
@@ -106,6 +106,13 @@
   mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6'/><polyline points='15 3 21 3 21 9'/><line x1='10' y1='14' x2='21' y2='3'/></svg>")
     center / contain no-repeat;
 }
+.content .ox-magic-link .ox-external-icon {
+  width: 0.62em;
+  height: 0.62em;
+  margin-inline-start: 0.02em;
+  opacity: 0.72;
+  flex: 0 0 auto;
+}
 .ox-back-to-top {
   position: fixed;
   right: 1.25rem;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -1105,21 +1105,27 @@ a:hover {
 .content .ox-magic-link {
   display: inline-flex;
   align-items: center;
-  gap: 0.3em;
-  padding: 0.05em 0.45em 0.05em 0.2em;
-  border: 1px solid var(--octc-color-border);
-  border-radius: 999px;
-  background: var(--octc-color-bg-alt);
+  gap: 0.26em;
+  max-width: 100%;
+  padding: 0.08em 0.38em 0.08em 0.24em;
+  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, transparent);
+  border-radius: 0.42em;
+  background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-bg) 18%);
   color: inherit;
+  line-height: 1;
   text-decoration: none;
-  vertical-align: 0.1em;
+  vertical-align: -0.08em;
 }
 .content .ox-magic-link:hover {
   border-color: color-mix(in srgb, var(--octc-color-primary) 45%, var(--octc-color-border));
 }
+.content .ox-magic-link:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--octc-color-primary) 72%, transparent);
+  outline-offset: 2px;
+}
 .content .ox-magic-link__image {
-  width: 1.1em;
-  height: 1.1em;
+  width: 1em;
+  height: 1em;
   border-radius: 999px;
   object-fit: cover;
   flex: 0 0 auto;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -1102,21 +1102,27 @@ a:hover {
 .content .ox-magic-link {
   display: inline-flex;
   align-items: center;
-  gap: 0.3em;
-  padding: 0.05em 0.45em 0.05em 0.2em;
-  border: 1px solid var(--octc-color-border);
-  border-radius: 999px;
-  background: var(--octc-color-bg-alt);
+  gap: 0.26em;
+  max-width: 100%;
+  padding: 0.08em 0.38em 0.08em 0.24em;
+  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, transparent);
+  border-radius: 0.42em;
+  background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-bg) 18%);
   color: inherit;
+  line-height: 1;
   text-decoration: none;
-  vertical-align: 0.1em;
+  vertical-align: -0.08em;
 }
 .content .ox-magic-link:hover {
   border-color: color-mix(in srgb, var(--octc-color-primary) 45%, var(--octc-color-border));
 }
+.content .ox-magic-link:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--octc-color-primary) 72%, transparent);
+  outline-offset: 2px;
+}
 .content .ox-magic-link__image {
-  width: 1.1em;
-  height: 1.1em;
+  width: 1em;
+  height: 1em;
   border-radius: 999px;
   object-fit: cover;
   flex: 0 0 auto;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -1102,21 +1102,27 @@ a:hover {
 .content .ox-magic-link {
   display: inline-flex;
   align-items: center;
-  gap: 0.3em;
-  padding: 0.05em 0.45em 0.05em 0.2em;
-  border: 1px solid var(--octc-color-border);
-  border-radius: 999px;
-  background: var(--octc-color-bg-alt);
+  gap: 0.26em;
+  max-width: 100%;
+  padding: 0.08em 0.38em 0.08em 0.24em;
+  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, transparent);
+  border-radius: 0.42em;
+  background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-bg) 18%);
   color: inherit;
+  line-height: 1;
   text-decoration: none;
-  vertical-align: 0.1em;
+  vertical-align: -0.08em;
 }
 .content .ox-magic-link:hover {
   border-color: color-mix(in srgb, var(--octc-color-primary) 45%, var(--octc-color-border));
 }
+.content .ox-magic-link:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--octc-color-primary) 72%, transparent);
+  outline-offset: 2px;
+}
 .content .ox-magic-link__image {
-  width: 1.1em;
-  height: 1.1em;
+  width: 1em;
+  height: 1em;
   border-radius: 999px;
   object-fit: cover;
   flex: 0 0 auto;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -1102,21 +1102,27 @@ a:hover {
 .content .ox-magic-link {
   display: inline-flex;
   align-items: center;
-  gap: 0.3em;
-  padding: 0.05em 0.45em 0.05em 0.2em;
-  border: 1px solid var(--octc-color-border);
-  border-radius: 999px;
-  background: var(--octc-color-bg-alt);
+  gap: 0.26em;
+  max-width: 100%;
+  padding: 0.08em 0.38em 0.08em 0.24em;
+  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, transparent);
+  border-radius: 0.42em;
+  background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-bg) 18%);
   color: inherit;
+  line-height: 1;
   text-decoration: none;
-  vertical-align: 0.1em;
+  vertical-align: -0.08em;
 }
 .content .ox-magic-link:hover {
   border-color: color-mix(in srgb, var(--octc-color-primary) 45%, var(--octc-color-border));
 }
+.content .ox-magic-link:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--octc-color-primary) 72%, transparent);
+  outline-offset: 2px;
+}
 .content .ox-magic-link__image {
-  width: 1.1em;
-  height: 1.1em;
+  width: 1em;
+  height: 1em;
   border-radius: 999px;
   object-fit: cover;
   flex: 0 0 auto;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -1102,21 +1102,27 @@ a:hover {
 .content .ox-magic-link {
   display: inline-flex;
   align-items: center;
-  gap: 0.3em;
-  padding: 0.05em 0.45em 0.05em 0.2em;
-  border: 1px solid var(--octc-color-border);
-  border-radius: 999px;
-  background: var(--octc-color-bg-alt);
+  gap: 0.26em;
+  max-width: 100%;
+  padding: 0.08em 0.38em 0.08em 0.24em;
+  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, transparent);
+  border-radius: 0.42em;
+  background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-bg) 18%);
   color: inherit;
+  line-height: 1;
   text-decoration: none;
-  vertical-align: 0.1em;
+  vertical-align: -0.08em;
 }
 .content .ox-magic-link:hover {
   border-color: color-mix(in srgb, var(--octc-color-primary) 45%, var(--octc-color-border));
 }
+.content .ox-magic-link:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--octc-color-primary) 72%, transparent);
+  outline-offset: 2px;
+}
 .content .ox-magic-link__image {
-  width: 1.1em;
-  height: 1.1em;
+  width: 1em;
+  height: 1em;
   border-radius: 999px;
   object-fit: cover;
   flex: 0 0 auto;

--- a/crates/ox_content_ssg/src/ssg.css
+++ b/crates/ox_content_ssg/src/ssg.css
@@ -1068,21 +1068,27 @@ a:hover {
 .content .ox-magic-link {
   display: inline-flex;
   align-items: center;
-  gap: 0.3em;
-  padding: 0.05em 0.45em 0.05em 0.2em;
-  border: 1px solid var(--octc-color-border);
-  border-radius: 999px;
-  background: var(--octc-color-bg-alt);
+  gap: 0.26em;
+  max-width: 100%;
+  padding: 0.08em 0.38em 0.08em 0.24em;
+  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, transparent);
+  border-radius: 0.42em;
+  background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-bg) 18%);
   color: inherit;
+  line-height: 1;
   text-decoration: none;
-  vertical-align: 0.1em;
+  vertical-align: -0.08em;
 }
 .content .ox-magic-link:hover {
   border-color: color-mix(in srgb, var(--octc-color-primary) 45%, var(--octc-color-border));
 }
+.content .ox-magic-link:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--octc-color-primary) 72%, transparent);
+  outline-offset: 2px;
+}
 .content .ox-magic-link__image {
-  width: 1.1em;
-  height: 1.1em;
+  width: 1em;
+  height: 1em;
   border-radius: 999px;
   object-fit: cover;
   flex: 0 0 auto;

--- a/npm/vite-plugin-ox-content/test/vrt/magic-link.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/magic-link.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+import { generateHtmlPage } from "../../src/ssg";
+import { transformMarkdown } from "../../src/transform";
+import { createDocsResolvedOptions } from "../fixtures/docs-fixture";
+
+test("magic links stay compact inside mobile prose", async ({ page }) => {
+  const result = await transformMarkdown(
+    "See {link:@ryoppippi} and {link:Oxc}.",
+    "docs/vrt-magic-link.md",
+    createDocsResolvedOptions({
+      magicLinks: {
+        enabled: true,
+        aliases: {
+          Oxc: {
+            href: "https://oxc.rs",
+            image: "https://github.com/oxc-project.png",
+          },
+        },
+        favicon: false,
+        imageOverrides: [],
+      },
+    }),
+  );
+  const html = await generateHtmlPage(
+    {
+      title: "Magic Links",
+      content: result.html,
+      toc: result.toc,
+      frontmatter: {},
+      path: "/vrt-magic-link",
+      href: "/vrt-magic-link/index.html",
+    },
+    [],
+    "Ox Content",
+    "/",
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    false,
+    { copy: false, externalLinks: true, backToTop: false },
+  );
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.setContent(html, { waitUntil: "load" });
+
+  const metrics = await page
+    .locator(".ox-magic-link")
+    .first()
+    .evaluate((link) => {
+      if (!(link instanceof HTMLElement)) {
+        throw new Error("Missing magic link");
+      }
+      const image = link.querySelector(".ox-magic-link__image");
+      const externalIcon = link.querySelector(".ox-external-icon");
+      if (!(image instanceof HTMLElement) || !(externalIcon instanceof HTMLElement)) {
+        throw new Error("Missing magic-link details");
+      }
+      const linkStyle = getComputedStyle(link);
+      const imageRect = image.getBoundingClientRect();
+      const iconRect = externalIcon.getBoundingClientRect();
+      const linkRect = link.getBoundingClientRect();
+      return {
+        borderRadius: Number.parseFloat(linkStyle.borderRadius),
+        iconWidth: iconRect.width,
+        imageWidth: imageRect.width,
+        linkHeight: linkRect.height,
+      };
+    });
+
+  expect(metrics.linkHeight).toBeLessThanOrEqual(32);
+  expect(metrics.borderRadius).toBeLessThan(12);
+  expect(metrics.imageWidth).toBeLessThanOrEqual(18);
+  expect(metrics.iconWidth).toBeLessThanOrEqual(12);
+});


### PR DESCRIPTION
## Summary
- tighten magic-link chip spacing, radius, and baseline alignment in prose
- keep reader-chrome external icons compact inside magic links without leaking reader-chrome CSS when disabled
- add a mobile VRT covering chip height, radius, avatar size, and external icon size

Closes #888

## Verification
- vp exec --filter @ox-content/napi -- napi build
- cargo test -p ox_content_ssg
- vp exec --filter @ox-content/vite-plugin -- playwright test test/vrt/magic-link.spec.ts
- vpr fmt:check
- node scripts/check-file-lines.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790278820&installation_model_id=422833&pr_number=921&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F921&signature=d2ba7838dd14a2a685523cef6eb881a9903d315334124d76f62e58edbf1f5c74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->