### PR TITLE
perf(ci): target PR benchmark lanes

### DIFF
--- a/.github/scripts/detect-pr-benchmark-scope.mjs
+++ b/.github/scripts/detect-pr-benchmark-scope.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const RUNTIME_AND_BUNDLE_PATTERNS = [
+  /^\.github\/workflows\/benchmark\.yml$/,
+  /^\.github\/scripts\/(?:detect-pr-benchmark-scope|run-pr-benchmark|compare-pr-benchmark)\.mjs$/,
+  /^benchmarks\/bundle-size\/(?:parse-benchmark|parse-benchmark-bun|compare-pr-benchmark)\.(?:mjs|test\.ts)$/,
+  /^benchmarks\/native-competitors\//,
+  /^crates\/(?:ox_content_allocator|ox_content_napi|ox_content_parser|ox_content_renderer|ox_content_wasm)\//,
+  /^Cargo\.(?:toml|lock)$/,
+  /^package\.json$/,
+  /^pnpm-lock\.yaml$/,
+  /^vite\.config\.ts$/,
+  /^\.node-version$/,
+];
+
+const RUNTIME_PATTERNS = [
+  /^benchmarks\/commonmark-conformance\//,
+  /^benchmarks\/polonius-borrowck\//,
+];
+
+const BUNDLE_PATTERNS = [
+  /^benchmarks\/bundle-size\//,
+  /^crates\//,
+  /^npm\//,
+  /^scripts\/(?:theme-colors|theme-skins)\//,
+];
+
+const BENCHMARK_NEUTRAL_PATTERNS = [
+  /^\.github\/(?:ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)\//,
+  /^\.github\/workflows\/(?!benchmark\.yml$)/,
+  /^docs\//,
+  /^examples\//,
+  /^README\.md$/,
+  /^CHANGELOG\.md$/,
+  /^CHENGELOG\.md$/,
+  /^LICENSE$/,
+  /^AGENTS\.md$/,
+  /\.(?:md|mdx|png|jpe?g|gif|webp|svg|avif)$/i,
+];
+
+const inputPath = process.argv[2];
+
+if (!inputPath || process.argv.includes("--help") || process.argv.includes("-h")) {
+  printUsage();
+  process.exit(inputPath ? 0 : 2);
+}
+
+const files = readFileSync(inputPath, "utf8")
+  .split(/\r?\n/)
+  .map((file) => file.trim())
+  .filter(Boolean);
+
+const scope = files.reduce(
+  (current, file) => {
+    const fileScope = classifyFile(file);
+    return {
+      runtime: current.runtime || fileScope.runtime,
+      bundle: current.bundle || fileScope.bundle,
+    };
+  },
+  { runtime: false, bundle: false },
+);
+
+console.error(
+  `Benchmark scope: runtime=${formatBoolean(scope.runtime)} bundle=${formatBoolean(
+    scope.bundle,
+  )} (${files.length} changed file${files.length === 1 ? "" : "s"})`,
+);
+console.log(`runtime=${formatBoolean(scope.runtime)}`);
+console.log(`bundle=${formatBoolean(scope.bundle)}`);
+
+/**
+ * @param {string} file
+ * @returns {{ runtime: boolean; bundle: boolean }}
+ */
+function classifyFile(file) {
+  if (matchesAny(file, RUNTIME_AND_BUNDLE_PATTERNS)) {
+    return { runtime: true, bundle: true };
+  }
+  if (matchesAny(file, RUNTIME_PATTERNS)) {
+    return { runtime: true, bundle: false };
+  }
+  if (matchesAny(file, BUNDLE_PATTERNS)) {
+    return { runtime: false, bundle: true };
+  }
+  if (matchesAny(file, BENCHMARK_NEUTRAL_PATTERNS)) {
+    return { runtime: false, bundle: false };
+  }
+
+  // Unknown paths stay conservative. This keeps new source trees protected
+  // until they are deliberately classified.
+  return { runtime: true, bundle: true };
+}
+
+/**
+ * @param {string} file
+ * @param {readonly RegExp[]} patterns
+ * @returns {boolean}
+ */
+function matchesAny(file, patterns) {
+  return patterns.some((pattern) => pattern.test(file));
+}
+
+/**
+ * @param {boolean} value
+ * @returns {"true" | "false"}
+ */
+function formatBoolean(value) {
+  return value ? "true" : "false";
+}
+
+function printUsage() {
+  console.log(`Usage: node .github/scripts/detect-pr-benchmark-scope.mjs <changed-files.txt>
+
+Writes GitHub Actions outputs:
+  runtime=true|false
+  bundle=true|false`);
+}

--- a/.github/scripts/run-pr-benchmark.mjs
+++ b/.github/scripts/run-pr-benchmark.mjs
@@ -1,11 +1,19 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { copyFileSync, mkdirSync } from "node:fs";
+import { copyFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { cpus, totalmem } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
 const options = parseOptions(process.argv.slice(2));
 const checkoutRoot = process.cwd();
+
+if (options.skipRuntime && options.skipBundle) {
+  writeSkippedRuntimeReport(options.runtimeJson);
+  writeSkippedBundleReport(options.bundleJson);
+  process.exit(0);
+}
+
 const sourceRoot = resolve(options.source ?? requiredEnv("GITHUB_WORKSPACE"));
 
 for (const file of [
@@ -24,18 +32,38 @@ for (const file of [
 
 run("vp", ["install"]);
 run("vp", ["run", "build:npm"]);
-run("node", [
-  "benchmarks/bundle-size/parse-benchmark.mjs",
-  "--runs",
-  options.runs,
-  "--json",
-  options.runtimeJson,
-]);
-run("node", ["benchmarks/bundle-size/measure.mjs", "--skip-install", "--json", options.bundleJson]);
+if (options.skipRuntime) {
+  writeSkippedRuntimeReport(options.runtimeJson);
+} else {
+  run("node", [
+    "benchmarks/bundle-size/parse-benchmark.mjs",
+    "--runs",
+    options.runs,
+    "--json",
+    options.runtimeJson,
+  ]);
+}
+if (options.skipBundle) {
+  writeSkippedBundleReport(options.bundleJson);
+} else {
+  run("node", [
+    "benchmarks/bundle-size/measure.mjs",
+    "--skip-install",
+    "--json",
+    options.bundleJson,
+  ]);
+}
 
 /**
  * @param {string[]} args
- * @returns {{ source: string | null; runtimeJson: string; bundleJson: string; runs: string }}
+ * @returns {{
+ *   source: string | null;
+ *   runtimeJson: string;
+ *   bundleJson: string;
+ *   runs: string;
+ *   skipRuntime: boolean;
+ *   skipBundle: boolean;
+ * }}
  */
 function parseOptions(args) {
   const parsed = {
@@ -43,6 +71,8 @@ function parseOptions(args) {
     runtimeJson: null,
     bundleJson: null,
     runs: process.env.OX_CONTENT_BENCHMARK_RUNS || "5",
+    skipRuntime: false,
+    skipBundle: false,
   };
 
   for (let index = 0; index < args.length; index++) {
@@ -61,6 +91,14 @@ function parseOptions(args) {
     }
     if (arg === "--runs") {
       parsed.runs = String(readPositiveIntegerOption(args, ++index, "--runs"));
+      continue;
+    }
+    if (arg === "--skip-runtime") {
+      parsed.skipRuntime = true;
+      continue;
+    }
+    if (arg === "--skip-bundle") {
+      parsed.skipBundle = true;
       continue;
     }
 
@@ -146,4 +184,65 @@ function run(command, args) {
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
   }
+}
+
+/**
+ * @param {string} path
+ */
+function writeSkippedRuntimeReport(path) {
+  writeFileSync(
+    path,
+    `${JSON.stringify(
+      {
+        name: "Parse/Render Speed Benchmark",
+        generatedAt: new Date().toISOString(),
+        skipped: true,
+        runs: Number.parseInt(options.runs, 10),
+        environment: collectEnvironment(),
+        sizes: {},
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+/**
+ * @param {string} path
+ */
+function writeSkippedBundleReport(path) {
+  writeFileSync(
+    path,
+    `${JSON.stringify(
+      {
+        name: "Bundle Size Benchmark",
+        generatedAt: new Date().toISOString(),
+        skipped: true,
+        environment: collectEnvironment(),
+        results: [],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+function collectEnvironment() {
+  const cpuList = cpus();
+  const firstCpu = cpuList[0];
+
+  return {
+    node: process.version,
+    v8: process.versions.v8,
+    platform: process.platform,
+    arch: process.arch,
+    ci: process.env.CI === "true",
+    runnerName: process.env.RUNNER_NAME ?? null,
+    runnerOs: process.env.RUNNER_OS ?? null,
+    runnerArch: process.env.RUNNER_ARCH ?? null,
+    runnerLabel: process.env.OX_CONTENT_BENCHMARK_RUNNER ?? null,
+    cpuModel: firstCpu?.model ?? null,
+    cpuCount: cpuList.length,
+    totalMemoryGB: Number((totalmem() / 1024 ** 3).toFixed(2)),
+  };
 }

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -50,12 +50,27 @@ jobs:
           cache: true
           run-install: false
 
+      - name: Detect benchmark scope
+        id: scope
+        env:
+          BASE_REPOSITORY: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git -C .benchmark/head fetch --no-tags --depth=1 "https://github.com/$BASE_REPOSITORY.git" "$BASE_SHA"
+          git -C .benchmark/head diff --name-only "$BASE_SHA" "$HEAD_SHA" > "$RUNNER_TEMP/benchmark-changed-files.txt"
+          node "$GITHUB_WORKSPACE/.github/scripts/detect-pr-benchmark-scope.mjs" \
+            "$RUNNER_TEMP/benchmark-changed-files.txt" >> "$GITHUB_OUTPUT"
+          echo "Changed files:"
+          sed 's/^/  /' "$RUNNER_TEMP/benchmark-changed-files.txt"
+
       # The parse/render benchmark compares against `Bun.markdown.html`, which
       # only exists in Bun >= 1.3.8. Without an explicit Bun the runner has no
       # (or too old a) bun, so `loadBunMarkdownBenchmarks` silently drops the
       # Bun.markdown row. Pin a version that ships the API so the comparison
       # always includes Bun.
       - name: Setup Bun
+        if: steps.scope.outputs.runtime == 'true'
         # oven-sh/setup-bun is outside this repo's allowed-actions policy, so
         # every workflow that referenced it died with a startup_failure before
         # any job ran. Install the same pinned Bun through npm (Node is set up
@@ -65,9 +80,11 @@ jobs:
         run: npm install --global bun@1.3.14 # zizmor: ignore[adhoc-packages]
 
       - name: Setup Rust
+        if: steps.scope.outputs.runtime == 'true' || steps.scope.outputs.bundle == 'true'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Mount sticky cache
+        if: steps.scope.outputs.runtime == 'true' || steps.scope.outputs.bundle == 'true'
         uses: ./.github/actions/mount-sticky-cache
         with:
           key-prefix: ${{ github.repository }}-benchmark-${{ github.job }}
@@ -76,8 +93,19 @@ jobs:
 
       - name: Benchmark base
         working-directory: .benchmark/base
+        env:
+          BENCHMARK_RUNTIME: ${{ steps.scope.outputs.runtime }}
+          BENCHMARK_BUNDLE: ${{ steps.scope.outputs.bundle }}
         run: |
+          skip_args=()
+          if [ "$BENCHMARK_RUNTIME" != "true" ]; then
+            skip_args+=(--skip-runtime)
+          fi
+          if [ "$BENCHMARK_BUNDLE" != "true" ]; then
+            skip_args+=(--skip-bundle)
+          fi
           node "$GITHUB_WORKSPACE/.github/scripts/run-pr-benchmark.mjs" \
+            "${skip_args[@]}" \
             --source "$GITHUB_WORKSPACE" \
             --runs "$OX_CONTENT_BENCHMARK_RUNS" \
             --runtime-json "$RUNNER_TEMP/benchmark-base.json" \
@@ -85,8 +113,19 @@ jobs:
 
       - name: Benchmark head
         working-directory: .benchmark/head
+        env:
+          BENCHMARK_RUNTIME: ${{ steps.scope.outputs.runtime }}
+          BENCHMARK_BUNDLE: ${{ steps.scope.outputs.bundle }}
         run: |
+          skip_args=()
+          if [ "$BENCHMARK_RUNTIME" != "true" ]; then
+            skip_args+=(--skip-runtime)
+          fi
+          if [ "$BENCHMARK_BUNDLE" != "true" ]; then
+            skip_args+=(--skip-bundle)
+          fi
           node "$GITHUB_WORKSPACE/.github/scripts/run-pr-benchmark.mjs" \
+            "${skip_args[@]}" \
             --source "$GITHUB_WORKSPACE" \
             --runs "$OX_CONTENT_BENCHMARK_RUNS" \
             --runtime-json "$RUNNER_TEMP/benchmark-head.json" \

--- a/benchmarks/bundle-size/pr-benchmark-scope.test.ts
+++ b/benchmarks/bundle-size/pr-benchmark-scope.test.ts
@@ -1,0 +1,67 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+
+const script = resolve(".github/scripts/detect-pr-benchmark-scope.mjs");
+
+describe("detect-pr-benchmark-scope", () => {
+  it("skips neutral documentation edits", () => {
+    const result = runScope(["docs/content/built-in/embeds.md", "README.md"]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ runtime: "false", bundle: "false" });
+  });
+
+  it("runs both gates for parser and renderer changes", () => {
+    const result = runScope(["crates/ox_content_parser/src/lib.rs"]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ runtime: "true", bundle: "true" });
+  });
+
+  it("runs only the bundle gate for theme and UI package edits", () => {
+    const result = runScope(["npm/theme/swiss/src/style.css"]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ runtime: "false", bundle: "true" });
+  });
+
+  it("runs both gates for benchmark harness edits", () => {
+    const result = runScope(["benchmarks/bundle-size/parse-benchmark.mjs"]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ runtime: "true", bundle: "true" });
+  });
+
+  it("falls back to both gates for unclassified paths", () => {
+    const result = runScope(["tools/new-source-tree/file.rs"]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ runtime: "true", bundle: "true" });
+  });
+});
+
+function runScope(files: string[]) {
+  const dir = mkdtempSync(join(tmpdir(), "ox-benchmark-scope-"));
+  const changedFilesPath = join(dir, "changed-files.txt");
+  writeFileSync(changedFilesPath, `${files.join("\n")}\n`);
+
+  return spawnSync(process.execPath, [script, changedFilesPath], {
+    encoding: "utf8",
+  });
+}
+
+function parseOutputs(stdout: string) {
+  return Object.fromEntries(
+    stdout
+      .trim()
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => {
+        const index = line.indexOf("=");
+        return [line.slice(0, index), line.slice(index + 1)];
+      }),
+  );
+}

--- a/benchmarks/bundle-size/run-pr-benchmark.test.ts
+++ b/benchmarks/bundle-size/run-pr-benchmark.test.ts
@@ -1,0 +1,44 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+
+const script = resolve(".github/scripts/run-pr-benchmark.mjs");
+
+describe("run-pr-benchmark", () => {
+  it("writes skipped reports without requiring a workspace checkout", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ox-pr-benchmark-"));
+    const runtimeJson = join(dir, "runtime.json");
+    const bundleJson = join(dir, "bundle.json");
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        script,
+        "--skip-runtime",
+        "--skip-bundle",
+        "--runtime-json",
+        runtimeJson,
+        "--bundle-json",
+        bundleJson,
+      ],
+      {
+        encoding: "utf8",
+        env: { ...process.env, GITHUB_WORKSPACE: "" },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(readFileSync(runtimeJson, "utf8"))).toMatchObject({
+      name: "Parse/Render Speed Benchmark",
+      skipped: true,
+      sizes: {},
+    });
+    expect(JSON.parse(readFileSync(bundleJson, "utf8"))).toMatchObject({
+      name: "Bundle Size Benchmark",
+      skipped: true,
+      results: [],
+    });
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -150,7 +150,9 @@ export default defineConfig({
       }),
       "test:code-play": task("vp exec --filter @ox-content/code-play -- vp test src"),
       "test:publish-targets": task("vp test scripts/verify-publish-targets.test.ts"),
-      "test:benchmark-scripts": task("vp test benchmarks/bundle-size/compare-pr-benchmark.test.ts"),
+      "test:benchmark-scripts": task(
+        "vp test benchmarks/bundle-size/compare-pr-benchmark.test.ts benchmarks/bundle-size/pr-benchmark-scope.test.ts benchmarks/bundle-size/run-pr-benchmark.test.ts",
+      ),
       "test:editor-publish-scripts": task("vp test scripts/publish-editor-extensions.test.ts"),
       "build:vite-plugin": task("vp run --filter @ox-content/vite-plugin build", {
         dependsOn: ["build:napi"],


### PR DESCRIPTION
## Summary
- classify PR changes into runtime and bundle benchmark scopes before running the heavy benchmark job
- skip Bun/Rust/cache setup and write skipped benchmark JSON reports when a scope is not relevant
- cover the scope detector and skip-only benchmark runner path with tests

## Evidence
- Previous StackBlitz PR benchmark base step ran from 2026-08-25T19:58:29Z to 2026-08-25T20:11:54Z, so docs-neutral PRs can avoid a 13m25s base leg plus the matching head leg.

## Verification
- `vp run test:benchmark-scripts`
- `vpr fmt:check`
- `node scripts/check-file-lines.ts`
- `git diff --check`

Closes #893

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790281046&installation_model_id=422833&pr_number=928&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F928&signature=5bc17497f6153e683b1d7ae7b0ab4124ef3ffa3a5ca5c7ea32f3583d97113e93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of whether runtime and bundle benchmarks are affected by a change.
  * Added options to skip unaffected benchmark categories while still generating compatible reports.
  * Benchmark reports now include expanded environment details for easier comparison.

* **Improvements**
  * Benchmark workflows avoid unnecessary setup and execution, improving pull request feedback speed.
  * Unclassified changes are handled conservatively to preserve benchmark coverage.

* **Tests**
  * Added coverage for scope detection, skipped benchmark reports, and benchmark workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->