### PR TITLE
fix(docs): polish tabs and install examples

### DIFF
--- a/crates/ox_content_ssg/src/plugins/tabs.css
+++ b/crates/ox_content_ssg/src/plugins/tabs.css
@@ -5,10 +5,14 @@
   border: 1px solid var(--octc-color-border);
   border-radius: 4px;
   overflow: hidden;
+  background: var(--octc-color-bg);
 }
 
 .ox-tabs-header {
   display: flex;
+  align-items: end;
+  gap: 0.125rem;
+  padding: 0.35rem 0.35rem 0;
   background: var(--octc-color-bg-alt);
   border-bottom: 1px solid var(--octc-color-border);
   overflow-x: auto;
@@ -37,26 +41,35 @@
 .ox-tabs label {
   display: inline-flex;
   align-items: center;
-  padding: 0.75rem 1rem;
+  justify-content: center;
+  flex: 1 0 max-content;
+  min-width: 3.5rem;
+  padding: 0.65rem 0.85rem;
   cursor: pointer;
   font-size: 0.875rem;
   font-weight: 500;
   color: var(--octc-color-text-muted);
+  border: 1px solid transparent;
   border-bottom: 2px solid transparent;
   margin-bottom: -1px;
+  border-radius: 4px 4px 0 0;
   white-space: nowrap;
   transition:
+    background-color 0.2s ease,
     color 0.2s ease,
     border-color 0.2s ease;
 }
 
 .ox-tabs label:hover {
   color: var(--octc-color-text);
+  background: color-mix(in srgb, var(--octc-color-bg) 72%, transparent);
 }
 
 /* Checked tab label */
 .ox-tabs input[type="radio"]:checked + label {
   color: var(--octc-color-primary);
+  background: var(--octc-color-bg);
+  border-color: var(--octc-color-border);
   border-bottom-color: var(--octc-color-primary);
 }
 
@@ -69,7 +82,8 @@
 /* Tab content panels */
 .ox-tab-panel {
   display: none;
-  padding: 1rem 1.25rem;
+  padding: 1rem;
+  background: var(--octc-color-bg);
 }
 
 /* Reset margins for first/last children in panels */
@@ -106,6 +120,19 @@
   }
   .ox-tabs:has(input[id$="-7"]:checked) .ox-tab-panel[data-tab="7"] {
     display: block;
+  }
+
+  .ox-tab-panel:has(> pre:only-child),
+  .ox-tabs-fallback .ox-tabs-fallback-content:has(> pre:only-child) {
+    padding: 0;
+    background: var(--octc-color-code-bg);
+  }
+
+  .ox-tab-panel:has(> pre:only-child) > pre,
+  .ox-tabs-fallback .ox-tabs-fallback-content:has(> pre:only-child) > pre {
+    margin: 0;
+    border: 0;
+    border-radius: 0;
   }
 }
 

--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -138,10 +138,10 @@ oxContent({
 ```
 
 ```md
-<pm>npm install -D @ox-content/vite-plugin</pm>
+<pm>npm install -D @ox-content/vite-plugin @ox-content/theme-swiss</pm>
 ```
 
-<pm>npm install -D @ox-content/vite-plugin</pm>
+<pm>npm install -D @ox-content/vite-plugin @ox-content/theme-swiss</pm>
 
 The command is converted natively in Rust — `npm install -D` becomes
 `pnpm add -D`, `yarn add -D`, `bun add -D`, and `vp install -D`, while
@@ -159,16 +159,50 @@ available in SSG builds and dev preview:
 
 ```md
 <tabs>
-  <tab label="macOS">brew install oxc</tab>
-  <tab label="Linux">apt install oxc</tab>
-  <tab label="Windows">winget install oxc</tab>
+<tab label="Install">
+<pre><code>pnpm add -D @ox-content/vite-plugin
+pnpm add -D @ox-content/theme-swiss</code></pre>
+</tab>
+<tab label="Config">
+<pre><code>oxContent({ srcDir: "content", embeds: { pm: true } })</code></pre>
+</tab>
+<tab label="Markdown">
+<pre><code>---
+title: Install
+---
+
+Install Ox Content with the package manager you prefer.
+
+&lt;pm&gt;npm install -D @ox-content/vite-plugin&lt;/pm&gt;</code></pre>
+</tab>
+<tab label="Build">
+<pre><code>pnpm vite build
+pnpm vite preview</code></pre>
+</tab>
 </tabs>
 ```
 
 <tabs>
-  <tab label="macOS">brew install oxc</tab>
-  <tab label="Linux">apt install oxc</tab>
-  <tab label="Windows">winget install oxc</tab>
+<tab label="Install">
+<pre><code>pnpm add -D @ox-content/vite-plugin
+pnpm add -D @ox-content/theme-swiss</code></pre>
+</tab>
+<tab label="Config">
+<pre><code>oxContent({ srcDir: "content", embeds: { pm: true } })</code></pre>
+</tab>
+<tab label="Markdown">
+<pre><code>---
+title: Install
+---
+
+Install Ox Content with the package manager you prefer.
+
+&lt;pm&gt;npm install -D @ox-content/vite-plugin&lt;/pm&gt;</code></pre>
+</tab>
+<tab label="Build">
+<pre><code>pnpm vite build
+pnpm vite preview</code></pre>
+</tab>
 </tabs>
 
 A `<tab>` without a `label` attribute falls back to `Tab 1`, `Tab 2`, and so

--- a/docs/content/examples/package-manager-tabs.md
+++ b/docs/content/examples/package-manager-tabs.md
@@ -32,7 +32,7 @@ export default {
 Write a `<pm>` element containing a single npm-style command:
 
 ```html
-<pm>npm install -D vite</pm>
+<pm>npm install -D @ox-content/vite-plugin</pm>
 ```
 
 The renderer expands it into the same tab widget used by `<tabs>`, so styling
@@ -42,7 +42,7 @@ body is a code block with the command converted for that package manager.
 
 ## Rendered example
 
-<pm>npm install -D vite</pm>
+<pm>npm install -D @ox-content/vite-plugin</pm>
 
 ## Conversion rules
 

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -117,10 +117,10 @@ oxContent({
 ```
 
 ```md
-<pm>npm install -D @ox-content/vite-plugin</pm>
+<pm>npm install -D @ox-content/vite-plugin @ox-content/theme-swiss</pm>
 ```
 
-<pm>npm install -D @ox-content/vite-plugin</pm>
+<pm>npm install -D @ox-content/vite-plugin @ox-content/theme-swiss</pm>
 
 コマンド変換は Rust ネイティブです。`npm install -D` は `pnpm add -D`、`yarn add -D`、`bun add -D`、`vp install -D` になり、`npx <bin>` は `vp exec -- <bin>` になります。タブはクライアント側 JavaScript なしで動きます。選択は CSS `:has()` です。`pm: { sync: true }` をオプトインすると、ページ上のすべてのブロックで選んだパッケージマネージャを `localStorage` 経由で同期します。変換表の全体は [Package Manager Tabs](/examples/package-manager-tabs.md) を見てください。
 
@@ -130,16 +130,50 @@ oxContent({
 
 ```md
 <tabs>
-  <tab label="macOS">brew install oxc</tab>
-  <tab label="Linux">apt install oxc</tab>
-  <tab label="Windows">winget install oxc</tab>
+<tab label="Install">
+<pre><code>pnpm add -D @ox-content/vite-plugin
+pnpm add -D @ox-content/theme-swiss</code></pre>
+</tab>
+<tab label="Config">
+<pre><code>oxContent({ srcDir: "content", embeds: { pm: true } })</code></pre>
+</tab>
+<tab label="Markdown">
+<pre><code>---
+title: Install
+---
+
+好きなパッケージマネージャで Ox Content を入れます。
+
+&lt;pm&gt;npm install -D @ox-content/vite-plugin&lt;/pm&gt;</code></pre>
+</tab>
+<tab label="Build">
+<pre><code>pnpm vite build
+pnpm vite preview</code></pre>
+</tab>
 </tabs>
 ```
 
 <tabs>
-  <tab label="macOS">brew install oxc</tab>
-  <tab label="Linux">apt install oxc</tab>
-  <tab label="Windows">winget install oxc</tab>
+<tab label="Install">
+<pre><code>pnpm add -D @ox-content/vite-plugin
+pnpm add -D @ox-content/theme-swiss</code></pre>
+</tab>
+<tab label="Config">
+<pre><code>oxContent({ srcDir: "content", embeds: { pm: true } })</code></pre>
+</tab>
+<tab label="Markdown">
+<pre><code>---
+title: Install
+---
+
+好きなパッケージマネージャで Ox Content を入れます。
+
+&lt;pm&gt;npm install -D @ox-content/vite-plugin&lt;/pm&gt;</code></pre>
+</tab>
+<tab label="Build">
+<pre><code>pnpm vite build
+pnpm vite preview</code></pre>
+</tab>
 </tabs>
 
 `label` 属性のない `<tab>` は `Tab 1`、`Tab 2` のように落ちます。

--- a/npm/vite-plugin-ox-content/test/vrt/tabs-polish.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/tabs-polish.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "@playwright/test";
+import { transformAllPlugins } from "../../src/plugins";
+import { resetTabGroupCounter } from "../../src/plugins/tabs";
+import { generateHtmlPage } from "../../src/ssg";
+import { transformMarkdown } from "../../src/transform";
+import { createDocsResolvedOptions } from "../fixtures/docs-fixture";
+
+async function render(markdown: string) {
+  resetTabGroupCounter();
+  const result = await transformMarkdown(
+    markdown,
+    "docs/vrt-tabs-polish.md",
+    createDocsResolvedOptions({
+      embeds: {
+        github: false,
+        openGraph: false,
+        pm: true,
+        spotify: false,
+        stackBlitz: false,
+        twitter: false,
+        bluesky: false,
+        webContainer: false,
+      },
+      highlight: false,
+    }),
+  );
+  const content = await transformAllPlugins(result.html, {
+    github: false,
+    openGraph: false,
+    pm: true,
+    spotify: false,
+    stackBlitz: false,
+    twitter: false,
+    bluesky: false,
+    webContainer: false,
+  });
+
+  return generateHtmlPage(
+    {
+      title: "Tabs",
+      content,
+      toc: result.toc,
+      frontmatter: {},
+      path: "/vrt-tabs-polish",
+      href: "/vrt-tabs-polish/index.html",
+    },
+    [],
+    "Ox Content",
+    "/",
+  );
+}
+
+test("package-manager tabs render code as an integrated panel on mobile", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.setContent(await render("<pm>npm install -D @ox-content/vite-plugin</pm>"), {
+    waitUntil: "load",
+  });
+
+  const metrics = await page
+    .locator(".ox-tabs")
+    .first()
+    .evaluate((tabs) => {
+      const panel = tabs.querySelector(".ox-tab-panel[data-tab='0']");
+      const pre = panel?.querySelector("pre");
+      const header = tabs.querySelector(".ox-tabs-header");
+      if (
+        !(tabs instanceof HTMLElement) ||
+        !(panel instanceof HTMLElement) ||
+        !(pre instanceof HTMLElement)
+      ) {
+        throw new Error("Missing tabs geometry targets");
+      }
+      const tabsRect = tabs.getBoundingClientRect();
+      const panelRect = panel.getBoundingClientRect();
+      const preRect = pre.getBoundingClientRect();
+      const headerRect = header?.getBoundingClientRect();
+      const panelStyle = getComputedStyle(panel);
+      const preStyle = getComputedStyle(pre);
+      return {
+        headerBottom: headerRect?.bottom ?? 0,
+        panelPaddingTop: Number.parseFloat(panelStyle.paddingTop),
+        preBorderRadius: Number.parseFloat(preStyle.borderTopLeftRadius),
+        preLeftGap: preRect.left - tabsRect.left,
+        preTopGap: preRect.top - panelRect.top,
+        tabsWidth: tabsRect.width,
+      };
+    });
+
+  expect(metrics.tabsWidth).toBeLessThanOrEqual(390);
+  expect(metrics.panelPaddingTop).toBe(0);
+  expect(metrics.preBorderRadius).toBe(0);
+  expect(metrics.preLeftGap).toBeLessThan(2);
+  expect(metrics.preTopGap).toBeLessThan(2);
+  expect(metrics.headerBottom).toBeGreaterThan(0);
+});
+
+test("generic tabs keep a long header scrollable without widening prose", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.setContent(
+    await render(
+      [
+        "<tabs>",
+        '  <tab label="Vite config"><pre><code>plugins: [oxContent({ srcDir: "content" })]</code></pre></tab>',
+        '  <tab label="Markdown source"><pre><code># Hello</code></pre></tab>',
+        '  <tab label="Static build"><pre><code>pnpm vite build</code></pre></tab>',
+        '  <tab label="Preview route"><pre><code>/docs/getting-started</code></pre></tab>',
+        '  <tab label="Deploy target"><pre><code>dist/client</code></pre></tab>',
+        "</tabs>",
+      ].join("\n"),
+    ),
+    { waitUntil: "load" },
+  );
+
+  const metrics = await page
+    .locator(".ox-tabs")
+    .first()
+    .evaluate((tabs) => {
+      const content = tabs.closest(".content");
+      const header = tabs.querySelector(".ox-tabs-header");
+      if (
+        !(tabs instanceof HTMLElement) ||
+        !(content instanceof HTMLElement) ||
+        !(header instanceof HTMLElement)
+      ) {
+        throw new Error("Missing tabs header targets");
+      }
+      return {
+        contentWidth: content.getBoundingClientRect().width,
+        headerClientWidth: header.clientWidth,
+        headerScrollWidth: header.scrollWidth,
+        tabsWidth: tabs.getBoundingClientRect().width,
+      };
+    });
+
+  expect(metrics.tabsWidth).toBeLessThanOrEqual(metrics.contentWidth + 1);
+  expect(metrics.headerScrollWidth).toBeGreaterThan(metrics.headerClientWidth);
+});


### PR DESCRIPTION
## Summary
- tune tab headers and code-only tab panels so install snippets read as one integrated widget
- replace minimal tabs docs with a more realistic install/config/markdown/build flow in English and Japanese docs
- add mobile VRT coverage for package-manager and generic tabs

Closes #885

## Verification
- vpr fmt:check
- pnpm --filter @ox-content/vite-plugin exec playwright test test/vrt/tabs-polish.spec.ts
- cargo test -p ox_content_ssg
- vp exec --filter @ox-content/vite-plugin -- vp test src/plugins/embed-transform.test.ts src/transform.test.ts
- node scripts/check-file-lines.ts
- git diff --check