### PR TITLE
fix(docs): highlight tab markup examples as html

### DIFF
--- a/crates/ox_content_highlight/src/tests.rs
+++ b/crates/ox_content_highlight/src/tests.rs
@@ -166,6 +166,22 @@ fn mdx_highlights_custom_element_closing_tags() {
 }
 
 #[test]
+fn html_highlights_tab_custom_elements() {
+    let html = highlight_to_html(
+        "<tabs>\n  <tab label=\"Install\">pnpm add -D @ox-content/vite-plugin</tab>\n</tabs>\n",
+        "html",
+    )
+    .expect("supported");
+    let closing = html.split("&lt;/").nth(1).expect("closing tab should be present");
+
+    assert!(html.contains("--octc-syntax-token-string"), "{html}");
+    assert!(html.contains("tabs"), "{html}");
+    assert!(html.contains("tab"), "{html}");
+    assert!(closing.contains("--octc-syntax-token-constant"), "{html}");
+    assert!(closing.contains("--octc-syntax-token-punctuation"), "{html}");
+}
+
+#[test]
 fn plain_text_renders_without_tokenizing() {
     // `text` is the third most common fence tag in the documentation corpus.
     // Declining it would send those pages to the fallback highlighter purely

--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -157,28 +157,28 @@ conversion table.
 Generic tab groups use the same widget as package-manager tabs and are always
 available in SSG builds and dev preview:
 
-```md
+```html
 <tabs>
-<tab label="Install">
-<pre><code>pnpm add -D @ox-content/vite-plugin
+  <tab label="Install">
+    <pre><code>pnpm add -D @ox-content/vite-plugin
 pnpm add -D @ox-content/theme-swiss</code></pre>
-</tab>
-<tab label="Config">
-<pre><code>oxContent({ srcDir: "content", embeds: { pm: true } })</code></pre>
-</tab>
-<tab label="Markdown">
-<pre><code>---
+  </tab>
+  <tab label="Config">
+    <pre><code>oxContent({ srcDir: "content", embeds: { pm: true } })</code></pre>
+  </tab>
+  <tab label="Markdown">
+    <pre><code>---
 title: Install
 ---
 
 Install Ox Content with the package manager you prefer.
 
 &lt;pm&gt;npm install -D @ox-content/vite-plugin&lt;/pm&gt;</code></pre>
-</tab>
-<tab label="Build">
-<pre><code>pnpm vite build
+  </tab>
+  <tab label="Build">
+    <pre><code>pnpm vite build
 pnpm vite preview</code></pre>
-</tab>
+  </tab>
 </tabs>
 ```
 

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -128,28 +128,28 @@ oxContent({
 
 汎用タブグループはパッケージマネージャタブと同じウィジェットで、SSG ビルドと dev preview では常に使えます。
 
-```md
+```html
 <tabs>
-<tab label="Install">
-<pre><code>pnpm add -D @ox-content/vite-plugin
+  <tab label="Install">
+    <pre><code>pnpm add -D @ox-content/vite-plugin
 pnpm add -D @ox-content/theme-swiss</code></pre>
-</tab>
-<tab label="Config">
-<pre><code>oxContent({ srcDir: "content", embeds: { pm: true } })</code></pre>
-</tab>
-<tab label="Markdown">
-<pre><code>---
+  </tab>
+  <tab label="Config">
+    <pre><code>oxContent({ srcDir: "content", embeds: { pm: true } })</code></pre>
+  </tab>
+  <tab label="Markdown">
+    <pre><code>---
 title: Install
 ---
 
 好きなパッケージマネージャで Ox Content を入れます。
 
 &lt;pm&gt;npm install -D @ox-content/vite-plugin&lt;/pm&gt;</code></pre>
-</tab>
-<tab label="Build">
-<pre><code>pnpm vite build
+  </tab>
+  <tab label="Build">
+    <pre><code>pnpm vite build
 pnpm vite preview</code></pre>
-</tab>
+  </tab>
 </tabs>
 ```
 


### PR DESCRIPTION
## Summary
- mark generic tab markup examples as HTML fences so custom tags receive HTML tokenization
- add native highlighter coverage for <tabs>/<tab> custom elements

## Verification
- cargo test -p ox_content_highlight
- vp exec --filter @ox-content/vite-plugin -- vp test src/highlight.test.ts
- vpr fmt:check
- node scripts/check-file-lines.ts
- git diff --check

Closes #890

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790283780&installation_model_id=422833&pr_number=938&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F938&signature=7858729ea46af1f51a2024695ccb5964a0973b5b352d20b3a2408a3fc2102a0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated tab embedding examples in English and Japanese documentation to identify them as HTML.
  - Improved indentation for nested tab and code block content, making examples easier to read.

- **Tests**
  - Added regression coverage confirming that custom HTML elements such as `<tabs>` and `<tab>` receive the expected syntax highlighting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->