### PR TITLE
fix(docs): separate steps preview from source

### DIFF
--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -1028,7 +1028,11 @@ a:hover {
   margin-bottom: 0;
 }
 .content .ox-steps {
-  margin: 1.25rem 0;
+  margin: 1.75rem 0 2rem;
+  padding: 1.1rem 1rem 1.1rem 0;
+  border: 1px solid var(--octc-color-border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
 }
 .content .ox-steps__list {
   list-style: none;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -1025,7 +1025,11 @@ a:hover {
   margin-bottom: 0;
 }
 .content .ox-steps {
-  margin: 1.25rem 0;
+  margin: 1.75rem 0 2rem;
+  padding: 1.1rem 1rem 1.1rem 0;
+  border: 1px solid var(--octc-color-border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
 }
 .content .ox-steps__list {
   list-style: none;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -1025,7 +1025,11 @@ a:hover {
   margin-bottom: 0;
 }
 .content .ox-steps {
-  margin: 1.25rem 0;
+  margin: 1.75rem 0 2rem;
+  padding: 1.1rem 1rem 1.1rem 0;
+  border: 1px solid var(--octc-color-border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
 }
 .content .ox-steps__list {
   list-style: none;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -1025,7 +1025,11 @@ a:hover {
   margin-bottom: 0;
 }
 .content .ox-steps {
-  margin: 1.25rem 0;
+  margin: 1.75rem 0 2rem;
+  padding: 1.1rem 1rem 1.1rem 0;
+  border: 1px solid var(--octc-color-border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
 }
 .content .ox-steps__list {
   list-style: none;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -1025,7 +1025,11 @@ a:hover {
   margin-bottom: 0;
 }
 .content .ox-steps {
-  margin: 1.25rem 0;
+  margin: 1.75rem 0 2rem;
+  padding: 1.1rem 1rem 1.1rem 0;
+  border: 1px solid var(--octc-color-border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
 }
 .content .ox-steps__list {
   list-style: none;

--- a/crates/ox_content_ssg/src/ssg.css
+++ b/crates/ox_content_ssg/src/ssg.css
@@ -991,7 +991,11 @@ a:hover {
   margin-bottom: 0;
 }
 .content .ox-steps {
-  margin: 1.25rem 0;
+  margin: 1.75rem 0 2rem;
+  padding: 1.1rem 1rem 1.1rem 0;
+  border: 1px solid var(--octc-color-border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--octc-color-bg-alt) 42%, transparent);
 }
 .content .ox-steps__list {
   list-style: none;

--- a/docs/content/built-in/steps.md
+++ b/docs/content/built-in/steps.md
@@ -40,7 +40,8 @@ nested lists — still renders inside each item.
    ```
 
 2. Run **build**
-   :::
+
+:::
 
 ````md
 ::: steps
@@ -52,7 +53,8 @@ nested lists — still renders inside each item.
    ```
 
 2. Run **build**
-   :::
+
+:::
 ````
 
 When enabled, the wrapper becomes `<div class="ox-steps">` with

--- a/docs/content/ja/built-in/steps.md
+++ b/docs/content/ja/built-in/steps.md
@@ -38,7 +38,8 @@ export default {
    ```
 
 2. Run **build**
-   :::
+
+:::
 
 ````md
 ::: steps
@@ -50,7 +51,8 @@ export default {
    ```
 
 2. Run **build**
-   :::
+
+:::
 ````
 
 有効にすると、ラッパーは `<div class="ox-steps">` になり、各項目は `<ol class="ox-steps__list">` と `<li class="ox-steps__item">` になります。

--- a/npm/vite-plugin-ox-content/test/vrt/steps-boundary.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/steps-boundary.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "@playwright/test";
+import { generateHtmlPage } from "../../src/ssg";
+import { transformMarkdown } from "../../src/transform";
+import { createDocsResolvedOptions } from "../fixtures/docs-fixture";
+
+async function render(markdown: string) {
+  const result = await transformMarkdown(
+    markdown,
+    "docs/vrt-steps-boundary.md",
+    createDocsResolvedOptions({
+      highlight: false,
+      steps: { enabled: true },
+    }),
+  );
+
+  return generateHtmlPage(
+    {
+      title: "Steps",
+      content: result.html,
+      toc: result.toc,
+      frontmatter: {},
+      path: "/vrt-steps-boundary",
+      href: "/vrt-steps-boundary/index.html",
+    },
+    [],
+    "Ox Content",
+    "/",
+  );
+}
+
+test("step previews keep a clear boundary before their source example", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.setContent(
+    await render(
+      [
+        "# Steps",
+        "",
+        "::: steps",
+        "",
+        "1. Install the CLI",
+        "",
+        "   ```sh",
+        "   npm i -g ox-content",
+        "   ```",
+        "",
+        "2. Run **build**",
+        "",
+        ":::",
+        "",
+        "````md",
+        "::: steps",
+        "",
+        "1. Install the CLI",
+        "",
+        "   ```sh",
+        "   npm i -g ox-content",
+        "   ```",
+        "",
+        "2. Run **build**",
+        ":::",
+        "````",
+      ].join("\n"),
+    ),
+    { waitUntil: "load" },
+  );
+
+  const metrics = await page.locator(".content").evaluate((content) => {
+    const steps = content.querySelector(".ox-steps");
+    const source = content.querySelector(":scope > pre:last-of-type");
+    if (!(steps instanceof HTMLElement) || !(source instanceof HTMLElement)) {
+      throw new Error("Missing steps preview or source block");
+    }
+
+    const stepsRect = steps.getBoundingClientRect();
+    const sourceRect = source.getBoundingClientRect();
+    const stepsStyle = getComputedStyle(steps);
+    const sourceText = source.innerText;
+
+    return {
+      borderTopWidth: Number.parseFloat(stepsStyle.borderTopWidth),
+      gap: sourceRect.top - stepsRect.bottom,
+      hasBackground: stepsStyle.backgroundColor !== "rgba(0, 0, 0, 0)",
+      sourceText,
+    };
+  });
+
+  expect(metrics.borderTopWidth).toBeGreaterThanOrEqual(1);
+  expect(metrics.gap).toBeGreaterThan(20);
+  expect(metrics.hasBackground).toBe(true);
+  expect(metrics.sourceText).toContain("\n:::");
+  expect(metrics.sourceText).not.toContain("   :::");
+});


### PR DESCRIPTION
## Summary
- place the closing steps fence at column zero in the rendered and source examples
- give rendered step previews a subtle boundary so they do not visually run into source code blocks
- add VRT coverage for the preview/source boundary

## Verification
- cargo test -p ox_content_transform features::steps
- pnpm --filter @ox-content/vite-plugin exec playwright test test/vrt/steps-boundary.spec.ts
- vpr fmt:check
- node scripts/check-file-lines.ts
- git diff --check

Closes #892

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790284062&installation_model_id=422833&pr_number=939&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F939&signature=5d0f5e6b197ff07ae158514c1170720d752c1d920fe27855910cd3b27ebb0b4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->