### PR TITLE
feat(highlight): add adjacent language aliases

### DIFF
--- a/crates/ox_content_highlight/src/languages.rs
+++ b/crates/ox_content_highlight/src/languages.rs
@@ -113,7 +113,7 @@ fn grammars() -> &'static [Grammar] {
         ),
         grammar!(
             "tsx",
-            ["tsx"],
+            ["tsx", "typescriptreact"],
             tree_sitter_typescript::LANGUAGE_TSX,
             tsx_highlights(),
             tree_sitter_javascript::INJECTIONS_QUERY,
@@ -121,7 +121,7 @@ fn grammars() -> &'static [Grammar] {
         ),
         grammar!(
             "javascript",
-            ["javascript", "js", "cjs", "mjs", "jsx", "mdx"],
+            ["javascript", "js", "cjs", "mjs", "jsx", "javascriptreact", "flow", "mdx"],
             tree_sitter_javascript::LANGUAGE,
             javascript_highlights(),
             tree_sitter_javascript::INJECTIONS_QUERY,
@@ -137,7 +137,7 @@ fn grammars() -> &'static [Grammar] {
         ),
         grammar!(
             "json",
-            ["json"],
+            ["json", "jsonc", "json5", "webmanifest"],
             tree_sitter_json::LANGUAGE,
             tree_sitter_json::HIGHLIGHTS_QUERY,
             "",
@@ -153,7 +153,7 @@ fn grammars() -> &'static [Grammar] {
         ),
         grammar!(
             "html",
-            ["html"],
+            ["html", "vue", "svelte", "astro", "angular"],
             tree_sitter_html::LANGUAGE,
             tree_sitter_html::HIGHLIGHTS_QUERY,
             tree_sitter_html::INJECTIONS_QUERY,
@@ -275,7 +275,23 @@ pub fn config_by_name(name: &str) -> Option<&'static HighlightConfiguration> {
 }
 
 /// Names for "this block has no syntax", rendered without tokenizing.
-pub const PLAIN_LANGUAGES: &[&str] = &["text", "plaintext", "txt", "plain"];
+pub const PLAIN_LANGUAGES: &[&str] = &[
+    "text",
+    "plaintext",
+    "txt",
+    "plain",
+    "dotenv",
+    "env",
+    ".env",
+    "gitignore",
+    "dockerignore",
+    "npmrc",
+    "yarnrc",
+    "properties",
+    "ini",
+    "conf",
+    "config",
+];
 
 /// Whether `lang` names a block that should render without tokenizing.
 pub fn is_plain(lang: &str) -> bool {

--- a/crates/ox_content_highlight/src/tests.rs
+++ b/crates/ox_content_highlight/src/tests.rs
@@ -14,10 +14,28 @@ fn aliases_resolve_to_the_same_grammar() {
     for alias in ["bash", "sh", "shell", "zsh"] {
         assert!(supports(alias), "{alias} should be supported");
     }
+    for alias in ["jsonc", "json5", "webmanifest"] {
+        assert!(supports(alias), "{alias} should be supported");
+    }
+    for alias in ["vue", "svelte", "astro", "angular"] {
+        assert!(supports(alias), "{alias} should be supported");
+    }
+    for alias in ["flow", "javascriptreact", "typescriptreact"] {
+        assert!(supports(alias), "{alias} should be supported");
+    }
     assert!(supports("mdx"));
     assert_eq!(
         highlight_to_html("const a = 1;", "ts"),
         highlight_to_html("const a = 1;", "typescript")
+    );
+    assert_eq!(highlight_to_html("{\"a\":1}", "jsonc"), highlight_to_html("{\"a\":1}", "json"));
+    assert_eq!(
+        highlight_to_html("<script>const a = 1;</script>\n", "vue"),
+        highlight_to_html("<script>const a = 1;</script>\n", "html")
+    );
+    assert_eq!(
+        highlight_to_html("export const C = () => <p />;\n", "typescriptreact"),
+        highlight_to_html("export const C = () => <p />;\n", "tsx")
     );
 }
 
@@ -108,6 +126,10 @@ fn the_visible_text_is_exactly_the_input() {
         ("# H\n\n*a* **b** `c` [d](http://e)\n", "md"),
         ("[package]\nname = \"demo\"\n", "toml"),
         ("@compute @workgroup_size(64)\nfn main() {\n    let x = 1;\n}\n", "wgsl"),
+        ("{\n  // comment\n  \"a\": true\n}\n", "jsonc"),
+        ("<script lang=\"ts\">let a = 1;</script>\n", "svelte"),
+        ("---\ntitle: Demo\n---\n<h1>{title}</h1>\n", "astro"),
+        ("FOO=a < b\n# comment\n", "dotenv"),
         ("no trailing newline", "ts"),
         ("\n\n\n", "ts"),
         ("tabs\tand  spaces\n", "ts"),
@@ -186,7 +208,24 @@ fn plain_text_renders_without_tokenizing() {
     // `text` is the third most common fence tag in the documentation corpus.
     // Declining it would send those pages to the fallback highlighter purely
     // to render prose, which is the cost this avoids.
-    for lang in ["text", "plaintext", "txt", "plain", "TEXT"] {
+    for lang in [
+        "text",
+        "plaintext",
+        "txt",
+        "plain",
+        "dotenv",
+        "env",
+        ".env",
+        "gitignore",
+        "dockerignore",
+        "npmrc",
+        "yarnrc",
+        "properties",
+        "ini",
+        "conf",
+        "config",
+        "TEXT",
+    ] {
         assert!(supports(lang), "{lang} should be supported");
     }
 

--- a/docs/content/built-in/code-blocks.md
+++ b/docs/content/built-in/code-blocks.md
@@ -25,6 +25,12 @@ On-demand **Run** / **Typecheck** for samples is a separate package,
 Highlighting is opt-in. When enabled, fenced blocks and language-tagged inline
 code go through the native tree-sitter engine. Languages with no native
 grammar stay as ordinary `<pre><code>` — they are not highlighted.
+Adjacent formats without their own bundled grammar use best-effort aliases
+when the existing grammar keeps source text safe: `jsonc` / `json5` /
+`webmanifest` use JSON, `vue` / `svelte` / `astro` / `angular` use HTML,
+`flow` / `javascriptreact` use JavaScript, and `typescriptreact` uses TSX.
+Dotfile and config tags such as `dotenv`, `.env`, `gitignore`, `npmrc`,
+`ini`, and `conf` render as escaped plain text.
 
 ```ts
 import { oxContent } from "@ox-content/vite-plugin";

--- a/docs/content/ja/built-in/code-blocks.md
+++ b/docs/content/ja/built-in/code-blocks.md
@@ -25,6 +25,12 @@ description: フェンス付きコードブロック向けのシンタックス�
 ハイライトはオプトインです。有効にすると、フェンス付きブロックと言語タグ付きインライン
 コードはネイティブ tree-sitter エンジンを通ります。ネイティブ文法がない言語は
 普通の `<pre><code>` のままです。ハイライトされません。
+専用の文法を同梱していない近い形式は、既存文法でソース文字列を安全に保てる場合だけ
+best-effort alias として扱います。`jsonc` / `json5` / `webmanifest` は JSON、
+`vue` / `svelte` / `astro` / `angular` は HTML、`flow` / `javascriptreact` は
+JavaScript、`typescriptreact` は TSX を使います。`dotenv`、`.env`、`gitignore`、
+`npmrc`、`ini`、`conf` などの dotfile / config タグは、エスケープ済みの plain text
+として描画します。
 
 ```ts
 import { oxContent } from "@ox-content/vite-plugin";

--- a/npm/vite-plugin-ox-content/src/highlight.test.ts
+++ b/npm/vite-plugin-ox-content/src/highlight.test.ts
@@ -24,14 +24,15 @@ describe("highlightCode", () => {
     expect(highlighted).not.toContain("--octc-syntax-token");
   });
 
-  it("leaves vue unhighlighted when the native engine has no grammar", async () => {
+  it("highlights vue through the native html-adjacent alias", async () => {
     const highlighted = await highlightCode(
       block("vue", "&lt;template&gt;&lt;p&gt;hi&lt;/p&gt;&lt;/template&gt;"),
     );
 
     expect(highlighted).toContain("template");
     expect(highlighted).toContain("hi");
-    expect(highlighted).not.toContain("--octc-syntax-token");
+    expect(highlighted).toContain("var(--octc-syntax-token-");
+    expect(highlighted).toContain('data-language="vue"');
   });
 
   it("highlights standalone language-tagged code inline", async () => {


### PR DESCRIPTION
## Summary

- add zero-dependency highlight aliases for adjacent JSON, web component, JavaScript, and TSX fence tags
- render common dotfile/config fence tags through the escaped plain-text path
- document the best-effort alias behavior in English and Japanese docs

Closes #940
Refs #857

## Validation

- `cargo test -p ox_content_highlight`
- `vp exec --filter @ox-content/vite-plugin -- vp test src/highlight.test.ts`
- `vpr fmt:check`
- `node scripts/check-file-lines.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790284762&installation_model_id=422833&pr_number=943&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F943&signature=71870eec5c91331d2470397d9fd1ca67d9288539cc07cdabdbedf7b4d6ed9ca9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded code block language recognition for JSON variants, Vue, Svelte, Astro, Angular, React/Flow, and TSX aliases.
  - Added support for dotenv, environment files, ignore files, and common configuration formats.
  - Related formats now use compatible syntax highlighting where safe; configuration and dotfiles render as escaped plain text.

- **Documentation**
  - Updated English and Japanese code block documentation to describe supported aliases and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->