### PR TITLE
fix(typed-hover): keep native preview external

### DIFF
--- a/npm/vite-plugin-ox-content/src/jsx-runtime.test.ts
+++ b/npm/vite-plugin-ox-content/src/jsx-runtime.test.ts
@@ -48,3 +48,11 @@ describe("jsx runtime packaging", () => {
     });
   }
 });
+
+describe("typed hover packaging", () => {
+  it("leaves the native-preview sync API external so it resolves its own tsgo binary", () => {
+    const neverBundle: string[] = require("../vite.config.ts").default.pack.deps.neverBundle;
+    expect(neverBundle).toContain("@typescript/native-preview");
+    expect(neverBundle).toContain("@typescript/native-preview/unstable/sync");
+  });
+});

--- a/npm/vite-plugin-ox-content/vite.config.ts
+++ b/npm/vite-plugin-ox-content/vite.config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
         "react-dom/server",
         "typescript",
         "@typescript/native-preview",
+        "@typescript/native-preview/unstable/sync",
       ],
     },
   }),


### PR DESCRIPTION
## Summary
- keep `@typescript/native-preview/unstable/sync` external in the vite-plugin package build
- prevent the packed bundle from running native-preview's `getExePath()` against `@ox-content/vite-plugin/package.json`
- add a packaging contract test for the native-preview external entry

Closes #951

## Verification
- `pnpm --filter @ox-content/vite-plugin run build`
- `rg -n "@typescript/native-preview|native-preview/lib/getExePath|Expected .*tsgo|dist/api/fs\.js" npm/vite-plugin-ox-content/dist/index.mjs npm/vite-plugin-ox-content/dist/index.cjs`
- `pnpm --filter ox-content-docs run build`
- `rg -n "ox-typed-hover-token|ox-typed-hover-data|ox-typed-hover-runtime" docs/dist/docs/built-in/typed-hover/index.html docs/dist/docs/ja/built-in/typed-hover/index.html`
- `vp exec --filter @ox-content/vite-plugin -- vp test src/jsx-runtime.test.ts src/typed-hover.test.ts`
- `vpr fmt:check`
- `node scripts/check-file-lines.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790286931&installation_model_id=422833&pr_number=952&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F952&signature=71d54f7912150178560116e9974ff4189685bee357e83c0de6b4fea55890c344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->