### PR TITLE
fix(theme): refine mobile header nav

### DIFF
--- a/crates/ox_content_ssg/src/html/header_chrome.css
+++ b/crates/ox_content_ssg/src/html/header_chrome.css
@@ -113,7 +113,37 @@
   display: none;
 }
 @media (max-width: 768px) {
+  .header-nav {
+    flex: 0 1 auto;
+    max-width: min(52vw, 18rem);
+    margin-inline-start: auto;
+    scrollbar-width: none;
+  }
+  .header-nav::-webkit-scrollbar {
+    display: none;
+  }
   .header-nav-list {
     flex-wrap: nowrap;
+    justify-content: flex-end;
+    width: max-content;
+    min-width: 100%;
+    gap: 0.125rem;
+  }
+  .header-nav-item > a,
+  .header-nav-dropdown > button {
+    min-height: 36px;
+    padding: 0.35rem 0.55rem;
+    color: var(--octc-color-text-muted);
+    font-size: 0.9rem;
+  }
+}
+@media (max-width: 420px) {
+  .header-nav {
+    max-width: max(6rem, calc(100vw - 12.5rem));
+  }
+  .header-nav-item > a,
+  .header-nav-dropdown > button {
+    padding-inline: 0.45rem;
+    font-size: 0.85rem;
   }
 }

--- a/crates/ox_content_ssg/src/html/header_chrome/tests/nav.rs
+++ b/crates/ox_content_ssg/src/html/header_chrome/tests/nav.rs
@@ -1,4 +1,4 @@
-use super::super::{HEADER_CHROME_JS, PageChromeFlags};
+use super::super::{HEADER_CHROME_CSS, HEADER_CHROME_JS, PageChromeFlags};
 use super::{dropdown, nav_item, render, theme_nav};
 
 #[test]
@@ -118,4 +118,28 @@ fn header_nav_css_scrolls_on_small_viewports() {
         PageChromeFlags::default(),
     );
     assert!(html.contains("overflow-x: auto") && html.contains("flex-wrap: nowrap"), "{html}");
+}
+
+#[test]
+fn header_nav_css_keeps_mobile_links_compact_and_intentional() {
+    assert!(
+        HEADER_CHROME_CSS
+            .contains("@media (max-width: 768px) {\n  .header-nav {\n    flex: 0 1 auto;")
+            && HEADER_CHROME_CSS.contains("margin-inline-start: auto;")
+            && HEADER_CHROME_CSS.contains("max-width: min(52vw, 18rem);"),
+        "mobile header nav should sit as a compact control aligned away from the brand"
+    );
+    assert!(
+        HEADER_CHROME_CSS.contains("scrollbar-width: none;")
+            && HEADER_CHROME_CSS.contains(".header-nav::-webkit-scrollbar")
+            && HEADER_CHROME_CSS.contains("width: max-content;")
+            && HEADER_CHROME_CSS.contains("min-width: 100%;"),
+        "overflowing mobile header nav needs hidden-scrollbar horizontal scrolling"
+    );
+    assert!(
+        HEADER_CHROME_CSS.contains("min-height: 36px;")
+            && HEADER_CHROME_CSS.contains("font-size: 0.9rem;")
+            && HEADER_CHROME_CSS.contains("@media (max-width: 420px)"),
+        "mobile header links need deliberate tap geometry at both narrow breakpoints"
+    );
 }


### PR DESCRIPTION
## Summary
- align mobile header nav links to the trailing side of the header instead of letting them sit loosely after the brand
- keep mobile header links compact, horizontally scrollable, and hidden-scrollbar when labels overflow
- add a Rust CSS contract test for the mobile header nav geometry

## Verification
- cargo fmt --check
- cargo test -p ox_content_ssg header_nav_css --lib
- node scripts/check-file-lines.ts
- git diff --check origin/main...HEAD
- pnpm --filter @ox-content/vite-plugin run build
- pnpm --filter ox-content-docs run build
- Playwright visual QA at 390x844 and 320x844; no horizontal document overflow

Closes #880

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790287566&installation_model_id=422833&pr_number=953&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F953&signature=086f34c9af6c0c576d345447afdc867e89ed4e2e1d51e797ef988d9028445933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive header navigation on mobile screens.
  * Added larger touch targets, clearer link styling, compact spacing, and smoother horizontal navigation.
  * Optimized the menu layout and typography for very narrow screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->