### PR TITLE
fix(code-blocks): quiet copy button chrome

### DIFF
--- a/crates/ox_content_ssg/src/html/reader_chrome.css
+++ b/crates/ox_content_ssg/src/html/reader_chrome.css
@@ -24,12 +24,12 @@
   height: 1.75rem;
   padding: 0;
   place-items: center;
-  border: 1px solid color-mix(in srgb, var(--octc-color-code-frame-border) 70%, transparent);
+  border: 1px solid transparent;
   border-radius: 4px;
-  background: color-mix(in srgb, var(--octc-color-code-bg) 74%, var(--octc-color-bg) 26%);
-  color: color-mix(in srgb, var(--octc-color-code-text) 82%, transparent);
+  background: transparent;
+  color: color-mix(in srgb, var(--octc-color-code-text) 70%, transparent);
   cursor: pointer;
-  opacity: 0.82;
+  opacity: 0.68;
   transition:
     opacity 0.15s ease,
     color 0.15s ease,
@@ -38,8 +38,8 @@
 }
 .ox-copy::before {
   content: "";
-  width: 0.875rem;
-  height: 0.875rem;
+  width: 0.8125rem;
+  height: 0.8125rem;
   background-color: currentColor;
   -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><rect x='9' y='9' width='11' height='11' rx='2'/><path d='M15 9V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h3'/></svg>")
     center / contain no-repeat;
@@ -51,15 +51,17 @@
   color: var(--octc-color-code-text);
   border-color: color-mix(
     in srgb,
-    var(--octc-color-primary) 54%,
+    var(--octc-color-primary) 42%,
     var(--octc-color-code-frame-border)
   );
-  background: color-mix(in srgb, var(--octc-color-code-bg) 58%, var(--octc-color-bg) 42%);
-  opacity: 1;
+  background: color-mix(in srgb, var(--octc-color-code-bg) 82%, var(--octc-color-bg) 18%);
+  opacity: 0.96;
 }
 .ox-copy[data-copy-state="copied"] {
   color: var(--octc-color-primary);
-  opacity: 1;
+  border-color: color-mix(in srgb, var(--octc-color-primary) 36%, transparent);
+  background: color-mix(in srgb, var(--octc-color-code-bg) 86%, var(--octc-color-bg) 14%);
+  opacity: 0.96;
 }
 .ox-copy[data-copy-state="copied"]::before {
   -webkit-mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'><path d='m5 12 4 4L19 6'/></svg>");
@@ -87,7 +89,7 @@
   }
   .ox-code:hover > .ox-copy,
   .ox-code:focus-within > .ox-copy {
-    opacity: 0.92;
+    opacity: 0.86;
     pointer-events: auto;
   }
 }

--- a/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
+++ b/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
@@ -204,9 +204,12 @@ fn copy_control_uses_capability_media_queries_and_stable_status_ui() {
         "the control needs a visible icon and a non-visual status region: {READER_CHROME_CSS}"
     );
     assert!(
-        READER_CHROME_CSS.contains("var(--octc-color-code-bg) 74%")
-            && READER_CHROME_CSS.contains(".ox-code:focus-within > .ox-copy {\n    opacity: 0.92;"),
-        "copy should blend into code blocks until hover/focus: {READER_CHROME_CSS}"
+        READER_CHROME_CSS.contains("border: 1px solid transparent;")
+            && READER_CHROME_CSS.contains("background: transparent;")
+            && READER_CHROME_CSS.contains(".ox-code:focus-within > .ox-copy {\n    opacity: 0.86;")
+            && READER_CHROME_CSS
+                .contains("background: color-mix(in srgb, var(--octc-color-code-bg) 82%"),
+        "copy should stay nearly icon-only until hover/focus: {READER_CHROME_CSS}"
     );
     assert!(
         READER_CHROME_JS.contains("data-ox-copy-status")

--- a/npm/vite-plugin-ox-content/test/vrt/copy-button.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/copy-button.spec.ts
@@ -51,8 +51,8 @@ test("code copy button stays compact on touch layouts", async ({ page }) => {
 
   expect(metrics.buttonWidth).toBeLessThanOrEqual(28);
   expect(metrics.buttonHeight).toBeLessThanOrEqual(28);
-  expect(metrics.iconWidth).toBeLessThanOrEqual(14);
-  expect(metrics.iconHeight).toBeLessThanOrEqual(14);
-  expect(metrics.opacity).toBeLessThan(0.9);
-  expect(metrics.backgroundColor).not.toBe("rgb(255, 255, 255)");
+  expect(metrics.iconWidth).toBeLessThanOrEqual(13);
+  expect(metrics.iconHeight).toBeLessThanOrEqual(13);
+  expect(metrics.opacity).toBeLessThanOrEqual(0.72);
+  expect(metrics.backgroundColor).toBe("rgba(0, 0, 0, 0)");
 });


### PR DESCRIPTION
## Summary
- make code-block copy buttons nearly icon-only by default
- keep hover/focus/copied states visible without a heavy always-on surface
- tighten the reader-chrome contract and VRT expectations for touch layouts

## Verification
- cargo fmt --check
- cargo test -p ox_content_ssg copy_control --lib
- pnpm --filter @ox-content/napi run build
- pnpm --filter @ox-content/vite-plugin run test:vrt -- test/vrt/copy-button.spec.ts
- pnpm --filter ox-content-docs run build
- vpr fmt:check
- node scripts/check-file-lines.ts
- git diff --check

Closes #954
Refs #875

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790287805&installation_model_id=422833&pr_number=955&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F955&signature=83e5150429a8de1fd5de3b32bceb76ee099dfbe96f3c9715b7873921dafdfd8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->