### PR TITLE
perf(vite-plugin): remove ineffective plugin imports

### DIFF
--- a/npm/vite-plugin-ox-content/src/plugins/index.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/index.ts
@@ -5,32 +5,23 @@
  * They generate static HTML at build time and require no client-side JS.
  */
 
-import type { GitHubOptions } from "./github";
-import type { MediaEmbedOptions } from "./media";
-import type { TwitterEmbedOptions } from "./twitter";
-import type { OgpOptions } from "./ogp";
-import type { PmOptions } from "./pm";
-
-export {
+import {
   transformTabs,
   generateTabsCSS,
   resetTabGroupCounter,
   getTabGroupCounter,
   setTabGroupCounter,
 } from "./tabs";
-
-export { transformPm, type PmOptions } from "./pm";
-
-export { transformYouTube, extractVideoId, type YouTubeOptions } from "./youtube";
-export { transformMediaEmbeds, type MediaEmbedOptions } from "./media";
-export {
+import { transformPm, type PmOptions } from "./pm";
+import { transformYouTube, extractVideoId, type YouTubeOptions } from "./youtube";
+import { transformMediaEmbeds, type MediaEmbedOptions } from "./media";
+import {
   createSyndicationToken,
   parseTweetReference,
   type TweetData,
   type TwitterEmbedOptions,
 } from "./twitter";
-
-export {
+import {
   transformGitHub,
   fetchRepoData,
   fetchGitHubSource,
@@ -47,8 +38,7 @@ export {
   type GitHubLineRange,
   type GitHubOptions,
 } from "./github";
-
-export {
+import {
   transformOgp,
   fetchOgpData,
   collectOgpUrls,
@@ -56,8 +46,53 @@ export {
   type OgpData,
   type OgpOptions,
 } from "./ogp";
+import { transformMermaidStatic, mermaidClientScript, type MermaidOptions } from "./mermaid";
 
-export { transformMermaidStatic, mermaidClientScript, type MermaidOptions } from "./mermaid";
+export {
+  transformTabs,
+  generateTabsCSS,
+  resetTabGroupCounter,
+  getTabGroupCounter,
+  setTabGroupCounter,
+  transformPm,
+  transformYouTube,
+  extractVideoId,
+  transformMediaEmbeds,
+  createSyndicationToken,
+  parseTweetReference,
+  transformGitHub,
+  fetchRepoData,
+  fetchGitHubSource,
+  collectGitHubRepos,
+  collectGitHubSources,
+  prefetchGitHubRepos,
+  prefetchGitHubSources,
+  parseGitHubPermalink,
+  parseGitHubLineRange,
+  transformOgp,
+  fetchOgpData,
+  collectOgpUrls,
+  prefetchOgpData,
+  transformMermaidStatic,
+  mermaidClientScript,
+};
+
+export type {
+  PmOptions,
+  YouTubeOptions,
+  MediaEmbedOptions,
+  TweetData,
+  TwitterEmbedOptions,
+  GitHubRepoData,
+  GitHubSourceCommit,
+  GitHubSourceData,
+  GitHubSourceRef,
+  GitHubLineRange,
+  GitHubOptions,
+  OgpData,
+  OgpOptions,
+  MermaidOptions,
+};
 
 const SELF_CLOSING_EMBED_TAG =
   /<(GitHub|OgCard|Tweet|XPost|Bluesky|Spotify|StackBlitz|WebContainer|YouTube)((?:[^>"']|"[^"]*"|'[^']*')*?)\s*\/>/gi;
@@ -130,7 +165,6 @@ export async function transformAllPlugins(
 
   // 1. Tabs (no external dependencies)
   if (tabs) {
-    const { transformTabs } = await import("./tabs");
     result = await transformTabs(result);
   }
 
@@ -138,26 +172,22 @@ export async function transformAllPlugins(
   // counter with the tabs transform, so it runs right after it. Syncing is
   // opt-in via `{ pm: { sync: true } }` and off by default.
   if (pm) {
-    const { transformPm } = await import("./pm");
     result = await transformPm(result, typeof pm === "object" ? pm : {});
   }
 
   // 2. YouTube (no external dependencies)
   if (youtube) {
-    const { transformYouTube } = await import("./youtube");
     result = await transformYouTube(result);
   }
 
   // 3. GitHub (requires API calls)
   if (github !== false) {
-    const { transformGitHub } = await import("./github");
     const options = typeof github === "object" ? github : {};
     result = await transformGitHub(result, undefined, { token: githubToken, ...options });
   }
 
   // 4. OGP (requires fetch calls)
   if (ogpOptions !== false) {
-    const { transformOgp } = await import("./ogp");
     result = await transformOgp(
       result,
       undefined,
@@ -167,13 +197,11 @@ export async function transformAllPlugins(
 
   const mediaOptions = { spotify, stackBlitz, twitter, bluesky, webContainer };
   if (Object.values(mediaOptions).some(Boolean)) {
-    const { transformMediaEmbeds } = await import("./media");
     result = await transformMediaEmbeds(result, mediaOptions);
   }
 
   // 5. Mermaid (requires mermaid library)
   if (mermaid) {
-    const { transformMermaidStatic } = await import("./mermaid");
     result = await transformMermaidStatic(result);
   }
 
@@ -199,7 +227,6 @@ export async function transformBuiltinEmbeds(
   let result = normalizeSelfClosingEmbeds(html);
 
   if (options.github) {
-    const { transformGitHub } = await import("./github");
     result = await transformGitHub(result, undefined, {
       token: process.env.GITHUB_TOKEN,
       ...options.github,
@@ -207,12 +234,10 @@ export async function transformBuiltinEmbeds(
   }
 
   if (options.openGraph) {
-    const { transformOgp } = await import("./ogp");
     result = await transformOgp(result, undefined, options.openGraph);
   }
 
   if (options.pm) {
-    const { transformPm } = await import("./pm");
     result = await transformPm(result, typeof options.pm === "object" ? options.pm : {});
   }
 
@@ -224,7 +249,6 @@ export async function transformBuiltinEmbeds(
     webContainer: options.webContainer,
   };
   if (Object.values(mediaOptions).some(Boolean)) {
-    const { transformMediaEmbeds } = await import("./media");
     result = await transformMediaEmbeds(result, mediaOptions);
   }
 


### PR DESCRIPTION
## Summary
- replace plugin pipeline dynamic imports that cannot split because the public entry already statically exports those modules
- keep the public plugin exports and transform order unchanged
- remove the ineffective dynamic import warnings from `vp pack`

## Verification
- vpr fmt
- vpr fmt:check
- node scripts/check-file-lines.ts
- git diff --check
- vp exec --filter @ox-content/vite-plugin -- vp test src/embed.test.ts src/plugins/embed-transform.test.ts
- pnpm --filter @ox-content/vite-plugin run build
- rg -n "INEFFECTIVE_DYNAMIC_IMPORT|dynamic import" /tmp/ox-content-vite-plugin-build-958-after-rebase.log || true

Closes #958
Refs #851
Refs #872

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790288436&installation_model_id=422833&pr_number=959&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F959&signature=259e01be87dd15fc00895dedce556497ccb6021fdc7311b12cc2be917d4b431d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal loading of built-in content plugins.
  * Preserved the existing plugin processing order and transformation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->