### PR TITLE
docs(highlight): mark embed examples as mdx

### DIFF
--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -53,7 +53,7 @@ third-party widget script.
 
 A repository card:
 
-```md
+```mdx
 <GitHub repo="ubugeeei-prod/ox-content" />
 ```
 
@@ -61,7 +61,7 @@ A repository card:
 
 A source snippet pinned to a ref and line range:
 
-```md
+```mdx
 <GitHub repo="ubugeeei-prod/ox-content" path="README.md" ref="main" loc="1-10" />
 ```
 
@@ -70,7 +70,7 @@ A source snippet pinned to a ref and line range:
 A permalink form is also supported — paste a GitHub blob URL with `#L10-L18`
 line anchors:
 
-```md
+```mdx
 <GitHub permalink="https://github.com/ubugeeei-prod/ox-content/blob/278098b/npm/vite-plugin-ox-content/src/plugins/github.ts#L10-L18" />
 ```
 
@@ -97,7 +97,7 @@ card instead of failing the build.
 `embeds.openGraph` fetches a page's Open Graph metadata at build time and
 renders a static link card:
 
-```md
+```mdx
 <OgCard url="https://vite.dev" />
 ```
 
@@ -137,7 +137,7 @@ oxContent({
 });
 ```
 
-```md
+```mdx
 <pm>npm install -D @ox-content/vite-plugin @ox-content/theme-swiss</pm>
 ```
 
@@ -214,7 +214,7 @@ YouTube embeds are always processed in SSG builds and dev preview. The iframe
 uses privacy-enhanced mode (`youtube-nocookie.com`) and lazy loading by
 default:
 
-```md
+```mdx
 <youtube id="aqz-KE-bpKQ" title="Big Buck Bunny" />
 ```
 
@@ -226,7 +226,7 @@ non-negative integer number of seconds and becomes `?start=` on the iframe
 URL. Invalid, negative, fractional, overflowing, or duplicated values are
 ignored. Omitting `start` leaves the previous URL unchanged.
 
-```md
+```mdx
 <youtube id="aqz-KE-bpKQ" title="Big Buck Bunny" start="4190" />
 ```
 
@@ -236,7 +236,7 @@ ignored. Omitting `start` leaves the previous URL unchanged.
 widget script. With `twitter: true`, the embed is a privacy-conscious link
 card:
 
-```md
+```mdx
 <XPost url="https://x.com/jack/status/20" />
 ```
 
@@ -292,7 +292,7 @@ are in [Credits](../credits.md). See
 `embeds.bluesky` renders a static card. The element body provides the text
 shown in the card, so no network request is needed at all:
 
-```md
+```mdx
 <Bluesky url="https://bsky.app/profile/bsky.app/post/3l6oveex3ii2l">
   👋 Bluesky is an open social network
 </Bluesky>
@@ -307,7 +307,7 @@ shown in the card, so no network request is needed at all:
 `embeds.spotify` renders the official iframe player for tracks, albums,
 playlists, episodes, shows, and artists:
 
-```md
+```mdx
 <Spotify url="https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC" />
 ```
 
@@ -322,7 +322,7 @@ is why it stays opt-in.
 `embeds.stackBlitz` turns a StackBlitz project URL into a sandboxed iframe
 with `embed=1` appended:
 
-```md
+```mdx
 <StackBlitz url="https://stackblitz.com/edit/vitejs-vite" />
 ```
 

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -46,7 +46,7 @@ export default {
 
 リポジトリカード:
 
-```md
+```mdx
 <GitHub repo="ubugeeei-prod/ox-content" />
 ```
 
@@ -54,7 +54,7 @@ export default {
 
 ref と行範囲を固定したソーススニペット:
 
-```md
+```mdx
 <GitHub repo="ubugeeei-prod/ox-content" path="README.md" ref="main" loc="1-10" />
 ```
 
@@ -62,7 +62,7 @@ ref と行範囲を固定したソーススニペット:
 
 パーマリンク形式も使えます。`#L10-L18` 行アンカー付きの GitHub blob URL を貼ります。
 
-```md
+```mdx
 <GitHub permalink="https://github.com/ubugeeei-prod/ox-content/blob/278098b/npm/vite-plugin-ox-content/src/plugins/github.ts#L10-L18" />
 ```
 
@@ -84,7 +84,7 @@ ref と行範囲を固定したソーススニペット:
 
 `embeds.openGraph` はビルド時にページの Open Graph メタデータを取り、静的リンクカードを描画します。
 
-```md
+```mdx
 <OgCard url="https://vite.dev" />
 ```
 
@@ -116,7 +116,7 @@ oxContent({
 });
 ```
 
-```md
+```mdx
 <pm>npm install -D @ox-content/vite-plugin @ox-content/theme-swiss</pm>
 ```
 
@@ -182,7 +182,7 @@ pnpm vite preview</code></pre>
 
 YouTube 埋め込みは SSG ビルドと dev preview で常に処理されます。iframe はプライバシー強化モード（`youtube-nocookie.com`）と遅延読み込みが既定です。
 
-```md
+```mdx
 <youtube id="aqz-KE-bpKQ" title="Big Buck Bunny" />
 ```
 
@@ -190,7 +190,7 @@ YouTube 埋め込みは SSG ビルドと dev preview で常に処理されます
 
 `id`、`url`、`href` 属性を受け付けます。`youtu.be`、`watch?v=`、`shorts`、`embed` の URL 形はどれも認識します。`start` は非負整数の秒で、iframe URL に `?start=` を付けます。不正、負、小数、オーバーフロー、重複した値は無視します。`start` を省略すると、これまでの URL のままです。
 
-```md
+```mdx
 <youtube id="aqz-KE-bpKQ" title="Big Buck Bunny" start="4190" />
 ```
 
@@ -198,7 +198,7 @@ YouTube 埋め込みは SSG ビルドと dev preview で常に処理されます
 
 `embeds.twitter` は投稿を静的カードとして描画し、第三者ウィジェットのスクリプトは決して読みません。`twitter: true` のとき、埋め込みはプライバシーを意識したリンクカードです。
 
-```md
+```mdx
 <XPost url="https://x.com/jack/status/20" />
 ```
 
@@ -239,7 +239,7 @@ oxContent({
 
 `embeds.bluesky` は静的カードを描画します。カードに出すテキストは要素本文なので、ネットワーク要求は一切要りません。
 
-```md
+```mdx
 <Bluesky url="https://bsky.app/profile/bsky.app/post/3l6oveex3ii2l">
   👋 Bluesky is an open social network
 </Bluesky>
@@ -253,7 +253,7 @@ oxContent({
 
 `embeds.spotify` はトラック、アルバム、プレイリスト、エピソード、番組、アーティスト向けの公式 iframe プレーヤーを描画します。
 
-```md
+```mdx
 <Spotify url="https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC" />
 ```
 
@@ -265,7 +265,7 @@ oxContent({
 
 `embeds.stackBlitz` は StackBlitz プロジェクト URL を、`embed=1` を付けたサンドボックス iframe にします。
 
-```md
+```mdx
 <StackBlitz url="https://stackblitz.com/edit/vitejs-vite" />
 ```
 

--- a/docs/content/ja/packages/vite-plugin-ox-content.md
+++ b/docs/content/ja/packages/vite-plugin-ox-content.md
@@ -222,7 +222,7 @@ oxContent({
 
 組み込みの静的埋め込みは変換時に描画され、クライアント側 JavaScript は使いません。非標準の埋め込みはオプトインです。既定表と描画例の全体は [埋め込み](../built-in/embeds.md) を見てください。
 
-```md
+```mdx
 <GitHub repo="ubugeeei-prod/ox-content" />
 
 <GitHub permalink="https://github.com/ubugeeei-prod/ox-content/blob/278098b/README.md#L1-L12" />

--- a/docs/content/packages/vite-plugin-ox-content.md
+++ b/docs/content/packages/vite-plugin-ox-content.md
@@ -222,7 +222,7 @@ Non-standard embeds are opt-in.
 See [Embeds](../built-in/embeds.md) for the full
 default table and rendered examples.
 
-```md
+```mdx
 <GitHub repo="ubugeeei-prod/ox-content" />
 
 <GitHub permalink="https://github.com/ubugeeei-prod/ox-content/blob/278098b/README.md#L1-L12" />


### PR DESCRIPTION
## Summary
- mark component-only embed snippets as `mdx` instead of `md`
- apply the same examples in English and Japanese docs
- keep true Markdown examples unchanged

## Verification
- cargo test -p ox_content_highlight --lib
- vpr fmt:check
- node scripts/check-file-lines.ts
- git diff --check
- pnpm --filter ox-content-docs run build
- generated embeds pages contain `data-language="mdx"` for the component snippets

Closes #960
Refs #857

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790288696&installation_model_id=422833&pr_number=961&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F961&signature=95adb3f8189195d83a2dd49112eb719c88a7764989efca3db2e317c0d917ca94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->