### PR TITLE
feat(bluesky): render rich static cards

### DIFF
--- a/crates/ox_content_ssg/src/plugins/social.css
+++ b/crates/ox_content_ssg/src/plugins/social.css
@@ -57,6 +57,85 @@
   color: var(--octc-color-text-muted);
 }
 
+.ox-bluesky__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.ox-bluesky__avatar-wrap {
+  flex: 0 0 auto;
+}
+
+.ox-bluesky__avatar,
+.ox-bluesky__avatar-fallback {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--octc-color-primary) 16%, var(--octc-color-bg-alt));
+  color: var(--octc-color-primary);
+  font-weight: 700;
+}
+
+.ox-bluesky__avatar {
+  object-fit: cover;
+}
+
+.ox-bluesky__identity {
+  display: grid;
+  min-width: 0;
+  gap: 0.125rem;
+}
+
+.ox-bluesky__author-name,
+.ox-bluesky__handle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ox-bluesky__author-name {
+  font-size: 0.95rem;
+  line-height: 1.2;
+  color: var(--octc-color-text);
+}
+
+.ox-bluesky__handle,
+.ox-bluesky__network,
+.ox-bluesky__meta {
+  color: var(--octc-color-text-muted);
+}
+
+.ox-bluesky__network {
+  margin-left: auto;
+  flex: 0 0 auto;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.ox-bluesky__body {
+  margin: 0.875rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: var(--octc-color-text);
+}
+
+.ox-bluesky__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem 0.8rem;
+  margin-top: 0.875rem;
+  font-size: 0.75rem;
+}
+
+.ox-bluesky__source {
+  color: var(--octc-color-primary);
+  font-weight: 600;
+}
+
 /* Fetched tweet cards (<Tweet> with `twitter: { fetch: true }`) */
 .ox-tweet--fetched > a {
   padding: 1rem 0;

--- a/crates/ox_content_transform/src/media_embeds/render.rs
+++ b/crates/ox_content_transform/src/media_embeds/render.rs
@@ -31,7 +31,7 @@ pub(super) fn render_bluesky(element: &ComponentElement<'_>) -> Option<String> {
     if !url.starts_with("https://bsky.app/profile/") {
         return None;
     }
-    Some(render_static_card("ox-bluesky", "Bluesky", url, element.body.trim()))
+    Some(render_bluesky_card(element, url))
 }
 
 pub(super) fn render_webcontainer(element: &ComponentElement<'_>) -> Option<String> {
@@ -82,6 +82,89 @@ fn tweet_url(input: &str) -> Option<String> {
         return Some(format!("https://x.com/i/web/status/{input}"));
     }
     None
+}
+
+fn render_bluesky_card(element: &ComponentElement<'_>, href: &str) -> String {
+    let handle = first_attr(element, &["handle", "authorHandle"])
+        .or_else(|| bluesky_handle_from_url(href))
+        .unwrap_or("bsky.app");
+    let author =
+        first_attr(element, &["displayName", "authorName", "name", "author"]).unwrap_or(handle);
+    let avatar = first_attr(element, &["avatar", "avatarUrl", "authorAvatar", "authorAvatarUrl"]);
+    let date = first_attr(element, &["datetime", "dateTime", "createdAt", "date", "timestamp"]);
+    let date_label = first_attr(element, &["dateLabel", "time", "publishedAtLabel"]).or(date);
+    let body = element.body.trim();
+
+    let mut html = String::new();
+    html.push_str(
+        "<article class=\"ox-bluesky ox-bluesky--rich\"><a class=\"ox-bluesky__card\" href=\"",
+    );
+    escape_attr(href, &mut html);
+    html.push_str("\" target=\"_blank\" rel=\"noopener noreferrer\"><header class=\"ox-bluesky__header\"><span class=\"ox-bluesky__avatar-wrap\">");
+    if let Some(avatar) = avatar {
+        html.push_str("<img class=\"ox-bluesky__avatar\" src=\"");
+        escape_attr(avatar, &mut html);
+        html.push_str("\" alt=\"\" loading=\"lazy\">");
+    } else {
+        html.push_str("<span class=\"ox-bluesky__avatar-fallback\" aria-hidden=\"true\">B</span>");
+    }
+    html.push_str(
+        "</span><span class=\"ox-bluesky__identity\"><strong class=\"ox-bluesky__author-name\">",
+    );
+    escape_text(author, &mut html);
+    html.push_str("</strong><span class=\"ox-bluesky__handle\">@");
+    escape_text(handle.trim_start_matches('@'), &mut html);
+    html.push_str("</span></span><span class=\"ox-bluesky__network\">Bluesky</span></header>");
+
+    if !body.is_empty() {
+        html.push_str("<p class=\"ox-bluesky__body\">");
+        escape_text(body, &mut html);
+        html.push_str("</p>");
+    }
+
+    html.push_str("<footer class=\"ox-bluesky__meta\">");
+    if let Some(date_label) = date_label {
+        html.push_str("<time datetime=\"");
+        escape_attr(date.unwrap_or(date_label), &mut html);
+        html.push_str("\">");
+        escape_text(date_label, &mut html);
+        html.push_str("</time>");
+    }
+    push_count(
+        &mut html,
+        first_attr(element, &["replies", "replyCount", "reply_count"]),
+        "replies",
+    );
+    push_count(
+        &mut html,
+        first_attr(element, &["reposts", "repostCount", "repost_count"]),
+        "reposts",
+    );
+    push_count(&mut html, first_attr(element, &["likes", "likeCount", "like_count"]), "likes");
+    push_count(&mut html, first_attr(element, &["quotes", "quoteCount", "quote_count"]), "quotes");
+    html.push_str("<span class=\"ox-bluesky__source\">Open post</span></footer></a></article>");
+    html
+}
+
+fn first_attr<'a>(element: &'a ComponentElement<'_>, names: &[&str]) -> Option<&'a str> {
+    names.iter().find_map(|name| attr(element, name))
+}
+
+fn bluesky_handle_from_url(url: &str) -> Option<&str> {
+    let rest = url.strip_prefix("https://bsky.app/profile/")?;
+    let (handle, _) = rest.split_once("/post/")?;
+    (!handle.is_empty()).then_some(handle)
+}
+
+fn push_count(html: &mut String, value: Option<&str>, label: &str) {
+    let Some(value) = value else {
+        return;
+    };
+    html.push_str("<span>");
+    escape_text(value, html);
+    html.push(' ');
+    html.push_str(label);
+    html.push_str("</span>");
 }
 
 fn render_iframe(class_name: &str, src: &str, title: &str, width: &str, height: &str) -> String {

--- a/crates/ox_content_transform/src/media_embeds/snapshots/ox_content_transform__media_embeds__tests__renders_bluesky_rich_card_with_metadata.snap
+++ b/crates/ox_content_transform/src/media_embeds/snapshots/ox_content_transform__media_embeds__tests__renders_bluesky_rich_card_with_metadata.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ox_content_transform/src/media_embeds/tests.rs
+expression: html
+---
+<article class="ox-bluesky ox-bluesky--rich"><a class="ox-bluesky__card" href="https://bsky.app/profile/bsky.app/post/3l6oveex3ii2l" target="_blank" rel="noopener noreferrer"><header class="ox-bluesky__header"><span class="ox-bluesky__avatar-wrap"><img class="ox-bluesky__avatar" src="https://bsky.app/static/apple-touch-icon.png" alt="" loading="lazy"></span><span class="ox-bluesky__identity"><strong class="ox-bluesky__author-name">Bluesky</strong><span class="ox-bluesky__handle">@bsky.app</span></span><span class="ox-bluesky__network">Bluesky</span></header><p class="ox-bluesky__body">hello sky</p><footer class="ox-bluesky__meta"><time datetime="2024-02-06T12:34:56Z">Feb 6, 2024</time><span>10 replies</span><span>20 reposts</span><span>30 likes</span><span>4 quotes</span><span class="ox-bluesky__source">Open post</span></footer></a></article>

--- a/crates/ox_content_transform/src/media_embeds/tests.rs
+++ b/crates/ox_content_transform/src/media_embeds/tests.rs
@@ -45,3 +45,18 @@ fn renders_static_tweet_card() {
     );
     insta::assert_snapshot!(html);
 }
+
+#[test]
+fn renders_bluesky_rich_card_with_metadata() {
+    let html = transform_media_embeds(
+        r#"<Bluesky url="https://bsky.app/profile/bsky.app/post/3l6oveex3ii2l" displayName="Bluesky" handle="bsky.app" avatar="https://bsky.app/static/apple-touch-icon.png" datetime="2024-02-06T12:34:56Z" dateLabel="Feb 6, 2024" replies="10" reposts="20" likes="30" quotes="4">hello sky</Bluesky>"#,
+        Some(&MediaEmbedsOptions {
+            spotify: None,
+            stack_blitz: None,
+            twitter: None,
+            bluesky: Some(true),
+            web_container: None,
+        }),
+    );
+    insta::assert_snapshot!(html);
+}

--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -289,17 +289,40 @@ are in [Credits](../credits.md). See
 
 ## Bluesky
 
-`embeds.bluesky` renders a static card. The element body provides the text
-shown in the card, so no network request is needed at all:
+`embeds.bluesky` renders a static card with optional author, avatar, timestamp,
+and engagement metadata. The element body provides the post text, so no network
+request is needed at all:
 
 ```mdx
-<Bluesky url="https://bsky.app/profile/bsky.app/post/3l6oveex3ii2l">
+<Bluesky
+  url="https://bsky.app/profile/bsky.app/post/3l6oveex3ii2l"
+  displayName="Bluesky"
+  handle="bsky.app"
+  avatar="https://bsky.app/static/apple-touch-icon.png"
+  dateTime="2024-02-06T12:34:56Z"
+  dateLabel="Feb 6, 2024"
+  replies="1.2k"
+  reposts="8.4k"
+  likes="21k"
+>
   👋 Bluesky is an open social network
 </Bluesky>
 ```
 
-<Bluesky url="https://bsky.app/profile/bsky.app/post/3l6oveex3ii2l">
-  👋 Bluesky is an open social network
+<Bluesky
+url="https://bsky.app/profile/bsky.app/post/3l6oveex3ii2l"
+displayName="Bluesky"
+handle="bsky.app"
+avatar="https://bsky.app/static/apple-touch-icon.png"
+dateTime="2024-02-06T12:34:56Z"
+dateLabel="Feb 6, 2024"
+replies="1.2k"
+reposts="8.4k"
+likes="21k"
+
+>
+
+👋 Bluesky is an open social network
 </Bluesky>
 
 ## Spotify

--- a/docs/content/examples/bluesky-embed.md
+++ b/docs/content/examples/bluesky-embed.md
@@ -5,7 +5,8 @@ description: Render Bluesky posts as static cards.
 
 # Bluesky Embed
 
-Bluesky embeds are opt-in and render static links/cards.
+Bluesky embeds are opt-in and render static cards with author, time, and
+engagement metadata when provided.
 
 ```ts
 import { oxContent } from "@ox-content/vite-plugin";
@@ -21,8 +22,18 @@ export default {
 };
 ```
 
-```html
-<Bluesky url="https://bsky.app/profile/example.com/post/abc123">
+```mdx
+<Bluesky
+  url="https://bsky.app/profile/example.com/post/abc123"
+  displayName="Example Author"
+  handle="example.com"
+  avatar="https://bsky.app/static/apple-touch-icon.png"
+  dateTime="2024-02-06T12:34:56Z"
+  dateLabel="Feb 6, 2024"
+  replies="12"
+  reposts="34"
+  likes="256"
+>
   Post text shown in the static card.
 </Bluesky>
 ```


### PR DESCRIPTION
## Summary
- render Bluesky opt-in embeds as rich static cards with author identity, avatar, timestamp, engagement counts, and a source link
- accept common Bluesky metadata attribute aliases such as authorName, dateTime, replyCount, repostCount, likeCount, and quoteCount
- document the richer MDX example and add an insta snapshot for the generated HTML

Closes #887

## Verification
- cargo test -p ox_content_transform
- vpr fmt:check
- node scripts/check-file-lines.ts && git diff --check
- vp run --filter ./docs build
- curl check for https://bsky.app/static/apple-touch-icon.png returned 200 image/png

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790290149&installation_model_id=422833&pr_number=965&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F965&signature=2c41a9d54a7b7e4f114f39410f68bd9868943c3a27103445723fe45faac5a408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->