### PR TITLE
perf(docs): skip unchanged theme gallery writes

### DIFF
--- a/scripts/theme-gallery.mjs
+++ b/scripts/theme-gallery.mjs
@@ -189,7 +189,10 @@ const html = `<title>Ox Content Theme Gallery</title>
 <script>${readFileSync(join(HERE, "theme-gallery.js"), "utf-8")}</script>
 `;
 
-writeFileSync(OUT, html);
+const changed = !existsSync(OUT) || readFileSync(OUT, "utf-8") !== html;
+if (changed) {
+  writeFileSync(OUT, html);
+}
 console.log(
-  `Wrote ${OUT} (${(html.length / 1024).toFixed(0)} kB, ${skins.length} skins x ${schemeData.length} schemes = ${skins.length * schemeData.length} combinations)`,
+  `${changed ? "Wrote" : "Skipped unchanged"} ${OUT} (${(html.length / 1024).toFixed(0)} kB, ${skins.length} skins x ${schemeData.length} schemes = ${skins.length * schemeData.length} combinations)`,
 );


### PR DESCRIPTION
## Summary
- avoid rewriting docs/public/theme-gallery.html when generated content is unchanged
- keep the docs buildStart safety net while preventing duplicate gallery generation from touching mtimes
- report whether the gallery was written or skipped so build logs show the cache behavior

Refs #851

## Verification
- node scripts/theme-gallery.mjs /tmp/ox-content-theme-gallery.html (initial write)
- node scripts/theme-gallery.mjs /tmp/ox-content-theme-gallery.html (skipped unchanged)
- vp run --filter ./docs build (theme gallery skipped in both generation hooks; remaining cache blocker is API docs generation)
- vpr fmt:check
- node scripts/check-file-lines.ts && git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790290319&installation_model_id=422833&pr_number=966&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F966&signature=b16b52faa5ecb6789c397d12fbda1c8d3f8656ccdfd321ef88695a5be12ef739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->