### PR TITLE
perf(docs): skip unchanged api doc writes

### DIFF
--- a/crates/ox_content_docs/src/output.rs
+++ b/crates/ox_content_docs/src/output.rs
@@ -107,7 +107,8 @@ pub fn write_docs_output(
         if let Some(parent) = output_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        fs::write(output_path, normalize_markdown_eof(content).as_bytes())?;
+        let content = normalize_markdown_eof(content);
+        write_if_changed(&output_path, content.as_bytes())?;
     }
 
     if let Some(extracted_docs) = extracted_docs {
@@ -125,20 +126,36 @@ pub fn write_docs_output(
                     single_entry_root: options.single_entry_root,
                 },
             );
-            fs::write(
-                out_dir.join(DOCS_NAV_FILE),
+            write_if_changed(
+                &out_dir.join(DOCS_NAV_FILE),
                 generate_nav_code(&nav_items, Some(DOCS_NAV_EXPORT_NAME)),
             )?;
         }
 
-        fs::write(
-            out_dir.join(DOCS_DATA_FILE),
+        write_if_changed(
+            &out_dir.join(DOCS_DATA_FILE),
             generate_docs_data_json(extracted_docs, &options.generated_at)?,
         )?;
     }
 
-    fs::write(out_dir.join(DOCS_MANIFEST_FILE), serde_json::to_string_pretty(&generated_files)?)?;
+    write_if_changed(
+        &out_dir.join(DOCS_MANIFEST_FILE),
+        serde_json::to_string_pretty(&generated_files)?,
+    )?;
 
+    Ok(())
+}
+
+fn write_if_changed(path: &Path, content: impl AsRef<[u8]>) -> DocsOutputResult<()> {
+    let content = content.as_ref();
+    match fs::read(path) {
+        Ok(existing) if existing == content => return Ok(()),
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+
+    fs::write(path, content)?;
     Ok(())
 }
 

--- a/crates/ox_content_docs/src/output/tests.rs
+++ b/crates/ox_content_docs/src/output/tests.rs
@@ -65,6 +65,22 @@ fn generated_markdown_has_one_terminal_newline() {
 }
 
 #[test]
+fn unchanged_docs_output_keeps_existing_mtime() {
+    let out_dir = temp_dir();
+    let docs = BTreeMap::from([("alpha.md".to_string(), "# Alpha".to_string())]);
+
+    write_docs_output(&docs, &out_dir, None, &options()).unwrap();
+    let path = out_dir.join("alpha.md");
+    let first_modified = fs::metadata(&path).unwrap().modified().unwrap();
+
+    std::thread::sleep(std::time::Duration::from_millis(20));
+    write_docs_output(&docs, &out_dir, None, &options()).unwrap();
+
+    assert_eq!(fs::metadata(&path).unwrap().modified().unwrap(), first_modified);
+    fs::remove_dir_all(out_dir).unwrap();
+}
+
+#[test]
 fn writes_and_removes_stale_nested_docs_output() {
     let out_dir = temp_dir();
     let mut docs = BTreeMap::new();


### PR DESCRIPTION
## Summary
- write generated API markdown, nav, docs data, and manifest files only when their bytes changed
- preserve existing mtimes for stable generated API docs so docs builds can be cached after the first generation
- add an output writer test that guards unchanged mtimes

Refs #851

## Verification
- cargo test -p ox_content_docs output::tests -- --nocapture
- cargo test -p ox_content_napi write_generated_docs -- --nocapture
- vp run --filter ./crates/ox_content_napi build
- vp run --filter ./docs build twice; second run removed the API-doc write blocker, leaving only theme-gallery.html from #966
- cargo clippy -p ox_content_docs --all-targets -- -D warnings
- vpr fmt:check
- node scripts/check-file-lines.ts && git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790290637&installation_model_id=422833&pr_number=967&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F967&signature=61b9477e2c0d4f9632379ca33d7383b22535c81997295014479f9ff8d891d4c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->