### PR TITLE
fix(embeds): normalize block embed paragraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - soften code copy button (#920)
 - avoid empty table stretch columns (#919)
+- keep block embeds out of generated paragraphs (#936)
 - restore typed hover overlays (#918)
 - contain mobile menu scrolling (#915)
 - highlight WebContainer examples as MDX (#914)

--- a/npm/vite-plugin-ox-content-react/src/__snapshots__/transform.test.ts.snap
+++ b/npm/vite-plugin-ox-content-react/src/__snapshots__/transform.test.ts.snap
@@ -6,7 +6,7 @@ import React, { createElement } from 'react';
 
 export const frontmatter = {};
 
-const rawHtml = "<p><GitHub repo=\\"ubugeeei-prod/ox-content\\"></GitHub></p>\\n";
+const rawHtml = "<github repo=\\"ubugeeei-prod/ox-content\\"></github>\\n";
 
 export default function MarkdownContent() {
   return createElement('div', {

--- a/npm/vite-plugin-ox-content-solid/src/__snapshots__/transform.test.ts.snap
+++ b/npm/vite-plugin-ox-content-solid/src/__snapshots__/transform.test.ts.snap
@@ -4,7 +4,7 @@ exports[`transformMarkdownWithSolid > honors disabled built-in embeds from frame
 "
 export const frontmatter = {};
 
-const rawHtml = "<p><GitHub repo=\\"ubugeeei-prod/ox-content\\"></GitHub></p>\\n";
+const rawHtml = "<github repo=\\"ubugeeei-prod/ox-content\\"></github>\\n";
 
 export default function MarkdownContent() {
   return <div class="ox-content" innerHTML={rawHtml} />;

--- a/npm/vite-plugin-ox-content-svelte/src/__snapshots__/transform.test.ts.snap
+++ b/npm/vite-plugin-ox-content-svelte/src/__snapshots__/transform.test.ts.snap
@@ -10,7 +10,7 @@ export default function Embed_md($$anchor, $$props) {
 	$.push($$props, true);
 
 	const frontmatter = {};
-	const rawHtml = "<p><GitHub repo=\\"ubugeeei-prod/ox-content\\"></GitHub></p>\\n";
+	const rawHtml = "<github repo=\\"ubugeeei-prod/ox-content\\"></github>\\n";
 	var $$exports = { frontmatter };
 	var div = root();
 

--- a/npm/vite-plugin-ox-content-vue/src/__snapshots__/transform.test.ts.snap
+++ b/npm/vite-plugin-ox-content-vue/src/__snapshots__/transform.test.ts.snap
@@ -6,7 +6,7 @@ import { h, ref, defineComponent } from 'vue';
 
 export const frontmatter = {};
 
-const rawHtml = "<p><GitHub repo=\\"ubugeeei-prod/ox-content\\"></GitHub></p>\\n";
+const rawHtml = "<github repo=\\"ubugeeei-prod/ox-content\\"></github>\\n";
 
 export default defineComponent({
   name: 'MarkdownContent',

--- a/npm/vite-plugin-ox-content/src/__snapshots__/transform.test.ts.snap
+++ b/npm/vite-plugin-ox-content/src/__snapshots__/transform.test.ts.snap
@@ -49,7 +49,7 @@ exports[`transformMarkdown > runs opt-in native transforms without changing defa
 `;
 
 exports[`transformMarkdown > sanitizes after opt-in embeds are rendered 1`] = `
-"<p><iframe class="ox-spotify" src="https://open.spotify.com/embed/track/abc123" width="100%" height="352" loading="lazy" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" referrerpolicy="strict-origin-when-cross-origin"></iframe></p>
+"<iframe class="ox-spotify" src="https://open.spotify.com/embed/track/abc123" width="100%" height="352" loading="lazy" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" referrerpolicy="strict-origin-when-cross-origin"></iframe>
 
 "
 `;

--- a/npm/vite-plugin-ox-content/src/embed.test.ts
+++ b/npm/vite-plugin-ox-content/src/embed.test.ts
@@ -177,6 +177,21 @@ describe("builtin embed input hardening", () => {
     expect(html).toMatchSnapshot();
   });
 
+  it("keeps block cards out of generated paragraphs", async () => {
+    const html = await transformBuiltinEmbeds(
+      '<p>Before <OgCard url="javascript:alert(1)"></OgCard> after.</p>',
+      {
+        github: false,
+        openGraph: {},
+      },
+    );
+
+    expect(html).toContain("<p>Before </p>");
+    expect(html).toContain('<a class="ox-ogp-simple"');
+    expect(html).toContain("<p> after.</p>");
+    expect(html).not.toContain('<p><a class="ox-ogp-simple"');
+  });
+
   it("does not let self-closing embed tags swallow trailing content", async () => {
     const html = await transformBuiltinEmbeds(
       '<GitHub repo="../secret" />\n<p>after github</p>\n<OgCard url="javascript:alert(1)" />\n<p>after ogp</p>',

--- a/npm/vite-plugin-ox-content/src/plugins/block-structure.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/block-structure.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vite-plus/test";
+import { normalizeBlockEmbedParagraphs } from "./block-structure";
+
+describe("block embed paragraph normalization", () => {
+  it("returns no-marker input byte-identical", async () => {
+    const html = `<p>Plain prose with <a href="/docs">a link</a>.</p>`;
+    expect(await normalizeBlockEmbedParagraphs(html)).toBe(html);
+  });
+
+  it("unwraps a standalone block embed from its paragraph", async () => {
+    const html = `<p><div class="ox-youtube">video</div></p>`;
+    expect(await normalizeBlockEmbedParagraphs(html)).toBe(`<div class="ox-youtube">video</div>`);
+  });
+
+  it("splits mixed prose around an Open Graph card", async () => {
+    const html = `<p data-note="keep">before <a class="ox-ogp-card" href="/">card</a> after</p>`;
+    expect(await normalizeBlockEmbedParagraphs(html)).toBe(
+      `<p data-note="keep">before </p><a class="ox-ogp-card" href="/">card</a><p data-note="keep"> after</p>`,
+    );
+  });
+
+  it("keeps adjacent embeds as sibling blocks without empty paragraphs", async () => {
+    const html = `<p>
+<figure class="ox-tweet">tweet</figure>
+<a class="ox-ogp-simple" href="/">card</a>
+</p>`;
+    const normalized = await normalizeBlockEmbedParagraphs(html);
+    expect(normalized).toContain(`<figure class="ox-tweet">tweet</figure>`);
+    expect(normalized).toContain(`<a class="ox-ogp-simple" href="/">card</a>`);
+    expect(normalized).not.toContain("<p>");
+  });
+
+  it("preserves the surrounding container while fixing nested paragraphs", async () => {
+    const html = `<blockquote><p>read <a class="ox-ogp-card" href="/">card</a> now</p></blockquote>`;
+    expect(await normalizeBlockEmbedParagraphs(html)).toBe(
+      `<blockquote><p>read </p><a class="ox-ogp-card" href="/">card</a><p> now</p></blockquote>`,
+    );
+  });
+
+  it("is idempotent", async () => {
+    const html = `<p>before <a class="ox-ogp-simple" href="/">card</a> after</p>`;
+    const once = await normalizeBlockEmbedParagraphs(html);
+    expect(await normalizeBlockEmbedParagraphs(once)).toBe(once);
+  });
+});

--- a/npm/vite-plugin-ox-content/src/plugins/block-structure.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/block-structure.ts
@@ -1,0 +1,135 @@
+import type { Element, ElementContent, Root } from "hast";
+import rehypeParsePlugin from "rehype-parse";
+import rehypeStringifyPlugin from "rehype-stringify";
+import { unified } from "unified";
+import { interopDefault } from "../interop";
+
+const rehypeParse = interopDefault(rehypeParsePlugin);
+const rehypeStringify = interopDefault(rehypeStringifyPlugin);
+
+const BLOCK_EMBED_CLASSES = new Set([
+  "ox-bluesky",
+  "ox-github-card",
+  "ox-github-code",
+  "ox-ogp-card",
+  "ox-ogp-simple",
+  "ox-spotify",
+  "ox-stackblitz",
+  "ox-tweet",
+  "ox-webcontainer",
+  "ox-youtube",
+]);
+
+const BLOCK_EMBED_TAGS = new Set([
+  "bluesky",
+  "github",
+  "ogcard",
+  "spotify",
+  "stackblitz",
+  "tweet",
+  "webcontainer",
+  "xpost",
+  "youtube",
+]);
+
+export async function normalizeBlockEmbedParagraphs(html: string): Promise<string> {
+  if (!shouldNormalizeBlockEmbeds(html)) return html;
+
+  const result = await unified()
+    .use(rehypeParse, { fragment: true })
+    .use(rehypeBlockEmbedParagraphs)
+    .use(rehypeStringify)
+    .process(html);
+
+  return String(result);
+}
+
+export function isBlockEmbedElement(node: ElementContent): node is Element {
+  if (node.type !== "element") return false;
+  return (
+    BLOCK_EMBED_TAGS.has(node.tagName.toLowerCase()) ||
+    classList(node).some((name) => BLOCK_EMBED_CLASSES.has(name))
+  );
+}
+
+function shouldNormalizeBlockEmbeds(html: string): boolean {
+  return (
+    /<p[\s>]/i.test(html) &&
+    (/\box-(?:bluesky|github|ogp|spotify|stackblitz|tweet|webcontainer|youtube)\b/i.test(html) ||
+      /<(?:bluesky|github|ogcard|spotify|stackblitz|tweet|webcontainer|xpost|youtube)[\s/>]/i.test(
+        html,
+      ))
+  );
+}
+
+function rehypeBlockEmbedParagraphs() {
+  return (tree: Root) => {
+    rewriteChildren(tree);
+  };
+}
+
+function rewriteChildren(parent: Root | Element): void {
+  const next: ElementContent[] = [];
+
+  for (const child of parent.children) {
+    if (child.type === "element" && child.children.length > 0) {
+      rewriteChildren(child);
+    }
+
+    if (isParagraph(child)) {
+      next.push(...splitParagraph(child));
+    } else {
+      next.push(child);
+    }
+  }
+
+  parent.children = next;
+}
+
+function splitParagraph(paragraph: Element): ElementContent[] {
+  const replacement: ElementContent[] = [];
+  let prose: ElementContent[] = [];
+  let changed = false;
+
+  const flushProse = () => {
+    if (hasMeaningfulContent(prose)) {
+      replacement.push({
+        ...paragraph,
+        properties: { ...paragraph.properties },
+        children: prose,
+      });
+    }
+    prose = [];
+  };
+
+  for (const child of paragraph.children) {
+    if (isBlockEmbedElement(child)) {
+      changed = true;
+      flushProse();
+      replacement.push(child);
+      continue;
+    }
+
+    prose.push(child);
+  }
+
+  flushProse();
+
+  if (changed) return replacement;
+  return hasMeaningfulContent(paragraph.children) ? [paragraph] : [];
+}
+
+function isParagraph(node: ElementContent): node is Element {
+  return node.type === "element" && node.tagName.toLowerCase() === "p";
+}
+
+function hasMeaningfulContent(children: ElementContent[]): boolean {
+  return children.some((child) => child.type !== "text" || child.value.trim() !== "");
+}
+
+function classList(node: Element): string[] {
+  const value = node.properties?.className;
+  if (Array.isArray(value)) return value.map(String);
+  if (typeof value === "string") return value.split(/\s+/).filter(Boolean);
+  return [];
+}

--- a/npm/vite-plugin-ox-content/src/plugins/embed-transform.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/embed-transform.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { transformAllPlugins } from ".";
 import { transformPm } from "./pm";
 import { resetTabGroupCounter, transformTabs } from "./tabs";
 import { transformYouTube } from "./youtube";
@@ -12,16 +13,22 @@ import { transformYouTube } from "./youtube";
  * equivalence target when the transforms are ported to Rust.
  */
 
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
 describe("transformYouTube output", () => {
   it("wraps a bare id in a privacy-enhanced responsive embed", async () => {
-    const html = await transformYouTube(`<p><youtube id="dQw4w9WgXcQ"></youtube></p>`);
+    const html = await transformYouTube(`<youtube id="dQw4w9WgXcQ"></youtube>`);
     expect(html).toBe(
-      `<p><div class="ox-youtube" style="aspect-ratio: 16/9;">` +
+      `<div class="ox-youtube" style="aspect-ratio: 16/9;">` +
         `<iframe src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ" ` +
         `title="YouTube video dQw4w9WgXcQ" ` +
         `allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" ` +
         `referrerpolicy="strict-origin-when-cross-origin" allowfullscreen loading="lazy">` +
-        `</iframe></div></p>`,
+        `</iframe></div>`,
     );
   });
 
@@ -48,6 +55,47 @@ describe("transformYouTube output", () => {
   it("returns input unchanged when there is no <youtube> element", async () => {
     const html = `<p>Plain prose with a <a href="/x">link</a> and no embeds.</p>`;
     expect(await transformYouTube(html)).toBe(html);
+  });
+});
+
+describe("transformAllPlugins block structure", () => {
+  it("keeps standalone YouTube embeds out of paragraphs", async () => {
+    const html = await transformAllPlugins(`<p><youtube id="dQw4w9WgXcQ"></youtube></p>`, {
+      github: false,
+      openGraph: false,
+      mermaid: false,
+    });
+
+    expect(html).toBe(
+      `<div class="ox-youtube" style="aspect-ratio: 16/9;">` +
+        `<iframe src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ" ` +
+        `title="YouTube video dQw4w9WgXcQ" ` +
+        `allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" ` +
+        `referrerpolicy="strict-origin-when-cross-origin" allowfullscreen loading="lazy">` +
+        `</iframe></div>`,
+    );
+  });
+
+  it("splits fetched Open Graph cards out of mixed paragraphs", async () => {
+    globalThis.fetch = async () =>
+      ({
+        ok: true,
+        text: async () =>
+          `<html><head><title>Example Domain</title><meta name="description" content="Example description"></head></html>`,
+      }) as Response;
+
+    const html = await transformAllPlugins(
+      `<p>See <OgCard url="https://example.com"></OgCard> today.</p>`,
+      {
+        github: false,
+        openGraph: { cache: false },
+        mermaid: false,
+      },
+    );
+
+    expect(html).toContain(`<p>See </p><a class="ox-ogp-card"`);
+    expect(html).toContain(`<p> today.</p>`);
+    expect(html).not.toContain(`<p><a class="ox-ogp-card"`);
   });
 });
 

--- a/npm/vite-plugin-ox-content/src/plugins/index.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/index.ts
@@ -47,6 +47,7 @@ import {
   type OgpOptions,
 } from "./ogp";
 import { transformMermaidStatic, mermaidClientScript, type MermaidOptions } from "./mermaid";
+import { normalizeBlockEmbedParagraphs } from "./block-structure";
 
 export {
   transformTabs,
@@ -75,6 +76,7 @@ export {
   prefetchOgpData,
   transformMermaidStatic,
   mermaidClientScript,
+  normalizeBlockEmbedParagraphs,
 };
 
 export type {
@@ -158,7 +160,7 @@ export async function transformAllPlugins(
     webContainer = false,
   } = options;
 
-  let result = normalizeSelfClosingEmbeds(html);
+  let result = await normalizeBlockEmbedParagraphs(normalizeSelfClosingEmbeds(html));
   const ogpOptions = openGraph ?? ogp ?? true;
 
   // Order matters: process in dependency order
@@ -200,6 +202,8 @@ export async function transformAllPlugins(
     result = await transformMediaEmbeds(result, mediaOptions);
   }
 
+  result = await normalizeBlockEmbedParagraphs(result);
+
   // 5. Mermaid (requires mermaid library)
   if (mermaid) {
     result = await transformMermaidStatic(result);
@@ -224,7 +228,7 @@ export async function transformBuiltinEmbeds(
     webContainer?: boolean;
   },
 ): Promise<string> {
-  let result = normalizeSelfClosingEmbeds(html);
+  let result = await normalizeBlockEmbedParagraphs(normalizeSelfClosingEmbeds(html));
 
   if (options.github) {
     result = await transformGitHub(result, undefined, {
@@ -252,5 +256,5 @@ export async function transformBuiltinEmbeds(
     result = await transformMediaEmbeds(result, mediaOptions);
   }
 
-  return result;
+  return normalizeBlockEmbedParagraphs(result);
 }


### PR DESCRIPTION
Closes #936

## Summary
- add a structural block-embed paragraph normalizer for composed plugin output
- unwrap authored block embed tags before transforms and rendered block roots before Mermaid
- cover direct normalization, transformAllPlugins, and builtin embed paths

## Contributor credit
- Credit to @ryoppippi for the downstream production reproduction and workaround described in #936.

## Verification
- vp run --filter ./crates/ox_content_napi build
- vp test run src/plugins/block-structure.test.ts src/plugins/embed-transform.test.ts src/embed.test.ts
- vp run check:ts
- vpr fmt:check
- node scripts/check-file-lines.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790293475&installation_model_id=422833&pr_number=971&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F971&signature=9676fbcdbb7d9c425f81db40d83d1bb428d38620b368839294a371fef6d3b1b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->