### PR TITLE
fix(attrs): preserve inline link and image attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+- preserve attrs on inline links and transformed images (#935)
 - soften code copy button (#920)
 - avoid empty table stretch columns (#919)
 - restore typed hover overlays (#918)

--- a/crates/ox_content_transform/src/features.rs
+++ b/crates/ox_content_transform/src/features.rs
@@ -120,7 +120,7 @@ impl TransformFeatureOptions {
         let file_tree = file_tree::resolve(options.file_tree.as_ref());
         let badges = badges::resolve(options.badges.as_ref());
         let magic_links = magic::resolve(options.magic_links.as_ref());
-        let images = images::resolve(options.images.as_ref());
+        let images = images::resolve(options.images.as_ref(), attributes);
         let math = math::resolve(options.math.as_ref());
         let edit_this_page = resolve_edit_this_page(
             options.edit_this_page.as_ref(),

--- a/crates/ox_content_transform/src/features/attr_tokens.rs
+++ b/crates/ox_content_transform/src/features/attr_tokens.rs
@@ -1,6 +1,6 @@
 use super::escape_html_attr;
 
-#[derive(Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(super) struct ParsedAttrs {
     id: Option<String>,
     classes: Vec<String>,
@@ -12,6 +12,13 @@ impl ParsedAttrs {
         self.id.as_deref()
     }
 
+    pub(super) fn attr_value(&self, name: &str) -> Option<&str> {
+        self.attrs
+            .iter()
+            .find(|(candidate, _)| candidate.eq_ignore_ascii_case(name))
+            .map(|(_, value)| value.as_str())
+    }
+
     pub(super) fn parse(value: &str) -> Option<Self> {
         if !value.contains('#') && !value.contains('.') && !value.contains('=') {
             return None;
@@ -19,21 +26,24 @@ impl ParsedAttrs {
         let mut parsed = Self::default();
         for token in split_attr_tokens(value) {
             if let Some(id) = token.strip_prefix('#') {
-                if !id.is_empty() {
-                    parsed.id = Some(id.to_string());
+                if id.is_empty() {
+                    return None;
                 }
+                parsed.id = Some(id.to_string());
             } else if let Some(class) = token.strip_prefix('.') {
-                if !class.is_empty() {
-                    parsed.classes.push(class.to_string());
+                if class.is_empty() {
+                    return None;
                 }
+                parsed.classes.push(class.to_string());
             } else if let Some((name, raw_value)) = token.split_once('=') {
                 let name = name.trim();
-                if is_safe_attr_name(name) {
-                    parsed.attrs.push((
-                        name.to_string(),
-                        raw_value.trim_matches(|ch| ch == '"' || ch == '\'').to_string(),
-                    ));
+                let value = raw_value.trim_matches(|ch| ch == '"' || ch == '\'');
+                if !is_safe_attr_name(name) || !is_safe_attr_value(name, value) {
+                    return None;
                 }
+                parsed.attrs.push((name.to_string(), value.to_string()));
+            } else {
+                return None;
             }
         }
         if parsed.id.is_none() && parsed.classes.is_empty() && parsed.attrs.is_empty() {
@@ -107,12 +117,18 @@ pub(super) fn strip_quoted_attr(open: &str, name: &str) -> String {
 }
 
 pub(super) fn write_attrs(out: &mut String, attrs: &ParsedAttrs) {
-    if let Some(id) = &attrs.id {
+    write_attrs_except(out, attrs, &[]);
+}
+
+pub(super) fn write_attrs_except(out: &mut String, attrs: &ParsedAttrs, excluded: &[&str]) {
+    if let Some(id) = &attrs.id
+        && !is_excluded_attr("id", excluded)
+    {
         out.push_str(" id=\"");
         escape_html_attr(id, out);
         out.push('"');
     }
-    if !attrs.classes.is_empty() {
+    if !attrs.classes.is_empty() && !is_excluded_attr("class", excluded) {
         out.push_str(" class=\"");
         for (index, class) in attrs.classes.iter().enumerate() {
             if index > 0 {
@@ -123,6 +139,9 @@ pub(super) fn write_attrs(out: &mut String, attrs: &ParsedAttrs) {
         out.push('"');
     }
     for (name, value) in &attrs.attrs {
+        if is_excluded_attr(name, excluded) {
+            continue;
+        }
         out.push(' ');
         out.push_str(name);
         out.push_str("=\"");
@@ -131,10 +150,37 @@ pub(super) fn write_attrs(out: &mut String, attrs: &ParsedAttrs) {
     }
 }
 
+fn is_excluded_attr(name: &str, excluded: &[&str]) -> bool {
+    excluded.iter().any(|excluded| name.eq_ignore_ascii_case(excluded))
+}
+
 fn is_safe_attr_name(name: &str) -> bool {
     !name.is_empty()
         && !name.to_ascii_lowercase().starts_with("on")
         && name
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b':' | b'_'))
+}
+
+fn is_safe_attr_value(name: &str, value: &str) -> bool {
+    !is_url_attr_name(name) || !is_dangerous_url(value)
+}
+
+fn is_url_attr_name(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "href" | "src" | "poster" | "action" | "formaction" | "xlink:href"
+    )
+}
+
+fn is_dangerous_url(value: &str) -> bool {
+    let compact: String = value
+        .chars()
+        .filter(|ch| !ch.is_ascii_whitespace())
+        .map(|ch| ch.to_ascii_lowercase())
+        .collect();
+    compact.starts_with("//")
+        || compact.starts_with("javascript:")
+        || compact.starts_with("data:")
+        || compact.starts_with("vbscript:")
 }

--- a/crates/ox_content_transform/src/features/attributes.rs
+++ b/crates/ox_content_transform/src/features/attributes.rs
@@ -1,6 +1,15 @@
 use super::attr_tokens::{ParsedAttrs, strip_quoted_attr, write_open_tag_attrs};
 use super::escape_html_attr;
 
+mod targets;
+#[cfg(test)]
+mod tests;
+
+use self::targets::{
+    find_previous_void_element, find_previous_wrapped_element, is_adjacent_inline_attr_target_tag,
+    is_attr_target_tag, scan_tag_end,
+};
+
 const HEADER_ANCHOR_OPEN: &str = "<a class=\"header-anchor\"";
 
 pub(super) fn transform_attribute_syntax(html: &str) -> Option<String> {
@@ -74,6 +83,14 @@ fn try_apply_attrs_inside_element(
         return None;
     }
 
+    if !is_heading_tag(&tag_name)
+        && let Some(next) = try_apply_attrs_to_adjacent_inline_child(
+            html, out, cursor, open_end, attr_start, attr_end, attrs,
+        )
+    {
+        return Some(next);
+    }
+
     let text_end = html[..attr_start].trim_end().len();
     let heading_inner = &html[open_end..text_end];
     out.push_str(&html[cursor..open_start]);
@@ -94,6 +111,48 @@ fn try_apply_attrs_inside_element(
     Some(attr_end + 1)
 }
 
+fn try_apply_attrs_to_adjacent_inline_child(
+    html: &str,
+    out: &mut String,
+    cursor: usize,
+    container_open_end: usize,
+    attr_start: usize,
+    attr_end: usize,
+    attrs: &ParsedAttrs,
+) -> Option<usize> {
+    let before = &html[..attr_start];
+    let trimmed_end = before.trim_end().len();
+    if trimmed_end == 0 || trimmed_end > attr_start {
+        return None;
+    }
+    let whitespace = &html[trimmed_end..attr_start];
+
+    if let Some((tag_start, tag_end, _close_end, tag_name)) =
+        find_previous_wrapped_element(html, trimmed_end)
+        && tag_start >= container_open_end
+        && is_adjacent_inline_attr_target_tag(&tag_name)
+    {
+        out.push_str(&html[cursor..tag_start]);
+        write_open_tag_attrs(out, &html[tag_start..tag_end], attrs);
+        out.push_str(&html[tag_end..trimmed_end]);
+        out.push_str(whitespace);
+        return Some(attr_end + 1);
+    }
+
+    if let Some((tag_start, tag_end, tag_name)) = find_previous_void_element(html, trimmed_end)
+        && tag_start >= container_open_end
+        && is_adjacent_inline_attr_target_tag(&tag_name)
+    {
+        out.push_str(&html[cursor..tag_start]);
+        write_open_tag_attrs(out, &html[tag_start..tag_end], attrs);
+        out.push_str(&html[tag_end..trimmed_end]);
+        out.push_str(whitespace);
+        return Some(attr_end + 1);
+    }
+
+    None
+}
+
 fn try_apply_attrs_to_previous_element(
     html: &str,
     out: &mut String,
@@ -108,7 +167,8 @@ fn try_apply_attrs_to_previous_element(
     }
     let whitespace = &html[trimmed_end..attr_start];
 
-    if let Some((tag_start, tag_end, close_end)) = find_previous_wrapped_element(html, trimmed_end)
+    if let Some((tag_start, tag_end, close_end, _tag_name)) =
+        find_previous_wrapped_element(html, trimmed_end)
     {
         out.push_str(&html[cursor..tag_start]);
         write_open_tag_attrs(out, &html[tag_start..tag_end], attrs);
@@ -124,7 +184,7 @@ fn try_apply_attrs_to_previous_element(
         return Some(close_end);
     }
 
-    if let Some((tag_start, tag_end)) = find_previous_void_element(html, trimmed_end) {
+    if let Some((tag_start, tag_end, _tag_name)) = find_previous_void_element(html, trimmed_end) {
         out.push_str(&html[cursor..tag_start]);
         write_open_tag_attrs(out, &html[tag_start..tag_end], attrs);
         out.push_str(&html[tag_end..trimmed_end]);
@@ -132,89 +192,6 @@ fn try_apply_attrs_to_previous_element(
         return Some(tag_end);
     }
 
-    None
-}
-
-fn find_previous_wrapped_element(html: &str, end: usize) -> Option<(usize, usize, usize)> {
-    let close_start = html[..end].rfind("</")?;
-    if close_start + 2 >= end {
-        return None;
-    }
-    let close_name_end = html[close_start + 2..end].find('>')? + close_start + 2;
-    let tag_name = html[close_start + 2..close_name_end].trim().to_ascii_lowercase();
-    if tag_name.is_empty() || !is_attr_target_tag(&tag_name) {
-        return None;
-    }
-    let open_marker = format!("<{tag_name}");
-    let open_start = html[..close_start].rfind(&open_marker)?;
-    let open_end = scan_tag_end(html, open_start)?;
-    Some((open_start, open_end - 1, close_name_end + 1))
-}
-
-fn find_previous_void_element(html: &str, end: usize) -> Option<(usize, usize)> {
-    let open_start = html[..end].rfind('<')?;
-    let open_end = scan_tag_end(html, open_start)?;
-    if open_end != end {
-        return None;
-    }
-    let name_start = open_start + 1;
-    let mut name_end = name_start;
-    let bytes = html.as_bytes();
-    while name_end < bytes.len()
-        && !bytes[name_end].is_ascii_whitespace()
-        && bytes[name_end] != b'>'
-        && bytes[name_end] != b'/'
-    {
-        name_end += 1;
-    }
-    let tag_name = html[name_start..name_end].to_ascii_lowercase();
-    if matches!(tag_name.as_str(), "img" | "br" | "hr" | "input") {
-        Some((open_start, open_end - 1))
-    } else {
-        None
-    }
-}
-
-fn is_attr_target_tag(tag: &str) -> bool {
-    matches!(
-        tag,
-        "h1" | "h2"
-            | "h3"
-            | "h4"
-            | "h5"
-            | "h6"
-            | "a"
-            | "img"
-            | "code"
-            | "pre"
-            | "p"
-            | "div"
-            | "span"
-            | "blockquote"
-            | "table"
-            | "tr"
-            | "th"
-            | "td"
-            | "ul"
-            | "ol"
-            | "li"
-    )
-}
-
-fn scan_tag_end(html: &str, start: usize) -> Option<usize> {
-    let bytes = html.as_bytes();
-    let mut i = start;
-    let mut quote = None;
-    while i < bytes.len() {
-        match quote {
-            Some(q) if bytes[i] == q => quote = None,
-            Some(_) => {}
-            None if bytes[i] == b'"' || bytes[i] == b'\'' => quote = Some(bytes[i]),
-            None if bytes[i] == b'>' => return Some(i + 1),
-            None => {}
-        }
-        i += 1;
-    }
     None
 }
 

--- a/crates/ox_content_transform/src/features/attributes/targets.rs
+++ b/crates/ox_content_transform/src/features/attributes/targets.rs
@@ -1,0 +1,92 @@
+pub(super) fn find_previous_wrapped_element(
+    html: &str,
+    end: usize,
+) -> Option<(usize, usize, usize, String)> {
+    let close_start = html[..end].rfind("</")?;
+    if close_start + 2 >= end {
+        return None;
+    }
+    let close_name_end = html[close_start + 2..end].find('>')? + close_start + 2;
+    if close_name_end + 1 != end {
+        return None;
+    }
+    let tag_name = html[close_start + 2..close_name_end].trim().to_ascii_lowercase();
+    if tag_name.is_empty() || !is_attr_target_tag(&tag_name) {
+        return None;
+    }
+    let open_marker = format!("<{tag_name}");
+    let open_start = html[..close_start].rfind(&open_marker)?;
+    let open_end = scan_tag_end(html, open_start)?;
+    Some((open_start, open_end - 1, close_name_end + 1, tag_name))
+}
+
+pub(super) fn find_previous_void_element(html: &str, end: usize) -> Option<(usize, usize, String)> {
+    let open_start = html[..end].rfind('<')?;
+    let open_end = scan_tag_end(html, open_start)?;
+    if open_end != end {
+        return None;
+    }
+    let name_start = open_start + 1;
+    let mut name_end = name_start;
+    let bytes = html.as_bytes();
+    while name_end < bytes.len()
+        && !bytes[name_end].is_ascii_whitespace()
+        && bytes[name_end] != b'>'
+        && bytes[name_end] != b'/'
+    {
+        name_end += 1;
+    }
+    let tag_name = html[name_start..name_end].to_ascii_lowercase();
+    if matches!(tag_name.as_str(), "img" | "br" | "hr" | "input") {
+        Some((open_start, open_end - 1, tag_name))
+    } else {
+        None
+    }
+}
+
+pub(super) fn is_adjacent_inline_attr_target_tag(tag: &str) -> bool {
+    matches!(tag, "a" | "img" | "code" | "span")
+}
+
+pub(super) fn is_attr_target_tag(tag: &str) -> bool {
+    matches!(
+        tag,
+        "h1" | "h2"
+            | "h3"
+            | "h4"
+            | "h5"
+            | "h6"
+            | "a"
+            | "img"
+            | "code"
+            | "pre"
+            | "p"
+            | "div"
+            | "span"
+            | "blockquote"
+            | "table"
+            | "tr"
+            | "th"
+            | "td"
+            | "ul"
+            | "ol"
+            | "li"
+    )
+}
+
+pub(super) fn scan_tag_end(html: &str, start: usize) -> Option<usize> {
+    let bytes = html.as_bytes();
+    let mut i = start;
+    let mut quote = None;
+    while i < bytes.len() {
+        match quote {
+            Some(q) if bytes[i] == q => quote = None,
+            Some(_) => {}
+            None if bytes[i] == b'"' || bytes[i] == b'\'' => quote = Some(bytes[i]),
+            None if bytes[i] == b'>' => return Some(i + 1),
+            None => {}
+        }
+        i += 1;
+    }
+    None
+}

--- a/crates/ox_content_transform/src/features/attributes/tests.rs
+++ b/crates/ox_content_transform/src/features/attributes/tests.rs
@@ -1,0 +1,65 @@
+use super::transform_attribute_syntax;
+
+fn apply(input: &str) -> String {
+    transform_attribute_syntax(input).unwrap_or_else(|| input.to_string())
+}
+
+#[test]
+fn adjacent_link_attrs_target_anchor_inside_paragraph() {
+    let html =
+        apply(r#"<p><a href="https://example.com">slides</a>{#deck .text-xl data-kind=deck}</p>"#);
+
+    assert_eq!(
+        html,
+        r#"<p><a href="https://example.com" id="deck" class="text-xl" data-kind="deck">slides</a></p>"#
+    );
+}
+
+#[test]
+fn adjacent_image_attrs_target_img_inside_paragraph() {
+    let html = apply(r#"<p><img src="./image.png" alt="alt">{#hero .w-1/2 width=480}</p>"#);
+
+    assert_eq!(
+        html,
+        r#"<p><img src="./image.png" alt="alt" id="hero" class="w-1/2" width="480"></p>"#
+    );
+}
+
+#[test]
+fn adjacent_code_and_span_attrs_target_inline_element() {
+    let html = apply(r"<p><code>codeBlockTypecheck</code>{.token} and <span>beta</span>{#b}</p>");
+
+    assert_eq!(
+        html,
+        r#"<p><code class="token">codeBlockTypecheck</code> and <span id="b">beta</span></p>"#
+    );
+}
+
+#[test]
+fn link_attrs_do_not_jump_across_text_or_comments() {
+    let text = apply(r#"<p><a href="/slides">slides</a> later {.lead}</p>"#);
+    let comment = apply(r#"<p><a href="/slides">slides</a><!-- stop -->{.lead}</p>"#);
+
+    assert_eq!(text, r#"<p class="lead"><a href="/slides">slides</a> later</p>"#);
+    assert_eq!(comment, r#"<p class="lead"><a href="/slides">slides</a><!-- stop --></p>"#);
+}
+
+#[test]
+fn heading_attrs_still_target_heading_and_rewrite_permalink() {
+    let html = apply(
+        r##"<h2 id="old">Install {#new .section}<a class="header-anchor" href="#old" aria-label="Permalink to &quot;Install&quot;">#</a></h2>"##,
+    );
+
+    assert!(html.starts_with(r#"<h2 id="new" class="section">Install"#), "{html}");
+    assert!(html.contains(r##"href="#new""##), "{html}");
+    assert!(!html.contains(r##"href="#old""##), "{html}");
+}
+
+#[test]
+fn unsafe_or_malformed_attr_blocks_stay_literal() {
+    let html = apply(r#"<p><a href="/slides">slides</a>{.ok onclick=alert(1)}</p>"#);
+    let href = apply(r#"<p><a href="/slides">slides</a>{href=javascript:alert(1)}</p>"#);
+
+    assert_eq!(html, r#"<p><a href="/slides">slides</a>{.ok onclick=alert(1)}</p>"#);
+    assert_eq!(href, r#"<p><a href="/slides">slides</a>{href=javascript:alert(1)}</p>"#);
+}

--- a/crates/ox_content_transform/src/features/images.rs
+++ b/crates/ox_content_transform/src/features/images.rs
@@ -5,6 +5,7 @@
 
 use crate::ImageOptions;
 
+use super::attr_tokens::{ParsedAttrs, write_attrs_except};
 use super::{escape_html_attr, escape_html_text};
 
 #[cfg(test)]
@@ -13,14 +14,15 @@ mod tests;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct ResolvedImageOptions {
     pub(super) lazy: bool,
+    pub(super) attrs: bool,
 }
 
-pub(super) fn resolve(options: Option<&ImageOptions>) -> Option<ResolvedImageOptions> {
+pub(super) fn resolve(options: Option<&ImageOptions>, attrs: bool) -> Option<ResolvedImageOptions> {
     let options = options?;
     if options.enabled == Some(false) {
         return None;
     }
-    Some(ResolvedImageOptions { lazy: options.lazy != Some(false) })
+    Some(ResolvedImageOptions { lazy: options.lazy != Some(false), attrs })
 }
 
 pub(super) fn preprocess(source: &str, options: &ResolvedImageOptions) -> Option<String> {
@@ -49,7 +51,7 @@ pub(super) fn replace_images(segment: &str, options: &ResolvedImageOptions, out:
     while let Some(relative) = segment[cursor..].find("![") {
         let start = cursor + relative;
         out.push_str(&segment[cursor..start]);
-        if let Some(parsed) = parse_image(&segment[start..]) {
+        if let Some(parsed) = parse_image(&segment[start..], options) {
             emit_image(out, options, &parsed);
             cursor = start + parsed.end;
         } else {
@@ -64,31 +66,41 @@ struct ParsedImage<'a> {
     alt: &'a str,
     src: Option<&'a str>,
     caption: Option<&'a str>,
-    width: Option<&'a str>,
-    height: Option<&'a str>,
+    attrs: Option<ParsedAttrs>,
+    width: Option<String>,
+    height: Option<String>,
     end: usize,
+}
+
+#[derive(Default)]
+struct ParsedImageAttrs {
+    attrs: Option<ParsedAttrs>,
+    width: Option<String>,
+    height: Option<String>,
+    consumed: usize,
 }
 
 fn is_indented_code_segment(segment: &str) -> bool {
     segment.starts_with('\t') || segment.starts_with("    ")
 }
 
-fn parse_image(input: &str) -> Option<ParsedImage<'_>> {
+fn parse_image<'a>(input: &'a str, options: &ResolvedImageOptions) -> Option<ParsedImage<'a>> {
     let rest = input.strip_prefix("![")?;
     let (alt, after_alt) = split_balanced(rest, b'[', b']')?;
     let after_alt = after_alt.strip_prefix('(')?;
     let (src_raw, after_src) = parse_destination(after_alt)?;
     let (caption, after_title) = parse_optional_title(after_src);
     let after_close = after_title.trim_start().strip_prefix(')')?;
-    let (width, height, consumed_attrs) = parse_trailing_dimensions(after_close);
+    let trailing_attrs = parse_trailing_image_attrs(after_close, options.attrs).unwrap_or_default();
     let src = sanitize_src(src_raw);
     Some(ParsedImage {
         alt,
         src,
         caption,
-        width,
-        height,
-        end: input.len() - after_close.len() + consumed_attrs,
+        attrs: trailing_attrs.attrs,
+        width: trailing_attrs.width,
+        height: trailing_attrs.height,
+        end: input.len() - after_close.len() + trailing_attrs.consumed,
     })
 }
 
@@ -167,38 +179,45 @@ fn parse_optional_title(input: &str) -> (Option<&str>, &str) {
     (None, input)
 }
 
-fn parse_trailing_dimensions(input: &str) -> (Option<&str>, Option<&str>, usize) {
+fn parse_trailing_image_attrs(input: &str, preserve_attrs: bool) -> Option<ParsedImageAttrs> {
     let trimmed = input.trim_start();
-    let Some(inner) = trimmed.strip_prefix('{') else {
-        return (None, None, 0);
-    };
-    let Some(close) = inner.find('}') else {
-        return (None, None, 0);
-    };
+    let inner = trimmed.strip_prefix('{')?;
+    let close = inner.find('}')?;
     let body = inner[..close].trim();
     let consumed = input.len() - inner.len() + close + 1;
+    if !preserve_attrs {
+        let (width, height) = parse_dimensions_only(body)?;
+        return Some(ParsedImageAttrs { attrs: None, width, height, consumed });
+    }
+    let attrs = ParsedAttrs::parse(body)?;
+    let width = parse_dimension_attr(&attrs, "width").ok()?;
+    let height = parse_dimension_attr(&attrs, "height").ok()?;
+    Some(ParsedImageAttrs { attrs: Some(attrs), width, height, consumed })
+}
+
+fn parse_dimensions_only(body: &str) -> Option<(Option<String>, Option<String>)> {
     let mut width = None;
     let mut height = None;
-    let mut valid = !body.is_empty();
+    if body.is_empty() {
+        return None;
+    }
     for token in body.split_whitespace() {
-        let Some((key, raw)) = token.split_once('=') else {
-            valid = false;
-            break;
-        };
-        let Some(value) = unsigned_int_value(raw) else {
-            valid = false;
-            break;
-        };
-        match key {
+        let (name, raw_value) = token.split_once('=')?;
+        let value = unsigned_int_value(raw_value)?.to_string();
+        match name {
             "width" if width.is_none() => width = Some(value),
             "height" if height.is_none() => height = Some(value),
-            _ => {
-                valid = false;
-                break;
-            }
+            _ => return None,
         }
     }
-    if valid { (width, height, consumed) } else { (None, None, consumed) }
+    if width.is_none() && height.is_none() { None } else { Some((width, height)) }
+}
+
+fn parse_dimension_attr(attrs: &ParsedAttrs, name: &str) -> Result<Option<String>, ()> {
+    let Some(value) = attrs.attr_value(name) else {
+        return Ok(None);
+    };
+    unsigned_int_value(value).map(|value| Some(value.to_string())).ok_or(())
 }
 
 fn unsigned_int_value(raw: &str) -> Option<&str> {
@@ -246,15 +265,18 @@ fn emit_image(out: &mut String, options: &ResolvedImageOptions, image: &ParsedIm
     out.push_str(" alt=\"");
     escape_html_attr(image.alt, out);
     out.push('"');
+    if let Some(attrs) = &image.attrs {
+        write_attrs_except(out, attrs, &["src", "alt", "loading", "width", "height"]);
+    }
     if options.lazy {
         out.push_str(" loading=\"lazy\"");
     }
-    if let Some(width) = image.width {
+    if let Some(width) = image.width.as_deref() {
         out.push_str(" width=\"");
         out.push_str(width);
         out.push('"');
     }
-    if let Some(height) = image.height {
+    if let Some(height) = image.height.as_deref() {
         out.push_str(" height=\"");
         out.push_str(height);
         out.push('"');

--- a/crates/ox_content_transform/src/features/images/tests.rs
+++ b/crates/ox_content_transform/src/features/images/tests.rs
@@ -3,7 +3,7 @@ use crate::transformer::MarkdownTransformer;
 use crate::{ImageOptions, TransformOptions};
 
 fn enabled() -> ResolvedImageOptions {
-    resolve(Some(&ImageOptions { enabled: Some(true), lazy: None })).expect("enabled")
+    resolve(Some(&ImageOptions { enabled: Some(true), lazy: None }), false).expect("enabled")
 }
 
 fn transform_html(source: &str, options: TransformOptions) -> String {
@@ -18,6 +18,15 @@ fn images_on() -> TransformOptions {
     }
 }
 
+fn images_with_attrs() -> TransformOptions {
+    TransformOptions {
+        gfm: Some(true),
+        images: Some(ImageOptions { enabled: Some(true), lazy: None }),
+        attributes: Some(crate::AttrsOptions { enabled: Some(true) }),
+        ..Default::default()
+    }
+}
+
 fn images_eager() -> TransformOptions {
     TransformOptions {
         gfm: Some(true),
@@ -28,17 +37,20 @@ fn images_eager() -> TransformOptions {
 
 #[test]
 fn resolve_is_none_when_option_is_omitted() {
-    assert!(resolve(None).is_none());
+    assert!(resolve(None, false).is_none());
 }
 
 #[test]
 fn resolve_is_none_when_explicitly_disabled() {
-    assert!(resolve(Some(&ImageOptions { enabled: Some(false), lazy: Some(true) })).is_none());
+    assert!(
+        resolve(Some(&ImageOptions { enabled: Some(false), lazy: Some(true) }), false).is_none()
+    );
 }
 
 #[test]
 fn resolve_is_some_when_object_is_present() {
-    let resolved = resolve(Some(&ImageOptions { enabled: None, lazy: None })).expect("enabled");
+    let resolved =
+        resolve(Some(&ImageOptions { enabled: None, lazy: None }), false).expect("enabled");
     assert!(resolved.lazy);
 }
 
@@ -128,18 +140,53 @@ fn safe_dimensions_emitted() {
 }
 
 #[test]
+fn image_attrs_are_preserved_with_dimensions() {
+    let html = transform_html(
+        "![Alt](/x.png){#hero .w-1/2 .mx-auto width=480 height=320 data-kind=illustration}\n",
+        images_with_attrs(),
+    );
+    assert!(html.contains(r#"<img src="/x.png" alt="Alt" id="hero" class="w-1/2 mx-auto" data-kind="illustration" loading="lazy" width="480" height="320">"#), "{html}");
+    assert!(!html.contains("{#hero"), "{html}");
+}
+
+#[test]
+fn image_attrs_require_attrs_feature() {
+    let html = transform_html("![Alt](/x.png){.hero width=480}\n", images_on());
+    assert!(html.contains("{.hero width=480}"), "{html}");
+    assert!(!html.contains(r#"class="hero""#), "{html}");
+    assert!(!html.contains(r#"width="480""#), "{html}");
+}
+
+#[test]
+fn captioned_image_attrs_stay_on_image() {
+    let html = transform_html("![Alt](/x.png \"Caption\"){.hero width=480}\n", images_with_attrs());
+    assert!(html.contains(r#"<figure class="ox-figure">"#), "{html}");
+    assert!(
+        html.contains(r#"<img src="/x.png" alt="Alt" class="hero" loading="lazy" width="480">"#),
+        "{html}"
+    );
+    assert!(!html.contains(r#"<figure class="ox-figure hero""#), "{html}");
+}
+
+#[test]
 fn hostile_dimensions_rejected() {
     let html = transform_html("![Alt](/x.png){width=100 onclick=alert(1)}\n", images_on());
-    assert!(!html.contains("onclick"), "{html}");
-    assert!(!html.contains("alert(1)"), "{html}");
+    assert!(html.contains("{width=100 onclick=alert(1)}"), "{html}");
     assert!(!html.contains(r#"width="100""#), "{html}");
 }
 
 #[test]
 fn quoted_hostile_width_is_rejected() {
     let html = transform_html(r#"![Alt](/x.png){width="100 onclick=alert(1)"}"#, images_on());
-    assert!(!html.contains("onclick"), "{html}");
-    assert!(!html.contains("alert(1)"), "{html}");
+    assert!(html.contains(r"{width=&quot;100 onclick=alert(1)&quot;}"), "{html}");
+    assert!(!html.contains(r#"width="100 onclick=alert(1)""#), "{html}");
+}
+
+#[test]
+fn unsafe_image_attrs_stay_literal_with_attrs_enabled() {
+    let html = transform_html("![Alt](/x.png){.ok onclick=alert(1)}\n", images_with_attrs());
+    assert!(html.contains("{.ok onclick=alert(1)}"), "{html}");
+    assert!(!html.contains(r#"class="ok""#), "{html}");
 }
 
 #[test]

--- a/docs/content/built-in/syntax-extensions.md
+++ b/docs/content/built-in/syntax-extensions.md
@@ -123,6 +123,10 @@ attaches to the element rendered from that line:
 A lead paragraph. {.lead}
 
 ## Install {.section data-section=install}
+
+[Slides](https://example.com/slides){.deck-link data-kind=deck}
+
+![Architecture](./architecture.png){.w-1/2 .mx-auto width=480}
 ```
 
 produces:
@@ -131,6 +135,10 @@ produces:
 <p class="lead">A lead paragraph.</p>
 
 <h2 id="install" class="section" data-section="install">Install</h2>
+
+<p><a href="https://example.com/slides" class="deck-link" data-kind="deck">Slides</a></p>
+
+<p><img src="./architecture.png" alt="Architecture" class="w-1/2 mx-auto" width="480" /></p>
 ```
 
 The transform runs as a post-render HTML pass over the full document — raw

--- a/docs/content/credits.md
+++ b/docs/content/credits.md
@@ -24,6 +24,18 @@ Contribution summary:
 - Improved documentation quality around generated API docs and user-facing
   docs.
 
+### ryoppippi
+
+Special thanks to [ryoppippi](https://github.com/ryoppippi) for production
+migration feedback on Markdown attributes and rich social embed parity.
+
+Contribution summary:
+
+- Reported the inline link and transformed image attribute target regression
+  found during the ryoppippi.com Ox Content migration.
+- Helped validate the expected Twitter/X full-card visual contract through
+  sveltweet.
+
 ## Third-party attribution
 
 ### react-tweet and sveltweet

--- a/docs/content/examples/attributes.md
+++ b/docs/content/examples/attributes.md
@@ -22,7 +22,11 @@ export default {
 ```md
 ## Install {.anchor .highlight data-section=install}
 
-[Docs](./index.md){.external}
+[Docs](./index.md){.external data-kind=guide}
+
+![Package graph](./package-graph.png){.w-1/2 .mx-auto width=480}
 ```
 
-Supported tokens include `#id`, `.class`, and `key=value`.
+Supported tokens include `#id`, `.class`, and `key=value`. Link attributes
+attach to the generated `<a>`, and image classes, dimensions, and safe data
+attributes stay on the generated `<img>`.

--- a/docs/content/ja/credits.md
+++ b/docs/content/ja/credits.md
@@ -22,6 +22,17 @@ JSDoc 対応とドキュメント品質まわりで、大きなコミュニテ�
 - Ox Content 自身のドキュメントで使っている API ドキュメント生成パイプラインに貢献しました。
 - 生成 API ドキュメントとユーザー向けドキュメントの品質を改善しました。
 
+### ryoppippi
+
+Markdown 属性とリッチなソーシャル埋め込みの見た目の同等性について、本番移行からの
+フィードバックをくれた [ryoppippi](https://github.com/ryoppippi) に感謝します。
+
+貢献の要約:
+
+- ryoppippi.com の Ox Content 移行中に見つかった、inline link と変換済み画像の
+  属性ターゲットの regression を報告しました。
+- sveltweet を通して、Twitter / X full card の見た目の契約の検証に協力しました。
+
 ## 第三者の帰属
 
 ### react-tweet と sveltweet

--- a/npm/vite-plugin-ox-content/src/transform.test.ts
+++ b/npm/vite-plugin-ox-content/src/transform.test.ts
@@ -89,6 +89,29 @@ describe("transformMarkdown", () => {
     expect(result.html).toMatchSnapshot();
   });
 
+  it("keeps attrs on inline links and transformed images", async () => {
+    const result = await transformMarkdown(
+      [
+        "[slides](https://example.com){#deck .text-xl data-kind=deck}",
+        "",
+        "![alt](./image.png){#hero .w-1/2 .mx-auto width=480 height=320}",
+      ].join("\n"),
+      "docs/attrs-images.md",
+      createResolvedOptions({
+        attrs: { enabled: true },
+        images: { enabled: true, lazy: true },
+      }),
+    );
+
+    expect(result.html).toContain('<p><a href="https://example.com"');
+    expect(result.html).toContain('id="deck" class="text-xl" data-kind="deck">slides</a></p>');
+    expect(result.html).toContain(
+      '<img src="./image.png" alt="alt" id="hero" class="w-1/2 mx-auto" loading="lazy" width="480" height="320">',
+    );
+    expect(result.html).not.toContain('<p id="deck"');
+    expect(result.html).not.toContain("{#hero");
+  });
+
   it("can append edit links and import source snippets when opted in", async () => {
     const result = await transformMarkdown(
       "<<< @/README.md{1-1}",


### PR DESCRIPTION
## Summary
- target trailing Markdown attributes at adjacent inline anchors/code/spans instead of the wrapping paragraph
- preserve opt-in image id/class/data attrs on the generated img while keeping width/height on the image feature path
- keep malformed or unsafe attr blocks literal and add docs/examples for link and image attrs

Closes #935

## Verification
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p ox_content_transform
- vp run --filter ./crates/ox_content_napi build
- vp exec --filter @ox-content/vite-plugin -- vp test src/transform.test.ts
- vp run check:ts
- vpr fmt:check
- node scripts/check-file-lines.ts
- git diff --check origin/main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserve safe custom attributes, IDs, classes, dimensions, and data attributes on links and transformed images.
  * Apply attributes more reliably to adjacent inline elements, wrapped elements, and void elements.
* **Bug Fixes**
  * Fixed attribute preservation for inline links and transformed images.
  * Improved validation of malformed and unsafe attribute values and URLs.
  * Prevented attributes from attaching across intervening text or comments.
* **Documentation**
  * Added examples covering attributes on headings, links, and images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->