### PR TITLE
test(mdx): cover expression island edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 - preserve attrs on inline links and transformed images (#935)
+- expand MDX parser and renderer edge-case coverage (#894)
 - soften code copy button (#920)
 - avoid empty table stretch columns (#919)
 - keep block embeds out of generated paragraphs (#936)

--- a/crates/ox_content_renderer/src/html/mdx_payload.rs
+++ b/crates/ox_content_renderer/src/html/mdx_payload.rs
@@ -23,11 +23,22 @@ impl IslandPayload {
 
     pub(super) fn into_json_value(self) -> Value {
         let mut object = Map::new();
-        object.insert("props".into(), Value::Object(self.props));
-        object.insert("expressions".into(), Value::Object(self.expressions));
+        object.insert("expressions".into(), Value::Object(sorted_map(self.expressions)));
+        object.insert("props".into(), Value::Object(sorted_map(self.props)));
         object.insert("spreads".into(), Value::Array(self.spreads));
         Value::Object(object)
     }
+}
+
+fn sorted_map(map: Map<String, Value>) -> Map<String, Value> {
+    let mut entries = map.into_iter().collect::<Vec<_>>();
+    entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+    let mut sorted = Map::new();
+    for (key, value) in entries {
+        sorted.insert(key, value);
+    }
+    sorted
 }
 
 pub(super) fn collect_island_payload(attributes: &[MdxJsxAttributeEntry<'_>]) -> IslandPayload {
@@ -97,7 +108,7 @@ mod tests {
         MdxJsxAttributeValueExpression, MdxJsxExpressionAttribute, Span,
     };
 
-    use super::{collect_island_payload, stringify_xss_safe};
+    use super::{IslandPayload, collect_island_payload, stringify_xss_safe};
 
     #[test]
     fn literals_and_json_expressions_become_props() {
@@ -150,6 +161,25 @@ mod tests {
         assert_eq!(payload.expressions["onClick"], "alert(1)");
         assert_eq!(payload.spreads, vec![serde_json::json!("...cardProps")]);
         assert!(payload.props.is_empty());
+    }
+
+    #[test]
+    fn serializes_payload_keys_in_a_stable_order() {
+        let mut payload = IslandPayload {
+            props: serde_json::Map::new(),
+            expressions: serde_json::Map::new(),
+            spreads: Vec::new(),
+        };
+        payload.props.insert("title".into(), serde_json::json!("Docs"));
+        payload.props.insert("data-kind".into(), serde_json::json!("guide"));
+        payload.expressions.insert("count".into(), serde_json::json!("count"));
+
+        let json = stringify_xss_safe(&payload.into_json_value());
+
+        assert_eq!(
+            json,
+            r#"{"expressions":{"count":"count"},"props":{"data-kind":"guide","title":"Docs"},"spreads":[]}"#
+        );
     }
 
     #[test]

--- a/crates/ox_content_transform/src/mdx_metadata/tests.rs
+++ b/crates/ox_content_transform/src/mdx_metadata/tests.rs
@@ -69,6 +69,37 @@ fn collects_export_names_without_evaluating_initializers() {
 }
 
 #[test]
+fn collects_type_only_imports_and_export_declarations() {
+    let meta = parse_doc(
+        "import type Props from './Props'\n\
+         import { type ChartData, Series as ChartSeries } from './chart'\n\
+         export type PageData = { title: string }\n\
+         export interface TocEntry { text: string }\n\
+         export enum LayoutKind { Docs }\n\
+         export async function load() {}\n\
+         export class ViewModel {}\n",
+    );
+
+    assert_eq!(
+        meta.imports,
+        vec![
+            MdxImport {
+                source: "./Props".into(),
+                specifiers: vec![spec("default", "Props", MdxImportSpecifierKind::Default)],
+            },
+            MdxImport {
+                source: "./chart".into(),
+                specifiers: vec![
+                    spec("ChartData", "ChartData", MdxImportSpecifierKind::Named),
+                    spec("Series", "ChartSeries", MdxImportSpecifierKind::Named),
+                ],
+            },
+        ]
+    );
+    assert_eq!(meta.exports, vec!["PageData", "TocEntry", "LayoutKind", "load", "ViewModel"]);
+}
+
+#[test]
 fn collects_unique_component_names_and_skips_fragments() {
     let meta = parse_doc(
         "<Alert />\n\

--- a/crates/ox_content_transform/src/transformer/snapshots/ox_content_transform__transformer__tests__mdx_renderer_handles_expression_props_and_nested_components.snap
+++ b/crates/ox_content_transform/src/transformer/snapshots/ox_content_transform__transformer__tests__mdx_renderer_handles_expression_props_and_nested_components.snap
@@ -1,0 +1,9 @@
+---
+source: crates/ox_content_transform/src/transformer/tests.rs
+expression: result.html
+---
+<h1 id="mdx-edge">MDX Edge</h1>
+<div class="ox-island" data-ox-island="Card" data-ox-props="{&quot;expressions&quot;:{&quot;count&quot;:&quot;count&quot;},&quot;props&quot;:{&quot;data-kind&quot;:&quot;guide&quot;,&quot;title&quot;:&quot;Docs&quot;},&quot;spreads&quot;:[]}"><script type="application/json">{"expressions":{"count":"count"},"props":{"data-kind":"guide","title":"Docs"},"spreads":[]}</script><p><strong>Bold</strong> copy</p>
+<div class="ox-island" data-ox-island="Badge" data-ox-props="{&quot;expressions&quot;:{},&quot;props&quot;:{&quot;label&quot;:&quot;beta&quot;},&quot;spreads&quot;:[]}"><script type="application/json">{"expressions":{},"props":{"label":"beta"},"spreads":[]}</script></div>
+</div>
+<p>Text <span class="ox-island" data-ox-island="Inline" data-ox-props="{&quot;expressions&quot;:{},&quot;props&quot;:{&quot;value&quot;:true},&quot;spreads&quot;:[]}"><script type="application/json">{"expressions":{},"props":{"value":true},"spreads":[]}</script></span> after.</p>

--- a/crates/ox_content_transform/src/transformer/tests.rs
+++ b/crates/ox_content_transform/src/transformer/tests.rs
@@ -69,6 +69,35 @@ fn mdx_transform_option_reaches_the_parser_and_renderer() {
 }
 
 #[test]
+fn mdx_renderer_handles_expression_props_and_nested_components() {
+    let transformer = MarkdownTransformer::from_options(&TransformOptions {
+        mdx: Some(true),
+        gfm: Some(true),
+        ..Default::default()
+    });
+    let result = transformer.transform(
+        "import Card from './Card'\n\
+         import { Badge } from './Badge'\n\
+         export const count = 2\n\n\
+         # MDX Edge\n\n\
+         <Card title=\"Docs\" count={count} data-kind=\"guide\">\n\
+         \n\
+         **Bold** copy\n\
+         \n\
+         <Badge label=\"beta\" />\n\
+         \n\
+         </Card>\n\n\
+         Text <Inline value={true} /> after.\n",
+    );
+
+    assert!(result.errors.is_empty(), "unexpected transform errors: {:?}", result.errors);
+    assert_eq!(result.imports.len(), 2);
+    assert_eq!(result.exports, vec!["count"]);
+    assert_eq!(result.components, vec!["Card", "Badge", "Inline"]);
+    insta::assert_snapshot!(result.html);
+}
+
+#[test]
 fn leaves_non_frontmatter_documents_untouched() {
     let (content, frontmatter) = super::parse_frontmatter("# Hello");
 


### PR DESCRIPTION
## Summary
- add MDX metadata coverage for type-only imports and export declarations
- snapshot expression props, nested flow JSX, and inline JSX island rendering
- record the rendered HTML artifact so future parser/renderer regressions are visible

Closes #894

## Verification
- cargo test -p ox_content_transform
- cargo clippy -p ox_content_transform --all-targets -- -D warnings
- vpr fmt:check
- node scripts/check-file-lines.ts
- git diff --check origin/main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790295542&installation_model_id=422833&pr_number=973&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F973&signature=2398345a0c71b11bd0f45d110d048fdb6bcb2cc99e1737d5382a83b2216df313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->