### PR TITLE
test(mdx): snapshot framework island outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - preserve attrs on inline links and transformed images (#935)
 - expand MDX parser and renderer edge-case coverage (#894)
+- snapshot framework MDX island outputs (#852)
 - soften code copy button (#920)
 - avoid empty table stretch columns (#919)
 - keep block embeds out of generated paragraphs (#936)

--- a/npm/vite-plugin-ox-content-react/src/__snapshots__/transform.test.ts.snap
+++ b/npm/vite-plugin-ox-content-react/src/__snapshots__/transform.test.ts.snap
@@ -1,5 +1,184 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`transformMarkdownWithReact > discovers nested, expression, and fragment islands from the MDX AST 1`] = `
+"
+import React, { useEffect, useRef, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
+import Callout from '../src/components/Callout.tsx';
+import Badge from '../src/components/Badge.tsx';
+
+export const frontmatter = {};
+
+const rawHtml = "<div class=\\"ox-island\\" data-ox-island=\\"Callout\\"><h1 id=\\"title\\">Title</h1>\\n<div class=\\"ox-island\\" data-ox-island=\\"Badge\\" data-ox-props=\\"{&quot;expressions&quot;:{},&quot;props&quot;:{&quot;title&quot;:&quot;hi&quot;},&quot;spreads&quot;:[]}\\"><script type=\\"application/json\\">{\\"expressions\\":{},\\"props\\":{\\"title\\":\\"hi\\"},\\"spreads\\":[]}</script></div>\\n</div>\\n";
+const components = {
+  Callout,
+  Badge,
+};
+
+function createReactHydrate() {
+  const mountedRoots = [];
+
+  return (element, props) => {
+    const componentName = element.dataset.oxIsland;
+    const Component = components[componentName];
+    if (!Component) return;
+
+    const islandContent = readIslandSlotHtml(element);
+    const vnode = islandContent
+      ? createElement(
+          Component,
+          props,
+          createElement('div', { dangerouslySetInnerHTML: { __html: islandContent } })
+        )
+      : createElement(Component, props);
+
+    const root = createRoot(element);
+    root.render(vnode);
+    mountedRoots.push(root);
+
+    return () => root.unmount();
+  };
+}
+
+export default function MarkdownContent() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const controller = initIslands(createReactHydrate(), {
+      selector: '.ox-content [data-ox-island]',
+    });
+    return () => controller.destroy();
+  }, []);
+
+  return createElement('div', {
+    className: 'ox-content',
+    ref: containerRef,
+    dangerouslySetInnerHTML: { __html: rawHtml },
+  });
+}
+"
+`;
+
+exports[`transformMarkdownWithReact > discovers nested, expression, and fragment islands from the MDX AST 2`] = `
+"
+import React, { useEffect, useRef, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
+import Alert from '../src/components/Alert.tsx';
+
+export const frontmatter = {};
+
+const rawHtml = "<div class=\\"ox-island\\" data-ox-island=\\"Alert\\" data-ox-props=\\"{&quot;expressions&quot;:{&quot;count&quot;:&quot;count + 1&quot;,&quot;title&quot;:&quot;foo&quot;},&quot;props&quot;:{},&quot;spreads&quot;:[]}\\"><script type=\\"application/json\\">{\\"expressions\\":{\\"count\\":\\"count + 1\\",\\"title\\":\\"foo\\"},\\"props\\":{},\\"spreads\\":[]}</script></div>\\n";
+const components = {
+  Alert,
+};
+
+function createReactHydrate() {
+  const mountedRoots = [];
+
+  return (element, props) => {
+    const componentName = element.dataset.oxIsland;
+    const Component = components[componentName];
+    if (!Component) return;
+
+    const islandContent = readIslandSlotHtml(element);
+    const vnode = islandContent
+      ? createElement(
+          Component,
+          props,
+          createElement('div', { dangerouslySetInnerHTML: { __html: islandContent } })
+        )
+      : createElement(Component, props);
+
+    const root = createRoot(element);
+    root.render(vnode);
+    mountedRoots.push(root);
+
+    return () => root.unmount();
+  };
+}
+
+export default function MarkdownContent() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const controller = initIslands(createReactHydrate(), {
+      selector: '.ox-content [data-ox-island]',
+    });
+    return () => controller.destroy();
+  }, []);
+
+  return createElement('div', {
+    className: 'ox-content',
+    ref: containerRef,
+    dangerouslySetInnerHTML: { __html: rawHtml },
+  });
+}
+"
+`;
+
+exports[`transformMarkdownWithReact > discovers nested, expression, and fragment islands from the MDX AST 3`] = `
+"
+import React, { useEffect, useRef, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
+import Alert from '../src/components/Alert.tsx';
+
+export const frontmatter = {};
+
+const rawHtml = "<div class=\\"ox-island\\" data-ox-island=\\"Alert\\" data-ox-props=\\"{&quot;expressions&quot;:{},&quot;props&quot;:{&quot;tone&quot;:&quot;info&quot;},&quot;spreads&quot;:[]}\\"><script type=\\"application/json\\">{\\"expressions\\":{},\\"props\\":{\\"tone\\":\\"info\\"},\\"spreads\\":[]}</script></div>\\n";
+const components = {
+  Alert,
+};
+
+function createReactHydrate() {
+  const mountedRoots = [];
+
+  return (element, props) => {
+    const componentName = element.dataset.oxIsland;
+    const Component = components[componentName];
+    if (!Component) return;
+
+    const islandContent = readIslandSlotHtml(element);
+    const vnode = islandContent
+      ? createElement(
+          Component,
+          props,
+          createElement('div', { dangerouslySetInnerHTML: { __html: islandContent } })
+        )
+      : createElement(Component, props);
+
+    const root = createRoot(element);
+    root.render(vnode);
+    mountedRoots.push(root);
+
+    return () => root.unmount();
+  };
+}
+
+export default function MarkdownContent() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const controller = initIslands(createReactHydrate(), {
+      selector: '.ox-content [data-ox-island]',
+    });
+    return () => controller.destroy();
+  }, []);
+
+  return createElement('div', {
+    className: 'ox-content',
+    ref: containerRef,
+    dangerouslySetInnerHTML: { __html: rawHtml },
+  });
+}
+"
+`;
+
 exports[`transformMarkdownWithReact > honors disabled built-in embeds from framework options 1`] = `
 "
 import React, { createElement } from 'react';

--- a/npm/vite-plugin-ox-content-react/src/transform.test.ts
+++ b/npm/vite-plugin-ox-content-react/src/transform.test.ts
@@ -56,6 +56,7 @@ describe("transformMarkdownWithReact", () => {
     expect(nested.code).toContain('data-ox-island=\\"Callout\\"');
     expect(nested.code).toContain('data-ox-island=\\"Badge\\"');
     expect(nested.code).toContain("readIslandSlotHtml");
+    expect(nested.code).toMatchSnapshot();
 
     const expr = await transformMarkdownWithReact(
       "<Alert title={foo} count={count + 1} />\n",
@@ -65,6 +66,7 @@ describe("transformMarkdownWithReact", () => {
     expect(expr.usedComponents).toEqual(["Alert"]);
     expect(expr.code).toContain('data-ox-island=\\"Alert\\"');
     expect(expr.code).toMatch(/count \+ 1|count \\u002b 1/);
+    expect(expr.code).toMatchSnapshot();
 
     const fragment = await transformMarkdownWithReact(
       '<>\n<Alert tone="info" />\n</>\n',
@@ -73,6 +75,7 @@ describe("transformMarkdownWithReact", () => {
     );
     expect(fragment.usedComponents).toEqual(["Alert"]);
     expect(fragment.code).toContain('data-ox-island=\\"Alert\\"');
+    expect(fragment.code).toMatchSnapshot();
   });
 
   it("keeps fenced JSX literal and skips unregistered MDX components", async () => {

--- a/npm/vite-plugin-ox-content-solid/src/__snapshots__/transform.test.ts.snap
+++ b/npm/vite-plugin-ox-content-solid/src/__snapshots__/transform.test.ts.snap
@@ -1,5 +1,166 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`transformMarkdownWithSolid > discovers nested, expression, and fragment islands from the MDX AST 1`] = `
+"
+import { onCleanup, onMount } from 'solid-js';
+import { render } from 'solid-js/web';
+import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
+import Callout from '../src/components/Callout.tsx';
+import Badge from '../src/components/Badge.tsx';
+
+export const frontmatter = {};
+
+const rawHtml = "<div class=\\"ox-island\\" data-ox-island=\\"Callout\\"><h1 id=\\"title\\">Title</h1>\\n<div class=\\"ox-island\\" data-ox-island=\\"Badge\\" data-ox-props=\\"{&quot;expressions&quot;:{},&quot;props&quot;:{&quot;title&quot;:&quot;hi&quot;},&quot;spreads&quot;:[]}\\"><script type=\\"application/json\\">{\\"expressions\\":{},\\"props\\":{\\"title\\":\\"hi\\"},\\"spreads\\":[]}</script></div>\\n</div>\\n";
+const components = {
+  Callout,
+  Badge,
+};
+
+function createSolidHydrate() {
+  return (element, props) => {
+    const componentName = element.dataset.oxIsland;
+    const Component = components[componentName];
+    if (!Component) return;
+
+    // Read the slot content before clearing: the island element still holds the
+    // markup the Markdown transform left behind.
+    const islandContent = readIslandSlotHtml(element);
+    element.innerHTML = '';
+
+    const dispose = render(
+      () =>
+        islandContent
+          ? <Component {...props}><div innerHTML={islandContent} /></Component>
+          : <Component {...props} />,
+      element,
+    );
+
+    return () => dispose();
+  };
+}
+
+export default function MarkdownContent() {
+  let container;
+
+  onMount(() => {
+    if (!container) return;
+    const controller = initIslands(createSolidHydrate(), {
+      selector: '.ox-content [data-ox-island]',
+    });
+    onCleanup(() => controller.destroy());
+  });
+
+  return <div class="ox-content" ref={container} innerHTML={rawHtml} />;
+}
+"
+`;
+
+exports[`transformMarkdownWithSolid > discovers nested, expression, and fragment islands from the MDX AST 2`] = `
+"
+import { onCleanup, onMount } from 'solid-js';
+import { render } from 'solid-js/web';
+import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
+import Alert from '../src/components/Alert.tsx';
+
+export const frontmatter = {};
+
+const rawHtml = "<div class=\\"ox-island\\" data-ox-island=\\"Alert\\" data-ox-props=\\"{&quot;expressions&quot;:{&quot;count&quot;:&quot;count + 1&quot;,&quot;title&quot;:&quot;foo&quot;},&quot;props&quot;:{},&quot;spreads&quot;:[]}\\"><script type=\\"application/json\\">{\\"expressions\\":{\\"count\\":\\"count + 1\\",\\"title\\":\\"foo\\"},\\"props\\":{},\\"spreads\\":[]}</script></div>\\n";
+const components = {
+  Alert,
+};
+
+function createSolidHydrate() {
+  return (element, props) => {
+    const componentName = element.dataset.oxIsland;
+    const Component = components[componentName];
+    if (!Component) return;
+
+    // Read the slot content before clearing: the island element still holds the
+    // markup the Markdown transform left behind.
+    const islandContent = readIslandSlotHtml(element);
+    element.innerHTML = '';
+
+    const dispose = render(
+      () =>
+        islandContent
+          ? <Component {...props}><div innerHTML={islandContent} /></Component>
+          : <Component {...props} />,
+      element,
+    );
+
+    return () => dispose();
+  };
+}
+
+export default function MarkdownContent() {
+  let container;
+
+  onMount(() => {
+    if (!container) return;
+    const controller = initIslands(createSolidHydrate(), {
+      selector: '.ox-content [data-ox-island]',
+    });
+    onCleanup(() => controller.destroy());
+  });
+
+  return <div class="ox-content" ref={container} innerHTML={rawHtml} />;
+}
+"
+`;
+
+exports[`transformMarkdownWithSolid > discovers nested, expression, and fragment islands from the MDX AST 3`] = `
+"
+import { onCleanup, onMount } from 'solid-js';
+import { render } from 'solid-js/web';
+import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
+import Alert from '../src/components/Alert.tsx';
+
+export const frontmatter = {};
+
+const rawHtml = "<div class=\\"ox-island\\" data-ox-island=\\"Alert\\" data-ox-props=\\"{&quot;expressions&quot;:{},&quot;props&quot;:{&quot;tone&quot;:&quot;info&quot;},&quot;spreads&quot;:[]}\\"><script type=\\"application/json\\">{\\"expressions\\":{},\\"props\\":{\\"tone\\":\\"info\\"},\\"spreads\\":[]}</script></div>\\n";
+const components = {
+  Alert,
+};
+
+function createSolidHydrate() {
+  return (element, props) => {
+    const componentName = element.dataset.oxIsland;
+    const Component = components[componentName];
+    if (!Component) return;
+
+    // Read the slot content before clearing: the island element still holds the
+    // markup the Markdown transform left behind.
+    const islandContent = readIslandSlotHtml(element);
+    element.innerHTML = '';
+
+    const dispose = render(
+      () =>
+        islandContent
+          ? <Component {...props}><div innerHTML={islandContent} /></Component>
+          : <Component {...props} />,
+      element,
+    );
+
+    return () => dispose();
+  };
+}
+
+export default function MarkdownContent() {
+  let container;
+
+  onMount(() => {
+    if (!container) return;
+    const controller = initIslands(createSolidHydrate(), {
+      selector: '.ox-content [data-ox-island]',
+    });
+    onCleanup(() => controller.destroy());
+  });
+
+  return <div class="ox-content" ref={container} innerHTML={rawHtml} />;
+}
+"
+`;
+
 exports[`transformMarkdownWithSolid > honors disabled built-in embeds from framework options 1`] = `
 "
 export const frontmatter = {};

--- a/npm/vite-plugin-ox-content-solid/src/transform.test.ts
+++ b/npm/vite-plugin-ox-content-solid/src/transform.test.ts
@@ -56,6 +56,7 @@ describe("transformMarkdownWithSolid", () => {
     expect(nested.code).toContain('data-ox-island=\\"Callout\\"');
     expect(nested.code).toContain('data-ox-island=\\"Badge\\"');
     expect(nested.code).toContain("readIslandSlotHtml");
+    expect(nested.code).toMatchSnapshot();
 
     const expr = await transformMarkdownWithSolid(
       "<Alert title={foo} count={count + 1} />\n",
@@ -65,6 +66,7 @@ describe("transformMarkdownWithSolid", () => {
     expect(expr.usedComponents).toEqual(["Alert"]);
     expect(expr.code).toContain('data-ox-island=\\"Alert\\"');
     expect(expr.code).toMatch(/count \+ 1|count \\u002b 1/);
+    expect(expr.code).toMatchSnapshot();
 
     const fragment = await transformMarkdownWithSolid(
       '<>\n<Alert tone="info" />\n</>\n',
@@ -73,6 +75,7 @@ describe("transformMarkdownWithSolid", () => {
     );
     expect(fragment.usedComponents).toEqual(["Alert"]);
     expect(fragment.code).toContain('data-ox-island=\\"Alert\\"');
+    expect(fragment.code).toMatchSnapshot();
   });
 
   it("keeps fenced JSX literal and skips unregistered MDX components", async () => {

--- a/npm/vite-plugin-ox-content-svelte/src/__snapshots__/transform.test.ts.snap
+++ b/npm/vite-plugin-ox-content-svelte/src/__snapshots__/transform.test.ts.snap
@@ -1,5 +1,192 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`transformMarkdownWithSvelte > discovers nested, expression, and fragment islands from the MDX AST 1`] = `
+"import 'svelte/internal/disclose-version';
+import * as $ from 'svelte/internal/client';
+import { createRawSnippet, onMount, mount, unmount } from 'svelte';
+import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
+import Callout from '../src/components/Callout.svelte';
+import Badge from '../src/components/Badge.svelte';
+
+var root = $.from_html(\`<div class="ox-content svelte-1s4aub"></div>\`);
+
+export default function Nested_mdx($$anchor, $$props) {
+	$.push($$props, true);
+
+	const frontmatter = {};
+	const rawHtml = "<div class=\\"ox-island\\" data-ox-island=\\"Callout\\"><h1 id=\\"title\\">Title</h1>\\n<div class=\\"ox-island\\" data-ox-island=\\"Badge\\" data-ox-props=\\"{&quot;expressions&quot;:{},&quot;props&quot;:{&quot;title&quot;:&quot;hi&quot;},&quot;spreads&quot;:[]}\\"><script type=\\"application/json\\">{\\"expressions\\":{},\\"props\\":{\\"title\\":\\"hi\\"},\\"spreads\\":[]}<\\/script></div>\\n</div>\\n";
+	const components = { Callout, Badge };
+	let container;
+
+	function createSvelteHydrate() {
+		const mounted = [];
+
+		return (element, props) => {
+			const componentName = element.dataset.oxIsland;
+			const Component = components[componentName];
+
+			if (!Component) return;
+
+			const islandContent = readIslandSlotHtml(element);
+			const componentProps = { ...props };
+
+			if (islandContent) {
+				componentProps.children = createRawSnippet(() => ({ render: () => \`<div>\${islandContent}</div>\` }));
+			}
+
+			const instance = mount(Component, { target: element, props: componentProps });
+
+			mounted.push(instance);
+
+			return () => unmount(instance);
+		};
+	}
+
+	onMount(() => {
+		if (!container) return;
+
+		const controller = initIslands(createSvelteHydrate(), { selector: '.ox-content [data-ox-island]' });
+
+		return () => controller.destroy();
+	});
+
+	var $$exports = { frontmatter };
+	var div = root();
+
+	$.html(div, () => rawHtml, true);
+	$.reset(div);
+	$.bind_this(div, ($$value) => container = $$value, () => container);
+	$.append($$anchor, div);
+
+	return $.pop($$exports);
+}
+export const frontmatter = {};"
+`;
+
+exports[`transformMarkdownWithSvelte > discovers nested, expression, and fragment islands from the MDX AST 2`] = `
+"import 'svelte/internal/disclose-version';
+import * as $ from 'svelte/internal/client';
+import { createRawSnippet, onMount, mount, unmount } from 'svelte';
+import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
+import Alert from '../src/components/Alert.svelte';
+
+var root = $.from_html(\`<div class="ox-content svelte-1wwhjsv"></div>\`);
+
+export default function Expr_mdx($$anchor, $$props) {
+	$.push($$props, true);
+
+	const frontmatter = {};
+	const rawHtml = "<div class=\\"ox-island\\" data-ox-island=\\"Alert\\" data-ox-props=\\"{&quot;expressions&quot;:{&quot;count&quot;:&quot;count + 1&quot;,&quot;title&quot;:&quot;foo&quot;},&quot;props&quot;:{},&quot;spreads&quot;:[]}\\"><script type=\\"application/json\\">{\\"expressions\\":{\\"count\\":\\"count + 1\\",\\"title\\":\\"foo\\"},\\"props\\":{},\\"spreads\\":[]}<\\/script></div>\\n";
+	const components = { Alert };
+	let container;
+
+	function createSvelteHydrate() {
+		const mounted = [];
+
+		return (element, props) => {
+			const componentName = element.dataset.oxIsland;
+			const Component = components[componentName];
+
+			if (!Component) return;
+
+			const islandContent = readIslandSlotHtml(element);
+			const componentProps = { ...props };
+
+			if (islandContent) {
+				componentProps.children = createRawSnippet(() => ({ render: () => \`<div>\${islandContent}</div>\` }));
+			}
+
+			const instance = mount(Component, { target: element, props: componentProps });
+
+			mounted.push(instance);
+
+			return () => unmount(instance);
+		};
+	}
+
+	onMount(() => {
+		if (!container) return;
+
+		const controller = initIslands(createSvelteHydrate(), { selector: '.ox-content [data-ox-island]' });
+
+		return () => controller.destroy();
+	});
+
+	var $$exports = { frontmatter };
+	var div = root();
+
+	$.html(div, () => rawHtml, true);
+	$.reset(div);
+	$.bind_this(div, ($$value) => container = $$value, () => container);
+	$.append($$anchor, div);
+
+	return $.pop($$exports);
+}
+export const frontmatter = {};"
+`;
+
+exports[`transformMarkdownWithSvelte > discovers nested, expression, and fragment islands from the MDX AST 3`] = `
+"import 'svelte/internal/disclose-version';
+import * as $ from 'svelte/internal/client';
+import { createRawSnippet, onMount, mount, unmount } from 'svelte';
+import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
+import Alert from '../src/components/Alert.svelte';
+
+var root = $.from_html(\`<div class="ox-content svelte-19q2n2e"></div>\`);
+
+export default function Fragment_mdx($$anchor, $$props) {
+	$.push($$props, true);
+
+	const frontmatter = {};
+	const rawHtml = "<div class=\\"ox-island\\" data-ox-island=\\"Alert\\" data-ox-props=\\"{&quot;expressions&quot;:{},&quot;props&quot;:{&quot;tone&quot;:&quot;info&quot;},&quot;spreads&quot;:[]}\\"><script type=\\"application/json\\">{\\"expressions\\":{},\\"props\\":{\\"tone\\":\\"info\\"},\\"spreads\\":[]}<\\/script></div>\\n";
+	const components = { Alert };
+	let container;
+
+	function createSvelteHydrate() {
+		const mounted = [];
+
+		return (element, props) => {
+			const componentName = element.dataset.oxIsland;
+			const Component = components[componentName];
+
+			if (!Component) return;
+
+			const islandContent = readIslandSlotHtml(element);
+			const componentProps = { ...props };
+
+			if (islandContent) {
+				componentProps.children = createRawSnippet(() => ({ render: () => \`<div>\${islandContent}</div>\` }));
+			}
+
+			const instance = mount(Component, { target: element, props: componentProps });
+
+			mounted.push(instance);
+
+			return () => unmount(instance);
+		};
+	}
+
+	onMount(() => {
+		if (!container) return;
+
+		const controller = initIslands(createSvelteHydrate(), { selector: '.ox-content [data-ox-island]' });
+
+		return () => controller.destroy();
+	});
+
+	var $$exports = { frontmatter };
+	var div = root();
+
+	$.html(div, () => rawHtml, true);
+	$.reset(div);
+	$.bind_this(div, ($$value) => container = $$value, () => container);
+	$.append($$anchor, div);
+
+	return $.pop($$exports);
+}
+export const frontmatter = {};"
+`;
+
 exports[`transformMarkdownWithSvelte > honors disabled built-in embeds from framework options 1`] = `
 "import 'svelte/internal/disclose-version';
 import * as $ from 'svelte/internal/client';

--- a/npm/vite-plugin-ox-content-svelte/src/transform.test.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/transform.test.ts
@@ -54,6 +54,7 @@ describe("transformMarkdownWithSvelte", () => {
     expect(nested.code).toContain("Callout");
     expect(nested.code).toContain("Badge");
     expect(nested.code).toContain("initIslands");
+    expect(nested.code).toMatchSnapshot();
 
     const expr = await transformMarkdownWithSvelte(
       "<Alert title={foo} count={count + 1} />\n",
@@ -62,6 +63,7 @@ describe("transformMarkdownWithSvelte", () => {
     );
     expect(expr.usedComponents).toEqual(["Alert"]);
     expect(expr.code).toContain("Alert");
+    expect(expr.code).toMatchSnapshot();
 
     const fragment = await transformMarkdownWithSvelte(
       '<>\n<Alert tone="info" />\n</>\n',
@@ -69,6 +71,7 @@ describe("transformMarkdownWithSvelte", () => {
       createOptions(),
     );
     expect(fragment.usedComponents).toEqual(["Alert"]);
+    expect(fragment.code).toMatchSnapshot();
   });
 
   it("keeps fenced JSX literal and skips unregistered MDX components", async () => {

--- a/npm/vite-plugin-ox-content-vue/src/__snapshots__/transform.test.ts.snap
+++ b/npm/vite-plugin-ox-content-vue/src/__snapshots__/transform.test.ts.snap
@@ -1,5 +1,202 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`transformMarkdownWithVue > discovers nested, expression, and fragment islands from the MDX AST 1`] = `
+"
+import { h, ref, onMounted, onBeforeUnmount, defineComponent, render } from 'vue';
+import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
+import Callout from '../src/components/Callout.vue';
+import Badge from '../src/components/Badge.vue';
+
+export const frontmatter = {};
+
+const rawHtml = "<div class=\\"ox-island\\" data-ox-island=\\"Callout\\"><h1 id=\\"title\\">Title</h1>\\n<div class=\\"ox-island\\" data-ox-island=\\"Badge\\" data-ox-props=\\"{&quot;expressions&quot;:{},&quot;props&quot;:{&quot;title&quot;:&quot;hi&quot;},&quot;spreads&quot;:[]}\\"><script type=\\"application/json\\">{\\"expressions\\":{},\\"props\\":{\\"title\\":\\"hi\\"},\\"spreads\\":[]}</script></div>\\n</div>\\n";
+const components = {
+  Callout,
+  Badge,
+};
+
+function createVueHydrate(container) {
+  const mountedTargets = [];
+
+  return (element, props) => {
+    const componentName = element.dataset.oxIsland;
+    const Component = components[componentName];
+    if (!Component) return;
+
+    const islandContent = readIslandSlotHtml(element);
+    const children = islandContent
+      ? { default: () => h('div', { innerHTML: islandContent }) }
+      : undefined;
+
+    const vnode = h(Component, props, children);
+    render(vnode, element);
+    mountedTargets.push(element);
+
+    return () => render(null, element);
+  };
+}
+
+export default defineComponent({
+  name: 'MarkdownContent',
+  setup(_, { expose }) {
+    const container = ref(null);
+    let controller;
+
+    onMounted(() => {
+      if (container.value) {
+        controller = initIslands(createVueHydrate(container.value), {
+          selector: '.ox-content [data-ox-island]',
+        });
+      }
+    });
+
+    onBeforeUnmount(() => {
+      if (controller) controller.destroy();
+    });
+
+    expose({ frontmatter });
+
+    return () =>
+      h('div', {
+        class: 'ox-content',
+        ref: container,
+        innerHTML: rawHtml,
+      });
+  },
+});
+"
+`;
+
+exports[`transformMarkdownWithVue > discovers nested, expression, and fragment islands from the MDX AST 2`] = `
+"
+import { h, ref, onMounted, onBeforeUnmount, defineComponent, render } from 'vue';
+import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
+import Alert from '../src/components/Alert.vue';
+
+export const frontmatter = {};
+
+const rawHtml = "<div class=\\"ox-island\\" data-ox-island=\\"Alert\\" data-ox-props=\\"{&quot;expressions&quot;:{&quot;count&quot;:&quot;count + 1&quot;,&quot;title&quot;:&quot;foo&quot;},&quot;props&quot;:{},&quot;spreads&quot;:[]}\\"><script type=\\"application/json\\">{\\"expressions\\":{\\"count\\":\\"count + 1\\",\\"title\\":\\"foo\\"},\\"props\\":{},\\"spreads\\":[]}</script></div>\\n";
+const components = {
+  Alert,
+};
+
+function createVueHydrate(container) {
+  const mountedTargets = [];
+
+  return (element, props) => {
+    const componentName = element.dataset.oxIsland;
+    const Component = components[componentName];
+    if (!Component) return;
+
+    const islandContent = readIslandSlotHtml(element);
+    const children = islandContent
+      ? { default: () => h('div', { innerHTML: islandContent }) }
+      : undefined;
+
+    const vnode = h(Component, props, children);
+    render(vnode, element);
+    mountedTargets.push(element);
+
+    return () => render(null, element);
+  };
+}
+
+export default defineComponent({
+  name: 'MarkdownContent',
+  setup(_, { expose }) {
+    const container = ref(null);
+    let controller;
+
+    onMounted(() => {
+      if (container.value) {
+        controller = initIslands(createVueHydrate(container.value), {
+          selector: '.ox-content [data-ox-island]',
+        });
+      }
+    });
+
+    onBeforeUnmount(() => {
+      if (controller) controller.destroy();
+    });
+
+    expose({ frontmatter });
+
+    return () =>
+      h('div', {
+        class: 'ox-content',
+        ref: container,
+        innerHTML: rawHtml,
+      });
+  },
+});
+"
+`;
+
+exports[`transformMarkdownWithVue > discovers nested, expression, and fragment islands from the MDX AST 3`] = `
+"
+import { h, ref, onMounted, onBeforeUnmount, defineComponent, render } from 'vue';
+import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
+import Alert from '../src/components/Alert.vue';
+
+export const frontmatter = {};
+
+const rawHtml = "<div class=\\"ox-island\\" data-ox-island=\\"Alert\\" data-ox-props=\\"{&quot;expressions&quot;:{},&quot;props&quot;:{&quot;tone&quot;:&quot;info&quot;},&quot;spreads&quot;:[]}\\"><script type=\\"application/json\\">{\\"expressions\\":{},\\"props\\":{\\"tone\\":\\"info\\"},\\"spreads\\":[]}</script></div>\\n";
+const components = {
+  Alert,
+};
+
+function createVueHydrate(container) {
+  const mountedTargets = [];
+
+  return (element, props) => {
+    const componentName = element.dataset.oxIsland;
+    const Component = components[componentName];
+    if (!Component) return;
+
+    const islandContent = readIslandSlotHtml(element);
+    const children = islandContent
+      ? { default: () => h('div', { innerHTML: islandContent }) }
+      : undefined;
+
+    const vnode = h(Component, props, children);
+    render(vnode, element);
+    mountedTargets.push(element);
+
+    return () => render(null, element);
+  };
+}
+
+export default defineComponent({
+  name: 'MarkdownContent',
+  setup(_, { expose }) {
+    const container = ref(null);
+    let controller;
+
+    onMounted(() => {
+      if (container.value) {
+        controller = initIslands(createVueHydrate(container.value), {
+          selector: '.ox-content [data-ox-island]',
+        });
+      }
+    });
+
+    onBeforeUnmount(() => {
+      if (controller) controller.destroy();
+    });
+
+    expose({ frontmatter });
+
+    return () =>
+      h('div', {
+        class: 'ox-content',
+        ref: container,
+        innerHTML: rawHtml,
+      });
+  },
+});
+"
+`;
+
 exports[`transformMarkdownWithVue > honors disabled built-in embeds from framework options 1`] = `
 "
 import { h, ref, defineComponent } from 'vue';

--- a/npm/vite-plugin-ox-content-vue/src/transform.test.ts
+++ b/npm/vite-plugin-ox-content-vue/src/transform.test.ts
@@ -56,6 +56,7 @@ describe("transformMarkdownWithVue", () => {
     expect(nested.code).toContain('data-ox-island=\\"Callout\\"');
     expect(nested.code).toContain('data-ox-island=\\"Badge\\"');
     expect(nested.code).toContain("readIslandSlotHtml");
+    expect(nested.code).toMatchSnapshot();
 
     const expr = await transformMarkdownWithVue(
       "<Alert title={foo} count={count + 1} />\n",
@@ -65,6 +66,7 @@ describe("transformMarkdownWithVue", () => {
     expect(expr.usedComponents).toEqual(["Alert"]);
     expect(expr.code).toContain('data-ox-island=\\"Alert\\"');
     expect(expr.code).toMatch(/count \+ 1|count \\u002b 1/);
+    expect(expr.code).toMatchSnapshot();
 
     const fragment = await transformMarkdownWithVue(
       '<>\n<Alert tone="info" />\n</>\n',
@@ -73,6 +75,7 @@ describe("transformMarkdownWithVue", () => {
     );
     expect(fragment.usedComponents).toEqual(["Alert"]);
     expect(fragment.code).toContain('data-ox-island=\\"Alert\\"');
+    expect(fragment.code).toMatchSnapshot();
   });
 
   it("keeps fenced JSX literal and skips unregistered MDX components", async () => {


### PR DESCRIPTION
## Summary
- add snapshot coverage for nested, expression, and fragment MDX islands across React, Vue, Solid, and Svelte framework adapters
- record the deterministic Rust island payload order in generated framework modules
- note the framework snapshot gate in the alpha changelog

Closes #852

## Validation
- vp run --filter ./crates/ox_content_napi build
- vp exec --filter @ox-content/vite-plugin-react -- vp test src/transform.test.ts
- vp exec --filter @ox-content/vite-plugin-vue -- vp test src/transform.test.ts
- vp exec --filter @ox-content/vite-plugin-solid -- vp test src/transform.test.ts
- vp exec --filter @ox-content/vite-plugin-svelte -- vp test src/transform.test.ts
- vp run check:ts
- vpr fmt:check
- node scripts/check-file-lines.ts
- git diff --check origin/main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790296820&installation_model_id=422833&pr_number=976&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F976&signature=6f09455b73541aa562cd14219c4b1757f228d452443fd823e258fe0239ea419d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved snapshot handling for framework MDX island outputs, including nested, expression-based, and fragment scenarios.

- **Tests**
  - Added coverage to verify consistent island transformations across React, Solid, Svelte, and Vue integrations.

- **Documentation**
  - Updated the changelog with details about the snapshotting fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->