### PR TITLE
perf(ci): skip test-only benchmark runs

### DIFF
--- a/.github/scripts/detect-pr-benchmark-scope.mjs
+++ b/.github/scripts/detect-pr-benchmark-scope.mjs
@@ -20,6 +20,11 @@ const RUNTIME_PATTERNS = [
   /^benchmarks\/polonius-borrowck\//,
 ];
 
+const TEST_ONLY_PATTERNS = [
+  /^npm\/[^/]+\/src\/.*\.test\.[cm]?[jt]sx?$/,
+  /^npm\/[^/]+\/src\/(?:.*\/)?__snapshots__\/.*\.snap$/,
+];
+
 const BUNDLE_PATTERNS = [
   /^benchmarks\/bundle-size\//,
   /^crates\//,
@@ -81,6 +86,9 @@ function classifyFile(file) {
   }
   if (matchesAny(file, RUNTIME_PATTERNS)) {
     return { runtime: true, bundle: false };
+  }
+  if (matchesAny(file, TEST_ONLY_PATTERNS)) {
+    return { runtime: false, bundle: false };
   }
   if (matchesAny(file, BUNDLE_PATTERNS)) {
     return { runtime: false, bundle: true };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 - highlight WebContainer examples as MDX (#914)
 - keep browser cancellation responsive (#870)
 
+### Performance
+
+- skip PR benchmarks for test-only package edits (#851)
+
 ## [3.0.0-alpha.8] - 2026-08-25
 
 ### Bug Fixes

--- a/benchmarks/bundle-size/pr-benchmark-scope.test.ts
+++ b/benchmarks/bundle-size/pr-benchmark-scope.test.ts
@@ -28,6 +28,23 @@ describe("detect-pr-benchmark-scope", () => {
     expect(parseOutputs(result.stdout)).toEqual({ runtime: "false", bundle: "true" });
   });
 
+  it("skips test-only package edits", () => {
+    const result = runScope([
+      "npm/vite-plugin-ox-content-react/src/transform.test.ts",
+      "npm/vite-plugin-ox-content-react/src/__snapshots__/transform.test.ts.snap",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ runtime: "false", bundle: "false" });
+  });
+
+  it("keeps package implementation edits on the bundle gate", () => {
+    const result = runScope(["npm/vite-plugin-ox-content-react/src/transform.ts"]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ runtime: "false", bundle: "true" });
+  });
+
   it("runs both gates for benchmark harness edits", () => {
     const result = runScope(["benchmarks/bundle-size/parse-benchmark.mjs"]);
 


### PR DESCRIPTION
## Summary

- skip runtime and bundle benchmark workflows when a PR only changes package tests or snapshots
- keep package implementation files classified as bundle-impacting
- add benchmark-scope coverage for the test-only path

Refs #851

## Validation

- `vp test benchmarks/bundle-size/pr-benchmark-scope.test.ts`
- `vp run check:ts`
- `vpr fmt:check`
- `node scripts/check-file-lines.ts`
- `git diff --check origin/main`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790297396&installation_model_id=422833&pr_number=977&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F977&signature=a84ef4654cc08231698aa704a6e81c3352eb804e4bd740f2f154f9157777aabc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->