### PR TITLE
perf(ci): skip neutral preview releases

### DIFF
--- a/.github/scripts/detect-pr-preview-scope.mjs
+++ b/.github/scripts/detect-pr-preview-scope.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const PACKAGE_PREVIEW_PATTERNS = [
+  /^\.github\/workflows\/(?:nightly|publish)\.yml$/,
+  /^\.github\/scripts\/detect-pr-preview-scope\.mjs$/,
+  /^binding-packages\//,
+  /^crates\//,
+  /^npm\/[^/]+\/package\.json$/,
+  /^npm\/[^/]+\/src\//,
+  /^scripts\/(?:package-dry-run|verify-publish-targets)\.(?:mjs|ts|test\.ts)$/,
+  /^Cargo\.(?:toml|lock)$/,
+  /^package\.json$/,
+  /^pnpm-lock\.yaml$/,
+  /^vite\.config\.ts$/,
+  /^\.node-version$/,
+];
+
+const TEST_ONLY_PATTERNS = [
+  /^npm\/[^/]+\/src\/.*\.test\.[cm]?[jt]sx?$/,
+  /^npm\/[^/]+\/src\/(?:.*\/)?__snapshots__\/.*\.snap$/,
+];
+
+const PREVIEW_NEUTRAL_PATTERNS = [
+  /^\.github\/(?:ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)\//,
+  /^\.github\/workflows\/(?!nightly\.yml$|publish\.yml$)/,
+  /^benchmarks\//,
+  /^docs\//,
+  /^examples\//,
+  /^README\.md$/,
+  /^CHANGELOG\.md$/,
+  /^CHENGELOG\.md$/,
+  /^LICENSE$/,
+  /^AGENTS\.md$/,
+  /\.(?:md|mdx|png|jpe?g|gif|webp|svg|avif)$/i,
+];
+
+const inputPath = process.argv[2];
+
+if (!inputPath || process.argv.includes("--help") || process.argv.includes("-h")) {
+  printUsage();
+  process.exit(inputPath ? 0 : 2);
+}
+
+const files = readFileSync(inputPath, "utf8")
+  .split(/\r?\n/)
+  .map((file) => file.trim())
+  .filter(Boolean);
+
+const preview = files.some((file) => classifyFile(file));
+
+console.error(
+  `Package preview scope: preview=${formatBoolean(preview)} (${files.length} changed file${
+    files.length === 1 ? "" : "s"
+  })`,
+);
+console.log(`preview=${formatBoolean(preview)}`);
+
+/**
+ * @param {string} file
+ * @returns {boolean}
+ */
+function classifyFile(file) {
+  if (matchesAny(file, TEST_ONLY_PATTERNS)) {
+    return false;
+  }
+  if (matchesAny(file, PACKAGE_PREVIEW_PATTERNS)) {
+    return true;
+  }
+  if (matchesAny(file, PREVIEW_NEUTRAL_PATTERNS)) {
+    return false;
+  }
+
+  // Unknown paths stay conservative. A new publishable surface should opt out
+  // only after it is deliberately classified.
+  return true;
+}
+
+/**
+ * @param {string} file
+ * @param {readonly RegExp[]} patterns
+ * @returns {boolean}
+ */
+function matchesAny(file, patterns) {
+  return patterns.some((pattern) => pattern.test(file));
+}
+
+/**
+ * @param {boolean} value
+ * @returns {"true" | "false"}
+ */
+function formatBoolean(value) {
+  return value ? "true" : "false";
+}
+
+function printUsage() {
+  console.log(`Usage: node .github/scripts/detect-pr-preview-scope.mjs <changed-files.txt>
+
+Writes GitHub Actions outputs:
+  preview=true|false`);
+}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,9 +33,43 @@ env:
   LINUX_GLIBC_VERSION: "2.17"
 
 jobs:
+  preview-scope:
+    name: Package preview scope
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    outputs:
+      preview: ${{ steps.scope.outputs.preview }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Detect package preview scope
+        id: scope
+        env:
+          BASE_REPOSITORY: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "preview=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch --no-tags --depth=1 "https://github.com/$BASE_REPOSITORY.git" "$BASE_SHA"
+          git diff --name-only "$BASE_SHA" "$GITHUB_SHA" > "$RUNNER_TEMP/preview-changed-files.txt"
+          node .github/scripts/detect-pr-preview-scope.mjs "$RUNNER_TEMP/preview-changed-files.txt" >> "$GITHUB_OUTPUT"
+
+          echo "Changed files:"
+          sed 's/^/  /' "$RUNNER_TEMP/preview-changed-files.txt"
+
   build-napi:
     name: Build NAPI - ${{ matrix.target }}
-    if: github.event_name != 'workflow_dispatch' || inputs.skip_build != true
+    needs: preview-scope
+    if: |
+      needs.preview-scope.outputs.preview == 'true' &&
+      (github.event_name != 'workflow_dispatch' || inputs.skip_build != true)
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -173,11 +207,14 @@ jobs:
   release:
     name: Publish preview via pkg-pr-new
     runs-on: blacksmith-32vcpu-ubuntu-2404
-    needs: build-napi
+    needs:
+      - preview-scope
+      - build-napi
     # Skip when explicitly disabled via workflow_dispatch.
     # Use always() so this still runs when build-napi was skipped (skip_build mode).
     if: |
       always() &&
+      needs.preview-scope.outputs.preview == 'true' &&
       (github.event_name != 'workflow_dispatch' || inputs.skip_release != true) &&
       (needs.build-napi.result == 'success' ||
        (github.event_name == 'workflow_dispatch' && inputs.skip_build == true))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Performance
 
+- skip package preview releases for neutral PR edits (#851)
 - skip PR benchmarks for test-only package edits (#851)
 
 ## [3.0.0-alpha.8] - 2026-08-25

--- a/scripts/pr-preview-scope.test.ts
+++ b/scripts/pr-preview-scope.test.ts
@@ -1,0 +1,77 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+
+const script = resolve(".github/scripts/detect-pr-preview-scope.mjs");
+
+describe("detect-pr-preview-scope", () => {
+  it("skips documentation-only preview builds", () => {
+    const result = runScope(["docs/content/built-in/embeds.md", "CHANGELOG.md"]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ preview: "false" });
+  });
+
+  it("skips package test and snapshot-only edits", () => {
+    const result = runScope([
+      "npm/vite-plugin-ox-content-react/src/transform.test.ts",
+      "npm/vite-plugin-ox-content-react/src/__snapshots__/transform.test.ts.snap",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ preview: "false" });
+  });
+
+  it("keeps package implementation edits on the preview release", () => {
+    const result = runScope(["npm/vite-plugin-ox-content-react/src/transform.ts"]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ preview: "true" });
+  });
+
+  it("keeps native and dependency edits on the preview release", () => {
+    const result = runScope(["crates/ox_content_renderer/src/html.rs", "pnpm-lock.yaml"]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ preview: "true" });
+  });
+
+  it("keeps publish workflow edits on the preview release", () => {
+    const result = runScope([".github/workflows/nightly.yml"]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ preview: "true" });
+  });
+
+  it("falls back to preview builds for unclassified paths", () => {
+    const result = runScope(["tools/new-publish-surface/file.ts"]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ preview: "true" });
+  });
+});
+
+function runScope(files: string[]) {
+  const dir = mkdtempSync(join(tmpdir(), "ox-preview-scope-"));
+  const changedFilesPath = join(dir, "changed-files.txt");
+  writeFileSync(changedFilesPath, `${files.join("\n")}\n`);
+
+  return spawnSync(process.execPath, [script, changedFilesPath], {
+    encoding: "utf8",
+  });
+}
+
+function parseOutputs(stdout: string) {
+  return Object.fromEntries(
+    stdout
+      .trim()
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => {
+        const index = line.indexOf("=");
+        return [line.slice(0, index), line.slice(index + 1)];
+      }),
+  );
+}


### PR DESCRIPTION
## Summary

- add a PR package-preview scope gate for the Nightly release workflow
- skip the NAPI preview matrix and pkg-pr-new publish when a PR only changes docs, benchmarks, tests, snapshots, or other neutral files
- keep native, dependency, package implementation, and publish workflow changes conservative

Refs #851

## Validation

- `vp test scripts/pr-preview-scope.test.ts benchmarks/bundle-size/pr-benchmark-scope.test.ts`
- `vp run check:ts`
- `vpr fmt:check`
- `node scripts/check-file-lines.ts`
- `git diff --check origin/main`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790298156&installation_model_id=422833&pr_number=978&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F978&signature=5835ff22ede9da26389d44432ff254d2ffa728a1f433160b1a742d0f2f0d966c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->