### PR TITLE
perf(ci): skip preview helper benchmarks

### DIFF
--- a/.github/scripts/detect-pr-benchmark-scope.mjs
+++ b/.github/scripts/detect-pr-benchmark-scope.mjs
@@ -34,9 +34,11 @@ const BUNDLE_PATTERNS = [
 
 const BENCHMARK_NEUTRAL_PATTERNS = [
   /^\.github\/(?:ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)\//,
+  /^\.github\/scripts\/(?!(?:detect-pr-benchmark-scope|run-pr-benchmark|compare-pr-benchmark)\.mjs$)[^/]+\.mjs$/,
   /^\.github\/workflows\/(?!benchmark\.yml$)/,
   /^docs\//,
   /^examples\//,
+  /^scripts\/.*\.test\.ts$/,
   /^README\.md$/,
   /^CHANGELOG\.md$/,
   /^CHENGELOG\.md$/,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Performance
 
+- skip PR benchmarks for package-preview helper edits (#851)
 - skip package preview releases for neutral PR edits (#851)
 - skip PR benchmarks for test-only package edits (#851)
 

--- a/benchmarks/bundle-size/pr-benchmark-scope.test.ts
+++ b/benchmarks/bundle-size/pr-benchmark-scope.test.ts
@@ -45,6 +45,16 @@ describe("detect-pr-benchmark-scope", () => {
     expect(parseOutputs(result.stdout)).toEqual({ runtime: "false", bundle: "true" });
   });
 
+  it("skips package preview helper edits", () => {
+    const result = runScope([
+      ".github/scripts/detect-pr-preview-scope.mjs",
+      "scripts/pr-preview-scope.test.ts",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ runtime: "false", bundle: "false" });
+  });
+
   it("runs both gates for benchmark harness edits", () => {
     const result = runScope(["benchmarks/bundle-size/parse-benchmark.mjs"]);
 


### PR DESCRIPTION
## Summary

- classify non-benchmark GitHub helper scripts as benchmark-neutral
- skip PR benchmarks for preview-scope helper tests
- keep benchmark workflow and benchmark helper edits conservative

Refs #851

## Validation

- `vp test benchmarks/bundle-size/pr-benchmark-scope.test.ts scripts/pr-preview-scope.test.ts`
- `vp run check:ts`
- `vpr fmt:check`
- `node scripts/check-file-lines.ts`
- `git diff --check origin/main`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790298875&installation_model_id=422833&pr_number=979&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F979&signature=e330609bf2be8dd29ea2e0f45d04d1f48f1f8b2a77609e42dacb69069c621406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->