### PR TITLE
perf(ci): skip benchmark helper previews

### DIFF
--- a/.github/scripts/detect-pr-preview-scope.mjs
+++ b/.github/scripts/detect-pr-preview-scope.mjs
@@ -24,6 +24,7 @@ const TEST_ONLY_PATTERNS = [
 
 const PREVIEW_NEUTRAL_PATTERNS = [
   /^\.github\/(?:ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)\//,
+  /^\.github\/scripts\/(?:detect-pr-benchmark-scope|run-pr-benchmark|compare-pr-benchmark)\.mjs$/,
   /^\.github\/workflows\/(?!nightly\.yml$|publish\.yml$)/,
   /^benchmarks\//,
   /^docs\//,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Performance
 
+- skip package preview releases for benchmark-helper edits (#851)
 - skip PR benchmarks for package-preview helper edits (#851)
 - skip package preview releases for neutral PR edits (#851)
 - skip PR benchmarks for test-only package edits (#851)

--- a/scripts/pr-preview-scope.test.ts
+++ b/scripts/pr-preview-scope.test.ts
@@ -45,6 +45,16 @@ describe("detect-pr-preview-scope", () => {
     expect(parseOutputs(result.stdout)).toEqual({ preview: "true" });
   });
 
+  it("skips benchmark helper edits", () => {
+    const result = runScope([
+      ".github/scripts/detect-pr-benchmark-scope.mjs",
+      "benchmarks/bundle-size/pr-benchmark-scope.test.ts",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ preview: "false" });
+  });
+
   it("falls back to preview builds for unclassified paths", () => {
     const result = runScope(["tools/new-publish-surface/file.ts"]);
 


### PR DESCRIPTION
## Summary

- classify benchmark workflow helper edits as package-preview neutral
- keep publish workflow and preview-scope edits conservative
- add preview-scope coverage for benchmark helper changes

Refs #851

## Validation

- `vp test scripts/pr-preview-scope.test.ts benchmarks/bundle-size/pr-benchmark-scope.test.ts`
- `vp run check:ts`
- `vpr fmt:check`
- `node scripts/check-file-lines.ts`
- `git diff --check origin/main`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790299499&installation_model_id=422833&pr_number=980&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F980&signature=72aa7b1c883f385cd6f6f0384750cc0871e1a99ae10c3706f700f9a469070341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved change detection so benchmark-only updates don’t trigger unnecessary preview builds.

* **Bug Fixes**
  * Prevented package preview releases from being generated for benchmark helper changes.

* **Documentation**
  * Added a changelog entry describing the updated preview behavior.

* **Tests**
  * Added coverage confirming benchmark-related changes are excluded from preview builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->