### PR TITLE
perf(ci): avoid duplicate branch preview builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,7 @@ name: Nightly release
 on:
   push:
     branches:
-      - "**"
+      - main
     tags:
       - "!**"
   pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Performance
 
+- avoid duplicate branch preview builds on pull requests (#851)
 - skip package preview releases for benchmark-helper edits (#851)
 - skip PR benchmarks for package-preview helper edits (#851)
 - skip package preview releases for neutral PR edits (#851)


### PR DESCRIPTION
## Summary
- restrict Nightly release branch-push runs to main so pull requests do not also trigger branch-push preview work
- keep pull_request and workflow_dispatch coverage unchanged
- document the CI perf slice in the changelog

Refs #851.

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly.yml"); puts "nightly.yml ok"'
- git diff --check origin/main
- vpr fmt:check
- vp run check:file-lines

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790300084&installation_model_id=422833&pr_number=981&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F981&signature=6203aee5c4d509af034efcd49b73e669990be786c2dabfbb6b01afd51b9a967d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->