### PR TITLE
fix(code-play): preserve remote executor endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+- return Code Play TypeScript fallback diagnostics when tsgo is unavailable (#916)
+- preserve Code Play remote endpoints for hydrated Python runs (#916)
 - preserve attrs on inline links and transformed images (#935)
 - expand MDX parser and renderer edge-case coverage (#894)
 - snapshot framework MDX island outputs (#852)

--- a/npm/ox-content-code-play/src/hydrate.ts
+++ b/npm/ox-content-code-play/src/hydrate.ts
@@ -5,7 +5,7 @@ import { errorMessage, errorResult } from "./result";
 import { CODE_PLAY_STYLES } from "./styles";
 import { JS_SANDBOX_FLAGS } from "./javascript-sandbox";
 import { applyActionBusy, renderPlayUi } from "./ui";
-import type { PlayPayload, RunResult } from "./types";
+import type { LanguageEnable, LanguageEnableOptions, PlayPayload, RunResult } from "./types";
 import {
   renderDiagnosticsHtml,
   renderProvenanceHtml,
@@ -47,7 +47,7 @@ export function mountCodePlay(element: Element, options: { client?: CodePlayClie
   const client =
     options.client ??
     createCodePlay({
-      languages: { [payload.language]: true },
+      languages: { [payload.language]: languageEnableFromPayload(payload) },
       endpoints: payload.endpoints,
     });
   const source = element.innerHTML;
@@ -182,18 +182,30 @@ function readForm(form: HTMLFormElement): Record<string, unknown> {
 }
 
 function createCodePlayFromPayloads(root: ParentNode) {
-  const languages: Record<string, true> = {};
+  const languages: Record<string, LanguageEnable> = {};
   let endpoints;
   for (const element of queryWidgets(root)) {
     try {
       const payload = decodePayload(element.getAttribute("data-ox-code-play") ?? "");
-      languages[payload.language] = true;
+      languages[payload.language] = languageEnableFromPayload(payload);
       endpoints = payload.endpoints ?? endpoints;
     } catch {
       // Ignore malformed widgets so one bad payload cannot block the page.
     }
   }
   return createCodePlay({ languages, endpoints });
+}
+
+function languageEnableFromPayload(payload: PlayPayload): LanguageEnableOptions {
+  const enable: LanguageEnableOptions = {
+    execute: payload.capabilities.execute,
+    typecheck: payload.capabilities.typecheck,
+    config: payload.config,
+  };
+  if (payload.endpoint) {
+    enable.endpoint = payload.endpoint;
+  }
+  return enable;
 }
 
 function queryWidgets(root: ParentNode): HTMLElement[] {

--- a/npm/ox-content-code-play/src/payload-factory.ts
+++ b/npm/ox-content-code-play/src/payload-factory.ts
@@ -6,7 +6,7 @@ import type { LanguageDefinition, PlayPayload, PlaygroundEndpoints } from "./typ
 export function payloadFromFence(fence: PlayFence, options: ResolvedCodePlayOptions): PlayPayload {
   const definition = resolveLanguage(fence.language);
   const enabled = definition ? options.languages.get(definition.id) : undefined;
-  return {
+  const payload: PlayPayload = {
     language: definition?.id ?? fence.language,
     code: fence.code,
     capabilities: {
@@ -24,6 +24,10 @@ export function payloadFromFence(fence: PlayFence, options: ResolvedCodePlayOpti
     timeoutMs: options.timeoutMs,
     endpoints: options.endpoints,
   };
+  if (enabled?.endpoint) {
+    payload.endpoint = enabled.endpoint;
+  }
+  return payload;
 }
 
 /** TypeScript typecheck in the browser needs a reachable endpoint; hide the dead button otherwise. */

--- a/npm/ox-content-code-play/src/plugin.test.ts
+++ b/npm/ox-content-code-play/src/plugin.test.ts
@@ -37,6 +37,16 @@ describe("codePlay vite plugin", () => {
     expect(payload.endpoints?.typecheck).toBe("https://example.test/typecheck");
   });
 
+  it("embeds remote language endpoints for hydrated Python runs", () => {
+    const plugin = codePlay({
+      languages: { python: { endpoint: "https://exec.example/api/v2/piston" } },
+    });
+    resolveCommand(plugin, "build");
+    const payload = payloadFromTransform(plugin, "```python play\nprint(1)\n```\n");
+    expect(payload.endpoint).toBe("https://exec.example/api/v2/piston");
+    expect(payload.capabilities.execute).toBe(true);
+  });
+
   it("keeps the Vite typecheck proxy on the dev server", () => {
     const plugin = codePlay({ languages: { typescript: { execute: true, typecheck: true } } });
     resolveCommand(plugin, "serve");

--- a/npm/ox-content-code-play/src/styles.ts
+++ b/npm/ox-content-code-play/src/styles.ts
@@ -25,12 +25,42 @@ export const CODE_PLAY_STYLES = `
   border: 1px solid var(--octc-color-border, color-mix(in srgb, currentColor 20%, transparent));
   background: color-mix(in srgb, var(--octc-color-text, CanvasText) 8%, transparent);
   color: var(--octc-color-text, CanvasText);
-  border-radius: 999px;
+  border-radius: 8px;
   padding: 0.25rem 0.75rem;
   font: 600 0.75rem/1.4 ui-sans-serif, system-ui, sans-serif;
   cursor: pointer;
 }
 .ox-code-play__toolbar button:disabled { opacity: 0.55; cursor: progress; }
+.ox-code-play__runtime {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: center;
+  padding: 0.55rem 0.8rem;
+  border-bottom: 1px solid var(--octc-color-border, color-mix(in srgb, currentColor 10%, transparent));
+  background: color-mix(in srgb, var(--octc-color-text, CanvasText) 4%, transparent);
+}
+.ox-code-play__runtime-chip {
+  display: inline-grid;
+  gap: 0.1rem;
+  min-width: 7.5rem;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--octc-color-border, color-mix(in srgb, currentColor 14%, transparent));
+  border-radius: 8px;
+  background: var(--octc-color-bg, Canvas);
+}
+.ox-code-play__runtime-chip span {
+  font: 600 0.62rem/1.1 ui-sans-serif, system-ui, sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.62;
+}
+.ox-code-play__runtime-chip strong {
+  font: 650 0.78rem/1.2 ui-sans-serif, system-ui, sans-serif;
+}
+.ox-code-play__runtime-chip--ok strong { color: var(--octc-color-primary, var(--octc-accent, #4f46e5)); }
+.ox-code-play__runtime-chip--warn strong { color: var(--octc-warning, #b54708); }
+.ox-code-play__runtime-chip--muted strong { opacity: 0.72; }
 .ox-code-play .ox-code { margin: 0; }
 .ox-code-play__source pre { margin: 0; border: 0; border-radius: 0; }
 .ox-code-play__tabs {

--- a/npm/ox-content-code-play/src/types.ts
+++ b/npm/ox-content-code-play/src/types.ts
@@ -174,6 +174,8 @@ export interface PlayPayload {
   code: string;
   capabilities: LanguageCapabilities;
   config: Record<string, unknown>;
+  /** Per-language executor endpoint for remote language backends. */
+  endpoint?: string;
   viewers: ViewerFlags;
   ui: CodePlayPreset;
   timeoutMs: number;

--- a/npm/ox-content-code-play/src/typescript.ts
+++ b/npm/ox-content-code-play/src/typescript.ts
@@ -1,7 +1,6 @@
 import {
   currentJavaScriptRuntime,
   executeScriptWithRuntime,
-  executionRuntimeFromError,
   javascriptRuntimeProvenance,
 } from "./javascript";
 import { hasNodeVm } from "./runtime-host";
@@ -69,7 +68,6 @@ export async function typecheckTypeScript(request: AdapterRequest): Promise<Adap
     if (isAbortError(error) || request.signal?.aborted) {
       throw error;
     }
-    executedRuntime = executionRuntimeFromError(error) ?? executedRuntime;
     tracker.stop();
     const message = error instanceof Error ? error.message : String(error);
     return {

--- a/npm/ox-content-code-play/src/ui.ts
+++ b/npm/ox-content-code-play/src/ui.ts
@@ -1,6 +1,6 @@
 import { resolveLanguage } from "./catalog";
 import { escapeHtml } from "./escape";
-import type { CodePlayPreset, PlayPayload, RunResult } from "./types";
+import type { CodePlayPreset, LanguageDefinition, PlayPayload, RunResult } from "./types";
 import {
   renderConfigHtml,
   renderDiagnosticsHtml,
@@ -34,6 +34,7 @@ export function renderPlayUi(state: UiState): string {
     ${canTypecheck ? `<button type="button" data-ox-action="typecheck"${actionButtonAttrs("typecheck", Boolean(state.busy))}>Typecheck</button>` : ""}
     <button type="button" data-ox-action="cancel"${actionButtonAttrs("cancel", Boolean(state.busy))}>Cancel</button>
   </div>
+  ${renderRuntimeStrip(state.payload, definition)}
   <div class="ox-code-play__source"></div>
   ${tabs}
   ${viewers.stdio ? `<div class="ox-code-play__panel" data-panel="stdio">${renderDiagnosticsHtml(state.result)}${renderStdioHtml(state.result?.stdio ?? [])}</div>` : ""}
@@ -42,6 +43,62 @@ export function renderPlayUi(state: UiState): string {
   <div class="ox-code-play__panel" data-panel="provenance"${hidden(panel, "provenance", preset)}>${renderProvenanceHtml(state.result?.provenance)}</div>
   <div class="ox-code-play__panel" data-panel="timing"${hidden(panel, "timing", preset)}>${renderTimingHtml(state.result?.timing)}</div>
 </div>`;
+}
+
+function renderRuntimeStrip(
+  payload: PlayPayload,
+  definition: LanguageDefinition | undefined,
+): string {
+  const runtime = runtimeLabel(payload, definition);
+  const executor = executorLabel(payload, definition);
+  const checks = payload.capabilities.typecheck ? "Typecheck ready" : "Run only";
+  const chips = [
+    runtimeChip("Runtime", runtime.label, runtime.kind),
+    runtimeChip("Executor", executor.label, executor.kind),
+    runtimeChip("Checks", checks, payload.capabilities.typecheck ? "ok" : "muted"),
+  ].join("");
+  return `<div class="ox-code-play__runtime" aria-label="Code Play runtime">${chips}</div>`;
+}
+
+function runtimeLabel(
+  payload: PlayPayload,
+  definition: LanguageDefinition | undefined,
+): { label: string; kind: "ok" | "warn" | "muted" } {
+  switch (definition?.backend) {
+    case "javascript":
+      return { label: "Browser sandbox", kind: "ok" };
+    case "typescript":
+      return { label: "TypeScript sandbox", kind: "ok" };
+    case "framework":
+      return { label: `${definition.name} iframe preview`, kind: "ok" };
+    case "rust-playground":
+      return { label: "Rust Playground", kind: payload.endpoints?.rust ? "ok" : "warn" };
+    case "go-playground":
+      return { label: "Go Playground", kind: payload.endpoints?.go ? "ok" : "warn" };
+    case "remote":
+      return payload.endpoint
+        ? { label: "Piston-compatible", kind: "ok" }
+        : { label: "Endpoint missing", kind: "warn" };
+    default:
+      return { label: definition?.name ?? payload.language, kind: "muted" };
+  }
+}
+
+function executorLabel(
+  payload: PlayPayload,
+  definition: LanguageDefinition | undefined,
+): { label: string; kind: "ok" | "warn" | "muted" } {
+  if (!payload.capabilities.execute) {
+    return { label: "Disabled", kind: "warn" };
+  }
+  if (definition?.backend === "remote" && !payload.endpoint) {
+    return { label: "Configure endpoint", kind: "warn" };
+  }
+  return { label: "On demand", kind: "ok" };
+}
+
+function runtimeChip(label: string, value: string, kind: "ok" | "warn" | "muted"): string {
+  return `<span class="ox-code-play__runtime-chip ox-code-play__runtime-chip--${kind}"><span>${escapeHtml(label)}</span><strong>${escapeHtml(value)}</strong></span>`;
 }
 
 function renderTabs(state: UiState, panel: string): string {

--- a/npm/ox-content-code-play/src/viewers.test.ts
+++ b/npm/ox-content-code-play/src/viewers.test.ts
@@ -105,7 +105,21 @@ describe("stderr UI flags", () => {
     const html = renderPlayUi({ payload: payload() });
     expect(html).toContain('data-ox-panel="stderr"');
     expect(html).toContain('data-panel="stderr"');
+    expect(html).toContain("Browser sandbox");
+    expect(html).toContain("On demand");
     expect(html).toContain("No stderr.");
+  });
+
+  it("shows remote executor readiness from the payload", () => {
+    const missing = renderPlayUi({ payload: payload({ language: "python" }) });
+    expect(missing).toContain("Endpoint missing");
+    expect(missing).toContain("Configure endpoint");
+
+    const ready = renderPlayUi({
+      payload: payload({ language: "python", endpoint: "https://exec.example/api/v2/piston" }),
+    });
+    expect(ready).toContain("Piston-compatible");
+    expect(ready).toContain("On demand");
   });
 
   it("omits the stderr tab and panel when viewers.stderr is false", () => {


### PR DESCRIPTION
## Summary
- carry per-language remote executor endpoints into Code Play payloads so hydrated Python/Piston widgets keep their on-demand runner
- rebuild hydrated clients from payload execute/typecheck/config/endpoint settings instead of a bare language enable
- add a compact runtime strip that shows sandbox/provider readiness and remote endpoint state
- remove a stale TypeScript fallback runtime reference so missing tsgo returns the intended diagnostic

Refs #916.

## Verification
- corepack pnpm exec tsgo --noEmit (in npm/ox-content-code-play)
- vpr test (in npm/ox-content-code-play)
- vpr fmt:check
- git diff --check origin/main
- vp run check:file-lines
- vp run check:ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790301253&installation_model_id=422833&pr_number=982&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F982&signature=094f74953e0853547ea4126d829f747a4b1f7cebea1b01ffb56af0d0252f6107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime status information to Code Play, including executor availability and typechecking status.
  * Added support for remote execution endpoints in hydrated Python runs.
  * Improved runtime labels and warnings for unavailable or disabled executors.
  * Updated toolbar controls with refined rounded styling.

* **Bug Fixes**
  * TypeScript fallback diagnostics are now returned when `tsgo` is unavailable.
  * Remote Code Play endpoints are preserved during hydration.
  * Failed TypeScript runs now retain the selected runtime information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->