### PR TITLE
ci(rust): add nightly language-feature experiment lanes

### DIFF
--- a/.github/workflows/nightly-rust-experiments.yml
+++ b/.github/workflows/nightly-rust-experiments.yml
@@ -1,0 +1,113 @@
+name: Nightly Rust experiments
+
+# Opt-in rustc experiment lanes. This workflow is not a required check.
+# Stable CI (.github/workflows/ci.yml) remains the release gate.
+#
+# NIGHTLY_TOOLCHAIN is a dated pin so a red run is attributable to one
+# compiler. To bump it: change the env value below (keep the rust-toolchain
+# action comment in sync) and dispatch this workflow from the Actions tab.
+# Flag names are not hardcoded blindly — each lane probes `rustc -Z help`
+# and validates the preferred -Z value, then fails with rustc's
+# accepted-values list if the name moved.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Daily 07:00 UTC, after typical nightly toolchain publish.
+    - cron: "0 7 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  # Dated pin so failures are diagnosable. Bump this (and the matching
+  # rust-toolchain comment) when refreshing the experiment snapshot.
+  NIGHTLY_TOOLCHAIN: nightly-2026-08-25
+
+jobs:
+  experiment:
+    name: ${{ matrix.lane.name }}
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        lane:
+          # Polonius Alpha is the nightly default as of nightly-2026-08-06
+          # (`-Zpolonius=off` vs `-Zpolonius=next`). Pass `next` explicitly
+          # and log rustc + flags even when it is already the default.
+          - name: Polonius Alpha
+            id: polonius
+            flag: polonius
+            preferred: next
+          # Next-gen trait solver is the nightly default as of ~2026-08-21.
+          # `-Znext-solver=globally` is the current enable-everywhere value;
+          # disable is `-Znext-solver=coherence`. Probe before using it.
+          - name: Next-gen trait solver
+            id: next-solver
+            flag: next-solver
+            preferred: globally
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # nightly-2026-08-25
+        with:
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
+
+      - name: Mount sticky cache
+        uses: ./.github/actions/mount-sticky-cache
+        with:
+          key-prefix: ${{ github.repository }}-nightly-rust-experiments-${{ matrix.lane.id }}
+          cargo: "true"
+          target: target
+
+      - name: Record rustc and resolve experiment flags
+        env:
+          EXPERIMENT_FLAG: ${{ matrix.lane.flag }}
+          PREFERRED_VALUE: ${{ matrix.lane.preferred }}
+        run: |
+          set -euo pipefail
+
+          echo "=== pinned toolchain ==="
+          echo "NIGHTLY_TOOLCHAIN=${NIGHTLY_TOOLCHAIN}"
+          echo "EXPERIMENT_FLAG=${EXPERIMENT_FLAG}"
+          echo "PREFERRED_VALUE=${PREFERRED_VALUE}"
+
+          echo "=== rustc -vV ==="
+          rustc -vV
+
+          echo "=== rustc -Z help (experiment flags) ==="
+          help_out="$(rustc -Z help 2>&1)" || true
+          if ! printf '%s\n' "$help_out" | grep -E "[[:space:]]${EXPERIMENT_FLAG}(=|[[:space:]])"; then
+            echo "::error::rustc -Z help on ${NIGHTLY_TOOLCHAIN} does not list '${EXPERIMENT_FLAG}'."
+            echo "Bump NIGHTLY_TOOLCHAIN or update the experiment flag name. Full -Z help:"
+            printf '%s\n' "$help_out"
+            exit 1
+          fi
+
+          # rustc parses -Z even with -vV. An invalid value prints the accepted list.
+          echo "=== validating -Z${EXPERIMENT_FLAG}=${PREFERRED_VALUE} ==="
+          if ! rustc -Z "${EXPERIMENT_FLAG}=${PREFERRED_VALUE}" -vV \
+            >/tmp/rustc-flag.out 2>/tmp/rustc-flag.err; then
+            echo "::error::-Z${EXPERIMENT_FLAG}=${PREFERRED_VALUE} is not accepted on ${NIGHTLY_TOOLCHAIN}."
+            echo "Update the lane preferred value from rustc's accepted-values list:"
+            cat /tmp/rustc-flag.err
+            exit 1
+          fi
+
+          {
+            echo "RUSTFLAGS=-Z${EXPERIMENT_FLAG}=${PREFERRED_VALUE}"
+          } >> "$GITHUB_ENV"
+
+          echo "=== experiment flags ==="
+          echo "RUSTFLAGS=-Z${EXPERIMENT_FLAG}=${PREFERRED_VALUE}"
+
+      - name: cargo check --workspace --all-targets
+        run: cargo check --workspace --all-targets


### PR DESCRIPTION
## Summary

- Add an opt-in `Nightly Rust experiments` workflow with Polonius Alpha and next-gen trait solver lanes (`cargo check --workspace --all-targets` on pinned `nightly-2026-08-25`).
- Probe `rustc -Z help` (and rustc's accepted-values list) before applying `-Zpolonius=next` / `-Znext-solver=globally`, and log `rustc -vV` plus the exact flags.
- Leave stable CI (`.github/workflows/ci.yml`) as the required release gate. This workflow is schedule + `workflow_dispatch` only and is not a required check.

Closes #903

## How to run

- Actions → **Nightly Rust experiments** → **Run workflow**
- Or wait for the daily 07:00 UTC schedule
- To refresh the snapshot: bump `NIGHTLY_TOOLCHAIN` (and the matching rust-toolchain action comment) and dispatch again

## Risk

- Risk level: low
- User or production impact: none — CI-only, no publish, `contents: read` only, no secrets
- Rollback plan: revert the workflow file, or disable the workflow in the Actions tab

## Validation

- [x] Automated tests or checks run: YAML parse; `nightly-2026-08-25` channel exists on static.rust-lang.org
- [x] Manual verification completed: confirmed `nightly.yml` is untouched (NAPI preview-publish); this is a new file only
- [x] Edge cases or failure modes considered: unknown/renamed `-Z` flags fail the job with rustc's accepted-values list instead of a dead flag; `fail-fast: false` so one lane does not hide the other

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790312536&installation_model_id=422833&pr_number=983&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F983&signature=267b09a0b33d5dd3ee714f1ccbbddeb07946b6b4189765bada64c977913e74d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in nightly workflow for testing Rust workspace compatibility with experimental compiler features.
  * Runs automatically each day or can be started manually.
  * Tests Polonius and the next-generation trait solver in separate, non-blocking experiment lanes.
  * Validates compiler support and reports clear diagnostics when experimental options are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->