### PR TITLE
fix(redirects): skip HTML pages for host wildcard rules (#929)

### DIFF
--- a/crates/ox_content_ssg/src/redirects.rs
+++ b/crates/ox_content_ssg/src/redirects.rs
@@ -90,7 +90,8 @@ pub fn generate_redirects(options: &RedirectsOptions, pages: &[RedirectPage]) ->
     let netlify = options.netlify.then(|| netlify_body(&entries));
     let headers = options.headers.then(|| headers_body(&entries));
     let json = options.json.then(|| json_body(&entries));
-    RedirectsOutput { pages: entries, netlify, headers, json }
+    let pages = entries.into_iter().filter(|entry| !is_host_wildcard_source(&entry.from)).collect();
+    RedirectsOutput { pages, netlify, headers, json }
 }
 
 /// Static HTML redirect body. `dest` is escaped; callers still validate it.
@@ -158,6 +159,11 @@ fn is_http_url(value: &str) -> bool {
 
 fn has_unsafe_path_segments(value: &str) -> bool {
     value.contains('\\') || value.split('/').any(|segment| matches!(segment, "." | ".."))
+}
+
+/// `*` is host-rule syntax (Netlify / Cloudflare), not a URL segment.
+fn is_host_wildcard_source(from: &str) -> bool {
+    from.contains('*')
 }
 
 fn upsert(

--- a/crates/ox_content_ssg/src/redirects/tests.rs
+++ b/crates/ox_content_ssg/src/redirects/tests.rs
@@ -203,3 +203,44 @@ fn host_files_and_json_are_opt_in() {
     assert_eq!(output.headers.as_deref(), Some("/old\n  Location: /guide\n"));
     assert_eq!(output.json.as_deref(), Some(r#"[{"from":"/old","to":"/guide"}]"#));
 }
+
+#[test]
+fn wildcard_sources_stay_in_host_files_but_skip_html() {
+    let mut options =
+        enabled(&[("/talks*", "/works/talks"), ("/projects*", "/works"), ("/old", "/guide")]);
+    options.netlify = true;
+    options.headers = true;
+    options.json = true;
+    let output = generate_redirects(&options, &[]);
+
+    assert_eq!(output.pages.len(), 1, "{output:?}");
+    assert_eq!(output.pages[0].from, "/old");
+    assert_eq!(output.pages[0].to, "/guide");
+    assert!(output.pages.iter().all(|entry| !entry.from.contains('*')), "{output:?}");
+    assert_eq!(
+        output.netlify.as_deref(),
+        Some("/talks* /works/talks 301\n/projects* /works 301\n/old /guide 301\n")
+    );
+    assert_eq!(
+        output.headers.as_deref(),
+        Some(
+            "/talks*\n  Location: /works/talks\n/projects*\n  Location: /works\n/old\n  Location: /guide\n"
+        )
+    );
+    assert_eq!(
+        output.json.as_deref(),
+        Some(
+            r#"[{"from":"/talks*","to":"/works/talks"},{"from":"/projects*","to":"/works"},{"from":"/old","to":"/guide"}]"#
+        )
+    );
+}
+
+#[test]
+fn wildcard_only_map_emits_host_files_without_html_pages() {
+    let mut options = enabled(&[("/talks*", "/works/talks")]);
+    options.netlify = true;
+    let output = generate_redirects(&options, &[]);
+
+    assert!(output.pages.is_empty(), "{output:?}");
+    assert_eq!(output.netlify.as_deref(), Some("/talks* /works/talks 301\n"));
+}

--- a/docs/content/built-in/redirects.md
+++ b/docs/content/built-in/redirects.md
@@ -101,7 +101,27 @@ an explicit map entry overrides a page alias for the same old path.
 Set `netlify: true` to also write a `_redirects` file
 (`/old /guide 301`). Set `headers: true` to write `_headers` with a
 `Location` line per source. Set `json: true` to write `redirects.json`.
-The HTML pages are still written.
+Normal (non-wildcard) sources still get HTML fallback pages.
+
+Sources that contain `*` are host-rule syntax (Netlify, Cloudflare Pages),
+not a literal URL segment. They still appear in `_redirects`, `_headers`,
+and `redirects.json` when those flags are on, but the SSG does not write
+a static HTML file such as `talks*/index.html`.
+
+```ts
+oxContent({
+  redirects: {
+    map: {
+      "/talks*": "/works/talks",
+      "/old-guide": "/guide",
+    },
+    netlify: true,
+  },
+});
+```
+
+That map writes `/talks* /works/talks 301` to `_redirects` and an HTML
+page only for `/old-guide`.
 
 ## Drafts
 

--- a/docs/content/ja/built-in/redirects.md
+++ b/docs/content/ja/built-in/redirects.md
@@ -82,7 +82,23 @@ redirect: /retired
 
 ## ホスト用ファイル
 
-`netlify: true` で `_redirects` ファイル（`/old /guide 301`）も書き出します。`headers: true` でソースごとの `Location` 行を持つ `_headers` を書き出します。`json: true` で `redirects.json` を書き出します。HTML ページはいずれの場合も書き出します。
+`netlify: true` で `_redirects` ファイル（`/old /guide 301`）も書き出します。`headers: true` でソースごとの `Location` 行を持つ `_headers` を書き出します。`json: true` で `redirects.json` を書き出します。通常の（ワイルドカードでない）ソースには、これまでどおり HTML のフォールバックページも出します。
+
+ソースに `*` が含まれる場合、それは Netlify や Cloudflare Pages 向けのホスト規則の構文であり、リテラルな URL セグメントではありません。該当フラグがオンなら `_redirects`、`_headers`、`redirects.json` には残しますが、`talks*/index.html` のような静的 HTML ファイルは書き出しません。
+
+```ts
+oxContent({
+  redirects: {
+    map: {
+      "/talks*": "/works/talks",
+      "/old-guide": "/guide",
+    },
+    netlify: true,
+  },
+});
+```
+
+このマップは `_redirects` に `/talks* /works/talks 301` を書き、HTML ページは `/old-guide` だけ出します。
 
 ## 下書き
 

--- a/npm/vite-plugin-ox-content/src/redirects.test.ts
+++ b/npm/vite-plugin-ox-content/src/redirects.test.ts
@@ -196,6 +196,40 @@ describe("planRedirectFiles", () => {
 
     expect(plan.files).toEqual([]);
   });
+
+  it("keeps wildcard sources in host files but omits HTML pages", () => {
+    const plan = planRedirectFiles({
+      options: {
+        ...on,
+        map: {
+          "/talks*": "/works/talks",
+          "/projects*": "/works",
+          "/old": "/guide",
+        },
+        netlify: true,
+        headers: true,
+        json: true,
+      },
+      pages: [],
+    });
+
+    expect(plan.files).toHaveLength(1);
+    expect(plan.files[0]).toMatchObject({
+      from: "/old",
+      to: "/guide",
+      relativePath: "old/index.html",
+    });
+    expect(
+      plan.files.some((file) => file.from.includes("*") || file.relativePath.includes("*")),
+    ).toBe(false);
+    expect(plan.netlify).toBe("/talks* /works/talks 301\n/projects* /works 301\n/old /guide 301\n");
+    expect(plan.headers).toBe(
+      "/talks*\n  Location: /works/talks\n/projects*\n  Location: /works\n/old\n  Location: /guide\n",
+    );
+    expect(plan.json).toBe(
+      '[{"from":"/talks*","to":"/works/talks"},{"from":"/projects*","to":"/works"},{"from":"/old","to":"/guide"}]',
+    );
+  });
 });
 
 describe("writeRedirectFiles", () => {
@@ -270,5 +304,29 @@ describe("writeRedirectFiles", () => {
 
     expect(result.files).toEqual([]);
     await expect(fs.access(path.join(outDir, "old", "index.html"))).rejects.toThrow();
+  });
+
+  it("does not write literal HTML directories for wildcard sources", async () => {
+    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-redirects-wild-"));
+    tempDirs.push(outDir);
+
+    const result = await writeRedirectFiles({
+      outDir,
+      options: {
+        ...on,
+        map: { "/talks*": "/works/talks", "/old": "/guide" },
+        netlify: true,
+      },
+      pages: [],
+    });
+
+    expect(await fs.readFile(path.join(outDir, "_redirects"), "utf8")).toBe(
+      "/talks* /works/talks 301\n/old /guide 301\n",
+    );
+    expect(await fs.readFile(path.join(outDir, "old", "index.html"), "utf8")).toContain(
+      "url=/guide",
+    );
+    await expect(fs.access(path.join(outDir, "talks*", "index.html"))).rejects.toThrow();
+    expect(result.files.some((file) => file.includes("talks*"))).toBe(false);
   });
 });

--- a/npm/vite-plugin-ox-content/src/redirects.ts
+++ b/npm/vite-plugin-ox-content/src/redirects.ts
@@ -140,7 +140,8 @@ export function planRedirectFiles(input: RedirectPlanInput): RedirectPlan {
     return { files: [] };
   }
 
-  const plan: RedirectPlan = { files };
+  const htmlFiles = files.filter((file) => !isHostWildcardSource(file.from));
+  const plan: RedirectPlan = { files: htmlFiles };
   if (input.options.netlify) {
     plan.netlify = files.map((file) => `${file.from} ${file.to} 301`).join("\n") + "\n";
   }
@@ -283,6 +284,11 @@ function readStringList(value: unknown): string[] {
     return [];
   }
   return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+/** `*` is host-rule syntax (Netlify / Cloudflare), not a URL segment. */
+function isHostWildcardSource(from: string): boolean {
+  return from.includes("*");
 }
 
 function applyBase(dest: string, base: string | undefined): string {


### PR DESCRIPTION
## Summary

- Treat redirect sources that contain `*` as host-only rules so `_redirects` / `_headers` / `redirects.json` still include them.
- Do not emit a literal HTML fallback such as `talks*/index.html`; normal non-wildcard sources still get static HTML pages.
- Keep the Rust planner and the TypeScript `planRedirectFiles` / `writeRedirectFiles` path in sync.

Closes #929

## Risk

- Risk level: low
- User or production impact: sites that used `*` in a source as a literal path segment lose the unused HTML directory; host rewrite files are unchanged.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run:
  - `cargo test -p ox_content_ssg redirects` (17 passed)
  - `vp exec --filter @ox-content/vite-plugin -- vp test src/redirects.test.ts` (19 passed)
- [ ] Manual verification completed:
- [x] Edge cases or failure modes considered: wildcard-only maps still emit host files; mixed maps keep HTML for exact sources.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790312599&installation_model_id=422833&pr_number=984&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F984&signature=bbe6e3bba0ba41b9b3859718a462cdee3477c775d584e78d0eccc583b50375ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Wildcard redirect sources containing `*` are no longer generated as static HTML fallback pages.
  - Wildcard redirects remain available in Netlify, headers, and JSON redirect outputs.
  - Standard redirect sources continue to generate HTML fallback pages as expected.

- **Documentation**
  - Updated English and Japanese redirect documentation to clarify wildcard behavior and output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->