### PR TITLE
fix(svelte): keep core SSG plugins in oxContentSvelte (#927)

### DIFF
--- a/npm/vite-plugin-ox-content-svelte/src/index.test.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/index.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { Plugin } from "vite";
+import { oxContentSvelte } from "./index";
+
+describe("oxContentSvelte", () => {
+  it("keeps core SSG plugins while replacing the markdown transform", () => {
+    const names = pluginNames(
+      oxContentSvelte({
+        ssg: { siteUrl: "https://example.com" },
+        redirects: { map: { "/old": "/new" }, netlify: true },
+      }),
+    );
+
+    expect(names).toContain("ox-content:svelte-transform");
+    expect(names).toContain("ox-content:svelte-environment");
+    expect(names).toContain("ox-content:ssg");
+    expect(names).toContain("ox-content:collections");
+    expect(names).toContain("ox-content:search");
+    expect(names).toContain("ox-content:docs");
+    expect(names).not.toContain("ox-content");
+    expect(names).not.toContain("ox-content:environment");
+  });
+});
+
+function pluginNames(plugins: ReturnType<typeof oxContentSvelte>): string[] {
+  return (plugins as Plugin[]).map((plugin) => plugin.name);
+}

--- a/npm/vite-plugin-ox-content-svelte/src/index.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/index.ts
@@ -69,6 +69,10 @@ export type {
 /**
  * Creates the Ox Content Svelte integration plugin.
  *
+ * Forwards core options such as `ssg`, `redirects`, `feeds`, and `siteMaps`.
+ * The Svelte Markdown transform and environments replace the generic core
+ * transform/`markdown` environment; other build plugins are kept.
+ *
  * @example
  * ```ts
  * // vite.config.ts
@@ -196,17 +200,12 @@ export function oxContentSvelte(options: SvelteIntegrationOptions = {}): PluginO
     },
   };
 
-  const basePlugins = oxContent(options).flatMap((plugin) =>
-    Array.isArray(plugin) ? plugin : [plugin],
-  ) as Plugin[];
-  const environmentPlugin = basePlugins.find((plugin) => plugin.name === "ox-content:environment");
-  const plugins: Plugin[] = [svelteTransformPlugin, svelteEnvironmentPlugin, svelteHmrPlugin];
+  const replacedCorePluginNames = new Set(["ox-content", "ox-content:environment"]);
+  const corePlugins = (
+    oxContent(options).flatMap((plugin) => (Array.isArray(plugin) ? plugin : [plugin])) as Plugin[]
+  ).filter((plugin) => !replacedCorePluginNames.has(plugin.name));
 
-  if (environmentPlugin) {
-    plugins.push(environmentPlugin);
-  }
-
-  return plugins;
+  return [svelteTransformPlugin, svelteEnvironmentPlugin, svelteHmrPlugin, ...corePlugins];
 }
 
 function resolveSvelteOptions(


### PR DESCRIPTION
## Summary

- `oxContentSvelte()` now keeps core build plugins from `oxContent()` (`ox-content:ssg`, `ox-content:collections`, `ox-content:search`, `ox-content:docs`, plus optional katex/i18n/og-viewer).
- Only the generic Markdown transform (`ox-content`) and `ox-content:environment` are replaced by the Svelte transform and `oxcontent_ssr` / `oxcontent_client` environments.
- SSG, redirects, feeds, and sitemaps therefore run when configured on the Svelte adapter alone.

Closes #927

## Follow-up

`oxContentVue`, `oxContentReact`, and `oxContentSolid` still keep only `ox-content:environment` and drop the same core build plugins. This PR is Svelte-only; those adapters need the same filter.

## Risk

- Risk level: low
- User or production impact: Svelte sites that already called both `oxContent()` and `oxContentSvelte()` will now get duplicate SSG/collections/search plugins. The documented adapter-only path starts emitting HTML / `_redirects` / feeds / sitemaps as intended.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run:
  - `vp test src/index.test.ts` in `npm/vite-plugin-ox-content-svelte` (1 passed)
  - `vp test src` in `npm/vite-plugin-ox-content-svelte` (15 passed)
- [ ] Manual verification completed:
- [x] Edge cases or failure modes considered: plugin-name filter keeps optional katex/i18n/og-viewer when `oxContent()` adds them; no Vite build fixture (none exists in this package).

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790312628&installation_model_id=422833&pr_number=985&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F985&signature=406fac30940c318ad1ff3e87d970a0766e5b4f49fb4f09fb9407b6e091027e57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->