### PR TITLE
feat(api): render Markdown from OxContentOptions (#877)

### DIFF
--- a/docs/content/ja/packages/vite-plugin-ox-content.md
+++ b/docs/content/ja/packages/vite-plugin-ox-content.md
@@ -135,6 +135,29 @@ oxContent({
 });
 ```
 
+Vite 経由で Markdown を import しない独自ホストでも、公開 `OxContentOptions`
+から同じパイプラインを実行し、構造化された `TransformResult` を受け取れます。
+プラグインの `transform` フックをキャストしたり、生成モジュールの
+`export const html = ...` をパースしたりする必要はありません。
+
+```ts
+import { renderMarkdown } from "@ox-content/vite-plugin";
+
+const result = await renderMarkdown("# Hi", "/virtual/article.md", {
+  ssg: false,
+  highlight: false,
+});
+
+result.html;
+result.frontmatter;
+result.toc;
+```
+
+`.md` / `.mdx` の判定は Vite プラグインと同じ (`resolveMdxForFilePath`) で、
+組み込みオプションの既定値も `oxContent()` と一致します。複数ドキュメントで
+オプション解決を一度だけにしたいときは `createMarkdownProcessor(options)` を
+使い、`processor.render(source, filePath)` を呼んでください。
+
 ### gfm
 
 - 型: `boolean`

--- a/docs/content/packages/vite-plugin-ox-content.md
+++ b/docs/content/packages/vite-plugin-ox-content.md
@@ -132,6 +132,29 @@ oxContent({
 });
 ```
 
+Custom hosts that never import Markdown through Vite can run the same pipeline
+from public `OxContentOptions` and receive a structured `TransformResult`.
+You do not need to cast the plugin `transform` hook or parse
+`export const html = ...` from generated module source.
+
+```ts
+import { renderMarkdown } from "@ox-content/vite-plugin";
+
+const result = await renderMarkdown("# Hi", "/virtual/article.md", {
+  ssg: false,
+  highlight: false,
+});
+
+result.html;
+result.frontmatter;
+result.toc;
+```
+
+`.md` / `.mdx` inference matches the Vite plugin (`resolveMdxForFilePath`),
+and built-in option defaults match `oxContent()`. To resolve options once
+for many documents, use `createMarkdownProcessor(options)` and call
+`processor.render(source, filePath)`.
+
 ### gfm
 
 - Type: `boolean`

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -10,27 +10,13 @@ import type { Plugin, ViteDevServer, ResolvedConfig } from "vite";
 import "./virtual";
 import { createMarkdownEnvironment } from "./environment";
 import { transformMarkdown } from "./transform";
-import { extractDocs, generateMarkdown, writeDocs, resolveDocsOptions } from "./docs";
-import { buildSsg, resolveSsgOptions } from "./ssg";
-import { resolveSiteMapsOptions } from "./site-maps";
-import { resolvePublishStateOptions } from "./publish-state";
-import { resolveCascadeOptions, resolvePermalinksOptions } from "./permalinks";
-import { resolveRedirectsOptions } from "./redirects";
+import { extractDocs, generateMarkdown, writeDocs } from "./docs";
+import { buildSsg } from "./ssg";
 import { notFoundSearchExcludeIds } from "./not-found";
-import { resolveFeedsOptions } from "./feeds";
-import { BlogFeedError, resolveBlogOptions } from "./blog";
-import { resolvePwaOptions } from "./pwa";
-import { resolveTaxonomiesOptions } from "./taxonomies";
-import { resolveVersionsOptions } from "./versions";
-import { PageResourceError, resolveResourcesOptions } from "./resources";
+import { BlogFeedError } from "./blog";
+import { PageResourceError } from "./resources";
 import { createKatexAssetsPlugin } from "./plugins/math-assets";
-import {
-  resolveSearchOptions,
-  buildSearchIndex,
-  writeSearchIndex,
-  generateSearchModule,
-} from "./search";
-import { resolveOgImageOptions } from "./og-image";
+import { buildSearchIndex, writeSearchIndex, generateSearchModule } from "./search";
 import {
   createDevServerMiddleware,
   createDevServerCache,
@@ -38,19 +24,11 @@ import {
   invalidatePageCache,
 } from "./dev-server";
 import { createOgViewerPlugin } from "./og-viewer";
-import { resolveI18nOptions, createI18nPlugin } from "./i18n";
-import { isMarkdownFilePath, normalizeMarkdownExtensions } from "./markdown";
-import { resolveImageOptions } from "./resolve-image-options";
-import { generateCollectionsVirtualModule, resolveCollectionsOptions } from "./collections";
-import type { BuiltinPmOptions, OxContentOptions, ResolvedOptions } from "./types";
-import { resolveCardOptions } from "./card-options";
-import { resolveFileTreeOptions } from "./file-tree-options";
-import { resolveHeadingPermalinksOptions } from "./heading-permalinks-options";
-import { resolveMagicLinkOptions } from "./magic-link-options";
-import { resolveTypedHoverOptions } from "./typed-hover";
-import { resolveIncludeOptions } from "./include-options";
-import { resolveStepsOptions } from "./step-options";
-import type { TwitterEmbedOptions } from "./plugins";
+import { createI18nPlugin } from "./i18n";
+import { isMarkdownFilePath } from "./markdown";
+import { generateCollectionsVirtualModule } from "./collections";
+import type { OxContentOptions, ResolvedOptions } from "./types";
+import { resolveOptions } from "./resolve-options";
 
 export type { OxContentOptions } from "./types";
 export type { TwitterEmbedOptions } from "./plugins";
@@ -647,304 +625,17 @@ function createSearchPlugin(resolvedOptions: ResolvedOptions, getRoot: () => str
   };
 }
 
-/**
- * Resolves plugin options with defaults.
- */
-function resolveOptions(options: OxContentOptions): ResolvedOptions {
-  return {
-    srcDir: options.srcDir ?? "content",
-    outDir: options.outDir ?? "dist",
-    base: options.base ?? "/",
-    extensions: normalizeMarkdownExtensions(options.extensions),
-    ssg: resolveSsgOptions(options.ssg),
-    siteMaps: resolveSiteMapsOptions(options.siteMaps),
-    publishState: resolvePublishStateOptions(options.publishState),
-    permalinks: resolvePermalinksOptions(options.permalinks),
-    cascade: resolveCascadeOptions(options.cascade),
-    redirects: resolveRedirectsOptions(options.redirects),
-    blog: resolveBlogOptions(
-      options.blog ??
-        (typeof options.ssg === "object" && options.ssg ? options.ssg.blog : undefined),
-    ),
-    feeds: resolveFeedsOptions(options.feeds),
-    pwa: resolvePwaOptions(options.pwa),
-    taxonomies: resolveTaxonomiesOptions(options.taxonomies),
-    versions: resolveVersionsOptions(options.versions),
-    resources: resolveResourcesOptions(options.resources),
-    gfm: options.gfm ?? true,
-    mdx: options.mdx,
-    footnotes: options.footnotes ?? true,
-    semanticFootnotes: options.semanticFootnotes ?? false,
-    tables: options.tables ?? true,
-    taskLists: options.taskLists ?? true,
-    strikethrough: options.strikethrough ?? true,
-    autolinks: options.autolinks ?? options.gfm ?? true,
-    highlight: options.highlight ?? false,
-    codeAnnotations: resolveCodeAnnotationsOptions(options.codeAnnotations),
-    wikiLinks: resolveWikiLinkOptions(options.wikiLinks, options.base ?? "/"),
-    emojiShortcodes: resolveEmojiShortcodeOptions(options.emojiShortcodes),
-    attrs: resolveAttrsOptions(options.attrs),
-    badges: resolveBadgeOptions(options.badges),
-    magicLinks: resolveMagicLinkOptions(options.magicLinks),
-    containers: resolveContainerOptions(options.containers),
-    images: resolveImageOptions(options.images),
-    codeImports: resolveCodeImportOptions(options.codeImports),
-    includes: resolveIncludeOptions(options.includes),
-    cards: resolveCardOptions(options.cards),
-    steps: resolveStepsOptions(options.steps),
-    fileTree: resolveFileTreeOptions(options.fileTree),
-    sanitize: resolveSanitizeOptions(options.sanitize),
-    editThisPage: resolveEditThisPageOptions(options.editThisPage),
-    cjkEmphasis: options.cjkEmphasis ?? false,
-    codeBlockLint: resolveCodeBlockLintOptions(options.codeBlockLint),
-    codeBlockTypecheck: resolveCodeBlockTypecheckOptions(options.codeBlockTypecheck),
-    typedHover: resolveTypedHoverOptions(options.typedHover),
-    docsTests: resolveDocsTestOptions(options.docsTests),
-    mermaid: options.mermaid ?? false,
-    math: resolveMathOptions(options.math),
-    frontmatter: options.frontmatter ?? true,
-    toc: options.toc ?? true,
-    tocMaxDepth: options.tocMaxDepth ?? 3,
-    headingPermalinks: resolveHeadingPermalinksOptions(options.headingPermalinks),
-    ogImage: options.ogImage ?? false,
-    ogImageOptions: resolveOgImageOptions(options.ogImageOptions),
-    transformers: options.transformers ?? [],
-    docs: resolveDocsOptions(options.docs),
-    search: resolveSearchOptions(options.search),
-    collections: resolveCollectionsOptions(options.collections),
-    ogViewer: options.ogViewer ?? true,
-    embeds: resolveBuiltinEmbedOptions(options.embeds),
-    i18n: resolveI18nOptions(options.i18n),
-  };
-}
-
-export function resolveBuiltinEmbedOptions(
-  options: OxContentOptions["embeds"],
-): ResolvedOptions["embeds"] {
-  if (options === false) {
-    return {
-      github: false,
-      openGraph: false,
-      pm: false,
-      spotify: false,
-      stackBlitz: false,
-      twitter: false,
-      bluesky: false,
-      webContainer: false,
-    };
-  }
-
-  return {
-    github: resolveSingleEmbedOptions(options?.github),
-    openGraph: resolveSingleEmbedOptions(options?.openGraph),
-    pm: resolvePmOptions(options?.pm),
-    spotify: options?.spotify === true,
-    stackBlitz: options?.stackBlitz === true,
-    twitter: resolveTwitterEmbedOptions(options?.twitter),
-    bluesky: options?.bluesky === true,
-    webContainer: options?.webContainer === true,
-  };
-}
-
-function resolveSingleEmbedOptions<T extends object>(options: boolean | T | undefined): T | false {
-  if (options === false) return false;
-  if (options === true || options === undefined) return {} as T;
-  return options;
-}
-
-function resolveTwitterEmbedOptions(
-  options: boolean | TwitterEmbedOptions | undefined,
-): TwitterEmbedOptions | false {
-  if (options === false || options === undefined) return false;
-  if (options === true) return {};
-  return options;
-}
-
-function resolvePmOptions(
-  options: boolean | BuiltinPmOptions | undefined,
-): BuiltinPmOptions | false {
-  if (options === false || options === undefined) return false;
-  if (options === true) return {};
-  return options;
-}
-
-function resolveWikiLinkOptions(
-  options: OxContentOptions["wikiLinks"],
-  baseUrl: string,
-): ResolvedOptions["wikiLinks"] {
-  if (!options) return { enabled: false, baseUrl };
-  if (options === true) return { enabled: true, baseUrl };
-  return { enabled: true, baseUrl: options.baseUrl ?? baseUrl };
-}
-
-function resolveEmojiShortcodeOptions(
-  options: OxContentOptions["emojiShortcodes"],
-): ResolvedOptions["emojiShortcodes"] {
-  if (!options) return { enabled: false, custom: {} };
-  if (options === true) return { enabled: true, custom: {} };
-  return { enabled: true, custom: options.custom ?? {} };
-}
-
-export function resolveMathOptions(options: OxContentOptions["math"]): ResolvedOptions["math"] {
-  if (!options) return { enabled: false };
-  if (options === true) return { enabled: true };
-  return { enabled: options.enabled ?? true };
-}
-
-function resolveAttrsOptions(options: OxContentOptions["attrs"]): ResolvedOptions["attrs"] {
-  if (!options) return { enabled: false };
-  if (options === true) return { enabled: true };
-  return { enabled: options.enabled ?? true };
-}
-
-export function resolveBadgeOptions(
-  options: OxContentOptions["badges"],
-): ResolvedOptions["badges"] {
-  if (!options) return { enabled: false };
-  if (options === true) return { enabled: true };
-  return { enabled: options.enabled ?? true };
-}
-
-function resolveContainerOptions(
-  options: OxContentOptions["containers"],
-): ResolvedOptions["containers"] {
-  if (!options) return { enabled: false, types: {} };
-  if (options === true) return { enabled: true, types: {} };
-  return { enabled: options.enabled ?? true, types: options.types ?? {} };
-}
-
-function resolveCodeImportOptions(
-  options: OxContentOptions["codeImports"],
-): ResolvedOptions["codeImports"] {
-  if (!options) return { enabled: false };
-  if (options === true) return { enabled: true };
-  return { enabled: true, rootDir: options.rootDir };
-}
-
+export {
+  resolveBadgeOptions,
+  resolveBuiltinEmbedOptions,
+  resolveMathOptions,
+} from "./resolve-options";
 export { resolveCardOptions } from "./card-options";
 export { resolveIncludeOptions } from "./include-options";
 export { resolveStepsOptions } from "./step-options";
 export { resolveFileTreeOptions } from "./file-tree-options";
 export { resolveHeadingPermalinksOptions } from "./heading-permalinks-options";
 export { resolveTypedHoverOptions } from "./typed-hover";
-
-function resolveSanitizeOptions(
-  options: OxContentOptions["sanitize"],
-): ResolvedOptions["sanitize"] {
-  if (!options) return { enabled: false };
-  if (options === true) return { enabled: true };
-  return {
-    enabled: true,
-    allowedTags: options.allowedTags,
-    allowedAttributes: options.allowedAttributes,
-    allowedUrlSchemes: options.allowedUrlSchemes,
-  };
-}
-
-function resolveEditThisPageOptions(
-  options: OxContentOptions["editThisPage"],
-): ResolvedOptions["editThisPage"] {
-  if (!options) return { enabled: false, branch: "main", label: "Edit this page" };
-  if (options === true) return { enabled: false, branch: "main", label: "Edit this page" };
-  return {
-    enabled: Boolean(options.repoUrl),
-    repoUrl: options.repoUrl,
-    branch: options.branch ?? "main",
-    rootDir: options.rootDir,
-    label: options.label ?? "Edit this page",
-  };
-}
-
-function resolveCodeBlockLintOptions(
-  options: OxContentOptions["codeBlockLint"],
-): ResolvedOptions["codeBlockLint"] {
-  if (!options) {
-    return { enabled: false, requireLanguage: false, trailingSpaces: true, mode: "warn" };
-  }
-  if (options === true) {
-    return { enabled: true, requireLanguage: false, trailingSpaces: true, mode: "warn" };
-  }
-  return {
-    enabled: true,
-    languages: options.languages,
-    requireLanguage: options.requireLanguage ?? false,
-    trailingSpaces: options.trailingSpaces ?? true,
-    mode: options.mode ?? "warn",
-  };
-}
-
-function resolveCodeBlockTypecheckOptions(
-  options: OxContentOptions["codeBlockTypecheck"],
-): ResolvedOptions["codeBlockTypecheck"] {
-  if (!options) {
-    return {
-      enabled: false,
-      languages: ["ts", "tsx"],
-      requireMeta: true,
-      tsgoCommand: "tsgo",
-      mode: "warn",
-    };
-  }
-  if (options === true) {
-    return {
-      enabled: true,
-      languages: ["ts", "tsx"],
-      requireMeta: true,
-      tsgoCommand: "tsgo",
-      mode: "warn",
-    };
-  }
-  return {
-    enabled: true,
-    languages: options.languages ?? ["ts", "tsx"],
-    requireMeta: options.requireMeta ?? true,
-    tsgoCommand: options.tsgoCommand ?? "tsgo",
-    mode: options.mode ?? "warn",
-  };
-}
-
-function resolveDocsTestOptions(
-  options: OxContentOptions["docsTests"],
-): ResolvedOptions["docsTests"] {
-  if (!options) return { enabled: false, languages: ["js", "jsx", "ts", "tsx"], requireMeta: true };
-  if (options === true) {
-    return { enabled: true, languages: ["js", "jsx", "ts", "tsx"], requireMeta: true };
-  }
-  return {
-    enabled: true,
-    languages: options.languages ?? ["js", "jsx", "ts", "tsx"],
-    requireMeta: options.requireMeta ?? true,
-  };
-}
-
-function resolveCodeAnnotationsOptions(
-  options: OxContentOptions["codeAnnotations"],
-): ResolvedOptions["codeAnnotations"] {
-  if (!options) {
-    return {
-      enabled: false,
-      notation: "attribute",
-      metaKey: "annotate",
-      defaultLineNumbers: false,
-    };
-  }
-
-  if (options === true) {
-    return {
-      enabled: true,
-      notation: "attribute",
-      metaKey: "annotate",
-      defaultLineNumbers: false,
-    };
-  }
-
-  return {
-    enabled: true,
-    notation: options.notation ?? "attribute",
-    metaKey: options.metaKey ?? "annotate",
-    defaultLineNumbers: options.defaultLineNumbers ?? false,
-  };
-}
 
 /**
  * Generates virtual module content.
@@ -1020,6 +711,8 @@ export {
   type MarkdownChunkSource,
 } from "./incremental";
 export { transformMarkdown } from "./transform";
+export { createMarkdownProcessor, renderMarkdown } from "./render-markdown";
+export type { MarkdownProcessor } from "./render-markdown";
 export { isMdxFilePath, resolveMdxForFilePath } from "./markdown";
 export {
   collectMdxIslandNamesFromHtml,

--- a/npm/vite-plugin-ox-content/src/public-exports.test.ts
+++ b/npm/vite-plugin-ox-content/src/public-exports.test.ts
@@ -24,6 +24,8 @@ describe("public export surface", () => {
       "generateMarkdown",
       "isMarkdownFilePath",
       "oxContent",
+      "createMarkdownProcessor",
+      "renderMarkdown",
       "resolveCollectionsOptions",
       "renderHtmlToReactCreateElement",
       "renderHtmlToVueH",

--- a/npm/vite-plugin-ox-content/src/render-markdown.test.ts
+++ b/npm/vite-plugin-ox-content/src/render-markdown.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vite-plus/test";
+import { renderMarkdown } from "./index";
+import { createMarkdownProcessor, renderMarkdown as renderMarkdownDirect } from "./render-markdown";
+import { resolveOptions } from "./resolve-options";
+import { transformMarkdown } from "./transform";
+
+const publicOptions = { ssg: false as const, highlight: false };
+
+describe("renderMarkdown", () => {
+  it("returns structured TransformResult from public OxContentOptions", async () => {
+    const result = await renderMarkdown("# Hi", "/virtual/article.md", publicOptions);
+
+    expect(result.html).toContain('<h1 id="hi">Hi</h1>');
+    expect(result.frontmatter).toEqual({});
+    expect(result.toc).toEqual([{ depth: 1, text: "Hi", slug: "hi", children: [] }]);
+    expect(result.imports).toEqual([]);
+    expect(result.exports).toEqual([]);
+    expect(result.components).toEqual([]);
+    expect(result.html).not.toMatch(/export const html = /);
+  });
+
+  it("parses frontmatter without reading generated module source", async () => {
+    const result = await renderMarkdown(
+      "---\ntitle: Guide\n---\n# Intro\n",
+      "/virtual/article.md",
+      publicOptions,
+    );
+
+    expect(result.frontmatter).toEqual({ title: "Guide" });
+    expect(result.html).toContain('<h1 id="intro">Intro</h1>');
+    expect(result.toc[0]?.text).toBe("Intro");
+  });
+
+  it("infers MDX from the file path the same way as the Vite plugin", async () => {
+    const source = "import Card from './Card'\n\n<Card>Visible copy</Card>\n";
+    const inferred = await renderMarkdown(source, "docs/Guide.MDX?raw", publicOptions);
+    const markdown = await renderMarkdown(source, "/virtual/article.md", publicOptions);
+    const optedOut = await renderMarkdown(source, "docs/guide.mdx", {
+      ...publicOptions,
+      mdx: false,
+    });
+    const optedIn = await renderMarkdown(source, "docs/guide.md", { ...publicOptions, mdx: true });
+
+    expect(inferred.html).toContain('data-ox-island="Card"');
+    expect(inferred.html).not.toContain("import Card");
+    expect(markdown.html).toContain("import Card");
+    expect(markdown.html).not.toContain('data-ox-island="Card"');
+    expect(optedOut.html).toContain("import Card");
+    expect(optedIn.html).toContain('data-ox-island="Card"');
+  });
+
+  it("matches oxContent / resolveOptions built-in defaults", async () => {
+    const source = "# Hi\n\nhttps://example.com\n";
+    const resolved = resolveOptions({});
+    const viaPublicApi = await renderMarkdownDirect(source, "/virtual/article.md");
+    const viaResolved = await transformMarkdown(source, "/virtual/article.md", resolved);
+
+    expect(resolved.gfm).toBe(true);
+    expect(resolved.highlight).toBe(false);
+    expect(resolved.frontmatter).toBe(true);
+    expect(resolved.toc).toBe(true);
+    expect(resolved.tocMaxDepth).toBe(3);
+    expect(viaPublicApi.html).toBe(viaResolved.html);
+    expect(viaPublicApi.toc).toEqual(viaResolved.toc);
+    expect(viaPublicApi.frontmatter).toEqual(viaResolved.frontmatter);
+    expect(viaPublicApi.html).toContain('href="https://example.com"');
+  });
+
+  it("reuses resolved options across documents with createMarkdownProcessor", async () => {
+    const processor = createMarkdownProcessor(publicOptions);
+    const first = await processor.render("# Alpha", "/virtual/a.md");
+    const second = await processor.render("# Beta", "/virtual/b.mdx");
+
+    expect(first.html).toContain('<h1 id="alpha">Alpha</h1>');
+    expect(second.html).toContain('<h1 id="beta">Beta</h1>');
+  });
+});

--- a/npm/vite-plugin-ox-content/src/render-markdown.ts
+++ b/npm/vite-plugin-ox-content/src/render-markdown.ts
@@ -1,0 +1,43 @@
+/**
+ * Programmatic Markdown/MDX pipeline for hosts that do not import files through Vite.
+ */
+
+import { resolveOptions } from "./resolve-options";
+import { transformMarkdown } from "./transform";
+import type { OxContentOptions, TransformResult } from "./types";
+
+export type { TransformResult };
+
+/**
+ * Processor that resolves `OxContentOptions` once and renders many documents.
+ */
+export interface MarkdownProcessor {
+  render(source: string, filePath: string): Promise<TransformResult>;
+}
+
+/**
+ * Resolves public options once so custom `ssg: false` hosts can reuse the pipeline.
+ */
+export function createMarkdownProcessor(options: OxContentOptions = {}): MarkdownProcessor {
+  const resolved = resolveOptions(options);
+  return {
+    render(source, filePath) {
+      return transformMarkdown(source, filePath, resolved);
+    },
+  };
+}
+
+/**
+ * Run the Vite plugin Markdown/MDX pipeline from public `OxContentOptions`.
+ *
+ * Returns structured `TransformResult` fields (`html`, `frontmatter`, `toc`,
+ * MDX metadata) so consumers do not need to cast a Vite hook or parse
+ * generated module source. `.md` / `.mdx` inference matches `oxContent()`.
+ */
+export function renderMarkdown(
+  source: string,
+  filePath: string,
+  options: OxContentOptions = {},
+): Promise<TransformResult> {
+  return createMarkdownProcessor(options).render(source, filePath);
+}

--- a/npm/vite-plugin-ox-content/src/resolve-options.ts
+++ b/npm/vite-plugin-ox-content/src/resolve-options.ts
@@ -1,0 +1,319 @@
+import { resolveBlogOptions } from "./blog";
+import { resolveCardOptions } from "./card-options";
+import { resolveCollectionsOptions } from "./collections";
+import { resolveDocsOptions } from "./docs";
+import { resolveFeedsOptions } from "./feeds";
+import { resolveFileTreeOptions } from "./file-tree-options";
+import { resolveHeadingPermalinksOptions } from "./heading-permalinks-options";
+import { resolveI18nOptions } from "./i18n";
+import { resolveIncludeOptions } from "./include-options";
+import { resolveMagicLinkOptions } from "./magic-link-options";
+import { normalizeMarkdownExtensions } from "./markdown";
+import { resolveOgImageOptions } from "./og-image";
+import { resolveCascadeOptions, resolvePermalinksOptions } from "./permalinks";
+import type { TwitterEmbedOptions } from "./plugins";
+import { resolvePublishStateOptions } from "./publish-state";
+import { resolvePwaOptions } from "./pwa";
+import { resolveRedirectsOptions } from "./redirects";
+import { resolveImageOptions } from "./resolve-image-options";
+import { resolveResourcesOptions } from "./resources";
+import { resolveSearchOptions } from "./search";
+import { resolveSiteMapsOptions } from "./site-maps";
+import { resolveSsgOptions } from "./ssg";
+import { resolveStepsOptions } from "./step-options";
+import { resolveTaxonomiesOptions } from "./taxonomies";
+import { resolveTypedHoverOptions } from "./typed-hover";
+import type { BuiltinPmOptions, OxContentOptions, ResolvedOptions } from "./types";
+import { resolveVersionsOptions } from "./versions";
+
+/**
+ * Resolves plugin options with defaults.
+ */
+export function resolveOptions(options: OxContentOptions): ResolvedOptions {
+  return {
+    srcDir: options.srcDir ?? "content",
+    outDir: options.outDir ?? "dist",
+    base: options.base ?? "/",
+    extensions: normalizeMarkdownExtensions(options.extensions),
+    ssg: resolveSsgOptions(options.ssg),
+    siteMaps: resolveSiteMapsOptions(options.siteMaps),
+    publishState: resolvePublishStateOptions(options.publishState),
+    permalinks: resolvePermalinksOptions(options.permalinks),
+    cascade: resolveCascadeOptions(options.cascade),
+    redirects: resolveRedirectsOptions(options.redirects),
+    blog: resolveBlogOptions(
+      options.blog ??
+        (typeof options.ssg === "object" && options.ssg ? options.ssg.blog : undefined),
+    ),
+    feeds: resolveFeedsOptions(options.feeds),
+    pwa: resolvePwaOptions(options.pwa),
+    taxonomies: resolveTaxonomiesOptions(options.taxonomies),
+    versions: resolveVersionsOptions(options.versions),
+    resources: resolveResourcesOptions(options.resources),
+    gfm: options.gfm ?? true,
+    mdx: options.mdx,
+    footnotes: options.footnotes ?? true,
+    semanticFootnotes: options.semanticFootnotes ?? false,
+    tables: options.tables ?? true,
+    taskLists: options.taskLists ?? true,
+    strikethrough: options.strikethrough ?? true,
+    autolinks: options.autolinks ?? options.gfm ?? true,
+    highlight: options.highlight ?? false,
+    codeAnnotations: resolveCodeAnnotationsOptions(options.codeAnnotations),
+    wikiLinks: resolveWikiLinkOptions(options.wikiLinks, options.base ?? "/"),
+    emojiShortcodes: resolveEmojiShortcodeOptions(options.emojiShortcodes),
+    attrs: resolveAttrsOptions(options.attrs),
+    badges: resolveBadgeOptions(options.badges),
+    magicLinks: resolveMagicLinkOptions(options.magicLinks),
+    containers: resolveContainerOptions(options.containers),
+    images: resolveImageOptions(options.images),
+    codeImports: resolveCodeImportOptions(options.codeImports),
+    includes: resolveIncludeOptions(options.includes),
+    cards: resolveCardOptions(options.cards),
+    steps: resolveStepsOptions(options.steps),
+    fileTree: resolveFileTreeOptions(options.fileTree),
+    sanitize: resolveSanitizeOptions(options.sanitize),
+    editThisPage: resolveEditThisPageOptions(options.editThisPage),
+    cjkEmphasis: options.cjkEmphasis ?? false,
+    codeBlockLint: resolveCodeBlockLintOptions(options.codeBlockLint),
+    codeBlockTypecheck: resolveCodeBlockTypecheckOptions(options.codeBlockTypecheck),
+    typedHover: resolveTypedHoverOptions(options.typedHover),
+    docsTests: resolveDocsTestOptions(options.docsTests),
+    mermaid: options.mermaid ?? false,
+    math: resolveMathOptions(options.math),
+    frontmatter: options.frontmatter ?? true,
+    toc: options.toc ?? true,
+    tocMaxDepth: options.tocMaxDepth ?? 3,
+    headingPermalinks: resolveHeadingPermalinksOptions(options.headingPermalinks),
+    ogImage: options.ogImage ?? false,
+    ogImageOptions: resolveOgImageOptions(options.ogImageOptions),
+    transformers: options.transformers ?? [],
+    docs: resolveDocsOptions(options.docs),
+    search: resolveSearchOptions(options.search),
+    collections: resolveCollectionsOptions(options.collections),
+    ogViewer: options.ogViewer ?? true,
+    embeds: resolveBuiltinEmbedOptions(options.embeds),
+    i18n: resolveI18nOptions(options.i18n),
+  };
+}
+
+export function resolveBuiltinEmbedOptions(
+  options: OxContentOptions["embeds"],
+): ResolvedOptions["embeds"] {
+  if (options === false) {
+    return {
+      github: false,
+      openGraph: false,
+      pm: false,
+      spotify: false,
+      stackBlitz: false,
+      twitter: false,
+      bluesky: false,
+      webContainer: false,
+    };
+  }
+
+  return {
+    github: resolveSingleEmbedOptions(options?.github),
+    openGraph: resolveSingleEmbedOptions(options?.openGraph),
+    pm: resolvePmOptions(options?.pm),
+    spotify: options?.spotify === true,
+    stackBlitz: options?.stackBlitz === true,
+    twitter: resolveTwitterEmbedOptions(options?.twitter),
+    bluesky: options?.bluesky === true,
+    webContainer: options?.webContainer === true,
+  };
+}
+
+function resolveSingleEmbedOptions<T extends object>(options: boolean | T | undefined): T | false {
+  if (options === false) return false;
+  if (options === true || options === undefined) return {} as T;
+  return options;
+}
+
+function resolveTwitterEmbedOptions(
+  options: boolean | TwitterEmbedOptions | undefined,
+): TwitterEmbedOptions | false {
+  if (options === false || options === undefined) return false;
+  if (options === true) return {};
+  return options;
+}
+
+function resolvePmOptions(
+  options: boolean | BuiltinPmOptions | undefined,
+): BuiltinPmOptions | false {
+  if (options === false || options === undefined) return false;
+  if (options === true) return {};
+  return options;
+}
+
+function resolveWikiLinkOptions(
+  options: OxContentOptions["wikiLinks"],
+  baseUrl: string,
+): ResolvedOptions["wikiLinks"] {
+  if (!options) return { enabled: false, baseUrl };
+  if (options === true) return { enabled: true, baseUrl };
+  return { enabled: true, baseUrl: options.baseUrl ?? baseUrl };
+}
+
+function resolveEmojiShortcodeOptions(
+  options: OxContentOptions["emojiShortcodes"],
+): ResolvedOptions["emojiShortcodes"] {
+  if (!options) return { enabled: false, custom: {} };
+  if (options === true) return { enabled: true, custom: {} };
+  return { enabled: true, custom: options.custom ?? {} };
+}
+
+export function resolveMathOptions(options: OxContentOptions["math"]): ResolvedOptions["math"] {
+  if (!options) return { enabled: false };
+  if (options === true) return { enabled: true };
+  return { enabled: options.enabled ?? true };
+}
+
+function resolveAttrsOptions(options: OxContentOptions["attrs"]): ResolvedOptions["attrs"] {
+  if (!options) return { enabled: false };
+  if (options === true) return { enabled: true };
+  return { enabled: options.enabled ?? true };
+}
+
+export function resolveBadgeOptions(
+  options: OxContentOptions["badges"],
+): ResolvedOptions["badges"] {
+  if (!options) return { enabled: false };
+  if (options === true) return { enabled: true };
+  return { enabled: options.enabled ?? true };
+}
+
+function resolveContainerOptions(
+  options: OxContentOptions["containers"],
+): ResolvedOptions["containers"] {
+  if (!options) return { enabled: false, types: {} };
+  if (options === true) return { enabled: true, types: {} };
+  return { enabled: options.enabled ?? true, types: options.types ?? {} };
+}
+
+function resolveCodeImportOptions(
+  options: OxContentOptions["codeImports"],
+): ResolvedOptions["codeImports"] {
+  if (!options) return { enabled: false };
+  if (options === true) return { enabled: true };
+  return { enabled: true, rootDir: options.rootDir };
+}
+
+function resolveSanitizeOptions(
+  options: OxContentOptions["sanitize"],
+): ResolvedOptions["sanitize"] {
+  if (!options) return { enabled: false };
+  if (options === true) return { enabled: true };
+  return {
+    enabled: true,
+    allowedTags: options.allowedTags,
+    allowedAttributes: options.allowedAttributes,
+    allowedUrlSchemes: options.allowedUrlSchemes,
+  };
+}
+
+function resolveEditThisPageOptions(
+  options: OxContentOptions["editThisPage"],
+): ResolvedOptions["editThisPage"] {
+  if (!options) return { enabled: false, branch: "main", label: "Edit this page" };
+  if (options === true) return { enabled: false, branch: "main", label: "Edit this page" };
+  return {
+    enabled: Boolean(options.repoUrl),
+    repoUrl: options.repoUrl,
+    branch: options.branch ?? "main",
+    rootDir: options.rootDir,
+    label: options.label ?? "Edit this page",
+  };
+}
+
+function resolveCodeBlockLintOptions(
+  options: OxContentOptions["codeBlockLint"],
+): ResolvedOptions["codeBlockLint"] {
+  if (!options) {
+    return { enabled: false, requireLanguage: false, trailingSpaces: true, mode: "warn" };
+  }
+  if (options === true) {
+    return { enabled: true, requireLanguage: false, trailingSpaces: true, mode: "warn" };
+  }
+  return {
+    enabled: true,
+    languages: options.languages,
+    requireLanguage: options.requireLanguage ?? false,
+    trailingSpaces: options.trailingSpaces ?? true,
+    mode: options.mode ?? "warn",
+  };
+}
+
+function resolveCodeBlockTypecheckOptions(
+  options: OxContentOptions["codeBlockTypecheck"],
+): ResolvedOptions["codeBlockTypecheck"] {
+  if (!options) {
+    return {
+      enabled: false,
+      languages: ["ts", "tsx"],
+      requireMeta: true,
+      tsgoCommand: "tsgo",
+      mode: "warn",
+    };
+  }
+  if (options === true) {
+    return {
+      enabled: true,
+      languages: ["ts", "tsx"],
+      requireMeta: true,
+      tsgoCommand: "tsgo",
+      mode: "warn",
+    };
+  }
+  return {
+    enabled: true,
+    languages: options.languages ?? ["ts", "tsx"],
+    requireMeta: options.requireMeta ?? true,
+    tsgoCommand: options.tsgoCommand ?? "tsgo",
+    mode: options.mode ?? "warn",
+  };
+}
+
+function resolveDocsTestOptions(
+  options: OxContentOptions["docsTests"],
+): ResolvedOptions["docsTests"] {
+  if (!options) return { enabled: false, languages: ["js", "jsx", "ts", "tsx"], requireMeta: true };
+  if (options === true) {
+    return { enabled: true, languages: ["js", "jsx", "ts", "tsx"], requireMeta: true };
+  }
+  return {
+    enabled: true,
+    languages: options.languages ?? ["js", "jsx", "ts", "tsx"],
+    requireMeta: options.requireMeta ?? true,
+  };
+}
+
+function resolveCodeAnnotationsOptions(
+  options: OxContentOptions["codeAnnotations"],
+): ResolvedOptions["codeAnnotations"] {
+  if (!options) {
+    return {
+      enabled: false,
+      notation: "attribute",
+      metaKey: "annotate",
+      defaultLineNumbers: false,
+    };
+  }
+
+  if (options === true) {
+    return {
+      enabled: true,
+      notation: "attribute",
+      metaKey: "annotate",
+      defaultLineNumbers: false,
+    };
+  }
+
+  return {
+    enabled: true,
+    notation: options.notation ?? "attribute",
+    metaKey: options.metaKey ?? "annotate",
+    defaultLineNumbers: options.defaultLineNumbers ?? false,
+  };
+}


### PR DESCRIPTION
## Summary

- Add `renderMarkdown(source, filePath, options?: OxContentOptions)` so custom `ssg: false` hosts can run the full Markdown/MDX pipeline and receive a structured `TransformResult` (`html`, `frontmatter`, `toc`, MDX metadata) without casting a Vite hook or parsing generated module source.
- Back the API with `createMarkdownProcessor(options)` so option resolution can be reused across documents. Built-in defaults and `.md` / `.mdx` inference match `oxContent()`.
- Extract `resolveOptions` (behavior unchanged) so the public renderer does not depend on private plugin internals.

Closes #877

## Example

```ts
import { renderMarkdown } from "@ox-content/vite-plugin";

const result = await renderMarkdown("# Hi", "/virtual/article.md", {
  ssg: false,
  highlight: false,
});

result.html;
result.frontmatter;
result.toc;
```

## Tests

- `src/render-markdown.test.ts`: heading HTML, frontmatter/toc, `.md` vs `.mdx` inference, default parity with `resolveOptions` / `transformMarkdown`, processor reuse
- `src/public-exports.test.ts`: `renderMarkdown` / `createMarkdownProcessor` on the public export surface
- `src/math-options.test.ts` / `src/badges.test.ts`: extracted resolver re-exports

## Risk

- Risk level: low
- User or production impact: new public API only; existing `oxContent()` behavior is unchanged besides moving `resolveOptions` to `resolve-options.ts`.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run: `vp test src/render-markdown.test.ts src/public-exports.test.ts src/math-options.test.ts src/badges.test.ts`
- [x] Manual verification completed: not required for this API-only change
- [x] Edge cases or failure modes considered: MDX path inference, default option parity, avoiding generated-module parsing

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790312748&installation_model_id=422833&pr_number=986&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F986&signature=f97eecb7b3acc130f6ab7f2e4986d628b39e3b16bb901c27c3cce4ec2f772aa9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->