### PR TITLE
fix(twitter): match react-tweet full-card actions and timezone (#922)

### DIFF
--- a/crates/ox_content_ssg/src/html/tests/social.rs
+++ b/crates/ox_content_ssg/src/html/tests/social.rs
@@ -83,6 +83,8 @@ fn full_tweet_css_keeps_rich_copy_and_replies_affordances() {
     assert!(SOCIAL_TWEET_FULL_CSS.contains("--ox-tweet-icon-copy"));
     assert!(SOCIAL_TWEET_FULL_CSS.contains(".ox-tweet__icon--copy"));
     assert!(SOCIAL_TWEET_FULL_CSS.contains(".ox-tweet--full .ox-tweet__action--copy:hover"));
+    assert!(SOCIAL_TWEET_FULL_CSS.contains("[data-ox-tweet-copied]"));
+    assert!(SOCIAL_TWEET_FULL_CSS.contains(".ox-tweet__copied-text"));
     assert!(
         SOCIAL_TWEET_FULL_CSS.contains(
             ".ox-tweet--full .ox-tweet__replies-link {\n  box-sizing: border-box;\n  display: flex;"
@@ -93,4 +95,6 @@ fn full_tweet_css_keeps_rich_copy_and_replies_affordances() {
         SOCIAL_TWEET_FULL_CSS.contains("\n  width: 100%;\n  min-height: 32px;"),
         "{SOCIAL_TWEET_FULL_CSS}"
     );
+    assert!(SOCIAL_TWEET_FULL_CSS.contains(".ox-tweet--full .ox-tweet__replies-link:hover"));
+    assert!(!SOCIAL_TWEET_FULL_CSS.contains("text-align: center"), "{SOCIAL_TWEET_FULL_CSS}");
 }

--- a/crates/ox_content_ssg/src/plugins/social-tweet-full-media.css
+++ b/crates/ox_content_ssg/src/plugins/social-tweet-full-media.css
@@ -145,14 +145,26 @@
   color: var(--ox-tweet-color-blue-text);
 }
 
-.ox-tweet--full .ox-tweet__action--copy:hover {
-  color: var(--ox-tweet-color-blue-text);
+.ox-tweet--full .ox-tweet__action--copy:hover,
+.ox-tweet--full .ox-tweet__action--copy[data-ox-tweet-copied] {
+  color: var(--ox-tweet-color-green);
+}
+
+.ox-tweet--full .ox-tweet__copied-text {
+  display: none;
+}
+
+.ox-tweet--full .ox-tweet__action--copy[data-ox-tweet-copied] .ox-tweet__copy-text {
+  display: none;
+}
+
+.ox-tweet--full .ox-tweet__action--copy[data-ox-tweet-copied] .ox-tweet__copied-text {
+  display: inline;
 }
 
 .ox-tweet--full .ox-tweet__replies {
-  padding: 0.25rem 0 0;
+  padding: 0.25rem 0;
   margin: 0.5rem 0 0;
-  text-align: center;
 }
 
 .ox-tweet--full .ox-tweet__replies-link {
@@ -168,6 +180,10 @@
   color: var(--ox-tweet-color-blue-text);
   border: var(--ox-tweet-border);
   border-radius: 9999px;
+}
+
+.ox-tweet--full .ox-tweet__replies-link:hover {
+  background-color: var(--ox-tweet-color-blue-hover);
 }
 
 @media (max-width: 400px) {

--- a/crates/ox_content_ssg/src/plugins/social-tweet-full.css
+++ b/crates/ox_content_ssg/src/plugins/social-tweet-full.css
@@ -56,6 +56,8 @@
   --ox-tweet-color-blue-hover: rgba(0, 111, 214, 0.1);
   --ox-tweet-color-red: rgb(249, 24, 128);
   --ox-tweet-color-red-hover: rgba(249, 24, 128, 0.1);
+  --ox-tweet-color-green: rgb(0, 186, 124);
+  --ox-tweet-color-green-hover: rgba(0, 186, 124, 0.1);
   --ox-tweet-verified-blue: var(--ox-tweet-color-blue);
   --ox-tweet-verified-gold: rgb(226, 179, 64);
   --ox-tweet-verified-gray: rgb(130, 154, 171);

--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -278,6 +278,7 @@ oxContent({
       fetch: true,
       lang: "en",
       appearance: "compact",
+      timeZone: "UTC",
       mediaOutputDir: "public/ox-content/twitter",
       mediaPublicPath: "/ox-content/twitter",
     },
@@ -297,6 +298,7 @@ oxContent({
 | `downloadVideo`   | `false`                     | Download MP4 video and animated GIF assets.      |
 | `maxVideoBytes`   | `8388608`                   | Skip videos larger than this (8 MiB).            |
 | `appearance`      | `"compact"`                 | `"full"` for sveltweet-shaped static chrome.     |
+| `timeZone`        | `"UTC"`                     | IANA zone for full-card timestamps.              |
 
 Downloaded media is served from your site, so a strict `img-src 'self'` CSP
 keeps working. Video and animated GIF posts use a self-hosted poster and a

--- a/docs/content/examples/twitter-embed.md
+++ b/docs/content/examples/twitter-embed.md
@@ -24,6 +24,7 @@ export default {
           fetch: true,
           lang: "en",
           appearance: "compact",
+          timeZone: "UTC",
           mediaOutputDir: "public/ox-content/twitter",
           mediaPublicPath: "/ox-content/twitter",
         },
@@ -60,6 +61,7 @@ root card.
 | `downloadVideo`   | `false`                     | Download MP4 video and animated GIF assets.      |
 | `maxVideoBytes`   | `8388608`                   | Skip videos larger than this (8 MiB).            |
 | `appearance`      | `"compact"`                 | `"full"` for sveltweet-shaped static chrome.     |
+| `timeZone`        | `"UTC"`                     | IANA zone for full-card timestamps.              |
 
 Full appearance is static HTML/CSS: no hydration, widget iframe, or per-card
 listeners. It reuses the same materialized avatar/photo/video assets as compact.
@@ -74,9 +76,13 @@ respective owners.
 
 Intentional differences from `sveltweet@0.5.1` / `react-tweet`:
 
-- Copy link is a static permalink action instead of a hydrated clipboard widget.
+- Copy link is a static permalink with `data-ox-tweet-copy` hooks. The card stays
+  useful without JavaScript; integrations that enhance those hooks get the same
+  Copy link / Copied! swap as react-tweet.
 - No fonts or assets from the X/Twitter CDN. The card uses the page font stack.
-- Timestamps use UTC so build output does not depend on the viewer timezone.
+- Timestamps default to UTC so build output does not depend on the builder
+  timezone. Set `timeZone: "Europe/London"` (or another IANA zone) to match a
+  site-local clock. Invalid zones fall back to UTC.
 - Downloaded video uses native `<video controls>` instead of a custom player.
 - Government / legacy verified badges share the checkmark glyph and change color
   only. Side-by-side sveltweet VRT is not in CI; HTML fixtures cover the states.

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -233,6 +233,7 @@ oxContent({
       fetch: true,
       lang: "en",
       appearance: "compact",
+      timeZone: "UTC",
       mediaOutputDir: "public/ox-content/twitter",
       mediaPublicPath: "/ox-content/twitter",
     },
@@ -252,6 +253,7 @@ oxContent({
 | `downloadVideo`   | `false`                     | ビルド時に MP4 動画とアニメーション GIF を取る。    |
 | `maxVideoBytes`   | `8388608`                   | これより大きい動画はスキップする（8 MiB）。         |
 | `appearance`      | `"compact"`                 | `"full"` で sveltweet 形の静的クロムを出す。        |
+| `timeZone`        | `"UTC"`                     | フルカード日時の IANA タイムゾーン。                |
 
 ダウンロードしたメディアは自分のサイトから出すので、厳しい `img-src 'self'` CSP も動き続けます。動画とアニメーション GIF は、`downloadVideo` をオンにしない限り自前のポスターと Watch on X パーマリンクを使い、生成 HTML に `video.twimg.com` は出しません。削除済みや非公開の投稿は、ビルドを落とさずリンクのみのカードに落ちます。引用投稿が欠けていても、元の投稿カードは残します。フルカード用 CSS は `.ox-tweet--full` を描画するページにだけ載ります。フルカードのクロムは MIT ライセンスの [react-tweet](https://github.com/vercel/react-tweet) と [sveltweet](https://github.com/ryoppippi/sveltweet) の見た目の契約に従います。帰属は [クレジット](../credits.md) にあります。詳細は [Twitter/X Embed](/examples/twitter-embed.md) を見てください。
 

--- a/npm/vite-plugin-ox-content/src/plugins/twitter-full.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter-full.test.ts
@@ -172,7 +172,11 @@ describe("full-fidelity Tweet cards", () => {
     expect(blue).toContain("data-ox-tweet-copy");
     expect(blue).toContain('data-ox-tweet-copy-url="https://x.com/i/web/status/555"');
     expect(blue).toContain('aria-label="Copy link to post"');
-    expect(blue).toContain(">Copy link</a>");
+    expect(blue).toContain("ox-tweet__copy-text");
+    expect(blue).toContain("Copy link");
+    expect(blue).toContain("ox-tweet__copied-text");
+    expect(blue).toContain("Copied!");
+    expect(blue).not.toContain("<script");
     expect(blue).toContain("1.5K");
     expect(blue).toContain("<strong>44</strong> reposts");
     expect(blue).toContain("<strong>3</strong> quotes");

--- a/npm/vite-plugin-ox-content/src/plugins/twitter.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vite-plus/test";
 import { transformMediaEmbeds } from "./media";
 import { clearTweetCache } from "./twitter/fetch";
-import { transformFetchedTweets } from "./twitter/transform";
+import { resolveTwitterEmbedOptions, transformFetchedTweets } from "./twitter/transform";
 import { createSyndicationToken, parseTweetReference } from "./twitter/url";
 
 const originalFetch = globalThis.fetch;
@@ -30,6 +30,15 @@ describe("fetched Twitter embeds", () => {
     expect(createSyndicationToken("1234567890123456789")).toBe(
       ((Number("1234567890123456789") / 1e15) * Math.PI).toString(36).replaceAll(/(0+|\.)/g, ""),
     );
+  });
+
+  it("defaults tweet timestamps to UTC and accepts a valid timeZone", () => {
+    expect(resolveTwitterEmbedOptions({}).timeZone).toBe("UTC");
+    expect(resolveTwitterEmbedOptions({ timeZone: "Europe/London" }).timeZone).toBe(
+      "Europe/London",
+    );
+    expect(resolveTwitterEmbedOptions({ timeZone: "Not/AZone" }).timeZone).toBe("UTC");
+    expect(resolveTwitterEmbedOptions({ timeZone: "   " }).timeZone).toBe("UTC");
   });
 
   it("renders fetched content, rewrites links, downloads media, and reuses disk cache", async () => {

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/copy.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/copy.ts
@@ -1,0 +1,62 @@
+// Progressive Copy link enhancement. Static cards stay useful without JS;
+// integrations that call this get the react-tweet Copy link / Copied! swap.
+
+export const TWEET_COPY_RESET_MS = 6000;
+
+export interface TweetCopyAction {
+  addEventListener(type: string, listener: (event: TweetCopyClickEvent) => unknown): void;
+  removeEventListener(type: string, listener: (event: TweetCopyClickEvent) => unknown): void;
+  getAttribute(name: string): string | null;
+  setAttribute(name: string, value: string): void;
+  removeAttribute(name: string): void;
+}
+
+export interface TweetCopyClickEvent {
+  preventDefault(): void;
+}
+
+export interface TweetCopyRoot {
+  querySelectorAll(selector: string): Iterable<TweetCopyAction>;
+}
+
+export interface EnhanceTweetCopyOptions {
+  clipboard?: Pick<Clipboard, "writeText">;
+  copiedMs?: number;
+}
+
+export function enhanceTweetCopyActions(
+  root: TweetCopyRoot = globalThis.document as TweetCopyRoot,
+  options: EnhanceTweetCopyOptions = {},
+): () => void {
+  const copiedMs = options.copiedMs ?? TWEET_COPY_RESET_MS;
+  const clipboard = options.clipboard ?? globalThis.navigator?.clipboard;
+  const cleanups: Array<() => void> = [];
+
+  for (const action of root.querySelectorAll("[data-ox-tweet-copy]")) {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const reset = () => {
+      action.removeAttribute("data-ox-tweet-copied");
+      action.setAttribute("aria-label", "Copy link to post");
+    };
+    const onClick = (event: TweetCopyClickEvent) => {
+      const url = action.getAttribute("data-ox-tweet-copy-url") ?? action.getAttribute("href");
+      if (!url || !clipboard?.writeText) return;
+      event.preventDefault();
+      return clipboard.writeText(url).then(() => {
+        action.setAttribute("data-ox-tweet-copied", "");
+        action.setAttribute("aria-label", "Copied!");
+        if (timer !== undefined) globalThis.clearTimeout(timer);
+        timer = globalThis.setTimeout(reset, copiedMs);
+      });
+    };
+    action.addEventListener("click", onClick);
+    cleanups.push(() => {
+      if (timer !== undefined) globalThis.clearTimeout(timer);
+      action.removeEventListener("click", onClick);
+    });
+  }
+
+  return () => {
+    for (const stop of cleanups) stop();
+  };
+}

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/date-utils.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/date-utils.ts
@@ -1,0 +1,41 @@
+// Port of react-tweet date-utils.ts (MIT, Copyright (c) 2023 Luis Alvarez).
+// Notices live in social-tweet-full.css and docs/content/credits.md.
+
+const DATE_OPTIONS: Intl.DateTimeFormatOptions = {
+  hour: "numeric",
+  minute: "2-digit",
+  hour12: true,
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+};
+
+export function resolveTweetTimeZone(timeZone?: string): string {
+  const candidate = timeZone?.trim();
+  if (!candidate) return "UTC";
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: candidate }).format();
+    return candidate;
+  } catch {
+    return "UTC";
+  }
+}
+
+export function formatFullDate(
+  createdAt: string | undefined,
+  timeZone = "UTC",
+): { iso: string; label: string } | undefined {
+  if (!createdAt) return undefined;
+  const date = new Date(createdAt);
+  if (Number.isNaN(date.valueOf())) return undefined;
+  const zone = resolveTweetTimeZone(timeZone);
+  const parts = new Intl.DateTimeFormat("en-US", { ...DATE_OPTIONS, timeZone: zone }).formatToParts(
+    date,
+  );
+  const get = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((part) => part.type === type)?.value ?? "";
+  return {
+    iso: date.toISOString(),
+    label: `${get("hour")}:${get("minute")} ${get("dayPeriod")} · ${get("month")} ${get("day")}, ${get("year")}`,
+  };
+}

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/full.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/full.ts
@@ -1,6 +1,7 @@
 // Static HTML for appearance: "full". Visual contract follows MIT-licensed
 // react-tweet (Copyright (c) 2023 Luis Alvarez) and sveltweet (Copyright (c)
 // 2024 ryoppippi). Notices live in social-tweet-full.css and docs/content/credits.md.
+import { formatFullDate } from "./date-utils";
 import { escapeAttribute, escapeHtml } from "./html";
 import { renderMedia } from "./markup";
 import { formatCount, renderTweetMetrics } from "./metrics";
@@ -10,7 +11,12 @@ import { quotedPermalink, replyPermalink, sanitizeScreenName, sanitizeStatusId }
 
 const HELP_HREF = "https://help.x.com/en/x-for-websites-ads-info-and-privacy";
 
-export function renderFullTweet(permalink: string, data: TweetData, assets: TweetAssets): string {
+export function renderFullTweet(
+  permalink: string,
+  data: TweetData,
+  assets: TweetAssets,
+  timeZone = "UTC",
+): string {
   const quote = data.quoted_tweet ? renderFullQuote(data.quoted_tweet, assets.quoted) : "";
   return [
     '<figure class="ox-tweet ox-tweet--fetched ox-tweet--full">',
@@ -19,7 +25,7 @@ export function renderFullTweet(permalink: string, data: TweetData, assets: Twee
     `<div class="ox-tweet__body">${renderTweetText(data, { omitTrailingQuoteUrl: Boolean(quote) })}</div>`,
     renderMedia(assets, permalink),
     quote,
-    renderInfo(permalink, data.created_at),
+    renderInfo(permalink, data.created_at, timeZone),
     renderTweetMetrics(data, { replies: false, likes: false }),
     renderActions(permalink, data),
     renderReplies(permalink, data.conversation_count),
@@ -86,8 +92,8 @@ function renderReply(data: TweetData): string {
   return `<p class="ox-tweet__reply"><a class="ox-tweet__reply-link" href="${escapeAttribute(href)}" target="_blank" rel="noopener noreferrer">Replying to @${escapeHtml(handle)}</a></p>`;
 }
 
-function renderInfo(permalink: string, createdAt: string | undefined): string {
-  const formatted = formatFullDate(createdAt);
+function renderInfo(permalink: string, createdAt: string | undefined, timeZone: string): string {
+  const formatted = formatFullDate(createdAt, timeZone);
   const time = formatted
     ? `<a class="ox-tweet__permalink" href="${escapeAttribute(permalink)}" target="_blank" rel="noopener noreferrer"><time datetime="${formatted.iso}">${escapeHtml(formatted.label)}</time></a>`
     : `<a class="ox-tweet__permalink" href="${escapeAttribute(permalink)}" target="_blank" rel="noopener noreferrer">View on X</a>`;
@@ -102,7 +108,7 @@ function renderActions(permalink: string, data: TweetData): string {
     '<div class="ox-tweet__actions">',
     `<a class="ox-tweet__action ox-tweet__action--like" href="https://x.com/intent/like?tweet_id=${id}" target="_blank" rel="noopener noreferrer"><span class="ox-tweet__icon ox-tweet__icon--like"></span><span>${likes}</span></a>`,
     `<a class="ox-tweet__action ox-tweet__action--reply" href="https://x.com/intent/tweet?in_reply_to=${id}" target="_blank" rel="noopener noreferrer"><span class="ox-tweet__icon ox-tweet__icon--reply"></span>Reply</a>`,
-    `<a class="ox-tweet__action ox-tweet__action--copy" href="${escapeAttribute(permalink)}" target="_blank" rel="noopener noreferrer" data-ox-tweet-copy data-ox-tweet-copy-url="${escapeAttribute(permalink)}" aria-label="Copy link to post"><span class="ox-tweet__icon ox-tweet__icon--copy"></span>Copy link</a>`,
+    `<a class="ox-tweet__action ox-tweet__action--copy" href="${escapeAttribute(permalink)}" target="_blank" rel="noopener noreferrer" data-ox-tweet-copy data-ox-tweet-copy-url="${escapeAttribute(permalink)}" aria-label="Copy link to post"><span class="ox-tweet__icon ox-tweet__icon--copy"></span><span class="ox-tweet__copy-text">Copy link</span><span class="ox-tweet__copied-text">Copied!</span></a>`,
     "</div>",
   ].join("");
 }
@@ -154,25 +160,4 @@ function repliesLabel(value: unknown): string {
   if (n === 0) return "Read more on X";
   if (n === 1) return "Read 1 reply";
   return `Read ${formatCount(n)} replies`;
-}
-
-function formatFullDate(createdAt: string | undefined): { iso: string; label: string } | undefined {
-  if (!createdAt) return undefined;
-  const date = new Date(createdAt);
-  if (Number.isNaN(date.valueOf())) return undefined;
-  const parts = new Intl.DateTimeFormat("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    timeZone: "UTC",
-  }).formatToParts(date);
-  const get = (type: Intl.DateTimeFormatPartTypes) =>
-    parts.find((part) => part.type === type)?.value ?? "";
-  return {
-    iso: date.toISOString(),
-    label: `${get("hour")}:${get("minute")} ${get("dayPeriod")} · ${get("month")} ${get("day")}, ${get("year")}`,
-  };
 }

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/index.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/index.ts
@@ -1,3 +1,5 @@
+export { enhanceTweetCopyActions, TWEET_COPY_RESET_MS } from "./copy";
+export { formatFullDate, resolveTweetTimeZone } from "./date-utils";
 export { fetchTweetData } from "./fetch";
 export { renderFetchedTweet, renderTweetText } from "./render";
 export { resolveTwitterEmbedOptions, transformFetchedTweets } from "./transform";

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/parity.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/parity.test.ts
@@ -1,0 +1,177 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { enhanceTweetCopyActions } from "./copy";
+import { formatFullDate } from "./date-utils";
+import { clearTweetCache } from "./fetch";
+import { transformFetchedTweets } from "./transform";
+import type { TwitterEmbedOptions } from "./types";
+
+const FULL_MEDIA_CSS = path.join(
+  import.meta.dirname,
+  "../../../../../crates/ox_content_ssg/src/plugins/social-tweet-full-media.css",
+);
+const FIXTURE_ID = "1941072675872641440";
+const FIXTURE_CREATED_AT = "2025-07-04T09:52:43.000Z";
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  clearTweetCache();
+});
+
+describe("full-card react-tweet parity", () => {
+  it("keeps replies as a full-width react-tweet control", async () => {
+    const html = await renderCard(
+      {
+        text: "Hello",
+        id_str: FIXTURE_ID,
+        conversation_count: 12,
+        user: user(),
+      },
+      { appearance: "full" },
+      { html: `<XPost id="${FIXTURE_ID}" />` },
+    );
+    expect(html).toContain('class="ox-tweet__replies"');
+    expect(html).toContain('class="ox-tweet__replies-link"');
+    expect(html).toContain("Read 12 replies");
+
+    const css = await readFile(FULL_MEDIA_CSS, "utf8");
+    expect(css).toMatch(
+      /\.ox-tweet--full \.ox-tweet__replies-link \{\n  box-sizing: border-box;\n  display: flex;/,
+    );
+    expect(css).toContain("\n  width: 100%;\n  min-height: 32px;");
+    expect(css).not.toMatch(/\.ox-tweet__replies-link \{[^}]*display:\s*inline-flex/);
+    expect(css).not.toMatch(/\.ox-tweet--full \.ox-tweet__replies \{[^}]*text-align:\s*center/);
+    expect(css).toContain(".ox-tweet--full .ox-tweet__replies-link:hover");
+  });
+
+  it("formats full-card timestamps in UTC by default and honors timeZone", async () => {
+    expect(formatFullDate(FIXTURE_CREATED_AT)).toEqual({
+      iso: FIXTURE_CREATED_AT,
+      label: "9:52 AM · Jul 4, 2025",
+    });
+    expect(formatFullDate(FIXTURE_CREATED_AT, "Europe/London")?.label).toBe(
+      "10:52 AM · Jul 4, 2025",
+    );
+    expect(formatFullDate(FIXTURE_CREATED_AT, "Not/AZone")?.label).toBe("9:52 AM · Jul 4, 2025");
+
+    const post = {
+      text: "Hello from London",
+      id_str: FIXTURE_ID,
+      created_at: FIXTURE_CREATED_AT,
+      user: user(),
+    };
+    const utc = await renderCard(
+      post,
+      { appearance: "full" },
+      { html: `<XPost id="${FIXTURE_ID}" />` },
+    );
+    expect(utc).toContain("9:52 AM · Jul 4, 2025");
+    expect(utc).toContain(`datetime="${FIXTURE_CREATED_AT}"`);
+
+    const london = await renderCard(
+      post,
+      { appearance: "full", timeZone: "Europe/London" },
+      { html: `<XPost id="${FIXTURE_ID}" />` },
+    );
+    expect(london).toContain("10:52 AM · Jul 4, 2025");
+  });
+
+  it("enhances Copy link to Copied! without requiring card JavaScript", async () => {
+    const written: string[] = [];
+    const action = fakeCopyAction("https://x.com/i/web/status/1941072675872641440");
+    const stop = enhanceTweetCopyActions(
+      { querySelectorAll: () => [action] },
+      {
+        clipboard: {
+          writeText: async (value: string) => {
+            written.push(value);
+          },
+        },
+        copiedMs: 5,
+      },
+    );
+
+    const event = {
+      defaultPrevented: false,
+      preventDefault() {
+        this.defaultPrevented = true;
+      },
+    };
+    await action.dispatch("click", event);
+    expect(event.defaultPrevented).toBe(true);
+    expect(written).toEqual(["https://x.com/i/web/status/1941072675872641440"]);
+    expect(action.getAttribute("data-ox-tweet-copied")).toBe("");
+    expect(action.getAttribute("aria-label")).toBe("Copied!");
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(action.getAttribute("data-ox-tweet-copied")).toBeNull();
+    expect(action.getAttribute("aria-label")).toBe("Copy link to post");
+    stop();
+  });
+});
+
+function user() {
+  return { name: "Ox Content", screen_name: "ox_content" };
+}
+
+function fakeCopyAction(url: string) {
+  const attributes = new Map<string, string>([
+    ["data-ox-tweet-copy", ""],
+    ["data-ox-tweet-copy-url", url],
+    ["href", url],
+    ["aria-label", "Copy link to post"],
+  ]);
+  const listeners = new Map<string, Array<(event: { preventDefault(): void }) => unknown>>();
+  return {
+    getAttribute(name: string) {
+      return attributes.has(name) ? (attributes.get(name) ?? "") : null;
+    },
+    setAttribute(name: string, value: string) {
+      attributes.set(name, value);
+    },
+    removeAttribute(name: string) {
+      attributes.delete(name);
+    },
+    addEventListener(type: string, listener: (event: { preventDefault(): void }) => unknown) {
+      listeners.set(type, [...(listeners.get(type) ?? []), listener]);
+    },
+    removeEventListener(type: string, listener: (event: { preventDefault(): void }) => unknown) {
+      listeners.set(
+        type,
+        (listeners.get(type) ?? []).filter((candidate) => candidate !== listener),
+      );
+    },
+    async dispatch(type: string, event: { preventDefault(): void }) {
+      await Promise.all((listeners.get(type) ?? []).map((listener) => listener(event)));
+    },
+  };
+}
+
+async function renderCard(
+  data: unknown,
+  twitter: TwitterEmbedOptions = {},
+  options?: { html?: string },
+): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "ox-tweet-parity-"));
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.startsWith("https://cdn.syndication.twimg.com/")) {
+      return { ok: true, json: async () => data } as Response;
+    }
+    return { ok: true, arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer } as Response;
+  };
+  try {
+    return await transformFetchedTweets(options?.html ?? `<XPost id="${FIXTURE_ID}" />`, {
+      fetch: true,
+      cache: false,
+      mediaOutputDir: path.join(root, "media"),
+      mediaPublicPath: "/tweets",
+      ...twitter,
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/render.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/render.ts
@@ -15,7 +15,7 @@ export function renderFetchedTweet(
   options: ResolvedTwitterEmbedOptions,
 ): string {
   if (options.appearance === "full") {
-    return renderFullTweet(permalink, data, assets);
+    return renderFullTweet(permalink, data, assets, options.timeZone);
   }
   const quote = data.quoted_tweet ? renderQuotedTweet(data.quoted_tweet, assets.quoted) : "";
   return [

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/transform.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/transform.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { resolveTweetTimeZone } from "./date-utils";
 import { fetchTweetData, materializeTweetAssets } from "./fetch";
 import { renderFetchedTweet } from "./render";
 import type { ResolvedTwitterEmbedOptions, TwitterEmbedOptions } from "./types";
@@ -20,6 +21,7 @@ export function resolveTwitterEmbedOptions(
     downloadVideo: options.downloadVideo ?? false,
     maxVideoBytes: options.maxVideoBytes ?? 8_388_608,
     appearance: options.appearance === "full" ? "full" : "compact",
+    timeZone: resolveTweetTimeZone(options.timeZone),
   };
 }
 

--- a/npm/vite-plugin-ox-content/src/plugins/twitter/types.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/twitter/types.ts
@@ -19,6 +19,12 @@ export interface TwitterEmbedOptions {
   maxVideoBytes?: number;
   /** Fetched-card chrome. `"full"` matches sveltweet / react-tweet. @default "compact" */
   appearance?: TweetAppearance;
+  /**
+   * IANA timezone for full-card timestamps.
+   * Invalid values fall back to UTC so build output stays deterministic.
+   * @default "UTC"
+   */
+  timeZone?: string;
 }
 
 export interface ResolvedTwitterEmbedOptions {
@@ -32,6 +38,7 @@ export interface ResolvedTwitterEmbedOptions {
   downloadVideo: boolean;
   maxVideoBytes: number;
   appearance: TweetAppearance;
+  timeZone: string;
 }
 
 export type TweetAppearance = "compact" | "full";


### PR DESCRIPTION
## Summary

- Restore react-tweet / sveltweet full-card parity for Copy link, a full-width Read replies control, and a configurable timestamp timezone (default UTC).
- Copy link stays static and CSP-safe (`data-ox-tweet-copy` hooks plus a Copy / Copied! label swap). Integrations that call `enhanceTweetCopyActions` get the clipboard affordance; cards remain useful without JavaScript.
- Timezone lives on twitter-local embed options (`twitter/types.ts`). Invalid IANA zones fall back to UTC so build output stays deterministic.

MIT attribution for the ported react-tweet / sveltweet visual contract is already present from #840 (`social-tweet-full.css` and Credits).

Closes #922

## Risk

- Risk level: low
- User or production impact: full-card markup adds Copy / Copied labels and may change replies spacing; compact cards and fetch/cache behavior are unchanged. Sites that want London (or another) wall time must set `timeZone`.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run:
  - `vp exec --filter @ox-content/vite-plugin -- vp test src/plugins/twitter-full.test.ts src/plugins/twitter.test.ts src/plugins/twitter/parity.test.ts src/plugins/twitter-video.test.ts` (28 passed)
  - `cargo test -p ox_content_ssg full_tweet --lib`
  - `cargo test -p ox_content_ssg full_tweet_css_keeps_rich_copy_and_replies_affordances --lib`
- [x] Manual verification completed: unit/markup coverage for copy action, replies CSS, timezone (`1941072675872641440` / `2025-07-04T09:52:43.000Z` → `10:52 AM` in `Europe/London`). No new VRT suite (none existed as a cheap twitter hook).
- [x] Edge cases or failure modes considered: invalid timezone → UTC; copy enhancement no-ops without clipboard and leaves the permalink; static HTML has no `<script>`.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790312940&installation_model_id=422833&pr_number=987&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F987&signature=5771963442c70fa7d749d0c3641dfea73482b5df0853fb7d56c26c0626300401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->