### PR TITLE
feat(redirects): add provider selection and CI auto-detection

### DIFF
--- a/docs/content/built-in/redirects.md
+++ b/docs/content/built-in/redirects.md
@@ -48,7 +48,7 @@ options object and enables the feature with that map.
 | --------------- | ----------------------------------------- | ------- |
 | `redirects`     | `boolean` / path map / `RedirectsOptions` | `false` |
 | `map`           | `Record<string, string>`                  | `{}`    |
-| `netlify`       | `boolean`                                 | `false` |
+| `provider`      | `"netlify"` / `"cloudflare"`              | detect  |
 | `headers`       | `boolean`                                 | `false` |
 | `json`          | `boolean`                                 | `false` |
 | `allowExternal` | `boolean`                                 | `false` |
@@ -98,14 +98,28 @@ an explicit map entry overrides a page alias for the same old path.
 
 ## Host files
 
-Set `netlify: true` to also write a `_redirects` file
-(`/old /guide 301`). Set `headers: true` to write `_headers` with a
-`Location` line per source. Set `json: true` to write `redirects.json`.
-Normal (non-wildcard) sources still get HTML fallback pages.
+Set `provider: "netlify"` or `provider: "cloudflare"` to also write a
+`_redirects` file (`/old /guide 301`). Both hosts use the same body today.
+Set `headers: true` to write `_headers` with a `Location` line per source.
+Set `json: true` to write `redirects.json`. HTML fallback pages stay
+independent of the provider selector.
+
+When `provider` is omitted, the build detects the host from CI env:
+
+- `CF_PAGES=1` or `WORKERS_CI=1` → Cloudflare
+- `NETLIFY=true` → Netlify
+
+An explicit `provider` always wins, including local builds and GitHub
+Actions. If both Cloudflare and Netlify variables are set, the build
+warns and skips `_redirects` instead of picking a host. With no match,
+`_redirects` is omitted — the same default as before.
+
+Cloudflare Workers applies `_redirects` only to static asset responses,
+not to requests handled by Worker code.
 
 Sources that contain `*` are host-rule syntax (Netlify, Cloudflare Pages),
 not a literal URL segment. They still appear in `_redirects`, `_headers`,
-and `redirects.json` when those flags are on, but the SSG does not write
+and `redirects.json` when those outputs are on, but the SSG does not write
 a static HTML file such as `talks*/index.html`.
 
 ```ts
@@ -115,13 +129,19 @@ oxContent({
       "/talks*": "/works/talks",
       "/old-guide": "/guide",
     },
-    netlify: true,
+    provider: "netlify",
   },
 });
 ```
 
 That map writes `/talks* /works/talks 301` to `_redirects` and an HTML
 page only for `/old-guide`.
+
+## Migrating from 2.x
+
+`redirects.netlify` is removed in 3.0. Replace `netlify: true` with
+`provider: "netlify"`, or omit `provider` when the CI environment should
+select the host.
 
 ## Drafts
 

--- a/docs/content/ja/built-in/redirects.md
+++ b/docs/content/ja/built-in/redirects.md
@@ -43,7 +43,7 @@ oxContent({
 | --------------- | ------------------------------------------- | ------- |
 | `redirects`     | `boolean` / パスマップ / `RedirectsOptions` | `false` |
 | `map`           | `Record<string, string>`                    | `{}`    |
-| `netlify`       | `boolean`                                   | `false` |
+| `provider`      | `"netlify"` / `"cloudflare"`                | 検出    |
 | `headers`       | `boolean`                                   | `false` |
 | `json`          | `boolean`                                   | `false` |
 | `allowExternal` | `boolean`                                   | `false` |
@@ -82,9 +82,18 @@ redirect: /retired
 
 ## ホスト用ファイル
 
-`netlify: true` で `_redirects` ファイル（`/old /guide 301`）も書き出します。`headers: true` でソースごとの `Location` 行を持つ `_headers` を書き出します。`json: true` で `redirects.json` を書き出します。通常の（ワイルドカードでない）ソースには、これまでどおり HTML のフォールバックページも出します。
+`provider: "netlify"` または `provider: "cloudflare"` で `_redirects` ファイル（`/old /guide 301`）も書き出します。どちらのホストも、いまは同じ本文です。`headers: true` でソースごとの `Location` 行を持つ `_headers` を書き出します。`json: true` で `redirects.json` を書き出します。HTML のフォールバックページは provider 選択とは独立です。
 
-ソースに `*` が含まれる場合、それは Netlify や Cloudflare Pages 向けのホスト規則の構文であり、リテラルな URL セグメントではありません。該当フラグがオンなら `_redirects`、`_headers`、`redirects.json` には残しますが、`talks*/index.html` のような静的 HTML ファイルは書き出しません。
+`provider` を省略すると、CI の環境変数からホストを検出します。
+
+- `CF_PAGES=1` または `WORKERS_CI=1` → Cloudflare
+- `NETLIFY=true` → Netlify
+
+明示した `provider` は常に勝ちます。ローカルビルドと GitHub Actions でも同じです。Cloudflare と Netlify の変数が同時に付いているときは警告し、ホストを黙って選ばず `_redirects` を出しません。一致がなければ `_redirects` は出しません（これまでの既定と同じです）。
+
+Cloudflare Workers の `_redirects` は静的アセットの応答にだけ効きます。Worker コードが処理するリクエストには適用されません。
+
+ソースに `*` が含まれる場合、それは Netlify や Cloudflare Pages 向けのホスト規則の構文であり、リテラルな URL セグメントではありません。該当出力がオンなら `_redirects`、`_headers`、`redirects.json` には残しますが、`talks*/index.html` のような静的 HTML ファイルは書き出しません。
 
 ```ts
 oxContent({
@@ -93,12 +102,16 @@ oxContent({
       "/talks*": "/works/talks",
       "/old-guide": "/guide",
     },
-    netlify: true,
+    provider: "netlify",
   },
 });
 ```
 
 このマップは `_redirects` に `/talks* /works/talks 301` を書き、HTML ページは `/old-guide` だけ出します。
+
+## 2.x からの移行
+
+3.0 では `redirects.netlify` を削除しました。`netlify: true` は `provider: "netlify"` に置き換えるか、CI 環境にホストを選ばせるなら `provider` を省略してください。
 
 ## 下書き
 

--- a/docs/content/ja/v3-roadmap.md
+++ b/docs/content/ja/v3-roadmap.md
@@ -28,6 +28,7 @@ description: テーマパッケージ、完全な MDX、Code Play、オプトイ
 - tree-sitter 文法がない言語はプレーンのままです。
 - テーマパッケージの peer 範囲は 3.x へ移ります。
 - 組み込み機能と Code Play は、メジャーバージョンが変わっただけでは **有効になりません**。それぞれ明示的なインストールかオプションが必要です。
+- `redirects.netlify` は削除されました。`provider: "netlify"` にするか、CI に Netlify / Cloudflare を検出させるなら `provider` を省略してください。
 
 シンタックストークンの CSS は `<pre class="ox-highlight css-variables">` 上の `--octc-syntax-*` カスタムプロパティです。カラーパッケージは対応する `syntax-*` トークンを定義します。
 

--- a/docs/content/v3-roadmap.md
+++ b/docs/content/v3-roadmap.md
@@ -30,6 +30,8 @@ Also tracked elsewhere and not duplicated here:
 - Theme package peer ranges move to 3.x.
 - Built-ins and Code Play do **not** turn on just because the major version
   changed. Each still needs an explicit install or option.
+- `redirects.netlify` is removed. Use `provider: "netlify"` or omit
+  `provider` so CI can detect Netlify / Cloudflare.
 
 Syntax token CSS uses `--octc-syntax-*` custom properties on
 `<pre class="ox-highlight css-variables">`. Color packages define the matching

--- a/npm/vite-plugin-ox-content-svelte/src/index.test.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/index.test.ts
@@ -7,7 +7,7 @@ describe("oxContentSvelte", () => {
     const names = pluginNames(
       oxContentSvelte({
         ssg: { siteUrl: "https://example.com" },
-        redirects: { map: { "/old": "/new" }, netlify: true },
+        redirects: { map: { "/old": "/new" }, provider: "netlify" },
       }),
     );
 

--- a/npm/vite-plugin-ox-content/src/framework.ts
+++ b/npm/vite-plugin-ox-content/src/framework.ts
@@ -68,7 +68,6 @@ export function createFrameworkMarkdownOptions(options: FrameworkMarkdownOptions
     redirects: {
       enabled: false,
       map: {},
-      netlify: false,
       headers: false,
       json: false,
       allowExternal: false,

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -118,6 +118,7 @@ export type {
   ResolvedPermalinksOptions,
   CascadeOptions,
   ResolvedCascadeOptions,
+  RedirectProvider,
   RedirectsOptions,
   ResolvedRedirectsOptions,
   BlogAuthor,

--- a/npm/vite-plugin-ox-content/src/redirect-provider.test.ts
+++ b/npm/vite-plugin-ox-content/src/redirect-provider.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { planRedirectFiles, resolveRedirectsOptions, writeRedirectFiles } from "./redirects";
+import type { ResolvedRedirectsOptions } from "./types";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+const on: ResolvedRedirectsOptions = {
+  enabled: true,
+  map: {},
+  headers: false,
+  json: false,
+  allowExternal: false,
+};
+
+const NETLIFY_REDIRECTS_BYTES = "/old /other 301\n";
+
+describe("redirect provider detection", () => {
+  it("detects Cloudflare Pages, Workers CI, and Netlify from injected env", () => {
+    expect(resolveRedirectsOptions({ map: { "/old": "/new" } }, { CF_PAGES: "1" })).toEqual({
+      enabled: true,
+      map: { "/old": "/new" },
+      provider: "cloudflare",
+      headers: false,
+      json: false,
+      allowExternal: false,
+    });
+    expect(resolveRedirectsOptions(true, { WORKERS_CI: "1" }).provider).toBe("cloudflare");
+    expect(resolveRedirectsOptions({ "/old": "/new" }, { NETLIFY: "true" }).provider).toBe(
+      "netlify",
+    );
+    expect(resolveRedirectsOptions(true, { CF_PAGES: "1", WORKERS_CI: "1" }).provider).toBe(
+      "cloudflare",
+    );
+  });
+
+  it("does not treat nearby env values as a provider match", () => {
+    expect(resolveRedirectsOptions(true, { CF_PAGES: "true" }).provider).toBeUndefined();
+    expect(resolveRedirectsOptions(true, { WORKERS_CI: "true" }).provider).toBeUndefined();
+    expect(resolveRedirectsOptions(true, { NETLIFY: "1" }).provider).toBeUndefined();
+  });
+
+  it("lets an explicit provider win over detected env", () => {
+    expect(
+      resolveRedirectsOptions({ provider: "netlify" }, { CF_PAGES: "1", WORKERS_CI: "1" }).provider,
+    ).toBe("netlify");
+    expect(resolveRedirectsOptions({ provider: "cloudflare" }, { NETLIFY: "true" }).provider).toBe(
+      "cloudflare",
+    );
+  });
+
+  it("warns and omits a provider when Cloudflare and Netlify env vars conflict", () => {
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+    try {
+      expect(
+        resolveRedirectsOptions({ map: { "/old": "/new" } }, { CF_PAGES: "1", NETLIFY: "true" }),
+      ).toEqual({
+        enabled: true,
+        map: { "/old": "/new" },
+        headers: false,
+        json: false,
+        allowExternal: false,
+      });
+      expect(resolveRedirectsOptions(true, { WORKERS_CI: "1", NETLIFY: "true" }).provider).toBe(
+        undefined,
+      );
+    } finally {
+      console.warn = original;
+    }
+    expect(warnings.join("\n")).toMatch(/conflict/i);
+    expect(warnings.join("\n")).toMatch(/provider/i);
+  });
+
+  it("does not detect a provider when the feature is disabled", () => {
+    expect(resolveRedirectsOptions(false, { NETLIFY: "true" }).provider).toBeUndefined();
+    expect(resolveRedirectsOptions(undefined, { CF_PAGES: "1" }).provider).toBeUndefined();
+  });
+});
+
+describe("redirect provider host files", () => {
+  it("writes the same _redirects body for explicit netlify and cloudflare", () => {
+    const map = { "/old": "/other" };
+    const netlify = planRedirectFiles({
+      options: { ...on, map, provider: "netlify" },
+      pages: [],
+    });
+    const cloudflare = planRedirectFiles({
+      options: { ...on, map, provider: "cloudflare" },
+      pages: [],
+    });
+
+    expect(netlify.netlify).toBe(NETLIFY_REDIRECTS_BYTES);
+    expect(cloudflare.netlify).toBe(netlify.netlify);
+  });
+
+  it("omits the host _redirects body when no provider is resolved", () => {
+    const plan = planRedirectFiles({
+      options: { ...on, map: { "/old": "/guide" } },
+      pages: [],
+    });
+
+    expect(plan.files).toHaveLength(1);
+    expect(plan.netlify).toBeUndefined();
+  });
+
+  it("skips wildcard HTML pages for an explicit cloudflare provider", () => {
+    const plan = planRedirectFiles({
+      options: {
+        ...on,
+        map: { "/talks*": "/works/talks", "/old": "/guide" },
+        provider: "cloudflare",
+      },
+      pages: [],
+    });
+
+    expect(plan.files).toHaveLength(1);
+    expect(plan.files[0]?.from).toBe("/old");
+    expect(plan.netlify).toBe("/talks* /works/talks 301\n/old /guide 301\n");
+  });
+
+  it("writes the same _redirects bytes for an explicit cloudflare provider", async () => {
+    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-redirects-cf-"));
+    tempDirs.push(outDir);
+
+    await writeRedirectFiles({
+      outDir,
+      options: {
+        ...on,
+        map: { "/old-guide": "/guide" },
+        provider: "cloudflare",
+      },
+      pages: [{ dest: "/guide", aliases: ["/old"] }],
+    });
+
+    expect(await fs.readFile(path.join(outDir, "_redirects"), "utf8")).toBe(
+      "/old /guide 301\n/old-guide /guide 301\n",
+    );
+  });
+
+  it("does not write _redirects without a provider", async () => {
+    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-redirects-nop-"));
+    tempDirs.push(outDir);
+
+    await writeRedirectFiles({
+      outDir,
+      options: { ...on, map: { "/old": "/guide" } },
+      pages: [],
+    });
+
+    expect(await fs.readFile(path.join(outDir, "old", "index.html"), "utf8")).toContain(
+      "url=/guide",
+    );
+    await expect(fs.access(path.join(outDir, "_redirects"))).rejects.toThrow();
+  });
+});

--- a/npm/vite-plugin-ox-content/src/redirect-provider.ts
+++ b/npm/vite-plugin-ox-content/src/redirect-provider.ts
@@ -1,0 +1,30 @@
+import type { RedirectProvider } from "./types";
+
+const CONFLICT_WARNING =
+  '[ox-content] Conflicting redirect provider environment variables (Cloudflare and Netlify). Set redirects.provider explicitly to "netlify" or "cloudflare". The host _redirects file will not be written.';
+
+/**
+ * Resolves the `_redirects` host from an explicit option or CI env.
+ *
+ * Pass `env` so tests can inject values without mutating `process.env`.
+ */
+export function resolveRedirectProvider(
+  explicit: RedirectProvider | undefined,
+  env: NodeJS.ProcessEnv,
+): { provider?: RedirectProvider; warning?: string } {
+  if (explicit) {
+    return { provider: explicit };
+  }
+  const cloudflare = env.CF_PAGES === "1" || env.WORKERS_CI === "1";
+  const netlify = env.NETLIFY === "true";
+  if (cloudflare && netlify) {
+    return { warning: CONFLICT_WARNING };
+  }
+  if (cloudflare) {
+    return { provider: "cloudflare" };
+  }
+  if (netlify) {
+    return { provider: "netlify" };
+  }
+  return {};
+}

--- a/npm/vite-plugin-ox-content/src/redirects.test.ts
+++ b/npm/vite-plugin-ox-content/src/redirects.test.ts
@@ -13,7 +13,6 @@ afterEach(async () => {
 const off = {
   enabled: false,
   map: {},
-  netlify: false,
   headers: false,
   json: false,
   allowExternal: false,
@@ -22,7 +21,6 @@ const off = {
 const on = {
   enabled: true,
   map: {},
-  netlify: false,
   headers: false,
   json: false,
   allowExternal: false,
@@ -30,28 +28,31 @@ const on = {
 
 describe("resolveRedirectsOptions", () => {
   it("disables the feature when omitted or false", () => {
-    expect(resolveRedirectsOptions(undefined)).toEqual(off);
-    expect(resolveRedirectsOptions(false)).toEqual(off);
+    expect(resolveRedirectsOptions(undefined, {})).toEqual(off);
+    expect(resolveRedirectsOptions(false, {})).toEqual(off);
   });
 
   it("enables defaults when true", () => {
-    expect(resolveRedirectsOptions(true)).toEqual(on);
+    expect(resolveRedirectsOptions(true, {})).toEqual(on);
   });
 
   it("enables from an object and overrides only set fields", () => {
-    expect(resolveRedirectsOptions({})).toEqual(on);
+    expect(resolveRedirectsOptions({}, {})).toEqual(on);
     expect(
-      resolveRedirectsOptions({
-        map: { "/old": "/guide" },
-        netlify: true,
-        headers: true,
-        json: true,
-        allowExternal: true,
-      }),
+      resolveRedirectsOptions(
+        {
+          map: { "/old": "/guide" },
+          provider: "netlify",
+          headers: true,
+          json: true,
+          allowExternal: true,
+        },
+        {},
+      ),
     ).toEqual({
       enabled: true,
       map: { "/old": "/guide" },
-      netlify: true,
+      provider: "netlify",
       headers: true,
       json: true,
       allowExternal: true,
@@ -59,7 +60,7 @@ describe("resolveRedirectsOptions", () => {
   });
 
   it("treats a path map as enabled defaults plus that map", () => {
-    expect(resolveRedirectsOptions({ "/old-guide": "/guide" })).toEqual({
+    expect(resolveRedirectsOptions({ "/old-guide": "/guide" }, {})).toEqual({
       ...on,
       map: { "/old-guide": "/guide" },
     });
@@ -97,7 +98,7 @@ describe("planRedirectFiles", () => {
 
   it("plans config-map redirects and last-wins after slash folding", () => {
     const plan = planRedirectFiles({
-      options: { ...on, map: { "/old/": "/guide/", "/old": "/other" }, netlify: true },
+      options: { ...on, map: { "/old/": "/guide/", "/old": "/other" }, provider: "netlify" },
       pages: [],
     });
 
@@ -206,7 +207,7 @@ describe("planRedirectFiles", () => {
           "/projects*": "/works",
           "/old": "/guide",
         },
-        netlify: true,
+        provider: "netlify",
         headers: true,
         json: true,
       },
@@ -242,7 +243,7 @@ describe("writeRedirectFiles", () => {
       options: {
         ...on,
         map: { "/old-guide": "/guide" },
-        netlify: true,
+        provider: "netlify",
         headers: true,
         json: true,
       },
@@ -255,7 +256,9 @@ describe("writeRedirectFiles", () => {
     expect(result.files).toHaveLength(5);
     expect(oldHtml).toContain("url=/guide");
     expect(mapHtml).toContain("url=/guide");
-    expect(await fs.readFile(path.join(outDir, "_redirects"), "utf8")).toContain("/old /guide 301");
+    expect(await fs.readFile(path.join(outDir, "_redirects"), "utf8")).toBe(
+      "/old /guide 301\n/old-guide /guide 301\n",
+    );
     expect(await fs.readFile(path.join(outDir, "_headers"), "utf8")).toContain("Location: /guide");
     expect(await fs.readFile(path.join(outDir, "redirects.json"), "utf8")).toContain('"/old"');
   });
@@ -315,7 +318,7 @@ describe("writeRedirectFiles", () => {
       options: {
         ...on,
         map: { "/talks*": "/works/talks", "/old": "/guide" },
-        netlify: true,
+        provider: "netlify",
       },
       pages: [],
     });

--- a/npm/vite-plugin-ox-content/src/redirects.ts
+++ b/npm/vite-plugin-ox-content/src/redirects.ts
@@ -7,9 +7,10 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { resolveRedirectProvider } from "./redirect-provider";
 import type { RedirectsOptions, ResolvedRedirectsOptions } from "./types";
 
-const OPTION_KEYS = new Set(["map", "netlify", "headers", "json", "allowExternal"]);
+const OPTION_KEYS = new Set(["map", "provider", "headers", "json", "allowExternal"]);
 
 /** One page that may declare aliases or a single `redirect` source. */
 export interface RedirectPageInput {
@@ -54,48 +55,42 @@ export interface WriteRedirectFilesInput {
  *
  * `false` / omitted stays off. `true` or `{}` enables empty defaults.
  * A path map (`{ "/old": "/new" }`) enables the feature with that map.
- * `{ map, netlify, headers, json, allowExternal }` overrides only set fields.
+ * `{ map, provider, headers, json, allowExternal }` overrides only set fields.
+ * Pass `env` to inject CI detection without reading the real `process.env`.
  */
 export function resolveRedirectsOptions(
   value: boolean | RedirectsOptions | Record<string, string> | undefined,
+  env: NodeJS.ProcessEnv = process.env,
 ): ResolvedRedirectsOptions {
   if (!value) {
-    return {
-      enabled: false,
-      map: {},
-      netlify: false,
-      headers: false,
-      json: false,
-      allowExternal: false,
-    };
+    return resolvedRedirects(false, {}, undefined, env);
   }
   if (value === true) {
-    return {
-      enabled: true,
-      map: {},
-      netlify: false,
-      headers: false,
-      json: false,
-      allowExternal: false,
-    };
+    return resolvedRedirects(true, {}, undefined, env);
   }
   if (isOptionsObject(value)) {
-    return {
-      enabled: true,
-      map: { ...value.map },
-      netlify: value.netlify ?? false,
-      headers: value.headers ?? false,
-      json: value.json ?? false,
-      allowExternal: value.allowExternal ?? false,
-    };
+    return resolvedRedirects(true, { ...value.map }, value, env);
+  }
+  return resolvedRedirects(true, { ...value }, undefined, env);
+}
+
+function resolvedRedirects(
+  enabled: boolean,
+  map: Record<string, string>,
+  value: RedirectsOptions | undefined,
+  env: NodeJS.ProcessEnv,
+): ResolvedRedirectsOptions {
+  const { provider, warning } = enabled ? resolveRedirectProvider(value?.provider, env) : {};
+  if (warning) {
+    console.warn(warning);
   }
   return {
-    enabled: true,
-    map: { ...value },
-    netlify: false,
-    headers: false,
-    json: false,
-    allowExternal: false,
+    enabled,
+    map,
+    ...(provider ? { provider } : {}),
+    headers: value?.headers ?? false,
+    json: value?.json ?? false,
+    allowExternal: value?.allowExternal ?? false,
   };
 }
 
@@ -142,7 +137,7 @@ export function planRedirectFiles(input: RedirectPlanInput): RedirectPlan {
 
   const htmlFiles = files.filter((file) => !isHostWildcardSource(file.from));
   const plan: RedirectPlan = { files: htmlFiles };
-  if (input.options.netlify) {
+  if (input.options.provider) {
     plan.netlify = files.map((file) => `${file.from} ${file.to} 301`).join("\n") + "\n";
   }
   if (input.options.headers) {

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -968,6 +968,14 @@ export interface ResolvedCascadeOptions {
 }
 
 /**
+ * Host that consumes the generated `_redirects` file.
+ *
+ * Both values write the same `_redirects` body today. The distinct names
+ * leave room for provider-specific limits and diagnostics later.
+ */
+export type RedirectProvider = "netlify" | "cloudflare";
+
+/**
  * Opt-in static redirects, aliases, and path rewrites.
  *
  * A path map such as `{ "/old-guide": "/guide" }` is also accepted in place
@@ -982,10 +990,13 @@ export interface RedirectsOptions {
   map?: Record<string, string>;
 
   /**
-   * Write a Netlify / Cloudflare `_redirects` file next to the HTML pages.
-   * @default false
+   * Host that should receive a `_redirects` file.
+   *
+   * Omit the field to detect `CF_PAGES=1`, `WORKERS_CI=1`, or `NETLIFY=true`.
+   * Local builds and GitHub Actions should set this explicitly. HTML redirect
+   * pages are independent of this selector.
    */
-  netlify?: boolean;
+  provider?: RedirectProvider;
 
   /**
    * Write a `_headers` Location map next to the HTML pages.
@@ -1013,7 +1024,7 @@ export interface RedirectsOptions {
 export interface ResolvedRedirectsOptions {
   enabled: boolean;
   map: Record<string, string>;
-  netlify: boolean;
+  provider?: RedirectProvider;
   headers: boolean;
   json: boolean;
   allowExternal: boolean;

--- a/npm/vite-plugin-ox-content/src/version-navigation.integration.test.ts
+++ b/npm/vite-plugin-ox-content/src/version-navigation.integration.test.ts
@@ -80,7 +80,6 @@ describe("versioned SSG navigation", () => {
         redirects: {
           enabled: true,
           map: { "/old-guide": "/getting-started" },
-          netlify: false,
           headers: false,
           json: false,
           allowExternal: false,

--- a/npm/vite-plugin-ox-content/test/fixtures/docs-fixture.ts
+++ b/npm/vite-plugin-ox-content/test/fixtures/docs-fixture.ts
@@ -120,7 +120,6 @@ export function createDocsResolvedOptions(
     redirects: {
       enabled: false,
       map: {},
-      netlify: false,
       headers: false,
       json: false,
       allowExternal: false,


### PR DESCRIPTION
## Summary

- **Breaking (3.0 alpha):** remove `redirects.netlify`. Use `provider: "netlify" | "cloudflare"` instead. There is no deprecated alias.
- Omit `provider` to auto-detect `CF_PAGES=1` / `WORKERS_CI=1` → Cloudflare and `NETLIFY=true` → Netlify. Conflicting env vars warn and skip `_redirects` instead of silently picking a host.
- Explicit `provider` always wins (local builds and GitHub Actions). No match still omits `_redirects`. Both providers write the same `_redirects` body; HTML pages stay independent. Wildcard HTML skip from #929 is unchanged.

Closes #926

## Test plan

- [x] `vp test src/redirects.test.ts src/redirect-provider.test.ts` (29 passed)
- [x] Explicit `netlify` and `cloudflare` both write `_redirects` with the same bytes as the old Netlify config
- [x] Injected `CF_PAGES=1`, `WORKERS_CI=1`, `NETLIFY=true` detect without mutating `process.env`
- [x] Conflicting Cloudflare + Netlify env warns and omits provider
- [x] Explicit provider beats detection
- [x] No env + no provider → no `_redirects`; HTML pages still write
- [x] Wildcard sources still skip HTML pages (#929)


Made with [Cursor](https://cursor.com)