### PR TITLE
fix(embeds): reserve built-in components before MDX island lowering (#879)

### DIFF
--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -24,6 +24,10 @@ Tabs and YouTube embeds are not part of the `embeds` option: they are always
 processed in SSG builds and dev preview, with no configuration needed. They are
 covered [below](#tabs) because they share the same authoring model.
 
+Documented PascalCase tags such as `<Tweet>` and `<OgCard>` work in both `.md`
+and `.mdx`. A document-local import of the same name (`import Tweet from
+"./Tweet"`) overrides the built-in and stays an MDX island.
+
 Disable every built-in embed with `embeds: false`, or configure embeds
 individually:
 

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -20,6 +20,8 @@ description: Markdown 中の HTML 風タグで書く GitHub / OG カード、パ
 
 タブと YouTube 埋め込みは `embeds` オプションの外です。SSG ビルドと dev preview では常に処理され、設定は不要です。同じ執筆モデルなので [下](#タブ) で扱います。
 
+`<Tweet>` や `<OgCard>` のようなドキュメント上の PascalCase タグは `.md` と `.mdx` の両方で動きます。同じ名前のドキュメントローカル import（`import Tweet from "./Tweet"`）は組み込みより優先され、MDX island のまま残ります。
+
 すべての組み込み埋め込みを切るときは `embeds: false`、個別に設定するときはオブジェクトです。
 
 ```ts

--- a/npm/vite-plugin-ox-content/src/embed.test.ts
+++ b/npm/vite-plugin-ox-content/src/embed.test.ts
@@ -11,6 +11,7 @@ import {
 import { summarizeCommitMessage } from "./plugins/github/source";
 import { transformBuiltinEmbeds } from "./plugins";
 import { collectOgpUrls, isSafeOgpUrl, transformOgp } from "./plugins/ogp";
+import { renderMarkdown } from "./render-markdown";
 import { transformMarkdown } from "./transform";
 
 function mockGitHubSourceFetch(): typeof fetch {
@@ -251,5 +252,115 @@ describe("builtin embed input hardening", () => {
     );
 
     expect(html).toMatchSnapshot();
+  });
+});
+
+const issue879Options = {
+  ssg: false as const,
+  frontmatter: false,
+  highlight: false,
+  embeds: {
+    github: false,
+    openGraph: false,
+    twitter: true,
+    bluesky: false,
+  },
+  ogViewer: false,
+  search: false,
+  toc: false,
+};
+
+describe("built-in embeds vs MDX island lowering (#879)", () => {
+  it("renders Tweet in .md without a dangling closer", async () => {
+    const result = await renderMarkdown('<Tweet id="1234567890" />', "/virtual/article.md", {
+      ...issue879Options,
+      mdx: false,
+    });
+
+    expect(result.html).toContain("ox-tweet");
+    expect(result.html).not.toMatch(/<\/Tweet>/i);
+    expect(result.html).not.toContain('data-ox-island="Tweet"');
+  });
+
+  it("renders Tweet in .mdx as a built-in embed, not an island", async () => {
+    const result = await renderMarkdown('<Tweet id="1234567890" />', "/virtual/article.mdx", {
+      ...issue879Options,
+      mdx: true,
+    });
+
+    expect(result.html).toContain("ox-tweet");
+    expect(result.html).not.toContain('data-ox-island="Tweet"');
+    expect(result.html).not.toMatch(/<\/Tweet>/i);
+  });
+
+  it("sends PascalCase OgCard to the OGP path in both .md and .mdx", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        text: async () =>
+          `<html><head><title>Example Domain</title><meta property="og:title" content="Example Domain"></head></html>`,
+      }) as Response) as typeof fetch;
+
+    try {
+      const ogOptions = {
+        ssg: false as const,
+        frontmatter: false,
+        highlight: false,
+        embeds: {
+          github: false,
+          openGraph: { cache: false },
+          twitter: false,
+          bluesky: false,
+        },
+        ogViewer: false,
+        search: false,
+        toc: false,
+      };
+      const source = '<OgCard url="https://example.com" />';
+
+      const markdown = await renderMarkdown(source, "/virtual/article.md", {
+        ...ogOptions,
+        mdx: false,
+      });
+      const mdx = await renderMarkdown(source, "/virtual/article.mdx", {
+        ...ogOptions,
+        mdx: true,
+      });
+
+      for (const result of [markdown, mdx]) {
+        expect(result.html).toMatch(/ox-ogp-(?:card|simple)/);
+        expect(result.html).not.toContain('data-ox-island="OgCard"');
+        expect(result.html).not.toMatch(/<\/OgCard>/i);
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("lets a document-local import override a built-in name", async () => {
+    const result = await renderMarkdown(
+      'import Tweet from "./Tweet"\n\n<Tweet id="1234567890" />\n',
+      "/virtual/article.mdx",
+      { ...issue879Options, mdx: true },
+    );
+
+    expect(result.html).toContain('data-ox-island="Tweet"');
+    expect(result.html).not.toContain("ox-tweet");
+    expect(result.components).toContain("Tweet");
+  });
+
+  it("keeps a Tweet inside a blockquote as valid block HTML", async () => {
+    const result = await renderMarkdown(
+      '> before\n>\n> <Tweet id="1234567890" />\n>\n> after\n',
+      "/virtual/article.md",
+      { ...issue879Options, mdx: false },
+    );
+
+    expect(result.html).toContain("<blockquote>");
+    expect(result.html).toContain("ox-tweet");
+    expect(result.html).not.toMatch(/<\/Tweet>/i);
+    expect(result.html).toMatch(/<blockquote>[\s\S]*<\/blockquote>/);
+    expect(result.html).not.toMatch(/<p>[\s\S]*<article class="ox-tweet"/);
   });
 });

--- a/npm/vite-plugin-ox-content/src/mdx-islands.test.ts
+++ b/npm/vite-plugin-ox-content/src/mdx-islands.test.ts
@@ -96,4 +96,19 @@ describe("discoverRegisteredMdxComponents", () => {
     });
     expect(override).toEqual(["Chart", "Alert"]);
   });
+
+  it("reserves built-in embed names unless a document-local import overrides them", async () => {
+    const builtin = await discoverRegisteredMdxComponents({
+      source: '<Tweet id="1234567890" />\n<OgCard url="https://example.com" />\n<Alert />\n',
+      components: { Tweet: "./Tweet.tsx", OgCard: "./OgCard.tsx", Alert: "./Alert.tsx" },
+    });
+    expect(builtin).toEqual(["Alert"]);
+
+    const localOverride = await discoverRegisteredMdxComponents({
+      source: '<Tweet id="1234567890" />\n<Alert />\n',
+      components: { Tweet: "./GlobalTweet.tsx", Alert: "./Alert.tsx" },
+      localNames: ["Tweet"],
+    });
+    expect(localOverride).toEqual(["Tweet", "Alert"]);
+  });
 });

--- a/npm/vite-plugin-ox-content/src/mdx-islands.ts
+++ b/npm/vite-plugin-ox-content/src/mdx-islands.ts
@@ -8,6 +8,7 @@
  */
 
 import { importNapiModule } from "./napi";
+import { isReservedBuiltinComponent } from "./plugins/embed-transform";
 
 /** Global component map: object, Map, or name list. */
 export type ComponentRegistry =
@@ -62,6 +63,9 @@ export function intersectHydratableComponentNames(
   const local = localNames ? new Set(localNames) : null;
   const used: string[] = [];
   for (const name of names) {
+    if (isReservedBuiltinComponent(name) && !local?.has(name)) {
+      continue;
+    }
     if ((local?.has(name) || isRegisteredComponent(name, components)) && !used.includes(name)) {
       used.push(name);
     }

--- a/npm/vite-plugin-ox-content/src/plugins/embed-transform.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/embed-transform.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it } from "vite-plus/test";
-import { transformAllPlugins } from ".";
+import { normalizeSelfClosingEmbeds, transformAllPlugins } from ".";
+import {
+  filterReservedBuiltinComponentNames,
+  isReservedBuiltinComponent,
+  restoreReservedBuiltinIslands,
+} from "./embed-transform";
 import { transformPm } from "./pm";
 import { resetTabGroupCounter, transformTabs } from "./tabs";
 import { transformYouTube } from "./youtube";
@@ -152,5 +157,42 @@ describe("transformPm output", () => {
     resetTabGroupCounter();
     const html = `<p>Plain prose with a <a href="/x">link</a> and no embeds.</p>`;
     expect(await transformPm(html)).toBe(html);
+  });
+});
+
+describe("reserved built-in islands (#879)", () => {
+  it("consumes a leftover closer after a self-closing built-in tag", () => {
+    expect(normalizeSelfClosingEmbeds('<Tweet id="1234567890" /></Tweet>')).toBe(
+      '<Tweet id="1234567890"></Tweet>',
+    );
+    expect(normalizeSelfClosingEmbeds('<Tweet id="1234567890" />\n</Tweet>')).toBe(
+      '<Tweet id="1234567890"></Tweet>',
+    );
+    expect(normalizeSelfClosingEmbeds('<OgCard url="https://example.com" />\n<p>after</p>')).toBe(
+      '<OgCard url="https://example.com"></OgCard>\n<p>after</p>',
+    );
+  });
+
+  it("restores reserved MDX islands to embed tags", () => {
+    const html =
+      `<div class="ox-island" data-ox-island="Tweet" data-ox-props="{&quot;props&quot;:{&quot;id&quot;:&quot;1234567890&quot;},&quot;expressions&quot;:{},&quot;spreads&quot;:[]}">` +
+      `<script type="application/json">{"props":{"id":"1234567890"},"expressions":{},"spreads":[]}</script></div>`;
+
+    expect(restoreReservedBuiltinIslands(html)).toBe('<Tweet id="1234567890"></Tweet>');
+  });
+
+  it("keeps a document-local override as an island", () => {
+    const html =
+      `<div class="ox-island" data-ox-island="Tweet" data-ox-props="{&quot;props&quot;:{&quot;id&quot;:&quot;1&quot;},&quot;expressions&quot;:{},&quot;spreads&quot;:[]}">` +
+      `<script type="application/json">{"props":{"id":"1"},"expressions":{},"spreads":[]}</script></div>`;
+
+    expect(restoreReservedBuiltinIslands(html, ["Tweet"])).toBe(html);
+    expect(isReservedBuiltinComponent("Tweet")).toBe(true);
+    expect(isReservedBuiltinComponent("Card")).toBe(false);
+    expect(filterReservedBuiltinComponentNames(["Tweet", "Card"], ["Tweet"])).toEqual([
+      "Tweet",
+      "Card",
+    ]);
+    expect(filterReservedBuiltinComponentNames(["Tweet", "Card"])).toEqual(["Card"]);
   });
 });

--- a/npm/vite-plugin-ox-content/src/plugins/embed-transform.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/embed-transform.ts
@@ -1,0 +1,235 @@
+/**
+ * Reserve first-party embed components so MDX island lowering cannot swallow them.
+ *
+ * Rust still emits `data-ox-island` for every PascalCase tag. This rewrite turns
+ * reserved built-in names back into HTML tags so `transformBuiltinEmbeds` can
+ * run. A document-local import of the same name keeps the island.
+ */
+
+const PAYLOAD_SCRIPT = /^\s*<script type="application\/json">[\s\S]*?<\/script>/;
+const RUST_PAYLOAD_KEYS = new Set(["props", "expressions", "spreads"]);
+
+/**
+ * Canonical PascalCase names for first-party embed / media components.
+ * Keep in sync with `SELF_CLOSING_EMBED_TAG` in `./index.ts`.
+ */
+export const RESERVED_BUILTIN_COMPONENTS = [
+  "GitHub",
+  "OgCard",
+  "Tweet",
+  "XPost",
+  "Bluesky",
+  "Spotify",
+  "StackBlitz",
+  "WebContainer",
+  "YouTube",
+] as const;
+
+const RESERVED_BUILTIN_COMPONENT_SET = new Set<string>(RESERVED_BUILTIN_COMPONENTS);
+
+export type ReservedBuiltinComponent = (typeof RESERVED_BUILTIN_COMPONENTS)[number];
+
+export function isReservedBuiltinComponent(name: string): boolean {
+  return RESERVED_BUILTIN_COMPONENT_SET.has(name);
+}
+
+export function documentLocalComponentNames(
+  imports: readonly { specifiers: readonly { local: string; kind: string }[] }[],
+): Set<string> {
+  const names = new Set<string>();
+  for (const statement of imports) {
+    for (const spec of statement.specifiers) {
+      if (spec.kind !== "namespace") {
+        names.add(spec.local);
+      }
+    }
+  }
+  return names;
+}
+
+/**
+ * Replace reserved built-in islands with the original HTML tags so embed
+ * transforms can see them. Document-local bindings of the same name stay islands.
+ */
+export function restoreReservedBuiltinIslands(html: string, localNames?: Iterable<string>): string {
+  if (!html.includes("data-ox-island=")) {
+    return html;
+  }
+
+  const local = localNames ? new Set(localNames) : new Set<string>();
+  const islands = findIslandRanges(html);
+  let output = html;
+
+  for (const island of islands.toReversed()) {
+    if (!isReservedBuiltinComponent(island.name) || local.has(island.name)) {
+      continue;
+    }
+
+    const inner = output.slice(island.innerStart, island.closeStart);
+    const scriptMatch = inner.match(PAYLOAD_SCRIPT);
+    const children = unwrapSingleParagraph(
+      (scriptMatch ? inner.slice(scriptMatch[0].length) : inner).trim(),
+    );
+    const props = parseLiteralProps(island.propsAttr, scriptMatch?.[0] ?? "");
+    const rebuilt = `<${island.name}${stringifyLiteralAttrs(props)}>${children}</${island.name}>`;
+    output = output.slice(0, island.openStart) + rebuilt + output.slice(island.closeEnd);
+  }
+
+  return output;
+}
+
+export function filterReservedBuiltinComponentNames(
+  names: readonly string[],
+  localNames?: Iterable<string>,
+): string[] {
+  const local = localNames ? new Set(localNames) : new Set<string>();
+  return names.filter((name) => !isReservedBuiltinComponent(name) || local.has(name));
+}
+
+interface IslandRange {
+  name: string;
+  openStart: number;
+  innerStart: number;
+  closeStart: number;
+  closeEnd: number;
+  propsAttr?: string;
+}
+
+function findIslandRanges(html: string): IslandRange[] {
+  const ranges: IslandRange[] = [];
+  const openRe = /<(div|span)\b([^>]*\bdata-ox-island="([^"]+)"[^>]*)>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = openRe.exec(html)) !== null) {
+    const tag = match[1];
+    const name = decodeHtmlAttr(match[3] ?? "");
+    if (!tag || !name) continue;
+    const innerStart = match.index + match[0].length;
+    const closeStart = findMatchingClose(html, innerStart, tag);
+    const closeEnd = closeStart < html.length ? closeStart + `</${tag}>`.length : html.length;
+    ranges.push({
+      name,
+      openStart: match.index,
+      innerStart,
+      closeStart,
+      closeEnd,
+      propsAttr: matchAttr(match[2] ?? "", "data-ox-props"),
+    });
+  }
+  return ranges;
+}
+
+function findMatchingClose(html: string, from: number, tag: string): number {
+  const openNeedle = `<${tag}`;
+  const closeNeedle = `</${tag}>`;
+  let depth = 1;
+  let cursor = from;
+  while (cursor < html.length) {
+    const nextOpen = indexOfTagOpen(html, openNeedle, cursor);
+    const nextClose = html.indexOf(closeNeedle, cursor);
+    if (nextClose === -1) return html.length;
+    if (nextOpen !== -1 && nextOpen < nextClose) {
+      depth += 1;
+      cursor = nextOpen + openNeedle.length;
+    } else {
+      depth -= 1;
+      if (depth === 0) return nextClose;
+      cursor = nextClose + closeNeedle.length;
+    }
+  }
+  return html.length;
+}
+
+function indexOfTagOpen(html: string, openNeedle: string, from: number): number {
+  let cursor = from;
+  while (cursor < html.length) {
+    const index = html.indexOf(openNeedle, cursor);
+    if (index === -1) return -1;
+    const next = html[index + openNeedle.length];
+    if (next === " " || next === ">" || next === "\t" || next === "\n" || next === "/") {
+      return index;
+    }
+    cursor = index + openNeedle.length;
+  }
+  return -1;
+}
+
+function matchAttr(attrs: string, name: string): string | undefined {
+  const match = new RegExp(`\\b${name}="([^"]*)"`, "i").exec(attrs);
+  return match?.[1] === undefined ? undefined : decodeHtmlAttr(match[1]);
+}
+
+function parseLiteralProps(propsAttr: string | undefined, script: string): Record<string, unknown> {
+  const fromAttr = propsAttr ? tryParseJson(propsAttr) : undefined;
+  if (fromAttr) return unwrapIslandProps(fromAttr);
+  const scriptBody = script.match(/<script type="application\/json">([\s\S]*?)<\/script>/i)?.[1];
+  return scriptBody ? unwrapIslandProps(tryParseJson(scriptBody) ?? {}) : {};
+}
+
+function tryParseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function unwrapIslandProps(parsed: unknown): Record<string, unknown> {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {};
+  }
+  const record = parsed as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (
+    keys.length > 0 &&
+    keys.every((key) => RUST_PAYLOAD_KEYS.has(key)) &&
+    record.props &&
+    typeof record.props === "object" &&
+    !Array.isArray(record.props)
+  ) {
+    return record.props as Record<string, unknown>;
+  }
+  return record;
+}
+
+function stringifyLiteralAttrs(props: Record<string, unknown>): string {
+  let attrs = "";
+  for (const [name, value] of Object.entries(props)) {
+    if (!isSafeAttrName(name) || value == null || value === false) {
+      continue;
+    }
+    if (value === true) {
+      attrs += ` ${name}`;
+      continue;
+    }
+    if (typeof value === "string" || typeof value === "number" || typeof value === "bigint") {
+      attrs += ` ${name}="${escapeAttribute(String(value))}"`;
+    }
+  }
+  return attrs;
+}
+
+function isSafeAttrName(name: string): boolean {
+  return /^[A-Za-z_:][\w:.-]*$/.test(name);
+}
+
+function unwrapSingleParagraph(html: string): string {
+  const wrapped = html.match(/^<p>([\s\S]*)<\/p>$/i);
+  return wrapped?.[1] ?? html;
+}
+
+function escapeAttribute(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function decodeHtmlAttr(value: string): string {
+  return value
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
+}

--- a/npm/vite-plugin-ox-content/src/plugins/index.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/index.ts
@@ -48,6 +48,13 @@ import {
 } from "./ogp";
 import { transformMermaidStatic, mermaidClientScript, type MermaidOptions } from "./mermaid";
 import { normalizeBlockEmbedParagraphs } from "./block-structure";
+import {
+  documentLocalComponentNames,
+  filterReservedBuiltinComponentNames,
+  isReservedBuiltinComponent,
+  restoreReservedBuiltinIslands,
+  RESERVED_BUILTIN_COMPONENTS,
+} from "./embed-transform";
 
 export {
   transformTabs,
@@ -77,6 +84,11 @@ export {
   transformMermaidStatic,
   mermaidClientScript,
   normalizeBlockEmbedParagraphs,
+  restoreReservedBuiltinIslands,
+  isReservedBuiltinComponent,
+  documentLocalComponentNames,
+  filterReservedBuiltinComponentNames,
+  RESERVED_BUILTIN_COMPONENTS,
 };
 
 export type {
@@ -97,14 +109,15 @@ export type {
 };
 
 const SELF_CLOSING_EMBED_TAG =
-  /<(GitHub|OgCard|Tweet|XPost|Bluesky|Spotify|StackBlitz|WebContainer|YouTube)((?:[^>"']|"[^"]*"|'[^']*')*?)\s*\/>/gi;
+  /<(GitHub|OgCard|Tweet|XPost|Bluesky|Spotify|StackBlitz|WebContainer|YouTube)((?:[^>"']|"[^"]*"|'[^']*')*?)\s*\/>(?:\s*<\/\1\s*>)?/gi;
 
 /**
  * Custom embed tags are not HTML void elements, so a self-closing authoring
  * form like `<GitHub ... />` reaches the HTML re-parsers (syntax highlighting,
  * embed transforms) as an unclosed element that swallows the rest of the
  * document. Normalize to an explicit open/close pair before any rehype pass
- * runs.
+ * runs. A leftover `</Tweet>` after `/>` (CommonMark HTML + self-close) is
+ * consumed so the closer cannot survive the embed rewrite.
  */
 export function normalizeSelfClosingEmbeds(html: string): string {
   return html.replace(SELF_CLOSING_EMBED_TAG, (_match, tag: string, attrs: string) => {
@@ -226,9 +239,16 @@ export async function transformBuiltinEmbeds(
     twitter?: boolean | TwitterEmbedOptions;
     bluesky?: boolean;
     webContainer?: boolean;
+    /**
+     * Document-local import bindings. A reserved built-in name in this set
+     * stays an MDX island instead of running the first-party embed transform.
+     */
+    localNames?: Iterable<string>;
   },
 ): Promise<string> {
-  let result = await normalizeBlockEmbedParagraphs(normalizeSelfClosingEmbeds(html));
+  let result = await normalizeBlockEmbedParagraphs(
+    restoreReservedBuiltinIslands(normalizeSelfClosingEmbeds(html), options.localNames),
+  );
 
   if (options.github) {
     result = await transformGitHub(result, undefined, {

--- a/npm/vite-plugin-ox-content/src/transform.ts
+++ b/npm/vite-plugin-ox-content/src/transform.ts
@@ -39,7 +39,12 @@ import { highlightPageHtml } from "./highlight";
 import { importNapiModule } from "./napi";
 import { transformMermaidStatic } from "./plugins/mermaid";
 import { renderKatexMath } from "./plugins/math";
-import { normalizeSelfClosingEmbeds, transformBuiltinEmbeds } from "./plugins";
+import {
+  documentLocalComponentNames,
+  filterReservedBuiltinComponentNames,
+  normalizeSelfClosingEmbeds,
+  transformBuiltinEmbeds,
+} from "./plugins";
 import { protectMermaidSvgs, restoreMermaidSvgs } from "./plugins/mermaid-protect";
 import { typecheckCodeBlocks } from "./code-blocks";
 import { applyTypedHover } from "./typed-hover";
@@ -681,14 +686,17 @@ export async function transformMarkdown(
     html = await highlightPageHtml(html, napi.mergeHighlightedCodeBlocks);
   }
 
-  // Render static built-in embeds while Mermaid SVG placeholders are protected.
-  html = await transformBuiltinEmbeds(
-    html,
-    options.embeds ?? {
+  const localNames = documentLocalComponentNames(result.imports ?? []);
+
+  // Reserved first-party names are restored from MDX islands before embed
+  // transforms, unless a document-local import overrides that name.
+  html = await transformBuiltinEmbeds(html, {
+    ...(options.embeds ?? {
       github: {},
       openGraph: {},
-    },
-  );
+    }),
+    localNames,
+  });
 
   // GitHub source cards are created after the first highlight pass, so run
   // highlighting again when those blocks are present.
@@ -709,7 +717,7 @@ export async function transformMarkdown(
 
   const imports = result.imports ?? [];
   const exports = result.exports ?? [];
-  const components = result.components ?? [];
+  const components = filterReservedBuiltinComponentNames(result.components ?? [], localNames);
   html = await applyTypedHover(source, html, options.typedHover);
 
   // Generate JavaScript module code


### PR DESCRIPTION
## Summary

- Restore documented PascalCase built-ins (`Tweet`, `OgCard`, and the other first-party embed tags) before generic MDX island lowering so `.mdx` no longer emits `data-ox-island="Tweet"`.
- Consume a leftover `</Tweet>` after a self-closing authoring form so `.md` output keeps tweet markup without a dangling closer.
- A document-local import of the same name stays an island and is test-covered; blockquote nesting still produces valid block HTML.

Closes #879

## Risk

- Risk level: low
- User or production impact: `.md` / `.mdx` documents that use built-in embed tags get the documented static cards. Sites that import a local `Tweet` / `OgCard` keep the island. Global `components` map entries with a built-in name no longer override the embed.
- Rollback plan: revert this PR.

## Validation

- [x] Automated tests or checks run:
  - `vp exec --filter @ox-content/vite-plugin -- vp test src/embed.test.ts src/plugins/embed-transform.test.ts src/mdx-islands.test.ts src/render-markdown.test.ts` (45 passed)
  - also `src/transform.test.ts`, `src/plugins/block-structure.test.ts`, `src/plugins/ogp.test.ts`, `src/mdx-metadata.test.ts`, `src/island-ssr.test.ts`, `src/document-imports.test.ts`, `src/plugins/twitter.test.ts`, `src/public-exports.test.ts`
- [x] Manual verification completed: reproduced the issue’s `/virtual/article.md` vs `.mdx` loop via `renderMarkdown`; `.md` has `ox-tweet` and no `</Tweet>`, `.mdx` has `ox-tweet` and is not `data-ox-island="Tweet"`, PascalCase `<OgCard>` reaches the OGP path in both.
- [x] Edge cases or failure modes considered: document-local import override; leftover closer after `/>`; newlines after self-closing tags must stay; blockquote nesting; expression/spread props are dropped when restoring literals only.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.


Made with [Cursor](https://cursor.com)