### PR TITLE
feat(ssg): support mounting a content root under a route prefix

### DIFF
--- a/crates/ox_content_ssg/src/lib.rs
+++ b/crates/ox_content_ssg/src/lib.rs
@@ -112,10 +112,10 @@ pub use redirects::{
     generate_redirects, is_safe_dest, normalize_path,
 };
 pub use routes::{
-    ManualNavigationGroup, ManualNavigationItem, RoutePaths, SidebarItem, build_nav_items,
-    build_theme_nav_items, collect_markdown_files, extract_title, format_title, get_href,
-    get_og_image_path, get_og_image_url, get_output_path, get_page_locale, get_url_path,
-    resolve_navigation_groups, resolve_route_paths,
+    ManualNavigationGroup, ManualNavigationItem, RoutePaths, SidebarItem, apply_route_prefix,
+    build_nav_items, build_theme_nav_items, collect_markdown_files, extract_title, format_title,
+    get_href, get_og_image_path, get_og_image_url, get_output_path, get_page_locale, get_url_path,
+    normalize_route_prefix, resolve_navigation_groups, resolve_route_paths,
 };
 pub use site_maps::{SiteMapPage, SiteMapsOptions, SiteMapsOutput, generate_site_maps};
 pub use vitepress::normalize_vitepress_frontmatter;

--- a/crates/ox_content_ssg/src/routes.rs
+++ b/crates/ox_content_ssg/src/routes.rs
@@ -4,6 +4,7 @@ mod files;
 mod manual;
 mod navigation;
 mod path;
+mod prefix;
 mod sidebar;
 
 pub use files::{collect_markdown_files, extract_title, format_title};
@@ -13,6 +14,7 @@ pub use path::{
     RoutePaths, get_href, get_og_image_path, get_og_image_url, get_output_path, get_page_locale,
     get_url_path, resolve_route_paths,
 };
+pub use prefix::{apply_route_prefix, normalize_route_prefix};
 pub use sidebar::{SidebarItem, build_theme_nav_items};
 
 const DEFAULT_NAV_GROUP_ORDER: &[&str] = &["", "examples", "packages", "api"];

--- a/crates/ox_content_ssg/src/routes/prefix.rs
+++ b/crates/ox_content_ssg/src/routes/prefix.rs
@@ -1,0 +1,144 @@
+//! Independent SSG route/output mount prefix (`routePrefix`).
+
+use std::path::{Path, PathBuf};
+
+use super::path::RoutePaths;
+
+/// `blog`, `/blog`, and `/blog/` all become `blog`. Empty or unsafe values stay off.
+pub fn normalize_route_prefix(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || trimmed.contains('\\')
+        || trimmed.contains('\0')
+        || trimmed.contains("://")
+        || trimmed.starts_with("//")
+        || is_windows_abs(trimmed)
+    {
+        return String::new();
+    }
+    let segments: Vec<&str> =
+        trimmed.trim_matches('/').split('/').filter(|segment| !segment.is_empty()).collect();
+    if segments.is_empty() || segments.iter().any(|segment| *segment == "." || *segment == "..") {
+        return String::new();
+    }
+    segments.join("/")
+}
+
+/// Mounts file-tree route paths under `prefix` without changing `base` or `out_dir`.
+pub fn apply_route_prefix(
+    paths: RoutePaths,
+    prefix: &str,
+    out_dir: &str,
+    base: &str,
+) -> RoutePaths {
+    let prefix = normalize_route_prefix(prefix);
+    if prefix.is_empty() {
+        return paths;
+    }
+    RoutePaths {
+        output_path: prefix_fs_path(&paths.output_path, out_dir, &prefix),
+        url_path: prefix_url_path(&paths.url_path, &prefix),
+        href: prefix_public_path(&paths.href, base, &prefix),
+        og_image_path: prefix_fs_path(&paths.og_image_path, out_dir, &prefix),
+        og_image_url: prefix_og_url(&paths.og_image_url, base, &prefix),
+    }
+}
+
+fn prefix_url_path(url_path: &str, prefix: &str) -> String {
+    if url_path.is_empty() || url_path == "/" {
+        prefix.to_string()
+    } else {
+        format!("{prefix}/{}", url_path.trim_start_matches('/'))
+    }
+}
+
+fn prefix_fs_path(output_path: &str, out_dir: &str, prefix: &str) -> String {
+    let output = Path::new(output_path);
+    let root = Path::new(out_dir);
+    let Ok(rel) = output.strip_prefix(root) else {
+        return output_path.to_string();
+    };
+    PathBuf::from(out_dir).join(prefix).join(rel).to_string_lossy().into_owned()
+}
+
+fn prefix_public_path(href: &str, base: &str, prefix: &str) -> String {
+    let root = normalize_base(base);
+    if let Some(rest) = href.strip_prefix(&root) {
+        format!("{root}{prefix}/{rest}")
+    } else if href.starts_with('/') {
+        format!("/{prefix}{href}")
+    } else {
+        format!("{root}{prefix}/{href}")
+    }
+}
+
+fn prefix_og_url(url: &str, base: &str, prefix: &str) -> String {
+    if let Some((origin, path)) = split_origin(url) {
+        format!("{origin}{}", prefix_public_path(path, base, prefix))
+    } else {
+        prefix_public_path(url, base, prefix)
+    }
+}
+
+fn normalize_base(base: &str) -> String {
+    if base.is_empty() || base == "/" {
+        "/".to_string()
+    } else if base.ends_with('/') {
+        base.to_string()
+    } else {
+        format!("{base}/")
+    }
+}
+
+fn split_origin(url: &str) -> Option<(&str, &str)> {
+    let scheme = url.find("://")?;
+    let rest = &url[scheme + 3..];
+    let slash = rest.find('/')?;
+    let origin_end = scheme + 3 + slash;
+    Some((&url[..origin_end], &url[origin_end..]))
+}
+
+fn is_windows_abs(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_slash_variants_and_rejects_escapes() {
+        assert_eq!(normalize_route_prefix("blog"), "blog");
+        assert_eq!(normalize_route_prefix("/blog"), "blog");
+        assert_eq!(normalize_route_prefix("/blog/"), "blog");
+        assert_eq!(normalize_route_prefix(""), "");
+        assert_eq!(normalize_route_prefix("../secret"), "");
+        assert_eq!(normalize_route_prefix("//evil.example"), "");
+    }
+
+    #[test]
+    fn prefixes_page_paths_and_leaves_empty_prefix_unchanged() {
+        let raw = RoutePaths {
+            output_path: "/repo/dist/first-post/index.html".into(),
+            url_path: "first-post".into(),
+            href: "/first-post/index.html".into(),
+            og_image_path: "/repo/dist/first-post/og-image.png".into(),
+            og_image_url: "https://example.com/first-post/og-image.png".into(),
+        };
+        assert_eq!(apply_route_prefix(raw.clone(), "", "/repo/dist", "/"), raw);
+
+        let prefixed = apply_route_prefix(raw, "/blog/", "/repo/dist", "/");
+        assert_eq!(
+            prefixed.output_path,
+            PathBuf::from("/repo/dist/blog/first-post/index.html").to_string_lossy()
+        );
+        assert_eq!(prefixed.url_path, "blog/first-post");
+        assert_eq!(prefixed.href, "/blog/first-post/index.html");
+        assert_eq!(
+            prefixed.og_image_path,
+            PathBuf::from("/repo/dist/blog/first-post/og-image.png").to_string_lossy()
+        );
+        assert_eq!(prefixed.og_image_url, "https://example.com/blog/first-post/og-image.png");
+    }
+}

--- a/docs/content/built-in/site-generation.md
+++ b/docs/content/built-in/site-generation.md
@@ -58,6 +58,7 @@ export default defineConfig({
 | ----------------- | -------------- | ----------------------------------------------------------------------------------------------------- |
 | `enabled`         | `true`         | Set `ssg: false` to keep only `.md` modules.                                                          |
 | `extension`       | `".html"`      | Generated page extension.                                                                             |
+| `routePrefix`     | —              | Mount page routes under a path without changing `base` or `outDir`.                                   |
 | `clean`           | `false`        | Remove generated output before writing.                                                               |
 | `bare`            | `false`        | Emit unthemed HTML without navigation.                                                                |
 | `render`          | —              | JSX component that owns the whole document.                                                           |
@@ -86,6 +87,26 @@ export default defineConfig({
 | `markdownSource`  | `false`        | Publish original Markdown beside each page. See [Markdown source companions](./markdown-source.md).   |
 | `theme`           | `defaultTheme` | Theme configuration via `defineTheme()`.                                                              |
 | `navigation`      | derived        | Explicit navigation groups instead of the file tree.                                                  |
+
+`ssg.routePrefix` mounts Markdown page routes under a path such as `/blog`
+without changing the deployment `base` or moving root host files. `blog`,
+`/blog`, and `/blog/` all mount under `/blog`. Page HTML and page-level assets
+follow the prefix; `_redirects`, `_headers`, root feeds, and the sitemap index
+stay at `outDir`. `base` stays the public URL prefix. A frontmatter
+`permalink` still wins when [permalinks](./permalinks.md) are enabled.
+
+```ts
+oxContent({
+  srcDir: "content/blog",
+  outDir: "build",
+  ssg: { routePrefix: "/blog" },
+  redirects: { netlify: true },
+  feeds: { path: "/" },
+});
+```
+
+That writes `build/blog/first-post/index.html` while `build/_redirects` and
+`build/feed.xml` stay at the deployment root.
 
 Theming — colors, fonts, header, footer, sidebar, custom CSS, and the opt-in
 page outline (`theme.aside`, default `false`) — is a topic of its own: see

--- a/docs/content/ja/built-in/site-generation.md
+++ b/docs/content/ja/built-in/site-generation.md
@@ -54,6 +54,7 @@ export default defineConfig({
 | ----------------- | -------------- | -------------------------------------------------------------------------------------------------------- |
 | `enabled`         | `true`         | `.md` モジュールだけ残すときは `ssg: false`。                                                            |
 | `extension`       | `".html"`      | 生成ページの拡張子。                                                                                     |
+| `routePrefix`     | —              | `base` や `outDir` を変えずにページルートをマウントする。                                                |
 | `clean`           | `false`        | 書き出す前に生成物を消す。                                                                               |
 | `bare`            | `false`        | ナビなしの、テーマなし HTML を出す。                                                                     |
 | `render`          | —              | 文書全体を所有する JSX コンポーネント。                                                                  |
@@ -82,6 +83,20 @@ export default defineConfig({
 | `markdownSource`  | `false`        | 各ページの横に元の Markdown を公開する。[Markdown ソースの併記](./markdown-source.md)。                  |
 | `theme`           | `defaultTheme` | `defineTheme()` によるテーマ設定。                                                                       |
 | `navigation`      | 派生           | ファイルツリーの代わりに明示的なナビグループ。                                                           |
+
+`ssg.routePrefix` はデプロイの `base` やルートのホストファイルを動かさずに、Markdown ページルートを `/blog` のようなパスへマウントします。`blog`、`/blog`、`/blog/` はどれも `/blog` 配下になります。ページ HTML とページ単位のアセットはプレフィックスに従い、`_redirects`、`_headers`、ルートのフィード、サイトマップ index は `outDir` に残ります。`base` は公開 URL のプレフィックスのままです。[パーマリンク](./permalinks.md) がオンのとき、frontmatter の `permalink` が勝ちます。
+
+```ts
+oxContent({
+  srcDir: "content/blog",
+  outDir: "build",
+  ssg: { routePrefix: "/blog" },
+  redirects: { netlify: true },
+  feeds: { path: "/" },
+});
+```
+
+これは `build/blog/first-post/index.html` を書き、`build/_redirects` と `build/feed.xml` はデプロイルートに残します。
 
 テーマ — 色、フォント、ヘッダー、フッター、サイドバー、独自 CSS、オプトインのページアウトライン（`theme.aside`、既定 `false`）— は別トピックです。[テーマ](../theming.md#ページアウトライン) を見てください。
 

--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -1,7 +1,10 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it } from "vite-plus/test";
 import {
   buildNavItems,
+  buildSsg,
   buildThemeNavItems,
   formatTitle,
   generateBareHtmlPage,
@@ -17,6 +20,13 @@ import {
 } from "./ssg";
 import { applyContributorOptions, filterGitContributors, gravatarAvatar } from "./contributors";
 import type { ResolvedOptions } from "./types";
+import { createDocsResolvedOptions } from "../test/fixtures/docs-fixture";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
 
 describe("resolveSsgOptions", () => {
   it("disables git timestamps by default", () => {
@@ -207,6 +217,23 @@ describe("resolveSsgOptions", () => {
     expect(resolved.bodyStart).toBe("<header>site</header>");
     expect(resolved.bodyEnd).toBe("<footer>end</footer>");
   });
+
+  it("leaves routePrefix off when omitted", () => {
+    expect(resolveSsgOptions(undefined).routePrefix).toBeUndefined();
+    expect(resolveSsgOptions(true).routePrefix).toBeUndefined();
+    expect(resolveSsgOptions({}).routePrefix).toBeUndefined();
+  });
+
+  it("normalizes routePrefix mounts to a slash-free path", () => {
+    expect(resolveSsgOptions({ routePrefix: "blog" }).routePrefix).toBe("blog");
+    expect(resolveSsgOptions({ routePrefix: "/blog" }).routePrefix).toBe("blog");
+    expect(resolveSsgOptions({ routePrefix: "/blog/" }).routePrefix).toBe("blog");
+  });
+
+  it("rejects path-escape routePrefix values", () => {
+    expect(resolveSsgOptions({ routePrefix: "../secret" }).routePrefix).toBeUndefined();
+    expect(resolveSsgOptions({ routePrefix: "//evil.example" }).routePrefix).toBeUndefined();
+  });
 });
 
 describe("generateBarePage", () => {
@@ -339,6 +366,21 @@ describe("SSG route helpers", () => {
       path.join(outDir, "components", "button", "index.html"),
     );
     expect(getUrlPath(mdxPath, srcDir)).toBe("components/button");
+  });
+
+  it("mounts file-tree routes under routePrefix without changing base", () => {
+    const srcDir = path.join(process.cwd(), "docs");
+    const outDir = path.join(process.cwd(), "dist");
+    const inputPath = path.join(srcDir, "guide", "intro.md");
+
+    expect(getOutputPath(inputPath, srcDir, outDir, ".html", "/blog/")).toBe(
+      path.join(outDir, "blog", "guide", "intro", "index.html"),
+    );
+    expect(getUrlPath(inputPath, srcDir, "/blog")).toBe("blog/guide/intro");
+    expect(getHref(inputPath, srcDir, "/docs/", ".html", "blog")).toBe(
+      "/docs/blog/guide/intro/index.html",
+    );
+    expect(getHref(inputPath, srcDir, "/", ".html", "/blog")).toBe("/blog/guide/intro/index.html");
   });
 
   it("builds nav groups in the default SSG order", () => {
@@ -488,3 +530,105 @@ describe("git contributors", () => {
     expect(ada.avatar).toMatch(/^https:\/\/www\.gravatar\.com\/avatar\/[a-f0-9]{32}\?d=mp&s=40$/);
   });
 });
+
+describe("SSG routePrefix", () => {
+  it("keeps existing page paths when routePrefix is omitted", async () => {
+    const root = await makeSite({
+      "first-post/index.md": "---\ntitle: First\n---\n# First\n",
+    });
+    const built = await buildSsg(routePrefixOptions(), root);
+
+    expect(built.files.some((file) => file.endsWith(path.join("first-post", "index.html")))).toBe(
+      true,
+    );
+    expect(built.files.some((file) => file.includes(`${path.sep}blog${path.sep}`))).toBe(false);
+    expect(built.errors).toEqual([]);
+  });
+
+  it("writes pages under the prefix and keeps _redirects at outDir", async () => {
+    const root = await makeSite({
+      "first-post/index.md":
+        "---\ntitle: First\naliases: [/old-post]\n---\n# First\n[Next](./second-post.md)\n",
+      "second-post/index.md": "---\ntitle: Second\n---\n# Second\n",
+    });
+    const built = await buildSsg(
+      routePrefixOptions({
+        ssg: { ...routePrefixOptions().ssg, routePrefix: "/blog" },
+        redirects: {
+          enabled: true,
+          map: {},
+          netlify: true,
+          headers: false,
+          json: false,
+          allowExternal: false,
+        },
+      }),
+      root,
+    );
+
+    expect(built.files).toEqual(
+      expect.arrayContaining([
+        path.join(root, "dist", "blog", "first-post", "index.html"),
+        path.join(root, "dist", "blog", "second-post", "index.html"),
+        path.join(root, "dist", "_redirects"),
+      ]),
+    );
+    expect(
+      built.files.some((file) => file.endsWith(path.join("dist", "first-post", "index.html"))),
+    ).toBe(false);
+    await expect(fs.access(path.join(root, "dist", "blog", "_redirects"))).rejects.toThrow();
+
+    const html = await fs.readFile(
+      path.join(root, "dist", "blog", "first-post", "index.html"),
+      "utf8",
+    );
+    expect(html).toContain("/blog/first-post/");
+    expect(built.errors).toEqual([]);
+  });
+
+  it("lets a permalink override win over routePrefix", async () => {
+    const root = await makeSite({
+      "first-post/index.md": "---\ntitle: First\npermalink: /standalone\n---\n# First\n",
+      "second-post/index.md": "---\ntitle: Second\n---\n# Second\n",
+    });
+    const built = await buildSsg(
+      routePrefixOptions({
+        ssg: { ...routePrefixOptions().ssg, routePrefix: "/blog" },
+        permalinks: { enabled: true },
+      }),
+      root,
+    );
+
+    expect(built.files).toEqual(
+      expect.arrayContaining([
+        path.join(root, "dist", "standalone", "index.html"),
+        path.join(root, "dist", "blog", "second-post", "index.html"),
+      ]),
+    );
+    expect(built.files.some((file) => file.includes(path.join("blog", "first-post")))).toBe(false);
+    expect(built.errors).toEqual([]);
+  });
+});
+
+async function makeSite(files: Record<string, string>): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-route-prefix-"));
+  tempDirs.push(root);
+  for (const [name, source] of Object.entries(files)) {
+    const full = path.join(root, "content", name);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, source);
+  }
+  return root;
+}
+
+function routePrefixOptions(overrides: Partial<ResolvedOptions> = {}): ResolvedOptions {
+  const base = createDocsResolvedOptions({
+    ssg: {
+      ...createDocsResolvedOptions().ssg,
+      bare: true,
+      siteUrl: "https://example.com",
+    },
+    search: { enabled: false, limit: 10, prefix: true, placeholder: "Search", hotkey: "/" },
+  });
+  return { ...base, ...overrides, ssg: { ...base.ssg, ...overrides.ssg } };
+}

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -174,6 +174,122 @@ interface SsgRoutePaths {
  */
 export const DEFAULT_HTML_TEMPLATE = "<!-- ox-content default HTML template is Rust-backed -->";
 
+/** Normalizes `blog` / `/blog` / `/blog/` to `blog`. Empty or unsafe values stay off. */
+export function normalizeRoutePrefix(value?: string): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (
+    !trimmed ||
+    trimmed.includes("\\") ||
+    trimmed.includes("\0") ||
+    trimmed.includes("://") ||
+    trimmed.startsWith("//") ||
+    /^[a-zA-Z]:/u.test(trimmed)
+  ) {
+    return undefined;
+  }
+  const segments = trimmed
+    .replaceAll(/^\/+|\/+$/gu, "")
+    .split("/")
+    .filter((segment) => segment.length > 0);
+  if (segments.length === 0 || segments.some((segment) => segment === "." || segment === "..")) {
+    return undefined;
+  }
+  return segments.join("/");
+}
+
+function resolvedRoutePrefix(value?: string): { routePrefix: string } | Record<string, never> {
+  const prefix = normalizeRoutePrefix(value);
+  return prefix ? { routePrefix: prefix } : {};
+}
+
+function applyUrlPrefix(urlPath: string, routePrefix?: string): string {
+  const prefix = normalizeRoutePrefix(routePrefix);
+  if (!prefix) {
+    return urlPath;
+  }
+  if (!urlPath || urlPath === "/") {
+    return prefix;
+  }
+  return `${prefix}/${urlPath.replace(/^\/+/u, "")}`;
+}
+
+function applyOutputPrefix(outputPath: string, outDir: string, routePrefix?: string): string {
+  const prefix = normalizeRoutePrefix(routePrefix);
+  if (!prefix) {
+    return outputPath;
+  }
+  const rel = path.relative(path.resolve(outDir), path.resolve(outputPath));
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    return outputPath;
+  }
+  return path.join(outDir, prefix, rel);
+}
+
+function applyHrefPrefix(href: string, base: string, routePrefix?: string): string {
+  const prefix = normalizeRoutePrefix(routePrefix);
+  if (!prefix) {
+    return href;
+  }
+  const root = !base || base === "/" ? "/" : base.endsWith("/") ? base : `${base}/`;
+  if (href.startsWith(root)) {
+    return `${root}${prefix}/${href.slice(root.length)}`;
+  }
+  return href.startsWith("/") ? `/${prefix}${href}` : `${root}${prefix}/${href}`;
+}
+
+function applyOgUrlPrefix(url: string, base: string, routePrefix?: string): string {
+  if (!normalizeRoutePrefix(routePrefix)) {
+    return url;
+  }
+  const scheme = url.indexOf("://");
+  if (scheme === -1) {
+    return applyHrefPrefix(url, base, routePrefix);
+  }
+  const pathStart = url.indexOf("/", scheme + 3);
+  if (pathStart === -1) {
+    return applyHrefPrefix(url, base, routePrefix);
+  }
+  return `${url.slice(0, pathStart)}${applyHrefPrefix(url.slice(pathStart), base, routePrefix)}`;
+}
+
+function applySsgRoutePrefix(
+  paths: SsgRoutePaths,
+  routePrefix: string | undefined,
+  outDir: string,
+  base: string,
+): SsgRoutePaths {
+  if (!normalizeRoutePrefix(routePrefix)) {
+    return paths;
+  }
+  return {
+    outputPath: applyOutputPrefix(paths.outputPath, outDir, routePrefix),
+    urlPath: applyUrlPrefix(paths.urlPath, routePrefix),
+    href: applyHrefPrefix(paths.href, base, routePrefix),
+    ogImagePath: applyOutputPrefix(paths.ogImagePath, outDir, routePrefix),
+    ogImageUrl: applyOgUrlPrefix(paths.ogImageUrl, base, routePrefix),
+  };
+}
+
+function publicBase(base: string, routePrefix?: string): string {
+  const root = !base || base === "/" ? "/" : base.endsWith("/") ? base : `${base}/`;
+  const prefix = normalizeRoutePrefix(routePrefix);
+  return prefix ? `${root}${prefix}/` : root;
+}
+
+function localeUrlPath(urlPath: string, routePrefix?: string): string {
+  const prefix = normalizeRoutePrefix(routePrefix);
+  if (!prefix) {
+    return urlPath;
+  }
+  if (urlPath === prefix) {
+    return "/";
+  }
+  return urlPath.startsWith(`${prefix}/`) ? urlPath.slice(prefix.length + 1) : urlPath;
+}
+
 /**
  * Resolves SSG options with defaults.
  */
@@ -232,6 +348,7 @@ export function resolveSsgOptions(ssg: SsgOptions | boolean | undefined): Resolv
   return {
     enabled: ssg.enabled ?? true,
     extension: ssg.extension ?? ".html",
+    ...resolvedRoutePrefix(ssg.routePrefix),
     clean: ssg.clean ?? false,
     bare: ssg.bare ?? false,
     render: ssg.render,
@@ -713,15 +830,20 @@ export function getOutputPath(
   srcDir: string,
   outDir: string,
   extension: string,
+  routePrefix?: string,
 ): string {
-  return importNapiModuleSync().getSsgOutputPath(inputPath, srcDir, outDir, extension);
+  return applyOutputPrefix(
+    importNapiModuleSync().getSsgOutputPath(inputPath, srcDir, outDir, extension),
+    outDir,
+    routePrefix,
+  );
 }
 
 /**
  * Converts a markdown file path to a relative URL path.
  */
-export function getUrlPath(inputPath: string, srcDir: string): string {
-  return importNapiModuleSync().getSsgUrlPath(inputPath, srcDir);
+export function getUrlPath(inputPath: string, srcDir: string, routePrefix?: string): string {
+  return applyUrlPrefix(importNapiModuleSync().getSsgUrlPath(inputPath, srcDir), routePrefix);
 }
 
 /**
@@ -732,8 +854,13 @@ export function getHref(
   srcDir: string,
   base: string,
   extension: string,
+  routePrefix?: string,
 ): string {
-  return importNapiModuleSync().getSsgHref(inputPath, srcDir, base, extension);
+  return applyHrefPrefix(
+    importNapiModuleSync().getSsgHref(inputPath, srcDir, base, extension),
+    base,
+    routePrefix,
+  );
 }
 
 /**
@@ -769,14 +896,20 @@ function getRoutePaths(
   base: string,
   extension: string,
   siteUrl?: string,
+  routePrefix?: string,
 ): SsgRoutePaths {
-  return importNapiModuleSync().resolveSsgRoutePaths(
-    inputPath,
-    srcDir,
+  return applySsgRoutePrefix(
+    importNapiModuleSync().resolveSsgRoutePaths(
+      inputPath,
+      srcDir,
+      outDir,
+      base,
+      extension,
+      siteUrl,
+    ),
+    routePrefix,
     outDir,
     base,
-    extension,
-    siteUrl,
   );
 }
 
@@ -1121,7 +1254,7 @@ function applyPermalinkRoutes(context: BuildSsgContext, collected: CollectedPage
 }
 
 function remapPermalinkNav(context: BuildSsgContext, listedPages: PageProcessResult[]): void {
-  if (!context.options.permalinks?.enabled) {
+  if (!context.options.permalinks?.enabled && !context.ssgOptions.routePrefix) {
     return;
   }
   const usedManualNav =
@@ -1221,7 +1354,7 @@ async function transformSsgPage(
   const content = await fs.readFile(inputPath, "utf-8");
   const result = await transformMarkdown(content, inputPath, context.options, {
     convertMdLinks: true,
-    baseUrl: context.base,
+    baseUrl: publicBase(context.base, context.ssgOptions.routePrefix),
     sourcePath: inputPath,
   });
   const frontmatter = normalizeVitePressFrontmatter(result.frontmatter);
@@ -1238,6 +1371,7 @@ async function transformSsgPage(
       context.base,
       context.ssgOptions.extension,
       context.ssgOptions.siteUrl,
+      context.ssgOptions.routePrefix,
     ),
     transformedHtml,
     title,
@@ -1444,7 +1578,10 @@ async function renderSsgPage(
         content: pageResult.transformedHtml,
         lang:
           context.ssgOptions.lang ??
-          getPageLocale(pageResult.routePaths.urlPath, context.options.i18n),
+          getPageLocale(
+            localeUrlPath(pageResult.routePaths.urlPath, context.ssgOptions.routePrefix),
+            context.options.i18n,
+          ),
         description: pageResult.description,
         canonicalUrl: canonicalPageUrl(context, pageResult.routePaths.urlPath),
         siteName: context.ssgOptions.siteName,
@@ -1474,7 +1611,7 @@ async function renderSsgPage(
   const localePath = versionNavigation
     ? unversionedPath(pageData.path, versionNavigation)
     : pageData.path;
-  const locale = getPageLocale(localePath, i18n);
+  const locale = getPageLocale(localeUrlPath(localePath, context.ssgOptions.routePrefix), i18n);
   const localeNav =
     i18n && locale
       ? {

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -176,6 +176,22 @@ export interface SsgOptions {
   extension?: string;
 
   /**
+   * Mount generated page routes under this path, independent from `base` and
+   * `outDir`.
+   *
+   * `blog`, `/blog`, and `/blog/` all mount under `/blog`. Page HTML and
+   * page-level assets follow the prefix. Root host files (`_redirects`,
+   * `_headers`, root feeds, sitemap index) stay at `outDir`. `base` remains
+   * the public deployment prefix and is not used as an output mount.
+   * Frontmatter `permalink` still wins when permalinks are enabled.
+   *
+   * Off when omitted.
+   *
+   * @default undefined
+   */
+  routePrefix?: string;
+
+  /**
    * Remove previously generated files from the output directory before writing
    * the new SSG result.
    *
@@ -624,6 +640,10 @@ export type ResolvedJsonLd =
 export interface ResolvedSsgOptions {
   enabled: boolean;
   extension: string;
+  /**
+   * Present after `resolveSsgOptions`. Omitted / empty means off.
+   */
+  routePrefix?: string;
   clean: boolean;
   bare: boolean;
   render?: ThemeComponent;


### PR DESCRIPTION
## Summary
- Add `ssg.routePrefix` so a content root can mount under `/blog` (or similar) without changing deployment `base` or `outDir`.
- Page HTML, hrefs, `routePaths`, and page-level assets follow the prefix; `_redirects`, `_headers`, root feeds, and the sitemap index stay at `outDir`.
- Frontmatter `permalink` still wins when permalinks are enabled. Omitted prefix leaves existing routes unchanged.

Closes #931

## Test plan
- [x] `vp exec --filter @ox-content/vite-plugin -- vp test src/ssg.test.ts src/permalinks.test.ts` (71 passed)
- [x] `cargo test -p ox_content_ssg --lib` (222 passed)
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)