### PR TITLE
fix: continue eliminating panic-prone production paths (#853)

### DIFF
--- a/config/panic-allowlist.json
+++ b/config/panic-allowlist.json
@@ -3,52 +3,10 @@
   "description": "Reviewed production panic-prone constructs. New hits fail CI. Lower counts when a site is removed. Follow-up PRs for #774 should shrink this list.",
   "entries": [
     {
-      "file": "crates/ox_content_docs/src/graph/docs.rs",
-      "kind": "expect",
-      "count": 1,
-      "reason": "Internal docs-cache lookup after insert. Follow-up: return a typed error."
-    },
-    {
-      "file": "crates/ox_content_docs/src/string_builder.rs",
-      "kind": "expect",
-      "count": 2,
-      "reason": "ASCII digit buffer is written by this crate; UTF-8 is an internal invariant."
-    },
-    {
-      "file": "crates/ox_content_link_checker/src/site.rs",
-      "kind": "expect",
-      "count": 1,
-      "reason": "Generated-page index lookup after the walker inserted the file. Follow-up: Result."
-    },
-    {
-      "file": "crates/ox_content_lsp/src/frontmatter/schema.rs",
-      "kind": "expect",
-      "count": 1,
-      "reason": "Compile-time builtin JSON schema. Follow-up: include_str parse once with documented fallback."
-    },
-    {
       "file": "crates/ox_content_profile_cli/src/markdown.rs",
       "kind": "unreachable",
       "count": 1,
-      "reason": "CLI dispatch exhaustiveness after command routing. Not a user-content path."
-    },
-    {
-      "file": "crates/ox_content_profiler/src/alloc/histogram.rs",
-      "kind": "expect",
-      "count": 1,
-      "reason": "ASCII digit buffer written by this crate; UTF-8 is an internal invariant."
-    },
-    {
-      "file": "crates/ox_content_profiler/src/report/format.rs",
-      "kind": "expect",
-      "count": 1,
-      "reason": "ASCII digit buffer written by this crate; UTF-8 is an internal invariant."
-    },
-    {
-      "file": "crates/ox_content_transform/src/youtube.rs",
-      "kind": "expect",
-      "count": 3,
-      "reason": "Compile-time Regex::new literals. Invalid patterns fail at startup, not on user HTML."
+      "reason": "CLI dispatch exhaustiveness after command routing. Proven: main run() sends only Parse/Render/Pipeline here; docs-* variants are handled first. Not a user-content path."
     }
   ]
 }

--- a/crates/ox_content_docs/src/graph/docs.rs
+++ b/crates/ox_content_docs/src/graph/docs.rs
@@ -71,14 +71,14 @@ pub(super) fn normalized_entries_for_module<'a>(
     // Dependency graph construction can revisit the same module through many
     // re-export edges. Cache normalized entries per resolved path so each file
     // is parsed and normalized once, then return borrowed slices for all later
-    // graph edges. The explicit insert-before-get shape keeps the returned
-    // borrow simple while avoiding repeated extractor work.
+    // graph edges. `contains_key` then `insert` avoids a get-after-insert expect
+    // and keeps the returned borrow simple.
     if !docs_cache.contains_key(module) {
         // Take the doc items the export-graph walk already extracted from this
         // module's AST when available - `remove` so they move into the cache
         // rather than being cloned (each module is normalized once). Only parse
         // the file again on a miss (the all-visibility fallback, or a module the
-        // walk didn't visit).
+        // walk didn't visit). Extraction failures stay typed.
         let items = match walk_docs.and_then(|docs| docs.remove(&normalize_existing_path(module))) {
             Some(items) => items,
             None => extractor
@@ -88,7 +88,10 @@ pub(super) fn normalized_entries_for_module<'a>(
         docs_cache.insert(module.clone(), normalize_doc_items(items, type_parameters));
     }
 
-    Ok(docs_cache.get(module).expect("normalized docs cache entry").as_slice())
+    // `insert` above is the only writer and this crate is single-threaded, so a
+    // miss here would be a HashMap bug. Return an empty slice instead of aborting
+    // so unexpected cache state degrades to missing-declaration diagnostics.
+    Ok(docs_cache.get(module).map_or(&[], Vec::as_slice))
 }
 
 pub(super) fn filtered_visibility_reason(
@@ -135,4 +138,92 @@ pub(super) fn export_entrypoint_message(
     message.push_char('"');
     message.push_str(suffix);
     message.into_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use rustc_hash::FxHashMap;
+
+    use super::*;
+    use crate::DocExtractor;
+
+    fn temp_module(name: &str) -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!("ox-content-docs-cache-{nanos}-{seq}"));
+        fs::create_dir_all(&dir).unwrap();
+        dir.join(name)
+    }
+
+    #[test]
+    fn missing_module_returns_extract_error() {
+        let mut cache = FxHashMap::default();
+        let extractor = DocExtractor::new();
+        let missing = PathBuf::from("/definitely/does-not-exist-853.ts");
+        let error = normalized_entries_for_module(&mut cache, None, &extractor, &missing, false)
+            .unwrap_err();
+        assert!(matches!(error, GraphError::Extract { path, .. } if path == missing));
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn unsupported_and_invalid_utf8_modules_return_extract_errors() {
+        let extractor = DocExtractor::new();
+
+        let readme = temp_module("README.md");
+        fs::write(&readme, "# not a module\n").unwrap();
+        let mut cache = FxHashMap::default();
+        let error = normalized_entries_for_module(&mut cache, None, &extractor, &readme, false)
+            .unwrap_err();
+        assert!(matches!(error, GraphError::Extract { .. }), "{error}");
+
+        let binary = temp_module("hostile.ts");
+        fs::write(&binary, [0xff, 0xfe, 0x00, 0x01]).unwrap();
+        let mut cache = FxHashMap::default();
+        let error = normalized_entries_for_module(&mut cache, None, &extractor, &binary, false)
+            .unwrap_err();
+        assert!(matches!(error, GraphError::Extract { .. }), "{error}");
+    }
+
+    #[test]
+    fn caches_normalized_entries_and_reuses_walk_docs() {
+        let path = temp_module("math.ts");
+        fs::write(&path, "/** Adds two numbers. */\nexport function add(a: number, b: number): number {\n  return a + b;\n}\n")
+            .unwrap();
+        let extractor = DocExtractor::new();
+        let mut cache = FxHashMap::default();
+
+        let first =
+            normalized_entries_for_module(&mut cache, None, &extractor, &path, false).unwrap();
+        assert!(first.iter().any(|entry| entry.name == "add"));
+        let first_len = first.len();
+
+        let second =
+            normalized_entries_for_module(&mut cache, None, &extractor, &path, false).unwrap();
+        assert_eq!(second.len(), first_len);
+
+        let items = extractor.extract_file(&path).unwrap();
+        let mut walk_docs = FxHashMap::default();
+        walk_docs.insert(normalize_existing_path(&path), items);
+        // Corrupt the file so a cache miss would surface as Extract, not success.
+        fs::write(&path, [0xff, 0xfe, 0x00]).unwrap();
+
+        let mut walk_cache = FxHashMap::default();
+        let walked = normalized_entries_for_module(
+            &mut walk_cache,
+            Some(&mut walk_docs),
+            &extractor,
+            &path,
+            false,
+        )
+        .unwrap();
+        assert!(walked.iter().any(|entry| entry.name == "add"));
+        assert!(walk_docs.is_empty());
+    }
 }

--- a/crates/ox_content_docs/src/string_builder.rs
+++ b/crates/ox_content_docs/src/string_builder.rs
@@ -32,20 +32,7 @@ impl StringBuilder {
         // valid suffix in one `push_str`; this replaces `value.to_string()`
         // in loops that render stats, anchors, headings, and file names.
         let mut buffer = [0_u8; 20];
-        let mut cursor = buffer.len();
-        let mut rest = value;
-
-        loop {
-            cursor -= 1;
-            buffer[cursor] = b'0' + (rest % 10) as u8;
-            rest /= 10;
-            if rest == 0 {
-                break;
-            }
-        }
-
-        let digits = std::str::from_utf8(&buffer[cursor..]).expect("digits are valid utf-8");
-        self.output.push_str(digits);
+        push_decimal_digits(&mut self.output, value as u128, &mut buffer);
     }
 
     #[cfg(test)]
@@ -53,20 +40,7 @@ impl StringBuilder {
         // Test-only wide variant for boundary coverage of the digit writer.
         // `u128::MAX` is 39 decimal digits.
         let mut buffer = [0_u8; 39];
-        let mut cursor = buffer.len();
-        let mut rest = value;
-
-        loop {
-            cursor -= 1;
-            buffer[cursor] = b'0' + (rest % 10) as u8;
-            rest /= 10;
-            if rest == 0 {
-                break;
-            }
-        }
-
-        let digits = std::str::from_utf8(&buffer[cursor..]).expect("digits are valid utf-8");
-        self.output.push_str(digits);
+        push_decimal_digits(&mut self.output, value, &mut buffer);
     }
 
     pub fn is_empty(&self) -> bool {
@@ -116,4 +90,59 @@ pub fn join5(first: &str, second: &str, third: &str, fourth: &str, fifth: &str) 
     out.push_str(fourth);
     out.push_str(fifth);
     out.into_string()
+}
+
+fn push_decimal_digits(output: &mut String, mut value: u128, buffer: &mut [u8]) {
+    // Caller-sized stack buffers are filled only with ASCII `'0'..='9'`.
+    // Interpret that suffix as UTF-8, and copy bytes as chars if the check
+    // ever fails rather than aborting a docs render.
+    if buffer.is_empty() {
+        return;
+    }
+    let mut cursor = buffer.len();
+    loop {
+        cursor -= 1;
+        buffer[cursor] = b'0' + (value % 10) as u8;
+        value /= 10;
+        if value == 0 || cursor == 0 {
+            break;
+        }
+    }
+    match std::str::from_utf8(&buffer[cursor..]) {
+        Ok(digits) => output.push_str(digits),
+        Err(_) => output.extend(buffer[cursor..].iter().copied().map(char::from)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_usize_writes_zero_and_wide_values() {
+        let mut out = StringBuilder::new();
+        out.push_usize(0);
+        out.push_char(' ');
+        out.push_usize(10);
+        out.push_char(' ');
+        out.push_usize(usize::MAX);
+        assert_eq!(out.into_string(), format!("0 10 {}", usize::MAX));
+    }
+
+    #[test]
+    fn push_u128_writes_max_without_panic() {
+        let mut out = StringBuilder::new();
+        out.push_u128(0);
+        out.push_char('-');
+        out.push_u128(u128::MAX);
+        assert_eq!(out.into_string(), format!("0-{}", u128::MAX));
+    }
+
+    #[test]
+    fn joins_preserve_empty_and_hostile_fragments() {
+        assert_eq!(join2("", "x"), "x");
+        assert_eq!(join3("<", "script", ">"), "<script>");
+        assert_eq!(join4("a", "\0", "b", "\u{1F680}"), "a\0b\u{1F680}");
+        assert_eq!(join5("", "", "", "", ""), "");
+    }
 }

--- a/crates/ox_content_link_checker/src/site.rs
+++ b/crates/ox_content_link_checker/src/site.rs
@@ -25,27 +25,31 @@ pub fn check_site(options: &SiteCheckOptions) -> io::Result<Vec<SiteReport>> {
     collect_html_files(&site_dir, &mut html_files)?;
     html_files.sort();
 
-    let mut pages = FxHashMap::default();
-    for file in &html_files {
-        let source = fs::read_to_string(file)?;
+    let mut ordered_pages = Vec::with_capacity(html_files.len());
+    for file in html_files {
+        let source = fs::read_to_string(&file)?;
         let document = parse_html(&source);
-        pages.insert(file.clone(), Page { source, document });
+        ordered_pages.push((file, Page { source, document }));
     }
 
+    // Walk the same owned pages we just parsed. Cross-file lookups go through
+    // this map; the current page never needs a fallible get-after-insert.
+    let pages: FxHashMap<&Path, &Page> =
+        ordered_pages.iter().map(|(file, page)| (file.as_path(), page)).collect();
+
     let mut reports = Vec::new();
-    for file in html_files {
-        let page = pages.get(&file).expect("indexed generated page");
+    for (file, page) in &ordered_pages {
         let line_index = LineIndex::new(&page.source);
         let mut diagnostics = Vec::new();
         for link in &page.document.links {
             if let Some(diagnostic) =
-                check_link(&site_dir, &file, &options.base, link, &pages, &line_index)
+                check_link(&site_dir, file, &options.base, link, &pages, &line_index)
             {
                 diagnostics.push(diagnostic);
             }
         }
         if !diagnostics.is_empty() {
-            reports.push(SiteReport { file_path: file, diagnostics });
+            reports.push(SiteReport { file_path: file.clone(), diagnostics });
         }
     }
     Ok(reports)
@@ -56,7 +60,7 @@ fn check_link(
     source_file: &Path,
     base: &str,
     link: &HtmlLink,
-    pages: &FxHashMap<PathBuf, Page>,
+    pages: &FxHashMap<&Path, &Page>,
     line_index: &LineIndex,
 ) -> Option<Diagnostic> {
     let target = link.target.trim();
@@ -90,7 +94,7 @@ fn check_link(
 
     if let Some(fragment) = anchor.filter(|fragment| !fragment.is_empty() && *fragment != "top") {
         let decoded = percent_decode(fragment);
-        let Some(target_page) = pages.get(&target_file) else {
+        let Some(target_page) = pages.get(target_file.as_path()) else {
             return Some(diagnostic(
                 line_index,
                 link,
@@ -116,7 +120,7 @@ fn check_link(
     }
 
     if !link.is_redirect_destination
-        && pages.get(&target_file).is_some_and(|page| page.document.is_redirect)
+        && pages.get(target_file.as_path()).is_some_and(|page| page.document.is_redirect)
     {
         return Some(diagnostic(
             line_index,

--- a/crates/ox_content_link_checker/src/site/tests.rs
+++ b/crates/ox_content_link_checker/src/site/tests.rs
@@ -106,3 +106,28 @@ fn generated_site_ignores_markup_like_text_inside_scripts_and_styles() {
     let reports = check_site(&options(&root)).unwrap();
     assert!(reports.is_empty(), "{reports:#?}");
 }
+
+#[test]
+fn generated_site_does_not_panic_on_hostile_markup() {
+    let root = fixture("hostile-markup");
+    let huge_href = format!("/ox-content/{}", "a".repeat(8_192));
+    write(
+        &root,
+        "index.html",
+        &format!(
+            r#"<a href="javascript:alert(1)">js</a>
+<a href="{huge_href}">huge</a>
+<a href="/ox-content/missing/#"><img src="data:text/html,<script>x</script>"></a>
+<a href="./#\0not-an-anchor">nul</a>
+<p>unclosed <a href="/ox-content/ok/#gone""#
+        ),
+    );
+    write(&root, "ok/index.html", r#"<h1 id="ok">Ok</h1>"#);
+
+    let reports = check_site(&options(&root)).unwrap();
+    let diagnostics = all_diagnostics(&reports);
+    assert!(
+        diagnostics.iter().any(|diagnostic| diagnostic.message.contains("does not exist")),
+        "{reports:#?}"
+    );
+}

--- a/crates/ox_content_lsp/src/frontmatter/schema.rs
+++ b/crates/ox_content_lsp/src/frontmatter/schema.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::Path;
+use std::sync::OnceLock;
 
 use crate::frontmatter::FrontmatterSchema;
 
@@ -18,7 +19,22 @@ pub fn load_schema(path: &Path) -> Result<FrontmatterSchema, String> {
 }
 
 pub fn builtin_schema() -> FrontmatterSchema {
-    serde_json::from_value(serde_json::json!({
+    static SCHEMA: OnceLock<FrontmatterSchema> = OnceLock::new();
+    SCHEMA.get_or_init(parse_builtin_schema).clone()
+}
+
+fn parse_builtin_schema() -> FrontmatterSchema {
+    // Compile-time object literal. A parse failure would mean the checked-in
+    // schema is invalid; fall back to an empty object schema so the language
+    // server still starts instead of aborting when a Markdown file is opened.
+    serde_json::from_value(builtin_schema_value()).unwrap_or_else(|_| FrontmatterSchema {
+        type_name: Some("object".to_string()),
+        ..FrontmatterSchema::default()
+    })
+}
+
+fn builtin_schema_value() -> serde_json::Value {
+    serde_json::json!({
         "type": "object",
         "properties": {
             "title": {
@@ -101,6 +117,70 @@ pub fn builtin_schema() -> FrontmatterSchema {
                 }
             }
         }
-    }))
-    .expect("builtin frontmatter schema is valid")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    fn temp_schema(name: &str) -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!("ox-content-lsp-schema-{nanos}-{seq}"));
+        fs::create_dir_all(&dir).unwrap();
+        dir.join(name)
+    }
+
+    #[test]
+    fn builtin_schema_exposes_core_frontmatter_fields() {
+        let schema = builtin_schema();
+        assert_eq!(schema.type_name.as_deref(), Some("object"));
+        for name in ["title", "description", "layout", "draft", "unlisted", "tags", "meta"] {
+            assert!(schema.property(name).is_some(), "missing {name}");
+        }
+        let layout = schema.property("layout").unwrap();
+        assert!(layout.enum_values.iter().any(|value| value.as_str() == Some("doc")));
+        let meta = schema.property("meta").unwrap();
+        assert_eq!(meta.additional_properties, Some(false));
+        assert!(meta.property("ogImage").is_some());
+    }
+
+    #[test]
+    fn load_schema_rejects_missing_and_hostile_inputs() {
+        let missing = PathBuf::from("/definitely/does-not-exist-853.json");
+        assert!(load_schema(&missing).unwrap_err().contains("Failed to read schema"));
+
+        let broken_json = temp_schema("broken.json");
+        fs::write(&broken_json, r#"{"type": "object", "properties": {"#).unwrap();
+        assert!(load_schema(&broken_json).unwrap_err().contains("Failed to parse schema"));
+
+        let broken_yaml = temp_schema("broken.yaml");
+        fs::write(&broken_yaml, "type: [unterminated\n").unwrap();
+        assert!(load_schema(&broken_yaml).unwrap_err().contains("Failed to parse schema"));
+
+        let not_object = temp_schema("array.json");
+        fs::write(&not_object, "[1, 2, 3]").unwrap();
+        assert!(load_schema(&not_object).is_err());
+    }
+
+    #[test]
+    fn load_schema_accepts_json_and_yaml_objects() {
+        let json = temp_schema("ok.json");
+        fs::write(&json, r#"{"type":"object","properties":{"title":{"type":"string"}}}"#).unwrap();
+        let schema = load_schema(&json).unwrap();
+        assert_eq!(schema.type_name.as_deref(), Some("object"));
+        assert!(schema.property("title").is_some());
+
+        let yaml = temp_schema("ok.yml");
+        fs::write(&yaml, "type: object\nproperties:\n  draft:\n    type: boolean\n").unwrap();
+        let schema = load_schema(&yaml).unwrap();
+        assert!(schema.property("draft").is_some());
+    }
 }

--- a/crates/ox_content_profiler/src/alloc/histogram.rs
+++ b/crates/ox_content_profiler/src/alloc/histogram.rs
@@ -16,7 +16,7 @@ impl SizeHistogram {
         if i == 1 {
             return "1".into();
         }
-        let lo = 1u64 << (i - 1);
+        let lo = 1u64 << (i - 1).min(63);
         let hi = 1u64 << i.min(63);
         let mut label = String::with_capacity(42);
         push_u64(&mut label, lo);
@@ -35,22 +35,24 @@ impl SizeHistogram {
     }
 }
 
-fn push_u64(output: &mut String, value: u64) {
+fn push_u64(output: &mut String, mut value: u64) {
+    // Stack buffer is filled only with ASCII `'0'..='9'`. Interpret that
+    // suffix as UTF-8, and copy bytes as chars if the check ever fails
+    // rather than aborting a profiler report.
     let mut buffer = [0_u8; 20];
     let mut cursor = buffer.len();
-    let mut rest = value;
-
     loop {
         cursor -= 1;
-        buffer[cursor] = b'0' + (rest % 10) as u8;
-        rest /= 10;
-        if rest == 0 {
+        buffer[cursor] = b'0' + (value % 10) as u8;
+        value /= 10;
+        if value == 0 {
             break;
         }
     }
-
-    let digits = std::str::from_utf8(&buffer[cursor..]).expect("digits are valid utf-8");
-    output.push_str(digits);
+    match std::str::from_utf8(&buffer[cursor..]) {
+        Ok(digits) => output.push_str(digits),
+        Err(_) => output.extend(buffer[cursor..].iter().copied().map(char::from)),
+    }
 }
 
 #[inline]

--- a/crates/ox_content_profiler/src/alloc/tests.rs
+++ b/crates/ox_content_profiler/src/alloc/tests.rs
@@ -16,6 +16,16 @@ fn bucket_layout_covers_typical_sizes() {
 }
 
 #[test]
+fn bucket_labels_cover_zero_and_wide_classes() {
+    assert_eq!(SizeHistogram::bucket_label(0), "0");
+    assert_eq!(SizeHistogram::bucket_label(1), "1");
+    assert_eq!(SizeHistogram::bucket_label(2), "2..4");
+    assert_eq!(SizeHistogram::bucket_label(6), "32..64");
+    assert_eq!(SizeHistogram::bucket_label(63), format!("{}..{}", 1u64 << 62, 1u64 << 63));
+    assert_eq!(SizeHistogram::bucket_label(usize::MAX), format!("{}..{}", 1u64 << 63, 1u64 << 63));
+}
+
+#[test]
 fn delta_handles_no_change() {
     let snap = AllocSnapshot::capture();
     let delta = snap.delta_from(&snap);

--- a/crates/ox_content_profiler/src/report/format.rs
+++ b/crates/ox_content_profiler/src/report/format.rs
@@ -48,8 +48,9 @@ pub(super) fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()
     } else {
+        let end = s.floor_char_boundary(max.saturating_sub(1));
         let mut t = String::with_capacity(max);
-        t.push_str(&s[..max.saturating_sub(1)]);
+        t.push_str(&s[..end]);
         t.push('…');
         t
     }
@@ -87,22 +88,24 @@ pub(super) fn push_fmt(output: &mut String, args: std::fmt::Arguments<'_>) {
     }
 }
 
-fn push_u128(output: &mut String, value: u128) {
+fn push_u128(output: &mut String, mut value: u128) {
+    // Stack buffer is filled only with ASCII `'0'..='9'`. Interpret that
+    // suffix as UTF-8, and copy bytes as chars if the check ever fails
+    // rather than aborting a profiler report.
     let mut buffer = [0_u8; 39];
     let mut cursor = buffer.len();
-    let mut rest = value;
-
     loop {
         cursor -= 1;
-        buffer[cursor] = b'0' + (rest % 10) as u8;
-        rest /= 10;
-        if rest == 0 {
+        buffer[cursor] = b'0' + (value % 10) as u8;
+        value /= 10;
+        if value == 0 {
             break;
         }
     }
-
-    let digits = std::str::from_utf8(&buffer[cursor..]).expect("digits are valid utf-8");
-    output.push_str(digits);
+    match std::str::from_utf8(&buffer[cursor..]) {
+        Ok(digits) => output.push_str(digits),
+        Err(_) => output.extend(buffer[cursor..].iter().copied().map(char::from)),
+    }
 }
 
 fn push_json_control_escape(output: &mut String, value: u32) {

--- a/crates/ox_content_profiler/src/report/tests.rs
+++ b/crates/ox_content_profiler/src/report/tests.rs
@@ -1,3 +1,6 @@
+use std::time::Duration;
+
+use super::format::{fmt_duration, truncate};
 use super::*;
 use crate::alloc::{AllocDelta, SizeHistogram};
 
@@ -54,4 +57,21 @@ fn table_render_is_non_empty() {
     let report = Report::from_iterations("smoke".into(), iters, cfg);
     let table = report.render_table();
     insta::assert_snapshot!(table);
+}
+
+#[test]
+fn fmt_duration_writes_nanoseconds_without_panic() {
+    assert_eq!(fmt_duration(Duration::from_nanos(0)), "0 ns");
+    assert_eq!(fmt_duration(Duration::from_nanos(999)), "999 ns");
+    assert!(fmt_duration(Duration::from_micros(12)).contains("µs"));
+    assert!(fmt_duration(Duration::from_millis(3)).contains("ms"));
+    assert!(fmt_duration(Duration::from_secs(2)).contains(" s"));
+}
+
+#[test]
+fn truncate_respects_utf8_boundaries() {
+    assert_eq!(truncate("abcd", 10), "abcd");
+    assert_eq!(truncate("abcdef", 4), "abc…");
+    assert_eq!(truncate("日本語テスト", 4), "日…");
+    assert_eq!(truncate("🚀🚀🚀", 3), "…");
 }

--- a/crates/ox_content_transform/src/youtube.rs
+++ b/crates/ox_content_transform/src/youtube.rs
@@ -14,14 +14,15 @@ mod render;
 #[cfg(test)]
 mod tests;
 
-use std::sync::LazyLock;
-
-use regex::Regex;
-
 use crate::html_scan::find_ci;
 
 use parser::find_youtube_element;
 use render::render_embed;
+
+const VIDEO_ID_LEN: usize = 11;
+const URL_ID_PREFIXES: &[&str] =
+    &["youtube.com/watch?v=", "youtu.be/", "youtube.com/embed/", "youtube.com/v/"];
+const SHORTS_PREFIX: &str = "youtube.com/shorts/";
 
 /// Options mirroring the TS `YouTubeOptions`, with the same defaults.
 #[derive(Debug, Clone)]
@@ -43,36 +44,45 @@ impl Default for YouTubeEmbedOptions {
     }
 }
 
-static VIDEO_ID: LazyLock<Regex> = LazyLock::new(|| {
-    #[allow(clippy::expect_used)]
-    Regex::new(r"^[a-zA-Z0-9_-]{11}$").expect("compile-time YouTube video id regex")
-});
-static URL_PATTERNS: LazyLock<[Regex; 2]> = LazyLock::new(|| {
-    #[allow(clippy::expect_used)]
-    [
-        Regex::new(
-            r"(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/embed/|youtube\.com/v/)([a-zA-Z0-9_-]{11})",
-        )
-        .expect("compile-time YouTube URL regex"),
-        Regex::new(r"youtube\.com/shorts/([a-zA-Z0-9_-]{11})")
-            .expect("compile-time YouTube shorts regex"),
-    ]
-});
+fn is_video_id(value: &str) -> bool {
+    value.len() == VIDEO_ID_LEN
+        && value.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_')
+}
 
-/// Extract a YouTube video id from a bare id or a watch/share/embed/shorts URL.
-/// Mirrors the TS `extractVideoId`.
-pub fn extract_video_id(input: &str) -> Option<String> {
-    if VIDEO_ID.is_match(input) {
-        return Some(input.to_string());
-    }
-    for pattern in URL_PATTERNS.iter() {
-        if let Some(captures) = pattern.captures(input)
-            && let Some(id) = captures.get(1)
-        {
-            return Some(id.as_str().to_string());
+fn video_id_after(input: &str, start: usize) -> Option<&str> {
+    let id = input.get(start..start + VIDEO_ID_LEN)?;
+    is_video_id(id).then_some(id)
+}
+
+/// Leftmost `prefix + 11-char id` match, continuing past prefixes that are not
+/// followed by a valid id. Mirrors the previous unanchored regex search.
+fn first_prefixed_id<'a>(input: &'a str, prefixes: &[&str]) -> Option<&'a str> {
+    let mut best: Option<(usize, &'a str)> = None;
+    for prefix in prefixes {
+        let mut search = 0;
+        while let Some(relative) = input.get(search..).and_then(|rest| rest.find(prefix)) {
+            let id_start = search + relative + prefix.len();
+            if let Some(id) = video_id_after(input, id_start) {
+                if best.is_none_or(|(position, _)| id_start < position) {
+                    best = Some((id_start, id));
+                }
+                break;
+            }
+            search += relative + 1;
         }
     }
-    None
+    best.map(|(_, id)| id)
+}
+
+/// Extract a YouTube video id from a bare id or a watch/share/embed/shorts URL.
+/// Mirrors the TS `extractVideoId` without compiling regexes at startup.
+pub fn extract_video_id(input: &str) -> Option<String> {
+    if is_video_id(input) {
+        return Some(input.to_string());
+    }
+    first_prefixed_id(input, URL_ID_PREFIXES)
+        .or_else(|| first_prefixed_id(input, &[SHORTS_PREFIX]))
+        .map(str::to_string)
 }
 
 /// Transform every `<youtube …>` element in `html` into an iframe embed.

--- a/crates/ox_content_transform/src/youtube/tests.rs
+++ b/crates/ox_content_transform/src/youtube/tests.rs
@@ -1,4 +1,4 @@
-use super::{YouTubeEmbedOptions, transform_youtube};
+use super::{YouTubeEmbedOptions, extract_video_id, transform_youtube};
 
 fn opts() -> YouTubeEmbedOptions {
     YouTubeEmbedOptions::default()
@@ -76,6 +76,45 @@ fn regular_host_keeps_start_query() {
 fn passes_through_when_no_element() {
     let html = r#"<p>Plain prose with a <a href="/x">link</a> and no embeds.</p>"#;
     assert_eq!(transform_youtube(html, &opts()), html);
+}
+
+#[test]
+fn extract_video_id_accepts_bare_ids_and_url_shapes() {
+    assert_eq!(extract_video_id("dQw4w9WgXcQ").as_deref(), Some("dQw4w9WgXcQ"));
+    assert_eq!(
+        extract_video_id("https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=30").as_deref(),
+        Some("dQw4w9WgXcQ")
+    );
+    assert_eq!(extract_video_id("https://youtu.be/dQw4w9WgXcQ").as_deref(), Some("dQw4w9WgXcQ"));
+    assert_eq!(
+        extract_video_id("https://www.youtube.com/embed/dQw4w9WgXcQ").as_deref(),
+        Some("dQw4w9WgXcQ")
+    );
+    assert_eq!(
+        extract_video_id("https://www.youtube.com/v/dQw4w9WgXcQ").as_deref(),
+        Some("dQw4w9WgXcQ")
+    );
+    assert_eq!(
+        extract_video_id("https://www.youtube.com/shorts/dQw4w9WgXcQ").as_deref(),
+        Some("dQw4w9WgXcQ")
+    );
+}
+
+#[test]
+fn extract_video_id_rejects_hostile_and_partial_inputs() {
+    assert_eq!(extract_video_id(""), None);
+    assert_eq!(extract_video_id("not-a-valid-id"), None);
+    assert_eq!(extract_video_id("dQw4w9WgXc"), None);
+    assert_eq!(extract_video_id("dQw4w9WgXcQQ"), None);
+    assert_eq!(extract_video_id("javascript:alert(1)"), None);
+    assert_eq!(extract_video_id("https://example.com/watch?v=dQw4w9WgXcQ"), None);
+    assert_eq!(extract_video_id("https://YOUTUBE.COM/watch?v=dQw4w9WgXcQ"), None);
+    assert_eq!(extract_video_id("<script>dQw4w9WgXcQ</script>"), None);
+    assert_eq!(
+        extract_video_id("https://youtube.com/shorts/abcdefghijk https://youtu.be/dQw4w9WgXcQ")
+            .as_deref(),
+        Some("dQw4w9WgXcQ")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Replace remaining user-content-adjacent production `expect`s (docs graph cache, generated-site index, LSP builtin schema, YouTube video-id regex) with typed errors, empty-slice/parse fallbacks, or prefix parsing.
- Drop ASCII digit-writer `expect`s in docs/profiler and make report truncation UTF-8-boundary safe.
- Shrink `config/panic-allowlist.json` to the one proven CLI-dispatch `unreachable!` in `ox_content_profile_cli`.

Closes #853

## Test plan
- [x] `node scripts/check-panic-constructs.mjs` (1 remaining production hit)
- [x] `cargo test -p ox_content_docs -p ox_content_link_checker -p ox_content_lsp -p ox_content_profiler -p ox_content_transform`
- [x] `cargo clippy` on the touched crates with `-D warnings`
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790314841&installation_model_id=422833&pr_number=993&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F993&signature=be32457acca61379f41344badc95f07851c72db6d271fa8487fad58fa6d7fa9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->