### PR TITLE
feat(styles): expose built-in component CSS to module-transformer consumers

### DIFF
--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -189,8 +189,22 @@ struct BarePageTemplate<'a> {
     body_end: &'a str,
 }
 
-/// CSS styles for SSG pages.
-const SSG_CSS: &str = include_str!("ssg.css");
+/// Marker expanded from `ssg.css` so Magic Link rules live in one file.
+const MAGIC_LINKS_INCLUDE_MARK: &str = "/* @include magic-links.css */\n";
+
+/// Published Magic Link stylesheet. Inlined into `SSG_CSS` at the same
+/// position the rules previously occupied in `ssg.css`.
+const MAGIC_LINKS_CSS: &str = include_str!("plugins/magic-links.css");
+
+/// CSS styles for SSG pages, with Magic Link rules spliced in.
+static SSG_CSS: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+    let template = include_str!("ssg.css");
+    assert!(
+        template.contains(MAGIC_LINKS_INCLUDE_MARK),
+        "ssg.css must include the magic-links marker so SSG and published CSS stay aligned"
+    );
+    template.replacen(MAGIC_LINKS_INCLUDE_MARK, MAGIC_LINKS_CSS, 1)
+});
 
 /// CSS styles for Entry pages (hero, features).
 const ENTRY_CSS: &str = include_str!("entry.css");

--- a/crates/ox_content_ssg/src/html/render.rs
+++ b/crates/ox_content_ssg/src/html/render.rs
@@ -101,7 +101,7 @@ fn generate_html_inner(
     // Build CSS as named sections instead of one anonymous blob. Shared,
     // content-addressed extraction can then pull out only the sections that are
     // globally cacheable and keep page-specific or relative-url CSS inline.
-    let mut css_sections = vec![wrap_css_section("base", SSG_CSS)];
+    let mut css_sections = vec![wrap_css_section("base", SSG_CSS.as_str())];
 
     if view_transitions_enabled(theme) {
         css_sections.push(wrap_css_section("mpa-navigation", MPA_NAVIGATION_CSS));

--- a/crates/ox_content_ssg/src/html/tests.rs
+++ b/crates/ox_content_ssg/src/html/tests.rs
@@ -54,9 +54,22 @@ fn mobile_menu_script_keeps_state_and_focus_synchronized() {
 }
 
 #[test]
+fn ssg_css_inlines_shared_magic_links_stylesheet() {
+    let magic_links = include_str!("../plugins/magic-links.css");
+    assert!(
+        super::SSG_CSS.contains(magic_links),
+        "built-in SSG must include the published magic-links stylesheet"
+    );
+    assert!(
+        !super::SSG_CSS.contains("/* @include magic-links.css */"),
+        "the include marker must be expanded before pages are rendered"
+    );
+}
+
+#[test]
 fn default_theme_surfaces_stay_flat() {
     let default_css = [
-        super::SSG_CSS,
+        super::SSG_CSS.as_str(),
         super::CONTRIBUTORS_CSS,
         super::FILE_TREE_CSS,
         super::header_chrome::HEADER_CHROME_CSS,

--- a/crates/ox_content_ssg/src/plugins/magic-links.css
+++ b/crates/ox_content_ssg/src/plugins/magic-links.css
@@ -1,0 +1,32 @@
+.content .ox-magic-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.26em;
+  max-width: 100%;
+  padding: 0.08em 0.38em 0.08em 0.24em;
+  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, transparent);
+  border-radius: 0.42em;
+  background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-bg) 18%);
+  color: inherit;
+  line-height: 1;
+  text-decoration: none;
+  vertical-align: -0.08em;
+}
+.content .ox-magic-link:hover {
+  border-color: color-mix(in srgb, var(--octc-color-primary) 45%, var(--octc-color-border));
+}
+.content .ox-magic-link:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--octc-color-primary) 72%, transparent);
+  outline-offset: 2px;
+}
+.content .ox-magic-link__image {
+  width: 1em;
+  height: 1em;
+  border-radius: 999px;
+  object-fit: cover;
+  flex: 0 0 auto;
+}
+.content .ox-magic-link__label {
+  font-weight: 600;
+  font-size: 0.9em;
+}

--- a/crates/ox_content_ssg/src/ssg.css
+++ b/crates/ox_content_ssg/src/ssg.css
@@ -1069,38 +1069,7 @@ a:hover {
 .content .ox-badge--required {
   --octc-badge-accent: #c2410c;
 }
-.content .ox-magic-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.26em;
-  max-width: 100%;
-  padding: 0.08em 0.38em 0.08em 0.24em;
-  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, transparent);
-  border-radius: 0.42em;
-  background: color-mix(in srgb, var(--octc-color-bg-alt) 82%, var(--octc-color-bg) 18%);
-  color: inherit;
-  line-height: 1;
-  text-decoration: none;
-  vertical-align: -0.08em;
-}
-.content .ox-magic-link:hover {
-  border-color: color-mix(in srgb, var(--octc-color-primary) 45%, var(--octc-color-border));
-}
-.content .ox-magic-link:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--octc-color-primary) 72%, transparent);
-  outline-offset: 2px;
-}
-.content .ox-magic-link__image {
-  width: 1em;
-  height: 1em;
-  border-radius: 999px;
-  object-fit: cover;
-  flex: 0 0 auto;
-}
-.content .ox-magic-link__label {
-  font-weight: 600;
-  font-size: 0.9em;
-}
+/* @include magic-links.css */
 .content .ox-figure {
   margin: 1.25rem 0;
 }

--- a/docs/content/built-in-features.md
+++ b/docs/content/built-in-features.md
@@ -42,6 +42,7 @@ inline**.
 | [Quality Checks](./built-in/quality-checks.md)              | Code block lint, type checking, docs tests, HTML sanitizer                  |
 | [Typed Hover](./built-in/typed-hover.md)                    | Opt-in build-time TypeScript hover overlays for `twoslash` fences           |
 | [Site Generation](./built-in/site-generation.md)            | SSG, OG images, edit links, collections, API docs, transformers             |
+| [Component styles](./built-in/component-styles.md)          | Official CSS for `ssg: false` and `transformAllPlugins()` hosts             |
 | [Page head](./built-in/page-head.md)                        | Build-time Unhead-compatible title / meta / link / JSON-LD API              |
 | [SEO](./built-in/seo.md)                                    | Canonical, robots, hreflang, and head validation on that API                |
 | [Previous / Next](./built-in/pagination.md)                 | Opt-in previous and next page links                                         |

--- a/docs/content/built-in/component-styles.md
+++ b/docs/content/built-in/component-styles.md
@@ -1,0 +1,100 @@
+---
+title: Component styles
+description: Official CSS entry points for ssg: false hosts and transformAllPlugins() consumers.
+---
+
+# Component styles
+
+The built-in SSG inlines feature CSS next to generated HTML. Custom hosts that
+set `ssg: false`, call `transformAllPlugins()`, or own the document with
+`ssg.render` get the same markup but not those styles.
+
+`@ox-content/vite-plugin` publishes the crate stylesheets the SSG already uses.
+Import what you render. Site-specific theming stays in your app.
+
+```css
+@import "@ox-content/vite-plugin/styles/core.css";
+@import "@ox-content/vite-plugin/styles/magic-links.css";
+@import "@ox-content/vite-plugin/styles/social.css";
+@import "@ox-content/vite-plugin/styles/twitter-full.css";
+```
+
+Or pull every feature sheet:
+
+```css
+@import "@ox-content/vite-plugin/styles/all.css";
+```
+
+`transformAllPlugins()` still returns HTML only. CSS is an explicit import so
+you can load compact Tweet chrome without the full-card sheet.
+
+## Entry points
+
+| Import                    | Covers                                                                             |
+| ------------------------- | ---------------------------------------------------------------------------------- |
+| `styles/core.css`         | Base tokens (`--octc-*`) and default prose/chrome from the SSG stylesheet          |
+| `styles/magic-links.css`  | `{link:...}` chips                                                                 |
+| `styles/social.css`       | Compact Tweet/X, Bluesky, Spotify, StackBlitz, WebContainer                        |
+| `styles/twitter-full.css` | `appearance: "full"` Tweet cards, including the react-tweet / sveltweet MIT notice |
+| `styles/ogp.css`          | Open Graph cards                                                                   |
+| `styles/github.css`       | GitHub repository and source cards                                                 |
+| `styles/youtube.css`      | YouTube embeds                                                                     |
+| `styles/tabs.css`         | Tabs and package-manager tabs                                                      |
+| `styles/mermaid.css`      | Mermaid diagrams                                                                   |
+| `styles/all.css`          | The feature sheets above, in that order                                            |
+
+Feature sheets that use `var(--octc-*)` expect `core.css` first, or the same
+tokens defined on your host. Full Tweet chrome defines its own `--ox-tweet-*`
+variables and does not require `core.css`.
+
+These files are copied from `crates/ox_content_ssg` at package build time. The
+built-in SSG includes the same sources, so official chrome cannot drift from
+what custom hosts import.
+
+## Custom hosts
+
+Module transformer (`ssg: false`):
+
+```ts
+import { oxContent } from "@ox-content/vite-plugin";
+
+export default {
+  plugins: [
+    oxContent({
+      srcDir: "content",
+      ssg: false,
+      embeds: { twitter: { fetch: true, appearance: "full" } },
+    }),
+  ],
+};
+```
+
+```css
+@import "@ox-content/vite-plugin/styles/core.css";
+@import "@ox-content/vite-plugin/styles/social.css";
+@import "@ox-content/vite-plugin/styles/twitter-full.css";
+```
+
+Direct `transformAllPlugins()`:
+
+```ts
+import { transformAllPlugins } from "@ox-content/vite-plugin";
+
+const html = await transformAllPlugins(sourceHtml, {
+  twitter: { fetch: true, appearance: "full" },
+});
+```
+
+Import the matching stylesheets in the host that renders `html`. Do not copy
+crate CSS into the app.
+
+`renderMarkdown()` and `createMarkdownProcessor()` follow the same rule: they
+return markup, and you import the official sheets for the features you enabled.
+
+## Related
+
+- [Site Generation](./site-generation.md)
+- [Magic Links](./magic-links.md)
+- [Embeds](./embeds.md)
+- [Twitter/X Embed](../examples/twitter-embed.md)
+- [@ox-content/vite-plugin](../packages/vite-plugin-ox-content.md)

--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -311,6 +311,9 @@ render `.ox-tweet--full`. The full-card chrome follows the MIT-licensed
 [sveltweet](https://github.com/ryoppippi/sveltweet) visual contract; notices
 are in [Credits](../credits.md). See
 [Twitter/X Embed](../examples/twitter-embed.md) for details.
+Custom hosts import `@ox-content/vite-plugin/styles/social.css` and, for
+`appearance: "full"`, `styles/twitter-full.css`. See
+[Component styles](./component-styles.md).
 
 ## Bluesky
 
@@ -402,4 +405,5 @@ requirements.
 ## Related
 
 - [Mermaid Diagrams](./mermaid.md) — diagram fences rendered to static SVG.
+- [Component styles](./component-styles.md) — official CSS for custom hosts.
 - [Built-in Features overview](../built-in-features.md)

--- a/docs/content/built-in/magic-links.md
+++ b/docs/content/built-in/magic-links.md
@@ -82,6 +82,10 @@ Output uses stable classes: `ox-magic-link`, `ox-magic-link--github` /
 `--alias` / `--url`, `ox-magic-link__image`, and `ox-magic-link__label`.
 The image is decorative (`alt=""`); the label is the accessible name.
 
+Custom `ssg: false` hosts should import
+`@ox-content/vite-plugin/styles/magic-links.css` (and usually `core.css` for
+`--octc-*` tokens). See [Component styles](./component-styles.md).
+
 ## Immunity
 
 Fenced, indented, and inline code, raw `<code>` / `<pre>` / `<script>` /
@@ -101,5 +105,6 @@ re-parse per name. There is no client JavaScript.
 
 - [Syntax Extensions](./syntax-extensions.md)
 - [Inline Badges](./badges.md)
+- [Component styles](./component-styles.md)
 - [Built-in Features overview](../built-in-features.md)
 - [markdown-it-magic-link](https://github.com/antfu/markdown-it-magic-link)

--- a/docs/content/built-in/site-generation.md
+++ b/docs/content/built-in/site-generation.md
@@ -54,38 +54,38 @@ export default defineConfig({
 });
 ```
 
-| Option            | Default        | Purpose                                                                                               |
-| ----------------- | -------------- | ----------------------------------------------------------------------------------------------------- |
-| `enabled`         | `true`         | Set `ssg: false` to keep only `.md` modules.                                                          |
-| `extension`       | `".html"`      | Generated page extension.                                                                             |
-| `clean`           | `false`        | Remove generated output before writing.                                                               |
-| `bare`            | `false`        | Emit unthemed HTML without navigation.                                                                |
-| `render`          | —              | JSX component that owns the whole document.                                                           |
-| `lang`            | `"en"`         | `lang` attribute on `<html>` (bare mode).                                                             |
-| `head`            | —              | Raw markup appended to `<head>` (bare mode).                                                          |
-| `bodyStart`       | —              | Raw markup after `<body>` (bare mode).                                                                |
-| `bodyEnd`         | —              | Raw markup before `</body>` (bare mode).                                                              |
-| `siteName`        | —              | Suffix for `<title>` and OG site name.                                                                |
-| `siteUrl`         | —              | Origin used for absolute OG URLs, canonical, and hreflang. See [SEO](./seo.md).                       |
-| `headValidation`  | `false`        | `warn` or `strict` for invalid head descriptors. See [SEO](./seo.md).                                 |
-| `ogImage`         | —              | Static fallback OG image URL.                                                                         |
-| `generateOgImage` | `false`        | Per-page OG images (see below).                                                                       |
-| `lastUpdated`     | `false`        | Show the git last-commit time per page.                                                               |
-| `contributors`    | `false`        | Unique git authors per page. See [Contributors](./contributors.md).                                   |
-| `pagination`      | `false`        | Previous/next links after the article.                                                                |
-| `breadcrumbs`     | `false`        | Trail from the site root through sidebar ancestors.                                                   |
-| `jsonLd`          | `false`        | JSON-LD for TechArticle / WebSite / BreadcrumbList.                                                   |
-| `readerChrome`    | `false`        | Copy, outbound-link icons, and back-to-top.                                                           |
-| `localeSwitcher`  | `false`        | Header locale dropdown when i18n locales are set.                                                     |
-| `a11y`            | `false`        | Skip link and print styles.                                                                           |
-| `notFound`        | `false`        | Themed 404 page. See [Custom 404](./not-found.md).                                                    |
-| `team`            | `false`        | Member cards on `layout: team`. See [Team](./team.md).                                                |
-| `blog`            | `false`        | Paginated index, authors, tags, archive, optional external feeds. See [Blog](./blog.md).              |
-| `sectionIndex`    | `false`        | Generated listings for directories without `index.md`. See [Section index pages](./section-index.md). |
-| `pageChrome`      | `false`        | Honor per-page frontmatter chrome flags.                                                              |
-| `markdownSource`  | `false`        | Publish original Markdown beside each page. See [Markdown source companions](./markdown-source.md).   |
-| `theme`           | `defaultTheme` | Theme configuration via `defineTheme()`.                                                              |
-| `navigation`      | derived        | Explicit navigation groups instead of the file tree.                                                  |
+| Option            | Default        | Purpose                                                                                                    |
+| ----------------- | -------------- | ---------------------------------------------------------------------------------------------------------- |
+| `enabled`         | `true`         | Set `ssg: false` to keep only `.md` modules. Import [component styles](./component-styles.md) in the host. |
+| `extension`       | `".html"`      | Generated page extension.                                                                                  |
+| `clean`           | `false`        | Remove generated output before writing.                                                                    |
+| `bare`            | `false`        | Emit unthemed HTML without navigation.                                                                     |
+| `render`          | —              | JSX component that owns the whole document.                                                                |
+| `lang`            | `"en"`         | `lang` attribute on `<html>` (bare mode).                                                                  |
+| `head`            | —              | Raw markup appended to `<head>` (bare mode).                                                               |
+| `bodyStart`       | —              | Raw markup after `<body>` (bare mode).                                                                     |
+| `bodyEnd`         | —              | Raw markup before `</body>` (bare mode).                                                                   |
+| `siteName`        | —              | Suffix for `<title>` and OG site name.                                                                     |
+| `siteUrl`         | —              | Origin used for absolute OG URLs, canonical, and hreflang. See [SEO](./seo.md).                            |
+| `headValidation`  | `false`        | `warn` or `strict` for invalid head descriptors. See [SEO](./seo.md).                                      |
+| `ogImage`         | —              | Static fallback OG image URL.                                                                              |
+| `generateOgImage` | `false`        | Per-page OG images (see below).                                                                            |
+| `lastUpdated`     | `false`        | Show the git last-commit time per page.                                                                    |
+| `contributors`    | `false`        | Unique git authors per page. See [Contributors](./contributors.md).                                        |
+| `pagination`      | `false`        | Previous/next links after the article.                                                                     |
+| `breadcrumbs`     | `false`        | Trail from the site root through sidebar ancestors.                                                        |
+| `jsonLd`          | `false`        | JSON-LD for TechArticle / WebSite / BreadcrumbList.                                                        |
+| `readerChrome`    | `false`        | Copy, outbound-link icons, and back-to-top.                                                                |
+| `localeSwitcher`  | `false`        | Header locale dropdown when i18n locales are set.                                                          |
+| `a11y`            | `false`        | Skip link and print styles.                                                                                |
+| `notFound`        | `false`        | Themed 404 page. See [Custom 404](./not-found.md).                                                         |
+| `team`            | `false`        | Member cards on `layout: team`. See [Team](./team.md).                                                     |
+| `blog`            | `false`        | Paginated index, authors, tags, archive, optional external feeds. See [Blog](./blog.md).                   |
+| `sectionIndex`    | `false`        | Generated listings for directories without `index.md`. See [Section index pages](./section-index.md).      |
+| `pageChrome`      | `false`        | Honor per-page frontmatter chrome flags.                                                                   |
+| `markdownSource`  | `false`        | Publish original Markdown beside each page. See [Markdown source companions](./markdown-source.md).        |
+| `theme`           | `defaultTheme` | Theme configuration via `defineTheme()`.                                                                   |
+| `navigation`      | derived        | Explicit navigation groups instead of the file tree.                                                       |
 
 Theming — colors, fonts, header, footer, sidebar, custom CSS, and the opt-in
 page outline (`theme.aside`, default `false`) — is a topic of its own: see

--- a/docs/content/examples/ssg-vite.md
+++ b/docs/content/examples/ssg-vite.md
@@ -89,6 +89,15 @@ oxContent({
 });
 ```
 
+The plugin then emits `.md` modules only. Import official component CSS in
+the host that renders `html` — see
+[Component styles](../built-in/component-styles.md).
+
+```css
+@import "@ox-content/vite-plugin/styles/core.css";
+@import "@ox-content/vite-plugin/styles/social.css";
+```
+
 ## Bare Mode
 
 For benchmarking or when using custom post-processing, use bare mode to output minimal HTML without navigation or styles:

--- a/docs/content/examples/twitter-embed.md
+++ b/docs/content/examples/twitter-embed.md
@@ -66,6 +66,9 @@ root card.
 Full appearance is static HTML/CSS: no hydration, widget iframe, or per-card
 listeners. It reuses the same materialized avatar/photo/video assets as compact.
 Pages that only render compact cards do not ship the full-card CSS.
+Custom `ssg: false` hosts import `@ox-content/vite-plugin/styles/social.css`
+and, for full cards, `styles/twitter-full.css`. See
+[Component styles](../built-in/component-styles.md).
 
 The full-card visual contract follows MIT-licensed
 [react-tweet](https://github.com/vercel/react-tweet) (Copyright (c) 2023 Luis

--- a/docs/content/ja/built-in-features.md
+++ b/docs/content/ja/built-in-features.md
@@ -38,6 +38,7 @@ Ox Content は、よく使うドキュメントの挙動を既定で載せ、非
 | [品質チェック](./built-in/quality-checks.md)             | lint、型チェック、docs テスト、HTML サニタイズ                                 |
 | [型ホバー](./built-in/typed-hover.md)                    | `twoslash` フェンスのビルド時 TypeScript 型オーバーレイ                        |
 | [サイト生成](./built-in/site-generation.md)              | SSG、OG 画像、編集リンク、API ドキュメント                                     |
+| [コンポーネント CSS](./built-in/component-styles.md)     | `ssg: false` と `transformAllPlugins()` 向けの公式 CSS                         |
 | [ページ head](./built-in/page-head.md)                   | ビルド時の Unhead 互換 title / meta / link / JSON-LD API                       |
 | [SEO](./built-in/seo.md)                                 | その API 上の canonical、robots、hreflang、検証                                |
 | [前へ / 次へ](./built-in/pagination.md)                  | サイドバー順の前後リンク                                                       |

--- a/docs/content/ja/built-in/component-styles.md
+++ b/docs/content/ja/built-in/component-styles.md
@@ -1,0 +1,101 @@
+---
+title: コンポーネント CSS
+description: ssg: false と transformAllPlugins() 向けの、公式コンポーネント CSS エントリ。
+---
+
+# コンポーネント CSS
+
+組み込み SSG は、生成 HTML の横に機能 CSS をインラインします。`ssg: false`、
+`transformAllPlugins()`、`ssg.render` で文書を自分で持つホストは、同じ
+マークアップは受け取れますが、そのスタイルは付きません。
+
+`@ox-content/vite-plugin` は、SSG がすでに使っている crate のスタイルシートを
+公開します。描画するものだけ import してください。サイト固有のテーマは
+アプリ側に残します。
+
+```css
+@import "@ox-content/vite-plugin/styles/core.css";
+@import "@ox-content/vite-plugin/styles/magic-links.css";
+@import "@ox-content/vite-plugin/styles/social.css";
+@import "@ox-content/vite-plugin/styles/twitter-full.css";
+```
+
+全部まとめて取るとき:
+
+```css
+@import "@ox-content/vite-plugin/styles/all.css";
+```
+
+`transformAllPlugins()` が返すのは今までどおり HTML だけです。CSS は明示
+import なので、コンパクトな Tweet だけ載せてフルカード用シートは省略できます。
+
+## エントリポイント
+
+| import                    | 対象                                                                            |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| `styles/core.css`         | ベーストークン（`--octc-*`）と、SSG スタイルシートの既定 prose / chrome         |
+| `styles/magic-links.css`  | `{link:...}` チップ                                                             |
+| `styles/social.css`       | コンパクトな Tweet/X、Bluesky、Spotify、StackBlitz、WebContainer                |
+| `styles/twitter-full.css` | `appearance: "full"` の Tweet カード。react-tweet / sveltweet の MIT 告知を含む |
+| `styles/ogp.css`          | Open Graph カード                                                               |
+| `styles/github.css`       | GitHub リポジトリ / ソースカード                                                |
+| `styles/youtube.css`      | YouTube 埋め込み                                                                |
+| `styles/tabs.css`         | タブとパッケージマネージャタブ                                                  |
+| `styles/mermaid.css`      | Mermaid 図                                                                      |
+| `styles/all.css`          | 上の機能シートをこの順で全部                                                    |
+
+`var(--octc-*)` を使う機能シートは、先に `core.css` を読むか、ホスト側で同じ
+トークンを定義してください。フル Tweet の chrome は独自の `--ox-tweet-*` を
+持つので `core.css` は不要です。
+
+これらのファイルはパッケージビルド時に `crates/ox_content_ssg` からコピー
+されます。組み込み SSG も同じソースを読むので、公式 chrome が独自ホスト向け
+import とずれません。
+
+## 独自ホスト
+
+モジュール変換器（`ssg: false`）:
+
+```ts
+import { oxContent } from "@ox-content/vite-plugin";
+
+export default {
+  plugins: [
+    oxContent({
+      srcDir: "content",
+      ssg: false,
+      embeds: { twitter: { fetch: true, appearance: "full" } },
+    }),
+  ],
+};
+```
+
+```css
+@import "@ox-content/vite-plugin/styles/core.css";
+@import "@ox-content/vite-plugin/styles/social.css";
+@import "@ox-content/vite-plugin/styles/twitter-full.css";
+```
+
+`transformAllPlugins()` を直接呼ぶとき:
+
+```ts
+import { transformAllPlugins } from "@ox-content/vite-plugin";
+
+const html = await transformAllPlugins(sourceHtml, {
+  twitter: { fetch: true, appearance: "full" },
+});
+```
+
+`html` を描画するホストで、対応するスタイルシートを import してください。
+crate の CSS をアプリにコピーしないでください。
+
+`renderMarkdown()` と `createMarkdownProcessor()` も同じです。返すのは
+マークアップで、有効にした機能の公式シートは自分で import します。
+
+## 関連
+
+- [サイト生成](./site-generation.md)
+- [マジックリンク](./magic-links.md)
+- [埋め込み](./embeds.md)
+- [Twitter/X 埋め込み](/examples/twitter-embed.md)
+- [@ox-content/vite-plugin](../packages/vite-plugin-ox-content.md)

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -256,6 +256,8 @@ oxContent({
 | `timeZone`        | `"UTC"`                     | フルカード日時の IANA タイムゾーン。                |
 
 ダウンロードしたメディアは自分のサイトから出すので、厳しい `img-src 'self'` CSP も動き続けます。動画とアニメーション GIF は、`downloadVideo` をオンにしない限り自前のポスターと Watch on X パーマリンクを使い、生成 HTML に `video.twimg.com` は出しません。削除済みや非公開の投稿は、ビルドを落とさずリンクのみのカードに落ちます。引用投稿が欠けていても、元の投稿カードは残します。フルカード用 CSS は `.ox-tweet--full` を描画するページにだけ載ります。フルカードのクロムは MIT ライセンスの [react-tweet](https://github.com/vercel/react-tweet) と [sveltweet](https://github.com/ryoppippi/sveltweet) の見た目の契約に従います。帰属は [クレジット](../credits.md) にあります。詳細は [Twitter/X Embed](/examples/twitter-embed.md) を見てください。
+独自ホストは `@ox-content/vite-plugin/styles/social.css` を、`appearance: "full"`
+なら `styles/twitter-full.css` も import します。[コンポーネント CSS](./component-styles.md) を見てください。
 
 ## Bluesky
 
@@ -315,4 +317,5 @@ oxContent({
 ## 関連
 
 - [Mermaid](./mermaid.md) — 静的 SVG に描画する図フェンス。
+- [コンポーネント CSS](./component-styles.md) — 独自ホスト向けの公式 CSS。
 - [組み込み機能の一覧](../built-in-features.md)

--- a/docs/content/ja/built-in/magic-links.md
+++ b/docs/content/ja/built-in/magic-links.md
@@ -80,6 +80,11 @@ fetch はしません。URL を書くだけです。`imageOverrides` は exact �
 `--alias` / `--url`、`ox-magic-link__image`、`ox-magic-link__label`。
 画像は装飾（`alt=""`）で、ラベルがアクセシブルな名前です。
 
+独自の `ssg: false` ホストは
+`@ox-content/vite-plugin/styles/magic-links.css` を import してください
+（`--octc-*` トークン用に `core.css` も大抵必要です）。
+[コンポーネント CSS](./component-styles.md) を見てください。
+
 ## 対象外
 
 フェンス、インデントコード、インラインコード、生の `<code>` / `<pre>` /
@@ -99,5 +104,6 @@ fetch はしません。URL を書くだけです。`imageOverrides` は exact �
 
 - [構文拡張](./syntax-extensions.md)
 - [インラインバッジ](./badges.md)
+- [コンポーネント CSS](./component-styles.md)
 - [組み込み機能の一覧](../built-in-features.md)
 - [markdown-it-magic-link](https://github.com/antfu/markdown-it-magic-link)

--- a/docs/content/ja/built-in/site-generation.md
+++ b/docs/content/ja/built-in/site-generation.md
@@ -50,38 +50,38 @@ export default defineConfig({
 });
 ```
 
-| オプション        | 既定           | 目的                                                                                                     |
-| ----------------- | -------------- | -------------------------------------------------------------------------------------------------------- |
-| `enabled`         | `true`         | `.md` モジュールだけ残すときは `ssg: false`。                                                            |
-| `extension`       | `".html"`      | 生成ページの拡張子。                                                                                     |
-| `clean`           | `false`        | 書き出す前に生成物を消す。                                                                               |
-| `bare`            | `false`        | ナビなしの、テーマなし HTML を出す。                                                                     |
-| `render`          | —              | 文書全体を所有する JSX コンポーネント。                                                                  |
-| `lang`            | `"en"`         | `<html>` の `lang` 属性（bare モード）。                                                                 |
-| `head`            | —              | `<head>` に足す生マークアップ（bare モード）。                                                           |
-| `bodyStart`       | —              | `<body>` の直後に足す生マークアップ（bare モード）。                                                     |
-| `bodyEnd`         | —              | `</body>` の直前に足す生マークアップ（bare モード）。                                                    |
-| `siteName`        | —              | `<title>` の接尾辞と OG サイト名。                                                                       |
-| `siteUrl`         | —              | 絶対 OG URL、canonical、hreflang に使うオリジン。[SEO](./seo.md)。                                       |
-| `headValidation`  | `false`        | 不正な head デスクリプタの `warn` / `strict`。[SEO](./seo.md)。                                          |
-| `ogImage`         | —              | 静的フォールバックの OG 画像 URL。                                                                       |
-| `generateOgImage` | `false`        | ページごとの OG 画像（後述）。                                                                           |
-| `lastUpdated`     | `false`        | ページごとの git 最終コミット時刻を出す。                                                                |
-| `contributors`    | `false`        | ページごとの一意な git 作者。[コントリビューター](./contributors.md) を見てください。                    |
-| `pagination`      | `false`        | 記事のあとに前へ / 次へリンク。                                                                          |
-| `breadcrumbs`     | `false`        | サイトルートからサイドバー祖先までの道筋。                                                               |
-| `jsonLd`          | `false`        | TechArticle / WebSite / BreadcrumbList の JSON-LD。                                                      |
-| `readerChrome`    | `false`        | コピー、外部リンクアイコン、先頭へ戻る。                                                                 |
-| `localeSwitcher`  | `false`        | i18n ロケールがあるときのヘッダーロケールドロップダウン。                                                |
-| `a11y`            | `false`        | スキップリンクと印刷スタイル。                                                                           |
-| `notFound`        | `false`        | テーマ付き 404。 [カスタム 404](./not-found.md) を見てください。                                         |
-| `team`            | `false`        | `layout: team` のメンバーカード。[チーム](./team.md) を見てください。                                    |
-| `blog`            | `false`        | ページ送り索引、著者、タグ、アーカイブ、任意の外部フィード。[ブログ](./blog.md) を見てください。         |
-| `sectionIndex`    | `false`        | `index.md` がないディレクトリ向けの生成一覧。[セクション索引ページ](./section-index.md) を見てください。 |
-| `pageChrome`      | `false`        | ページ単位の frontmatter chrome フラグを尊重する。                                                       |
-| `markdownSource`  | `false`        | 各ページの横に元の Markdown を公開する。[Markdown ソースの併記](./markdown-source.md)。                  |
-| `theme`           | `defaultTheme` | `defineTheme()` によるテーマ設定。                                                                       |
-| `navigation`      | 派生           | ファイルツリーの代わりに明示的なナビグループ。                                                           |
+| オプション        | 既定           | 目的                                                                                                                 |
+| ----------------- | -------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `enabled`         | `true`         | `.md` モジュールだけ残すときは `ssg: false`。ホスト側で [コンポーネント CSS](./component-styles.md) を import する。 |
+| `extension`       | `".html"`      | 生成ページの拡張子。                                                                                                 |
+| `clean`           | `false`        | 書き出す前に生成物を消す。                                                                                           |
+| `bare`            | `false`        | ナビなしの、テーマなし HTML を出す。                                                                                 |
+| `render`          | —              | 文書全体を所有する JSX コンポーネント。                                                                              |
+| `lang`            | `"en"`         | `<html>` の `lang` 属性（bare モード）。                                                                             |
+| `head`            | —              | `<head>` に足す生マークアップ（bare モード）。                                                                       |
+| `bodyStart`       | —              | `<body>` の直後に足す生マークアップ（bare モード）。                                                                 |
+| `bodyEnd`         | —              | `</body>` の直前に足す生マークアップ（bare モード）。                                                                |
+| `siteName`        | —              | `<title>` の接尾辞と OG サイト名。                                                                                   |
+| `siteUrl`         | —              | 絶対 OG URL、canonical、hreflang に使うオリジン。[SEO](./seo.md)。                                                   |
+| `headValidation`  | `false`        | 不正な head デスクリプタの `warn` / `strict`。[SEO](./seo.md)。                                                      |
+| `ogImage`         | —              | 静的フォールバックの OG 画像 URL。                                                                                   |
+| `generateOgImage` | `false`        | ページごとの OG 画像（後述）。                                                                                       |
+| `lastUpdated`     | `false`        | ページごとの git 最終コミット時刻を出す。                                                                            |
+| `contributors`    | `false`        | ページごとの一意な git 作者。[コントリビューター](./contributors.md) を見てください。                                |
+| `pagination`      | `false`        | 記事のあとに前へ / 次へリンク。                                                                                      |
+| `breadcrumbs`     | `false`        | サイトルートからサイドバー祖先までの道筋。                                                                           |
+| `jsonLd`          | `false`        | TechArticle / WebSite / BreadcrumbList の JSON-LD。                                                                  |
+| `readerChrome`    | `false`        | コピー、外部リンクアイコン、先頭へ戻る。                                                                             |
+| `localeSwitcher`  | `false`        | i18n ロケールがあるときのヘッダーロケールドロップダウン。                                                            |
+| `a11y`            | `false`        | スキップリンクと印刷スタイル。                                                                                       |
+| `notFound`        | `false`        | テーマ付き 404。 [カスタム 404](./not-found.md) を見てください。                                                     |
+| `team`            | `false`        | `layout: team` のメンバーカード。[チーム](./team.md) を見てください。                                                |
+| `blog`            | `false`        | ページ送り索引、著者、タグ、アーカイブ、任意の外部フィード。[ブログ](./blog.md) を見てください。                     |
+| `sectionIndex`    | `false`        | `index.md` がないディレクトリ向けの生成一覧。[セクション索引ページ](./section-index.md) を見てください。             |
+| `pageChrome`      | `false`        | ページ単位の frontmatter chrome フラグを尊重する。                                                                   |
+| `markdownSource`  | `false`        | 各ページの横に元の Markdown を公開する。[Markdown ソースの併記](./markdown-source.md)。                              |
+| `theme`           | `defaultTheme` | `defineTheme()` によるテーマ設定。                                                                                   |
+| `navigation`      | 派生           | ファイルツリーの代わりに明示的なナビグループ。                                                                       |
 
 テーマ — 色、フォント、ヘッダー、フッター、サイドバー、独自 CSS、オプトインのページアウトライン（`theme.aside`、既定 `false`）— は別トピックです。[テーマ](../theming.md#ページアウトライン) を見てください。
 

--- a/docs/content/ja/packages/vite-plugin-ox-content.md
+++ b/docs/content/ja/packages/vite-plugin-ox-content.md
@@ -158,6 +158,18 @@ result.toc;
 オプション解決を一度だけにしたいときは `createMarkdownProcessor(options)` を
 使い、`processor.render(source, filePath)` を呼んでください。
 
+`ssg: false`、`renderMarkdown()`、`transformAllPlugins()` が返すのは
+マークアップだけです。その HTML を描画するホストで公式の機能スタイルシートを
+import してください。crate の CSS をアプリにコピーしないでください。
+[コンポーネント CSS](../built-in/component-styles.md) を見てください。
+
+```css
+@import "@ox-content/vite-plugin/styles/core.css";
+@import "@ox-content/vite-plugin/styles/magic-links.css";
+@import "@ox-content/vite-plugin/styles/social.css";
+@import "@ox-content/vite-plugin/styles/twitter-full.css";
+```
+
 ### gfm
 
 - 型: `boolean`

--- a/docs/content/packages/vite-plugin-ox-content.md
+++ b/docs/content/packages/vite-plugin-ox-content.md
@@ -155,6 +155,18 @@ and built-in option defaults match `oxContent()`. To resolve options once
 for many documents, use `createMarkdownProcessor(options)` and call
 `processor.render(source, filePath)`.
 
+`ssg: false`, `renderMarkdown()`, and `transformAllPlugins()` return markup
+only. Import the official feature stylesheets in the host that renders that
+HTML — do not copy crate CSS into the app. See
+[Component styles](../built-in/component-styles.md).
+
+```css
+@import "@ox-content/vite-plugin/styles/core.css";
+@import "@ox-content/vite-plugin/styles/magic-links.css";
+@import "@ox-content/vite-plugin/styles/social.css";
+@import "@ox-content/vite-plugin/styles/twitter-full.css";
+```
+
 ### gfm
 
 - Type: `boolean`

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -155,6 +155,7 @@ export default defineConfig(({ mode }) => {
                       { text: "Quality Checks", link: "/built-in/quality-checks.md" },
                       { text: "Typed Hover", link: "/built-in/typed-hover.md" },
                       { text: "Site Generation", link: "/built-in/site-generation.md" },
+                      { text: "Component styles", link: "/built-in/component-styles.md" },
                       { text: "Page head", link: "/built-in/page-head.md" },
                       { text: "SEO", link: "/built-in/seo.md" },
                       { text: "Previous / Next", link: "/built-in/pagination.md" },

--- a/npm/vite-plugin-ox-content/package.json
+++ b/npm/vite-plugin-ox-content/package.json
@@ -51,14 +51,25 @@
       "import": "./dist/jsx-dev-runtime.mjs",
       "require": "./dist/jsx-dev-runtime.cjs",
       "types": "./dist/jsx-dev-runtime.d.mts"
-    }
+    },
+    "./styles/all.css": "./dist/styles/all.css",
+    "./styles/core.css": "./dist/styles/core.css",
+    "./styles/magic-links.css": "./dist/styles/magic-links.css",
+    "./styles/social.css": "./dist/styles/social.css",
+    "./styles/twitter-full.css": "./dist/styles/twitter-full.css",
+    "./styles/ogp.css": "./dist/styles/ogp.css",
+    "./styles/github.css": "./dist/styles/github.css",
+    "./styles/youtube.css": "./dist/styles/youtube.css",
+    "./styles/tabs.css": "./dist/styles/tabs.css",
+    "./styles/mermaid.css": "./dist/styles/mermaid.css"
   },
   "publishConfig": {
     "access": "public",
     "provenance": true
   },
   "scripts": {
-    "build": "vp pack",
+    "build": "vp pack && node scripts/copy-component-styles.mjs",
+    "build:styles": "node scripts/copy-component-styles.mjs",
     "dev": "vp pack --watch",
     "typecheck": "tsgo --noEmit",
     "test:vrt": "playwright test",

--- a/npm/vite-plugin-ox-content/scripts/copy-component-styles.mjs
+++ b/npm/vite-plugin-ox-content/scripts/copy-component-styles.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+/**
+ * Copy crate SSG stylesheets into `dist/styles/` so
+ * `@ox-content/vite-plugin/styles/*.css` is the same source the built-in SSG
+ * inlines. Feature files that the SSG concatenates stay concatenated here.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const packageRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+const ssgSrc = join(packageRoot, "../../crates/ox_content_ssg/src");
+const outDir = join(packageRoot, "dist/styles");
+
+/** @typedef {{ name: string, sources: string[] }} StyleEntry */
+
+/** Public feature stylesheets. Filenames are package API. */
+export const STYLE_ENTRIES = /** @type {const} */ ([
+  { name: "core.css", sources: ["ssg.css"] },
+  { name: "magic-links.css", sources: ["plugins/magic-links.css"] },
+  {
+    name: "social.css",
+    sources: ["plugins/social.css", "plugins/social-twitter-rich.css"],
+  },
+  {
+    name: "twitter-full.css",
+    sources: ["plugins/social-tweet-full.css", "plugins/social-tweet-full-media.css"],
+  },
+  { name: "ogp.css", sources: ["plugins/ogp.css"] },
+  { name: "github.css", sources: ["plugins/github.css"] },
+  { name: "youtube.css", sources: ["plugins/youtube.css"] },
+  { name: "tabs.css", sources: ["plugins/tabs.css"] },
+  { name: "mermaid.css", sources: ["plugins/mermaid.css"] },
+]);
+
+export const ALL_STYLESHEET = "all.css";
+
+export const STYLE_EXPORT_NAMES = [...STYLE_ENTRIES.map((entry) => entry.name), ALL_STYLESHEET];
+
+function crateCss(relativePath) {
+  return readFileSync(join(ssgSrc, relativePath), "utf8");
+}
+
+function writeGenerated(name, contents) {
+  writeFileSync(join(outDir, name), contents);
+}
+
+export function copyComponentStyles() {
+  mkdirSync(outDir, { recursive: true });
+
+  for (const entry of STYLE_ENTRIES) {
+    writeGenerated(entry.name, entry.sources.map(crateCss).join(""));
+  }
+
+  const imports = STYLE_ENTRIES.map((entry) => `@import "./${entry.name}";`).join("\n");
+  writeGenerated(ALL_STYLESHEET, `${imports}\n`);
+
+  return {
+    outDir,
+    files: STYLE_EXPORT_NAMES.map((name) => join(outDir, name)),
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const { files } = copyComponentStyles();
+  console.log(`Wrote ${files.length} component stylesheets to ${outDir}`);
+}

--- a/npm/vite-plugin-ox-content/src/published-styles.test.ts
+++ b/npm/vite-plugin-ox-content/src/published-styles.test.ts
@@ -1,0 +1,122 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vite-plus/test";
+import packageJson from "../package.json" with { type: "json" };
+
+const packageRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+const ssgSrc = join(packageRoot, "../../crates/ox_content_ssg/src");
+
+const DOCUMENTED_STYLE_IMPORTS = [
+  "core.css",
+  "magic-links.css",
+  "social.css",
+  "twitter-full.css",
+  "ogp.css",
+  "github.css",
+  "youtube.css",
+  "tabs.css",
+  "mermaid.css",
+  "all.css",
+] as const;
+
+const CRATE_SOURCES: Record<
+  Exclude<(typeof DOCUMENTED_STYLE_IMPORTS)[number], "all.css">,
+  string[]
+> = {
+  "core.css": ["ssg.css"],
+  "magic-links.css": ["plugins/magic-links.css"],
+  "social.css": ["plugins/social.css", "plugins/social-twitter-rich.css"],
+  "twitter-full.css": ["plugins/social-tweet-full.css", "plugins/social-tweet-full-media.css"],
+  "ogp.css": ["plugins/ogp.css"],
+  "github.css": ["plugins/github.css"],
+  "youtube.css": ["plugins/youtube.css"],
+  "tabs.css": ["plugins/tabs.css"],
+  "mermaid.css": ["plugins/mermaid.css"],
+};
+
+function crateCss(relativePath: string): string {
+  return readFileSync(join(ssgSrc, relativePath), "utf8");
+}
+
+function packedCss(tarball: string, name: string): string {
+  const result = spawnSync("tar", ["-xOf", tarball, `package/dist/styles/${name}`], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `failed to read package/dist/styles/${name}`);
+  }
+  return result.stdout;
+}
+
+function generateStyles(): void {
+  const result = spawnSync("node", ["scripts/copy-component-styles.mjs"], {
+    cwd: packageRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout || "copy-component-styles failed");
+  }
+}
+
+function packPlugin(): { tarball: string; cleanup: () => void } {
+  const dest = mkdtempSync(join(tmpdir(), "ox-content-style-pack-"));
+  const result = spawnSync("pnpm", ["pack", "--json", "--pack-destination", dest], {
+    cwd: packageRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    rmSync(dest, { recursive: true, force: true });
+    throw new Error(result.stderr || result.stdout || "pnpm pack failed");
+  }
+  const jsonStart = result.stdout.search(/[[{]/);
+  const packed = JSON.parse(result.stdout.slice(jsonStart)) as { filename?: string };
+  if (!packed.filename) {
+    rmSync(dest, { recursive: true, force: true });
+    throw new Error(`pnpm pack did not emit a filename:\n${result.stdout}`);
+  }
+  return {
+    tarball: packed.filename,
+    cleanup() {
+      rmSync(dest, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("published component styles", () => {
+  it("documents every feature stylesheet in package exports", () => {
+    const exportsField = packageJson.exports as Record<string, unknown>;
+    for (const name of DOCUMENTED_STYLE_IMPORTS) {
+      expect(exportsField[`./styles/${name}`]).toBe(`./dist/styles/${name}`);
+    }
+  });
+
+  it("packs the documented CSS imports from the crate sources", () => {
+    generateStyles();
+    const { tarball, cleanup } = packPlugin();
+    try {
+      for (const [name, sources] of Object.entries(CRATE_SOURCES)) {
+        expect(packedCss(tarball, name)).toBe(sources.map(crateCss).join(""));
+      }
+
+      const twitterFull = packedCss(tarball, "twitter-full.css");
+      expect(twitterFull).toContain("react-tweet");
+      expect(twitterFull).toContain("sveltweet");
+      expect(twitterFull).toContain("Copyright (c) 2023 Luis Alvarez");
+      expect(twitterFull).toContain("Copyright (c) 2024 ryoppippi");
+      expect(twitterFull).toContain("Permission is hereby granted");
+
+      const allCss = packedCss(tarball, "all.css");
+      for (const name of Object.keys(CRATE_SOURCES)) {
+        expect(allCss).toContain(`@import "./${name}";`);
+      }
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -555,9 +555,8 @@ describe("SSG routePrefix", () => {
       routePrefixOptions({
         ssg: { ...routePrefixOptions().ssg, routePrefix: "/blog" },
         redirects: {
-          enabled: true,
           map: {},
-          netlify: true,
+          provider: "netlify",
           headers: false,
           json: false,
           allowExternal: false,

--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -555,6 +555,7 @@ describe("SSG routePrefix", () => {
       routePrefixOptions({
         ssg: { ...routePrefixOptions().ssg, routePrefix: "/blog" },
         redirects: {
+          enabled: true,
           map: {},
           provider: "netlify",
           headers: false,


### PR DESCRIPTION
## Summary
- Publish official feature CSS from `@ox-content/vite-plugin/styles/*.css` so `ssg: false` / `transformAllPlugins()` hosts can import the same chrome the built-in SSG inlines.
- Copy crate styles into `dist/styles/` at package build time (`core`, `magic-links`, `social`, `twitter-full`, `ogp`, `github`, `youtube`, `tabs`, `mermaid`, plus `all.css`).
- Extract Magic Link rules into `crates/ox_content_ssg/src/plugins/magic-links.css` and splice them back into SSG CSS at the original position so rendered pages stay byte-identical.
- Preserve react-tweet / sveltweet MIT notices in the published full-Tweet stylesheet.
- Document the style API for custom hosts and add a pack/export test that the documented CSS imports exist after `pnpm pack`.

Closes #924

## Test plan
- [x] `cargo test -p ox_content_ssg` HTML snapshot / Magic Link include tests
- [x] `vp test src/published-styles.test.ts` pack export + MIT notice + crate-source equality
- [ ] CI package dry-run includes the new `./styles/*.css` export targets after `build:npm`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790315042&installation_model_id=422833&pr_number=995&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F995&signature=4165098402e216b32de1811991b7268d61d30d11ae1e6e8dd0afb174037e9145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->