### PR TITLE
fix(ssg): use redirects.provider in the routePrefix test

### DIFF
--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -555,9 +555,8 @@ describe("SSG routePrefix", () => {
       routePrefixOptions({
         ssg: { ...routePrefixOptions().ssg, routePrefix: "/blog" },
         redirects: {
-          enabled: true,
           map: {},
-          netlify: true,
+          provider: "netlify",
           headers: false,
           json: false,
           allowExternal: false,

--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -555,6 +555,7 @@ describe("SSG routePrefix", () => {
       routePrefixOptions({
         ssg: { ...routePrefixOptions().ssg, routePrefix: "/blog" },
         redirects: {
+          enabled: true,
           map: {},
           provider: "netlify",
           headers: false,


### PR DESCRIPTION
## Summary
- `#991` landed a `routePrefix` test that still passed `redirects.netlify: true` after `#988` replaced that field with `provider`.
- Local/GitHub Actions therefore never selected a host, skipped `_redirects`, and wrote alias HTML instead. That failed `CI / Test` on `main` and blocked every open PR merge commit.

Closes nothing; unblocks #994, #992, #995, and #990.

## Risk
- Risk level: low
- User or production impact: test-only; no runtime change
- Rollback plan: revert this commit

## Validation
- [x] Automated tests or checks run: assertion now matches the `#988` provider API
- [ ] Manual verification completed: n/a
- [x] Edge cases or failure modes considered: alias HTML is the no-provider fallback

## Release and docs checklist
- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790322379&installation_model_id=422833&pr_number=996&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F996&signature=3ff73227289fc1a9f3d587c5bac6614cfd573387eda89e833b84c34263e30e5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->