### PR TITLE
feat(theme): fetch and self-host configured web fonts

### DIFF
--- a/docs/content/credits.md
+++ b/docs/content/credits.md
@@ -35,6 +35,8 @@ Contribution summary:
   found during the ryoppippi.com Ox Content migration.
 - Helped validate the expected Twitter/X full-card visual contract through
   sveltweet.
+- Requested self-hosted web font acquisition for the built-in theme during the
+  ryoppippi.com migration.
 
 ## Third-party attribution
 

--- a/docs/content/ja/credits.md
+++ b/docs/content/ja/credits.md
@@ -32,6 +32,8 @@ Markdown 属性とリッチなソーシャル埋め込みの見た目の同等�
 - ryoppippi.com の Ox Content 移行中に見つかった、inline link と変換済み画像の
   属性ターゲットの regression を報告しました。
 - sveltweet を通して、Twitter / X full card の見た目の契約の検証に協力しました。
+- ryoppippi.com の移行中に、組み込みテーマ向けのセルフホスト Web フォント取得を
+  要望しました。
 
 ## 第三者の帰属
 

--- a/docs/content/ja/theming.md
+++ b/docs/content/ja/theming.md
@@ -164,10 +164,52 @@ JSX 向けに `tsconfig.json` を設定します。
 
 ### フォント
 
-| オプション   | CSS 変数           | 説明                         |
-| ------------ | ------------------ | ---------------------------- |
-| `fonts.sans` | `--octc-font-sans` | サンセリフのフォントスタック |
-| `fonts.mono` | `--octc-font-mono` | 等幅のフォントスタック       |
+| オプション    | CSS 変数             | 説明                                                       |
+| ------------- | -------------------- | ---------------------------------------------------------- |
+| `fonts.sans`  | `--octc-font-sans`   | サンセリフのフォントスタック、またはセルフホストファミリー |
+| `fonts.mono`  | `--octc-font-mono`   | 等幅のフォントスタック、またはセルフホストファミリー       |
+| `fonts.named` | `--octc-font-<name>` | カスタム CSS 向けの追加ファミリー                          |
+
+`sans` と `mono` は CSS スタック文字列か Web フォントオブジェクトのどちらかです。文字列形式はこれまでどおりです。
+
+```ts
+fonts: {
+  sans: "Inter, sans-serif",
+  mono: "DM Mono, monospace",
+}
+```
+
+オブジェクト形式はファミリー名を指定します。`selfHost: true` のとき、Ox Content は要求されたウェイトとサブセットを SSG 出力へコピーし `@font-face` を出すので、公開サイトは実行時に Google Fonts へリクエストしません。
+
+```ts
+fonts: {
+  sans: {
+    family: "Inter",
+    provider: "google",
+    weights: [400, 600],
+    subsets: ["latin"],
+    display: "swap",
+    selfHost: true,
+  },
+  mono: "DM Mono, monospace",
+  named: {
+    code: {
+      family: "JetBrains Mono",
+      provider: "google",
+      weights: [400],
+      selfHost: true,
+    },
+  },
+}
+```
+
+- `sans` / `mono` はこれまでどおり `--octc-font-sans` と `--octc-font-mono` に対応します。
+- `named` のファミリーは `--octc-font-<name>`（例: `--octc-font-code`）として出ます。
+- `provider: "local"` はファイルまたは `@fontsource/*` ディレクトリを読み、ネットワーク不要です。CI や、すでにファイルを同梱している場合に使います。
+- `preload: true`（またはウェイトの配列）は、そのフェイスに `<link rel="preload">` を出します。
+- ダウンロードは `node_modules/.cache/ox-content/fonts` にキャッシュされます。
+
+`selfHost: true` がないオブジェクトは CSS スタックだけを設定し、ファイルの取得や出力はしません。
 
 セットしたキーだけが出ます。省略した色、フォント、レイアウトは [既定テーマの値](#既定テーマの値) に落ちるので、アクセント 1 つを上書きするためにパレット全体を書き直す必要はありません。
 

--- a/docs/content/theming.md
+++ b/docs/content/theming.md
@@ -182,10 +182,58 @@ theme config (below) or override them directly from [custom CSS](#custom-css-and
 
 ### Fonts
 
-| Option       | CSS Variable       | Description           |
-| ------------ | ------------------ | --------------------- |
-| `fonts.sans` | `--octc-font-sans` | Sans-serif font stack |
-| `fonts.mono` | `--octc-font-mono` | Monospace font stack  |
+| Option        | CSS Variable         | Description                                 |
+| ------------- | -------------------- | ------------------------------------------- |
+| `fonts.sans`  | `--octc-font-sans`   | Sans-serif font stack or self-hosted family |
+| `fonts.mono`  | `--octc-font-mono`   | Monospace font stack or self-hosted family  |
+| `fonts.named` | `--octc-font-<name>` | Extra families for custom theme CSS         |
+
+`sans` and `mono` accept either a CSS stack string or a web-font object. The
+string form is unchanged:
+
+```ts
+fonts: {
+  sans: "Inter, sans-serif",
+  mono: "DM Mono, monospace",
+}
+```
+
+The object form names a family. With `selfHost: true`, Ox Content copies the
+requested weights and subsets into the SSG output and emits `@font-face`, so
+the published site does not request Google Fonts at runtime:
+
+```ts
+fonts: {
+  sans: {
+    family: "Inter",
+    provider: "google",
+    weights: [400, 600],
+    subsets: ["latin"],
+    display: "swap",
+    selfHost: true,
+  },
+  mono: "DM Mono, monospace",
+  named: {
+    code: {
+      family: "JetBrains Mono",
+      provider: "google",
+      weights: [400],
+      selfHost: true,
+    },
+  },
+}
+```
+
+- `sans` / `mono` still map to `--octc-font-sans` and `--octc-font-mono`.
+- `named` families expose `--octc-font-<name>` (for example `--octc-font-code`).
+- `provider: "local"` reads a file or an `@fontsource/*` directory and needs no
+  network. Use it in CI or when you already vendor the files.
+- `preload: true` (or a weight list) emits `<link rel="preload">` for those
+  faces.
+- Downloads are cached under `node_modules/.cache/ox-content/fonts`.
+
+Object families without `selfHost: true` only set the CSS stack; they do not
+download or emit font files.
 
 Only the keys you set are emitted. Omitted colors, fonts, and layout values fall
 back to the [default theme](#default-theme-values), so overriding a single accent

--- a/npm/vite-plugin-ox-content/src/fixtures/ox-test-font.woff2
+++ b/npm/vite-plugin-ox-content/src/fixtures/ox-test-font.woff2
@@ -1,0 +1,1 @@
+ox-content-test-font-v1

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -881,6 +881,8 @@ export type {
   ThemeColors,
   ThemeLayout,
   ThemeFonts,
+  ThemeFontValue,
+  ThemeWebFont,
   ThemeEntryPage,
   ThemeHeader,
   ThemeFooter,

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -9,6 +9,7 @@ import { generateOgImages } from "./og-image";
 import type { OgImagePageEntry } from "./og-image";
 import { transformAllPlugins } from "./plugins";
 import { copyKatexAssets } from "./plugins/math-assets";
+import { writeSelfHostedThemeFonts } from "./theme-fonts";
 import type { TransformAllOptions } from "./plugins";
 import { protectMermaidSvgs, restoreMermaidSvgs } from "./plugins/mermaid-protect";
 import { transformIslands, hasIslands } from "./island";
@@ -672,7 +673,7 @@ export async function generateHtmlPage(
   const navGroupsForRust = convertNavGroupsForRust(navGroups);
 
   // Convert theme to NAPI format if provided
-  const themeForRust = theme ? themeToNapi(theme, locale) : undefined;
+  const themeForRust = theme ? themeToNapi(theme, locale, base) : undefined;
 
   // Convert entry page to NAPI format if provided
   const entryPageForRust = pageData.entryPage
@@ -1111,6 +1112,9 @@ export async function buildSsg(options: ResolvedOptions, root: string): Promise<
   if (options.math?.enabled) {
     generatedFiles.push(...(await copyKatexAssets(outDir)));
   }
+  generatedFiles.push(
+    ...(await writeSelfHostedThemeFonts({ fonts: ssgOptions.theme.fonts, outDir, root })),
+  );
 
   return {
     files: generatedFiles,

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -1113,7 +1113,7 @@ export async function buildSsg(options: ResolvedOptions, root: string): Promise<
     generatedFiles.push(...(await copyKatexAssets(outDir)));
   }
   generatedFiles.push(
-    ...(await writeSelfHostedThemeFonts({ fonts: ssgOptions.theme.fonts, outDir, root })),
+    ...(await writeSelfHostedThemeFonts({ fonts: ssgOptions.theme?.fonts ?? {}, outDir, root })),
   );
 
   return {

--- a/npm/vite-plugin-ox-content/src/theme-fonts-acquire.ts
+++ b/npm/vite-plugin-ox-content/src/theme-fonts-acquire.ts
@@ -1,0 +1,250 @@
+/**
+ * Resolve self-hosted faces from a local file / `@fontsource` directory or
+ * Google Fonts. Downloads are cached; tests inject `fetch` so CI never hits
+ * the network.
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { isAbsolute, join, resolve } from "node:path";
+import type { PlannedSelfHostFace, WriteThemeFontsOptions } from "./theme-fonts";
+
+export type FontFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+const GOOGLE_CSS = "https://fonts.googleapis.com/css2";
+const GOOGLE_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
+const ALLOWED_HOSTS = new Set(["fonts.googleapis.com", "fonts.gstatic.com"]);
+
+export interface AcquiredSelfHostFace extends PlannedSelfHostFace {
+  bytes: Uint8Array;
+}
+
+export function fontMime(fileName: string): string {
+  if (fileName.endsWith(".woff")) {
+    return "font/woff";
+  }
+  if (fileName.endsWith(".ttf")) {
+    return "font/ttf";
+  }
+  if (fileName.endsWith(".otf")) {
+    return "font/otf";
+  }
+  return "font/woff2";
+}
+
+export function renderFontFaceCss(faces: AcquiredSelfHostFace[]): string {
+  return faces
+    .map((face) => {
+      const range = face.unicodeRange ? `\n  unicode-range: ${face.unicodeRange};` : "";
+      const fileName = face.fileName;
+      const format = fileName.endsWith(".woff")
+        ? "woff"
+        : fileName.endsWith(".ttf")
+          ? "truetype"
+          : fileName.endsWith(".otf")
+            ? "opentype"
+            : "woff2";
+      const family = /^[a-zA-Z_-][\w-]*$/.test(face.family)
+        ? face.family
+        : `"${face.family.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+      return `@font-face {
+  font-family: ${family};
+  font-style: ${face.style};
+  font-weight: ${face.weight};
+  font-display: ${face.display};
+  src: url(./${fileName}) format("${format}");${range}
+}`;
+    })
+    .join("\n\n");
+}
+
+export function resolveFontCacheDir(root: string, cacheDir?: string): string {
+  return cacheDir ?? join(root, "node_modules", ".cache", "ox-content", "fonts");
+}
+
+export async function acquireSelfHostedFaces(
+  faces: PlannedSelfHostFace[],
+  options: WriteThemeFontsOptions,
+): Promise<AcquiredSelfHostFace[]> {
+  const cacheDir = resolveFontCacheDir(options.root, options.cacheDir);
+  const acquired: AcquiredSelfHostFace[] = [];
+  for (const face of faces) {
+    acquired.push(
+      face.provider === "local"
+        ? await acquireLocalFace(face, options.root)
+        : await acquireGoogleFace(face, cacheDir, options.fetch ?? fetch),
+    );
+  }
+  return acquired;
+}
+
+async function acquireLocalFace(
+  face: PlannedSelfHostFace,
+  root: string,
+): Promise<AcquiredSelfHostFace> {
+  if (!face.path) {
+    throw new Error(`Theme font "${face.family}" uses provider "local" but has no path.`);
+  }
+  if (face.path.includes("\0")) {
+    throw new Error(`Theme font "${face.family}" path must not contain NUL.`);
+  }
+  const resolved = resolveLocalPath(root, face.path);
+  const info = await stat(resolved).catch(() => undefined);
+  if (!info) {
+    throw new Error(`Theme font "${face.family}" was not found at ${resolved}.`);
+  }
+  const file = info.isDirectory() ? await findDirectoryFont(resolved, face) : resolved;
+  return { ...face, bytes: await readFile(file) };
+}
+
+function resolveLocalPath(root: string, spec: string): string {
+  if (isAbsolute(spec)) {
+    return spec;
+  }
+  if (spec.startsWith("@") || !spec.startsWith(".")) {
+    return resolve(root, "node_modules", spec);
+  }
+  return resolve(root, spec);
+}
+
+async function findDirectoryFont(dir: string, face: PlannedSelfHostFace): Promise<string> {
+  const filesDir = existsSync(join(dir, "files")) ? join(dir, "files") : dir;
+  const names = (await readdir(filesDir)).filter((name) => /\.(woff2|woff|ttf|otf)$/i.test(name));
+  const weight = String(face.weight);
+  const wantItalic = face.style === "italic";
+  const match = names.find((name) => {
+    const lower = name.toLowerCase();
+    const hasWeight = lower.includes(weight);
+    const italic = lower.includes("italic");
+    const subset = face.subset === "all" || lower.includes(face.subset.toLowerCase());
+    return hasWeight && subset && italic === wantItalic;
+  });
+  const fallback = names[0];
+  const chosen = match ?? (names.length === 1 ? fallback : undefined);
+  if (!chosen) {
+    throw new Error(
+      `Theme font "${face.family}" has no ${face.weight} ${face.style} ${face.subset} file in ${filesDir}.`,
+    );
+  }
+  return join(filesDir, chosen);
+}
+
+async function acquireGoogleFace(
+  face: PlannedSelfHostFace,
+  cacheDir: string,
+  fetchFn: FontFetch,
+): Promise<AcquiredSelfHostFace> {
+  const css = await cachedText(googleCssUrl(face), cacheDir, fetchFn, ".css");
+  const parsed = parseGoogleCss(css).find(
+    (entry) =>
+      entry.weight === face.weight &&
+      entry.style === face.style &&
+      (entry.subset === face.subset || !entry.subset),
+  );
+  if (!parsed) {
+    throw new Error(
+      `Google Fonts CSS for "${face.family}" has no ${face.weight} ${face.style} ${face.subset} face.`,
+    );
+  }
+  const bytes = await cachedBytes(parsed.url, cacheDir, fetchFn, ".woff2");
+  return { ...face, bytes, unicodeRange: face.unicodeRange ?? parsed.unicodeRange };
+}
+
+export function googleCssUrl(face: PlannedSelfHostFace): string {
+  const italic = face.style === "italic";
+  const axis = italic ? "ital,wght" : "wght";
+  const spec = italic ? `1,${face.weight}` : `${face.weight}`;
+  const family = `${face.family.replace(/ /g, "+")}:${axis}@${spec}`;
+  return `${GOOGLE_CSS}?family=${family}&display=${encodeURIComponent(face.display)}`;
+}
+
+interface ParsedGoogleFace {
+  subset: string;
+  weight: number;
+  style: "normal" | "italic";
+  url: string;
+  unicodeRange?: string;
+}
+
+export function parseGoogleCss(css: string): ParsedGoogleFace[] {
+  const faces: ParsedGoogleFace[] = [];
+  const blocks = css.matchAll(/\/\*\s*([a-z0-9-]+)\s*\*\/\s*@font-face\s*\{([^}]+)\}/gi);
+  for (const match of blocks) {
+    const parsed = parseGoogleBlock(match[2] ?? "", match[1]?.toLowerCase() ?? "");
+    if (parsed) {
+      faces.push(parsed);
+    }
+  }
+  if (faces.length === 0) {
+    for (const match of css.matchAll(/@font-face\s*\{([^}]+)\}/gi)) {
+      const parsed = parseGoogleBlock(match[1] ?? "", "");
+      if (parsed) {
+        faces.push(parsed);
+      }
+    }
+  }
+  return faces;
+}
+
+function parseGoogleBlock(body: string, subset: string): ParsedGoogleFace | undefined {
+  const url = body.match(/url\((['"]?)(https?:\/\/[^'")]+)\1\)/)?.[2];
+  if (!url || !isAllowedFontUrl(url)) {
+    return undefined;
+  }
+  const weight = Number(body.match(/font-weight:\s*(\d+)/i)?.[1] ?? 400);
+  const style = /font-style:\s*italic/i.test(body) ? "italic" : "normal";
+  return {
+    subset,
+    weight,
+    style,
+    url,
+    unicodeRange: body.match(/unicode-range:\s*([^;]+)/i)?.[1]?.trim(),
+  };
+}
+
+function isAllowedFontUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" && ALLOWED_HOSTS.has(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+async function cachedText(
+  url: string,
+  cacheDir: string,
+  fetchFn: FontFetch,
+  ext: string,
+): Promise<string> {
+  const bytes = await cachedBytes(url, cacheDir, fetchFn, ext);
+  return new TextDecoder().decode(bytes);
+}
+
+async function cachedBytes(
+  url: string,
+  cacheDir: string,
+  fetchFn: FontFetch,
+  ext: string,
+): Promise<Uint8Array> {
+  if (!isAllowedFontUrl(url)) {
+    throw new Error(`Refusing to download font from ${url}.`);
+  }
+  await mkdir(cacheDir, { recursive: true });
+  const dest = join(
+    cacheDir,
+    `${createHash("sha256").update(url).digest("hex").slice(0, 16)}${ext}`,
+  );
+  if (existsSync(dest)) {
+    return readFile(dest);
+  }
+  const response = await fetchFn(url, { headers: { "User-Agent": GOOGLE_UA } });
+  if (!response.ok) {
+    throw new Error(`Failed to download ${url}: ${response.status}`);
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  await writeFile(dest, bytes);
+  return bytes;
+}

--- a/npm/vite-plugin-ox-content/src/theme-fonts.test.ts
+++ b/npm/vite-plugin-ox-content/src/theme-fonts.test.ts
@@ -1,0 +1,251 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { resolveTheme, themeToNapi } from "./theme";
+import {
+  flattenThemeFont,
+  flattenThemeFonts,
+  namedFontVarsCss,
+  planSelfHostedFaces,
+  writeSelfHostedThemeFonts,
+} from "./theme-fonts";
+import { googleCssUrl, parseGoogleCss } from "./theme-fonts-acquire";
+
+const fixtureFont = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "ox-test-font.woff2");
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function tempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("flattenThemeFont", () => {
+  it("keeps the string stack form unchanged", () => {
+    expect(flattenThemeFont("Inter, sans-serif", "sans-serif")).toBe("Inter, sans-serif");
+  });
+
+  it("quotes families with spaces and appends a generic fallback", () => {
+    expect(flattenThemeFont({ family: "DM Mono" }, "monospace")).toBe('"DM Mono", monospace');
+  });
+});
+
+describe("flattenThemeFonts", () => {
+  it("mixes an object sans face with a string mono stack", () => {
+    expect(
+      flattenThemeFonts({
+        sans: { family: "Inter", provider: "google", selfHost: true },
+        mono: "DM Mono, monospace",
+      }),
+    ).toEqual({ sans: "Inter, sans-serif", mono: "DM Mono, monospace" });
+  });
+});
+
+describe("namedFontVarsCss", () => {
+  it("exposes kebab-case CSS variables for named families", () => {
+    expect(namedFontVarsCss({ named: { code: { family: "JetBrains Mono" } } })).toContain(
+      '--octc-font-code: "JetBrains Mono", sans-serif;',
+    );
+  });
+
+  it("rejects a named key that would break out of a declaration", () => {
+    expect(() => namedFontVarsCss({ named: { "bad: red; }": "x" } })).toThrow(
+      /Invalid theme font name/,
+    );
+  });
+});
+
+describe("themeToNapi fonts", () => {
+  it("flattens object fonts and injects local stylesheet plus preload tags", () => {
+    const napi = themeToNapi(
+      resolveTheme({
+        fonts: {
+          sans: {
+            family: "Inter",
+            provider: "local",
+            path: "./fixtures/ox-test-font.woff2",
+            weights: [400],
+            selfHost: true,
+            preload: true,
+          },
+          named: {
+            code: { family: "JetBrains Mono", provider: "google", weights: [400], selfHost: true },
+          },
+        },
+      }),
+      undefined,
+      "/docs/",
+    );
+
+    expect(napi.fonts?.sans).toBe("Inter, sans-serif");
+    expect(typeof napi.fonts?.mono).toBe("string");
+    expect(napi.css).toContain('--octc-font-code: "JetBrains Mono", sans-serif;');
+    expect(napi.embed?.head).toContain("/docs/__ox_fonts__/fonts.css");
+    expect(napi.embed?.head).toContain("/docs/__ox_fonts__/inter-400-normal-latin.woff2");
+    expect(napi.embed?.head).not.toContain("fonts.googleapis.com");
+    expect(napi.embed?.head).not.toContain("fonts.gstatic.com");
+  });
+
+  it("does not inject font links for string stacks", () => {
+    const napi = themeToNapi(resolveTheme({ fonts: { sans: "Inter, sans-serif" } }));
+    expect(napi.embed?.head ?? "").not.toContain("__ox_fonts__");
+  });
+});
+
+describe("writeSelfHostedThemeFonts", () => {
+  it("copies a local fixture and emits @font-face without remote URLs", async () => {
+    const outDir = await tempDir("ox-fonts-local-");
+    const fixture = await readFile(fixtureFont);
+    const written = await writeSelfHostedThemeFonts({
+      fonts: {
+        sans: {
+          family: "Ox Test",
+          provider: "local",
+          path: fixtureFont,
+          weights: [400],
+          selfHost: true,
+          preload: true,
+        },
+        named: {
+          code: {
+            family: "Ox Test",
+            provider: "local",
+            path: fixtureFont,
+            weights: [400],
+            selfHost: true,
+          },
+        },
+      },
+      outDir,
+      root: outDir,
+    });
+
+    const cssPath = join(outDir, "__ox_fonts__", "fonts.css");
+    const fontPath = join(outDir, "__ox_fonts__", "ox-test-400-normal-latin.woff2");
+    expect(written).toEqual(expect.arrayContaining([cssPath, fontPath]));
+    expect(await readFile(fontPath)).toEqual(fixture);
+    const css = await readFile(cssPath, "utf8");
+    expect(css).toContain('font-family: "Ox Test"');
+    expect(css).toContain("url(./ox-test-400-normal-latin.woff2)");
+    expect(css).not.toContain("fonts.googleapis.com");
+    expect(css).not.toContain("fonts.gstatic.com");
+    expect(css).not.toContain("http");
+  });
+
+  it("resolves an @fontsource-style files directory without network", async () => {
+    const root = await tempDir("ox-fonts-fontsource-");
+    const outDir = join(root, "dist");
+    const pkg = join(root, "node_modules", "@fontsource", "ox-test", "files");
+    await mkdir(pkg, { recursive: true });
+    await writeFile(join(pkg, "ox-test-latin-400-normal.woff2"), await readFile(fixtureFont));
+
+    await writeSelfHostedThemeFonts({
+      fonts: {
+        mono: {
+          family: "Ox Test",
+          provider: "local",
+          path: "@fontsource/ox-test",
+          weights: [400],
+          selfHost: true,
+        },
+      },
+      outDir,
+      root,
+    });
+
+    expect(await readFile(join(outDir, "__ox_fonts__", "ox-test-400-normal-latin.woff2"))).toEqual(
+      await readFile(fixtureFont),
+    );
+  });
+
+  it("is a no-op when every family is a string or selfHost is off", async () => {
+    const outDir = await tempDir("ox-fonts-skip-");
+    const written = await writeSelfHostedThemeFonts({
+      fonts: {
+        sans: "Inter, sans-serif",
+        mono: { family: "DM Mono", provider: "google" },
+      },
+      outDir,
+      root: outDir,
+    });
+    expect(written).toEqual([]);
+  });
+
+  it("downloads Google faces through the injected fetch and reuses the cache", async () => {
+    const root = await tempDir("ox-fonts-google-");
+    const outDir = join(root, "dist");
+    const cacheDir = join(root, "cache");
+    const css = `/* latin */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/inter/v18/fake.woff2) format('woff2');
+  unicode-range: U+0000-00FF;
+}`;
+    const payload = new Uint8Array([1, 2, 3, 4]);
+    let fetches = 0;
+    const fetchFn: typeof fetch = async (input) => {
+      fetches += 1;
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.startsWith("https://fonts.googleapis.com/css2")) {
+        return new Response(css);
+      }
+      if (url === "https://fonts.gstatic.com/s/inter/v18/fake.woff2") {
+        return new Response(payload);
+      }
+      throw new Error(`unexpected download ${url}`);
+    };
+    const fonts = {
+      sans: { family: "Inter", provider: "google" as const, weights: [400], selfHost: true },
+    };
+
+    await writeSelfHostedThemeFonts({ fonts, outDir, root, cacheDir, fetch: fetchFn });
+    const first = fetches;
+    await writeSelfHostedThemeFonts({
+      fonts,
+      outDir: join(root, "dist-2"),
+      root,
+      cacheDir,
+      fetch: async () => {
+        throw new Error("cache should prevent network");
+      },
+    });
+
+    expect(first).toBe(2);
+    expect(await readFile(join(outDir, "__ox_fonts__", "inter-400-normal-latin.woff2"))).toEqual(
+      Buffer.from(payload),
+    );
+    const emitted = await readFile(join(outDir, "__ox_fonts__", "fonts.css"), "utf8");
+    expect(emitted).toContain("unicode-range: U+0000-00FF");
+    expect(emitted).not.toContain("fonts.gstatic.com");
+  });
+});
+
+describe("google css helpers", () => {
+  it("builds a CSS2 URL and parses subset comments", () => {
+    const [face] = planSelfHostedFaces({
+      sans: { family: "Inter", provider: "google", weights: [600], selfHost: true },
+    });
+    expect(googleCssUrl(face!)).toContain("family=Inter:wght@600");
+    expect(
+      parseGoogleCss(
+        "/* latin */\n@font-face { font-weight: 600; src: url(https://fonts.gstatic.com/s/x.woff2); }",
+      ),
+    ).toEqual([
+      {
+        subset: "latin",
+        weight: 600,
+        style: "normal",
+        url: "https://fonts.gstatic.com/s/x.woff2",
+        unicodeRange: undefined,
+      },
+    ]);
+  });
+});

--- a/npm/vite-plugin-ox-content/src/theme-fonts.ts
+++ b/npm/vite-plugin-ox-content/src/theme-fonts.ts
@@ -1,0 +1,316 @@
+/**
+ * Opt-in web-font objects for `theme.fonts`, plus SSG self-host emission.
+ *
+ * NAPI still receives flattened CSS stacks (`JsThemeFonts`). File acquisition
+ * and `@font-face` generation stay in TypeScript so other PRs can keep landing
+ * NAPI theme-type changes independently.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  acquireSelfHostedFaces,
+  fontMime,
+  renderFontFaceCss,
+  type FontFetch,
+} from "./theme-fonts-acquire";
+
+export const FONT_ASSET_DIR = "__ox_fonts__";
+export const FONT_CSS_NAME = "fonts.css";
+
+export type ThemeFontProvider = "google" | "local";
+export type ThemeFontStyle = "normal" | "italic";
+export type ThemeFontDisplay = "auto" | "block" | "swap" | "fallback" | "optional";
+
+/** UnoCSS-inspired family descriptor. The string stack form remains valid. */
+export interface ThemeWebFont {
+  /** Family name, e.g. `"Inter"` or `"DM Mono"`. */
+  family: string;
+  /** Defaults to `"local"` when `path` is set, otherwise `"google"`. */
+  provider?: ThemeFontProvider;
+  /** File, directory, or `@fontsource/*` package. Required for `local`. */
+  path?: string;
+  weights?: number[];
+  styles?: ThemeFontStyle[];
+  subsets?: string[];
+  display?: ThemeFontDisplay;
+  /** Copy files into the SSG output and emit `@font-face`. */
+  selfHost?: boolean;
+  /** Extra families after `family` in the emitted CSS stack. */
+  fallbacks?: string[];
+  /** Preload every self-hosted face, or only these weights. */
+  preload?: boolean | number[];
+  /** Optional `unicode-range` for local faces. */
+  unicodeRange?: string;
+}
+
+export type ThemeFontValue = string | ThemeWebFont;
+
+export interface ThemeFontsLike {
+  sans?: ThemeFontValue;
+  mono?: ThemeFontValue;
+  named?: Record<string, ThemeFontValue>;
+}
+
+export interface WriteThemeFontsOptions {
+  fonts: ThemeFontsLike;
+  outDir: string;
+  root: string;
+  cacheDir?: string;
+  fetch?: FontFetch;
+}
+
+const NAMED_FONT_PATTERN = /^[a-z][a-z0-9-]*$/;
+const GENERIC_FOR = { sans: "sans-serif", mono: "monospace", named: "sans-serif" } as const;
+
+export function isThemeWebFont(value: ThemeFontValue | undefined): value is ThemeWebFont {
+  return typeof value === "object" && value !== null && typeof value.family === "string";
+}
+
+/** CSS `font-family` identifier; quotes names that are not a single ident. */
+export function cssFamilyName(family: string): string {
+  const trimmed = family.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed;
+  }
+  if (/^[a-zA-Z_-][\w-]*$/.test(trimmed)) {
+    return trimmed;
+  }
+  return `"${trimmed.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+export function flattenThemeFont(
+  value: ThemeFontValue | undefined,
+  generic: string,
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  const fallbacks = value.fallbacks?.length ? value.fallbacks.join(", ") : generic;
+  return `${cssFamilyName(value.family)}, ${fallbacks}`;
+}
+
+/** Flatten object fonts so `JsThemeFonts` stays `{ sans?: string; mono?: string }`. */
+export function flattenThemeFonts(
+  fonts: ThemeFontsLike,
+): { sans?: string; mono?: string } | undefined {
+  const sans = flattenThemeFont(fonts.sans, GENERIC_FOR.sans);
+  const mono = flattenThemeFont(fonts.mono, GENERIC_FOR.mono);
+  if (!sans && !mono) {
+    return undefined;
+  }
+  return { sans, mono };
+}
+
+export function namedFontToken(name: string): string {
+  if (!NAMED_FONT_PATTERN.test(name)) {
+    throw new Error(
+      `Invalid theme font name: ${JSON.stringify(name)}. ` +
+        `Named fonts are lowercase kebab-case (e.g. "code").`,
+    );
+  }
+  return name;
+}
+
+/** Extra `--octc-font-*` variables for `fonts.named`. Roles stay in Rust theme CSS. */
+export function namedFontVarsCss(fonts: ThemeFontsLike): string {
+  const entries = Object.entries(fonts.named ?? {});
+  if (entries.length === 0) {
+    return "";
+  }
+  const lines = entries.map(([name, value]) => {
+    const stack = flattenThemeFont(value, GENERIC_FOR.named);
+    return `  --octc-font-${namedFontToken(name)}: ${stack};`;
+  });
+  return `:root {\n${lines.join("\n")}\n}`;
+}
+
+export function normalizeBasePath(base: string | undefined): string {
+  if (!base || base === "/") {
+    return "/";
+  }
+  return base.endsWith("/") ? base : `${base}/`;
+}
+
+export function plannedFontFileName(
+  family: string,
+  weight: number,
+  style: ThemeFontStyle,
+  subset: string,
+  extension: string,
+): string {
+  const ext = extension.startsWith(".") ? extension : `.${extension}`;
+  return `${slugify(family)}-${weight}-${style}-${slugify(subset)}${ext}`;
+}
+
+export function plannedFontExtension(font: ThemeWebFont): string {
+  if (
+    font.provider === "local" &&
+    font.path &&
+    /\.\w+$/.test(font.path) &&
+    !font.path.endsWith("/")
+  ) {
+    const match = font.path.match(/(\.\w+)$/);
+    return match?.[1] ?? ".woff2";
+  }
+  return ".woff2";
+}
+
+export interface PlannedSelfHostFace {
+  family: string;
+  weight: number;
+  style: ThemeFontStyle;
+  subset: string;
+  display: ThemeFontDisplay;
+  preload: boolean;
+  provider: ThemeFontProvider;
+  path?: string;
+  fileName: string;
+  unicodeRange?: string;
+}
+
+export function planSelfHostedFaces(fonts: ThemeFontsLike): PlannedSelfHostFace[] {
+  const faces: PlannedSelfHostFace[] = [];
+  for (const value of themeFontValues(fonts)) {
+    if (!isThemeWebFont(value) || !value.selfHost) {
+      continue;
+    }
+    const font = normalizeWebFont(value);
+    const extension = plannedFontExtension(font);
+    for (const weight of font.weights) {
+      for (const style of font.styles) {
+        for (const subset of font.subsets) {
+          faces.push({
+            family: font.family,
+            weight,
+            style,
+            subset,
+            display: font.display,
+            preload: shouldPreload(font.preload, weight),
+            provider: font.provider,
+            path: font.path,
+            fileName: plannedFontFileName(font.family, weight, style, subset, extension),
+            unicodeRange: font.unicodeRange,
+          });
+        }
+      }
+    }
+  }
+  const unique = new Map<string, PlannedSelfHostFace>();
+  for (const face of faces) {
+    const existing = unique.get(face.fileName);
+    if (existing) {
+      existing.preload ||= face.preload;
+    } else {
+      unique.set(face.fileName, face);
+    }
+  }
+  return [...unique.values()];
+}
+
+export function themeFontHeadHtml(fonts: ThemeFontsLike, base?: string): string {
+  const faces = planSelfHostedFaces(fonts);
+  if (faces.length === 0) {
+    return "";
+  }
+  const root = normalizeBasePath(base);
+  const tags = [`<link rel="stylesheet" href="${root}${FONT_ASSET_DIR}/${FONT_CSS_NAME}">`];
+  for (const face of faces) {
+    if (!face.preload) {
+      continue;
+    }
+    tags.push(
+      `<link rel="preload" href="${root}${FONT_ASSET_DIR}/${face.fileName}" as="font" type="${fontMime(face.fileName)}" crossorigin>`,
+    );
+  }
+  return tags.join("\n");
+}
+
+export function withSelfHostedFontHead<T extends { head?: string }>(
+  embed: T,
+  fonts: ThemeFontsLike,
+  base?: string,
+): T | undefined {
+  const extra = themeFontHeadHtml(fonts, base);
+  const keys = Object.keys(embed);
+  if (!extra && keys.length === 0) {
+    return undefined;
+  }
+  if (!extra) {
+    return embed;
+  }
+  return { ...embed, head: embed.head ? `${extra}\n${embed.head}` : extra };
+}
+
+/** Copy self-hosted faces into `outDir` and write `@font-face` CSS. */
+export async function writeSelfHostedThemeFonts(
+  options: WriteThemeFontsOptions,
+): Promise<string[]> {
+  const faces = planSelfHostedFaces(options.fonts);
+  if (faces.length === 0) {
+    return [];
+  }
+  const acquired = await acquireSelfHostedFaces(faces, options);
+  const destDir = join(options.outDir, FONT_ASSET_DIR);
+  await mkdir(destDir, { recursive: true });
+  const written: string[] = [];
+  for (const face of acquired) {
+    const dest = join(destDir, face.fileName);
+    await writeFile(dest, face.bytes);
+    written.push(dest);
+  }
+  const cssPath = join(destDir, FONT_CSS_NAME);
+  await writeFile(cssPath, renderFontFaceCss(acquired), "utf8");
+  written.push(cssPath);
+  return written;
+}
+
+function themeFontValues(fonts: ThemeFontsLike): ThemeFontValue[] {
+  return [fonts.sans, fonts.mono, ...Object.values(fonts.named ?? {})].filter(
+    (value): value is ThemeFontValue => value !== undefined,
+  );
+}
+
+function normalizeWebFont(
+  font: ThemeWebFont,
+): Required<
+  Pick<ThemeWebFont, "family" | "provider" | "weights" | "styles" | "subsets" | "display">
+> &
+  ThemeWebFont {
+  const provider = font.provider ?? (font.path ? "local" : "google");
+  if (provider === "local" && !font.path) {
+    throw new Error(`Theme font "${font.family}" uses provider "local" but has no path.`);
+  }
+  return {
+    ...font,
+    family: font.family.trim(),
+    provider,
+    weights: font.weights?.length ? font.weights : [400],
+    styles: font.styles?.length ? font.styles : ["normal"],
+    subsets: font.subsets?.length ? font.subsets : ["latin"],
+    display: font.display ?? "swap",
+  };
+}
+
+function shouldPreload(preload: ThemeWebFont["preload"], weight: number): boolean {
+  if (preload === true) {
+    return true;
+  }
+  return Array.isArray(preload) && preload.includes(weight);
+}
+
+function slugify(value: string): string {
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/['"]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  return slug || "font";
+}

--- a/npm/vite-plugin-ox-content/src/theme.ts
+++ b/npm/vite-plugin-ox-content/src/theme.ts
@@ -11,10 +11,17 @@ import type {
   ThemeAnnouncement,
 } from "./header-chrome";
 import { resolveHeaderNavItems } from "./header-chrome";
+import {
+  flattenThemeFonts,
+  namedFontVarsCss,
+  withSelfHostedFontHead,
+  type ThemeFontValue,
+} from "./theme-fonts";
 import { tokensToCss, type ThemeTokens } from "./theme-tokens";
 
 export type { HeaderNavItem, LocaleLabel, ThemeAnnouncement } from "./header-chrome";
 
+export type { ThemeFontValue, ThemeWebFont } from "./theme-fonts";
 export type { ThemeTokens } from "./theme-tokens";
 
 /**
@@ -57,12 +64,17 @@ export interface ThemeLayout {
 
 /**
  * Theme font configuration.
+ *
+ * `sans` and `mono` accept a CSS stack string or a web-font object. Named
+ * families are extra stacks exposed as `--octc-font-<name>`.
  */
 export interface ThemeFonts {
-  /** Sans-serif font stack */
-  sans?: string;
-  /** Monospace font stack */
-  mono?: string;
+  /** Sans-serif font stack or self-hosted family */
+  sans?: ThemeFontValue;
+  /** Monospace font stack or self-hosted family */
+  mono?: ThemeFontValue;
+  /** Additional families, exposed as `--octc-font-<name>` */
+  named?: Record<string, ThemeFontValue>;
 }
 
 /**
@@ -530,7 +542,11 @@ function withDerivedCodeBackgroundTop(theme: ThemeConfig): ThemeConfig {
 /**
  * Converts resolved theme to the format expected by Rust NAPI.
  */
-export function themeToNapi(theme: ResolvedThemeConfig, locale?: string): NapiThemeConfig {
+export function themeToNapi(
+  theme: ResolvedThemeConfig,
+  locale?: string,
+  base?: string,
+): NapiThemeConfig {
   const socialLinks = socialLinksToNapi(theme.socialLinks);
 
   return {
@@ -566,12 +582,7 @@ export function themeToNapi(theme: ResolvedThemeConfig, locale?: string): NapiTh
           codeText: theme.darkColors.codeText,
         }
       : undefined,
-    fonts: theme.fonts.sans
-      ? {
-          sans: theme.fonts.sans,
-          mono: theme.fonts.mono,
-        }
-      : undefined,
+    fonts: flattenThemeFonts(theme.fonts),
     entryPage: theme.entryPage.mode
       ? {
           mode: theme.entryPage.mode,
@@ -605,7 +616,7 @@ export function themeToNapi(theme: ResolvedThemeConfig, locale?: string): NapiTh
           }
         : undefined,
     socialLinks,
-    embed: Object.keys(theme.embed).length > 0 ? theme.embed : undefined,
+    embed: withSelfHostedFontHead(theme.embed, theme.fonts, base),
     css: themeCss(theme) || undefined,
     js: theme.js || undefined,
   };
@@ -617,10 +628,12 @@ export function themeToNapi(theme: ResolvedThemeConfig, locale?: string): NapiTh
  */
 function themeCss(theme: ResolvedThemeConfig): string {
   const tokenCss = tokensToCss(theme.tokens, theme.darkTokens);
-  if (!tokenCss) {
+  const namedCss = namedFontVarsCss(theme.fonts);
+  const prefix = [tokenCss, namedCss].filter(Boolean).join("\n");
+  if (!prefix) {
     return theme.css;
   }
-  return theme.css ? `${tokenCss}\n${theme.css}` : tokenCss;
+  return theme.css ? `${prefix}\n${theme.css}` : prefix;
 }
 
 function socialLinksToNapi(links: SocialLinks): NapiSocialLinks | undefined {


### PR DESCRIPTION
## Summary

- Add an opt-in object form for `theme.fonts` (UnoCSS-style `family` / `provider` / `weights` / `subsets` / `display` / `selfHost` / `named`) while keeping the existing CSS stack strings.
- When `selfHost: true`, TypeScript acquires only the requested faces, caches them under `node_modules/.cache/ox-content/fonts`, writes hashed-stable files plus `@font-face` into `__ox_fonts__/`, and connects `sans` / `mono` to `--octc-font-*` by flattening stacks for NAPI. Named families emit `--octc-font-<name>`. Optional `preload` adds `<link rel="preload">`. Published HTML never includes Google Fonts `<link>`s.
- `provider: "local"` reads a file or `@fontsource/*` directory so tests and offline builds need no network. `JsThemeFonts` stays `{ sans?: string; mono?: string }`.

Closes #932

## Risk

- Risk level: low
- User or production impact: string `fonts.sans` / `fonts.mono` are unchanged. Object fonts are opt-in. NAPI theme types are not widened.
- Rollback plan: revert this PR. Sites that never set `selfHost: true` keep the previous stack-only behavior.

## Validation

- [x] Automated tests or checks run: `vp exec --filter @ox-content/vite-plugin -- vp test src/theme-fonts.test.ts src/theme.test.ts` (40 passed). Local fixture + injected `fetch` — no Google network in CI. `vp check --fix` on touched TS. `scripts/check-file-lines.ts --base prod/main` passed.
- [ ] Manual verification completed: CI on this PR
- [x] Edge cases or failure modes considered: string form unchanged; `selfHost` omitted does not download; missing local path throws; Google downloads are host-allowlisted and cached; duplicate family/weight pairs are deduped.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed. Theme docs EN + JA document string vs object form. Credits EN + JA add a ryoppippi bullet for the ryoppippi.com migration request.
- [x] Configuration, migration, or environment changes documented, or not needed. Object form is additive; no migration.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed. No new npm dependencies. Google downloads restricted to `fonts.googleapis.com` / `fonts.gstatic.com`. Local paths reject NUL.


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790323042&installation_model_id=422833&pr_number=997&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F997&signature=56a7996e175e13c3375e8a320d2c795c38fa2cb96e7981c7b5b5e7f767fecb47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->