### PR TITLE
feat(theme): raise default theme and package quality

### DIFF
--- a/crates/ox_content_ssg/src/entry.css
+++ b/crates/ox_content_ssg/src/entry.css
@@ -156,7 +156,7 @@
 }
 
 .hero-action-brand {
-  color: #ffffff;
+  color: var(--octc-color-on-primary);
   background: var(--octc-color-primary);
   border-color: var(--octc-color-primary);
 }
@@ -165,7 +165,7 @@
   background: var(--octc-color-primary-hover);
   border-color: var(--octc-color-primary-hover);
   text-decoration: none;
-  color: #ffffff;
+  color: var(--octc-color-on-primary);
 }
 
 .hero-action-alt {
@@ -228,7 +228,7 @@
   width: 3rem;
   height: 3rem;
   font-size: 1.25rem;
-  color: #ffffff;
+  color: var(--octc-color-on-primary);
   border-radius: 4px;
   background: color-mix(in srgb, var(--octc-color-primary) 88%, #8ec9ff);
   flex-shrink: 0;
@@ -249,7 +249,7 @@
   mask-repeat: no-repeat;
   -webkit-mask-position: center;
   mask-position: center;
-  background-color: #ffffff;
+  background-color: var(--octc-color-on-primary);
 }
 
 .feature-card .feature-body {

--- a/crates/ox_content_ssg/src/html/file_tree.css
+++ b/crates/ox_content_ssg/src/html/file_tree.css
@@ -45,8 +45,8 @@
   outline: none;
 }
 .content .ox-file-tree summary:focus-visible {
-  outline: 2px solid var(--octc-color-primary);
-  outline-offset: 2px;
+  outline: var(--octc-focus-ring);
+  outline-offset: var(--octc-focus-offset);
   border-radius: 2px;
 }
 .content .ox-file-tree__twisty {

--- a/crates/ox_content_ssg/src/html/header_chrome.css
+++ b/crates/ox_content_ssg/src/html/header_chrome.css
@@ -70,7 +70,7 @@
   min-height: 2.25rem;
   padding: 0.35rem 1.25rem;
   background: var(--octc-color-primary);
-  color: #fff;
+  color: var(--octc-color-on-primary);
   font-size: 0.875rem;
 }
 .ox-announce[hidden] {
@@ -85,7 +85,7 @@
 }
 .ox-announce-dismiss {
   background: transparent;
-  border: 1px solid color-mix(in srgb, #fff 55%, transparent);
+  border: 1px solid color-mix(in srgb, var(--octc-color-on-primary) 55%, transparent);
   border-radius: 4px;
   color: inherit;
   cursor: pointer;

--- a/crates/ox_content_ssg/src/html/heading_permalinks.css
+++ b/crates/ox_content_ssg/src/html/heading_permalinks.css
@@ -11,8 +11,8 @@
   color: var(--octc-color-primary);
 }
 .header-anchor:focus-visible {
-  outline: 2px solid var(--octc-color-primary);
-  outline-offset: 2px;
+  outline: var(--octc-focus-ring);
+  outline-offset: var(--octc-focus-offset);
 }
 @media (hover: hover) and (pointer: fine) {
   body:not(.ox-heading-permalinks--always) :is(h1, h2, h3, h4, h5, h6) > .header-anchor {

--- a/crates/ox_content_ssg/src/html/tests.rs
+++ b/crates/ox_content_ssg/src/html/tests.rs
@@ -27,6 +27,7 @@ mod navigation_state;
 mod rendering;
 mod social;
 mod theme;
+mod theme_quality;
 
 #[test]
 fn search_keydown_ignores_ime_composition() {

--- a/crates/ox_content_ssg/src/html/tests/mobile_css.rs
+++ b/crates/ox_content_ssg/src/html/tests/mobile_css.rs
@@ -77,8 +77,10 @@ fn menu_stays_reachable_and_touch_safe() {
         "the menu overlay must cover the reading pane instead of staying transparent"
     );
     assert!(
-        SSG_CSS.contains(".sidebar .nav-link {\n    min-height: 44px;")
-            && SSG_CSS.contains(".sidebar .nav-title--summary {\n    min-height: 44px;"),
+        SSG_CSS.contains(".sidebar .nav-link {\n    min-height: var(--octc-touch-target);")
+            && SSG_CSS.contains(
+                ".sidebar .nav-title--summary {\n    min-height: var(--octc-touch-target);"
+            ),
         "every mobile navigation control needs a reliable touch target"
     );
     assert!(

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -84,6 +84,25 @@ expression: "super::snapshot_text(&html)"
   --octc-surface-line: #e2e9f3;
   --octc-surface-noise-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 180'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.2' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='180' height='180' filter='url(%23noise)' opacity='0.062'/%3E%3C/svg%3E");
   --octc-surface-noise-size: 164px 164px;
+  --octc-color-on-primary: var(--octc-color-bg);
+  --octc-color-tip: #0891b2;
+  --octc-color-info: #2563eb;
+  --octc-color-warning: #d97706;
+  --octc-color-danger: #dc2626;
+  --octc-color-success: #16a34a;
+  --octc-color-deprecated: #7c3aed;
+  --octc-color-required: #c2410c;
+  --octc-focus-ring: 2px solid var(--octc-color-primary);
+  --octc-focus-offset: 2px;
+  --octc-motion-base: 150ms;
+  --octc-motion-ease: ease;
+  --octc-code-pad-block: 1rem;
+  --octc-code-pad-inline: 1.25rem;
+  --octc-code-title-pad-block: 0.75rem;
+  --octc-code-title-gap: 0.875rem;
+  --octc-table-cell-pad-block: 0.75rem;
+  --octc-table-cell-pad-inline: 1rem;
+  --octc-touch-target: 44px;
 }
 [data-theme="light"] {
   color-scheme: light;
@@ -164,8 +183,12 @@ expression: "super::snapshot_text(&html)"
 html {
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
-  scroll-behavior: smooth;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);
+}
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
 }
 body {
   font-family: var(--octc-font-sans);
@@ -386,7 +409,7 @@ a:hover {
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
   background: color-mix(in srgb, var(--octc-color-bg-alt) 90%, var(--octc-color-primary) 10%);
-  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, white);
+  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, var(--octc-color-bg));
   border-radius: 4px;
   color: var(--octc-color-text-muted);
   cursor: pointer;
@@ -698,7 +721,7 @@ a:hover {
   color: var(--octc-color-text-muted);
   transform: rotate(-45deg);
   transform-origin: center;
-  transition: transform 150ms ease;
+  transition: transform var(--octc-motion-base) var(--octc-motion-ease);
 }
 .nav-details > .nav-summary::before {
   margin-block-start: 0.8rem;
@@ -711,11 +734,6 @@ a:hover {
 [dir="rtl"] .nav-section--collapsible:not([open]) > .nav-title--summary::before,
 [dir="rtl"] .nav-details:not([open]) > .nav-summary::before {
   transform: rotate(135deg);
-}
-.nav-title--summary:focus-visible,
-.nav-details > .nav-summary:focus-visible {
-  outline: 2px solid var(--octc-color-primary);
-  outline-offset: 2px;
 }
 .nav-list {
   list-style: none;
@@ -777,6 +795,10 @@ a:hover {
   .nav-title--summary::before,
   .nav-details > .nav-summary::before {
     transition: none;
+  }
+  .content pre.ox-code-block.has-focused .line,
+  .content pre.ox-code-block .ox-code-line--dimmed {
+    filter: none;
   }
 }
 .main {
@@ -940,13 +962,13 @@ a:hover {
   --octc-callout-accent: var(--octc-color-primary);
 }
 .content blockquote.ox-callout.ox-callout--tip {
-  --octc-callout-accent: #0891b2;
+  --octc-callout-accent: var(--octc-color-tip);
 }
 .content blockquote.ox-callout.ox-callout--warning {
-  --octc-callout-accent: #d97706;
+  --octc-callout-accent: var(--octc-color-warning);
 }
 .content blockquote.ox-callout.ox-callout--caution {
-  --octc-callout-accent: #dc2626;
+  --octc-callout-accent: var(--octc-color-danger);
 }
 .content .ox-callout-title {
   margin: 0 0 0.5rem;
@@ -971,14 +993,14 @@ a:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 92%, var(--octc-container-accent) 8%);
 }
 .content .ox-container--tip {
-  --octc-container-accent: #0891b2;
+  --octc-container-accent: var(--octc-color-tip);
 }
 .content .ox-container--warning,
 .content .ox-container--caution {
-  --octc-container-accent: #d97706;
+  --octc-container-accent: var(--octc-color-warning);
 }
 .content .ox-container--danger {
-  --octc-container-accent: #dc2626;
+  --octc-container-accent: var(--octc-color-danger);
 }
 .content .ox-container-title,
 .content .ox-container summary {
@@ -1083,28 +1105,28 @@ a:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-badge-accent) 12%);
 }
 .content .ox-badge--tip {
-  --octc-badge-accent: #0891b2;
+  --octc-badge-accent: var(--octc-color-tip);
 }
 .content .ox-badge--note {
   --octc-badge-accent: var(--octc-color-primary);
 }
 .content .ox-badge--info {
-  --octc-badge-accent: #2563eb;
+  --octc-badge-accent: var(--octc-color-info);
 }
 .content .ox-badge--warning {
-  --octc-badge-accent: #d97706;
+  --octc-badge-accent: var(--octc-color-warning);
 }
 .content .ox-badge--danger {
-  --octc-badge-accent: #dc2626;
+  --octc-badge-accent: var(--octc-color-danger);
 }
 .content .ox-badge--success {
-  --octc-badge-accent: #16a34a;
+  --octc-badge-accent: var(--octc-color-success);
 }
 .content .ox-badge--deprecated {
-  --octc-badge-accent: #7c3aed;
+  --octc-badge-accent: var(--octc-color-deprecated);
 }
 .content .ox-badge--required {
-  --octc-badge-accent: #c2410c;
+  --octc-badge-accent: var(--octc-color-required);
 }
 .content .ox-magic-link {
   display: inline-flex;
@@ -1124,8 +1146,8 @@ a:hover {
   border-color: color-mix(in srgb, var(--octc-color-primary) 45%, var(--octc-color-border));
 }
 .content .ox-magic-link:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--octc-color-primary) 72%, transparent);
-  outline-offset: 2px;
+  outline: var(--octc-focus-ring);
+  outline-offset: var(--octc-focus-offset);
 }
 .content .ox-magic-link__image {
   width: 1em;
@@ -1175,7 +1197,7 @@ a:hover {
 .content pre {
   background: var(--octc-color-code-bg) !important;
   color: var(--octc-color-code-text);
-  padding: 1rem 1.25rem;
+  padding: var(--octc-code-pad-block) var(--octc-code-pad-inline);
   border-radius: 4px;
   border: 1px solid var(--octc-color-code-frame-border);
   overflow-x: auto;
@@ -1196,8 +1218,9 @@ a:hover {
 .content pre.ox-code-block[data-code-title]::before {
   content: attr(data-code-title);
   display: block;
-  margin: -1rem -1.25rem 0.875rem;
-  padding: 0.75rem 1.25rem;
+  margin: calc(-1 * var(--octc-code-pad-block)) calc(-1 * var(--octc-code-pad-inline))
+    var(--octc-code-title-gap);
+  padding: var(--octc-code-title-pad-block) var(--octc-code-pad-inline);
   border-bottom: 1px solid var(--octc-color-code-title-border);
   background: var(--octc-color-code-title-bg);
   color: var(--octc-color-code-title-text);
@@ -1208,8 +1231,8 @@ a:hover {
 }
 .content pre.ox-code-block .line {
   display: block;
-  margin: 0 -1.25rem;
-  padding: 0 1.25rem;
+  margin: 0 calc(-1 * var(--octc-code-pad-inline));
+  padding: 0 var(--octc-code-pad-inline);
   position: relative;
 }
 .content pre.ox-code-block.line-numbers-mode .line {
@@ -1218,7 +1241,7 @@ a:hover {
 .content pre.ox-code-block.line-numbers-mode .line::before {
   content: attr(data-line-number);
   position: absolute;
-  left: 1.25rem;
+  left: var(--octc-code-pad-inline);
   width: 2rem;
   text-align: right;
   color: var(--octc-color-code-line-number);
@@ -1278,7 +1301,7 @@ a:hover {
   border: 0;
   border-inline-end: 1px solid var(--octc-color-border);
   border-block-end: 1px solid var(--octc-color-border);
-  padding: 0.75rem 1rem;
+  padding: var(--octc-table-cell-pad-block) var(--octc-table-cell-pad-inline);
   text-align: start;
 }
 .content tr > :last-child {
@@ -1837,6 +1860,14 @@ a:hover {
   display: none;
 }
 @media (max-width: 768px) {
+  :root {
+    --octc-code-pad-block: 0.85rem;
+    --octc-code-pad-inline: 0.95rem;
+    --octc-code-title-pad-block: 0.65rem;
+    --octc-code-title-gap: 0.75rem;
+    --octc-table-cell-pad-block: 0.5rem;
+    --octc-table-cell-pad-inline: 0.75rem;
+  }
   .header-actions {
     display: none;
   }
@@ -1931,14 +1962,14 @@ a:hover {
     pointer-events: auto;
   }
   .sidebar .nav-link {
-    min-height: 44px;
+    min-height: var(--octc-touch-target);
     display: flex;
     align-items: center;
     padding-block: 0.625rem;
     line-height: 1.35;
   }
   .sidebar .nav-title--summary {
-    min-height: 44px;
+    min-height: var(--octc-touch-target);
     align-items: center;
   }
   .sidebar .nav-title--summary::before,
@@ -1971,7 +2002,6 @@ a:hover {
     padding: 0.16em 0.34em;
   }
   .content pre {
-    padding: 0.85rem 0.95rem;
     font-size: 0.78rem;
     margin: 1rem 0;
     border-radius: 8px;
@@ -2101,19 +2131,10 @@ a:hover {
     border-radius: 8px !important;
     font-size: 0.82rem !important;
   }
-  .content pre.ox-code-block[data-code-title]::before {
-    margin: -0.85rem -0.95rem 0.75rem;
-    padding: 0.65rem 0.95rem;
-  }
-  .content pre.ox-code-block .line {
-    margin: 0 -0.95rem;
-    padding: 0 0.95rem;
-  }
   .content pre.ox-code-block.line-numbers-mode .line {
     padding-left: 3.7rem;
   }
   .content pre.ox-code-block.line-numbers-mode .line::before {
-    left: 0.95rem;
     width: 1.75rem;
   }
   .content table {
@@ -2122,7 +2143,6 @@ a:hover {
   }
   .content th,
   .content td {
-    padding: 0.5rem 0.75rem;
     white-space: nowrap;
     vertical-align: top;
   }
@@ -2171,6 +2191,14 @@ a:hover {
 }
 
 @media (max-width: 480px) {
+  :root {
+    --octc-code-pad-block: 0.78rem;
+    --octc-code-pad-inline: 0.85rem;
+    --octc-code-title-pad-block: 0.6rem;
+    --octc-code-title-gap: 0.72rem;
+    --octc-table-cell-pad-block: 0.375rem;
+    --octc-table-cell-pad-inline: 0.5rem;
+  }
   .main {
     padding-block-start: 0.75rem;
     padding-bottom: calc(
@@ -2185,7 +2213,6 @@ a:hover {
   }
   .content pre {
     font-size: 0.72rem;
-    padding: 0.78rem 0.85rem;
   }
   .content pre code {
     font-size: 0.72rem;
@@ -2199,24 +2226,14 @@ a:hover {
   .content .ox-api-module__count {
     font-size: 0.68rem;
   }
-  .content pre.ox-code-block[data-code-title]::before {
-    margin: -0.78rem -0.85rem 0.72rem;
-    padding: 0.6rem 0.85rem;
-  }
-  .content pre.ox-code-block .line {
-    margin: 0 -0.85rem;
-    padding: 0 0.85rem;
-  }
-  .content pre.ox-code-block.line-numbers-mode .line::before {
-    left: 0.85rem;
-  }
   .content table {
     font-size: 0.75rem;
   }
-  .content th,
-  .content td {
-    padding: 0.375rem 0.5rem;
-  }
+}
+
+:focus-visible {
+  outline: var(--octc-focus-ring);
+  outline-offset: var(--octc-focus-offset);
 }
 
 /* ox-content:css:base:end */

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -81,6 +81,25 @@ expression: "super::snapshot_text(&html)"
   --octc-surface-line: #e2e9f3;
   --octc-surface-noise-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 180'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.2' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='180' height='180' filter='url(%23noise)' opacity='0.062'/%3E%3C/svg%3E");
   --octc-surface-noise-size: 164px 164px;
+  --octc-color-on-primary: var(--octc-color-bg);
+  --octc-color-tip: #0891b2;
+  --octc-color-info: #2563eb;
+  --octc-color-warning: #d97706;
+  --octc-color-danger: #dc2626;
+  --octc-color-success: #16a34a;
+  --octc-color-deprecated: #7c3aed;
+  --octc-color-required: #c2410c;
+  --octc-focus-ring: 2px solid var(--octc-color-primary);
+  --octc-focus-offset: 2px;
+  --octc-motion-base: 150ms;
+  --octc-motion-ease: ease;
+  --octc-code-pad-block: 1rem;
+  --octc-code-pad-inline: 1.25rem;
+  --octc-code-title-pad-block: 0.75rem;
+  --octc-code-title-gap: 0.875rem;
+  --octc-table-cell-pad-block: 0.75rem;
+  --octc-table-cell-pad-inline: 1rem;
+  --octc-touch-target: 44px;
 }
 [data-theme="light"] {
   color-scheme: light;
@@ -161,8 +180,12 @@ expression: "super::snapshot_text(&html)"
 html {
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
-  scroll-behavior: smooth;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);
+}
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
 }
 body {
   font-family: var(--octc-font-sans);
@@ -383,7 +406,7 @@ a:hover {
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
   background: color-mix(in srgb, var(--octc-color-bg-alt) 90%, var(--octc-color-primary) 10%);
-  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, white);
+  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, var(--octc-color-bg));
   border-radius: 4px;
   color: var(--octc-color-text-muted);
   cursor: pointer;
@@ -695,7 +718,7 @@ a:hover {
   color: var(--octc-color-text-muted);
   transform: rotate(-45deg);
   transform-origin: center;
-  transition: transform 150ms ease;
+  transition: transform var(--octc-motion-base) var(--octc-motion-ease);
 }
 .nav-details > .nav-summary::before {
   margin-block-start: 0.8rem;
@@ -708,11 +731,6 @@ a:hover {
 [dir="rtl"] .nav-section--collapsible:not([open]) > .nav-title--summary::before,
 [dir="rtl"] .nav-details:not([open]) > .nav-summary::before {
   transform: rotate(135deg);
-}
-.nav-title--summary:focus-visible,
-.nav-details > .nav-summary:focus-visible {
-  outline: 2px solid var(--octc-color-primary);
-  outline-offset: 2px;
 }
 .nav-list {
   list-style: none;
@@ -774,6 +792,10 @@ a:hover {
   .nav-title--summary::before,
   .nav-details > .nav-summary::before {
     transition: none;
+  }
+  .content pre.ox-code-block.has-focused .line,
+  .content pre.ox-code-block .ox-code-line--dimmed {
+    filter: none;
   }
 }
 .main {
@@ -937,13 +959,13 @@ a:hover {
   --octc-callout-accent: var(--octc-color-primary);
 }
 .content blockquote.ox-callout.ox-callout--tip {
-  --octc-callout-accent: #0891b2;
+  --octc-callout-accent: var(--octc-color-tip);
 }
 .content blockquote.ox-callout.ox-callout--warning {
-  --octc-callout-accent: #d97706;
+  --octc-callout-accent: var(--octc-color-warning);
 }
 .content blockquote.ox-callout.ox-callout--caution {
-  --octc-callout-accent: #dc2626;
+  --octc-callout-accent: var(--octc-color-danger);
 }
 .content .ox-callout-title {
   margin: 0 0 0.5rem;
@@ -968,14 +990,14 @@ a:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 92%, var(--octc-container-accent) 8%);
 }
 .content .ox-container--tip {
-  --octc-container-accent: #0891b2;
+  --octc-container-accent: var(--octc-color-tip);
 }
 .content .ox-container--warning,
 .content .ox-container--caution {
-  --octc-container-accent: #d97706;
+  --octc-container-accent: var(--octc-color-warning);
 }
 .content .ox-container--danger {
-  --octc-container-accent: #dc2626;
+  --octc-container-accent: var(--octc-color-danger);
 }
 .content .ox-container-title,
 .content .ox-container summary {
@@ -1080,28 +1102,28 @@ a:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-badge-accent) 12%);
 }
 .content .ox-badge--tip {
-  --octc-badge-accent: #0891b2;
+  --octc-badge-accent: var(--octc-color-tip);
 }
 .content .ox-badge--note {
   --octc-badge-accent: var(--octc-color-primary);
 }
 .content .ox-badge--info {
-  --octc-badge-accent: #2563eb;
+  --octc-badge-accent: var(--octc-color-info);
 }
 .content .ox-badge--warning {
-  --octc-badge-accent: #d97706;
+  --octc-badge-accent: var(--octc-color-warning);
 }
 .content .ox-badge--danger {
-  --octc-badge-accent: #dc2626;
+  --octc-badge-accent: var(--octc-color-danger);
 }
 .content .ox-badge--success {
-  --octc-badge-accent: #16a34a;
+  --octc-badge-accent: var(--octc-color-success);
 }
 .content .ox-badge--deprecated {
-  --octc-badge-accent: #7c3aed;
+  --octc-badge-accent: var(--octc-color-deprecated);
 }
 .content .ox-badge--required {
-  --octc-badge-accent: #c2410c;
+  --octc-badge-accent: var(--octc-color-required);
 }
 .content .ox-magic-link {
   display: inline-flex;
@@ -1121,8 +1143,8 @@ a:hover {
   border-color: color-mix(in srgb, var(--octc-color-primary) 45%, var(--octc-color-border));
 }
 .content .ox-magic-link:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--octc-color-primary) 72%, transparent);
-  outline-offset: 2px;
+  outline: var(--octc-focus-ring);
+  outline-offset: var(--octc-focus-offset);
 }
 .content .ox-magic-link__image {
   width: 1em;
@@ -1172,7 +1194,7 @@ a:hover {
 .content pre {
   background: var(--octc-color-code-bg) !important;
   color: var(--octc-color-code-text);
-  padding: 1rem 1.25rem;
+  padding: var(--octc-code-pad-block) var(--octc-code-pad-inline);
   border-radius: 4px;
   border: 1px solid var(--octc-color-code-frame-border);
   overflow-x: auto;
@@ -1193,8 +1215,9 @@ a:hover {
 .content pre.ox-code-block[data-code-title]::before {
   content: attr(data-code-title);
   display: block;
-  margin: -1rem -1.25rem 0.875rem;
-  padding: 0.75rem 1.25rem;
+  margin: calc(-1 * var(--octc-code-pad-block)) calc(-1 * var(--octc-code-pad-inline))
+    var(--octc-code-title-gap);
+  padding: var(--octc-code-title-pad-block) var(--octc-code-pad-inline);
   border-bottom: 1px solid var(--octc-color-code-title-border);
   background: var(--octc-color-code-title-bg);
   color: var(--octc-color-code-title-text);
@@ -1205,8 +1228,8 @@ a:hover {
 }
 .content pre.ox-code-block .line {
   display: block;
-  margin: 0 -1.25rem;
-  padding: 0 1.25rem;
+  margin: 0 calc(-1 * var(--octc-code-pad-inline));
+  padding: 0 var(--octc-code-pad-inline);
   position: relative;
 }
 .content pre.ox-code-block.line-numbers-mode .line {
@@ -1215,7 +1238,7 @@ a:hover {
 .content pre.ox-code-block.line-numbers-mode .line::before {
   content: attr(data-line-number);
   position: absolute;
-  left: 1.25rem;
+  left: var(--octc-code-pad-inline);
   width: 2rem;
   text-align: right;
   color: var(--octc-color-code-line-number);
@@ -1275,7 +1298,7 @@ a:hover {
   border: 0;
   border-inline-end: 1px solid var(--octc-color-border);
   border-block-end: 1px solid var(--octc-color-border);
-  padding: 0.75rem 1rem;
+  padding: var(--octc-table-cell-pad-block) var(--octc-table-cell-pad-inline);
   text-align: start;
 }
 .content tr > :last-child {
@@ -1834,6 +1857,14 @@ a:hover {
   display: none;
 }
 @media (max-width: 768px) {
+  :root {
+    --octc-code-pad-block: 0.85rem;
+    --octc-code-pad-inline: 0.95rem;
+    --octc-code-title-pad-block: 0.65rem;
+    --octc-code-title-gap: 0.75rem;
+    --octc-table-cell-pad-block: 0.5rem;
+    --octc-table-cell-pad-inline: 0.75rem;
+  }
   .header-actions {
     display: none;
   }
@@ -1928,14 +1959,14 @@ a:hover {
     pointer-events: auto;
   }
   .sidebar .nav-link {
-    min-height: 44px;
+    min-height: var(--octc-touch-target);
     display: flex;
     align-items: center;
     padding-block: 0.625rem;
     line-height: 1.35;
   }
   .sidebar .nav-title--summary {
-    min-height: 44px;
+    min-height: var(--octc-touch-target);
     align-items: center;
   }
   .sidebar .nav-title--summary::before,
@@ -1968,7 +1999,6 @@ a:hover {
     padding: 0.16em 0.34em;
   }
   .content pre {
-    padding: 0.85rem 0.95rem;
     font-size: 0.78rem;
     margin: 1rem 0;
     border-radius: 8px;
@@ -2098,19 +2128,10 @@ a:hover {
     border-radius: 8px !important;
     font-size: 0.82rem !important;
   }
-  .content pre.ox-code-block[data-code-title]::before {
-    margin: -0.85rem -0.95rem 0.75rem;
-    padding: 0.65rem 0.95rem;
-  }
-  .content pre.ox-code-block .line {
-    margin: 0 -0.95rem;
-    padding: 0 0.95rem;
-  }
   .content pre.ox-code-block.line-numbers-mode .line {
     padding-left: 3.7rem;
   }
   .content pre.ox-code-block.line-numbers-mode .line::before {
-    left: 0.95rem;
     width: 1.75rem;
   }
   .content table {
@@ -2119,7 +2140,6 @@ a:hover {
   }
   .content th,
   .content td {
-    padding: 0.5rem 0.75rem;
     white-space: nowrap;
     vertical-align: top;
   }
@@ -2168,6 +2188,14 @@ a:hover {
 }
 
 @media (max-width: 480px) {
+  :root {
+    --octc-code-pad-block: 0.78rem;
+    --octc-code-pad-inline: 0.85rem;
+    --octc-code-title-pad-block: 0.6rem;
+    --octc-code-title-gap: 0.72rem;
+    --octc-table-cell-pad-block: 0.375rem;
+    --octc-table-cell-pad-inline: 0.5rem;
+  }
   .main {
     padding-block-start: 0.75rem;
     padding-bottom: calc(
@@ -2182,7 +2210,6 @@ a:hover {
   }
   .content pre {
     font-size: 0.72rem;
-    padding: 0.78rem 0.85rem;
   }
   .content pre code {
     font-size: 0.72rem;
@@ -2196,24 +2223,14 @@ a:hover {
   .content .ox-api-module__count {
     font-size: 0.68rem;
   }
-  .content pre.ox-code-block[data-code-title]::before {
-    margin: -0.78rem -0.85rem 0.72rem;
-    padding: 0.6rem 0.85rem;
-  }
-  .content pre.ox-code-block .line {
-    margin: 0 -0.85rem;
-    padding: 0 0.85rem;
-  }
-  .content pre.ox-code-block.line-numbers-mode .line::before {
-    left: 0.85rem;
-  }
   .content table {
     font-size: 0.75rem;
   }
-  .content th,
-  .content td {
-    padding: 0.375rem 0.5rem;
-  }
+}
+
+:focus-visible {
+  outline: var(--octc-focus-ring);
+  outline-offset: var(--octc-focus-offset);
 }
 
 /* ox-content:css:base:end */

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -81,6 +81,25 @@ expression: "super::snapshot_text(&html)"
   --octc-surface-line: #e2e9f3;
   --octc-surface-noise-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 180'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.2' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='180' height='180' filter='url(%23noise)' opacity='0.062'/%3E%3C/svg%3E");
   --octc-surface-noise-size: 164px 164px;
+  --octc-color-on-primary: var(--octc-color-bg);
+  --octc-color-tip: #0891b2;
+  --octc-color-info: #2563eb;
+  --octc-color-warning: #d97706;
+  --octc-color-danger: #dc2626;
+  --octc-color-success: #16a34a;
+  --octc-color-deprecated: #7c3aed;
+  --octc-color-required: #c2410c;
+  --octc-focus-ring: 2px solid var(--octc-color-primary);
+  --octc-focus-offset: 2px;
+  --octc-motion-base: 150ms;
+  --octc-motion-ease: ease;
+  --octc-code-pad-block: 1rem;
+  --octc-code-pad-inline: 1.25rem;
+  --octc-code-title-pad-block: 0.75rem;
+  --octc-code-title-gap: 0.875rem;
+  --octc-table-cell-pad-block: 0.75rem;
+  --octc-table-cell-pad-inline: 1rem;
+  --octc-touch-target: 44px;
 }
 [data-theme="light"] {
   color-scheme: light;
@@ -161,8 +180,12 @@ expression: "super::snapshot_text(&html)"
 html {
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
-  scroll-behavior: smooth;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);
+}
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
 }
 body {
   font-family: var(--octc-font-sans);
@@ -383,7 +406,7 @@ a:hover {
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
   background: color-mix(in srgb, var(--octc-color-bg-alt) 90%, var(--octc-color-primary) 10%);
-  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, white);
+  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, var(--octc-color-bg));
   border-radius: 4px;
   color: var(--octc-color-text-muted);
   cursor: pointer;
@@ -695,7 +718,7 @@ a:hover {
   color: var(--octc-color-text-muted);
   transform: rotate(-45deg);
   transform-origin: center;
-  transition: transform 150ms ease;
+  transition: transform var(--octc-motion-base) var(--octc-motion-ease);
 }
 .nav-details > .nav-summary::before {
   margin-block-start: 0.8rem;
@@ -708,11 +731,6 @@ a:hover {
 [dir="rtl"] .nav-section--collapsible:not([open]) > .nav-title--summary::before,
 [dir="rtl"] .nav-details:not([open]) > .nav-summary::before {
   transform: rotate(135deg);
-}
-.nav-title--summary:focus-visible,
-.nav-details > .nav-summary:focus-visible {
-  outline: 2px solid var(--octc-color-primary);
-  outline-offset: 2px;
 }
 .nav-list {
   list-style: none;
@@ -774,6 +792,10 @@ a:hover {
   .nav-title--summary::before,
   .nav-details > .nav-summary::before {
     transition: none;
+  }
+  .content pre.ox-code-block.has-focused .line,
+  .content pre.ox-code-block .ox-code-line--dimmed {
+    filter: none;
   }
 }
 .main {
@@ -937,13 +959,13 @@ a:hover {
   --octc-callout-accent: var(--octc-color-primary);
 }
 .content blockquote.ox-callout.ox-callout--tip {
-  --octc-callout-accent: #0891b2;
+  --octc-callout-accent: var(--octc-color-tip);
 }
 .content blockquote.ox-callout.ox-callout--warning {
-  --octc-callout-accent: #d97706;
+  --octc-callout-accent: var(--octc-color-warning);
 }
 .content blockquote.ox-callout.ox-callout--caution {
-  --octc-callout-accent: #dc2626;
+  --octc-callout-accent: var(--octc-color-danger);
 }
 .content .ox-callout-title {
   margin: 0 0 0.5rem;
@@ -968,14 +990,14 @@ a:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 92%, var(--octc-container-accent) 8%);
 }
 .content .ox-container--tip {
-  --octc-container-accent: #0891b2;
+  --octc-container-accent: var(--octc-color-tip);
 }
 .content .ox-container--warning,
 .content .ox-container--caution {
-  --octc-container-accent: #d97706;
+  --octc-container-accent: var(--octc-color-warning);
 }
 .content .ox-container--danger {
-  --octc-container-accent: #dc2626;
+  --octc-container-accent: var(--octc-color-danger);
 }
 .content .ox-container-title,
 .content .ox-container summary {
@@ -1080,28 +1102,28 @@ a:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-badge-accent) 12%);
 }
 .content .ox-badge--tip {
-  --octc-badge-accent: #0891b2;
+  --octc-badge-accent: var(--octc-color-tip);
 }
 .content .ox-badge--note {
   --octc-badge-accent: var(--octc-color-primary);
 }
 .content .ox-badge--info {
-  --octc-badge-accent: #2563eb;
+  --octc-badge-accent: var(--octc-color-info);
 }
 .content .ox-badge--warning {
-  --octc-badge-accent: #d97706;
+  --octc-badge-accent: var(--octc-color-warning);
 }
 .content .ox-badge--danger {
-  --octc-badge-accent: #dc2626;
+  --octc-badge-accent: var(--octc-color-danger);
 }
 .content .ox-badge--success {
-  --octc-badge-accent: #16a34a;
+  --octc-badge-accent: var(--octc-color-success);
 }
 .content .ox-badge--deprecated {
-  --octc-badge-accent: #7c3aed;
+  --octc-badge-accent: var(--octc-color-deprecated);
 }
 .content .ox-badge--required {
-  --octc-badge-accent: #c2410c;
+  --octc-badge-accent: var(--octc-color-required);
 }
 .content .ox-magic-link {
   display: inline-flex;
@@ -1121,8 +1143,8 @@ a:hover {
   border-color: color-mix(in srgb, var(--octc-color-primary) 45%, var(--octc-color-border));
 }
 .content .ox-magic-link:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--octc-color-primary) 72%, transparent);
-  outline-offset: 2px;
+  outline: var(--octc-focus-ring);
+  outline-offset: var(--octc-focus-offset);
 }
 .content .ox-magic-link__image {
   width: 1em;
@@ -1172,7 +1194,7 @@ a:hover {
 .content pre {
   background: var(--octc-color-code-bg) !important;
   color: var(--octc-color-code-text);
-  padding: 1rem 1.25rem;
+  padding: var(--octc-code-pad-block) var(--octc-code-pad-inline);
   border-radius: 4px;
   border: 1px solid var(--octc-color-code-frame-border);
   overflow-x: auto;
@@ -1193,8 +1215,9 @@ a:hover {
 .content pre.ox-code-block[data-code-title]::before {
   content: attr(data-code-title);
   display: block;
-  margin: -1rem -1.25rem 0.875rem;
-  padding: 0.75rem 1.25rem;
+  margin: calc(-1 * var(--octc-code-pad-block)) calc(-1 * var(--octc-code-pad-inline))
+    var(--octc-code-title-gap);
+  padding: var(--octc-code-title-pad-block) var(--octc-code-pad-inline);
   border-bottom: 1px solid var(--octc-color-code-title-border);
   background: var(--octc-color-code-title-bg);
   color: var(--octc-color-code-title-text);
@@ -1205,8 +1228,8 @@ a:hover {
 }
 .content pre.ox-code-block .line {
   display: block;
-  margin: 0 -1.25rem;
-  padding: 0 1.25rem;
+  margin: 0 calc(-1 * var(--octc-code-pad-inline));
+  padding: 0 var(--octc-code-pad-inline);
   position: relative;
 }
 .content pre.ox-code-block.line-numbers-mode .line {
@@ -1215,7 +1238,7 @@ a:hover {
 .content pre.ox-code-block.line-numbers-mode .line::before {
   content: attr(data-line-number);
   position: absolute;
-  left: 1.25rem;
+  left: var(--octc-code-pad-inline);
   width: 2rem;
   text-align: right;
   color: var(--octc-color-code-line-number);
@@ -1275,7 +1298,7 @@ a:hover {
   border: 0;
   border-inline-end: 1px solid var(--octc-color-border);
   border-block-end: 1px solid var(--octc-color-border);
-  padding: 0.75rem 1rem;
+  padding: var(--octc-table-cell-pad-block) var(--octc-table-cell-pad-inline);
   text-align: start;
 }
 .content tr > :last-child {
@@ -1834,6 +1857,14 @@ a:hover {
   display: none;
 }
 @media (max-width: 768px) {
+  :root {
+    --octc-code-pad-block: 0.85rem;
+    --octc-code-pad-inline: 0.95rem;
+    --octc-code-title-pad-block: 0.65rem;
+    --octc-code-title-gap: 0.75rem;
+    --octc-table-cell-pad-block: 0.5rem;
+    --octc-table-cell-pad-inline: 0.75rem;
+  }
   .header-actions {
     display: none;
   }
@@ -1928,14 +1959,14 @@ a:hover {
     pointer-events: auto;
   }
   .sidebar .nav-link {
-    min-height: 44px;
+    min-height: var(--octc-touch-target);
     display: flex;
     align-items: center;
     padding-block: 0.625rem;
     line-height: 1.35;
   }
   .sidebar .nav-title--summary {
-    min-height: 44px;
+    min-height: var(--octc-touch-target);
     align-items: center;
   }
   .sidebar .nav-title--summary::before,
@@ -1968,7 +1999,6 @@ a:hover {
     padding: 0.16em 0.34em;
   }
   .content pre {
-    padding: 0.85rem 0.95rem;
     font-size: 0.78rem;
     margin: 1rem 0;
     border-radius: 8px;
@@ -2098,19 +2128,10 @@ a:hover {
     border-radius: 8px !important;
     font-size: 0.82rem !important;
   }
-  .content pre.ox-code-block[data-code-title]::before {
-    margin: -0.85rem -0.95rem 0.75rem;
-    padding: 0.65rem 0.95rem;
-  }
-  .content pre.ox-code-block .line {
-    margin: 0 -0.95rem;
-    padding: 0 0.95rem;
-  }
   .content pre.ox-code-block.line-numbers-mode .line {
     padding-left: 3.7rem;
   }
   .content pre.ox-code-block.line-numbers-mode .line::before {
-    left: 0.95rem;
     width: 1.75rem;
   }
   .content table {
@@ -2119,7 +2140,6 @@ a:hover {
   }
   .content th,
   .content td {
-    padding: 0.5rem 0.75rem;
     white-space: nowrap;
     vertical-align: top;
   }
@@ -2168,6 +2188,14 @@ a:hover {
 }
 
 @media (max-width: 480px) {
+  :root {
+    --octc-code-pad-block: 0.78rem;
+    --octc-code-pad-inline: 0.85rem;
+    --octc-code-title-pad-block: 0.6rem;
+    --octc-code-title-gap: 0.72rem;
+    --octc-table-cell-pad-block: 0.375rem;
+    --octc-table-cell-pad-inline: 0.5rem;
+  }
   .main {
     padding-block-start: 0.75rem;
     padding-bottom: calc(
@@ -2182,7 +2210,6 @@ a:hover {
   }
   .content pre {
     font-size: 0.72rem;
-    padding: 0.78rem 0.85rem;
   }
   .content pre code {
     font-size: 0.72rem;
@@ -2196,24 +2223,14 @@ a:hover {
   .content .ox-api-module__count {
     font-size: 0.68rem;
   }
-  .content pre.ox-code-block[data-code-title]::before {
-    margin: -0.78rem -0.85rem 0.72rem;
-    padding: 0.6rem 0.85rem;
-  }
-  .content pre.ox-code-block .line {
-    margin: 0 -0.85rem;
-    padding: 0 0.85rem;
-  }
-  .content pre.ox-code-block.line-numbers-mode .line::before {
-    left: 0.85rem;
-  }
   .content table {
     font-size: 0.75rem;
   }
-  .content th,
-  .content td {
-    padding: 0.375rem 0.5rem;
-  }
+}
+
+:focus-visible {
+  outline: var(--octc-focus-ring);
+  outline-offset: var(--octc-focus-offset);
 }
 
 /* ox-content:css:base:end */

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -81,6 +81,25 @@ expression: "super::snapshot_text(&html)"
   --octc-surface-line: #e2e9f3;
   --octc-surface-noise-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 180'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.2' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='180' height='180' filter='url(%23noise)' opacity='0.062'/%3E%3C/svg%3E");
   --octc-surface-noise-size: 164px 164px;
+  --octc-color-on-primary: var(--octc-color-bg);
+  --octc-color-tip: #0891b2;
+  --octc-color-info: #2563eb;
+  --octc-color-warning: #d97706;
+  --octc-color-danger: #dc2626;
+  --octc-color-success: #16a34a;
+  --octc-color-deprecated: #7c3aed;
+  --octc-color-required: #c2410c;
+  --octc-focus-ring: 2px solid var(--octc-color-primary);
+  --octc-focus-offset: 2px;
+  --octc-motion-base: 150ms;
+  --octc-motion-ease: ease;
+  --octc-code-pad-block: 1rem;
+  --octc-code-pad-inline: 1.25rem;
+  --octc-code-title-pad-block: 0.75rem;
+  --octc-code-title-gap: 0.875rem;
+  --octc-table-cell-pad-block: 0.75rem;
+  --octc-table-cell-pad-inline: 1rem;
+  --octc-touch-target: 44px;
 }
 [data-theme="light"] {
   color-scheme: light;
@@ -161,8 +180,12 @@ expression: "super::snapshot_text(&html)"
 html {
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
-  scroll-behavior: smooth;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);
+}
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
 }
 body {
   font-family: var(--octc-font-sans);
@@ -383,7 +406,7 @@ a:hover {
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
   background: color-mix(in srgb, var(--octc-color-bg-alt) 90%, var(--octc-color-primary) 10%);
-  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, white);
+  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, var(--octc-color-bg));
   border-radius: 4px;
   color: var(--octc-color-text-muted);
   cursor: pointer;
@@ -695,7 +718,7 @@ a:hover {
   color: var(--octc-color-text-muted);
   transform: rotate(-45deg);
   transform-origin: center;
-  transition: transform 150ms ease;
+  transition: transform var(--octc-motion-base) var(--octc-motion-ease);
 }
 .nav-details > .nav-summary::before {
   margin-block-start: 0.8rem;
@@ -708,11 +731,6 @@ a:hover {
 [dir="rtl"] .nav-section--collapsible:not([open]) > .nav-title--summary::before,
 [dir="rtl"] .nav-details:not([open]) > .nav-summary::before {
   transform: rotate(135deg);
-}
-.nav-title--summary:focus-visible,
-.nav-details > .nav-summary:focus-visible {
-  outline: 2px solid var(--octc-color-primary);
-  outline-offset: 2px;
 }
 .nav-list {
   list-style: none;
@@ -774,6 +792,10 @@ a:hover {
   .nav-title--summary::before,
   .nav-details > .nav-summary::before {
     transition: none;
+  }
+  .content pre.ox-code-block.has-focused .line,
+  .content pre.ox-code-block .ox-code-line--dimmed {
+    filter: none;
   }
 }
 .main {
@@ -937,13 +959,13 @@ a:hover {
   --octc-callout-accent: var(--octc-color-primary);
 }
 .content blockquote.ox-callout.ox-callout--tip {
-  --octc-callout-accent: #0891b2;
+  --octc-callout-accent: var(--octc-color-tip);
 }
 .content blockquote.ox-callout.ox-callout--warning {
-  --octc-callout-accent: #d97706;
+  --octc-callout-accent: var(--octc-color-warning);
 }
 .content blockquote.ox-callout.ox-callout--caution {
-  --octc-callout-accent: #dc2626;
+  --octc-callout-accent: var(--octc-color-danger);
 }
 .content .ox-callout-title {
   margin: 0 0 0.5rem;
@@ -968,14 +990,14 @@ a:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 92%, var(--octc-container-accent) 8%);
 }
 .content .ox-container--tip {
-  --octc-container-accent: #0891b2;
+  --octc-container-accent: var(--octc-color-tip);
 }
 .content .ox-container--warning,
 .content .ox-container--caution {
-  --octc-container-accent: #d97706;
+  --octc-container-accent: var(--octc-color-warning);
 }
 .content .ox-container--danger {
-  --octc-container-accent: #dc2626;
+  --octc-container-accent: var(--octc-color-danger);
 }
 .content .ox-container-title,
 .content .ox-container summary {
@@ -1080,28 +1102,28 @@ a:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-badge-accent) 12%);
 }
 .content .ox-badge--tip {
-  --octc-badge-accent: #0891b2;
+  --octc-badge-accent: var(--octc-color-tip);
 }
 .content .ox-badge--note {
   --octc-badge-accent: var(--octc-color-primary);
 }
 .content .ox-badge--info {
-  --octc-badge-accent: #2563eb;
+  --octc-badge-accent: var(--octc-color-info);
 }
 .content .ox-badge--warning {
-  --octc-badge-accent: #d97706;
+  --octc-badge-accent: var(--octc-color-warning);
 }
 .content .ox-badge--danger {
-  --octc-badge-accent: #dc2626;
+  --octc-badge-accent: var(--octc-color-danger);
 }
 .content .ox-badge--success {
-  --octc-badge-accent: #16a34a;
+  --octc-badge-accent: var(--octc-color-success);
 }
 .content .ox-badge--deprecated {
-  --octc-badge-accent: #7c3aed;
+  --octc-badge-accent: var(--octc-color-deprecated);
 }
 .content .ox-badge--required {
-  --octc-badge-accent: #c2410c;
+  --octc-badge-accent: var(--octc-color-required);
 }
 .content .ox-magic-link {
   display: inline-flex;
@@ -1121,8 +1143,8 @@ a:hover {
   border-color: color-mix(in srgb, var(--octc-color-primary) 45%, var(--octc-color-border));
 }
 .content .ox-magic-link:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--octc-color-primary) 72%, transparent);
-  outline-offset: 2px;
+  outline: var(--octc-focus-ring);
+  outline-offset: var(--octc-focus-offset);
 }
 .content .ox-magic-link__image {
   width: 1em;
@@ -1172,7 +1194,7 @@ a:hover {
 .content pre {
   background: var(--octc-color-code-bg) !important;
   color: var(--octc-color-code-text);
-  padding: 1rem 1.25rem;
+  padding: var(--octc-code-pad-block) var(--octc-code-pad-inline);
   border-radius: 4px;
   border: 1px solid var(--octc-color-code-frame-border);
   overflow-x: auto;
@@ -1193,8 +1215,9 @@ a:hover {
 .content pre.ox-code-block[data-code-title]::before {
   content: attr(data-code-title);
   display: block;
-  margin: -1rem -1.25rem 0.875rem;
-  padding: 0.75rem 1.25rem;
+  margin: calc(-1 * var(--octc-code-pad-block)) calc(-1 * var(--octc-code-pad-inline))
+    var(--octc-code-title-gap);
+  padding: var(--octc-code-title-pad-block) var(--octc-code-pad-inline);
   border-bottom: 1px solid var(--octc-color-code-title-border);
   background: var(--octc-color-code-title-bg);
   color: var(--octc-color-code-title-text);
@@ -1205,8 +1228,8 @@ a:hover {
 }
 .content pre.ox-code-block .line {
   display: block;
-  margin: 0 -1.25rem;
-  padding: 0 1.25rem;
+  margin: 0 calc(-1 * var(--octc-code-pad-inline));
+  padding: 0 var(--octc-code-pad-inline);
   position: relative;
 }
 .content pre.ox-code-block.line-numbers-mode .line {
@@ -1215,7 +1238,7 @@ a:hover {
 .content pre.ox-code-block.line-numbers-mode .line::before {
   content: attr(data-line-number);
   position: absolute;
-  left: 1.25rem;
+  left: var(--octc-code-pad-inline);
   width: 2rem;
   text-align: right;
   color: var(--octc-color-code-line-number);
@@ -1275,7 +1298,7 @@ a:hover {
   border: 0;
   border-inline-end: 1px solid var(--octc-color-border);
   border-block-end: 1px solid var(--octc-color-border);
-  padding: 0.75rem 1rem;
+  padding: var(--octc-table-cell-pad-block) var(--octc-table-cell-pad-inline);
   text-align: start;
 }
 .content tr > :last-child {
@@ -1834,6 +1857,14 @@ a:hover {
   display: none;
 }
 @media (max-width: 768px) {
+  :root {
+    --octc-code-pad-block: 0.85rem;
+    --octc-code-pad-inline: 0.95rem;
+    --octc-code-title-pad-block: 0.65rem;
+    --octc-code-title-gap: 0.75rem;
+    --octc-table-cell-pad-block: 0.5rem;
+    --octc-table-cell-pad-inline: 0.75rem;
+  }
   .header-actions {
     display: none;
   }
@@ -1928,14 +1959,14 @@ a:hover {
     pointer-events: auto;
   }
   .sidebar .nav-link {
-    min-height: 44px;
+    min-height: var(--octc-touch-target);
     display: flex;
     align-items: center;
     padding-block: 0.625rem;
     line-height: 1.35;
   }
   .sidebar .nav-title--summary {
-    min-height: 44px;
+    min-height: var(--octc-touch-target);
     align-items: center;
   }
   .sidebar .nav-title--summary::before,
@@ -1968,7 +1999,6 @@ a:hover {
     padding: 0.16em 0.34em;
   }
   .content pre {
-    padding: 0.85rem 0.95rem;
     font-size: 0.78rem;
     margin: 1rem 0;
     border-radius: 8px;
@@ -2098,19 +2128,10 @@ a:hover {
     border-radius: 8px !important;
     font-size: 0.82rem !important;
   }
-  .content pre.ox-code-block[data-code-title]::before {
-    margin: -0.85rem -0.95rem 0.75rem;
-    padding: 0.65rem 0.95rem;
-  }
-  .content pre.ox-code-block .line {
-    margin: 0 -0.95rem;
-    padding: 0 0.95rem;
-  }
   .content pre.ox-code-block.line-numbers-mode .line {
     padding-left: 3.7rem;
   }
   .content pre.ox-code-block.line-numbers-mode .line::before {
-    left: 0.95rem;
     width: 1.75rem;
   }
   .content table {
@@ -2119,7 +2140,6 @@ a:hover {
   }
   .content th,
   .content td {
-    padding: 0.5rem 0.75rem;
     white-space: nowrap;
     vertical-align: top;
   }
@@ -2168,6 +2188,14 @@ a:hover {
 }
 
 @media (max-width: 480px) {
+  :root {
+    --octc-code-pad-block: 0.78rem;
+    --octc-code-pad-inline: 0.85rem;
+    --octc-code-title-pad-block: 0.6rem;
+    --octc-code-title-gap: 0.72rem;
+    --octc-table-cell-pad-block: 0.375rem;
+    --octc-table-cell-pad-inline: 0.5rem;
+  }
   .main {
     padding-block-start: 0.75rem;
     padding-bottom: calc(
@@ -2182,7 +2210,6 @@ a:hover {
   }
   .content pre {
     font-size: 0.72rem;
-    padding: 0.78rem 0.85rem;
   }
   .content pre code {
     font-size: 0.72rem;
@@ -2196,24 +2223,14 @@ a:hover {
   .content .ox-api-module__count {
     font-size: 0.68rem;
   }
-  .content pre.ox-code-block[data-code-title]::before {
-    margin: -0.78rem -0.85rem 0.72rem;
-    padding: 0.6rem 0.85rem;
-  }
-  .content pre.ox-code-block .line {
-    margin: 0 -0.85rem;
-    padding: 0 0.85rem;
-  }
-  .content pre.ox-code-block.line-numbers-mode .line::before {
-    left: 0.85rem;
-  }
   .content table {
     font-size: 0.75rem;
   }
-  .content th,
-  .content td {
-    padding: 0.375rem 0.5rem;
-  }
+}
+
+:focus-visible {
+  outline: var(--octc-focus-ring);
+  outline-offset: var(--octc-focus-offset);
 }
 
 /* ox-content:css:base:end */

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -81,6 +81,25 @@ expression: "super::snapshot_text(&html)"
   --octc-surface-line: #e2e9f3;
   --octc-surface-noise-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 180'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.2' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='180' height='180' filter='url(%23noise)' opacity='0.062'/%3E%3C/svg%3E");
   --octc-surface-noise-size: 164px 164px;
+  --octc-color-on-primary: var(--octc-color-bg);
+  --octc-color-tip: #0891b2;
+  --octc-color-info: #2563eb;
+  --octc-color-warning: #d97706;
+  --octc-color-danger: #dc2626;
+  --octc-color-success: #16a34a;
+  --octc-color-deprecated: #7c3aed;
+  --octc-color-required: #c2410c;
+  --octc-focus-ring: 2px solid var(--octc-color-primary);
+  --octc-focus-offset: 2px;
+  --octc-motion-base: 150ms;
+  --octc-motion-ease: ease;
+  --octc-code-pad-block: 1rem;
+  --octc-code-pad-inline: 1.25rem;
+  --octc-code-title-pad-block: 0.75rem;
+  --octc-code-title-gap: 0.875rem;
+  --octc-table-cell-pad-block: 0.75rem;
+  --octc-table-cell-pad-inline: 1rem;
+  --octc-touch-target: 44px;
 }
 [data-theme="light"] {
   color-scheme: light;
@@ -161,8 +180,12 @@ expression: "super::snapshot_text(&html)"
 html {
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
-  scroll-behavior: smooth;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);
+}
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
 }
 body {
   font-family: var(--octc-font-sans);
@@ -383,7 +406,7 @@ a:hover {
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
   background: color-mix(in srgb, var(--octc-color-bg-alt) 90%, var(--octc-color-primary) 10%);
-  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, white);
+  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, var(--octc-color-bg));
   border-radius: 4px;
   color: var(--octc-color-text-muted);
   cursor: pointer;
@@ -695,7 +718,7 @@ a:hover {
   color: var(--octc-color-text-muted);
   transform: rotate(-45deg);
   transform-origin: center;
-  transition: transform 150ms ease;
+  transition: transform var(--octc-motion-base) var(--octc-motion-ease);
 }
 .nav-details > .nav-summary::before {
   margin-block-start: 0.8rem;
@@ -708,11 +731,6 @@ a:hover {
 [dir="rtl"] .nav-section--collapsible:not([open]) > .nav-title--summary::before,
 [dir="rtl"] .nav-details:not([open]) > .nav-summary::before {
   transform: rotate(135deg);
-}
-.nav-title--summary:focus-visible,
-.nav-details > .nav-summary:focus-visible {
-  outline: 2px solid var(--octc-color-primary);
-  outline-offset: 2px;
 }
 .nav-list {
   list-style: none;
@@ -774,6 +792,10 @@ a:hover {
   .nav-title--summary::before,
   .nav-details > .nav-summary::before {
     transition: none;
+  }
+  .content pre.ox-code-block.has-focused .line,
+  .content pre.ox-code-block .ox-code-line--dimmed {
+    filter: none;
   }
 }
 .main {
@@ -937,13 +959,13 @@ a:hover {
   --octc-callout-accent: var(--octc-color-primary);
 }
 .content blockquote.ox-callout.ox-callout--tip {
-  --octc-callout-accent: #0891b2;
+  --octc-callout-accent: var(--octc-color-tip);
 }
 .content blockquote.ox-callout.ox-callout--warning {
-  --octc-callout-accent: #d97706;
+  --octc-callout-accent: var(--octc-color-warning);
 }
 .content blockquote.ox-callout.ox-callout--caution {
-  --octc-callout-accent: #dc2626;
+  --octc-callout-accent: var(--octc-color-danger);
 }
 .content .ox-callout-title {
   margin: 0 0 0.5rem;
@@ -968,14 +990,14 @@ a:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 92%, var(--octc-container-accent) 8%);
 }
 .content .ox-container--tip {
-  --octc-container-accent: #0891b2;
+  --octc-container-accent: var(--octc-color-tip);
 }
 .content .ox-container--warning,
 .content .ox-container--caution {
-  --octc-container-accent: #d97706;
+  --octc-container-accent: var(--octc-color-warning);
 }
 .content .ox-container--danger {
-  --octc-container-accent: #dc2626;
+  --octc-container-accent: var(--octc-color-danger);
 }
 .content .ox-container-title,
 .content .ox-container summary {
@@ -1080,28 +1102,28 @@ a:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-badge-accent) 12%);
 }
 .content .ox-badge--tip {
-  --octc-badge-accent: #0891b2;
+  --octc-badge-accent: var(--octc-color-tip);
 }
 .content .ox-badge--note {
   --octc-badge-accent: var(--octc-color-primary);
 }
 .content .ox-badge--info {
-  --octc-badge-accent: #2563eb;
+  --octc-badge-accent: var(--octc-color-info);
 }
 .content .ox-badge--warning {
-  --octc-badge-accent: #d97706;
+  --octc-badge-accent: var(--octc-color-warning);
 }
 .content .ox-badge--danger {
-  --octc-badge-accent: #dc2626;
+  --octc-badge-accent: var(--octc-color-danger);
 }
 .content .ox-badge--success {
-  --octc-badge-accent: #16a34a;
+  --octc-badge-accent: var(--octc-color-success);
 }
 .content .ox-badge--deprecated {
-  --octc-badge-accent: #7c3aed;
+  --octc-badge-accent: var(--octc-color-deprecated);
 }
 .content .ox-badge--required {
-  --octc-badge-accent: #c2410c;
+  --octc-badge-accent: var(--octc-color-required);
 }
 .content .ox-magic-link {
   display: inline-flex;
@@ -1121,8 +1143,8 @@ a:hover {
   border-color: color-mix(in srgb, var(--octc-color-primary) 45%, var(--octc-color-border));
 }
 .content .ox-magic-link:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--octc-color-primary) 72%, transparent);
-  outline-offset: 2px;
+  outline: var(--octc-focus-ring);
+  outline-offset: var(--octc-focus-offset);
 }
 .content .ox-magic-link__image {
   width: 1em;
@@ -1172,7 +1194,7 @@ a:hover {
 .content pre {
   background: var(--octc-color-code-bg) !important;
   color: var(--octc-color-code-text);
-  padding: 1rem 1.25rem;
+  padding: var(--octc-code-pad-block) var(--octc-code-pad-inline);
   border-radius: 4px;
   border: 1px solid var(--octc-color-code-frame-border);
   overflow-x: auto;
@@ -1193,8 +1215,9 @@ a:hover {
 .content pre.ox-code-block[data-code-title]::before {
   content: attr(data-code-title);
   display: block;
-  margin: -1rem -1.25rem 0.875rem;
-  padding: 0.75rem 1.25rem;
+  margin: calc(-1 * var(--octc-code-pad-block)) calc(-1 * var(--octc-code-pad-inline))
+    var(--octc-code-title-gap);
+  padding: var(--octc-code-title-pad-block) var(--octc-code-pad-inline);
   border-bottom: 1px solid var(--octc-color-code-title-border);
   background: var(--octc-color-code-title-bg);
   color: var(--octc-color-code-title-text);
@@ -1205,8 +1228,8 @@ a:hover {
 }
 .content pre.ox-code-block .line {
   display: block;
-  margin: 0 -1.25rem;
-  padding: 0 1.25rem;
+  margin: 0 calc(-1 * var(--octc-code-pad-inline));
+  padding: 0 var(--octc-code-pad-inline);
   position: relative;
 }
 .content pre.ox-code-block.line-numbers-mode .line {
@@ -1215,7 +1238,7 @@ a:hover {
 .content pre.ox-code-block.line-numbers-mode .line::before {
   content: attr(data-line-number);
   position: absolute;
-  left: 1.25rem;
+  left: var(--octc-code-pad-inline);
   width: 2rem;
   text-align: right;
   color: var(--octc-color-code-line-number);
@@ -1275,7 +1298,7 @@ a:hover {
   border: 0;
   border-inline-end: 1px solid var(--octc-color-border);
   border-block-end: 1px solid var(--octc-color-border);
-  padding: 0.75rem 1rem;
+  padding: var(--octc-table-cell-pad-block) var(--octc-table-cell-pad-inline);
   text-align: start;
 }
 .content tr > :last-child {
@@ -1834,6 +1857,14 @@ a:hover {
   display: none;
 }
 @media (max-width: 768px) {
+  :root {
+    --octc-code-pad-block: 0.85rem;
+    --octc-code-pad-inline: 0.95rem;
+    --octc-code-title-pad-block: 0.65rem;
+    --octc-code-title-gap: 0.75rem;
+    --octc-table-cell-pad-block: 0.5rem;
+    --octc-table-cell-pad-inline: 0.75rem;
+  }
   .header-actions {
     display: none;
   }
@@ -1928,14 +1959,14 @@ a:hover {
     pointer-events: auto;
   }
   .sidebar .nav-link {
-    min-height: 44px;
+    min-height: var(--octc-touch-target);
     display: flex;
     align-items: center;
     padding-block: 0.625rem;
     line-height: 1.35;
   }
   .sidebar .nav-title--summary {
-    min-height: 44px;
+    min-height: var(--octc-touch-target);
     align-items: center;
   }
   .sidebar .nav-title--summary::before,
@@ -1968,7 +1999,6 @@ a:hover {
     padding: 0.16em 0.34em;
   }
   .content pre {
-    padding: 0.85rem 0.95rem;
     font-size: 0.78rem;
     margin: 1rem 0;
     border-radius: 8px;
@@ -2098,19 +2128,10 @@ a:hover {
     border-radius: 8px !important;
     font-size: 0.82rem !important;
   }
-  .content pre.ox-code-block[data-code-title]::before {
-    margin: -0.85rem -0.95rem 0.75rem;
-    padding: 0.65rem 0.95rem;
-  }
-  .content pre.ox-code-block .line {
-    margin: 0 -0.95rem;
-    padding: 0 0.95rem;
-  }
   .content pre.ox-code-block.line-numbers-mode .line {
     padding-left: 3.7rem;
   }
   .content pre.ox-code-block.line-numbers-mode .line::before {
-    left: 0.95rem;
     width: 1.75rem;
   }
   .content table {
@@ -2119,7 +2140,6 @@ a:hover {
   }
   .content th,
   .content td {
-    padding: 0.5rem 0.75rem;
     white-space: nowrap;
     vertical-align: top;
   }
@@ -2168,6 +2188,14 @@ a:hover {
 }
 
 @media (max-width: 480px) {
+  :root {
+    --octc-code-pad-block: 0.78rem;
+    --octc-code-pad-inline: 0.85rem;
+    --octc-code-title-pad-block: 0.6rem;
+    --octc-code-title-gap: 0.72rem;
+    --octc-table-cell-pad-block: 0.375rem;
+    --octc-table-cell-pad-inline: 0.5rem;
+  }
   .main {
     padding-block-start: 0.75rem;
     padding-bottom: calc(
@@ -2182,7 +2210,6 @@ a:hover {
   }
   .content pre {
     font-size: 0.72rem;
-    padding: 0.78rem 0.85rem;
   }
   .content pre code {
     font-size: 0.72rem;
@@ -2196,24 +2223,14 @@ a:hover {
   .content .ox-api-module__count {
     font-size: 0.68rem;
   }
-  .content pre.ox-code-block[data-code-title]::before {
-    margin: -0.78rem -0.85rem 0.72rem;
-    padding: 0.6rem 0.85rem;
-  }
-  .content pre.ox-code-block .line {
-    margin: 0 -0.85rem;
-    padding: 0 0.85rem;
-  }
-  .content pre.ox-code-block.line-numbers-mode .line::before {
-    left: 0.85rem;
-  }
   .content table {
     font-size: 0.75rem;
   }
-  .content th,
-  .content td {
-    padding: 0.375rem 0.5rem;
-  }
+}
+
+:focus-visible {
+  outline: var(--octc-focus-ring);
+  outline-offset: var(--octc-focus-offset);
 }
 
 /* ox-content:css:base:end */

--- a/crates/ox_content_ssg/src/html/tests/theme_quality.rs
+++ b/crates/ox_content_ssg/src/html/tests/theme_quality.rs
@@ -1,0 +1,105 @@
+use super::super::{ENTRY_CSS, SSG_CSS, header_chrome::HEADER_CHROME_CSS};
+
+const QUALITY_TOKENS: &[&str] = &[
+    "--octc-color-on-primary:",
+    "--octc-color-tip:",
+    "--octc-color-info:",
+    "--octc-color-warning:",
+    "--octc-color-danger:",
+    "--octc-color-success:",
+    "--octc-focus-ring:",
+    "--octc-focus-offset:",
+    "--octc-motion-base:",
+    "--octc-motion-ease:",
+    "--octc-code-pad-block:",
+    "--octc-code-pad-inline:",
+    "--octc-table-cell-pad-block:",
+    "--octc-table-cell-pad-inline:",
+    "--octc-touch-target:",
+];
+
+#[test]
+fn default_theme_exposes_quality_tokens() {
+    for token in QUALITY_TOKENS {
+        assert!(SSG_CSS.contains(token), "missing quality token {token}");
+    }
+    assert!(
+        !SSG_CSS.contains("--octc-callout-accent: #")
+            && !SSG_CSS.contains("--octc-badge-accent: #")
+            && !SSG_CSS.contains("--octc-container-accent: #"),
+        "status chrome must use semantic tokens instead of hex escapes"
+    );
+}
+
+#[test]
+fn default_theme_focus_and_reduced_motion_are_tokenized() {
+    assert!(
+        SSG_CSS.contains(":focus-visible {\n  outline: var(--octc-focus-ring);")
+            && SSG_CSS.contains("outline-offset: var(--octc-focus-offset);"),
+        "keyboard focus must share one tokenized ring"
+    );
+    assert!(
+        SSG_CSS.contains("@media (prefers-reduced-motion: no-preference)")
+            && SSG_CSS.contains("scroll-behavior: smooth;"),
+        "smooth scrolling must opt in only when motion is allowed"
+    );
+    assert!(
+        SSG_CSS.contains("@media (prefers-reduced-motion: reduce)")
+            && SSG_CSS.contains("transition: none;")
+            && SSG_CSS.contains("filter: none;"),
+        "reduced motion must disable nav motion and code-line blur"
+    );
+    assert!(
+        SSG_CSS.contains("transition: transform var(--octc-motion-base) var(--octc-motion-ease);"),
+        "nav disclosure motion must use the shared motion tokens"
+    );
+}
+
+#[test]
+fn code_table_and_mobile_nav_share_spacing_tokens() {
+    assert!(
+        SSG_CSS.contains("padding: var(--octc-code-pad-block) var(--octc-code-pad-inline);")
+            && SSG_CSS
+                .contains("padding: var(--octc-code-title-pad-block) var(--octc-code-pad-inline);")
+            && SSG_CSS.contains("left: var(--octc-code-pad-inline);"),
+        "code frames, titles, and line gutters must stay on one pad contract"
+    );
+    assert!(
+        SSG_CSS.contains(
+            "padding: var(--octc-table-cell-pad-block) var(--octc-table-cell-pad-inline);"
+        ),
+        "table cells must use the shared cell-pad tokens"
+    );
+    assert!(
+        SSG_CSS.contains("min-height: var(--octc-touch-target);"),
+        "mobile nav targets must use the shared touch token"
+    );
+    assert!(
+        !SSG_CSS.contains("padding: 0.85rem 0.95rem;")
+            && !SSG_CSS.contains("padding: 0.78rem 0.85rem;")
+            && !SSG_CSS.contains("padding: 0.375rem 0.5rem;"),
+        "mobile breakpoints must retune tokens instead of restating pad literals"
+    );
+}
+
+#[test]
+fn default_theme_replaces_on_primary_hex_escapes() {
+    assert!(
+        ENTRY_CSS.contains("color: var(--octc-color-on-primary);")
+            && !ENTRY_CSS.contains("color: #ffffff")
+            && !ENTRY_CSS.contains("color: #fff"),
+        "entry chrome must put on-primary ink on brand fills"
+    );
+    assert!(
+        HEADER_CHROME_CSS.contains("color: var(--octc-color-on-primary);")
+            && !HEADER_CHROME_CSS.contains("color: #fff"),
+        "announcement chrome must use on-primary instead of hardcoded white"
+    );
+}
+
+#[test]
+fn default_theme_css_payload_stays_visible() {
+    let bytes = SSG_CSS.len();
+    assert!(bytes > 40_000, "default stylesheet is unexpectedly small: {bytes}");
+    assert!(bytes < 90_000, "default stylesheet grew past the visible budget: {bytes}");
+}

--- a/crates/ox_content_ssg/src/plugins/magic-links.css
+++ b/crates/ox_content_ssg/src/plugins/magic-links.css
@@ -16,8 +16,8 @@
   border-color: color-mix(in srgb, var(--octc-color-primary) 45%, var(--octc-color-border));
 }
 .content .ox-magic-link:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--octc-color-primary) 72%, transparent);
-  outline-offset: 2px;
+  outline: var(--octc-focus-ring);
+  outline-offset: var(--octc-focus-offset);
 }
 .content .ox-magic-link__image {
   width: 1em;

--- a/crates/ox_content_ssg/src/plugins/not-by-ai.css
+++ b/crates/ox_content_ssg/src/plugins/not-by-ai.css
@@ -6,8 +6,8 @@
   vertical-align: middle;
 }
 .ox-not-by-ai:focus-visible {
-  outline: 2px solid var(--octc-color-primary, currentColor);
-  outline-offset: 2px;
+  outline: var(--octc-focus-ring, 2px solid currentColor);
+  outline-offset: var(--octc-focus-offset, 2px);
 }
 .ox-not-by-ai__badge {
   display: block;

--- a/crates/ox_content_ssg/src/plugins/tabs.css
+++ b/crates/ox_content_ssg/src/plugins/tabs.css
@@ -75,7 +75,7 @@
 
 /* Focus styles for accessibility */
 .ox-tabs input[type="radio"]:focus-visible + label {
-  outline: 2px solid var(--octc-color-primary);
+  outline: var(--octc-focus-ring);
   outline-offset: -2px;
 }
 

--- a/crates/ox_content_ssg/src/ssg.css
+++ b/crates/ox_content_ssg/src/ssg.css
@@ -47,6 +47,25 @@
   --octc-surface-line: #e2e9f3;
   --octc-surface-noise-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 180'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.2' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='180' height='180' filter='url(%23noise)' opacity='0.062'/%3E%3C/svg%3E");
   --octc-surface-noise-size: 164px 164px;
+  --octc-color-on-primary: var(--octc-color-bg);
+  --octc-color-tip: #0891b2;
+  --octc-color-info: #2563eb;
+  --octc-color-warning: #d97706;
+  --octc-color-danger: #dc2626;
+  --octc-color-success: #16a34a;
+  --octc-color-deprecated: #7c3aed;
+  --octc-color-required: #c2410c;
+  --octc-focus-ring: 2px solid var(--octc-color-primary);
+  --octc-focus-offset: 2px;
+  --octc-motion-base: 150ms;
+  --octc-motion-ease: ease;
+  --octc-code-pad-block: 1rem;
+  --octc-code-pad-inline: 1.25rem;
+  --octc-code-title-pad-block: 0.75rem;
+  --octc-code-title-gap: 0.875rem;
+  --octc-table-cell-pad-block: 0.75rem;
+  --octc-table-cell-pad-inline: 1rem;
+  --octc-touch-target: 44px;
 }
 [data-theme="light"] {
   color-scheme: light;
@@ -127,8 +146,12 @@
 html {
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
-  scroll-behavior: smooth;
   scroll-padding-top: calc(var(--octc-header-height) + 1rem);
+}
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
 }
 body {
   font-family: var(--octc-font-sans);
@@ -349,7 +372,7 @@ a:hover {
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
   background: color-mix(in srgb, var(--octc-color-bg-alt) 90%, var(--octc-color-primary) 10%);
-  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, white);
+  border: 1px solid color-mix(in srgb, var(--octc-color-border) 88%, var(--octc-color-bg));
   border-radius: 4px;
   color: var(--octc-color-text-muted);
   cursor: pointer;
@@ -661,7 +684,7 @@ a:hover {
   color: var(--octc-color-text-muted);
   transform: rotate(-45deg);
   transform-origin: center;
-  transition: transform 150ms ease;
+  transition: transform var(--octc-motion-base) var(--octc-motion-ease);
 }
 .nav-details > .nav-summary::before {
   margin-block-start: 0.8rem;
@@ -674,11 +697,6 @@ a:hover {
 [dir="rtl"] .nav-section--collapsible:not([open]) > .nav-title--summary::before,
 [dir="rtl"] .nav-details:not([open]) > .nav-summary::before {
   transform: rotate(135deg);
-}
-.nav-title--summary:focus-visible,
-.nav-details > .nav-summary:focus-visible {
-  outline: 2px solid var(--octc-color-primary);
-  outline-offset: 2px;
 }
 .nav-list {
   list-style: none;
@@ -740,6 +758,10 @@ a:hover {
   .nav-title--summary::before,
   .nav-details > .nav-summary::before {
     transition: none;
+  }
+  .content pre.ox-code-block.has-focused .line,
+  .content pre.ox-code-block .ox-code-line--dimmed {
+    filter: none;
   }
 }
 .main {
@@ -903,13 +925,13 @@ a:hover {
   --octc-callout-accent: var(--octc-color-primary);
 }
 .content blockquote.ox-callout.ox-callout--tip {
-  --octc-callout-accent: #0891b2;
+  --octc-callout-accent: var(--octc-color-tip);
 }
 .content blockquote.ox-callout.ox-callout--warning {
-  --octc-callout-accent: #d97706;
+  --octc-callout-accent: var(--octc-color-warning);
 }
 .content blockquote.ox-callout.ox-callout--caution {
-  --octc-callout-accent: #dc2626;
+  --octc-callout-accent: var(--octc-color-danger);
 }
 .content .ox-callout-title {
   margin: 0 0 0.5rem;
@@ -934,14 +956,14 @@ a:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 92%, var(--octc-container-accent) 8%);
 }
 .content .ox-container--tip {
-  --octc-container-accent: #0891b2;
+  --octc-container-accent: var(--octc-color-tip);
 }
 .content .ox-container--warning,
 .content .ox-container--caution {
-  --octc-container-accent: #d97706;
+  --octc-container-accent: var(--octc-color-warning);
 }
 .content .ox-container--danger {
-  --octc-container-accent: #dc2626;
+  --octc-container-accent: var(--octc-color-danger);
 }
 .content .ox-container-title,
 .content .ox-container summary {
@@ -1046,28 +1068,28 @@ a:hover {
   background: color-mix(in srgb, var(--octc-color-bg-alt) 88%, var(--octc-badge-accent) 12%);
 }
 .content .ox-badge--tip {
-  --octc-badge-accent: #0891b2;
+  --octc-badge-accent: var(--octc-color-tip);
 }
 .content .ox-badge--note {
   --octc-badge-accent: var(--octc-color-primary);
 }
 .content .ox-badge--info {
-  --octc-badge-accent: #2563eb;
+  --octc-badge-accent: var(--octc-color-info);
 }
 .content .ox-badge--warning {
-  --octc-badge-accent: #d97706;
+  --octc-badge-accent: var(--octc-color-warning);
 }
 .content .ox-badge--danger {
-  --octc-badge-accent: #dc2626;
+  --octc-badge-accent: var(--octc-color-danger);
 }
 .content .ox-badge--success {
-  --octc-badge-accent: #16a34a;
+  --octc-badge-accent: var(--octc-color-success);
 }
 .content .ox-badge--deprecated {
-  --octc-badge-accent: #7c3aed;
+  --octc-badge-accent: var(--octc-color-deprecated);
 }
 .content .ox-badge--required {
-  --octc-badge-accent: #c2410c;
+  --octc-badge-accent: var(--octc-color-required);
 }
 /* @include magic-links.css */
 .content .ox-figure {
@@ -1107,7 +1129,7 @@ a:hover {
 .content pre {
   background: var(--octc-color-code-bg) !important;
   color: var(--octc-color-code-text);
-  padding: 1rem 1.25rem;
+  padding: var(--octc-code-pad-block) var(--octc-code-pad-inline);
   border-radius: 4px;
   border: 1px solid var(--octc-color-code-frame-border);
   overflow-x: auto;
@@ -1128,8 +1150,9 @@ a:hover {
 .content pre.ox-code-block[data-code-title]::before {
   content: attr(data-code-title);
   display: block;
-  margin: -1rem -1.25rem 0.875rem;
-  padding: 0.75rem 1.25rem;
+  margin: calc(-1 * var(--octc-code-pad-block)) calc(-1 * var(--octc-code-pad-inline))
+    var(--octc-code-title-gap);
+  padding: var(--octc-code-title-pad-block) var(--octc-code-pad-inline);
   border-bottom: 1px solid var(--octc-color-code-title-border);
   background: var(--octc-color-code-title-bg);
   color: var(--octc-color-code-title-text);
@@ -1140,8 +1163,8 @@ a:hover {
 }
 .content pre.ox-code-block .line {
   display: block;
-  margin: 0 -1.25rem;
-  padding: 0 1.25rem;
+  margin: 0 calc(-1 * var(--octc-code-pad-inline));
+  padding: 0 var(--octc-code-pad-inline);
   position: relative;
 }
 .content pre.ox-code-block.line-numbers-mode .line {
@@ -1150,7 +1173,7 @@ a:hover {
 .content pre.ox-code-block.line-numbers-mode .line::before {
   content: attr(data-line-number);
   position: absolute;
-  left: 1.25rem;
+  left: var(--octc-code-pad-inline);
   width: 2rem;
   text-align: right;
   color: var(--octc-color-code-line-number);
@@ -1210,7 +1233,7 @@ a:hover {
   border: 0;
   border-inline-end: 1px solid var(--octc-color-border);
   border-block-end: 1px solid var(--octc-color-border);
-  padding: 0.75rem 1rem;
+  padding: var(--octc-table-cell-pad-block) var(--octc-table-cell-pad-inline);
   text-align: start;
 }
 .content tr > :last-child {
@@ -1769,6 +1792,14 @@ a:hover {
   display: none;
 }
 @media (max-width: 768px) {
+  :root {
+    --octc-code-pad-block: 0.85rem;
+    --octc-code-pad-inline: 0.95rem;
+    --octc-code-title-pad-block: 0.65rem;
+    --octc-code-title-gap: 0.75rem;
+    --octc-table-cell-pad-block: 0.5rem;
+    --octc-table-cell-pad-inline: 0.75rem;
+  }
   .header-actions {
     display: none;
   }
@@ -1863,14 +1894,14 @@ a:hover {
     pointer-events: auto;
   }
   .sidebar .nav-link {
-    min-height: 44px;
+    min-height: var(--octc-touch-target);
     display: flex;
     align-items: center;
     padding-block: 0.625rem;
     line-height: 1.35;
   }
   .sidebar .nav-title--summary {
-    min-height: 44px;
+    min-height: var(--octc-touch-target);
     align-items: center;
   }
   .sidebar .nav-title--summary::before,
@@ -1903,7 +1934,6 @@ a:hover {
     padding: 0.16em 0.34em;
   }
   .content pre {
-    padding: 0.85rem 0.95rem;
     font-size: 0.78rem;
     margin: 1rem 0;
     border-radius: 8px;
@@ -2033,19 +2063,10 @@ a:hover {
     border-radius: 8px !important;
     font-size: 0.82rem !important;
   }
-  .content pre.ox-code-block[data-code-title]::before {
-    margin: -0.85rem -0.95rem 0.75rem;
-    padding: 0.65rem 0.95rem;
-  }
-  .content pre.ox-code-block .line {
-    margin: 0 -0.95rem;
-    padding: 0 0.95rem;
-  }
   .content pre.ox-code-block.line-numbers-mode .line {
     padding-left: 3.7rem;
   }
   .content pre.ox-code-block.line-numbers-mode .line::before {
-    left: 0.95rem;
     width: 1.75rem;
   }
   .content table {
@@ -2054,7 +2075,6 @@ a:hover {
   }
   .content th,
   .content td {
-    padding: 0.5rem 0.75rem;
     white-space: nowrap;
     vertical-align: top;
   }
@@ -2103,6 +2123,14 @@ a:hover {
 }
 
 @media (max-width: 480px) {
+  :root {
+    --octc-code-pad-block: 0.78rem;
+    --octc-code-pad-inline: 0.85rem;
+    --octc-code-title-pad-block: 0.6rem;
+    --octc-code-title-gap: 0.72rem;
+    --octc-table-cell-pad-block: 0.375rem;
+    --octc-table-cell-pad-inline: 0.5rem;
+  }
   .main {
     padding-block-start: 0.75rem;
     padding-bottom: calc(
@@ -2117,7 +2145,6 @@ a:hover {
   }
   .content pre {
     font-size: 0.72rem;
-    padding: 0.78rem 0.85rem;
   }
   .content pre code {
     font-size: 0.72rem;
@@ -2131,22 +2158,12 @@ a:hover {
   .content .ox-api-module__count {
     font-size: 0.68rem;
   }
-  .content pre.ox-code-block[data-code-title]::before {
-    margin: -0.78rem -0.85rem 0.72rem;
-    padding: 0.6rem 0.85rem;
-  }
-  .content pre.ox-code-block .line {
-    margin: 0 -0.85rem;
-    padding: 0 0.85rem;
-  }
-  .content pre.ox-code-block.line-numbers-mode .line::before {
-    left: 0.85rem;
-  }
   .content table {
     font-size: 0.75rem;
   }
-  .content th,
-  .content td {
-    padding: 0.375rem 0.5rem;
-  }
+}
+
+:focus-visible {
+  outline: var(--octc-focus-ring);
+  outline-offset: var(--octc-focus-offset);
 }

--- a/docs/content/ja/theme-presets.md
+++ b/docs/content/ja/theme-presets.md
@@ -502,3 +502,20 @@ export default defineTheme({
   css: `.header { border-bottom: 2px solid var(--octc-color-primary); }`,
 });
 ```
+
+## デフォルトテーマの品質
+
+組み込みスタイルシート（`ssg.css`）が、すべてのスキンと配色が乗る品質の下限です。値をハードコードする代わりに、次のトークンを上書きしてください。
+
+| トークン                                                            | 役割                                                |
+| ------------------------------------------------------------------- | --------------------------------------------------- |
+| `--octc-focus-ring` / `--octc-focus-offset`                         | 共有の `:focus-visible` リング                      |
+| `--octc-motion-base` / `--octc-motion-ease`                         | 既定のモーション。`prefers-reduced-motion` では無効 |
+| `--octc-code-pad-*` / `--octc-table-cell-pad-*`                     | コード枠と表セルの余白                              |
+| `--octc-touch-target`                                               | モバイルナビのヒット領域                            |
+| `--octc-color-on-primary`                                           | ブランド塗りつぶし上の文字（ヒーロー、告知バー）    |
+| `--octc-color-tip` / `--octc-color-warning` / `--octc-color-danger` | ステータス用クローム                                |
+
+`html` のスムーススクロールは `prefers-reduced-motion: no-preference` のときだけ有効です。コード行のぼかしとナビのシェブロン遷移は、モーション低減時に切れます。PR ベンチマークはデフォルトテーマの CSS/JS サイズを出し続けます。クロームを足すより、これらのトークンを調整してください。
+
+**ここでの対象外:** セルフホストフォント、Iconify CSS、tweet / full-card の見た目、印刷用スタイルシート、スキンごとのギャラリースクショ更新。回帰したら個別の follow-up として切ってください。

--- a/docs/content/theme-presets.md
+++ b/docs/content/theme-presets.md
@@ -561,3 +561,27 @@ export default defineTheme({
   css: `.header { border-bottom: 2px solid var(--octc-color-primary); }`,
 });
 ```
+
+## Default theme quality
+
+The built-in stylesheet (`ssg.css`) is the quality floor every skin and scheme
+composes onto. Override these tokens instead of hardcoding a second set of
+values:
+
+| Token                                                               | Role                                               |
+| ------------------------------------------------------------------- | -------------------------------------------------- |
+| `--octc-focus-ring` / `--octc-focus-offset`                         | Shared `:focus-visible` ring                       |
+| `--octc-motion-base` / `--octc-motion-ease`                         | Default motion; off under `prefers-reduced-motion` |
+| `--octc-code-pad-*` / `--octc-table-cell-pad-*`                     | Code frame and table cell spacing                  |
+| `--octc-touch-target`                                               | Mobile nav hit area                                |
+| `--octc-color-on-primary`                                           | Ink on brand fills (hero, announcement)            |
+| `--octc-color-tip` / `--octc-color-warning` / `--octc-color-danger` | Status chrome                                      |
+
+`html` smooth-scrolling is gated behind `prefers-reduced-motion: no-preference`.
+Code-line dim blur and nav chevron transitions turn off when motion is reduced.
+PR benchmarks still report default theme CSS/JS size — prefer retuning these
+tokens over adding chrome.
+
+**Out of scope here:** self-hosted fonts, Iconify CSS, tweet/full-card styling,
+print stylesheets, and per-skin gallery screenshot refreshes. File those as
+focused follow-ups when they regress.

--- a/npm/vite-plugin-ox-content/src/theme-contract.test.ts
+++ b/npm/vite-plugin-ox-content/src/theme-contract.test.ts
@@ -245,6 +245,39 @@ describe("theme package contract", () => {
     expect(page).toMatch(/must not hard-code/i);
   });
 
+  it("locks the default theme quality token contract", () => {
+    const css = readFileSync(join(repoRoot, "crates/ox_content_ssg/src/ssg.css"), "utf8");
+    for (const token of [
+      "--octc-focus-ring:",
+      "--octc-focus-offset:",
+      "--octc-motion-base:",
+      "--octc-code-pad-inline:",
+      "--octc-table-cell-pad-inline:",
+      "--octc-touch-target:",
+      "--octc-color-on-primary:",
+    ]) {
+      expect(css, token).toContain(token);
+    }
+    expect(css).toContain(":focus-visible {\n  outline: var(--octc-focus-ring);");
+    expect(css).toMatch(
+      /@media \(prefers-reduced-motion: no-preference\) \{\n  html \{\n    scroll-behavior: smooth;/,
+    );
+    expect(css).toMatch(/@media \(prefers-reduced-motion: reduce\)/);
+  });
+
+  it("documents default theme quality and remaining follow-ups", () => {
+    for (const localePath of [
+      "docs/content/theme-presets.md",
+      "docs/content/ja/theme-presets.md",
+    ]) {
+      const page = readFileSync(join(repoRoot, localePath), "utf8");
+      expect(page, localePath).toMatch(/## Default theme quality|## デフォルトテーマの品質/);
+      expect(page, localePath).toMatch(/--octc-focus-ring/);
+      expect(page, localePath).toMatch(/prefers-reduced-motion/);
+      expect(page, localePath).toMatch(/out of scope|対象外/i);
+    }
+  });
+
   it("keeps color scheme previews synchronized with the palette catalog", () => {
     const expectedIds = paletteCatalog.palettes.map((palette) => palette.id);
     const packageIds = schemes


### PR DESCRIPTION
## Summary

- Tokenize default-theme focus, motion, status, code/table spacing, and on-primary ink so packages override `--octc-*` instead of hex escapes.
- Gate smooth scrolling and code-line blur behind `prefers-reduced-motion`, share one `:focus-visible` ring, and retune mobile code/table/nav spacing through those tokens.
- Lock the contract with SSG + theme-package tests and document the quality floor plus remaining follow-ups. Closes #858.

## Risk

- Risk level: low
- User or production impact: Default sites get a keyboard focus ring, darker ink on brand fills in dark mode (fixes failing contrast on `#86a4da`), and slightly retuned mobile code/table padding via the same visual values. No JS payload change. Tweet/full-card, fonts, and Iconify CSS are untouched.
- Rollback plan: Revert this PR. Token names are additive; skins that already set `--octc-motion-base` keep winning.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_ssg --lib` (240 passed, insta HTML snapshots refreshed); `vp exec --filter @ox-content/vite-plugin -- vp test src/theme-contract.test.ts` (11 passed); `vp check --fix`; `check-file-lines --base prod/main`.
- [x] Manual verification completed: Reviewed default `ssg.css` token/media-query contract and confirmed mobile breakpoints now retune tokens instead of restating pad literals.
- [x] Edge cases or failure modes considered: coarse-pointer tap still suppresses `:focus` outline; keyboard `:focus-visible` wins; reduced-motion disables chevron transition and dim blur; on-primary tracks `--octc-color-bg`.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed.

## Follow-ups (out of scope)

- Self-hosted fonts (#932) and Iconify CSS (#933).
- Tweet / full-card restyle.
- Richer print stylesheet beyond opt-in a11y print CSS.
- Per-skin gallery screenshot refresh and remaining feature-icon tint (`#8ec9ff`).


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790330591&installation_model_id=422833&pr_number=1006&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1006&signature=3111076cc19ec3bcb27216455a745b4535e6e346603cf73a052562ead4a9b8c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved focus indicators across navigation, tabs, links, and interactive elements.
  - Standardized touch-target sizing and reduced-motion behavior.
- **Design**
  - Added theme-aware color, spacing, focus, motion, and touch-target styling.
  - Improved consistency across light, dark, branded, and responsive layouts.
- **Documentation**
  - Documented default theme quality standards and customization tokens in English and Japanese.
- **Tests**
  - Added coverage for theme tokens, accessibility behavior, motion preferences, and stylesheet quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->