### PR TITLE
perf(runtime): lazy-load optional docs widgets by feature

### DIFF
--- a/crates/ox_content_ssg/src/assets.rs
+++ b/crates/ox_content_ssg/src/assets.rs
@@ -154,6 +154,63 @@ mod tests {
         insta::assert_debug_snapshot!(result);
     }
 
+    #[test]
+    fn feature_js_sections_emit_only_needed_script_srcs() {
+        let pages = vec![
+            GeneratedHtmlPage {
+                input_path: "plain.md".to_string(),
+                output_path: "/tmp/site/plain/index.html".to_string(),
+                html: format_sectioned_page("Plain", false),
+            },
+            GeneratedHtmlPage {
+                input_path: "tabs.md".to_string(),
+                output_path: "/tmp/site/tabs/index.html".to_string(),
+                html: format_sectioned_page("Tabs", true),
+            },
+        ];
+
+        let result = externalize_shared_page_assets(pages, "/tmp/site", "/docs/");
+        let plain = &result.pages[0].html;
+        let tabs = &result.pages[1].html;
+
+        assert!(plain.contains("ox-content-core-"), "{plain}");
+        assert!(!plain.contains("ox-content-search-"), "{plain}");
+        assert!(!plain.contains("ox-content-tabs-"), "{plain}");
+        assert!(!plain.contains("ox-code-play"), "{plain}");
+        assert!(!plain.contains("island"), "{plain}");
+        assert!(tabs.contains("ox-content-tabs-"), "{tabs}");
+        assert!(
+            result.assets.iter().any(|asset| asset.public_path.contains("ox-content-search-")),
+            "{result:?}"
+        );
+    }
+
+    fn format_sectioned_page(title: &str, tabs: bool) -> String {
+        let tabs_js = if tabs {
+            "// ox-content:js:tabs:start\nconst tabs = true;\n// ox-content:js:tabs:end\n"
+        } else {
+            ""
+        };
+        format!(
+            r#"<!doctype html>
+<html>
+<head></head>
+<body>
+  <h1>{title}</h1>
+  <!-- ox-content:scripts:start -->
+  <script>// ox-content:js:core:start
+const boot = "__OX_CONTENT_SEARCH_CHUNK__";
+// ox-content:search:start
+const searchData = true;
+// ox-content:search:end
+// ox-content:js:core:end
+{tabs_js}</script>
+  <!-- ox-content:scripts:end -->
+</body>
+</html>"#
+        )
+    }
+
     fn format_page(title: &str) -> String {
         format!(
             r#"<!doctype html>

--- a/crates/ox_content_ssg/src/assets/script.rs
+++ b/crates/ox_content_ssg/src/assets/script.rs
@@ -1,9 +1,19 @@
 use super::blocks::BlockMatch;
 use super::chunk::{AssetCache, AssetKind};
 
+const JS_SECTION_PREFIX: &str = "// ox-content:js:";
+const JS_SECTION_START_SUFFIX: &str = ":start";
+const JS_SECTION_END_SUFFIX: &str = ":end";
 const SEARCH_CHUNK_START: &str = "// ox-content:search:start";
 const SEARCH_CHUNK_END: &str = "// ox-content:search:end";
 const SEARCH_CHUNK_PLACEHOLDER: &str = "__OX_CONTENT_SEARCH_CHUNK__";
+const LAZY_JS_SECTIONS: [&str; 1] = ["search"];
+
+#[derive(Debug, Clone)]
+struct JsSection {
+    name: String,
+    content: String,
+}
 
 pub(super) fn build_script_replacement(
     js_content: &str,
@@ -11,51 +21,141 @@ pub(super) fn build_script_replacement(
     out_dir: &str,
     base: &str,
 ) -> String {
-    // The search UI runtime is large and only needed after the user opens
-    // search. Split it into its own deferred chunk and replace the placeholder
-    // in the core runtime with that chunk URL. If the marker is absent, fall
-    // back to one shared JS asset for the whole script block.
-    if let Some(search_chunk) = find_search_chunk(js_content)
-        && js_content.contains(SEARCH_CHUNK_PLACEHOLDER)
-    {
-        let search_content = search_chunk.content.trim();
-        if !search_content.is_empty() {
-            let search_public_path = js_chunks
-                .get_or_create(AssetKind::Js, "search", search_content, out_dir, base)
-                .public_path
-                .clone();
-            let mut core_content = String::new();
-            core_content.push_str(&js_content[..search_chunk.start]);
-            core_content.push_str(&js_content[search_chunk.end..]);
-            let core_content = core_content
-                .replace(SEARCH_CHUNK_PLACEHOLDER, &search_public_path)
-                .trim()
-                .to_string();
+    // Feature sections (`// ox-content:js:*`) become one file per widget, the
+    // same way CSS sections become one file per plugin. Search stays lazy: the
+    // chunk is written, but pages only get a `<script src>` after the user
+    // opens search. Unmarked scripts fall back to one shared JS asset.
+    let sections = extract_js_sections(js_content);
+    if sections.is_empty() {
+        return emit_legacy_script(js_content, js_chunks, out_dir, base);
+    }
 
-            if !core_content.is_empty() {
-                let core_chunk =
-                    js_chunks.get_or_create(AssetKind::Js, "core", &core_content, out_dir, base);
-                return format!("  <script defer src=\"{}\"></script>", core_chunk.public_path);
-            }
+    let mut fragments = Vec::new();
+    for section in sections {
+        if LAZY_JS_SECTIONS.contains(&section.name.as_str()) {
+            let _ = js_chunks.get_or_create(
+                AssetKind::Js,
+                &section.name,
+                &section.content,
+                out_dir,
+                base,
+            );
+            continue;
         }
+
+        let content = split_lazy_search_from_core(&section, js_chunks, out_dir, base);
+        if content.is_empty() {
+            continue;
+        }
+        let chunk = js_chunks.get_or_create(AssetKind::Js, &section.name, &content, out_dir, base);
+        fragments.push(script_src_tag(&chunk.public_path));
     }
 
-    let fallback_content = js_content.trim();
-    if fallback_content.is_empty() {
-        return String::new();
-    }
-
-    let chunk = js_chunks.get_or_create(AssetKind::Js, "js", fallback_content, out_dir, base);
-    format!("  <script defer src=\"{}\"></script>", chunk.public_path)
+    fragments.join("\n")
 }
 
-fn find_search_chunk(js_content: &str) -> Option<BlockMatch> {
-    let start = js_content.find(SEARCH_CHUNK_START)?;
-    let content_start = start + SEARCH_CHUNK_START.len();
-    let end_start = content_start + js_content[content_start..].find(SEARCH_CHUNK_END)?;
+fn emit_legacy_script(
+    js_content: &str,
+    js_chunks: &mut AssetCache,
+    out_dir: &str,
+    base: &str,
+) -> String {
+    let has_search =
+        js_content.contains(SEARCH_CHUNK_START) && js_content.contains(SEARCH_CHUNK_PLACEHOLDER);
+    let core = JsSection { name: "js".to_string(), content: js_content.to_string() };
+    let content = split_lazy_search_from_core(&core, js_chunks, out_dir, base);
+    if content.is_empty() {
+        return String::new();
+    }
+    let label = if has_search { "core" } else { "js" };
+    let chunk = js_chunks.get_or_create(AssetKind::Js, label, &content, out_dir, base);
+    script_src_tag(&chunk.public_path)
+}
+
+fn split_lazy_search_from_core(
+    section: &JsSection,
+    js_chunks: &mut AssetCache,
+    out_dir: &str,
+    base: &str,
+) -> String {
+    // Search UI is large and only needed after the user opens search. Peel it
+    // out of the core runtime, write a deferred chunk, and rewrite the
+    // placeholder URL. Other feature sections pass through unchanged.
+    if section.name != "core" && section.name != "js" {
+        return section.content.trim().to_string();
+    }
+    let Some(search_chunk) =
+        find_marked_js_chunk(&section.content, SEARCH_CHUNK_START, SEARCH_CHUNK_END)
+    else {
+        return section.content.trim().to_string();
+    };
+    if !section.content.contains(SEARCH_CHUNK_PLACEHOLDER) {
+        return section.content.trim().to_string();
+    }
+
+    let search_content = search_chunk.content.trim();
+    if search_content.is_empty() {
+        return section.content.trim().to_string();
+    }
+
+    let search_public_path = js_chunks
+        .get_or_create(AssetKind::Js, "search", search_content, out_dir, base)
+        .public_path
+        .clone();
+    let mut core_content = String::new();
+    core_content.push_str(&section.content[..search_chunk.start]);
+    core_content.push_str(&section.content[search_chunk.end..]);
+    core_content.replace(SEARCH_CHUNK_PLACEHOLDER, &search_public_path).trim().to_string()
+}
+
+fn extract_js_sections(js_content: &str) -> Vec<JsSection> {
+    let mut sections = Vec::new();
+    let mut cursor = 0;
+
+    while let Some(start_rel) = js_content[cursor..].find(JS_SECTION_PREFIX) {
+        let marker_start = cursor + start_rel;
+        let name_start = marker_start + JS_SECTION_PREFIX.len();
+        let Some(name_end_rel) = js_content[name_start..].find(JS_SECTION_START_SUFFIX) else {
+            break;
+        };
+        let name_end = name_start + name_end_rel;
+        let name = &js_content[name_start..name_end];
+        if !name.chars().all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-') {
+            cursor = name_end;
+            continue;
+        }
+
+        let content_start = name_end + JS_SECTION_START_SUFFIX.len();
+        let end_marker = format!("{JS_SECTION_PREFIX}{name}{JS_SECTION_END_SUFFIX}");
+        let Some(end_rel) = js_content[content_start..].find(&end_marker) else {
+            break;
+        };
+        let content_end = content_start + end_rel;
+        let content = js_content[content_start..content_end].trim();
+        if !content.is_empty() {
+            sections.push(JsSection { name: name.to_string(), content: content.to_string() });
+        }
+        cursor = content_end + end_marker.len();
+    }
+
+    sections
+}
+
+fn find_marked_js_chunk(
+    js_content: &str,
+    start_marker: &str,
+    end_marker: &str,
+) -> Option<BlockMatch> {
+    let start = js_content.find(start_marker)?;
+    let content_start = start + start_marker.len();
+    let end_start = content_start + js_content[content_start..].find(end_marker)?;
     Some(BlockMatch {
         start,
-        end: end_start + SEARCH_CHUNK_END.len(),
+        end: end_start + end_marker.len(),
         content: js_content[content_start..end_start].trim().to_string(),
     })
+}
+
+fn script_src_tag(public_path: &str) -> String {
+    format!("  <script defer src=\"{public_path}\"></script>")
 }

--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -18,6 +18,7 @@ mod mpa_navigation;
 mod nav;
 mod not_by_ai;
 mod page;
+mod page_js;
 mod pagination;
 mod reader_chrome;
 mod render;

--- a/crates/ox_content_ssg/src/html/header_chrome.js
+++ b/crates/ox_content_ssg/src/html/header_chrome.js
@@ -1,4 +1,10 @@
 (() => {
+  const hydratedControls =
+    ".header-nav-dropdown > button, .ox-locale-switcher > button, [data-ox-copy-markdown]";
+  document.querySelectorAll(hydratedControls).forEach((button) => {
+    if (button instanceof HTMLButtonElement) button.disabled = false;
+  });
+
   const dropdownTriggers = ".header-nav-dropdown > button, .ox-locale-switcher > button";
   const openDropdowns =
     ".header-nav-dropdown > button[aria-expanded='true'], .ox-locale-switcher > button[aria-expanded='true'], .ox-version-switcher > button[aria-expanded='true']";

--- a/crates/ox_content_ssg/src/html/header_chrome.rs
+++ b/crates/ox_content_ssg/src/html/header_chrome.rs
@@ -111,7 +111,7 @@ fn render_nav_item(item: &HeaderNavItem) -> String {
     let children: String = item.items.iter().map(render_nav_item).collect();
     if !children.is_empty() {
         return format!(
-            "        <li class=\"header-nav-item header-nav-dropdown\">\n          <button type=\"button\" aria-expanded=\"false\" aria-haspopup=\"true\">{escaped}</button>\n          <ul class=\"header-nav-menu\">\n{children}          </ul>\n        </li>\n"
+            "        <li class=\"header-nav-item header-nav-dropdown\">\n          <button type=\"button\" disabled aria-expanded=\"false\" aria-haspopup=\"true\">{escaped}</button>\n          <ul class=\"header-nav-menu\">\n{children}          </ul>\n        </li>\n"
         );
     }
     let Some(href) = item.link.as_deref().map(str::trim).filter(|href| !href.is_empty()) else {
@@ -170,19 +170,6 @@ pub(super) fn push_header_chrome_css(
 ) {
     if header_chrome_needs_css(nav_html, announcement_html, chrome, markdown_source) {
         css_sections.push(wrap_css_section("header-chrome", HEADER_CHROME_CSS));
-    }
-}
-
-pub(super) fn push_header_chrome_js(
-    all_js: &mut String,
-    nav_html: &str,
-    announcement_html: &str,
-    locale_switcher_html: &str,
-    markdown_source: bool,
-) {
-    if header_chrome_needs_js(nav_html, announcement_html, locale_switcher_html, markdown_source) {
-        all_js.push('\n');
-        all_js.push_str(HEADER_CHROME_JS);
     }
 }
 

--- a/crates/ox_content_ssg/src/html/header_chrome/markdown_source.rs
+++ b/crates/ox_content_ssg/src/html/header_chrome/markdown_source.rs
@@ -16,7 +16,7 @@ fn render_markdown_source_chrome(href: &str) -> String {
     let escaped = escape_html(href);
     format!(
         "<p class=\"ox-markdown-source\">\
-<button type=\"button\" class=\"ox-copy-markdown\" data-ox-copy-markdown aria-label=\"Copy as Markdown\">Copy as Markdown</button>\
+<button type=\"button\" class=\"ox-copy-markdown\" data-ox-copy-markdown disabled aria-label=\"Copy as Markdown\">Copy as Markdown</button>\
 <a class=\"ox-view-markdown\" href=\"{escaped}\">View Markdown</a>\
 <span class=\"ox-copy-markdown-status\" data-ox-copy-markdown-status role=\"status\" aria-live=\"polite\"></span>\
 </p>\n"

--- a/crates/ox_content_ssg/src/html/header_chrome/tests/markdown_source.rs
+++ b/crates/ox_content_ssg/src/html/header_chrome/tests/markdown_source.rs
@@ -31,7 +31,7 @@ fn copy_as_markdown_points_at_the_companion_when_on() {
     );
     assert!(
         html.contains(
-            r#"<button type="button" class="ox-copy-markdown" data-ox-copy-markdown aria-label="Copy as Markdown">Copy as Markdown</button>"#
+            r#"<button type="button" class="ox-copy-markdown" data-ox-copy-markdown disabled aria-label="Copy as Markdown">Copy as Markdown</button>"#
         ),
         "{html}"
     );

--- a/crates/ox_content_ssg/src/html/header_chrome/tests/nav.rs
+++ b/crates/ox_content_ssg/src/html/header_chrome/tests/nav.rs
@@ -52,7 +52,7 @@ fn nav_dropdown_markup_has_aria() {
 
     assert!(
         nav.contains(
-            r#"<button type="button" aria-expanded="false" aria-haspopup="true">API</button>"#
+            r#"<button type="button" disabled aria-expanded="false" aria-haspopup="true">API</button>"#
         ),
         "{nav}"
     );
@@ -105,7 +105,8 @@ fn dropdown_js_closes_on_escape_and_restores_focus() {
     assert!(
         HEADER_CHROME_JS.contains("Escape")
             && HEADER_CHROME_JS.contains(".focus(")
-            && HEADER_CHROME_JS.contains(".ox-locale-switcher > button"),
+            && HEADER_CHROME_JS.contains(".ox-locale-switcher > button")
+            && HEADER_CHROME_JS.contains("button.disabled = false"),
         "{HEADER_CHROME_JS}"
     );
 }

--- a/crates/ox_content_ssg/src/html/locale_switcher.rs
+++ b/crates/ox_content_ssg/src/html/locale_switcher.rs
@@ -22,7 +22,9 @@ pub(super) fn render_locale_switcher(config: &SsgConfig) -> String {
         .unwrap_or_default();
     let mut html =
         String::from("<nav class=\"ox-header-select ox-locale-switcher\" aria-label=\"Language\">");
-    html.push_str("<button type=\"button\" aria-expanded=\"false\" aria-haspopup=\"true\">");
+    html.push_str(
+        "<button type=\"button\" disabled aria-expanded=\"false\" aria-haspopup=\"true\">",
+    );
     html.push_str(&current_name);
     html.push_str("</button><ul class=\"ox-header-select-menu\">");
     for locale in locales {

--- a/crates/ox_content_ssg/src/html/locale_switcher/tests.rs
+++ b/crates/ox_content_ssg/src/html/locale_switcher/tests.rs
@@ -151,7 +151,7 @@ fn happy_path_lists_locales_and_marks_current() {
     );
     assert!(
         switcher.contains(
-            r#"<button type="button" aria-expanded="false" aria-haspopup="true">日本語</button>"#
+            r#"<button type="button" disabled aria-expanded="false" aria-haspopup="true">日本語</button>"#
         ),
         "{switcher}"
     );
@@ -294,9 +294,9 @@ fn dropdown_trigger_escapes_current_name() {
     );
     let switcher = switcher_html(&html).expect("enabled switcher must render");
     assert!(
-        switcher
-            .contains("<button type=\"button\" aria-expanded=\"false\" aria-haspopup=\"true\">")
-            && switcher.contains("&lt;script&gt;alert(1)&lt;/script&gt;"),
+        switcher.contains(
+            "<button type=\"button\" disabled aria-expanded=\"false\" aria-haspopup=\"true\">"
+        ) && switcher.contains("&lt;script&gt;alert(1)&lt;/script&gt;"),
         "{switcher}"
     );
     assert!(!switcher.contains("<script>alert(1)</script>"), "{switcher}");

--- a/crates/ox_content_ssg/src/html/page_js.rs
+++ b/crates/ox_content_ssg/src/html/page_js.rs
@@ -1,0 +1,100 @@
+use super::header_chrome::{HEADER_CHROME_JS, header_chrome_needs_js};
+use super::reader_chrome::READER_CHROME_JS;
+use super::utils::{page_content_contains_any, wrap_js_section};
+use super::{SSG_JS, TABS_JS};
+
+pub(super) struct PageJsInput<'a> {
+    pub content: &'a str,
+    pub base: &'a str,
+    pub custom_js: &'a str,
+    pub header_nav_html: &'a str,
+    pub announcement_html: &'a str,
+    pub locale_switcher_html: &'a str,
+    pub markdown_source_chrome: bool,
+    pub reader_needs_js: bool,
+}
+
+/// Assembles feature-level JS the same way page CSS is sectioned.
+///
+/// Core chrome (menu, theme, search *loader*) is always present on themed
+/// pages. Search *implementation* stays inside the core blob with lazy-load
+/// markers. Optional widgets are omitted unless the page content needs them:
+/// synced tabs, reader chrome, header chrome, and custom theme JS. Mermaid is
+/// static SVG. Islands and Code Play are injected by their own hosts.
+pub(super) fn assemble_page_js(input: &PageJsInput<'_>) -> String {
+    let mut sections = Vec::new();
+    sections.push(wrap_js_section("core", &SSG_JS.replace("{{base}}", input.base)));
+    if page_content_contains_any(input.content, &["data-ox-tab-group"]) {
+        sections.push(wrap_js_section("tabs", TABS_JS));
+    }
+    if input.reader_needs_js {
+        sections.push(wrap_js_section("reader-chrome", READER_CHROME_JS));
+    }
+    if header_chrome_needs_js(
+        input.header_nav_html,
+        input.announcement_html,
+        input.locale_switcher_html,
+        input.markdown_source_chrome,
+    ) {
+        sections.push(wrap_js_section("header-chrome", HEADER_CHROME_JS));
+    }
+    if !input.custom_js.trim().is_empty() {
+        sections.push(wrap_js_section("theme", input.custom_js));
+    }
+    sections.concat()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input<'a>(content: &'a str, custom_js: &'a str) -> PageJsInput<'a> {
+        PageJsInput {
+            content,
+            base: "/docs/",
+            custom_js,
+            header_nav_html: "",
+            announcement_html: "",
+            locale_switcher_html: "",
+            markdown_source_chrome: false,
+            reader_needs_js: false,
+        }
+    }
+
+    #[test]
+    fn core_is_always_present_and_optional_widgets_are_omitted() {
+        let js = assemble_page_js(&input("<p>Hello</p>", ""));
+        assert!(js.contains("// ox-content:js:core:start"), "{js}");
+        assert!(js.contains("__OX_CONTENT_SEARCH_CHUNK__"), "{js}");
+        assert!(js.contains("// ox-content:search:start"), "{js}");
+        assert!(!js.contains("// ox-content:js:tabs:"), "{js}");
+        assert!(!js.contains("data-ox-tab-group"), "{js}");
+        assert!(!js.contains("ox-code-play"), "{js}");
+        assert!(!js.contains("initIslands"), "{js}");
+        assert!(!js.contains("mermaid"), "{js}");
+    }
+
+    #[test]
+    fn synced_tabs_are_the_only_reason_to_emit_tabs_js() {
+        let static_tabs = assemble_page_js(&input(r#"<div class="ox-tabs"></div>"#, ""));
+        assert!(!static_tabs.contains("// ox-content:js:tabs:"), "{static_tabs}");
+
+        let synced =
+            assemble_page_js(&input(r#"<div class="ox-tabs" data-ox-tab-group="pkg"></div>"#, ""));
+        assert!(synced.contains("// ox-content:js:tabs:start"), "{synced}");
+        assert!(synced.contains("STORAGE_PREFIX"), "{synced}");
+    }
+
+    #[test]
+    fn header_and_reader_chrome_are_feature_sections() {
+        let mut header = input("<p>Hello</p>", "");
+        header.header_nav_html = r#"<button aria-expanded="false"></button>"#;
+        let js = assemble_page_js(&header);
+        assert!(js.contains("// ox-content:js:header-chrome:start"), "{js}");
+
+        let mut reader = input("<p>Hello</p>", "");
+        reader.reader_needs_js = true;
+        let js = assemble_page_js(&reader);
+        assert!(js.contains("// ox-content:js:reader-chrome:start"), "{js}");
+    }
+}

--- a/crates/ox_content_ssg/src/html/render_inner.rs
+++ b/crates/ox_content_ssg/src/html/render_inner.rs
@@ -8,8 +8,7 @@ use super::footer::{FOOTER_CSS, generate_footer_html};
 use super::head::{RenderedHead, render_themed_head};
 use super::header_chrome::{
     enhance_article_html, markdown_source_chrome_enabled, push_header_chrome_body_classes,
-    push_header_chrome_css, push_header_chrome_js, render_announcement, render_header_nav,
-    resolve_page_chrome,
+    push_header_chrome_css, render_announcement, render_header_nav, resolve_page_chrome,
 };
 use super::heading_permalinks::{push_heading_permalink_body_class, push_heading_permalink_css};
 use super::json_ld::render_json_ld;
@@ -17,8 +16,9 @@ use super::locale_switcher::render_locale_switcher;
 use super::mpa_navigation::{MPA_NAVIGATION_CSS, THEME_BOOTSTRAP_JS, view_transitions_enabled};
 use super::nav::generate_nav_html;
 use super::not_by_ai::push_not_by_ai_css;
+use super::page_js::{PageJsInput, assemble_page_js};
 use super::pagination::resolve_pager;
-use super::reader_chrome::{READER_CHROME_CSS, READER_CHROME_JS};
+use super::reader_chrome::READER_CHROME_CSS;
 use super::section_index::SECTION_INDEX_CSS;
 use super::social::{generate_mobile_social_links_html, generate_social_links_html};
 use super::team::TEAM_CSS;
@@ -29,8 +29,8 @@ use super::utils::{
 };
 use super::{
     CONTRIBUTORS_CSS, ENTRY_CSS, FILE_TREE_CSS, GITHUB_CSS, ISLAND_CSS, MERMAID_CSS, NavGroup,
-    OGP_CSS, PageData, PageTemplate, SOCIAL_CSS, SOCIAL_TWEET_FULL_CSS, SSG_CSS, SSG_JS, SsgConfig,
-    TABS_CSS, TABS_JS, YOUTUBE_CSS,
+    OGP_CSS, PageData, PageTemplate, SOCIAL_CSS, SOCIAL_TWEET_FULL_CSS, SSG_CSS, SsgConfig,
+    TABS_CSS, YOUTUBE_CSS,
 };
 
 pub(super) struct GeneratedPage {
@@ -219,19 +219,16 @@ pub(super) fn generate_html_inner(
     let logo_dark_src = header_config.and_then(|h| h.logo_dark.as_deref()).map(resolve_theme_asset);
     let locale_switcher_html = render_locale_switcher(config);
     let custom_js = theme.and_then(|t| t.js.as_deref()).unwrap_or("");
-    let mut all_js =
-        format!("{}\n{}\n{}", SSG_JS.replace("{{base}}", &config.base), TABS_JS, custom_js);
-    if reader_chrome.needs_js() {
-        all_js.push('\n');
-        all_js.push_str(READER_CHROME_JS);
-    }
-    push_header_chrome_js(
-        &mut all_js,
-        &header_nav_html,
-        &announcement_html,
-        &locale_switcher_html,
+    let all_js = assemble_page_js(&PageJsInput {
+        content: &page_data.content,
+        base: &config.base,
+        custom_js,
+        header_nav_html: &header_nav_html,
+        announcement_html: &announcement_html,
+        locale_switcher_html: &locale_switcher_html,
         markdown_source_chrome,
-    );
+        reader_needs_js: reader_chrome.needs_js(),
+    });
     let self_hosted_icons = theme_has_self_hosted_icons(theme);
     let social_links_html = theme
         .and_then(|t| t.social_links.as_ref())

--- a/crates/ox_content_ssg/src/html/tests.rs
+++ b/crates/ox_content_ssg/src/html/tests.rs
@@ -21,6 +21,7 @@ fn snapshot_text(value: &str) -> String {
 
 mod aside;
 mod contributors;
+mod lazy_widgets;
 mod mobile_css;
 mod mpa_navigation;
 mod navigation_state;

--- a/crates/ox_content_ssg/src/html/tests/lazy_widgets.rs
+++ b/crates/ox_content_ssg/src/html/tests/lazy_widgets.rs
@@ -1,0 +1,140 @@
+use super::super::*;
+use crate::{GeneratedHtmlPage, externalize_shared_page_assets};
+
+fn page(content: &str) -> PageData {
+    PageData {
+        title: "Guide".to_string(),
+        description: None,
+        content: content.to_string(),
+        toc: vec![],
+        last_updated: None,
+        contributors: vec![],
+        path: "guide".to_string(),
+        entry_page: None,
+        prev: None,
+        next: None,
+        breadcrumbs: None,
+        chrome: PageChromeFlags::default(),
+        robots: None,
+        canonical: None,
+        markdown_source: None,
+    }
+}
+
+fn config() -> SsgConfig {
+    SsgConfig {
+        site_name: "Docs".to_string(),
+        base: "/docs/".to_string(),
+        breadcrumb_root_href: None,
+        og_image: None,
+        theme: None,
+        locale: None,
+        available_locales: None,
+        pagination: false,
+        breadcrumbs: false,
+        reader_chrome: ReaderChrome::default(),
+        locale_switcher: false,
+        locale_paths: vec![],
+        a11y: A11y::default(),
+        page_chrome: false,
+        json_ld: JsonLd::default(),
+        site_url: None,
+        head_validation: HeadValidation::Off,
+    }
+}
+
+fn externalize(html: String) -> crate::ExternalizedAssets {
+    externalize_shared_page_assets(
+        vec![GeneratedHtmlPage {
+            input_path: "guide.md".to_string(),
+            output_path: "/tmp/site/guide/index.html".to_string(),
+            html,
+        }],
+        "/tmp/site",
+        "/docs/",
+    )
+}
+
+fn script_srcs(html: &str) -> Vec<String> {
+    html.split("<script")
+        .skip(1)
+        .filter_map(|part| {
+            let after_tag = part.split('>').next()?;
+            let src = after_tag.split("src=\"").nth(1)?.split('"').next()?;
+            Some(src.to_string())
+        })
+        .collect()
+}
+
+fn assert_no_optional_widget_script_srcs(html: &str) {
+    let srcs = script_srcs(html);
+    for src in &srcs {
+        assert!(
+            !src.contains("search") && !src.contains("code-play") && !src.contains("island"),
+            "optional widget script leaked onto a plain page: {src} in {html}"
+        );
+        assert!(!src.contains("tabs"), "static pages must not load tabs JS: {src}");
+        assert!(!src.contains("mermaid"), "mermaid is static SVG: {src}");
+    }
+}
+
+#[test]
+fn generate_bare_html_has_no_optional_widget_scripts() {
+    let html = generate_bare_html("<p>Hello</p>", "Bare");
+    assert!(!html.contains("<script"), "{html}");
+    assert_no_optional_widget_script_srcs(&html);
+}
+
+#[test]
+fn themed_page_without_widgets_does_not_emit_optional_script_srcs() {
+    let html = generate_html(&page("<h1>Hello</h1><p>Plain prose.</p>"), &[], &config());
+    assert!(html.contains("// ox-content:js:core:start"), "{html}");
+    assert!(!html.contains("// ox-content:js:tabs:"), "{html}");
+    assert!(!html.contains("ox-code-play"), "{html}");
+    assert!(!html.contains("data-ox-island"), "{html}");
+
+    let result = externalize(html);
+    let page_html = &result.pages[0].html;
+    assert_no_optional_widget_script_srcs(page_html);
+    assert!(
+        result.assets.iter().any(|asset| asset.public_path.contains("ox-content-search-")),
+        "search stays a lazy asset, not a script src: {result:?}"
+    );
+    assert!(
+        !result.assets.iter().any(|asset| asset.public_path.contains("tabs")
+            || asset.public_path.contains("code-play")
+            || asset.public_path.contains("island")
+            || asset.public_path.contains("mermaid")),
+        "{result:?}"
+    );
+}
+
+#[test]
+fn synced_tabs_emit_a_tabs_script_src() {
+    let html = generate_html(
+        &page(
+            r#"<div class="ox-tabs" data-ox-tab-group="pkg"><div class="ox-tab-panel">A</div></div>"#,
+        ),
+        &[],
+        &config(),
+    );
+    assert!(html.contains("// ox-content:js:tabs:start"), "{html}");
+
+    let result = externalize(html);
+    let srcs = script_srcs(&result.pages[0].html);
+    assert!(
+        srcs.iter().any(|src| src.contains("ox-content-tabs-")),
+        "synced tabs must emit a tabs chunk: {srcs:?}\n{}",
+        result.pages[0].html
+    );
+    assert_no_optional_widget_script_srcs_except_tabs(&result.pages[0].html);
+}
+
+fn assert_no_optional_widget_script_srcs_except_tabs(html: &str) {
+    for src in script_srcs(html) {
+        assert!(
+            !src.contains("search") && !src.contains("code-play") && !src.contains("island"),
+            "{src}"
+        );
+    }
+}

--- a/crates/ox_content_ssg/src/html/tests/rendering.rs
+++ b/crates/ox_content_ssg/src/html/tests/rendering.rs
@@ -275,6 +275,32 @@ fn kbd_css_is_included_only_when_ox_kbd_is_present() {
 }
 
 #[test]
+fn tabs_js_is_included_only_when_tab_groups_sync() {
+    let config = config("Test Site", "/", None);
+    let static_tabs = generate_html(
+        &page("Tabs", None, r#"<div class="ox-tabs"></div>"#, vec![], None, "tabs"),
+        &[],
+        &config,
+    );
+    assert!(static_tabs.contains("ox-content:css:plugin-tabs:start"), "{static_tabs}");
+    assert!(!static_tabs.contains("ox-content:js:tabs:"), "{static_tabs}");
+
+    let synced = generate_html(
+        &page(
+            "Tabs",
+            None,
+            r#"<div class="ox-tabs" data-ox-tab-group="pkg"></div>"#,
+            vec![],
+            None,
+            "tabs-sync",
+        ),
+        &[],
+        &config,
+    );
+    assert!(synced.contains("ox-content:js:tabs:start"), "{synced}");
+}
+
+#[test]
 fn test_generate_toc_html_escapes_entries() {
     let html = generate_toc_html(&[TocEntry {
         depth: 2,

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -2342,7 +2342,8 @@ a:hover {
     </button>
   </footer>
   <!-- ox-content:scripts:start -->
-  <script>const toggle = document.querySelector(".menu-toggle"),
+  <script>// ox-content:js:core:start
+const toggle = document.querySelector(".menu-toggle"),
   mobileMenuBtn = document.querySelector("[data-mobile-menu]"),
   sidebar = document.querySelector(".sidebar"),
   overlay = document.querySelector(".overlay");
@@ -2970,94 +2971,7 @@ window.__oxContentInitSearch = (() => {
 })();
 // ox-content:search:end
 
-// Opt-in synced tab groups.
-//
-// Tab groups rendered with a `data-ox-tab-group="<key>"` attribute (emitted only
-// when syncing is enabled) keep their active tab in sync across the page and
-// persist the choice in localStorage. Groups without the attribute are left
-// alone, so the default no-JavaScript CSS widget is unaffected.
-(() => {
-  const GROUP_SELECTOR = ".ox-tabs[data-ox-tab-group]";
-  const STORAGE_PREFIX = "ox-tab-group:";
-
-  function storageKey(group) {
-    return STORAGE_PREFIX + group;
-  }
-
-  function readStored(group) {
-    try {
-      return window.localStorage.getItem(storageKey(group));
-    } catch {
-      return null;
-    }
-  }
-
-  function writeStored(group, label) {
-    try {
-      window.localStorage.setItem(storageKey(group), label);
-    } catch {
-      // Ignore storage failures (private mode, quota, etc.).
-    }
-  }
-
-  // Map a group element's inputs to their tab labels, in order.
-  function labelFor(tabs, input) {
-    const id = input.id;
-    const label = tabs.querySelector('label[for="' + id + '"]');
-    return label ? label.textContent.trim() : null;
-  }
-
-  function selectByLabel(tabs, label) {
-    const inputs = tabs.querySelectorAll('input[type="radio"]');
-    for (const input of inputs) {
-      if (labelFor(tabs, input) === label) {
-        if (!input.checked) input.checked = true;
-        return true;
-      }
-    }
-    return false;
-  }
-
-  function init() {
-    const groups = Array.from(document.querySelectorAll(GROUP_SELECTOR));
-    if (groups.length === 0) return;
-
-    // Restore persisted selections first.
-    for (const tabs of groups) {
-      const group = tabs.getAttribute("data-ox-tab-group");
-      const stored = readStored(group);
-      if (stored) selectByLabel(tabs, stored);
-    }
-
-    // Broadcast a selection to every group sharing the same key.
-    function broadcast(group, label, source) {
-      writeStored(group, label);
-      for (const tabs of groups) {
-        if (tabs === source) continue;
-        if (tabs.getAttribute("data-ox-tab-group") === group) {
-          selectByLabel(tabs, label);
-        }
-      }
-    }
-
-    for (const tabs of groups) {
-      const group = tabs.getAttribute("data-ox-tab-group");
-      tabs.addEventListener("change", (event) => {
-        const input = event.target;
-        if (!input || input.type !== "radio") return;
-        const label = labelFor(tabs, input);
-        if (label) broadcast(group, label, tabs);
-      });
-    }
-  }
-
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", init);
-  } else {
-    init();
-  }
-})();
-
+// ox-content:js:core:end
 </script>
   <!-- ox-content:scripts:end -->
 </body>

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -2323,7 +2323,8 @@ a:hover {
     </button>
   </footer>
   <!-- ox-content:scripts:start -->
-  <script>const toggle = document.querySelector(".menu-toggle"),
+  <script>// ox-content:js:core:start
+const toggle = document.querySelector(".menu-toggle"),
   mobileMenuBtn = document.querySelector("[data-mobile-menu]"),
   sidebar = document.querySelector(".sidebar"),
   overlay = document.querySelector(".overlay");
@@ -2951,94 +2952,7 @@ window.__oxContentInitSearch = (() => {
 })();
 // ox-content:search:end
 
-// Opt-in synced tab groups.
-//
-// Tab groups rendered with a `data-ox-tab-group="<key>"` attribute (emitted only
-// when syncing is enabled) keep their active tab in sync across the page and
-// persist the choice in localStorage. Groups without the attribute are left
-// alone, so the default no-JavaScript CSS widget is unaffected.
-(() => {
-  const GROUP_SELECTOR = ".ox-tabs[data-ox-tab-group]";
-  const STORAGE_PREFIX = "ox-tab-group:";
-
-  function storageKey(group) {
-    return STORAGE_PREFIX + group;
-  }
-
-  function readStored(group) {
-    try {
-      return window.localStorage.getItem(storageKey(group));
-    } catch {
-      return null;
-    }
-  }
-
-  function writeStored(group, label) {
-    try {
-      window.localStorage.setItem(storageKey(group), label);
-    } catch {
-      // Ignore storage failures (private mode, quota, etc.).
-    }
-  }
-
-  // Map a group element's inputs to their tab labels, in order.
-  function labelFor(tabs, input) {
-    const id = input.id;
-    const label = tabs.querySelector('label[for="' + id + '"]');
-    return label ? label.textContent.trim() : null;
-  }
-
-  function selectByLabel(tabs, label) {
-    const inputs = tabs.querySelectorAll('input[type="radio"]');
-    for (const input of inputs) {
-      if (labelFor(tabs, input) === label) {
-        if (!input.checked) input.checked = true;
-        return true;
-      }
-    }
-    return false;
-  }
-
-  function init() {
-    const groups = Array.from(document.querySelectorAll(GROUP_SELECTOR));
-    if (groups.length === 0) return;
-
-    // Restore persisted selections first.
-    for (const tabs of groups) {
-      const group = tabs.getAttribute("data-ox-tab-group");
-      const stored = readStored(group);
-      if (stored) selectByLabel(tabs, stored);
-    }
-
-    // Broadcast a selection to every group sharing the same key.
-    function broadcast(group, label, source) {
-      writeStored(group, label);
-      for (const tabs of groups) {
-        if (tabs === source) continue;
-        if (tabs.getAttribute("data-ox-tab-group") === group) {
-          selectByLabel(tabs, label);
-        }
-      }
-    }
-
-    for (const tabs of groups) {
-      const group = tabs.getAttribute("data-ox-tab-group");
-      tabs.addEventListener("change", (event) => {
-        const input = event.target;
-        if (!input || input.type !== "radio") return;
-        const label = labelFor(tabs, input);
-        if (label) broadcast(group, label, tabs);
-      });
-    }
-  }
-
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", init);
-  } else {
-    init();
-  }
-})();
-
+// ox-content:js:core:end
 </script>
   <!-- ox-content:scripts:end -->
 </body>

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -2323,7 +2323,8 @@ a:hover {
     </button>
   </footer>
   <!-- ox-content:scripts:start -->
-  <script>const toggle = document.querySelector(".menu-toggle"),
+  <script>// ox-content:js:core:start
+const toggle = document.querySelector(".menu-toggle"),
   mobileMenuBtn = document.querySelector("[data-mobile-menu]"),
   sidebar = document.querySelector(".sidebar"),
   overlay = document.querySelector(".overlay");
@@ -2951,94 +2952,7 @@ window.__oxContentInitSearch = (() => {
 })();
 // ox-content:search:end
 
-// Opt-in synced tab groups.
-//
-// Tab groups rendered with a `data-ox-tab-group="<key>"` attribute (emitted only
-// when syncing is enabled) keep their active tab in sync across the page and
-// persist the choice in localStorage. Groups without the attribute are left
-// alone, so the default no-JavaScript CSS widget is unaffected.
-(() => {
-  const GROUP_SELECTOR = ".ox-tabs[data-ox-tab-group]";
-  const STORAGE_PREFIX = "ox-tab-group:";
-
-  function storageKey(group) {
-    return STORAGE_PREFIX + group;
-  }
-
-  function readStored(group) {
-    try {
-      return window.localStorage.getItem(storageKey(group));
-    } catch {
-      return null;
-    }
-  }
-
-  function writeStored(group, label) {
-    try {
-      window.localStorage.setItem(storageKey(group), label);
-    } catch {
-      // Ignore storage failures (private mode, quota, etc.).
-    }
-  }
-
-  // Map a group element's inputs to their tab labels, in order.
-  function labelFor(tabs, input) {
-    const id = input.id;
-    const label = tabs.querySelector('label[for="' + id + '"]');
-    return label ? label.textContent.trim() : null;
-  }
-
-  function selectByLabel(tabs, label) {
-    const inputs = tabs.querySelectorAll('input[type="radio"]');
-    for (const input of inputs) {
-      if (labelFor(tabs, input) === label) {
-        if (!input.checked) input.checked = true;
-        return true;
-      }
-    }
-    return false;
-  }
-
-  function init() {
-    const groups = Array.from(document.querySelectorAll(GROUP_SELECTOR));
-    if (groups.length === 0) return;
-
-    // Restore persisted selections first.
-    for (const tabs of groups) {
-      const group = tabs.getAttribute("data-ox-tab-group");
-      const stored = readStored(group);
-      if (stored) selectByLabel(tabs, stored);
-    }
-
-    // Broadcast a selection to every group sharing the same key.
-    function broadcast(group, label, source) {
-      writeStored(group, label);
-      for (const tabs of groups) {
-        if (tabs === source) continue;
-        if (tabs.getAttribute("data-ox-tab-group") === group) {
-          selectByLabel(tabs, label);
-        }
-      }
-    }
-
-    for (const tabs of groups) {
-      const group = tabs.getAttribute("data-ox-tab-group");
-      tabs.addEventListener("change", (event) => {
-        const input = event.target;
-        if (!input || input.type !== "radio") return;
-        const label = labelFor(tabs, input);
-        if (label) broadcast(group, label, tabs);
-      });
-    }
-  }
-
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", init);
-  } else {
-    init();
-  }
-})();
-
+// ox-content:js:core:end
 </script>
   <!-- ox-content:scripts:end -->
 </body>

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -2325,7 +2325,8 @@ a:hover {
     </button>
   </footer>
   <!-- ox-content:scripts:start -->
-  <script>const toggle = document.querySelector(".menu-toggle"),
+  <script>// ox-content:js:core:start
+const toggle = document.querySelector(".menu-toggle"),
   mobileMenuBtn = document.querySelector("[data-mobile-menu]"),
   sidebar = document.querySelector(".sidebar"),
   overlay = document.querySelector(".overlay");
@@ -2953,94 +2954,7 @@ window.__oxContentInitSearch = (() => {
 })();
 // ox-content:search:end
 
-// Opt-in synced tab groups.
-//
-// Tab groups rendered with a `data-ox-tab-group="<key>"` attribute (emitted only
-// when syncing is enabled) keep their active tab in sync across the page and
-// persist the choice in localStorage. Groups without the attribute are left
-// alone, so the default no-JavaScript CSS widget is unaffected.
-(() => {
-  const GROUP_SELECTOR = ".ox-tabs[data-ox-tab-group]";
-  const STORAGE_PREFIX = "ox-tab-group:";
-
-  function storageKey(group) {
-    return STORAGE_PREFIX + group;
-  }
-
-  function readStored(group) {
-    try {
-      return window.localStorage.getItem(storageKey(group));
-    } catch {
-      return null;
-    }
-  }
-
-  function writeStored(group, label) {
-    try {
-      window.localStorage.setItem(storageKey(group), label);
-    } catch {
-      // Ignore storage failures (private mode, quota, etc.).
-    }
-  }
-
-  // Map a group element's inputs to their tab labels, in order.
-  function labelFor(tabs, input) {
-    const id = input.id;
-    const label = tabs.querySelector('label[for="' + id + '"]');
-    return label ? label.textContent.trim() : null;
-  }
-
-  function selectByLabel(tabs, label) {
-    const inputs = tabs.querySelectorAll('input[type="radio"]');
-    for (const input of inputs) {
-      if (labelFor(tabs, input) === label) {
-        if (!input.checked) input.checked = true;
-        return true;
-      }
-    }
-    return false;
-  }
-
-  function init() {
-    const groups = Array.from(document.querySelectorAll(GROUP_SELECTOR));
-    if (groups.length === 0) return;
-
-    // Restore persisted selections first.
-    for (const tabs of groups) {
-      const group = tabs.getAttribute("data-ox-tab-group");
-      const stored = readStored(group);
-      if (stored) selectByLabel(tabs, stored);
-    }
-
-    // Broadcast a selection to every group sharing the same key.
-    function broadcast(group, label, source) {
-      writeStored(group, label);
-      for (const tabs of groups) {
-        if (tabs === source) continue;
-        if (tabs.getAttribute("data-ox-tab-group") === group) {
-          selectByLabel(tabs, label);
-        }
-      }
-    }
-
-    for (const tabs of groups) {
-      const group = tabs.getAttribute("data-ox-tab-group");
-      tabs.addEventListener("change", (event) => {
-        const input = event.target;
-        if (!input || input.type !== "radio") return;
-        const label = labelFor(tabs, input);
-        if (label) broadcast(group, label, tabs);
-      });
-    }
-  }
-
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", init);
-  } else {
-    init();
-  }
-})();
-
+// ox-content:js:core:end
 </script>
   <!-- ox-content:scripts:end -->
 </body>

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -2358,7 +2358,8 @@ a:hover {
     </button>
   </footer>
   <!-- ox-content:scripts:start -->
-  <script>const toggle = document.querySelector(".menu-toggle"),
+  <script>// ox-content:js:core:start
+const toggle = document.querySelector(".menu-toggle"),
   mobileMenuBtn = document.querySelector("[data-mobile-menu]"),
   sidebar = document.querySelector(".sidebar"),
   overlay = document.querySelector(".overlay");
@@ -2986,94 +2987,7 @@ window.__oxContentInitSearch = (() => {
 })();
 // ox-content:search:end
 
-// Opt-in synced tab groups.
-//
-// Tab groups rendered with a `data-ox-tab-group="<key>"` attribute (emitted only
-// when syncing is enabled) keep their active tab in sync across the page and
-// persist the choice in localStorage. Groups without the attribute are left
-// alone, so the default no-JavaScript CSS widget is unaffected.
-(() => {
-  const GROUP_SELECTOR = ".ox-tabs[data-ox-tab-group]";
-  const STORAGE_PREFIX = "ox-tab-group:";
-
-  function storageKey(group) {
-    return STORAGE_PREFIX + group;
-  }
-
-  function readStored(group) {
-    try {
-      return window.localStorage.getItem(storageKey(group));
-    } catch {
-      return null;
-    }
-  }
-
-  function writeStored(group, label) {
-    try {
-      window.localStorage.setItem(storageKey(group), label);
-    } catch {
-      // Ignore storage failures (private mode, quota, etc.).
-    }
-  }
-
-  // Map a group element's inputs to their tab labels, in order.
-  function labelFor(tabs, input) {
-    const id = input.id;
-    const label = tabs.querySelector('label[for="' + id + '"]');
-    return label ? label.textContent.trim() : null;
-  }
-
-  function selectByLabel(tabs, label) {
-    const inputs = tabs.querySelectorAll('input[type="radio"]');
-    for (const input of inputs) {
-      if (labelFor(tabs, input) === label) {
-        if (!input.checked) input.checked = true;
-        return true;
-      }
-    }
-    return false;
-  }
-
-  function init() {
-    const groups = Array.from(document.querySelectorAll(GROUP_SELECTOR));
-    if (groups.length === 0) return;
-
-    // Restore persisted selections first.
-    for (const tabs of groups) {
-      const group = tabs.getAttribute("data-ox-tab-group");
-      const stored = readStored(group);
-      if (stored) selectByLabel(tabs, stored);
-    }
-
-    // Broadcast a selection to every group sharing the same key.
-    function broadcast(group, label, source) {
-      writeStored(group, label);
-      for (const tabs of groups) {
-        if (tabs === source) continue;
-        if (tabs.getAttribute("data-ox-tab-group") === group) {
-          selectByLabel(tabs, label);
-        }
-      }
-    }
-
-    for (const tabs of groups) {
-      const group = tabs.getAttribute("data-ox-tab-group");
-      tabs.addEventListener("change", (event) => {
-        const input = event.target;
-        if (!input || input.type !== "radio") return;
-        const label = labelFor(tabs, input);
-        if (label) broadcast(group, label, tabs);
-      });
-    }
-  }
-
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", init);
-  } else {
-    init();
-  }
-})();
-
+// ox-content:js:core:end
 </script>
   <!-- ox-content:scripts:end -->
 </body>

--- a/crates/ox_content_ssg/src/html/utils.rs
+++ b/crates/ox_content_ssg/src/html/utils.rs
@@ -13,6 +13,16 @@ pub(super) fn wrap_css_section(name: &str, css: &str) -> String {
     format!("/* ox-content:css:{name}:start */\n{css}\n/* ox-content:css:{name}:end */\n")
 }
 
+pub(super) fn wrap_js_section(name: &str, js: &str) -> String {
+    if js.trim().is_empty() {
+        return String::new();
+    }
+
+    // Same idea as CSS sections: JS comments survive template rendering and
+    // let the asset pass emit one file per feature instead of one blob.
+    format!("// ox-content:js:{name}:start\n{js}\n// ox-content:js:{name}:end\n")
+}
+
 pub(super) fn page_content_contains_any(content: &str, needles: &[&str]) -> bool {
     // Page asset detection checks for a small set of HTML markers in the final
     // content. `memmem` keeps each probe on optimized byte search instead of

--- a/npm/ox-content-code-play/src/html.ts
+++ b/npm/ox-content-code-play/src/html.ts
@@ -115,7 +115,7 @@ function wrapMatchingFences(
 }
 
 function wrapWidget(payload: string, inner: string): string {
-  return `<ox-code-play data-ox-code-play="${escapeAttribute(payload)}">${inner}</ox-code-play>`;
+  return `<ox-code-play data-ox-code-play="${escapeAttribute(payload)}" inert>${inner}</ox-code-play>`;
 }
 
 function readJsonString(source: string, start: number): { value: string; end: number } | undefined {

--- a/npm/ox-content-code-play/src/hydrate.ts
+++ b/npm/ox-content-code-play/src/hydrate.ts
@@ -63,6 +63,7 @@ export function mountCodePlay(element: Element, options: { client?: CodePlayClie
   }
   element.replaceChildren(widget);
   element.dataset.oxCodePlayMounted = "true";
+  element.removeAttribute("inert");
   bindWidget(element, payload, client);
 }
 

--- a/npm/ox-content-code-play/src/markdown.test.ts
+++ b/npm/ox-content-code-play/src/markdown.test.ts
@@ -69,6 +69,7 @@ describe("markdown and viewers", () => {
       },
     );
     expect(commented).toContain("<ox-code-play data-ox-code-play=");
+    expect(commented).toContain(" inert>");
     expect(commented).toContain("/ox-code-play.js");
 
     const matched = enhancePlayHtml(`<pre><code class="language-js">console.log(1)</code></pre>`, {

--- a/npm/ox-content-code-play/src/plugin-ssg.test.ts
+++ b/npm/ox-content-code-play/src/plugin-ssg.test.ts
@@ -35,8 +35,36 @@ describe("codePlay SSG HTML enhance", () => {
     const html = readFileSync(path.join(outDir, "index.html"), "utf8");
     expect(html).toContain("data-ox-code-play");
     expect(html).toContain("<ox-code-play");
+    expect(html).toContain(" inert>");
     expect(html).toContain("ox-code-play.js");
     expect(html).toContain('type="module"');
+  });
+
+  it("does not inject ox-code-play.js on a page without play widgets", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "ox-code-play-ssg-plain-"));
+    const srcDir = path.join(root, "content");
+    const outDir = path.join(root, "dist");
+    mkdirSync(srcDir, { recursive: true });
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(path.join(srcDir, "index.md"), "# Plain\n\nHello.\n");
+    writeFileSync(path.join(outDir, "index.html"), `<p>Hello.</p>\n`);
+
+    const plugin = codePlay({
+      languages: { javascript: true },
+      srcDir: "content",
+      outDir: "dist",
+    });
+    hookFn(plugin.configResolved)({
+      command: "build",
+      root,
+      base: "/",
+      build: { outDir: "dist" },
+    } as never);
+    await hookFn(plugin.closeBundle)();
+
+    const html = readFileSync(path.join(outDir, "index.html"), "utf8");
+    expect(html).not.toContain("ox-code-play.js");
+    expect(html).not.toContain("data-ox-code-play");
   });
 
   it("omits TypeScript typecheck from written SSG payloads without an endpoint", async () => {

--- a/npm/vite-plugin-ox-content/src/ssg-lazy-widgets.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg-lazy-widgets.test.ts
@@ -1,0 +1,70 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { buildSsg } from "./ssg";
+import type { ResolvedOptions } from "./types";
+import { createDocsResolvedOptions } from "../test/fixtures/docs-fixture";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("SSG optional widget scripts", () => {
+  it("does not emit search, code-play, or island script srcs on a plain page", async () => {
+    const root = await makeSite({ "guide.md": "# Guide\n\nHello.\n" });
+    const built = await buildSsg(themedOptions(), root);
+    const html = await fs.readFile(path.join(root, "dist", "guide", "index.html"), "utf8");
+    const srcs = scriptSrcs(html);
+
+    expect(built.errors).toEqual([]);
+    expect(srcs.join("\n")).not.toMatch(/search|code-play|island|ox-islands|mermaid|tabs/i);
+    expect(html).not.toContain("ox-code-play.js");
+    expect(html).not.toContain("data-ox-island");
+    expect(html).not.toContain("data-ox-tab-group");
+  });
+
+  it("emits a tabs chunk only when a page syncs tab groups", async () => {
+    const root = await makeSite({
+      "plain.md": "# Plain\n\nHello.\n",
+      "tabs.md":
+        '# Tabs\n\n<div class="ox-tabs" data-ox-tab-group="pkg"><div class="ox-tab-panel">A</div></div>\n',
+    });
+    const built = await buildSsg(themedOptions(), root);
+    expect(built.errors).toEqual([]);
+
+    const plain = await fs.readFile(path.join(root, "dist", "plain", "index.html"), "utf8");
+    const tabs = await fs.readFile(path.join(root, "dist", "tabs", "index.html"), "utf8");
+    expect(scriptSrcs(plain).join("\n")).not.toMatch(/tabs/i);
+    expect(scriptSrcs(tabs).join("\n")).toMatch(/ox-content-tabs-/);
+  });
+});
+
+function scriptSrcs(html: string): string[] {
+  return [...html.matchAll(/<script\b[^>]*\bsrc="([^"]+)"/g)].map((match) => match[1] ?? "");
+}
+
+async function makeSite(files: Record<string, string>): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-lazy-widgets-"));
+  tempDirs.push(root);
+  for (const [name, source] of Object.entries(files)) {
+    const full = path.join(root, "content", name);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, source);
+  }
+  return root;
+}
+
+function themedOptions(): ResolvedOptions {
+  const base = createDocsResolvedOptions({
+    ssg: {
+      ...createDocsResolvedOptions().ssg,
+      bare: false,
+      siteUrl: "https://example.com",
+    },
+    mermaid: false,
+  });
+  return base;
+}


### PR DESCRIPTION
## Summary

- Split optional docs widget JS into feature-level chunks (`core`, `tabs`, `header-chrome`, `reader-chrome`, `theme`) using the same `page_content_contains_any` markers as conditional CSS, so pages emit/preload a script only when they need that widget.
- Search stays a lazy chunk (written, not a page `<script src>`). Static tabs stay CSS-only; synced `data-ox-tab-group` is the only reason to load tabs JS. Mermaid remains static SVG; islands stay host-injected; Code Play still injects only on pages with widgets and is `inert` until hydrate.
- Interactive header/locale/copy-markdown controls start `disabled` and become keyboard-ready on hydrate. Closes #872.

## Risk

- Risk level: low
- User or production impact: themed pages no longer ship unused tabs/header/reader JS. Search still loads on first open. Header dropdowns, locale switcher, and copy-as-markdown stay inert until their chrome script hydrates. Code Play widgets stay `inert` until mount.
- Rollback plan: revert this PR. Pages fall back to the previous combined runtime blob.

## Validation

- [x] Automated tests or checks run: `cargo test -p ox_content_ssg --lib` (page_js, lazy_widgets, tabs, asset sectioning); `vp test` for `@ox-content/code-play` and `src/ssg-lazy-widgets.test.ts`; `cargo clippy -p ox_content_ssg --lib -- -D warnings`; `vp fmt` / `vp check --fix`; `node scripts/check-file-lines.ts --base prod/main`.
- [x] Manual verification completed: not a visual layout change; assertions cover script `src` absence on bare/plain pages and tabs chunk emission only when groups sync.
- [x] Edge cases or failure modes considered: static tabs without JS; search chunk written but not preloaded; Code Play omitted on pages without widgets; header/reader chrome omitted when unused; mermaid/islands never enter the SSG core blob.

## Release and docs checklist

- [x] Documentation, comments, or runbooks updated, or not needed. Runtime split is internal; no new user-facing option.
- [x] Configuration, migration, or environment changes documented, or not needed.
- [x] Observability, logging, and alerting impact considered, or not needed.
- [x] Security, privacy, and dependency impact considered, or not needed. Controls stay disabled/inert until hydrated so they are not keyboard-usable before listeners attach.


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790331115&installation_model_id=422833&pr_number=1010&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1010&signature=27c534ed16f4df19b14a4920d5d7853ded265897fa0287a99742a50d25dc9a06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->