### PR TITLE
feat(code-play): polish GA authoring and runtime states

### DIFF
--- a/docs/content/examples/code-play.md
+++ b/docs/content/examples/code-play.md
@@ -7,6 +7,8 @@ description: Opt-in on-demand sample execution with stdio, stderr, config, prove
 
 This page uses `@ox-content/code-play` with **JavaScript** and **TypeScript**
 enabled. Other languages stay ordinary fences until a site opts them in.
+Routes without a `play` fence stay ordinary docs pages and do not load
+`ox-code-play.js`.
 
 A copy-paste Vite app lives at
 [`examples/code-play`](https://github.com/ubugeeei-prod/ox-content/tree/main/examples/code-play)
@@ -42,15 +44,26 @@ TypeScript by stripping types into the sandbox iframe. The stdio, stderr,
 config, provenance, and timing tabs are the same objects the headless API
 returns. `console.warn` lands in `run.stderr`.
 
-```ts play typecheck
+```ts play typecheck play-title="Strict TypeScript" play-target=ESNext
 const message: string = "hello from Code Play";
 console.log(message);
 console.warn("this warning is a stderr chunk");
 ```
 
+## Per-sample config
+
+`play-<config-key>=...` overrides the language config for one sample. This
+sample intentionally disables strict TypeScript checking while keeping the
+page-level defaults strict.
+
+```ts play typecheck play-title="Loose TypeScript" play-strict=false play-compact
+const label = "works without an explicit type annotation";
+console.log(label.toUpperCase());
+```
+
 ## Live JavaScript sample
 
-```js play
+```js play play-title="JavaScript sum"
 function add(left, right) {
   return left + right;
 }
@@ -64,7 +77,7 @@ During `vite dev`, **Typecheck** should fail on this sample. On a published
 page the button is omitted unless `endpoints.typecheck` is set. **Run** still
 executes after types are stripped, so execute and type-check stay separate.
 
-```ts play typecheck
+```ts play typecheck play-title="Typecheck failure"
 const n: number = "not a number";
 console.log(n);
 ```
@@ -74,7 +87,7 @@ console.log(n);
 `throw` becomes a diagnostic and a stderr chunk. The stderr tab opens when the
 run produces stderr or an error diagnostic.
 
-```js play
+```js play play-title="Runtime error"
 console.log("before");
 throw new Error("boom from the example");
 ```
@@ -99,6 +112,8 @@ result.provenance.execute;
 result.timing.phases;
 ```
 
+`RunActionState` helpers model idle, running, result, error, and offline states
+for custom UIs. Transport/CORS failures return `status: "offline"`.
 `ui: "compact"` hides the tab list and keeps stdio plus stderr. `ui: "headless"`
 renders no chrome — use `createCodePlay()` from your own UI.
 

--- a/docs/content/ja/examples/code-play.md
+++ b/docs/content/ja/examples/code-play.md
@@ -1,0 +1,80 @@
+---
+title: Code Play
+description: stdio、stderr、config、provenance、timing ビューアー付きのオンデマンドサンプル実行です。
+---
+
+# Code Play
+
+このページは `@ox-content/code-play` で **JavaScript** と **TypeScript** だけを有効にします。
+Code Play がないページは通常の docs ページのままで、`ox-code-play.js` を読み込みません。
+
+## プラグインを有効にする
+
+```ts
+import { oxContent } from "@ox-content/vite-plugin";
+import { codePlay } from "@ox-content/code-play";
+
+export default {
+  plugins: [
+    oxContent({ highlight: true }),
+    codePlay({
+      languages: {
+        javascript: true,
+        typescript: { execute: true, typecheck: true },
+      },
+      ui: "default",
+      viewers: { config: true, stdio: true, stderr: true, provenance: true, timing: true },
+    }),
+  ],
+};
+```
+
+## TypeScript サンプル
+
+```ts play typecheck play-title="Strict TypeScript" play-target=ESNext
+const message: string = "hello from Code Play";
+console.log(message);
+console.warn("this warning is a stderr chunk");
+```
+
+## サンプルごとの config
+
+`play-<config-key>=...` は、そのサンプルだけ言語 config を上書きします。
+
+```ts play typecheck play-title="Loose TypeScript" play-strict=false play-compact
+const label = "works without an explicit type annotation";
+console.log(label.toUpperCase());
+```
+
+## 実行時エラー
+
+```js play play-title="Runtime error"
+console.log("before");
+throw new Error("boom from the example");
+```
+
+## Headless usage
+
+```ts
+import { createCodePlay } from "@ox-content/code-play";
+
+const play = createCodePlay({ languages: { typescript: true } });
+const session = play.createSession({
+  language: "ts",
+  code: "const n: number = 1;",
+});
+
+const result = await session.run();
+result.stdio;
+result.stdout;
+result.stderr;
+result.provenance.compile;
+result.provenance.execute;
+result.timing.phases;
+```
+
+`RunActionState` ヘルパーは idle、running、result、error、offline を表します。
+transport / CORS の失敗は `status: "offline"` です。
+
+詳しくは [@ox-content/code-play](/packages/code-play.md) と
+[ロードマップ](/code-play-roadmap.md) を見てください。

--- a/docs/content/ja/packages/code-play.md
+++ b/docs/content/ja/packages/code-play.md
@@ -40,6 +40,8 @@ export default {
 
 このプラグインは、パッケージインストールの上に乗る二段目のオプトインです。
 `play` のないフェンス、または一覧にない言語は、普通のハイライト付きブロックのままです。
+Code Play ブロックがないページには hydrate スクリプトは入りません。
+ビルド全体で Code Play を使わない場合は `ox-code-play.js` も出力されません。
 
 ## プラグインオプション
 
@@ -64,22 +66,31 @@ export default {
 フェンスに `play` を付けます。言語が対応しているときは `typecheck` も足せます。
 
 ````md
-```ts play
+```ts play typecheck play-title="Strict TypeScript" play-strict=false play-target=ESNext
 const n: number = 1;
 console.log(n);
 ```
 
-```rust play typecheck
+```rust play typecheck play-title="Release-mode Rust" play-mode=release
 fn main() {
     println!("ok");
 }
 ```
 ````
 
+`play-title` はウィジェットのラベルです。`play-compact` / `play-headless` は
+そのサンプルだけ UI プリセットを変え、`play-timeout=2500` はタイムアウトを変えます。
+`play-viewers=stdio,stderr,-timing` でビューアーを切り替えられます。
+`play-<config-key>=...` は言語ごとの config 値なので、TypeScript は
+`play-strict=false`、Rust は `play-edition=2021`、Go は `play-withVet=false`
+のように書けます。
+
 HTML / MDX 形式:
 
 ```html
-<CodePlay lang="python"> print("hello") </CodePlay>
+<CodePlay lang="ts" title="Loose TS" typecheck ui="compact" config-strict="false">
+  const n = 1;
+</CodePlay>
 ```
 
 ## Headless API
@@ -111,18 +122,23 @@ session.config; // editable language config
 テストでは `transport`（たとえば `createMemoryTransport`）を注入し、
 CI がライブのプレイグラウンドに触れないようにします。
 
-| フィールド        | 意味                                                        |
-| ----------------- | ----------------------------------------------------------- |
-| `run.status`      | `ok` / `error` / `timeout` / `cancelled` / `unsupported`    |
-| `run.stdio`       | タイムスタンプ付きの `stdin` / `stdout` / `stderr` イベント |
-| `run.stdout`      | 連結した stdout テキスト                                    |
-| `run.stderr`      | 連結した stderr テキスト                                    |
-| `run.diagnostics` | 任意の行 / 列付きのコンパイラ / ランタイムメッセージ        |
-| `run.provenance`  | どこでコンパイルし、どこで実行したか                        |
-| `run.timing`      | フェーズ時間と `totalMs`                                    |
-| `run.preview`     | バックエンドが UI のときのフレームワーク iframe `srcdoc`    |
-| `session.stdout`  | `lastResult.stdout` と同じ                                  |
-| `session.stderr`  | `lastResult.stderr` と同じ                                  |
+| フィールド        | 意味                                                                 |
+| ----------------- | -------------------------------------------------------------------- |
+| `run.status`      | `ok` / `error` / `offline` / `timeout` / `cancelled` / `unsupported` |
+| `run.stdio`       | タイムスタンプ付きの `stdin` / `stdout` / `stderr` イベント          |
+| `run.stdout`      | 連結した stdout テキスト                                             |
+| `run.stderr`      | 連結した stderr テキスト                                             |
+| `run.diagnostics` | 任意の行 / 列付きのコンパイラ / ランタイムメッセージ                 |
+| `run.provenance`  | どこでコンパイルし、どこで実行したか                                 |
+| `run.timing`      | フェーズ時間と `totalMs`                                             |
+| `run.preview`     | バックエンドが UI のときのフレームワーク iframe `srcdoc`             |
+| `session.stdout`  | `lastResult.stdout` と同じ                                           |
+| `session.stderr`  | `lastResult.stderr` と同じ                                           |
+
+独自 UI では、export されている `RunActionState` ヘルパー
+`idleRunActionState()`、`runningRunActionState(action)`、
+`resultRunActionState(action, result)` を使えます。transport や CORS の失敗は
+`status: "offline"` になり、コンパイル / ランタイムエラーとは別に扱えます。
 
 ## UI
 
@@ -132,7 +148,8 @@ CI がライブのプレイグラウンドに触れないようにします。
 | `compact`  | Run / type-check と stdio、stderr                               |
 | `headless` | DOM クロムなし。セッション API を使う                           |
 
-ビューアーは `viewers` で個別に切り替えられます。
+ビューアーは `viewers` で個別に切り替えられます。hydrate 後のウィジェットは
+polite なステータス領域、`aria-busy`、tab panel、矢印キーによるタブ移動を提供します。
 
 ## 言語
 

--- a/docs/content/packages/code-play.md
+++ b/docs/content/packages/code-play.md
@@ -41,6 +41,8 @@ export default {
 The plugin is a second opt-in layer on top of the package install. A fence
 without `play`, or a language that is not listed, stays an ordinary highlighted
 block.
+Pages without a matching Code Play block do not receive the hydration script,
+and builds that never use Code Play do not emit `ox-code-play.js`.
 
 ## Plugin options
 
@@ -65,22 +67,31 @@ block.
 Mark a fence with `play`. Add `typecheck` when the language supports it.
 
 ````md
-```ts play
+```ts play typecheck play-title="Strict TypeScript" play-strict=false play-target=ESNext
 const n: number = 1;
 console.log(n);
 ```
 
-```rust play typecheck
+```rust play typecheck play-title="Release-mode Rust" play-mode=release
 fn main() {
     println!("ok");
 }
 ```
 ````
 
+`play-title` labels the widget. `play-compact` / `play-headless` override
+the UI preset for one sample, `play-timeout=2500` overrides the timeout, and
+`play-viewers=stdio,stderr,-timing` toggles viewers. `play-<config-key>=...`
+sets one language config value for that sample, so TypeScript can use
+`play-strict=false`, Rust can use `play-edition=2021`, and Go can use
+`play-withVet=false`.
+
 HTML / MDX form:
 
 ```html
-<CodePlay lang="python"> print("hello") </CodePlay>
+<CodePlay lang="ts" title="Loose TS" typecheck ui="compact" config-strict="false">
+  const n = 1;
+</CodePlay>
 ```
 
 ## Headless API
@@ -112,18 +123,24 @@ returns `status: "cancelled"`. The default toolbar shows **Cancel** while a
 run is busy. Inject `transport` (for example `createMemoryTransport`) in
 tests so CI never hits a live playground.
 
-| Field             | Meaning                                                  |
-| ----------------- | -------------------------------------------------------- |
-| `run.status`      | `ok` / `error` / `timeout` / `cancelled` / `unsupported` |
-| `run.stdio`       | Timestamped `stdin` / `stdout` / `stderr` events         |
-| `run.stdout`      | Concatenated stdout text                                 |
-| `run.stderr`      | Concatenated stderr text                                 |
-| `run.diagnostics` | Compiler / runtime messages with optional line/col       |
-| `run.provenance`  | Where it compiled and where it ran                       |
-| `run.timing`      | Phase durations and `totalMs`                            |
-| `run.preview`     | Framework iframe `srcdoc` when the backend is UI         |
-| `session.stdout`  | Same as `lastResult.stdout`                              |
-| `session.stderr`  | Same as `lastResult.stderr`                              |
+| Field             | Meaning                                                              |
+| ----------------- | -------------------------------------------------------------------- |
+| `run.status`      | `ok` / `error` / `offline` / `timeout` / `cancelled` / `unsupported` |
+| `run.stdio`       | Timestamped `stdin` / `stdout` / `stderr` events                     |
+| `run.stdout`      | Concatenated stdout text                                             |
+| `run.stderr`      | Concatenated stderr text                                             |
+| `run.diagnostics` | Compiler / runtime messages with optional line/col                   |
+| `run.provenance`  | Where it compiled and where it ran                                   |
+| `run.timing`      | Phase durations and `totalMs`                                        |
+| `run.preview`     | Framework iframe `srcdoc` when the backend is UI                     |
+| `session.stdout`  | Same as `lastResult.stdout`                                          |
+| `session.stderr`  | Same as `lastResult.stderr`                                          |
+
+Custom UIs can use the exported `RunActionState` helpers:
+`idleRunActionState()`, `runningRunActionState(action)`, and
+`resultRunActionState(action, result)`. Transport and CORS failures use
+`status: "offline"` so they can be styled separately from compiler/runtime
+errors.
 
 ## UI
 
@@ -133,7 +150,9 @@ tests so CI never hits a live playground.
 | `compact`  | Run / type-check plus stdio and stderr                          |
 | `headless` | No DOM chrome; use the session API                              |
 
-Viewers can be toggled independently through `viewers`.
+Viewers can be toggled independently through `viewers`. The hydrated widget
+exposes a polite status region, `aria-busy`, tab panels, and arrow-key tab
+navigation.
 
 ## Languages
 

--- a/examples/code-play/README.md
+++ b/examples/code-play/README.md
@@ -16,6 +16,9 @@ corepack pnpm --filter ./examples/code-play build
 corepack pnpm --filter ./examples/code-play preview
 ```
 
+After `build`, `dist/plain.html` should not contain `ox-code-play.js`; only
+routes with `play` fences load the runtime.
+
 The plugin never executes samples during Markdown transform or SSG. Readers
 trigger **Run** in the browser. TypeScript **Typecheck** needs the Vite dev
 proxy or a reachable `endpoints.typecheck`.

--- a/examples/code-play/content/index.md
+++ b/examples/code-play/content/index.md
@@ -9,13 +9,20 @@ This site enables **JavaScript** and **TypeScript** only. Mark a fence with
 `play`. **Typecheck** shows during `vite dev`, or on a published page if you
 set `endpoints.typecheck`.
 
-```ts play typecheck
+See the [plain page](./plain.md) for a route with no Code Play runtime.
+
+```ts play typecheck play-title="Strict TypeScript" play-target=ESNext
 const message: string = "hello from examples/code-play";
 console.log(message);
 console.warn("stderr from console.warn");
 ```
 
-```js play
+```ts play typecheck play-title="Loose TypeScript" play-strict=false play-compact
+const label = "per-sample config";
+console.log(label);
+```
+
+```js play play-title="JavaScript sum"
 console.log(2 + 40);
 ```
 

--- a/examples/code-play/content/plain.md
+++ b/examples/code-play/content/plain.md
@@ -1,0 +1,14 @@
+---
+title: Plain example page
+description: Route without Code Play blocks.
+---
+
+# Plain example page
+
+This route has no `play` fences. Its built HTML should not include
+`ox-code-play.js`.
+
+```ts
+const highlightedOnly = true;
+console.log(highlightedOnly);
+```

--- a/npm/ox-content-code-play/README.md
+++ b/npm/ox-content-code-play/README.md
@@ -4,6 +4,7 @@ Opt-in Code Play plugin for Ox Content. It runs documentation samples on demand
 and exposes a headless API plus Headless / preset UI.
 
 Nothing runs until you install this package **and** enable specific languages.
+Pages without matching `play` blocks do not load `ox-code-play.js`.
 
 ## Install
 
@@ -33,20 +34,27 @@ export default {
 ## Authoring
 
 ````md
-```ts play
+```ts play typecheck play-title="Strict TypeScript" play-strict=false play-target=ESNext
 const n: number = 1;
 console.log(n);
 ```
 
-```rust play typecheck
+```rust play typecheck play-title="Release-mode Rust" play-mode=release
 fn main() {
     println!("ok");
 }
 ```
 ````
 
+Use `play-title`, `play-compact` / `play-headless`, `play-timeout=2500`,
+`play-viewers=stdio,stderr,-timing`, and `play-<config-key>=...` for one
+sample. The MDX-style `<CodePlay>` tag accepts `title`, `ui`, `timeout`,
+`viewers`, and `config-*` attributes.
+
 ```html
-<CodePlay lang="python"> print("hello") </CodePlay>
+<CodePlay lang="ts" title="Loose TS" typecheck ui="compact" config-strict="false">
+  const n = 1;
+</CodePlay>
 ```
 
 ## Headless API
@@ -65,6 +73,10 @@ run.stderr;
 run.provenance;
 run.timing;
 ```
+
+`run.status` is `ok`, `error`, `offline`, `timeout`, `cancelled`, or
+`unsupported`. Custom UIs can use the exported `RunActionState` helpers to
+model idle, running, result, error, and offline states.
 
 ## Security
 

--- a/npm/ox-content-code-play/src/authoring.ts
+++ b/npm/ox-content-code-play/src/authoring.ts
@@ -1,0 +1,220 @@
+import type { CodePlayPreset, ViewerFlags } from "./types";
+
+export interface ParsedPlayOptions {
+  typecheck: boolean;
+  title?: string;
+  config: Record<string, unknown>;
+  ui?: CodePlayPreset;
+  viewers?: Partial<ViewerFlags>;
+  timeoutMs?: number;
+}
+
+export function parsePlayMeta(meta: string): ParsedPlayOptions {
+  const options = emptyPlayOptions();
+  for (const token of splitPlayInfo(meta)) {
+    if (token === "typecheck") {
+      options.typecheck = true;
+      continue;
+    }
+    if (token === "play-compact") {
+      options.ui = "compact";
+      continue;
+    }
+    if (token === "play-headless") {
+      options.ui = "headless";
+      continue;
+    }
+    const pair = readTokenPair(token);
+    if (!pair) {
+      continue;
+    }
+    applyPlayOption(options, pair.name, pair.value);
+  }
+  return options;
+}
+
+export function parseCodePlayAttributes(attrs: string): ParsedPlayOptions {
+  const options = emptyPlayOptions();
+  for (const [name, value] of readAttributes(attrs)) {
+    if (name === "typecheck") {
+      options.typecheck = value !== "false";
+      continue;
+    }
+    if (name === "title") {
+      options.title = value;
+      continue;
+    }
+    if (name === "ui") {
+      options.ui = parseUi(value);
+      continue;
+    }
+    if (name === "timeout" || name === "timeout-ms" || name === "timeoutms") {
+      options.timeoutMs = parsePositiveInt(value);
+      continue;
+    }
+    if (name === "viewers") {
+      options.viewers = parseViewers(value);
+      continue;
+    }
+    if (name.startsWith("config-")) {
+      options.config[configKeyFromAttribute(name.slice("config-".length))] =
+        coerceOptionValue(value);
+    }
+  }
+  return options;
+}
+
+export function readCodePlayAttribute(attrs: string, name: string): string | undefined {
+  return readAttributes(attrs).get(name.toLowerCase());
+}
+
+export function splitPlayInfo(info: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+  for (const char of info.trim()) {
+    if (escaped) {
+      current += `\\${char}`;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        current += char;
+        quote = undefined;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      current += char;
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (current) {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
+function emptyPlayOptions(): ParsedPlayOptions {
+  return { typecheck: false, config: {} };
+}
+
+function applyPlayOption(options: ParsedPlayOptions, rawName: string, value: string): void {
+  const name = rawName.toLowerCase();
+  if (name === "play-title") {
+    options.title = value;
+    return;
+  }
+  if (name === "play-ui") {
+    options.ui = parseUi(value);
+    return;
+  }
+  if (name === "play-timeout" || name === "play-timeout-ms" || name === "play-timeoutms") {
+    options.timeoutMs = parsePositiveInt(value);
+    return;
+  }
+  if (name === "play-viewers") {
+    options.viewers = parseViewers(value);
+    return;
+  }
+  const configKey =
+    name.startsWith("play-config:") || name.startsWith("play-config.")
+      ? rawName.slice("play-config:".length)
+      : name.startsWith("play-")
+        ? rawName.slice("play-".length)
+        : "";
+  if (configKey) {
+    options.config[configKey] = coerceOptionValue(value);
+  }
+}
+
+function readTokenPair(token: string): { name: string; value: string } | undefined {
+  const index = token.indexOf("=");
+  if (index === -1) {
+    return undefined;
+  }
+  return { name: token.slice(0, index), value: unquote(token.slice(index + 1)) };
+}
+
+function readAttributes(attrs: string): Map<string, string> {
+  const values = new Map<string, string>();
+  const pattern = /([:\w-]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+)))?/g;
+  for (const match of attrs.matchAll(pattern)) {
+    const name = match[1]?.toLowerCase();
+    if (!name) {
+      continue;
+    }
+    values.set(name, match[2] ?? match[3] ?? match[4] ?? "true");
+  }
+  return values;
+}
+
+function parseUi(value: string): CodePlayPreset | undefined {
+  return value === "default" || value === "compact" || value === "headless" ? value : undefined;
+}
+
+function parsePositiveInt(value: string): number | undefined {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseViewers(value: string): Partial<ViewerFlags> | undefined {
+  const viewers: Partial<ViewerFlags> = {};
+  for (const token of value.split(",")) {
+    const trimmed = token.trim();
+    const enabled = !trimmed.startsWith("-");
+    const key = (enabled ? trimmed : trimmed.slice(1)) as keyof ViewerFlags;
+    if (
+      key === "config" ||
+      key === "stdio" ||
+      key === "stderr" ||
+      key === "provenance" ||
+      key === "timing"
+    ) {
+      viewers[key] = enabled;
+    }
+  }
+  return Object.keys(viewers).length > 0 ? viewers : undefined;
+}
+
+function coerceOptionValue(value: string): string | number | boolean {
+  if (value === "true") {
+    return true;
+  }
+  if (value === "false") {
+    return false;
+  }
+  const numeric = Number(value);
+  return value.trim() !== "" && Number.isFinite(numeric) ? numeric : value;
+}
+
+function configKeyFromAttribute(value: string): string {
+  return value.replace(/-([a-z])/g, (_, char: string) => char.toUpperCase());
+}
+
+function unquote(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}

--- a/npm/ox-content-code-play/src/client.test.ts
+++ b/npm/ox-content-code-play/src/client.test.ts
@@ -132,7 +132,7 @@ describe("createCodePlay", () => {
   it("explains browser CORS failures instead of a raw fetch TypeError", () => {
     const error = new TypeError("Failed to fetch");
     expect(friendlyTransportMessage(error)).toMatch(/CORS/);
-    expect(friendlyTransportMessage(new Error("offline"))).toBe("offline");
+    expect(friendlyTransportMessage(new Error("syntax error"))).toBe("syntax error");
   });
 
   it("does not run JavaScript through page-origin Function", () => {
@@ -148,7 +148,7 @@ describe("createCodePlay", () => {
     expect(resolveTypecheckBackend(false, undefined)).toBe("unavailable");
   });
 
-  it("turns transport throws into error results instead of rejecting", async () => {
+  it("turns transport throws into offline results instead of rejecting", async () => {
     const play = createCodePlay({
       languages: { rust: true },
       transport: createMemoryTransport(() => {
@@ -156,8 +156,8 @@ describe("createCodePlay", () => {
       }),
     });
     const result = await play.createSession({ language: "rust", code: "fn main() {}" }).run();
-    expect(result.status).toBe("error");
-    expect(result.diagnostics[0]?.message).toBe("offline");
+    expect(result.status).toBe("offline");
+    expect(result.diagnostics[0]?.message).toMatch(/offline|unreachable/i);
   });
 
   it("explains a missing static-host typecheck endpoint", () => {

--- a/npm/ox-content-code-play/src/html.ts
+++ b/npm/ox-content-code-play/src/html.ts
@@ -1,6 +1,7 @@
 import { resolveLanguage } from "./catalog";
 import { DEFAULT_ENDPOINTS, DEFAULT_VIEWERS } from "./config";
 import { decodeHtml, escapeAttribute } from "./escape";
+import { parseCodePlayAttributes } from "./markdown";
 import { payloadTypecheckEnabled } from "./payload-factory";
 import type { PlaygroundEndpoints, PlayPayload } from "./types";
 
@@ -65,22 +66,19 @@ function upgradeCodePlayTags(html: string, options: HtmlEnhanceOptions): string 
     const code = decodeHtml(body).replace(/^\n/, "").replace(/\n$/, "");
     const definition = resolveLanguage(language);
     const endpoints = options.endpoints ?? DEFAULT_ENDPOINTS;
+    const playOptions = parseCodePlayAttributes(attrs);
     const payload = options.encodePayload({
       language: definition?.id ?? language,
       code,
+      title: playOptions.title,
       capabilities: {
         execute: true,
-        typecheck: payloadTypecheckEnabled(
-          /\btypecheck\b/i.test(attrs),
-          undefined,
-          definition,
-          endpoints,
-        ),
+        typecheck: payloadTypecheckEnabled(playOptions.typecheck, undefined, definition, endpoints),
       },
-      config: {},
-      viewers: { ...DEFAULT_VIEWERS },
-      ui: "default",
-      timeoutMs: 10_000,
+      config: { ...definition?.defaultConfig, ...playOptions.config },
+      viewers: { ...DEFAULT_VIEWERS, ...playOptions.viewers },
+      ui: playOptions.ui ?? "default",
+      timeoutMs: playOptions.timeoutMs ?? 10_000,
       endpoints,
     });
     return wrapWidget(

--- a/npm/ox-content-code-play/src/hydrate-action.test.ts
+++ b/npm/ox-content-code-play/src/hydrate-action.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vite-plus/test";
-import { readPlayPayload, runPlayAction } from "./hydrate-action";
+import {
+  idleRunActionState,
+  readPlayPayload,
+  resultRunActionState,
+  runningRunActionState,
+  runPlayAction,
+} from "./hydrate-action";
 import { resultPanelToShow } from "./hydrate";
 import { encodePayload } from "./payload";
 import { DEFAULT_VIEWERS } from "./config";
@@ -57,6 +63,26 @@ describe("runPlayAction", () => {
     expect(setBusy.mock.calls.map((call) => call[0])).toEqual([true, false]);
     expect(errors).toHaveLength(1);
     expect(errors[0]).toBeInstanceOf(Error);
+  });
+});
+
+describe("run action states", () => {
+  it("models idle, running, ok, offline, and cancelled states", () => {
+    expect(idleRunActionState()).toEqual({ phase: "idle" });
+    expect(runningRunActionState("execute", 12)).toEqual({
+      phase: "running",
+      action: "execute",
+      startedAtMs: 12,
+    });
+    expect(resultRunActionState("execute", errorResult("ok", "code-play", "ok"), 20)).toEqual(
+      expect.objectContaining({ phase: "result", action: "execute", finishedAtMs: 20 }),
+    );
+    expect(
+      resultRunActionState("execute", errorResult("offline", "code-play", "offline"), 20),
+    ).toEqual(expect.objectContaining({ phase: "offline", message: "offline" }));
+    expect(
+      resultRunActionState("execute", errorResult("Run cancelled.", "code-play", "cancelled"), 20),
+    ).toEqual(expect.objectContaining({ phase: "result", message: "Run cancelled." }));
   });
 });
 

--- a/npm/ox-content-code-play/src/hydrate-action.ts
+++ b/npm/ox-content-code-play/src/hydrate-action.ts
@@ -1,5 +1,6 @@
 import { decodePayload } from "./payload";
-import type { PlayPayload, RunResult } from "./types";
+import { errorMessage } from "./result";
+import type { PlayPayload, RunAction, RunActionState, RunResult } from "./types";
 
 export function readPlayPayload(encoded: string): PlayPayload | undefined {
   try {
@@ -23,4 +24,45 @@ export async function runPlayAction(input: {
   } finally {
     input.setBusy(false);
   }
+}
+
+export function idleRunActionState(): RunActionState {
+  return { phase: "idle" };
+}
+
+export function runningRunActionState(action: RunAction, startedAtMs = Date.now()): RunActionState {
+  return { phase: "running", action, startedAtMs };
+}
+
+export function resultRunActionState(
+  action: RunAction,
+  result: RunResult,
+  finishedAtMs = Date.now(),
+): RunActionState {
+  const phase =
+    result.status === "offline"
+      ? "offline"
+      : result.status === "ok" || result.status === "cancelled"
+        ? "result"
+        : "error";
+  return {
+    phase,
+    action,
+    result,
+    message: result.diagnostics[0]?.message,
+    finishedAtMs,
+  };
+}
+
+export function errorRunActionState(
+  action: RunAction,
+  error: unknown,
+  finishedAtMs = Date.now(),
+): RunActionState {
+  return {
+    phase: "error",
+    action,
+    message: errorMessage(error),
+    finishedAtMs,
+  };
 }

--- a/npm/ox-content-code-play/src/hydrate.ts
+++ b/npm/ox-content-code-play/src/hydrate.ts
@@ -1,11 +1,24 @@
 import { createCodePlay, type CodePlayClient } from "./client";
-import { readPlayPayload, runPlayAction } from "./hydrate-action";
+import {
+  errorRunActionState,
+  readPlayPayload,
+  resultRunActionState,
+  runningRunActionState,
+  runPlayAction,
+} from "./hydrate-action";
 import { decodePayload, encodePayload } from "./payload";
 import { errorMessage, errorResult } from "./result";
 import { CODE_PLAY_STYLES } from "./styles";
 import { JS_SANDBOX_FLAGS } from "./javascript-sandbox";
-import { applyActionBusy, renderPlayUi } from "./ui";
-import type { LanguageEnable, LanguageEnableOptions, PlayPayload, RunResult } from "./types";
+import { applyActionBusy, renderPlayUi, renderRunStatusText } from "./ui";
+import type {
+  LanguageEnable,
+  LanguageEnableOptions,
+  PlayPayload,
+  RunAction,
+  RunActionState,
+  RunResult,
+} from "./types";
 import {
   renderDiagnosticsHtml,
   renderProvenanceHtml,
@@ -20,6 +33,7 @@ export interface HydrateOptions {
 }
 
 const STYLE_ID = "ox-code-play-styles";
+let widgetId = 0;
 
 export function hydrateCodePlay(
   root: ParentNode = defaultRoot(),
@@ -65,6 +79,7 @@ export function mountCodePlay(element: Element, options: { client?: CodePlayClie
   element.dataset.oxCodePlayMounted = "true";
   element.removeAttribute("inert");
   bindWidget(element, payload, client);
+  prepareA11y(element);
 }
 
 function bindWidget(element: HTMLElement, payload: PlayPayload, client: CodePlayClient): void {
@@ -80,6 +95,11 @@ function bindWidget(element: HTMLElement, payload: PlayPayload, client: CodePlay
   runButton?.addEventListener("click", () => void run("execute"));
   checkButton?.addEventListener("click", () => void run("typecheck"));
   cancelButton?.addEventListener("click", () => session.cancel());
+  element.addEventListener("keydown", (event) => {
+    if (event.target instanceof HTMLElement && event.target.matches('[role="tab"]')) {
+      handleTabKeydown(element, event);
+    }
+  });
   element.addEventListener("click", (event) => {
     const target = event.target;
     if (!(target instanceof HTMLElement)) {
@@ -99,17 +119,31 @@ function bindWidget(element: HTMLElement, payload: PlayPayload, client: CodePlay
     current = { ...current, config: session.config };
   });
 
-  async function run(action: "execute" | "typecheck"): Promise<void> {
+  async function run(action: RunAction): Promise<void> {
     await runPlayAction({
       action: () => (action === "typecheck" ? session.typecheck() : session.run()),
-      setBusy: (busy) => applyActionBusy(element, busy),
-      onResult: (result) => paintResult(element, current, result),
-      onError: (error) => paintResult(element, current, errorResult(errorMessage(error))),
+      setBusy: (busy) => {
+        applyActionBusy(element, busy);
+        if (busy) {
+          paintRunState(element, runningRunActionState(action));
+        }
+      },
+      onResult: (result) => paintResult(element, current, result, action),
+      onError: (error) => {
+        paintRunState(element, errorRunActionState(action, error));
+        paintResult(element, current, errorResult(errorMessage(error)), action);
+      },
     });
   }
 }
 
-function paintResult(element: HTMLElement, _payload: PlayPayload, result: RunResult): void {
+function paintResult(
+  element: HTMLElement,
+  _payload: PlayPayload,
+  result: RunResult,
+  action: RunAction,
+): void {
+  paintRunState(element, resultRunActionState(action, result));
   const stdio = element.querySelector('[data-panel="stdio"]');
   if (stdio) {
     stdio.innerHTML = `${renderDiagnosticsHtml(result)}${renderStdioHtml(result.stdio)}`;
@@ -139,6 +173,16 @@ function paintResult(element: HTMLElement, _payload: PlayPayload, result: RunRes
   showPanel(element, resultPanelToShow(result, Boolean(stderr)));
 }
 
+function paintRunState(element: HTMLElement, state: RunActionState): void {
+  const widget = element.querySelector<HTMLElement>(".ox-code-play");
+  widget?.setAttribute("data-ox-run-state", state.phase);
+  widget?.setAttribute("aria-busy", state.phase === "running" ? "true" : "false");
+  const status = element.querySelector<HTMLElement>("[data-ox-status]");
+  if (status) {
+    status.textContent = renderRunStatusText(state);
+  }
+}
+
 export function resultPanelToShow(result: RunResult, hasStderrPanel: boolean): "stderr" | "stdio" {
   if (!hasStderrPanel) {
     return "stdio";
@@ -155,10 +199,9 @@ export function resultPanelToShow(result: RunResult, hasStderrPanel: boolean): "
 function showPanel(element: HTMLElement, panel: string): void {
   const compact = Boolean(element.querySelector(".ox-code-play--compact"));
   for (const tab of element.querySelectorAll("[data-ox-panel]")) {
-    tab.setAttribute(
-      "aria-selected",
-      tab.getAttribute("data-ox-panel") === panel ? "true" : "false",
-    );
+    const selected = tab.getAttribute("data-ox-panel") === panel;
+    tab.setAttribute("aria-selected", selected ? "true" : "false");
+    (tab as HTMLElement).tabIndex = selected ? 0 : -1;
   }
   for (const node of element.querySelectorAll<HTMLElement>(".ox-code-play__panel")) {
     const id = node.dataset.panel;
@@ -167,6 +210,57 @@ function showPanel(element: HTMLElement, panel: string): void {
       continue;
     }
     node.hidden = id !== panel;
+  }
+}
+
+function handleTabKeydown(element: HTMLElement, event: KeyboardEvent): void {
+  if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) {
+    return;
+  }
+  const tabs = [...element.querySelectorAll<HTMLElement>("[data-ox-panel]")];
+  const current = tabs.indexOf(event.target as HTMLElement);
+  if (current === -1) {
+    return;
+  }
+  event.preventDefault();
+  const nextIndex =
+    event.key === "Home"
+      ? 0
+      : event.key === "End"
+        ? tabs.length - 1
+        : event.key === "ArrowRight"
+          ? (current + 1) % tabs.length
+          : (current - 1 + tabs.length) % tabs.length;
+  const next = tabs[nextIndex];
+  const panel = next?.dataset.oxPanel;
+  if (!next || !panel) {
+    return;
+  }
+  showPanel(element, panel);
+  next.focus();
+}
+
+function prepareA11y(element: HTMLElement): void {
+  const widget = element.querySelector<HTMLElement>(".ox-code-play");
+  if (!widget) {
+    return;
+  }
+  if (!widget.id) {
+    widget.id = `ox-code-play-${++widgetId}`;
+  }
+  for (const tab of element.querySelectorAll<HTMLElement>("[data-ox-panel]")) {
+    const panelName = tab.dataset.oxPanel;
+    const panel = panelName
+      ? element.querySelector<HTMLElement>(`[data-panel="${panelName}"]`)
+      : null;
+    if (!panelName || !panel) {
+      continue;
+    }
+    tab.id ||= `${widget.id}-${panelName}-tab`;
+    panel.id ||= `${widget.id}-${panelName}-panel`;
+    tab.setAttribute("aria-controls", panel.id);
+    panel.setAttribute("aria-labelledby", tab.id);
+    panel.removeAttribute("aria-label");
   }
 }
 

--- a/npm/ox-content-code-play/src/index.ts
+++ b/npm/ox-content-code-play/src/index.ts
@@ -16,7 +16,15 @@ export { joinStream, selectStream, withStdioText } from "./stdio";
 export { createFetchTransport, createMemoryTransport } from "./transport";
 export { bootCodePlay } from "./boot";
 export { hydrateCodePlay, mountCodePlay } from "./hydrate";
-export { renderPlayUi } from "./ui";
+export {
+  errorRunActionState,
+  idleRunActionState,
+  readPlayPayload,
+  resultRunActionState,
+  runningRunActionState,
+  runPlayAction,
+} from "./hydrate-action";
+export { renderPlayUi, renderRunStatusText } from "./ui";
 export {
   renderConfigHtml,
   renderDiagnosticsHtml,
@@ -39,7 +47,11 @@ export type {
   LanguageEnable,
   PlayPayload,
   Provenance,
+  RunAction,
+  RunActionPhase,
+  RunActionState,
   RunResult,
+  RunStatus,
   SessionInput,
   StdioEvent,
   TimingReport,

--- a/npm/ox-content-code-play/src/markdown.test.ts
+++ b/npm/ox-content-code-play/src/markdown.test.ts
@@ -32,6 +32,21 @@ describe("markdown and viewers", () => {
     expect(stripPlayMeta(fences[0]?.meta ?? "")).toBe('annotate="highlight:1"');
   });
 
+  it("parses authoring options without preserving play-only metadata", () => {
+    const source = [
+      '```ts play typecheck play-title="Strict sample" play-compact play-timeout=2500 play-strict=false play-target=ESNext play-viewers=stdio,stderr,-timing annotate="highlight:1"',
+      "const live = 1;",
+      "```",
+    ].join("\n");
+    const fence = parsePlayFences(source)[0];
+    expect(fence?.title).toBe("Strict sample");
+    expect(fence?.ui).toBe("compact");
+    expect(fence?.timeoutMs).toBe(2500);
+    expect(fence?.config).toEqual({ strict: false, target: "ESNext" });
+    expect(fence?.viewers).toEqual({ stdio: true, stderr: true, timing: false });
+    expect(stripPlayMeta(fence?.meta ?? "")).toBe('annotate="highlight:1"');
+  });
+
   it("rewrites play fences to comments and parses CodePlay tags", () => {
     const options = resolveCodePlayOptions({ languages: { typescript: true } });
     const rewritten = rewritePlayFences("```ts play\nconst n = 1;\n```", (fence) =>
@@ -41,7 +56,21 @@ describe("markdown and viewers", () => {
     expect(rewritten).toContain("```ts\nconst n = 1;\n```");
 
     const tags = parseCodePlayTags(`<CodePlay lang="python" typecheck>\nprint(1)\n</CodePlay>`);
-    expect(tags[0]).toMatchObject({ language: "python", typecheck: true, code: "print(1)" });
+    expect(tags[0]).toMatchObject({
+      language: "python",
+      typecheck: true,
+      code: "print(1)",
+      config: {},
+    });
+    const configuredTags = parseCodePlayTags(
+      `<CodePlay lang="ts" title="Loose TS" ui="compact" timeout="3000" config-strict="false" config-with-vet="false">\nconst n = 1\n</CodePlay>`,
+    );
+    expect(configuredTags[0]).toMatchObject({
+      title: "Loose TS",
+      ui: "compact",
+      timeoutMs: 3000,
+      config: { strict: false, withVet: false },
+    });
   });
 
   it("wraps commented pre blocks and matching SSG fences in HTML", () => {
@@ -56,6 +85,7 @@ describe("markdown and viewers", () => {
           start: 0,
           end: 0,
           typecheck: false,
+          config: {},
         },
         options,
       ),
@@ -89,6 +119,7 @@ describe("markdown and viewers", () => {
           start: 0,
           end: 0,
           typecheck: false,
+          config: {},
         },
         resolveCodePlayOptions({ languages: { rust: true } }),
       ),
@@ -150,6 +181,7 @@ describe("markdown and viewers", () => {
         payload: {
           language: "typescript",
           code: "const n = 1;",
+          title: "Strict TS",
           capabilities: { execute: true, typecheck: true },
           config: { strict: true },
           viewers: { ...DEFAULT_VIEWERS },
@@ -158,6 +190,20 @@ describe("markdown and viewers", () => {
         },
       }),
     ).toContain("Typecheck");
+    expect(
+      renderPlayUi({
+        payload: {
+          language: "typescript",
+          code: "const n = 1;",
+          title: "Strict TS",
+          capabilities: { execute: true, typecheck: true },
+          config: { strict: true },
+          viewers: { ...DEFAULT_VIEWERS },
+          ui: "default",
+          timeoutMs: 1000,
+        },
+      }),
+    ).toContain('role="region"');
   });
 
   it("decodes the same payload it encodes", () => {

--- a/npm/ox-content-code-play/src/markdown.ts
+++ b/npm/ox-content-code-play/src/markdown.ts
@@ -1,3 +1,13 @@
+import {
+  parseCodePlayAttributes,
+  parsePlayMeta,
+  readCodePlayAttribute,
+  splitPlayInfo,
+} from "./authoring";
+import type { CodePlayPreset, ViewerFlags } from "./types";
+
+export { parseCodePlayAttributes, parsePlayMeta, type ParsedPlayOptions } from "./authoring";
+
 export interface PlayFence {
   language: string;
   meta: string;
@@ -6,6 +16,11 @@ export interface PlayFence {
   start: number;
   end: number;
   typecheck: boolean;
+  title?: string;
+  config: Record<string, unknown>;
+  ui?: CodePlayPreset;
+  viewers?: Partial<ViewerFlags>;
+  timeoutMs?: number;
 }
 
 export interface ParsedFence {
@@ -39,7 +54,7 @@ export function parseTopLevelFences(source: string): ParsedFence[] {
     const indent = open[1] ?? "";
     const marker = open[2] ?? "```";
     const info = (open[3] ?? "").trim();
-    const [language = "", ...metaParts] = splitInfo(info);
+    const { language, meta } = readFenceInfo(info);
     const start = offset;
     index += 1;
     offset += line.length + 1;
@@ -52,7 +67,7 @@ export function parseTopLevelFences(source: string): ParsedFence[] {
         const raw = `${line}\n${body.join("\n")}${body.length > 0 ? "\n" : ""}${candidate}`;
         fences.push({
           language,
-          meta: metaParts.join(" "),
+          meta,
           code: body.join("\n"),
           raw,
           start,
@@ -76,22 +91,34 @@ export function parseTopLevelFences(source: string): ParsedFence[] {
 export function parsePlayFences(source: string): PlayFence[] {
   return parseTopLevelFences(source)
     .filter((fence) => hasToken(fence.meta, "play"))
-    .map((fence) => ({
-      language: fence.language,
-      meta: fence.meta,
-      code: fence.code,
-      raw: fence.raw,
-      start: fence.start,
-      end: fence.end,
-      typecheck: hasToken(fence.meta, "typecheck"),
-    }));
+    .map((fence) => {
+      const options = parsePlayMeta(fence.meta);
+      return {
+        language: fence.language,
+        meta: fence.meta,
+        code: fence.code,
+        raw: fence.raw,
+        start: fence.start,
+        end: fence.end,
+        typecheck: options.typecheck,
+        title: options.title,
+        config: options.config,
+        ui: options.ui,
+        viewers: options.viewers,
+        timeoutMs: options.timeoutMs,
+      };
+    });
 }
 
 export function stripPlayMeta(meta: string): string {
-  return meta
-    .split(/\s+/)
+  return splitPlayInfo(meta)
     .filter(
-      (token) => token && token !== "play" && token !== "typecheck" && !token.startsWith("play-"),
+      (token) =>
+        token &&
+        token !== "play" &&
+        token !== "typecheck" &&
+        !token.startsWith("play-") &&
+        !token.startsWith("play:"),
     )
     .join(" ");
 }
@@ -128,7 +155,9 @@ export function parseCodePlayTags(source: string): PlayFence[] {
   const pattern = /<CodePlay\b([^>]*)>([\s\S]*?)<\/CodePlay>/gi;
   for (const match of source.matchAll(pattern)) {
     const attrs = match[1] ?? "";
-    const language = readAttr(attrs, "lang") ?? readAttr(attrs, "language") ?? "text";
+    const language =
+      readCodePlayAttribute(attrs, "lang") ?? readCodePlayAttribute(attrs, "language") ?? "text";
+    const options = parseCodePlayAttributes(attrs);
     tags.push({
       language,
       meta: "play",
@@ -136,27 +165,28 @@ export function parseCodePlayTags(source: string): PlayFence[] {
       raw: match[0] ?? "",
       start: match.index ?? 0,
       end: (match.index ?? 0) + (match[0]?.length ?? 0),
-      typecheck: /\btypecheck\b/i.test(attrs),
+      typecheck: options.typecheck,
+      title: options.title,
+      config: options.config,
+      ui: options.ui,
+      viewers: options.viewers,
+      timeoutMs: options.timeoutMs,
     });
   }
   return tags;
 }
 
-function splitInfo(info: string): string[] {
-  return info.trim().split(/\s+/).filter(Boolean);
+function readFenceInfo(info: string): { language: string; meta: string } {
+  const match = /^(\S+)(?:\s+([\s\S]*))?$/.exec(info);
+  return { language: match?.[1] ?? "", meta: match?.[2]?.trim() ?? "" };
 }
 
 function hasToken(meta: string, token: string): boolean {
-  return meta.split(/\s+/).includes(token);
+  return splitPlayInfo(meta).includes(token);
 }
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function readAttr(attrs: string, name: string): string | undefined {
-  const match = new RegExp(`(?:^|\\s)${name}\\s*=\\s*"([^"]+)"`, "i").exec(attrs);
-  return match?.[1];
 }
 
 function stripIndent(value: string): string {

--- a/npm/ox-content-code-play/src/payload-factory.ts
+++ b/npm/ox-content-code-play/src/payload-factory.ts
@@ -9,6 +9,7 @@ export function payloadFromFence(fence: PlayFence, options: ResolvedCodePlayOpti
   const payload: PlayPayload = {
     language: definition?.id ?? fence.language,
     code: fence.code,
+    title: fence.title,
     capabilities: {
       execute: enabled?.execute ?? Boolean(definition?.capabilities.execute),
       typecheck: payloadTypecheckEnabled(
@@ -18,10 +19,10 @@ export function payloadFromFence(fence: PlayFence, options: ResolvedCodePlayOpti
         options.endpoints,
       ),
     },
-    config: { ...definition?.defaultConfig, ...enabled?.config },
-    viewers: options.viewers,
-    ui: options.ui,
-    timeoutMs: options.timeoutMs,
+    config: { ...definition?.defaultConfig, ...enabled?.config, ...fence.config },
+    viewers: { ...options.viewers, ...fence.viewers },
+    ui: fence.ui ?? options.ui,
+    timeoutMs: fence.timeoutMs ?? options.timeoutMs,
     endpoints: options.endpoints,
   };
   if (enabled?.endpoint) {

--- a/npm/ox-content-code-play/src/plugin-assets.ts
+++ b/npm/ox-content-code-play/src/plugin-assets.ts
@@ -1,0 +1,10 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export async function writeClientAsset(outDir: string, source: string | undefined): Promise<void> {
+  if (!source) {
+    return;
+  }
+  await mkdir(outDir, { recursive: true });
+  await writeFile(path.join(outDir, "ox-code-play.js"), source);
+}

--- a/npm/ox-content-code-play/src/plugin-ssg.test.ts
+++ b/npm/ox-content-code-play/src/plugin-ssg.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vite-plus/test";
@@ -65,6 +65,7 @@ describe("codePlay SSG HTML enhance", () => {
     const html = readFileSync(path.join(outDir, "index.html"), "utf8");
     expect(html).not.toContain("ox-code-play.js");
     expect(html).not.toContain("data-ox-code-play");
+    expect(existsSync(path.join(outDir, "ox-code-play.js"))).toBe(false);
   });
 
   it("omits TypeScript typecheck from written SSG payloads without an endpoint", async () => {

--- a/npm/ox-content-code-play/src/plugin.test.ts
+++ b/npm/ox-content-code-play/src/plugin.test.ts
@@ -47,6 +47,32 @@ describe("codePlay vite plugin", () => {
     expect(payload.capabilities.execute).toBe(true);
   });
 
+  it("embeds per-sample authoring options in payloads", () => {
+    const plugin = codePlay({ languages: { typescript: true } });
+    resolveCommand(plugin, "serve");
+    const payload = payloadFromTransform(
+      plugin,
+      '```ts play play-title="Loose sample" play-compact play-timeout=2500 play-strict=false\nconst n = 1;\n```',
+    );
+    expect(payload.title).toBe("Loose sample");
+    expect(payload.ui).toBe("compact");
+    expect(payload.timeoutMs).toBe(2500);
+    expect(payload.config.strict).toBe(false);
+  });
+
+  it("does not request a browser client asset until a play fence is transformed", async () => {
+    const plugin = codePlay({ languages: { javascript: true } });
+    resolveCommand(plugin, "build");
+    const emitted: unknown[] = [];
+    const context = { emitFile: (file: unknown) => emitted.push(file) };
+    await hookFn(plugin.generateBundle).call(context);
+    expect(emitted).toEqual([]);
+    const transform = hookFn(plugin.transform) as (source: string, id: string) => string | null;
+    expect(transform("```js\nconsole.log(1);\n```", "plain.md")).toBeNull();
+    await hookFn(plugin.generateBundle).call(context);
+    expect(emitted).toEqual([]);
+  });
+
   it("keeps the Vite typecheck proxy on the dev server", () => {
     const plugin = codePlay({ languages: { typescript: { execute: true, typecheck: true } } });
     resolveCommand(plugin, "serve");

--- a/npm/ox-content-code-play/src/plugin.ts
+++ b/npm/ox-content-code-play/src/plugin.ts
@@ -18,6 +18,7 @@ import {
   resolveClientFile,
   resolveHydrateSpecifier,
 } from "./plugin-client";
+import { writeClientAsset } from "./plugin-assets";
 import { proxy, typecheckProxy } from "./plugin-proxy";
 
 export type CodePlayPluginOptions = RawCodePlayOptions;
@@ -33,6 +34,9 @@ export function codePlay(options: CodePlayPluginOptions = {}): Plugin {
   let command: "build" | "serve" = "serve";
   let outDir = resolved.outDir;
   let root = process.cwd();
+  let needsClientAsset = false;
+  let emittedClientAsset = false;
+  let clientSource: string | undefined;
 
   const enhanceOptions = (
     matchFences?: Array<{ language: string; code: string; payload: string }>,
@@ -75,7 +79,11 @@ export function codePlay(options: CodePlayPluginOptions = {}): Plugin {
     transform(code, id) {
       if (!MARKDOWN_RE.test(id)) {
         if (code.includes("export const html = ") && code.includes("ox-code-play:")) {
-          return enhanceGeneratedModule(code, enhanceOptions());
+          const enhanced = enhanceGeneratedModule(code, enhanceOptions());
+          if (enhanced !== code) {
+            needsClientAsset = true;
+          }
+          return enhanced;
         }
         return null;
       }
@@ -86,7 +94,11 @@ export function codePlay(options: CodePlayPluginOptions = {}): Plugin {
         }
         return encodePayload(payloadFromFence(fence, resolved));
       });
-      return rewritten === code ? null : rewritten;
+      if (rewritten === code) {
+        return null;
+      }
+      needsClientAsset = true;
+      return rewritten;
     },
 
     configureServer(server) {
@@ -112,15 +124,19 @@ export function codePlay(options: CodePlayPluginOptions = {}): Plugin {
     },
 
     async generateBundle() {
-      const file = resolveClientFile();
-      if (!file || command !== "build") {
+      if (command !== "build" || !needsClientAsset) {
+        return;
+      }
+      const source = await loadClientSource();
+      if (!source) {
         return;
       }
       this.emitFile({
         type: "asset",
         fileName: "ox-code-play.js",
-        source: assertBrowserClientSource(await readFile(file, "utf8")),
+        source,
       });
+      emittedClientAsset = true;
     },
 
     async closeBundle() {
@@ -132,9 +148,28 @@ export function codePlay(options: CodePlayPluginOptions = {}): Plugin {
       if (!existsSync(srcDir) || !existsSync(destination)) {
         return;
       }
-      await enhanceWrittenPages(srcDir, destination, resolved, enhanceOptions);
+      const enhancedAny = await enhanceWrittenPages(srcDir, destination, resolved, enhanceOptions);
+      if (!enhancedAny) {
+        return;
+      }
+      needsClientAsset = true;
+      if (!emittedClientAsset) {
+        await writeClientAsset(destination, await loadClientSource());
+      }
     },
   };
+
+  async function loadClientSource(): Promise<string | undefined> {
+    if (clientSource) {
+      return clientSource;
+    }
+    const file = resolveClientFile();
+    if (!file) {
+      return undefined;
+    }
+    clientSource = assertBrowserClientSource(await readFile(file, "utf8"));
+    return clientSource;
+  }
 }
 
 function interceptHtml(
@@ -239,7 +274,8 @@ async function enhanceWrittenPages(
   enhance: (
     matchFences?: Array<{ language: string; code: string; payload: string }>,
   ) => HtmlEnhanceOptions,
-): Promise<void> {
+): Promise<boolean> {
+  let enhancedAny = false;
   for (const file of walkFiles(srcDir)) {
     if (!MARKDOWN_RE.test(file)) {
       continue;
@@ -269,8 +305,10 @@ async function enhanceWrittenPages(
     );
     if (enhanced !== html) {
       await writeFile(htmlPath, enhanced);
+      enhancedAny = true;
     }
   }
+  return enhancedAny;
 }
 
 function guessHtmlPath(file: string, srcDir: string, outDir: string): string | undefined {

--- a/npm/ox-content-code-play/src/result.ts
+++ b/npm/ox-content-code-play/src/result.ts
@@ -8,15 +8,14 @@ export function errorMessage(error: unknown): string {
 
 export function friendlyTransportMessage(error: unknown): string {
   const message = errorMessage(error);
-  const typeError =
-    error instanceof TypeError || (error instanceof Error && error.name === "TypeError");
-  if (
-    typeError &&
-    /failed to fetch|networkerror|load failed|network request failed/i.test(message)
-  ) {
-    return "The executor could not be reached from this page (often CORS). Set endpoints to a host that allows browser POST, or use the Vite dev proxy.";
+  if (isOfflineError(error)) {
+    return "The executor is offline or unreachable from this page (for example, CORS). Set endpoints to a host that allows browser POST, or use the Vite dev proxy.";
   }
   return message;
+}
+
+export function transportFailureStatus(error: unknown): RunStatus {
+  return isOfflineError(error) ? "offline" : "error";
 }
 
 export function errorResult(
@@ -37,4 +36,21 @@ export function errorResult(
     provenance: {},
     timing: emptyTiming(),
   });
+}
+
+function isOfflineError(error: unknown): boolean {
+  const message = errorMessage(error);
+  const name =
+    error && typeof error === "object" && "name" in error ? String(error.name) : undefined;
+  const typeError = error instanceof TypeError || name === "TypeError";
+  if (name === "MissingTransportError") {
+    return true;
+  }
+  if (
+    typeError &&
+    /failed to fetch|networkerror|load failed|network request failed/i.test(message)
+  ) {
+    return true;
+  }
+  return /\boffline\b|no code play transport|network request failed/i.test(message);
 }

--- a/npm/ox-content-code-play/src/session.ts
+++ b/npm/ox-content-code-play/src/session.ts
@@ -1,6 +1,6 @@
 import { executeAdapter, typecheckAdapter } from "./adapters";
 import { mergeConfig } from "./config";
-import { friendlyTransportMessage, errorResult } from "./result";
+import { friendlyTransportMessage, errorResult, transportFailureStatus } from "./result";
 import { withStdioText } from "./stdio";
 import { isAbortError } from "./transport";
 import type {
@@ -105,7 +105,9 @@ export class CodePlaySession {
       if (signal.aborted || isAbortError(error)) {
         return this.finish(errorResult("Run cancelled.", "code-play", "cancelled"));
       }
-      return this.finish(errorResult(friendlyTransportMessage(error)));
+      return this.finish(
+        errorResult(friendlyTransportMessage(error), "code-play", transportFailureStatus(error)),
+      );
     }
   }
 

--- a/npm/ox-content-code-play/src/styles.test.ts
+++ b/npm/ox-content-code-play/src/styles.test.ts
@@ -17,4 +17,11 @@ describe("CODE_PLAY_STYLES", () => {
     expect(CODE_PLAY_STYLES).toContain(".ox-code-play__panel pre");
     expect(CODE_PLAY_STYLES).toContain("background: transparent !important");
   });
+
+  it("styles status and keyboard focus states", () => {
+    expect(CODE_PLAY_STYLES).toContain(".ox-code-play__status");
+    expect(CODE_PLAY_STYLES).toContain('[data-ox-run-state="offline"]');
+    expect(CODE_PLAY_STYLES).toContain(":focus-visible");
+    expect(CODE_PLAY_STYLES).toContain("border-radius: 8px");
+  });
 });

--- a/npm/ox-content-code-play/src/styles.ts
+++ b/npm/ox-content-code-play/src/styles.ts
@@ -1,7 +1,7 @@
 export const CODE_PLAY_STYLES = `
 .ox-code-play {
   border: 1px solid var(--octc-color-border, color-mix(in srgb, currentColor 16%, transparent));
-  border-radius: 12px;
+  border-radius: 8px;
   background: var(--octc-color-bg-alt, var(--octc-color-bg, Canvas));
   color: var(--octc-color-text, CanvasText);
   overflow: hidden;
@@ -15,10 +15,39 @@ export const CODE_PLAY_STYLES = `
   padding: 0.6rem 0.8rem;
   border-bottom: 1px solid var(--octc-color-border, color-mix(in srgb, currentColor 12%, transparent));
 }
+.ox-code-play__summary {
+  display: inline-flex;
+  flex: 1 1 12rem;
+  min-width: 9rem;
+  gap: 0.45rem;
+  align-items: baseline;
+}
 .ox-code-play__lang {
   font: 600 0.8rem/1.2 ui-sans-serif, system-ui, sans-serif;
-  margin-right: auto;
   color: var(--octc-color-text, CanvasText);
+}
+.ox-code-play__title {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font: 500 0.78rem/1.25 ui-sans-serif, system-ui, sans-serif;
+  opacity: 0.72;
+}
+.ox-code-play__status {
+  min-width: 5.25rem;
+  text-align: center;
+  border: 1px solid var(--octc-color-border, color-mix(in srgb, currentColor 16%, transparent));
+  border-radius: 6px;
+  padding: 0.18rem 0.5rem;
+  font: 650 0.68rem/1.25 ui-sans-serif, system-ui, sans-serif;
+  color: var(--octc-color-text, CanvasText);
+  background: var(--octc-color-bg, Canvas);
+}
+.ox-code-play[data-ox-run-state="running"] .ox-code-play__status {
+  color: var(--octc-color-primary, var(--octc-accent, #4f46e5));
+}
+.ox-code-play[data-ox-run-state="error"] .ox-code-play__status,
+.ox-code-play[data-ox-run-state="offline"] .ox-code-play__status {
+  color: var(--octc-danger, #b42318);
 }
 .ox-code-play__toolbar button {
   appearance: none;
@@ -31,6 +60,14 @@ export const CODE_PLAY_STYLES = `
   cursor: pointer;
 }
 .ox-code-play__toolbar button:disabled { opacity: 0.55; cursor: progress; }
+.ox-code-play__toolbar button:focus-visible,
+.ox-code-play__tabs button:focus-visible,
+.ox-code-play__field input:focus-visible,
+.ox-code-play__field select:focus-visible,
+.ox-code-play__panel:focus-visible {
+  outline: 2px solid var(--octc-color-primary, var(--octc-accent, #4f46e5));
+  outline-offset: 2px;
+}
 .ox-code-play__runtime {
   display: flex;
   flex-wrap: wrap;
@@ -46,7 +83,7 @@ export const CODE_PLAY_STYLES = `
   min-width: 7.5rem;
   padding: 0.35rem 0.5rem;
   border: 1px solid var(--octc-color-border, color-mix(in srgb, currentColor 14%, transparent));
-  border-radius: 8px;
+  border-radius: 6px;
   background: var(--octc-color-bg, Canvas);
 }
 .ox-code-play__runtime-chip span {
@@ -74,7 +111,7 @@ export const CODE_PLAY_STYLES = `
   background: transparent;
   color: var(--octc-color-text, CanvasText);
   padding: 0.35rem 0.55rem;
-  border-radius: 8px 8px 0 0;
+  border-radius: 6px 6px 0 0;
   font: 600 0.75rem/1.2 ui-sans-serif, system-ui, sans-serif;
   cursor: pointer;
 }
@@ -101,7 +138,7 @@ export const CODE_PLAY_STYLES = `
 .ox-code-play__field input, .ox-code-play__field select {
   font: inherit;
   padding: 0.3rem 0.45rem;
-  border-radius: 8px;
+  border-radius: 6px;
   border: 1px solid var(--octc-color-border, color-mix(in srgb, currentColor 18%, transparent));
   background: var(--octc-color-bg, Canvas);
   color: var(--octc-color-text, CanvasText);

--- a/npm/ox-content-code-play/src/types.ts
+++ b/npm/ox-content-code-play/src/types.ts
@@ -37,7 +37,7 @@ export interface TimingReport {
   phases: TimingPhase[];
 }
 
-export type RunStatus = "ok" | "error" | "timeout" | "cancelled" | "unsupported";
+export type RunStatus = "ok" | "error" | "offline" | "timeout" | "cancelled" | "unsupported";
 
 export interface Diagnostic {
   message: string;
@@ -67,6 +67,19 @@ export interface RunResult extends AdapterResult {
   stdout: string;
   /** Concatenated `stderr` chunks from `stdio`. */
   stderr: string;
+}
+
+export type RunAction = "execute" | "typecheck";
+
+export type RunActionPhase = "idle" | "running" | "result" | "error" | "offline";
+
+export interface RunActionState {
+  phase: RunActionPhase;
+  action?: RunAction;
+  result?: RunResult;
+  message?: string;
+  startedAtMs?: number;
+  finishedAtMs?: number;
 }
 
 export type ConfigFieldType = "string" | "boolean" | "select" | "number";
@@ -172,6 +185,7 @@ export interface SessionInput {
 export interface PlayPayload {
   language: string;
   code: string;
+  title?: string;
   capabilities: LanguageCapabilities;
   config: Record<string, unknown>;
   /** Per-language executor endpoint for remote language backends. */

--- a/npm/ox-content-code-play/src/ui.ts
+++ b/npm/ox-content-code-play/src/ui.ts
@@ -1,6 +1,13 @@
 import { resolveLanguage } from "./catalog";
 import { escapeHtml } from "./escape";
-import type { CodePlayPreset, LanguageDefinition, PlayPayload, RunResult } from "./types";
+import { idleRunActionState } from "./hydrate-action";
+import type {
+  CodePlayPreset,
+  LanguageDefinition,
+  PlayPayload,
+  RunActionState,
+  RunResult,
+} from "./types";
 import {
   renderConfigHtml,
   renderDiagnosticsHtml,
@@ -14,6 +21,7 @@ export interface UiState {
   payload: PlayPayload;
   result?: RunResult;
   busy?: boolean;
+  runState?: RunActionState;
   panel?: "stdio" | "stderr" | "config" | "provenance" | "timing";
 }
 
@@ -25,24 +33,55 @@ export function renderPlayUi(state: UiState): string {
   }
   const panel = state.panel ?? "stdio";
   const canTypecheck = state.payload.capabilities.typecheck;
+  const runState =
+    state.runState ??
+    (state.busy ? { phase: "running" as const, action: "execute" as const } : idleRunActionState());
+  const isBusy = Boolean(state.busy) || runState.phase === "running";
   const tabs = renderTabs(state, panel);
   const viewers = state.payload.viewers;
-  return `<div class="ox-code-play ox-code-play--${preset}" data-ox-code-play-ui>
+  const label = widgetLabel(state.payload, definition);
+  return `<div class="ox-code-play ox-code-play--${preset}" data-ox-code-play-ui data-ox-run-state="${runState.phase}" role="region" aria-label="${escapeHtml(label)}" aria-busy="${isBusy ? "true" : "false"}">
   <div class="ox-code-play__toolbar">
-    <span class="ox-code-play__lang">${escapeHtml(definition?.name ?? state.payload.language)}</span>
-    <button type="button" data-ox-action="run"${actionButtonAttrs("run", Boolean(state.busy))}>Run</button>
-    ${canTypecheck ? `<button type="button" data-ox-action="typecheck"${actionButtonAttrs("typecheck", Boolean(state.busy))}>Typecheck</button>` : ""}
-    <button type="button" data-ox-action="cancel"${actionButtonAttrs("cancel", Boolean(state.busy))}>Cancel</button>
+    <span class="ox-code-play__summary"><span class="ox-code-play__lang">${escapeHtml(definition?.name ?? state.payload.language)}</span>${state.payload.title ? `<span class="ox-code-play__title">${escapeHtml(state.payload.title)}</span>` : ""}</span>
+    <span class="ox-code-play__status" data-ox-status role="status" aria-live="polite">${renderRunStatusText(runState)}</span>
+    <button type="button" data-ox-action="run" aria-label="${escapeHtml(`Run ${label}`)}"${actionButtonAttrs("run", Boolean(state.busy))}>Run</button>
+    ${canTypecheck ? `<button type="button" data-ox-action="typecheck" aria-label="${escapeHtml(`Typecheck ${label}`)}"${actionButtonAttrs("typecheck", Boolean(state.busy))}>Typecheck</button>` : ""}
+    <button type="button" data-ox-action="cancel" aria-label="${escapeHtml(`Cancel ${label}`)}"${actionButtonAttrs("cancel", Boolean(state.busy))}>Cancel</button>
   </div>
   ${renderRuntimeStrip(state.payload, definition)}
   <div class="ox-code-play__source"></div>
   ${tabs}
-  ${viewers.stdio ? `<div class="ox-code-play__panel" data-panel="stdio">${renderDiagnosticsHtml(state.result)}${renderStdioHtml(state.result?.stdio ?? [])}</div>` : ""}
-  ${viewers.stderr ? `<div class="ox-code-play__panel" data-panel="stderr"${hidden(panel, "stderr", preset)}>${renderStderrHtml(state.result)}</div>` : ""}
-  <div class="ox-code-play__panel" data-panel="config"${hidden(panel, "config", preset)}>${renderConfigHtml(definition?.configSchema ?? [], state.payload.config)}</div>
-  <div class="ox-code-play__panel" data-panel="provenance"${hidden(panel, "provenance", preset)}>${renderProvenanceHtml(state.result?.provenance)}</div>
-  <div class="ox-code-play__panel" data-panel="timing"${hidden(panel, "timing", preset)}>${renderTimingHtml(state.result?.timing)}</div>
+  ${viewers.stdio ? renderPanel("stdio", "Stdio", panel, preset, `${renderDiagnosticsHtml(state.result)}${renderStdioHtml(state.result?.stdio ?? [])}`) : ""}
+  ${viewers.stderr ? renderPanel("stderr", "Stderr", panel, preset, renderStderrHtml(state.result)) : ""}
+  ${viewers.config ? renderPanel("config", "Config", panel, preset, renderConfigHtml(definition?.configSchema ?? [], state.payload.config)) : ""}
+  ${viewers.provenance ? renderPanel("provenance", "Provenance", panel, preset, renderProvenanceHtml(state.result?.provenance)) : ""}
+  ${viewers.timing ? renderPanel("timing", "Timing", panel, preset, renderTimingHtml(state.result?.timing)) : ""}
 </div>`;
+}
+
+export function renderRunStatusText(state: RunActionState): string {
+  if (state.phase === "running") {
+    return state.action === "typecheck" ? "Typechecking" : "Running";
+  }
+  if (state.phase === "offline") {
+    return "Offline";
+  }
+  if (state.phase === "error") {
+    if (state.result?.status === "timeout") {
+      return "Timed out";
+    }
+    if (state.result?.status === "unsupported") {
+      return "Unsupported";
+    }
+    return "Error";
+  }
+  if (state.phase === "result") {
+    if (state.result?.status === "cancelled") {
+      return "Cancelled";
+    }
+    return "Done";
+  }
+  return "Ready";
 }
 
 function renderRuntimeStrip(
@@ -107,11 +146,11 @@ function renderTabs(state: UiState, panel: string): string {
   }
   const viewers = state.payload.viewers;
   const buttons = [
-    viewers.stdio ? tab("stdio", "stdio", panel) : "",
-    viewers.stderr ? tab("stderr", "stderr", panel) : "",
-    viewers.config ? tab("config", "config", panel) : "",
-    viewers.provenance ? tab("provenance", "provenance", panel) : "",
-    viewers.timing ? tab("timing", "timing", panel) : "",
+    viewers.stdio ? tab("stdio", "Stdio", panel) : "",
+    viewers.stderr ? tab("stderr", "Stderr", panel) : "",
+    viewers.config ? tab("config", "Config", panel) : "",
+    viewers.provenance ? tab("provenance", "Provenance", panel) : "",
+    viewers.timing ? tab("timing", "Timing", panel) : "",
   ]
     .filter(Boolean)
     .join("");
@@ -119,12 +158,13 @@ function renderTabs(state: UiState, panel: string): string {
 }
 
 function tab(id: string, label: string, selected: string): string {
-  return `<button type="button" role="tab" data-ox-panel="${id}" aria-selected="${selected === id ? "true" : "false"}">${label}</button>`;
+  const isSelected = selected === id;
+  return `<button type="button" role="tab" data-ox-panel="${id}" aria-selected="${isSelected ? "true" : "false"}" tabindex="${isSelected ? "0" : "-1"}">${label}</button>`;
 }
 
 export function actionButtonAttrs(action: string, busy: boolean): string {
   const state = actionBusyState(action, busy);
-  return `${state.disabled ? " disabled" : ""}${state.hidden ? " hidden" : ""}`;
+  return `${state.disabled ? ' disabled aria-disabled="true"' : ""}${state.hidden ? " hidden" : ""}`;
 }
 
 export function actionBusyState(
@@ -142,7 +182,21 @@ export function applyActionBusy(root: ParentNode, busy: boolean): void {
     const state = actionBusyState(button.dataset.oxAction ?? "", busy);
     button.disabled = state.disabled;
     button.hidden = state.hidden;
+    button.setAttribute("aria-disabled", state.disabled ? "true" : "false");
   }
+  for (const widget of queryPlayWidgets(root)) {
+    widget.setAttribute("aria-busy", busy ? "true" : "false");
+  }
+}
+
+function renderPanel(
+  id: string,
+  label: string,
+  current: string,
+  preset: CodePlayPreset,
+  html: string,
+): string {
+  return `<div class="ox-code-play__panel" role="tabpanel" tabindex="0" aria-label="${escapeHtml(label)}" data-panel="${id}"${hidden(current, id, preset)}>${html}</div>`;
 }
 
 function hidden(current: string, id: string, preset: CodePlayPreset): string {
@@ -150,4 +204,21 @@ function hidden(current: string, id: string, preset: CodePlayPreset): string {
     return "";
   }
   return current === id ? "" : " hidden";
+}
+
+function widgetLabel(payload: PlayPayload, definition: LanguageDefinition | undefined): string {
+  const language = definition?.name ?? payload.language;
+  return payload.title ? `${payload.title} (${language})` : `${language} Code Play`;
+}
+
+function queryPlayWidgets(root: ParentNode): HTMLElement[] {
+  const widgets = [...root.querySelectorAll<HTMLElement>(".ox-code-play")];
+  if (
+    typeof HTMLElement !== "undefined" &&
+    root instanceof HTMLElement &&
+    root.matches(".ox-code-play")
+  ) {
+    widgets.unshift(root);
+  }
+  return widgets;
 }

--- a/npm/ox-content-code-play/src/viewers.test.ts
+++ b/npm/ox-content-code-play/src/viewers.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { DEFAULT_VIEWERS } from "./config";
 import { withStdioText } from "./stdio";
 import type { PlayPayload, RunResult } from "./types";
-import { actionBusyState, renderPlayUi } from "./ui";
+import { actionBusyState, renderPlayUi, renderRunStatusText } from "./ui";
 import { renderStderrHtml, renderStdioHtml } from "./viewers";
 
 function result(partial: Partial<RunResult> = {}): RunResult {
@@ -102,9 +102,14 @@ describe("stderr viewer", () => {
 
 describe("stderr UI flags", () => {
   it("adds a stderr tab and panel when viewers.stderr is enabled", () => {
-    const html = renderPlayUi({ payload: payload() });
+    const html = renderPlayUi({ payload: payload({ title: "Hello sample" }) });
+    expect(html).toContain('role="region"');
+    expect(html).toContain('aria-label="Hello sample (JavaScript)"');
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-live="polite"');
     expect(html).toContain('data-ox-panel="stderr"');
     expect(html).toContain('data-panel="stderr"');
+    expect(html).toContain('role="tabpanel"');
     expect(html).toContain("Browser sandbox");
     expect(html).toContain("On demand");
     expect(html).toContain("No stderr.");
@@ -140,7 +145,21 @@ describe("stderr UI flags", () => {
     expect(actionBusyState("run", true)).toEqual({ disabled: true, hidden: false });
     const busy = renderPlayUi({ payload: payload(), busy: true });
     expect(busy).toMatch(/data-ox-action="run"[^>]*\bdisabled\b/);
+    expect(busy).toContain('aria-busy="true"');
     expect(busy).not.toMatch(/data-ox-action="cancel"[^>]*\bhidden\b/);
+  });
+
+  it("renders typed run-state labels for toolbar status", () => {
+    expect(renderRunStatusText({ phase: "idle" })).toBe("Ready");
+    expect(renderRunStatusText({ phase: "running", action: "typecheck" })).toBe("Typechecking");
+    expect(renderRunStatusText({ phase: "offline" })).toBe("Offline");
+    expect(renderRunStatusText({ phase: "error" })).toBe("Error");
+    expect(
+      renderPlayUi({
+        payload: payload(),
+        runState: { phase: "offline", message: "unreachable" },
+      }),
+    ).toContain('data-ox-run-state="offline"');
   });
 
   it("keeps the compact stderr panel visible and hides compact tabs", () => {


### PR DESCRIPTION
## Summary
- add per-sample Code Play authoring options for titles, UI preset, timeout, viewers, and language config
- add typed run action states plus offline transport/CORS status handling in the UI and API
- emit/load the Code Play browser runtime only when runnable widgets are present, with docs/examples covering no-runtime pages

Closes #856

## Validation
- vp run test --filter @ox-content/code-play (Code Play task passed; runner ended non-zero after forwarding --filter to a final node task)
- vp exec --filter @ox-content/code-play -- vp test src
- corepack pnpm --filter @ox-content/code-play typecheck
- corepack pnpm --filter @ox-content/code-play build
- corepack pnpm --filter ./examples/code-play build
- node -e plain/index Code Play runtime assertion
- vp fmt npm/ox-content-code-play docs/content/packages/code-play.md docs/content/ja/packages/code-play.md docs/content/examples/code-play.md docs/content/ja/examples/code-play.md examples/code-play --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790339514&installation_model_id=422833&pr_number=1014&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1014&signature=40ac3f7903a8f508c9f79971cfa880291b50f8c485d25bffde6238425f7b2899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->