### PR TITLE
feat(seo): audit generated-site metadata conflicts

### DIFF
--- a/crates/ox_content_ssg/src/html/head/resolve.rs
+++ b/crates/ox_content_ssg/src/html/head/resolve.rs
@@ -4,6 +4,14 @@ use super::input::{HeadAlternate, HeadInput, HeadJsonLd, HeadLink, HeadMeta, Hea
 use crate::html::urls::{is_safe_href, safe_http_url};
 use crate::html::utils::escape_json_for_script;
 
+mod diagnostics;
+mod identity;
+
+use diagnostics::{
+    diagnose_canonical_og_url_conflict, diagnose_link_replacement, diagnose_meta_replacement,
+};
+use identity::{json_ld_identity, link_identity, meta_identity};
+
 /// One resolved tag ready to serialize.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResolvedTag {
@@ -47,12 +55,7 @@ pub fn resolve_head(input: &HeadInput) -> ResolvedHead {
     {
         upsert_link(
             &mut tags,
-            HeadLink {
-                key: Some("canonical".into()),
-                rel: "canonical".into(),
-                href: canonical.clone(),
-                ..HeadLink::default()
-            },
+            HeadLink { rel: "canonical".into(), href: canonical.clone(), ..HeadLink::default() },
         );
         if input.social {
             push_meta(&mut tags, property_meta("og:url", Some(canonical.as_str())));
@@ -83,17 +86,20 @@ pub fn resolve_head(input: &HeadInput) -> ResolvedHead {
 
     for meta in &input.metas {
         if let Some(meta) = sanitize_meta(meta, &mut diagnostics) {
-            upsert_meta(&mut tags, meta);
+            let previous = upsert_meta(&mut tags, meta.clone());
+            diagnose_meta_replacement(previous.as_ref(), &meta, &mut diagnostics);
         }
     }
     for alternate in &input.alternates {
         if let Some(link) = sanitize_alternate(alternate, &mut diagnostics) {
-            upsert_link(&mut tags, link);
+            let previous = upsert_link(&mut tags, link.clone());
+            diagnose_link_replacement(previous.as_ref(), &link, &mut diagnostics);
         }
     }
     for link in &input.links {
         if let Some(link) = sanitize_link(link, &mut diagnostics) {
-            upsert_link(&mut tags, link);
+            let previous = upsert_link(&mut tags, link.clone());
+            diagnose_link_replacement(previous.as_ref(), &link, &mut diagnostics);
         }
     }
     for node in &input.json_ld {
@@ -101,6 +107,7 @@ pub fn resolve_head(input: &HeadInput) -> ResolvedHead {
             upsert_json_ld(&mut tags, tag);
         }
     }
+    diagnose_canonical_og_url_conflict(&tags, &mut diagnostics);
 
     if input.validation == HeadValidation::Off {
         diagnostics.clear();
@@ -110,18 +117,12 @@ pub fn resolve_head(input: &HeadInput) -> ResolvedHead {
 
 fn name_meta(name: &str, content: Option<&str>) -> Option<HeadMeta> {
     let content = content.map(str::trim).filter(|value| !value.is_empty())?;
-    Some(HeadMeta {
-        key: Some(format!("name:{name}")),
-        name: Some(name.into()),
-        content: content.to_string(),
-        ..HeadMeta::default()
-    })
+    Some(HeadMeta { name: Some(name.into()), content: content.to_string(), ..HeadMeta::default() })
 }
 
 fn property_meta(property: &str, content: Option<&str>) -> Option<HeadMeta> {
     let content = content.map(str::trim).filter(|value| !value.is_empty())?;
     Some(HeadMeta {
-        key: Some(format!("property:{property}")),
         property: Some(property.into()),
         content: content.to_string(),
         ..HeadMeta::default()
@@ -130,32 +131,36 @@ fn property_meta(property: &str, content: Option<&str>) -> Option<HeadMeta> {
 
 fn push_meta(tags: &mut Vec<ResolvedTag>, meta: Option<HeadMeta>) {
     if let Some(meta) = meta {
-        upsert_meta(tags, meta);
+        let _ = upsert_meta(tags, meta);
     }
 }
 
-fn upsert_meta(tags: &mut Vec<ResolvedTag>, meta: HeadMeta) {
+fn upsert_meta(tags: &mut Vec<ResolvedTag>, meta: HeadMeta) -> Option<HeadMeta> {
     let identity = meta_identity(&meta);
-    if let Some(existing) = tags.iter_mut().find(|tag| match tag {
-        ResolvedTag::Meta(current) => meta_identity(current) == identity,
-        _ => false,
+    if let Some(current) = tags.iter_mut().find_map(|tag| match tag {
+        ResolvedTag::Meta(current) if meta_identity(current) == identity => Some(current),
+        _ => None,
     }) {
-        *existing = ResolvedTag::Meta(meta);
-        return;
+        let previous = current.clone();
+        *current = meta;
+        return Some(previous);
     }
     tags.push(ResolvedTag::Meta(meta));
+    None
 }
 
-fn upsert_link(tags: &mut Vec<ResolvedTag>, link: HeadLink) {
+fn upsert_link(tags: &mut Vec<ResolvedTag>, link: HeadLink) -> Option<HeadLink> {
     let identity = link_identity(&link);
-    if let Some(existing) = tags.iter_mut().find(|tag| match tag {
-        ResolvedTag::Link(current) => link_identity(current) == identity,
-        _ => false,
+    if let Some(current) = tags.iter_mut().find_map(|tag| match tag {
+        ResolvedTag::Link(current) if link_identity(current) == identity => Some(current),
+        _ => None,
     }) {
-        *existing = ResolvedTag::Link(link);
-        return;
+        let previous = current.clone();
+        *current = link;
+        return Some(previous);
     }
     tags.push(ResolvedTag::Link(link));
+    None
 }
 
 fn upsert_json_ld(tags: &mut Vec<ResolvedTag>, tag: ResolvedTag) {
@@ -167,36 +172,6 @@ fn upsert_json_ld(tags: &mut Vec<ResolvedTag>, tag: ResolvedTag) {
         return;
     }
     tags.push(tag);
-}
-
-fn meta_identity(meta: &HeadMeta) -> String {
-    if let Some(key) = meta.key.as_deref().map(str::trim).filter(|key| !key.is_empty()) {
-        return format!("key:{key}");
-    }
-    if let Some(name) = meta.name.as_deref() {
-        return format!("name:{name}");
-    }
-    if let Some(property) = meta.property.as_deref() {
-        return format!("property:{property}");
-    }
-    format!("http-equiv:{}", meta.http_equiv.as_deref().unwrap_or(""))
-}
-
-fn link_identity(link: &HeadLink) -> String {
-    if let Some(key) = link.key.as_deref().map(str::trim).filter(|key| !key.is_empty()) {
-        return format!("key:{key}");
-    }
-    if link.rel == "alternate" {
-        return format!("alternate:{}", link.hreflang.as_deref().unwrap_or(""));
-    }
-    link.rel.clone()
-}
-
-fn json_ld_identity(tag: &ResolvedTag) -> Option<String> {
-    match tag {
-        ResolvedTag::JsonLd { key, .. } => key.clone(),
-        _ => None,
-    }
 }
 
 fn resolve_url(
@@ -263,7 +238,6 @@ fn sanitize_alternate(
         return None;
     }
     Some(HeadLink {
-        key: Some(format!("alternate:{lang}")),
         rel: "alternate".into(),
         href: alternate.href.trim().to_string(),
         hreflang: Some(lang.to_string()),

--- a/crates/ox_content_ssg/src/html/head/resolve/diagnostics.rs
+++ b/crates/ox_content_ssg/src/html/head/resolve/diagnostics.rs
@@ -1,0 +1,94 @@
+use super::super::input::{HeadLink, HeadMeta};
+use super::identity::{link_identity, meta_identity};
+use super::{HeadDiagnostic, ResolvedTag};
+
+pub(super) fn diagnose_meta_replacement(
+    previous: Option<&HeadMeta>,
+    next: &HeadMeta,
+    diagnostics: &mut Vec<HeadDiagnostic>,
+) {
+    let Some(previous) = previous else {
+        return;
+    };
+    let Some(label) = seo_meta_label(next).or_else(|| seo_meta_label(previous)) else {
+        return;
+    };
+    diagnostics.push(HeadDiagnostic {
+        strict: false,
+        message: format!("{label} meta overrides earlier SEO metadata; last descriptor wins"),
+    });
+}
+
+pub(super) fn diagnose_link_replacement(
+    previous: Option<&HeadLink>,
+    next: &HeadLink,
+    diagnostics: &mut Vec<HeadDiagnostic>,
+) {
+    let Some(previous) = previous else {
+        return;
+    };
+    let Some(label) = seo_link_label(next).or_else(|| seo_link_label(previous)) else {
+        return;
+    };
+    diagnostics.push(HeadDiagnostic {
+        strict: false,
+        message: format!("{label} overrides earlier SEO metadata; last descriptor wins"),
+    });
+}
+
+fn seo_meta_label(meta: &HeadMeta) -> Option<&'static str> {
+    match meta_identity(meta).as_str() {
+        "name:description" => Some("description"),
+        "name:robots" => Some("robots"),
+        "name:twitter:card" => Some("twitter:card"),
+        "name:twitter:description" => Some("twitter:description"),
+        "name:twitter:image" => Some("twitter:image"),
+        "name:twitter:title" => Some("twitter:title"),
+        "property:og:description" => Some("og:description"),
+        "property:og:image" => Some("og:image"),
+        "property:og:site_name" => Some("og:site_name"),
+        "property:og:title" => Some("og:title"),
+        "property:og:type" => Some("og:type"),
+        "property:og:url" => Some("og:url"),
+        _ => None,
+    }
+}
+
+fn seo_link_label(link: &HeadLink) -> Option<String> {
+    match link_identity(link).as_str() {
+        "canonical" => Some("canonical link".into()),
+        identity if identity.starts_with("alternate:") => Some(format!(
+            "hreflang \"{}\" alternate",
+            link.hreflang.as_deref().map(str::trim).filter(|value| !value.is_empty()).unwrap_or("")
+        )),
+        _ => None,
+    }
+}
+
+pub(super) fn diagnose_canonical_og_url_conflict(
+    tags: &[ResolvedTag],
+    diagnostics: &mut Vec<HeadDiagnostic>,
+) {
+    let canonical = tags.iter().find_map(|tag| match tag {
+        ResolvedTag::Link(link) if link_identity(link) == "canonical" => Some(link.href.trim()),
+        _ => None,
+    });
+    let og_url = tags.iter().find_map(|tag| match tag {
+        ResolvedTag::Meta(meta) if meta_identity(meta) == "property:og:url" => {
+            Some(meta.content.trim())
+        }
+        _ => None,
+    });
+    let Some(canonical) = canonical else {
+        return;
+    };
+    let Some(og_url) = og_url else {
+        return;
+    };
+    if !canonical.is_empty() && !og_url.is_empty() && canonical != og_url {
+        diagnostics.push(HeadDiagnostic {
+            strict: false,
+            message: "canonical link and og:url disagree; emitted descriptors were kept".into(),
+        });
+    }
+}

--- a/crates/ox_content_ssg/src/html/head/resolve/identity.rs
+++ b/crates/ox_content_ssg/src/html/head/resolve/identity.rs
@@ -1,0 +1,67 @@
+use super::super::input::{HeadLink, HeadMeta};
+use super::ResolvedTag;
+
+pub(super) fn meta_identity(meta: &HeadMeta) -> String {
+    if let Some(key) = meta.key.as_deref().map(str::trim).filter(|key| !key.is_empty()) {
+        let key_lower = key.to_ascii_lowercase();
+        for identity in [
+            keyed_identity("name", meta.name.as_deref()),
+            keyed_identity("property", meta.property.as_deref()),
+            keyed_identity("http-equiv", meta.http_equiv.as_deref()),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            if key_lower == identity {
+                return identity;
+            }
+        }
+        return format!("key:{key}");
+    }
+    if let Some(name) = meta.name.as_deref() {
+        return format!("name:{}", normalize_identity_attr(name));
+    }
+    if let Some(property) = meta.property.as_deref() {
+        return format!("property:{}", normalize_identity_attr(property));
+    }
+    format!(
+        "http-equiv:{}",
+        meta.http_equiv.as_deref().map(normalize_identity_attr).unwrap_or_default()
+    )
+}
+
+pub(super) fn link_identity(link: &HeadLink) -> String {
+    let rel = normalize_identity_attr(&link.rel);
+    let hreflang = link.hreflang.as_deref().map(normalize_identity_attr).unwrap_or_default();
+    if let Some(key) = link.key.as_deref().map(str::trim).filter(|key| !key.is_empty()) {
+        if rel == "canonical" && key.eq_ignore_ascii_case("canonical") {
+            return "canonical".into();
+        }
+        if rel == "alternate" && !hreflang.is_empty() {
+            let expected = format!("alternate:{hreflang}");
+            if key.eq_ignore_ascii_case(&expected) {
+                return expected;
+            }
+        }
+        return format!("key:{key}");
+    }
+    if rel == "alternate" {
+        return format!("alternate:{hreflang}");
+    }
+    rel
+}
+
+pub(super) fn json_ld_identity(tag: &ResolvedTag) -> Option<String> {
+    match tag {
+        ResolvedTag::JsonLd { key, .. } => key.clone(),
+        _ => None,
+    }
+}
+
+fn normalize_identity_attr(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
+}
+
+fn keyed_identity(prefix: &str, value: Option<&str>) -> Option<String> {
+    Some(format!("{prefix}:{}", normalize_identity_attr(value?)))
+}

--- a/crates/ox_content_ssg/src/html/head/tests.rs
+++ b/crates/ox_content_ssg/src/html/head/tests.rs
@@ -1,4 +1,4 @@
-use super::{HeadInput, HeadJsonLd, HeadLink, HeadMeta, SiteHead, render_head};
+use super::{HeadAlternate, HeadInput, HeadJsonLd, HeadLink, HeadMeta, SiteHead, render_head};
 use crate::html::page::HeadValidation;
 use crate::html::urls::{is_safe_href, page_absolute_url, safe_http_url};
 
@@ -61,6 +61,110 @@ fn later_descriptor_wins_and_keeps_first_position() {
     assert!(html.contains("content=\"second\""));
     assert!(!html.contains("content=\"first\""));
     assert_eq!(html.matches("name=\"description\"").count(), 1);
+}
+
+#[test]
+fn seo_conflicts_replace_built_ins_without_duplicate_tags() {
+    let rendered = render_head(&HeadInput {
+        site: SiteHead { name: Some("Docs".into()), ..SiteHead::default() },
+        title: Some("Guide".into()),
+        description: Some("Built-in summary".into()),
+        canonical: Some("https://example.com/guide/".into()),
+        robots: Some("noindex".into()),
+        validation: HeadValidation::Strict,
+        metas: vec![
+            HeadMeta {
+                name: Some("description".into()),
+                content: "Custom summary".into(),
+                ..HeadMeta::default()
+            },
+            HeadMeta {
+                name: Some("robots".into()),
+                content: "index, follow".into(),
+                ..HeadMeta::default()
+            },
+            HeadMeta {
+                property: Some("og:url".into()),
+                content: "https://example.com/social/".into(),
+                ..HeadMeta::default()
+            },
+        ],
+        alternates: vec![
+            HeadAlternate { lang: "en".into(), href: "https://example.com/en/guide/".into() },
+            HeadAlternate { lang: "EN".into(), href: "https://example.com/en-us/guide/".into() },
+        ],
+        links: vec![HeadLink {
+            rel: "canonical".into(),
+            href: "https://example.com/custom/".into(),
+            ..HeadLink::default()
+        }],
+        ..HeadInput::default()
+    });
+
+    assert_eq!(rendered.html.matches("name=\"description\"").count(), 1);
+    assert_eq!(rendered.html.matches("name=\"robots\"").count(), 1);
+    assert_eq!(rendered.html.matches("property=\"og:url\"").count(), 1);
+    assert_eq!(rendered.html.matches("rel=\"canonical\"").count(), 1);
+    assert_eq!(rendered.html.matches("rel=\"alternate\"").count(), 1);
+    assert!(rendered.html.contains("content=\"Custom summary\""), "{}", rendered.html);
+    assert!(rendered.html.contains("content=\"index, follow\""), "{}", rendered.html);
+    assert!(rendered.html.contains("content=\"https://example.com/social/\""), "{}", rendered.html);
+    assert!(rendered.html.contains("href=\"https://example.com/custom/\""), "{}", rendered.html);
+    assert!(
+        rendered.html.contains("href=\"https://example.com/en-us/guide/\""),
+        "{}",
+        rendered.html
+    );
+    assert!(rendered.diagnostics.iter().all(|diagnostic| !diagnostic.strict));
+    assert!(
+        rendered
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("description meta overrides")),
+        "{:?}",
+        rendered.diagnostics
+    );
+    assert!(
+        rendered
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("canonical link overrides")),
+        "{:?}",
+        rendered.diagnostics
+    );
+    assert!(
+        rendered
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("hreflang \"EN\" alternate overrides")),
+        "{:?}",
+        rendered.diagnostics
+    );
+    assert!(
+        rendered
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("canonical link and og:url disagree")),
+        "{:?}",
+        rendered.diagnostics
+    );
+}
+
+#[test]
+fn seo_conflict_diagnostics_stay_silent_when_validation_is_off() {
+    let rendered = render_head(&HeadInput {
+        description: Some("Built-in summary".into()),
+        metas: vec![HeadMeta {
+            name: Some("description".into()),
+            content: "Custom summary".into(),
+            ..HeadMeta::default()
+        }],
+        ..HeadInput::default()
+    });
+
+    assert!(rendered.diagnostics.is_empty());
+    assert_eq!(rendered.html.matches("name=\"description\"").count(), 1);
+    assert!(rendered.html.contains("content=\"Custom summary\""), "{}", rendered.html);
 }
 
 #[test]

--- a/docs/content/built-in/seo.md
+++ b/docs/content/built-in/seo.md
@@ -64,6 +64,20 @@ Invalid custom descriptors are dropped in every mode. `strict` is for CI.
 `renderHead({ validation: "strict", ... })` returns the same findings in
 `diagnostics` for custom hosts.
 
+## Deterministic conflicts
+
+Built-ins and custom descriptors are deduped by their effective SEO identity:
+`description`, `robots`, `og:*`, `twitter:*`, canonical links, and matching
+`hreflang` alternates produce one tag. If a later custom descriptor conflicts
+with an earlier SEO tag, `warn` logs a non-fatal diagnostic and `strict` returns
+the same diagnostic without failing the build. `strict` still fails only unsafe
+URLs, invalid `hreflang`, and invalid JSON-LD.
+
+`ssg.siteUrl` must be a safe absolute `http(s)` URL for feeds and crawl
+manifests. Named feeds are preflighted before writing; duplicate feed output
+paths or paths that escape the output directory skip feed generation with a
+warning instead of silently overwriting files.
+
 ## JSON-LD variants
 
 `ssg.jsonLd.type` can be `TechArticle` (default), `BlogPosting`, or `WebPage`.

--- a/docs/content/ja/built-in/seo.md
+++ b/docs/content/ja/built-in/seo.md
@@ -64,6 +64,20 @@ oxContent({
 独自ホストは `renderHead({ validation: "strict", ... })` の `diagnostics` で
 同じ指摘を受け取れます。
 
+## 決定的な競合
+
+組み込みと独自デスクリプタは、有効な SEO identity で重複排除します。
+`description`、`robots`、`og:*`、`twitter:*`、canonical link、一致する
+`hreflang` alternate は 1 タグになります。後続の独自デスクリプタが先の
+SEO タグと競合すると、`warn` は非 fatal の診断をログし、`strict` も
+ビルドを落とさず同じ診断を返します。`strict` が落とすのは危険な URL、
+不正な `hreflang`、不正な JSON-LD だけです。
+
+feeds と crawl manifest で使う `ssg.siteUrl` は、安全な絶対 `http(s)`
+URL である必要があります。名前付き feed は書き込み前に検査します。
+feed の出力パス重複や、出力ディレクトリ外へ逃げるパスは、ファイルを
+静かに上書きせず警告付きで feed 生成をスキップします。
+
 ## JSON-LD の型
 
 `ssg.jsonLd.type` は `TechArticle`（既定）、`BlogPosting`、`WebPage` です。

--- a/npm/vite-plugin-ox-content/src/feeds-items.ts
+++ b/npm/vite-plugin-ox-content/src/feeds-items.ts
@@ -1,0 +1,101 @@
+import { parseDate } from "./feed-format";
+import type { FeedEntry } from "./feed-format";
+import { homePageUrl } from "./feeds-output";
+import { classifyPublishState } from "./publish-state";
+import type { ResolvedPublishStateOptions } from "./types";
+import type { FeedItemInput, FeedsRenderInput } from "./feeds";
+
+const DEFAULT_LIMIT = 20;
+
+function rawItems(input: FeedsRenderInput): readonly FeedItemInput[] {
+  if (input.items) {
+    return input.items;
+  }
+  const names = input.collectionNames ?? Object.keys(input.collections ?? {});
+  const name = resolveFeedCollectionName(input.options?.collection, names);
+  return name ? (input.collections?.[name] ?? []) : [];
+}
+
+function resolveFeedCollectionName(
+  requested: string | undefined,
+  collectionNames: readonly string[],
+): string | undefined {
+  if (requested) {
+    return requested;
+  }
+  if (collectionNames.includes("content")) {
+    return "content";
+  }
+  return collectionNames[0];
+}
+
+export function publishedItems(input: FeedsRenderInput): FeedEntry[] {
+  const published = rawItems(input)
+    .filter((item) => !isExcludedFromFeed(item, input.publishState))
+    .map((item) => normalizeItem(item, input))
+    .filter((item) => item.loc.length > 0);
+  published.sort((left, right) => {
+    const dateCmp =
+      (right.date?.unix ?? Number.NEGATIVE_INFINITY) -
+      (left.date?.unix ?? Number.NEGATIVE_INFINITY);
+    return dateCmp !== 0 ? dateCmp : left.loc < right.loc ? -1 : left.loc > right.loc ? 1 : 0;
+  });
+  return published.slice(0, input.options?.limit ?? DEFAULT_LIMIT);
+}
+
+function isExcludedFromFeed(
+  item: FeedItemInput,
+  publishState: ResolvedPublishStateOptions | undefined,
+): boolean {
+  const frontmatter = item.frontmatter ?? {};
+  if (item.draft === true || frontmatter.draft === true) {
+    return true;
+  }
+  if (item.unlisted === true || frontmatter.unlisted === true) {
+    return true;
+  }
+  if (frontmatter.external === true) {
+    return true;
+  }
+  if (!publishState?.enabled) {
+    return false;
+  }
+  return !classifyPublishState(
+    {
+      ...frontmatter,
+      ...(item.draft === true ? { draft: true } : {}),
+      ...(item.unlisted === true ? { unlisted: true } : {}),
+    },
+    publishState,
+  ).listed;
+}
+
+function normalizeItem(item: FeedItemInput, input: FeedsRenderInput): FeedEntry {
+  return {
+    title: item.title ?? "",
+    description: typeof item.description === "string" ? item.description : undefined,
+    loc: item.loc || itemLoc(input, item),
+    date:
+      parseDate(dateField(item.date ?? item.frontmatter?.date)) ??
+      parseDate(dateField(item.lastUpdated ?? item.frontmatter?.lastUpdated)),
+  };
+}
+
+function itemLoc(input: FeedsRenderInput, item: FeedItemInput): string {
+  const home = homePageUrl(input.siteUrl, input.base);
+  const urlPath = (item.path ?? "").replace(/^\/+|\/+$/g, "");
+  return urlPath ? `${home}${urlPath}/` : home;
+}
+
+function dateField(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value.toISOString();
+  }
+  return undefined;
+}

--- a/npm/vite-plugin-ox-content/src/feeds-named.test.ts
+++ b/npm/vite-plugin-ox-content/src/feeds-named.test.ts
@@ -196,6 +196,30 @@ describe("writeFeedFiles named feeds", () => {
     expect(media).not.toContain("Blog post");
   });
 
+  it("rejects duplicate named feed output paths before writing files", async () => {
+    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-feeds-named-"));
+    tempDirs.push(outDir);
+
+    const result = await writeFeedFiles({
+      outDir,
+      siteUrl: "https://example.com",
+      base: "/",
+      siteName: "example.com",
+      options: resolveFeedsOptions([
+        { formats: ["rss"], collection: "blog", path: "/" },
+        { formats: ["rss"], collection: "media", path: "/" },
+      ]),
+      collections: { blog: blogItems, media: mediaItems },
+      collectionNames: ["blog", "media"],
+    });
+
+    expect(result.files).toEqual([]);
+    expect(result.warning).toContain('feeds output path "feed.xml"');
+    expect(result.warning).toContain('"blog"');
+    expect(result.warning).toContain('"media"');
+    await expect(fs.access(path.join(outDir, "feed.xml"))).rejects.toThrow();
+  });
+
   it("writes nothing when feeds is false", async () => {
     const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-feeds-off-"));
     tempDirs.push(outDir);

--- a/npm/vite-plugin-ox-content/src/feeds-output.ts
+++ b/npm/vite-plugin-ox-content/src/feeds-output.ts
@@ -1,0 +1,104 @@
+import * as path from "node:path";
+import type { FeedFormat, ResolvedFeedChannel } from "./types";
+
+const MISSING_SITE_URL =
+  "[ox-content] feeds is enabled but ssg.siteUrl is not set; RSS, Atom, and JSON feeds were not written";
+const UNSAFE_SITE_URL =
+  "[ox-content] feeds requires ssg.siteUrl to be a safe absolute http(s) URL; RSS, Atom, and JSON feeds were not written";
+
+const FORMAT_OUTPUTS: Record<FeedFormat, string> = {
+  rss: "feed.xml",
+  atom: "atom.xml",
+  json: "feed.json",
+};
+
+export function homePageUrl(siteUrl: string | undefined, base = "/"): string {
+  const origin = (siteUrl ?? "").trim().replace(/\/+$/, "");
+  const prefix = !base || base === "/" ? "/" : base.endsWith("/") ? base : `${base}/`;
+  return `${origin}${prefix}`;
+}
+
+export function siteUrlWarning(siteUrl: string | undefined): string | undefined {
+  const trimmed = siteUrl?.trim();
+  if (!trimmed) {
+    return MISSING_SITE_URL;
+  }
+  return isSafeHttpUrl(trimmed) ? undefined : UNSAFE_SITE_URL;
+}
+
+function isSafeHttpUrl(value: string): boolean {
+  if (/\s/u.test(value)) {
+    return false;
+  }
+  const lower = value.toLowerCase();
+  if (!lower.startsWith("https://") && !lower.startsWith("http://")) {
+    return false;
+  }
+  try {
+    const url = new URL(value);
+    return (url.protocol === "https:" || url.protocol === "http:") && url.hostname.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export function outputDir(outDir: string, feedPath: string): string | undefined {
+  const relative = feedPath.replace(/^\/+|\/+$/g, "");
+  if (!relative) {
+    return outDir;
+  }
+  if (relative.includes("\\")) {
+    return undefined;
+  }
+  const normalized = path.posix.normalize(relative);
+  if (normalized === ".." || normalized.startsWith("../")) {
+    return undefined;
+  }
+  return path.join(outDir, ...normalized.split("/"));
+}
+
+export function feedOutputWarning(
+  outDir: string,
+  channels: readonly ResolvedFeedChannel[],
+): string | undefined {
+  const seen = new Map<string, string>();
+  for (const [index, channel] of channels.entries()) {
+    const dest = outputDir(outDir, channel.path);
+    if (!dest) {
+      return unsafeFeedPathWarning(channel, index);
+    }
+    for (const fileName of feedOutputFileNames(channel.formats)) {
+      const outputPath = path.join(dest, fileName);
+      const previous = seen.get(outputPath);
+      const label = feedChannelLabel(channel, index);
+      if (previous) {
+        return `[ox-content] feeds output path "${displayOutputPath(outDir, outputPath)}" is used by both ${previous} and ${label}; feed files were not written`;
+      }
+      seen.set(outputPath, label);
+    }
+  }
+  return undefined;
+}
+
+function feedOutputFileNames(formats: readonly FeedFormat[]): string[] {
+  const seen = new Set<string>();
+  for (const format of formats) {
+    const fileName = FORMAT_OUTPUTS[format];
+    if (fileName) {
+      seen.add(fileName);
+    }
+  }
+  return [...seen];
+}
+
+function feedChannelLabel(channel: ResolvedFeedChannel, index: number): string {
+  return JSON.stringify(channel.name ?? channel.collection ?? `#${index + 1}`);
+}
+
+export function unsafeFeedPathWarning(channel: ResolvedFeedChannel, index: number): string {
+  return `[ox-content] feeds channel ${feedChannelLabel(channel, index)} uses an unsafe output path; feed files were not written`;
+}
+
+function displayOutputPath(outDir: string, outputPath: string): string {
+  return path.relative(outDir, outputPath).split(path.sep).join("/");
+}

--- a/npm/vite-plugin-ox-content/src/feeds-write.test.ts
+++ b/npm/vite-plugin-ox-content/src/feeds-write.test.ts
@@ -58,6 +58,40 @@ describe("writeFeedFiles", () => {
     await expect(fs.access(path.join(outDir, "feed.xml"))).rejects.toThrow();
   });
 
+  it("does not write files when siteUrl is unsafe", async () => {
+    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-feeds-"));
+    tempDirs.push(outDir);
+
+    const result = await writeFeedFiles({
+      outDir,
+      siteUrl: "javascript:alert(1)",
+      base: "/",
+      options: { enabled: true, formats: ["rss"], limit: 20, path: "/" },
+      items: sampleItems,
+    });
+
+    expect(result.files).toEqual([]);
+    expect(result.warning).toContain("safe absolute http(s) URL");
+    await expect(fs.access(path.join(outDir, "feed.xml"))).rejects.toThrow();
+  });
+
+  it("rejects unsafe feed output paths before writing files", async () => {
+    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-feeds-"));
+    tempDirs.push(outDir);
+
+    const result = await writeFeedFiles({
+      outDir,
+      siteUrl: "https://example.com",
+      base: "/",
+      options: { enabled: true, formats: ["rss"], limit: 20, path: "../feeds" },
+      items: sampleItems,
+    });
+
+    expect(result.files).toEqual([]);
+    expect(result.warning).toContain("uses an unsafe output path");
+    await expect(fs.readdir(outDir)).resolves.toEqual([]);
+  });
+
   it("writes the enabled files next to generated HTML", async () => {
     const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-feeds-"));
     tempDirs.push(outDir);

--- a/npm/vite-plugin-ox-content/src/feeds.test.ts
+++ b/npm/vite-plugin-ox-content/src/feeds.test.ts
@@ -104,6 +104,16 @@ describe("generateFeeds", () => {
         items: sampleItems,
       }).warning,
     ).toBeDefined();
+    expect(
+      generateFeeds({
+        options: { ...enabled },
+        siteUrl: "javascript:alert(1)",
+        items: sampleItems,
+      }),
+    ).toEqual({
+      warning:
+        "[ox-content] feeds requires ssg.siteUrl to be a safe absolute http(s) URL; RSS, Atom, and JSON feeds were not written",
+    });
   });
 
   it("writes a sorted RSS, Atom, and JSON feed", () => {

--- a/npm/vite-plugin-ox-content/src/feeds.ts
+++ b/npm/vite-plugin-ox-content/src/feeds.ts
@@ -8,9 +8,16 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { applyAtomMeta, applyJsonMeta, applyRssMeta, channelMeta } from "./feed-channel-meta";
-import { generateAtom, generateJson, generateRss, parseDate } from "./feed-format";
-import type { FeedDocument, FeedEntry } from "./feed-format";
-import { classifyPublishState } from "./publish-state";
+import { generateAtom, generateJson, generateRss } from "./feed-format";
+import type { FeedDocument } from "./feed-format";
+import {
+  homePageUrl,
+  outputDir,
+  feedOutputWarning,
+  siteUrlWarning,
+  unsafeFeedPathWarning,
+} from "./feeds-output";
+import { publishedItems } from "./feeds-items";
 import type {
   FeedChannelOptions,
   FeedFormat,
@@ -19,9 +26,6 @@ import type {
   ResolvedFeedsOptions,
   ResolvedPublishStateOptions,
 } from "./types";
-
-const MISSING_SITE_URL =
-  "[ox-content] feeds is enabled but ssg.siteUrl is not set; RSS, Atom, and JSON feeds were not written";
 
 const DEFAULT_FORMATS: FeedFormat[] = ["rss", "atom", "json"];
 const DEFAULT_LIMIT = 20;
@@ -127,8 +131,9 @@ export function generateFeeds(input: FeedsRenderInput): FeedsRenderResult {
   if (!input.options?.enabled) {
     return {};
   }
-  if (!hasSiteUrl(input.siteUrl)) {
-    return { warning: MISSING_SITE_URL };
+  const warning = siteUrlWarning(input.siteUrl);
+  if (warning) {
+    return { warning };
   }
 
   const published = publishedItems(input);
@@ -151,8 +156,21 @@ export function generateFeeds(input: FeedsRenderInput): FeedsRenderResult {
 export async function writeFeedFiles(
   input: WriteFeedFilesInput,
 ): Promise<{ files: string[]; warning?: string }> {
+  if (input.options?.enabled) {
+    const warning = siteUrlWarning(input.siteUrl);
+    if (warning) {
+      return { files: [], warning };
+    }
+  }
+
+  const channels = feedChannels(input.options);
+  const outputWarning = feedOutputWarning(input.outDir, channels);
+  if (outputWarning) {
+    return { files: [], warning: outputWarning };
+  }
+
   const files: string[] = [];
-  for (const channel of feedChannels(input.options)) {
+  for (const channel of channels) {
     const generated = generateFeeds({ ...input, options: { enabled: true, ...channel } });
     if (generated.warning) {
       return { files: [], warning: generated.warning };
@@ -166,6 +184,9 @@ export async function writeFeedFiles(
       continue;
     }
     const dest = outputDir(input.outDir, channel.path);
+    if (!dest) {
+      return { files: [], warning: unsafeFeedPathWarning(channel, 0) };
+    }
     await fs.mkdir(dest, { recursive: true });
     for (const [body, name] of outputs) {
       const outputPath = path.join(dest, name);
@@ -236,16 +257,6 @@ function normalizeFormats(formats: readonly FeedFormat[] | undefined): FeedForma
   return resolved;
 }
 
-function hasSiteUrl(siteUrl: string | undefined): boolean {
-  return Boolean(siteUrl && siteUrl.trim());
-}
-
-function homePageUrl(siteUrl: string | undefined, base = "/"): string {
-  const origin = (siteUrl ?? "").trim().replace(/\/+$/, "");
-  const prefix = !base || base === "/" ? "/" : base.endsWith("/") ? base : `${base}/`;
-  return `${origin}${prefix}`;
-}
-
 function feedDocument(input: FeedsRenderInput): FeedDocument {
   const home = homePageUrl(input.siteUrl, input.base);
   const dir = (input.options?.path ?? DEFAULT_PATH).replace(/^\/+|\/+$/g, "");
@@ -257,89 +268,4 @@ function feedDocument(input: FeedsRenderInput): FeedDocument {
     atomUrl: `${prefix}atom.xml`,
     jsonUrl: `${prefix}feed.json`,
   };
-}
-
-function outputDir(outDir: string, feedPath: string): string {
-  const relative = feedPath.replace(/^\/+|\/+$/g, "");
-  return relative ? path.join(outDir, relative) : outDir;
-}
-
-function rawItems(input: FeedsRenderInput): readonly FeedItemInput[] {
-  if (input.items) {
-    return input.items;
-  }
-  const names = input.collectionNames ?? Object.keys(input.collections ?? {});
-  const name = resolveFeedCollectionName(input.options?.collection, names);
-  return name ? (input.collections?.[name] ?? []) : [];
-}
-
-function publishedItems(input: FeedsRenderInput): FeedEntry[] {
-  const published = rawItems(input)
-    .filter((item) => !isExcludedFromFeed(item, input.publishState))
-    .map((item) => normalizeItem(item, input))
-    .filter((item) => item.loc.length > 0);
-  published.sort((left, right) => {
-    const dateCmp =
-      (right.date?.unix ?? Number.NEGATIVE_INFINITY) -
-      (left.date?.unix ?? Number.NEGATIVE_INFINITY);
-    return dateCmp !== 0 ? dateCmp : left.loc < right.loc ? -1 : left.loc > right.loc ? 1 : 0;
-  });
-  return published.slice(0, input.options?.limit ?? DEFAULT_LIMIT);
-}
-
-function isExcludedFromFeed(
-  item: FeedItemInput,
-  publishState: ResolvedPublishStateOptions | undefined,
-): boolean {
-  const frontmatter = item.frontmatter ?? {};
-  if (item.draft === true || frontmatter.draft === true) {
-    return true;
-  }
-  if (item.unlisted === true || frontmatter.unlisted === true) {
-    return true;
-  }
-  if (frontmatter.external === true) {
-    return true;
-  }
-  if (!publishState?.enabled) {
-    return false;
-  }
-  return !classifyPublishState(
-    {
-      ...frontmatter,
-      ...(item.draft === true ? { draft: true } : {}),
-      ...(item.unlisted === true ? { unlisted: true } : {}),
-    },
-    publishState,
-  ).listed;
-}
-
-function normalizeItem(item: FeedItemInput, input: FeedsRenderInput): FeedEntry {
-  return {
-    title: item.title ?? "",
-    description: typeof item.description === "string" ? item.description : undefined,
-    loc: item.loc || itemLoc(input, item),
-    date:
-      parseDate(dateField(item.date ?? item.frontmatter?.date)) ??
-      parseDate(dateField(item.lastUpdated ?? item.frontmatter?.lastUpdated)),
-  };
-}
-
-function itemLoc(input: FeedsRenderInput, item: FeedItemInput): string {
-  const home = homePageUrl(input.siteUrl, input.base);
-  const urlPath = (item.path ?? "").replace(/^\/+|\/+$/g, "");
-  return urlPath ? `${home}${urlPath}/` : home;
-}
-
-function dateField(value: unknown): string | undefined {
-  if (typeof value === "string" && value.trim()) {
-    return value.trim();
-  }
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return String(value);
-  }
-  if (value instanceof Date && !Number.isNaN(value.getTime())) {
-    return value.toISOString();
-  }
-  return undefined;
 }

--- a/npm/vite-plugin-ox-content/src/site-maps.test.ts
+++ b/npm/vite-plugin-ox-content/src/site-maps.test.ts
@@ -89,6 +89,17 @@ describe("generateSiteMaps", () => {
         pages: samplePages,
       }).warning,
     ).toBeDefined();
+    expect(
+      generateSiteMaps({
+        options: { enabled: true, robots: true, llms: true },
+        siteUrl: "javascript:alert(1)",
+        sitemapLoc: "javascript:alert(1)",
+        pages: samplePages,
+      }),
+    ).toEqual({
+      warning:
+        "[ox-content] siteMaps requires ssg.siteUrl to be a safe absolute http(s) URL; sitemap.xml, robots.txt, and llms.txt were not written",
+    });
   });
 
   it("writes a sorted sitemap, robots.txt, and llms.txt", () => {

--- a/npm/vite-plugin-ox-content/src/site-maps.ts
+++ b/npm/vite-plugin-ox-content/src/site-maps.ts
@@ -11,6 +11,8 @@ import type { ResolvedSiteMapsOptions, SiteMapsOptions } from "./types";
 
 const MISSING_SITE_URL =
   "[ox-content] siteMaps is enabled but ssg.siteUrl is not set; sitemap.xml, robots.txt, and llms.txt were not written";
+const UNSAFE_SITE_URL =
+  "[ox-content] siteMaps requires ssg.siteUrl to be a safe absolute http(s) URL; sitemap.xml, robots.txt, and llms.txt were not written";
 
 /** One page considered for crawl manifests. */
 export interface SiteMapPageInput {
@@ -79,8 +81,9 @@ export function generateSiteMaps(input: SiteMapsRenderInput): SiteMapsRenderResu
   if (!input.options?.enabled) {
     return {};
   }
-  if (!hasSiteUrl(input.siteUrl)) {
-    return { warning: MISSING_SITE_URL };
+  const warning = siteUrlWarning(input.siteUrl);
+  if (warning) {
+    return { warning };
   }
 
   const published = input.pages
@@ -147,17 +150,37 @@ export function formatLastmod(timestampMs: number | undefined): string | undefin
   return date.toISOString().slice(0, 10);
 }
 
-function hasSiteUrl(siteUrl: string | undefined): boolean {
-  return Boolean(siteUrl && siteUrl.trim());
-}
-
 function absoluteSitemapUrl(siteUrl: string | undefined, base: string): string {
-  if (!hasSiteUrl(siteUrl)) {
+  if (siteUrlWarning(siteUrl)) {
     return "";
   }
   const origin = (siteUrl ?? "").trim().replace(/\/+$/, "");
   const prefix = !base || base === "/" ? "/" : base.endsWith("/") ? base : `${base}/`;
   return `${origin}${prefix}sitemap.xml`;
+}
+
+function siteUrlWarning(siteUrl: string | undefined): string | undefined {
+  const trimmed = siteUrl?.trim();
+  if (!trimmed) {
+    return MISSING_SITE_URL;
+  }
+  return isSafeHttpUrl(trimmed) ? undefined : UNSAFE_SITE_URL;
+}
+
+function isSafeHttpUrl(value: string): boolean {
+  if (/\s/u.test(value)) {
+    return false;
+  }
+  const lower = value.toLowerCase();
+  if (!lower.startsWith("https://") && !lower.startsWith("http://")) {
+    return false;
+  }
+  try {
+    const url = new URL(value);
+    return (url.protocol === "https:" || url.protocol === "http:") && url.hostname.length > 0;
+  } catch {
+    return false;
+  }
 }
 
 function generateSitemapXml(pages: readonly SiteMapPageInput[]): string {


### PR DESCRIPTION
Closes #860.

## Summary
- dedupe built-in SEO head tags against custom meta/link descriptors and report non-fatal conflict diagnostics
- reject unsafe feed/sitemap site URLs and preflight named feed output collisions/path escapes before writing
- document deterministic SEO conflict and validation behavior

## Validation
- PATH=/Users/nishimura/.local/share/mise/installs/node/26.5.1/bin:$PATH pnpm exec vp test npm/vite-plugin-ox-content/src/feeds.test.ts npm/vite-plugin-ox-content/src/feeds-write.test.ts npm/vite-plugin-ox-content/src/feeds-named.test.ts npm/vite-plugin-ox-content/src/site-maps.test.ts
- cargo +1.95.0 test -p ox_content_ssg html::head
- pnpm exec vp fmt --check npm/vite-plugin-ox-content/src/feeds.ts npm/vite-plugin-ox-content/src/feeds.test.ts npm/vite-plugin-ox-content/src/feeds-write.test.ts npm/vite-plugin-ox-content/src/feeds-named.test.ts npm/vite-plugin-ox-content/src/site-maps.ts npm/vite-plugin-ox-content/src/site-maps.test.ts docs/content/built-in/seo.md docs/content/ja/built-in/seo.md
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 check --workspace --all-targets
- PATH=/Users/nishimura/.local/share/mise/installs/node/26.5.1/bin:$PATH pnpm --filter @ox-content/vite-plugin build
- PATH=/Users/nishimura/.local/share/mise/installs/node/26.5.1/bin:$PATH pnpm --filter @ox-content/code-play build (ignored dist prerequisite for docs build)
- PATH=/Users/nishimura/.local/share/mise/installs/node/26.5.1/bin:$PATH pnpm --filter @ox-content/napi build (ignored native prerequisite for docs build)
- PATH=/Users/nishimura/.local/share/mise/installs/node/26.5.1/bin:$PATH pnpm --dir docs exec vp build

Docs build completed with the existing transform warning for docs/content/ja/built-in/options.json not being found.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790339618&installation_model_id=422833&pr_number=1015&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1015&signature=7543387c81f8d37c6e235dcabd34cfc2ed532bc8503edf7dc495d0fe59bbb262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SEO metadata and link descriptors now resolve deterministically, preventing duplicate tags while allowing custom values to override built-ins.
  * Optional diagnostics identify SEO conflicts, including canonical and social URL disagreements.
  * Feed and sitemap generation now validates site URLs and output paths before writing files.

* **Bug Fixes**
  * Unsafe URLs, traversal paths, and duplicate feed destinations are rejected without creating files.

* **Documentation**
  * Added English and Japanese guidance for SEO conflicts, validation, and feed safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->