### PR TITLE
feat(mdx): accept Svelte document props

### DIFF
--- a/docs/content/examples/integ-svelte.md
+++ b/docs/content/examples/integ-svelte.md
@@ -23,8 +23,11 @@ export default defineConfig({
     svelte(),
     oxContentSvelte({
       srcDir: "docs",
+      ssg: false,
       // Auto-discover all Svelte components
       components: "./src/components/*.svelte",
+      // Opt in when .mdx files are rendered as custom page templates.
+      mdxDocumentProps: true,
     }),
   ],
 });
@@ -81,6 +84,35 @@ export default defineConfig({
   Be careful with this feature!
 </Alert>
 ```
+
+## MDX Page Template Props
+
+Custom `ssg: false` hosts can opt in to render build-time props from `.mdx`
+documents during Svelte SSR:
+
+```mdx
+import PostList from "./PostList.svelte";
+
+# Page Template
+
+Hello {title}.
+
+<PostList items={items} />
+```
+
+```svelte
+<script>
+  import PageTemplate from '../docs/page-template.mdx';
+
+  const posts = [{ title: 'Ox Content with Svelte', href: '/posts/svelte' }];
+</script>
+
+<PageTemplate title="Blog" items={posts} />
+```
+
+Only identifiers and dotted property paths are resolved from Svelte component
+props. Missing values throw a deterministic SSR error instead of rendering an
+empty string.
 
 ## Svelte 5 Features
 

--- a/examples/integ-svelte/docs/PostList.svelte
+++ b/examples/integ-svelte/docs/PostList.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  interface PostItem {
+    title: string;
+    href: string;
+  }
+
+  let { items = [] }: { items?: PostItem[] } = $props();
+</script>
+
+<ul class="post-list">
+  {#each items as item}
+    <li>
+      <a href={item.href}>{item.title}</a>
+    </li>
+  {/each}
+</ul>
+
+<style>
+  .post-list {
+    display: grid;
+    gap: 0.5rem;
+    margin: 1rem 0;
+    padding-left: 1.25rem;
+  }
+
+  a {
+    color: #8bd3ff;
+  }
+</style>

--- a/examples/integ-svelte/docs/page-template.mdx
+++ b/examples/integ-svelte/docs/page-template.mdx
@@ -1,0 +1,9 @@
+import PostList from "./PostList.svelte";
+
+# Page Template
+
+Hello {title}.
+
+Path: {pathname}
+
+<PostList items={items} />

--- a/examples/integ-svelte/src/App.svelte
+++ b/examples/integ-svelte/src/App.svelte
@@ -1,6 +1,12 @@
 <script>
   // Import Markdown document as Svelte component
   import IndexDoc from '../docs/index.md';
+  import PageTemplate from '../docs/page-template.mdx';
+
+  const posts = [
+    { title: 'Ox Content with Svelte', href: '/posts/ox-content-svelte' },
+    { title: 'MDX page templates', href: '/posts/mdx-page-templates' },
+  ];
 </script>
 
 <div class="app">
@@ -10,6 +16,7 @@
   </header>
   <main>
     <IndexDoc />
+    <PageTemplate title="Blog" pathname="/blog" items={posts} />
   </main>
 </div>
 

--- a/examples/integ-svelte/src/vite-env.d.ts
+++ b/examples/integ-svelte/src/vite-env.d.ts
@@ -5,3 +5,8 @@ declare module "*.md" {
   const Component: import("svelte").ComponentType;
   export default Component;
 }
+
+declare module "*.mdx" {
+  const Component: import("svelte").ComponentType;
+  export default Component;
+}

--- a/examples/integ-svelte/vite.config.ts
+++ b/examples/integ-svelte/vite.config.ts
@@ -7,8 +7,10 @@ export default defineConfig({
     svelte(),
     oxContentSvelte({
       srcDir: "docs",
+      ssg: false,
       // Auto-discover components using glob pattern
       components: "./src/components/*.svelte",
+      mdxDocumentProps: true,
     }),
   ],
 });

--- a/npm/vite-plugin-ox-content-svelte/src/document-imports.test.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/document-imports.test.ts
@@ -134,6 +134,7 @@ function createOptions(overrides: Partial<ResolvedSvelteOptions> = {}): Resolved
     runes: true,
     embeds: { github: false, openGraph: false },
     root: "/repo",
+    mdxDocumentProps: false,
     ...overrides,
-  };
+  } as ResolvedSvelteOptions;
 }

--- a/npm/vite-plugin-ox-content-svelte/src/index.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/index.ts
@@ -59,6 +59,7 @@ export type {
   ComponentsOption,
   ComponentsMap,
   BuiltinEmbedOptions,
+  MdxDocumentPropsOption,
   GitHubEmbedOptions,
   OpenGraphEmbedOptions,
   ResolvedBuiltinEmbedOptions,
@@ -116,7 +117,7 @@ export function oxContentSvelte(options: SvelteIntegrationOptions = {}): PluginO
       }
     },
 
-    async transform(code, id) {
+    async transform(code, id, transformOptions) {
       if (!isMarkdownFilePath(id, resolved.extensions)) {
         return null;
       }
@@ -126,6 +127,7 @@ export function oxContentSvelte(options: SvelteIntegrationOptions = {}): PluginO
         components: Object.fromEntries(componentMap),
         root: config.root,
         renderIsland: options.renderIsland,
+        ssr: transformOptions?.ssr,
       });
 
       return {
@@ -225,6 +227,7 @@ function resolveSvelteOptions(
     runes: options.runes ?? true,
     embeds: resolveBuiltinEmbedOptions(options.embeds),
     mdx: options.mdx,
+    mdxDocumentProps: options.mdxDocumentProps ?? false,
   };
 }
 

--- a/npm/vite-plugin-ox-content-svelte/src/transform.test.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/transform.test.ts
@@ -1,6 +1,14 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vite-plus/test";
+import { render } from "svelte/server";
 import { transformMarkdownWithSvelte } from "./transform";
+import type { Component } from "svelte";
 import type { ResolvedSvelteOptions } from "./types";
+
+type GeneratedComponent = Component<Record<string, unknown>>;
 
 describe("transformMarkdownWithSvelte", () => {
   it("turns registered components into islands and leaves fenced tags literal", async () => {
@@ -116,6 +124,93 @@ describe("transformMarkdownWithSvelte", () => {
 
     expect(result.code).toMatchSnapshot();
   });
+
+  it("keeps MDX document props static unless explicitly enabled", async () => {
+    const result = await transformMarkdownWithSvelte(
+      "# Page\n\nHello {title}.\n",
+      "/repo/docs/page.mdx",
+      createOptions({ ssr: true }),
+    );
+
+    expect(result.code).toContain("Hello .");
+    expect(result.code).not.toContain("__ox_mdx_document_prop");
+    await withGeneratedModule(result.code, (Page) => {
+      const rendered = render(Page, { props: { title: "Blog" } });
+      expect(rendered.html).toContain("Hello .");
+    });
+  });
+
+  it("renders opt-in MDX document text props during SSR", async () => {
+    const result = await transformMarkdownWithSvelte(
+      "# Page\n\nHello {title}.\n",
+      "/repo/docs/page.mdx",
+      createOptions({ mdxDocumentProps: true, ssr: true }),
+    );
+
+    expect(result.code).toContain("__ox_mdx_document_prop");
+    expect(result.code).not.toContain("eval(");
+    expect(result.code).not.toContain("new Function");
+    await withGeneratedModule(result.code, (Page) => {
+      const rendered = render(Page, { props: { title: "Blog" } });
+      expect(stripSvelteComments(rendered.html)).toContain("Hello Blog.");
+    });
+  });
+
+  it("passes host object and array props to document-local MDX components during SSR", async () => {
+    const result = await transformMarkdownWithSvelte(
+      "import PostList from './PostList.svelte'\n\n<PostList items={items} meta={meta} />\n",
+      "/repo/docs/page.mdx",
+      createOptions({ components: {}, mdxDocumentProps: true, ssr: true }),
+    );
+    const code = result.code.replace(
+      "import PostList from './PostList.svelte';",
+      [
+        "const PostList = ($$renderer, $$props) => {",
+        "  $$renderer.push('<pre>' + $$props.items.map((item) => item.title).join(',') + ':' + $$props.meta.kind + '</pre>');",
+        "};",
+      ].join("\n"),
+    );
+
+    expect(result.usedComponents).toEqual(["PostList"]);
+    expect(result.code).toContain(
+      'items: __ox_mdx_document_prop(__ox_mdx_props, ["items"], "items")',
+    );
+    await withGeneratedModule(code, (Page) => {
+      const rendered = render(Page, {
+        props: {
+          items: [{ title: "Alpha" }, { title: "Beta" }],
+          meta: { kind: "blog" },
+        },
+      });
+      expect(rendered.html).toContain("<pre>Alpha,Beta:blog</pre>");
+    });
+  });
+
+  it("throws a deterministic diagnostic for missing MDX document props", async () => {
+    const result = await transformMarkdownWithSvelte(
+      "# Page\n\nHello {title}.\n",
+      "/repo/docs/page.mdx",
+      createOptions({ mdxDocumentProps: true, ssr: true }),
+    );
+
+    await withGeneratedModule(result.code, (Page) => {
+      expect(() => render(Page, { props: {} }).html).toThrow(
+        '[ox-content-svelte] Missing MDX document prop "title" in /repo/docs/page.mdx for expression {title}.',
+      );
+    });
+  });
+
+  it("rejects unsupported MDX document prop expressions without eval fallback", async () => {
+    await expect(
+      transformMarkdownWithSvelte(
+        "<Alert title={title + suffix} />\n",
+        "/repo/docs/page.mdx",
+        createOptions({ mdxDocumentProps: true, ssr: true }),
+      ),
+    ).rejects.toThrow(
+      '[ox-content-svelte] Unsupported MDX document prop expression "{title + suffix}" for prop "title" in /repo/docs/page.mdx. Only identifiers and dotted property paths are supported.',
+    );
+  });
 });
 
 function createOptions(overrides: Partial<ResolvedSvelteOptions> = {}): ResolvedSvelteOptions {
@@ -133,6 +228,28 @@ function createOptions(overrides: Partial<ResolvedSvelteOptions> = {}): Resolved
     runes: true,
     embeds: { github: false, openGraph: false },
     root: "/repo",
+    mdxDocumentProps: false,
     ...overrides,
-  };
+  } as ResolvedSvelteOptions;
+}
+
+async function withGeneratedModule(
+  code: string,
+  callback: (component: GeneratedComponent) => void | Promise<void>,
+): Promise<void> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "ox-content-svelte-mdx-props-"));
+  const file = path.join(dir, "page.mjs");
+  await writeFile(file, code, "utf8");
+  try {
+    const mod = (await import(`${pathToFileURL(file).href}?t=${Date.now()}`)) as {
+      default: GeneratedComponent;
+    };
+    await callback(mod.default);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function stripSvelteComments(html: string): string {
+  return html.replace(/<!--[\s\S]*?-->/g, "");
 }

--- a/npm/vite-plugin-ox-content-svelte/src/transform.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/transform.ts
@@ -20,6 +20,10 @@ const PROP_REGEX = /([a-zA-Z0-9-]+)(?:=(?:"([^"]*)"|'([^']*)'|{([^}]*)}|\[([^\]]
 
 const ISLAND_MARKER_PREFIX = "OXCONTENT-ISLAND-";
 const ISLAND_MARKER_SUFFIX = "-PLACEHOLDER";
+const DOCUMENT_PROP_MARKER_PREFIX = "OXCONTENT-DOCUMENT-PROP-";
+const DOCUMENT_PROP_MARKER_SUFFIX = "-PLACEHOLDER";
+const PAYLOAD_SCRIPT = /^\s*<script type="application\/json">[\s\S]*?<\/script>/i;
+const RUST_PAYLOAD_KEYS = new Set(["props", "expressions", "spreads"]);
 
 interface Range {
   start: number;
@@ -93,7 +97,10 @@ export async function transformMarkdownWithSvelte(
   };
 
   if (mdx) {
-    const transformed = await baseTransformMarkdown(markdownContent, id, baseOptions);
+    const documentExpressions = options.mdxDocumentProps
+      ? prepareMdxDocumentExpressions(markdownContent, id)
+      : { content: markdownContent, expressions: [] };
+    const transformed = await baseTransformMarkdown(documentExpressions.content, id, baseOptions);
     const discovered = await discoverDocumentMdxIslands({
       source: markdownContent,
       html: transformed.html,
@@ -103,6 +110,23 @@ export async function transformMarkdownWithSvelte(
       contentRoot: resolveContentRootPath({ srcDir: options.srcDir, root: options.root }),
       srcDir: options.srcDir,
     });
+    if (options.mdxDocumentProps) {
+      return compileSvelteResult(
+        generateMdxDocumentPropsSvelteModule(
+          transformed.html,
+          discovered.usedComponents,
+          frontmatter,
+          options,
+          id,
+          discovered.localBindings,
+          documentExpressions.expressions,
+        ),
+        id,
+        discovered.usedComponents,
+        frontmatter,
+        options.ssr,
+      );
+    }
     const html = options.renderIsland
       ? await applyIslandSsrHtml(
           transformed.html,
@@ -124,6 +148,7 @@ export async function transformMarkdownWithSvelte(
       id,
       discovered.usedComponents,
       frontmatter,
+      options.ssr,
     );
   }
 
@@ -180,6 +205,7 @@ export async function transformMarkdownWithSvelte(
     id,
     usedComponents,
     frontmatter,
+    options.ssr,
   );
 }
 
@@ -188,10 +214,11 @@ function compileSvelteResult(
   id: string,
   usedComponents: string[],
   frontmatter: Record<string, unknown>,
+  ssr = false,
 ): SvelteTransformResult {
   const compiled = compile(svelteCode, {
     filename: id,
-    generate: "client",
+    generate: ssr ? "server" : "client",
     runes: true,
   });
 
@@ -339,6 +366,633 @@ function parseProps(propsString: string): Record<string, unknown> {
     }
   }
   return props;
+}
+
+interface MdxDocumentExpression {
+  marker: string;
+  expression: string;
+  path: string[];
+}
+
+interface PreparedMdxDocumentExpressions {
+  content: string;
+  expressions: MdxDocumentExpression[];
+}
+
+interface MdxIslandRange {
+  name: string;
+  tag: string;
+  openStart: number;
+  openEnd: number;
+  innerStart: number;
+  contentStart: number;
+  closeStart: number;
+  closeEnd: number;
+  propsAttr?: string;
+  script?: string;
+}
+
+interface MdxIslandPayload {
+  props: Record<string, unknown>;
+  expressions: Record<string, string>;
+  spreads: string[];
+}
+
+interface MdxTemplateContext {
+  html: string;
+  filePath: string;
+  usedComponents: Set<string>;
+  expressionsByMarker: Map<string, MdxDocumentExpression>;
+  islandRanges: MdxIslandRange[];
+}
+
+function prepareMdxDocumentExpressions(
+  content: string,
+  filePath: string,
+): PreparedMdxDocumentExpressions {
+  const skipRanges = mergeRanges([
+    ...collectFenceRanges(content),
+    ...collectInlineCodeRanges(content),
+    ...collectMdxEsmLineRanges(content),
+  ]);
+  const expressions: MdxDocumentExpression[] = [];
+  let output = "";
+  let cursor = 0;
+  let rangeIndex = 0;
+  let inTag = false;
+  let quote: string | null = null;
+
+  while (cursor < content.length) {
+    const range = skipRanges[rangeIndex];
+    if (range && cursor >= range.end) {
+      rangeIndex += 1;
+      continue;
+    }
+    if (range && cursor === range.start) {
+      output += content.slice(range.start, range.end);
+      cursor = range.end;
+      continue;
+    }
+
+    const char = content[cursor]!;
+    if (inTag) {
+      output += char;
+      if (quote) {
+        if (char === quote && content[cursor - 1] !== "\\") {
+          quote = null;
+        }
+      } else if (char === '"' || char === "'") {
+        quote = char;
+      } else if (char === ">") {
+        inTag = false;
+      }
+      cursor += 1;
+      continue;
+    }
+
+    if (char === "<" && startsHtmlLikeTag(content, cursor)) {
+      inTag = true;
+      output += char;
+      cursor += 1;
+      continue;
+    }
+
+    if (char === "{" && content[cursor - 1] !== "\\") {
+      const end = findMdxExpressionEnd(content, cursor + 1);
+      if (end !== -1) {
+        const expression = content.slice(cursor + 1, end).trim();
+        const path = parseDocumentPropPath(expression);
+        if (!path) {
+          throw new Error(
+            `[ox-content-svelte] Unsupported MDX document prop expression "{${expression}}" in ${filePath}. Only identifiers and dotted property paths are supported.`,
+          );
+        }
+        const marker = `${DOCUMENT_PROP_MARKER_PREFIX}${expressions.length}${DOCUMENT_PROP_MARKER_SUFFIX}`;
+        expressions.push({ marker, expression, path });
+        output += marker;
+        cursor = end + 1;
+        continue;
+      }
+    }
+
+    output += char;
+    cursor += 1;
+  }
+
+  return { content: output, expressions };
+}
+
+function collectInlineCodeRanges(content: string): Range[] {
+  const ranges: Range[] = [];
+  const fenceRanges = collectFenceRanges(content);
+  let lineStart = 0;
+
+  while (lineStart < content.length) {
+    const lineEnd = content.indexOf("\n", lineStart);
+    const end = lineEnd === -1 ? content.length : lineEnd;
+    if (!isInRanges(lineStart, end, fenceRanges)) {
+      let cursor = lineStart;
+      while (cursor < end) {
+        const marker = matchBacktickRun(content, cursor);
+        if (!marker) {
+          cursor += 1;
+          continue;
+        }
+        const close = content.indexOf(marker, cursor + marker.length);
+        if (close === -1 || close >= end) {
+          cursor += marker.length;
+          continue;
+        }
+        ranges.push({ start: cursor, end: close + marker.length });
+        cursor = close + marker.length;
+      }
+    }
+    lineStart = lineEnd === -1 ? content.length : lineEnd + 1;
+  }
+
+  return ranges;
+}
+
+function collectMdxEsmLineRanges(content: string): Range[] {
+  const ranges: Range[] = [];
+  const fenceRanges = collectFenceRanges(content);
+  let lineStart = 0;
+
+  while (lineStart < content.length) {
+    const lineEnd = content.indexOf("\n", lineStart);
+    const end = lineEnd === -1 ? content.length : lineEnd + 1;
+    const contentEnd = lineEnd === -1 ? content.length : lineEnd;
+    if (!isInRanges(lineStart, contentEnd, fenceRanges)) {
+      const line = content.slice(lineStart, contentEnd).trimStart();
+      if (line.startsWith("import ") || line.startsWith("export ")) {
+        ranges.push({ start: lineStart, end });
+      }
+    }
+    lineStart = lineEnd === -1 ? content.length : lineEnd + 1;
+  }
+
+  return ranges;
+}
+
+function mergeRanges(ranges: Range[]): Range[] {
+  const sorted = ranges
+    .filter((range) => range.end > range.start)
+    .sort((left, right) => left.start - right.start || left.end - right.end);
+  const merged: Range[] = [];
+
+  for (const range of sorted) {
+    const previous = merged.at(-1);
+    if (previous && range.start <= previous.end) {
+      previous.end = Math.max(previous.end, range.end);
+    } else {
+      merged.push({ ...range });
+    }
+  }
+
+  return merged;
+}
+
+function matchBacktickRun(content: string, index: number): string | null {
+  if (content[index] !== "`") return null;
+  let end = index + 1;
+  while (content[end] === "`") {
+    end += 1;
+  }
+  return content.slice(index, end);
+}
+
+function startsHtmlLikeTag(content: string, index: number): boolean {
+  const next = content[index + 1];
+  return next === "/" || next === "!" || next === "?" || /[A-Za-z]/.test(next ?? "");
+}
+
+function findMdxExpressionEnd(content: string, start: number): number {
+  let depth = 1;
+  let quote: string | null = null;
+  let escaped = false;
+
+  for (let index = start; index < content.length; index += 1) {
+    const char = content[index]!;
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+
+  return -1;
+}
+
+function parseDocumentPropPath(expression: string): string[] | null {
+  if (
+    !/^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*$/.test(expression) ||
+    RESERVED_DOCUMENT_PROP_WORDS.has(expression)
+  ) {
+    return null;
+  }
+  return expression.split(".");
+}
+
+const RESERVED_DOCUMENT_PROP_WORDS = new Set([
+  "false",
+  "Infinity",
+  "NaN",
+  "null",
+  "this",
+  "true",
+  "undefined",
+]);
+
+function generateMdxDocumentPropsSvelteModule(
+  html: string,
+  usedComponents: string[],
+  frontmatter: Record<string, unknown>,
+  options: ResolvedSvelteOptions & { root?: string },
+  id: string,
+  localBindings: ReadonlyMap<string, ResolvedDocumentComponentImport>,
+  documentExpressions: readonly MdxDocumentExpression[],
+): string {
+  const filePathLiteral = JSON.stringify(id);
+  const imports = renderIslandComponentImports(usedComponents, {
+    globalComponents: options.components,
+    localBindings,
+    documentPath: id,
+    root: options.root,
+  });
+  const template = renderMdxDocumentTemplate(html, usedComponents, id, documentExpressions);
+
+  return `
+<script>
+  ${imports}
+
+  const frontmatter = ${JSON.stringify(frontmatter)};
+  export { frontmatter };
+
+  let __ox_mdx_props = $props();
+
+  function __ox_mdx_document_prop(props, path, expression) {
+    const propName = path.join(".");
+    let value = props;
+    for (const segment of path) {
+      if (
+        value == null ||
+        (typeof value !== "object" && typeof value !== "function") ||
+        !(segment in Object(value))
+      ) {
+        throw new Error('[ox-content-svelte] Missing MDX document prop "' + propName + '" in ' + ${filePathLiteral} + ' for expression {' + expression + '}.');
+      }
+      value = value[segment];
+    }
+    if (value === undefined) {
+      throw new Error('[ox-content-svelte] Missing MDX document prop "' + propName + '" in ' + ${filePathLiteral} + ' for expression {' + expression + '}.');
+    }
+    return value;
+  }
+</script>
+
+<div class="ox-content">${template}</div>
+
+<style>
+  .ox-content {
+    line-height: 1.6;
+  }
+</style>
+`;
+}
+
+function renderMdxDocumentTemplate(
+  html: string,
+  usedComponents: string[],
+  filePath: string,
+  documentExpressions: readonly MdxDocumentExpression[],
+): string {
+  const context: MdxTemplateContext = {
+    html,
+    filePath,
+    usedComponents: new Set(usedComponents),
+    expressionsByMarker: new Map(
+      documentExpressions.map((expression) => [expression.marker, expression] as const),
+    ),
+    islandRanges: findMdxIslandRanges(html),
+  };
+  return renderHtmlRange(context, 0, html.length);
+}
+
+function renderHtmlRange(context: MdxTemplateContext, start: number, end: number): string {
+  let output = "";
+  let cursor = start;
+
+  while (cursor < end) {
+    const island = findNextIslandRange(context, cursor, end);
+    if (!island) {
+      output += renderRawHtmlTemplate(context.html.slice(cursor, end), context.expressionsByMarker);
+      break;
+    }
+
+    output += renderRawHtmlTemplate(
+      context.html.slice(cursor, island.openStart),
+      context.expressionsByMarker,
+    );
+    output += renderMdxIslandTemplate(context, island);
+    cursor = island.closeEnd;
+  }
+
+  return output;
+}
+
+function findNextIslandRange(
+  context: MdxTemplateContext,
+  cursor: number,
+  end: number,
+): MdxIslandRange | null {
+  for (const island of context.islandRanges) {
+    if (island.openStart < cursor || island.closeEnd > end) {
+      continue;
+    }
+    if (context.usedComponents.has(island.name)) {
+      return island;
+    }
+  }
+  return null;
+}
+
+function renderRawHtmlTemplate(
+  html: string,
+  expressionsByMarker: ReadonlyMap<string, MdxDocumentExpression>,
+): string {
+  if (!html) return "";
+  let output = "";
+  let cursor = 0;
+
+  while (cursor < html.length) {
+    const next = findNextDocumentExpressionMarker(html, cursor, expressionsByMarker);
+    if (!next) {
+      output += renderRawHtmlBlock(html.slice(cursor));
+      break;
+    }
+    output += renderRawHtmlBlock(html.slice(cursor, next.index));
+    output += renderDocumentExpression(next.expression);
+    cursor = next.index + next.expression.marker.length;
+  }
+
+  return output;
+}
+
+function findNextDocumentExpressionMarker(
+  html: string,
+  start: number,
+  expressionsByMarker: ReadonlyMap<string, MdxDocumentExpression>,
+): { index: number; expression: MdxDocumentExpression } | null {
+  let nextIndex = -1;
+  let nextExpression: MdxDocumentExpression | undefined;
+
+  for (const expression of expressionsByMarker.values()) {
+    const index = html.indexOf(expression.marker, start);
+    if (index !== -1 && (nextIndex === -1 || index < nextIndex)) {
+      nextIndex = index;
+      nextExpression = expression;
+    }
+  }
+
+  return nextExpression ? { index: nextIndex, expression: nextExpression } : null;
+}
+
+function renderRawHtmlBlock(html: string): string {
+  return html ? `{@html ${JSON.stringify(html).replaceAll("</script", "<\\/script")}}` : "";
+}
+
+function renderDocumentExpression(expression: MdxDocumentExpression): string {
+  return `{${documentPropResolverExpression(expression.path, expression.expression)}}`;
+}
+
+function renderMdxIslandTemplate(context: MdxTemplateContext, island: MdxIslandRange): string {
+  assertSvelteComponentName(island.name, context.filePath);
+  const attrs = renderMdxIslandAttributes(readMdxIslandPayload(island), context.filePath);
+  const children = renderHtmlRange(context, island.contentStart, island.closeStart);
+  return children
+    ? `<${island.name}${attrs}>${children}</${island.name}>`
+    : `<${island.name}${attrs} />`;
+}
+
+function renderMdxIslandAttributes(payload: MdxIslandPayload, filePath: string): string {
+  const attrs: string[] = [];
+
+  for (const spread of payload.spreads) {
+    const expression = spread.trim().startsWith("...")
+      ? spread.trim().slice(3).trim()
+      : spread.trim();
+    const path = parseDocumentPropPath(expression);
+    if (!path) {
+      throw new Error(
+        `[ox-content-svelte] Unsupported MDX document prop spread "{${spread}}" in ${filePath}. Only identifiers and dotted property paths are supported.`,
+      );
+    }
+    attrs.push(`{...${documentPropResolverExpression(path, expression)}}`);
+  }
+
+  for (const [name, value] of Object.entries(payload.props)) {
+    assertSvelteAttributeName(name, filePath);
+    attrs.push(`${name}={${renderSvelteLiteral(value)}}`);
+  }
+
+  for (const [name, expression] of Object.entries(payload.expressions)) {
+    assertSvelteAttributeName(name, filePath);
+    const path = parseDocumentPropPath(expression.trim());
+    if (!path) {
+      throw new Error(
+        `[ox-content-svelte] Unsupported MDX document prop expression "{${expression}}" for prop "${name}" in ${filePath}. Only identifiers and dotted property paths are supported.`,
+      );
+    }
+    attrs.push(`${name}={${documentPropResolverExpression(path, expression.trim())}}`);
+  }
+
+  return attrs.length > 0 ? ` ${attrs.join(" ")}` : "";
+}
+
+function documentPropResolverExpression(path: readonly string[], expression: string): string {
+  return `__ox_mdx_document_prop(__ox_mdx_props, ${JSON.stringify(path)}, ${JSON.stringify(expression)})`;
+}
+
+function renderSvelteLiteral(value: unknown): string {
+  const literal = JSON.stringify(value);
+  return literal === undefined ? "undefined" : literal.replaceAll("</script", "<\\/script");
+}
+
+function findMdxIslandRanges(html: string): MdxIslandRange[] {
+  const ranges: MdxIslandRange[] = [];
+  const openRe = /<(div|span)\b([^>]*\bdata-ox-island="([^"]+)"[^>]*)>/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = openRe.exec(html)) !== null) {
+    const tag = match[1]!;
+    const name = decodeHtmlAttr(match[3] ?? "");
+    if (!name) continue;
+    const openStart = match.index;
+    const openEnd = match.index + match[0].length;
+    const closeStart = findMatchingClose(html, openEnd, tag);
+    const closeEnd = closeStart < html.length ? closeStart + tag.length + 3 : html.length;
+    const inner = html.slice(openEnd, closeStart);
+    const scriptMatch = inner.match(PAYLOAD_SCRIPT);
+    const script = scriptMatch?.[0];
+    ranges.push({
+      name,
+      tag,
+      openStart,
+      openEnd,
+      innerStart: openEnd,
+      contentStart: openEnd + (script?.length ?? 0),
+      closeStart,
+      closeEnd,
+      propsAttr: matchAttr(match[2] ?? "", "data-ox-props"),
+      script,
+    });
+  }
+
+  return ranges.sort((left, right) => left.openStart - right.openStart);
+}
+
+function findMatchingClose(html: string, from: number, tag: string): number {
+  const openNeedle = `<${tag}`;
+  const closeNeedle = `</${tag}>`;
+  let depth = 1;
+  let cursor = from;
+
+  while (cursor < html.length) {
+    const nextOpen = indexOfTagOpen(html, openNeedle, cursor);
+    const nextClose = html.indexOf(closeNeedle, cursor);
+    if (nextClose === -1) return html.length;
+    if (nextOpen !== -1 && nextOpen < nextClose) {
+      depth += 1;
+      cursor = nextOpen + openNeedle.length;
+    } else {
+      depth -= 1;
+      if (depth === 0) return nextClose;
+      cursor = nextClose + closeNeedle.length;
+    }
+  }
+
+  return html.length;
+}
+
+function indexOfTagOpen(html: string, openNeedle: string, from: number): number {
+  let cursor = from;
+  while (cursor < html.length) {
+    const index = html.indexOf(openNeedle, cursor);
+    if (index === -1) return -1;
+    const next = html[index + openNeedle.length];
+    if (next === " " || next === ">" || next === "\t" || next === "\n" || next === "/") {
+      return index;
+    }
+    cursor = index + openNeedle.length;
+  }
+  return -1;
+}
+
+function matchAttr(attrs: string, name: string): string | undefined {
+  const match = new RegExp(`\\b${name}="([^"]*)"`, "i").exec(attrs);
+  return match?.[1] === undefined ? undefined : decodeHtmlAttr(match[1]);
+}
+
+function readMdxIslandPayload(island: MdxIslandRange): MdxIslandPayload {
+  const fromAttr = island.propsAttr ? tryParseJson(island.propsAttr) : undefined;
+  const fromScript = island.script
+    ? tryParseJson(
+        island.script.match(/<script type="application\/json">([\s\S]*?)<\/script>/i)?.[1] ?? "",
+      )
+    : undefined;
+  return normalizeMdxIslandPayload(fromAttr ?? fromScript ?? {});
+}
+
+function normalizeMdxIslandPayload(parsed: unknown): MdxIslandPayload {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { props: {}, expressions: {}, spreads: [] };
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (keys.length > 0 && keys.every((key) => RUST_PAYLOAD_KEYS.has(key))) {
+    return {
+      props: toRecord(record.props),
+      expressions: toStringRecord(record.expressions),
+      spreads: toStringArray(record.spreads),
+    };
+  }
+
+  return { props: record, expressions: {}, spreads: [] };
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function toStringRecord(value: unknown): Record<string, string> {
+  const record = toRecord(value);
+  const output: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(record)) {
+    if (typeof entry === "string") {
+      output[key] = entry;
+    }
+  }
+  return output;
+}
+
+function toStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function tryParseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function decodeHtmlAttr(value: string): string {
+  return value
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
+}
+
+function assertSvelteComponentName(name: string, filePath: string): void {
+  if (!/^[A-Z][A-Za-z0-9_$]*$/.test(name)) {
+    throw new Error(
+      `[ox-content-svelte] Unsupported MDX component name "${name}" in ${filePath} for mdxDocumentProps. Only simple Svelte component identifiers are supported.`,
+    );
+  }
+}
+
+function assertSvelteAttributeName(name: string, filePath: string): void {
+  if (!/^[A-Za-z_$][\w$-]*$/.test(name)) {
+    throw new Error(
+      `[ox-content-svelte] Unsupported MDX component prop name "${name}" in ${filePath}.`,
+    );
+  }
 }
 
 function generateSvelteModule(

--- a/npm/vite-plugin-ox-content-svelte/src/types.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/types.ts
@@ -35,6 +35,15 @@ export type ComponentsMap = Record<string, string>;
 export type ComponentsOption = ComponentsMap | string | string[];
 
 /**
+ * Opt-in build-time props for MDX documents imported as Svelte components.
+ *
+ * Keep this disabled for static content documents. Enable it when a custom
+ * `ssg: false` host renders `.mdx` files as page templates and passes data
+ * through Svelte component props during SSR.
+ */
+export type MdxDocumentPropsOption = boolean;
+
+/**
  * Svelte integration plugin options.
  *
  * This extends the core ox-content options with Svelte component registration
@@ -105,6 +114,19 @@ export interface SvelteIntegrationOptions extends OxContentOptions {
    * runtime from `@ox-content/vite-plugin`.
    */
   renderIsland?: RenderIslandFn;
+
+  /**
+   * Resolve MDX text expressions and component expression props from Svelte
+   * component props at render time.
+   *
+   * This is off by default so normal `.mdx` documents keep their static,
+   * no-evaluation output. When enabled, only identifiers and dotted property
+   * paths are accepted, for example `{title}` and `items={posts}`. Missing
+   * props throw a deterministic SSR error.
+   *
+   * @default false
+   */
+  mdxDocumentProps?: MdxDocumentPropsOption;
 }
 
 /**
@@ -210,6 +232,8 @@ export interface ResolvedSvelteOptions {
   mdx?: boolean;
   root?: string;
   renderIsland?: RenderIslandFn;
+  mdxDocumentProps: boolean;
+  ssr?: boolean;
 }
 
 export interface SvelteTransformResult {


### PR DESCRIPTION
## Summary
- add opt-in `mdxDocumentProps` for Svelte custom hosts so MDX text expressions and component expression props resolve from SSR props
- render document-local MDX components directly in the prop-bound Svelte path without client eval
- document and demonstrate the custom-host Svelte usage

Closes #866.

## Tests
- `pnpm exec vp exec --filter @ox-content/vite-plugin-svelte -- vp test src`
- `pnpm --filter @ox-content/vite-plugin-svelte typecheck`
- `pnpm exec vp exec --filter @ox-content/vite-plugin-svelte -- vp lint src`
- `pnpm --filter @ox-content/vite-plugin-svelte build`
- `pnpm --filter ox-content-integ-svelte-example build`
- `pnpm run check:file-lines`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790339675&installation_model_id=422833&pr_number=1016&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1016&signature=cdd78825ba3531137b9a070605d7835102a1b870d17e658e91f98a1822f67a75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->