### PR TITLE
feat(api-docs): generate OpenAPI reference docs

### DIFF
--- a/crates/ox_content_docs/Cargo.toml
+++ b/crates/ox_content_docs/Cargo.toml
@@ -23,6 +23,7 @@ ox_jsdoc = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
 phf = { workspace = true }

--- a/crates/ox_content_docs/src/lib.rs
+++ b/crates/ox_content_docs/src/lib.rs
@@ -38,6 +38,7 @@ mod model;
 mod module_routes;
 mod nav;
 mod normalize;
+mod openapi;
 mod output;
 mod string_builder;
 
@@ -72,5 +73,9 @@ pub use normalize::{
     NormalizedDocEntry, NormalizedDocKind, NormalizedMember, NormalizedMemberKind,
     NormalizedParamDoc, NormalizedReturnDoc, NormalizedThrowsDoc, NormalizedTypeParam,
     normalize_doc_item, normalize_doc_items,
+};
+pub use openapi::{
+    GeneratedOpenApiDocs, OpenApiDocsError, OpenApiDocsOptions, OpenApiDocsResult,
+    OpenApiSpecInput, generate_openapi_docs,
 };
 pub use output::{DocsOutputError, DocsOutputOptions, DocsOutputResult, write_docs_output};

--- a/crates/ox_content_docs/src/openapi.rs
+++ b/crates/ox_content_docs/src/openapi.rs
@@ -1,0 +1,226 @@
+//! Static OpenAPI reference generation.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+use thiserror::Error;
+
+use crate::nav::DocsNavItem;
+
+mod inspect;
+mod render;
+mod routes;
+#[cfg(test)]
+mod tests;
+mod value;
+
+const SPEC_SLUG_PLACEHOLDER: &str = "{spec}";
+
+/// One local OpenAPI document to render.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenApiSpecInput {
+    /// Local JSON or YAML file path, resolved against `OpenApiDocsOptions::root`.
+    pub path: PathBuf,
+    /// Optional display name. Defaults to `info.title` or the file stem.
+    pub name: Option<String>,
+    /// Whether unresolved or remote `$ref` values fail generation.
+    pub fail_on_unresolved_refs: bool,
+}
+
+impl Default for OpenApiSpecInput {
+    fn default() -> Self {
+        Self { path: PathBuf::new(), name: None, fail_on_unresolved_refs: true }
+    }
+}
+
+/// Options shared by all OpenAPI inputs.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OpenApiDocsOptions {
+    /// Project root used for path-safety checks. Defaults to the current directory.
+    pub root: Option<PathBuf>,
+    /// Route prefix used by generated nav paths.
+    pub base_path: Option<String>,
+}
+
+/// Generated OpenAPI Markdown pages and sidebar metadata.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GeneratedOpenApiDocs {
+    /// Markdown files keyed by path relative to the docs output directory.
+    pub pages: BTreeMap<String, String>,
+    /// Nav items that point at the generated files.
+    pub nav_items: Vec<DocsNavItem>,
+}
+
+/// Error returned while generating OpenAPI docs.
+#[derive(Debug, Error)]
+pub enum OpenApiDocsError {
+    /// IO error.
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// JSON parse error.
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// YAML parse error.
+    #[error("YAML error: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+
+    /// The input path escaped the configured root.
+    #[error("OpenAPI path `{path}` is outside the configured root `{root}`")]
+    UnsafePath { path: String, root: String },
+
+    /// The document was not a supported OpenAPI document.
+    #[error("Invalid OpenAPI document `{path}`: {message}")]
+    InvalidSpec { path: String, message: String },
+
+    /// The OpenAPI version is unsupported.
+    #[error("Unsupported OpenAPI version `{version}` in `{path}`")]
+    UnsupportedVersion { path: String, version: String },
+
+    /// A `$ref` could not be resolved.
+    #[error("Unresolved OpenAPI ref `{reference}` in `{path}`")]
+    UnresolvedRef { path: String, reference: String },
+}
+
+/// Result type for OpenAPI docs generation.
+pub type OpenApiDocsResult<T> = Result<T, OpenApiDocsError>;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct SpecDoc {
+    pub title: String,
+    pub description: String,
+    pub version: String,
+    pub slug: String,
+    pub servers: Vec<String>,
+    pub operations: Vec<OperationDoc>,
+    pub schemas: Vec<SchemaDoc>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct OperationDoc {
+    pub method: String,
+    pub path: String,
+    pub title: String,
+    pub file_name: String,
+    pub summary: String,
+    pub description: String,
+    pub operation_id: Option<String>,
+    pub tags: Vec<String>,
+    pub deprecated: bool,
+    pub parameters: Vec<ParameterDoc>,
+    pub request_body: Option<RequestBodyDoc>,
+    pub responses: Vec<ResponseDoc>,
+    pub security: Vec<SecurityRequirementDoc>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ParameterDoc {
+    pub name: String,
+    pub location: String,
+    pub required: bool,
+    pub schema: String,
+    pub description: String,
+    pub example: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct RequestBodyDoc {
+    pub required: bool,
+    pub description: String,
+    pub content: Vec<MediaTypeDoc>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ResponseDoc {
+    pub status: String,
+    pub description: String,
+    pub content: Vec<MediaTypeDoc>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct MediaTypeDoc {
+    pub media_type: String,
+    pub schema: String,
+    pub examples: Vec<ExampleDoc>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ExampleDoc {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct SecurityRequirementDoc {
+    pub name: String,
+    pub kind: String,
+    pub scopes: Vec<String>,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct SchemaDoc {
+    pub name: String,
+    pub schema: String,
+    pub description: String,
+    pub required: Vec<String>,
+    pub properties: Vec<SchemaPropertyDoc>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct SchemaPropertyDoc {
+    pub name: String,
+    pub schema: String,
+    pub required: bool,
+    pub description: String,
+}
+
+/// Generates Markdown reference pages and nav metadata from local OpenAPI files.
+pub fn generate_openapi_docs(
+    inputs: &[OpenApiSpecInput],
+    options: &OpenApiDocsOptions,
+) -> OpenApiDocsResult<GeneratedOpenApiDocs> {
+    let root = options.root.clone().unwrap_or(std::env::current_dir()?);
+    let mut generated = GeneratedOpenApiDocs::default();
+    let mut spec_slugs = BTreeSet::new();
+
+    for input in inputs {
+        let path = resolve_local_input_path(&root, &input.path)?;
+        let value = parse_openapi_file(&path)?;
+        let source_path = path.to_string_lossy().into_owned();
+        let mut spec = value::build_spec_doc(&value, &source_path, input)?;
+        spec.slug = inspect::unique_slug(&spec.slug, &mut spec_slugs);
+        let rendered = render::render_spec_doc(&spec, options.base_path.as_deref());
+        generated.pages.extend(rendered.pages);
+        generated.nav_items.push(rendered.nav_item);
+    }
+
+    Ok(generated)
+}
+
+fn resolve_local_input_path(root: &Path, input_path: &Path) -> OpenApiDocsResult<PathBuf> {
+    let root = root.canonicalize()?;
+    let candidate =
+        if input_path.is_absolute() { input_path.to_path_buf() } else { root.join(input_path) };
+    let canonical = candidate.canonicalize()?;
+
+    if !canonical.starts_with(&root) {
+        return Err(OpenApiDocsError::UnsafePath {
+            path: canonical.to_string_lossy().into_owned(),
+            root: root.to_string_lossy().into_owned(),
+        });
+    }
+
+    Ok(canonical)
+}
+
+fn parse_openapi_file(path: &Path) -> OpenApiDocsResult<Value> {
+    let source = fs::read_to_string(path)?;
+    if path.extension().and_then(|extension| extension.to_str()) == Some("json") {
+        return Ok(serde_json::from_str(&source)?);
+    }
+    Ok(serde_yaml::from_str(&source)?)
+}

--- a/crates/ox_content_docs/src/openapi/inspect.rs
+++ b/crates/ox_content_docs/src/openapi/inspect.rs
@@ -1,0 +1,207 @@
+use std::collections::BTreeSet;
+
+use serde_json::{Map, Value};
+
+use crate::string_builder::{join2, join3};
+
+use super::{OpenApiDocsError, OpenApiDocsResult, OpenApiSpecInput};
+
+pub(super) fn schema_label(
+    root: &Value,
+    schema: &Value,
+    source_path: &str,
+    input: &OpenApiSpecInput,
+) -> OpenApiDocsResult<String> {
+    if let Some(reference) = schema.get("$ref").and_then(Value::as_str) {
+        resolve_ref(root, reference, source_path, input)?;
+        return Ok(ref_name(reference));
+    }
+    let Some(object) = schema.as_object() else {
+        return Ok("-".to_string());
+    };
+    if let Some(items) = object.get("items") {
+        return Ok(join3("array<", &schema_label(root, items, source_path, input)?, ">"));
+    }
+    if let Some(values) = object.get("enum").and_then(Value::as_array) {
+        let labels = values.iter().map(enum_value).collect::<Vec<_>>();
+        return Ok(join2("enum: ", &labels.join(" | ")));
+    }
+    for key in ["oneOf", "anyOf", "allOf"] {
+        if let Some(values) = object.get(key).and_then(Value::as_array) {
+            let mut labels = Vec::new();
+            for value in values {
+                labels.push(schema_label(root, value, source_path, input)?);
+            }
+            return Ok(labels.join(if key == "allOf" { " & " } else { " | " }));
+        }
+    }
+    let ty = string_field(object, "type").unwrap_or("object");
+    Ok(object
+        .get("format")
+        .and_then(Value::as_str)
+        .map_or_else(|| ty.to_string(), |format| join3(ty, " (", &join2(format, ")"))))
+}
+
+pub(super) fn resolve_node(
+    root: &Value,
+    value: &Value,
+    source_path: &str,
+    input: &OpenApiSpecInput,
+) -> OpenApiDocsResult<Value> {
+    match value.get("$ref").and_then(Value::as_str) {
+        Some(reference) => resolve_ref(root, reference, source_path, input),
+        None => Ok(value.clone()),
+    }
+}
+
+pub(super) fn sorted_child_objects(value: Option<&Value>) -> Vec<(&str, &Map<String, Value>)> {
+    let mut entries = value
+        .and_then(Value::as_object)
+        .into_iter()
+        .flat_map(Map::iter)
+        .filter_map(|(key, value)| value.as_object().map(|object| (key.as_str(), object)))
+        .collect::<Vec<_>>();
+    entries.sort_unstable_by(|left, right| left.0.cmp(right.0));
+    entries
+}
+
+pub(super) fn sorted_child_values(value: Option<&Value>) -> Vec<(&str, &Value)> {
+    let mut entries = value
+        .and_then(Value::as_object)
+        .into_iter()
+        .flat_map(Map::iter)
+        .map(|(key, value)| (key.as_str(), value))
+        .collect::<Vec<_>>();
+    entries.sort_unstable_by(|left, right| left.0.cmp(right.0));
+    entries
+}
+
+pub(super) fn string_field<'a>(object: &'a Map<String, Value>, key: &str) -> Option<&'a str> {
+    object.get(key).and_then(Value::as_str)
+}
+
+pub(super) fn object_string<'a>(object: &'a Map<String, Value>, key: &str) -> Option<&'a str> {
+    object.get(key).and_then(Value::as_str)
+}
+
+pub(super) fn pointer_string(root: &Value, path: &[&str]) -> Option<String> {
+    let mut current = root;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    current.as_str().map(ToOwned::to_owned)
+}
+
+pub(super) fn string_array(value: Option<&Value>) -> Vec<String> {
+    value
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+pub(super) fn server_urls(root: &Value) -> Vec<String> {
+    root.get("servers")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|server| server.get("url").and_then(Value::as_str))
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+pub(super) fn fallback_title(source_path: &str) -> String {
+    std::path::Path::new(source_path)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("OpenAPI")
+        .to_string()
+}
+
+pub(super) fn slugify(value: &str) -> String {
+    let mut slug = String::new();
+    let mut previous_dash = false;
+    for ch in value.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch);
+            previous_dash = false;
+        } else if !previous_dash && !slug.is_empty() {
+            slug.push('-');
+            previous_dash = true;
+        }
+    }
+    let trimmed = slug.trim_matches('-');
+    if trimmed.is_empty() { "openapi".to_string() } else { trimmed.to_string() }
+}
+
+pub(super) fn unique_slug(base: &str, used: &mut BTreeSet<String>) -> String {
+    let base = if base.is_empty() { "operation" } else { base };
+    let mut slug = base.to_string();
+    let mut suffix = 2;
+    while used.contains(&slug) {
+        slug = join3(base, "-", &suffix.to_string());
+        suffix += 1;
+    }
+    used.insert(slug.clone());
+    slug
+}
+
+pub(super) fn example_value(value: &Value) -> String {
+    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+}
+
+pub(super) fn invalid(path: &str, message: &str) -> OpenApiDocsError {
+    OpenApiDocsError::InvalidSpec { path: path.to_string(), message: message.to_string() }
+}
+
+fn resolve_ref(
+    root: &Value,
+    reference: &str,
+    source_path: &str,
+    input: &OpenApiSpecInput,
+) -> OpenApiDocsResult<Value> {
+    if !reference.starts_with("#/") {
+        return unresolved_ref(source_path, reference, input);
+    }
+    let pointer = decode_json_pointer(reference);
+    match root.pointer(&pointer) {
+        Some(value) => Ok(value.clone()),
+        None => unresolved_ref(source_path, reference, input),
+    }
+}
+
+fn unresolved_ref(
+    source_path: &str,
+    reference: &str,
+    input: &OpenApiSpecInput,
+) -> OpenApiDocsResult<Value> {
+    if input.fail_on_unresolved_refs {
+        return Err(OpenApiDocsError::UnresolvedRef {
+            path: source_path.to_string(),
+            reference: reference.to_string(),
+        });
+    }
+    Ok(Value::Null)
+}
+
+fn decode_json_pointer(reference: &str) -> String {
+    let mut decoded = String::from("/");
+    decoded.push_str(
+        &reference[2..]
+            .split('/')
+            .map(|segment| segment.replace("~1", "/").replace("~0", "~"))
+            .collect::<Vec<_>>()
+            .join("/"),
+    );
+    decoded
+}
+
+fn ref_name(reference: &str) -> String {
+    reference.rsplit('/').next().unwrap_or(reference).replace("~1", "/").replace("~0", "~")
+}
+
+fn enum_value(value: &Value) -> String {
+    value.as_str().map_or_else(|| value.to_string(), ToOwned::to_owned)
+}

--- a/crates/ox_content_docs/src/openapi/render.rs
+++ b/crates/ox_content_docs/src/openapi/render.rs
@@ -1,0 +1,330 @@
+use std::collections::BTreeMap;
+
+use crate::nav::DocsNavItem;
+use crate::string_builder::{StringBuilder, join3};
+
+use super::routes::{operation_file, route_path, spec_file};
+use super::{MediaTypeDoc, OperationDoc, SchemaDoc, SpecDoc};
+
+pub struct RenderedOpenApiSpec {
+    pub pages: BTreeMap<String, String>,
+    pub nav_item: DocsNavItem,
+}
+
+pub(super) fn render_spec_doc(spec: &SpecDoc, base_path: Option<&str>) -> RenderedOpenApiSpec {
+    let mut pages = BTreeMap::new();
+    let index_file = spec_file(spec, "index.md");
+    pages.insert(index_file.clone(), render_index(spec));
+
+    for operation in &spec.operations {
+        let file_name = operation_file(operation, spec);
+        pages.insert(file_name, render_operation(spec, operation));
+    }
+
+    if !spec.schemas.is_empty() {
+        pages.insert(spec_file(spec, "schemas.md"), render_schemas(spec));
+    }
+
+    RenderedOpenApiSpec { nav_item: render_nav(spec, base_path, &index_file), pages }
+}
+
+fn render_index(spec: &SpecDoc) -> String {
+    let mut out = page_frontmatter(&spec.title, &spec.description);
+    out.push_str("# ");
+    out.push_str(&spec.title);
+    out.push_str("\n\n");
+    if !spec.description.is_empty() {
+        out.push_str(&spec.description);
+        out.push_str("\n\n");
+    }
+    if !spec.version.is_empty() {
+        out.push_str("- Version: `");
+        out.push_str(&spec.version);
+        out.push_str("`\n");
+    }
+    if !spec.servers.is_empty() {
+        out.push_str("- Servers: ");
+        out.push_str(
+            &spec.servers.iter().map(|server| inline_code(server)).collect::<Vec<_>>().join(", "),
+        );
+        out.push('\n');
+    }
+    if !spec.version.is_empty() || !spec.servers.is_empty() {
+        out.push('\n');
+    }
+    out.push_str("| Endpoint | Summary | Tags |\n| --- | --- | --- |\n");
+    for operation in &spec.operations {
+        let file_name = operation_file(operation, spec);
+        let link = file_name.rsplit('/').next().unwrap_or(&file_name);
+        out.push_str("| [");
+        out.push_str(&escape_table_cell(&operation.title));
+        out.push_str("](./");
+        out.push_str(link);
+        out.push_str(") | ");
+        out.push_str(&escape_table_cell(&operation.summary));
+        out.push_str(" | ");
+        out.push_str(&escape_table_cell(&operation.tags.join(", ")));
+        out.push_str(" |\n");
+    }
+    if !spec.schemas.is_empty() {
+        out.push_str("\n[Schema reference](./schemas.md)\n");
+    }
+    out
+}
+
+fn render_operation(spec: &SpecDoc, operation: &OperationDoc) -> String {
+    let description = first_non_empty(&operation.summary, &operation.description);
+    let mut out = page_frontmatter(&operation.title, description);
+    out.push_str("# ");
+    out.push_str(&operation.title);
+    out.push_str("\n\n");
+    if !operation.summary.is_empty() {
+        out.push_str(&operation.summary);
+        out.push_str("\n\n");
+    }
+    if !operation.description.is_empty() {
+        out.push_str(&operation.description);
+        out.push_str("\n\n");
+    }
+    out.push_str("## Endpoint\n\n");
+    out.push_str("- Method: `");
+    out.push_str(&operation.method);
+    out.push_str("`\n- Path: `");
+    out.push_str(&operation.path);
+    out.push_str("`\n");
+    if let Some(operation_id) = &operation.operation_id {
+        out.push_str("- Operation ID: `");
+        out.push_str(operation_id);
+        out.push_str("`\n");
+    }
+    if !operation.tags.is_empty() {
+        out.push_str("- Tags: ");
+        out.push_str(
+            &operation.tags.iter().map(|tag| inline_code(tag)).collect::<Vec<_>>().join(", "),
+        );
+        out.push('\n');
+    }
+    if operation.deprecated {
+        out.push_str("- Deprecated: `true`\n");
+    }
+    render_security(&mut out, operation);
+    render_parameters(&mut out, operation);
+    render_request_body(&mut out, operation);
+    render_responses(&mut out, operation);
+
+    if !spec.schemas.is_empty() {
+        out.push_str("\n[Back to ");
+        out.push_str(&spec.title);
+        out.push_str("](./index.md)\n");
+    }
+    out
+}
+
+fn render_security(out: &mut String, operation: &OperationDoc) {
+    out.push_str("\n## Security\n\n");
+    if operation.security.is_empty() {
+        out.push_str("No security requirements.\n");
+        return;
+    }
+    out.push_str("| Scheme | Type | Scopes | Description |\n| --- | --- | --- | --- |\n");
+    for requirement in &operation.security {
+        out.push_str(&table_row(&[
+            &requirement.name,
+            &requirement.kind,
+            &requirement.scopes.join(", "),
+            &requirement.description,
+        ]));
+    }
+}
+
+fn render_parameters(out: &mut String, operation: &OperationDoc) {
+    out.push_str("\n## Parameters\n\n");
+    if operation.parameters.is_empty() {
+        out.push_str("No parameters.\n");
+        return;
+    }
+    out.push_str(
+        "| Name | In | Required | Schema | Description |\n| --- | --- | --- | --- | --- |\n",
+    );
+    for parameter in &operation.parameters {
+        out.push_str(&table_row(&[
+            &parameter.name,
+            &parameter.location,
+            if parameter.required { "yes" } else { "no" },
+            &parameter.schema,
+            &parameter.description,
+        ]));
+        if let Some(example) = &parameter.example {
+            out.push_str("\nExample for `");
+            out.push_str(&parameter.name);
+            out.push_str("`:\n\n```json\n");
+            out.push_str(example);
+            out.push_str("\n```\n");
+        }
+    }
+}
+
+fn render_request_body(out: &mut String, operation: &OperationDoc) {
+    out.push_str("\n## Request Body\n\n");
+    let Some(body) = &operation.request_body else {
+        out.push_str("No request body.\n");
+        return;
+    };
+    if !body.description.is_empty() {
+        out.push_str(&body.description);
+        out.push_str("\n\n");
+    }
+    out.push_str("- Required: `");
+    out.push_str(if body.required { "true" } else { "false" });
+    out.push_str("`\n\n");
+    render_media_types(out, &body.content);
+}
+
+fn render_responses(out: &mut String, operation: &OperationDoc) {
+    out.push_str("\n## Responses\n\n");
+    if operation.responses.is_empty() {
+        out.push_str("No responses declared.\n");
+        return;
+    }
+    for response in &operation.responses {
+        out.push_str("### `");
+        out.push_str(&response.status);
+        out.push_str("`\n\n");
+        if !response.description.is_empty() {
+            out.push_str(&response.description);
+            out.push_str("\n\n");
+        }
+        render_media_types(out, &response.content);
+    }
+}
+
+fn render_media_types(out: &mut String, content: &[MediaTypeDoc]) {
+    if content.is_empty() {
+        out.push_str("No content types declared.\n");
+        return;
+    }
+    out.push_str("| Media type | Schema |\n| --- | --- |\n");
+    for media in content {
+        out.push_str(&table_row(&[&media.media_type, &media.schema]));
+    }
+    for media in content {
+        for example in &media.examples {
+            out.push_str("\nExample `");
+            out.push_str(&example.name);
+            out.push_str("` for `");
+            out.push_str(&media.media_type);
+            out.push_str("`:\n\n```json\n");
+            out.push_str(&example.value);
+            out.push_str("\n```\n");
+        }
+    }
+}
+
+fn render_schemas(spec: &SpecDoc) -> String {
+    let mut out = page_frontmatter("Schema reference", "OpenAPI component schemas.");
+    out.push_str("# Schema Reference\n\n");
+    for schema in &spec.schemas {
+        render_schema(&mut out, schema);
+    }
+    out
+}
+
+fn render_schema(out: &mut String, schema: &SchemaDoc) {
+    out.push_str("## ");
+    out.push_str(&schema.name);
+    out.push_str("\n\n");
+    if !schema.description.is_empty() {
+        out.push_str(&schema.description);
+        out.push_str("\n\n");
+    }
+    out.push_str("- Schema: `");
+    out.push_str(&schema.schema);
+    out.push_str("`\n");
+    if !schema.required.is_empty() {
+        out.push_str("- Required: ");
+        out.push_str(
+            &schema.required.iter().map(|name| inline_code(name)).collect::<Vec<_>>().join(", "),
+        );
+        out.push('\n');
+    }
+    if schema.properties.is_empty() {
+        out.push('\n');
+        return;
+    }
+    out.push_str("\n| Property | Required | Schema | Description |\n| --- | --- | --- | --- |\n");
+    for property in &schema.properties {
+        out.push_str(&table_row(&[
+            &property.name,
+            if property.required { "yes" } else { "no" },
+            &property.schema,
+            &property.description,
+        ]));
+    }
+    out.push('\n');
+}
+
+fn render_nav(spec: &SpecDoc, base_path: Option<&str>, index_file: &str) -> DocsNavItem {
+    let mut tag_groups = BTreeMap::<String, Vec<DocsNavItem>>::new();
+    for operation in &spec.operations {
+        let tag = operation.tags.first().cloned().unwrap_or_else(|| "Endpoints".to_string());
+        let file_name = operation_file(operation, spec);
+        tag_groups.entry(tag).or_default().push(DocsNavItem {
+            title: operation.title.clone(),
+            path: route_path(base_path, &file_name),
+            children: None,
+        });
+    }
+    let mut children = tag_groups
+        .into_iter()
+        .map(|(title, items)| DocsNavItem {
+            title,
+            path: route_path(base_path, index_file),
+            children: Some(items),
+        })
+        .collect::<Vec<_>>();
+    if !spec.schemas.is_empty() {
+        children.push(DocsNavItem {
+            title: "Schemas".to_string(),
+            path: route_path(base_path, &spec_file(spec, "schemas.md")),
+            children: None,
+        });
+    }
+    DocsNavItem {
+        title: spec.title.clone(),
+        path: route_path(base_path, index_file),
+        children: Some(children),
+    }
+}
+
+fn page_frontmatter(title: &str, description: &str) -> String {
+    let mut out = StringBuilder::with_capacity(title.len() + description.len() + 80);
+    out.push_str("---\ntitle: ");
+    out.push_str(&yaml_string(title));
+    if !description.is_empty() {
+        out.push_str("\ndescription: ");
+        out.push_str(&yaml_string(description));
+    }
+    out.push_str("\napiReference: true\n---\n\n");
+    out.into_string()
+}
+
+fn inline_code(value: &str) -> String {
+    join3("`", value, "`")
+}
+
+fn yaml_string(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
+}
+
+fn escape_table_cell(value: &str) -> String {
+    value.replace('|', "\\|").replace('\n', "<br>")
+}
+
+fn table_row(cells: &[&str]) -> String {
+    let escaped = cells.iter().map(|cell| escape_table_cell(cell)).collect::<Vec<_>>();
+    join3("| ", &escaped.join(" | "), " |\n")
+}
+
+fn first_non_empty<'a>(first: &'a str, second: &'a str) -> &'a str {
+    if first.is_empty() { second } else { first }
+}

--- a/crates/ox_content_docs/src/openapi/routes.rs
+++ b/crates/ox_content_docs/src/openapi/routes.rs
@@ -1,0 +1,32 @@
+use crate::string_builder::{join2, join3};
+
+use super::{OperationDoc, SPEC_SLUG_PLACEHOLDER, SpecDoc};
+
+pub(super) fn operation_file(operation: &OperationDoc, spec: &SpecDoc) -> String {
+    operation.file_name.replace(SPEC_SLUG_PLACEHOLDER, &spec.slug)
+}
+
+pub(super) fn spec_file(spec: &SpecDoc, file_name: &str) -> String {
+    join3("openapi/", &spec.slug, &join2("/", file_name))
+}
+
+pub(super) fn route_path(base_path: Option<&str>, file_name: &str) -> String {
+    let normalized_base = normalize_base_path(base_path.unwrap_or("/api"));
+    let mut route = file_name.strip_suffix(".md").unwrap_or(file_name).to_string();
+    if let Some(stripped) = route.strip_suffix("/index") {
+        route = stripped.to_string();
+    }
+    if normalized_base.is_empty() {
+        join2("/", &route)
+    } else {
+        join3(&normalized_base, "/", &route)
+    }
+}
+
+fn normalize_base_path(base_path: &str) -> String {
+    let value = base_path.trim().trim_end_matches('/');
+    if value.is_empty() || value == "/" {
+        return String::new();
+    }
+    if value.starts_with('/') { value.to_string() } else { join2("/", value) }
+}

--- a/crates/ox_content_docs/src/openapi/tests.rs
+++ b/crates/ox_content_docs/src/openapi/tests.rs
@@ -1,0 +1,181 @@
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use super::{OpenApiDocsOptions, OpenApiSpecInput, generate_openapi_docs};
+
+#[test]
+fn renders_openapi_30_json_operations_schemas_and_nav() {
+    let root = temp_root("json");
+    let spec = root.join("petstore.json");
+    fs::write(
+        &spec,
+        r##"{
+  "openapi": "3.0.3",
+  "info": { "title": "Pet Store", "version": "1.0.0", "description": "Store API." },
+  "servers": [{ "url": "https://api.example.com" }],
+  "security": [{ "ApiKeyAuth": [] }],
+  "paths": {
+    "/pets/{id}": {
+      "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+      "get": {
+        "operationId": "getPet",
+        "summary": "Read one pet.",
+        "tags": ["Pets"],
+        "responses": {
+          "200": {
+            "description": "Pet found.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Pet" },
+                "example": { "id": "pet-1", "name": "Nori" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": { "ApiKeyAuth": { "type": "apiKey", "description": "Header key." } },
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "description": "A pet resource.",
+        "required": ["id"],
+        "properties": {
+          "id": { "type": "string", "description": "Stable id." },
+          "tags": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    }
+  }
+}"##,
+    )
+    .unwrap();
+
+    let generated = generate_openapi_docs(
+        &[OpenApiSpecInput { path: PathBuf::from("petstore.json"), ..OpenApiSpecInput::default() }],
+        &OpenApiDocsOptions { root: Some(root.clone()), base_path: Some("/reference".to_string()) },
+    )
+    .unwrap();
+
+    let index = generated.pages.get("openapi/pet-store/index.md").unwrap();
+    assert!(index.contains("# Pet Store"));
+    assert!(index.contains("[GET /pets/{id}](./getpet.md)"));
+    let operation = generated.pages.get("openapi/pet-store/getpet.md").unwrap();
+    assert!(operation.contains("Method: `GET`"));
+    assert!(operation.contains("| id | path | yes | string |"));
+    assert!(operation.contains("| ApiKeyAuth | apiKey |"));
+    assert!(operation.contains("| application/json | Pet |"));
+    let schemas = generated.pages.get("openapi/pet-store/schemas.md").unwrap();
+    assert!(schemas.contains("## Pet"));
+    assert!(schemas.contains("| tags | no | array<string> |"));
+    assert_eq!(generated.nav_items[0].path, "/reference/openapi/pet-store");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn renders_openapi_31_yaml_and_dedupes_operation_ids() {
+    let root = temp_root("yaml");
+    fs::write(
+        root.join("billing.yaml"),
+        r#"
+openapi: 3.1.0
+info:
+  title: Billing API
+  version: 2026-08
+paths:
+  /invoices:
+    get:
+      operationId: list
+      summary: List invoices.
+      responses:
+        "200":
+          description: OK
+  /payments:
+    get:
+      operationId: list
+      summary: List payments.
+      responses:
+        "200":
+          description: OK
+"#,
+    )
+    .unwrap();
+
+    let generated = generate_openapi_docs(
+        &[OpenApiSpecInput { path: PathBuf::from("billing.yaml"), ..OpenApiSpecInput::default() }],
+        &OpenApiDocsOptions { root: Some(root.clone()), base_path: None },
+    )
+    .unwrap();
+
+    assert!(generated.pages.contains_key("openapi/billing-api/list.md"));
+    assert!(generated.pages.contains_key("openapi/billing-api/list-2.md"));
+    assert_eq!(generated.nav_items[0].path, "/api/openapi/billing-api");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn unresolved_refs_fail_with_the_ref_name() {
+    let root = temp_root("ref");
+    fs::write(
+        root.join("broken.json"),
+        r##"{
+  "openapi": "3.0.3",
+  "info": { "title": "Broken", "version": "1" },
+  "paths": {
+    "/pets": {
+      "get": {
+        "responses": {
+          "200": { "$ref": "#/components/responses/Missing" }
+        }
+      }
+    }
+  }
+}"##,
+    )
+    .unwrap();
+
+    let error = generate_openapi_docs(
+        &[OpenApiSpecInput { path: PathBuf::from("broken.json"), ..OpenApiSpecInput::default() }],
+        &OpenApiDocsOptions { root: Some(root.clone()), base_path: None },
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("#/components/responses/Missing"));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn rejects_paths_outside_the_configured_root() {
+    let root = temp_root("root");
+    let outside = temp_root("outside");
+    let spec = outside.join("outside.json");
+    fs::write(&spec, r#"{"openapi":"3.0.3","info":{"title":"Outside","version":"1"},"paths":{}}"#)
+        .unwrap();
+
+    let error = generate_openapi_docs(
+        &[OpenApiSpecInput { path: spec, ..OpenApiSpecInput::default() }],
+        &OpenApiDocsOptions { root: Some(root.clone()), base_path: None },
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("outside the configured root"));
+    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(outside);
+}
+
+fn temp_root(suffix: &str) -> PathBuf {
+    static TEMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let mut name = String::from("ox-content-openapi-");
+    name.push_str(suffix);
+    name.push('-');
+    name.push_str(&std::process::id().to_string());
+    name.push('-');
+    name.push_str(&TEMP_COUNTER.fetch_add(1, Ordering::Relaxed).to_string());
+    let path = std::env::temp_dir().join(name);
+    let _ = fs::remove_dir_all(&path);
+    fs::create_dir_all(&path).unwrap();
+    path
+}

--- a/crates/ox_content_docs/src/openapi/value.rs
+++ b/crates/ox_content_docs/src/openapi/value.rs
@@ -1,0 +1,329 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::{Map, Value};
+
+use crate::string_builder::join3;
+
+use super::{
+    ExampleDoc, MediaTypeDoc, OpenApiDocsError, OpenApiDocsResult, OpenApiSpecInput, OperationDoc,
+    ParameterDoc, RequestBodyDoc, ResponseDoc, SPEC_SLUG_PLACEHOLDER, SchemaDoc, SchemaPropertyDoc,
+    SecurityRequirementDoc, SpecDoc, inspect,
+};
+use inspect::{
+    example_value, fallback_title, invalid, object_string, pointer_string, resolve_node,
+    schema_label, server_urls, slugify, sorted_child_objects, sorted_child_values, string_array,
+    string_field, unique_slug,
+};
+
+const METHODS: &[&str] = &["get", "put", "post", "delete", "options", "head", "patch", "trace"];
+
+#[derive(Debug, Clone, Default)]
+struct SecurityScheme {
+    kind: String,
+    description: String,
+}
+
+pub(super) fn build_spec_doc(
+    root: &Value,
+    source_path: &str,
+    input: &OpenApiSpecInput,
+) -> OpenApiDocsResult<SpecDoc> {
+    let object = root.as_object().ok_or_else(|| invalid(source_path, "expected an object"))?;
+    let version = string_field(object, "openapi")
+        .ok_or_else(|| invalid(source_path, "missing `openapi` version"))?;
+    if !version.starts_with("3.0.") && !version.starts_with("3.1.") {
+        return Err(OpenApiDocsError::UnsupportedVersion {
+            path: source_path.to_string(),
+            version: version.to_string(),
+        });
+    }
+
+    let title = input
+        .name
+        .clone()
+        .or_else(|| pointer_string(root, &["info", "title"]))
+        .unwrap_or_else(|| fallback_title(source_path));
+    let security_schemes = collect_security_schemes(root, source_path, input)?;
+    let root_security = security_requirements(root.get("security"), &security_schemes);
+
+    Ok(SpecDoc {
+        title: title.clone(),
+        description: pointer_string(root, &["info", "description"]).unwrap_or_default(),
+        version: pointer_string(root, &["info", "version"]).unwrap_or_default(),
+        slug: inspect::slugify(&title),
+        servers: server_urls(root),
+        operations: collect_operations(
+            root,
+            source_path,
+            input,
+            &security_schemes,
+            &root_security,
+        )?,
+        schemas: collect_schemas(root, source_path, input)?,
+    })
+}
+
+fn collect_operations(
+    root: &Value,
+    source_path: &str,
+    input: &OpenApiSpecInput,
+    schemes: &BTreeMap<String, SecurityScheme>,
+    root_security: &[SecurityRequirementDoc],
+) -> OpenApiDocsResult<Vec<OperationDoc>> {
+    let mut operations = Vec::new();
+    let mut slugs = BTreeSet::new();
+
+    for (path_name, path_item) in sorted_child_objects(root.pointer("/paths")) {
+        let common_parameters = collect_parameters(
+            root,
+            path_item.get("parameters").and_then(Value::as_array),
+            source_path,
+            input,
+        )?;
+        for method in METHODS {
+            let Some(operation) = path_item.get(*method).and_then(Value::as_object) else {
+                continue;
+            };
+            let mut parameters = common_parameters.clone();
+            parameters.extend(collect_parameters(
+                root,
+                operation.get("parameters").and_then(Value::as_array),
+                source_path,
+                input,
+            )?);
+            let slug_seed = string_field(operation, "operationId")
+                .map_or_else(|| join3(method, " ", path_name), ToOwned::to_owned);
+            let operation_slug = unique_slug(&slugify(&slug_seed), &mut slugs);
+            let method_name = method.to_ascii_uppercase();
+            operations.push(OperationDoc {
+                title: join3(&method_name, " ", path_name),
+                file_name: join3(
+                    "openapi/",
+                    SPEC_SLUG_PLACEHOLDER,
+                    &join3("/", &operation_slug, ".md"),
+                ),
+                method: method_name,
+                path: path_name.to_string(),
+                summary: string_field(operation, "summary").unwrap_or_default().to_string(),
+                description: string_field(operation, "description").unwrap_or_default().to_string(),
+                operation_id: string_field(operation, "operationId").map(ToOwned::to_owned),
+                tags: string_array(operation.get("tags")),
+                deprecated: operation.get("deprecated").and_then(Value::as_bool).unwrap_or(false),
+                parameters,
+                request_body: collect_request_body(
+                    root,
+                    operation.get("requestBody"),
+                    source_path,
+                    input,
+                )?,
+                responses: collect_responses(root, operation.get("responses"), source_path, input)?,
+                security: operation.get("security").map_or_else(
+                    || root_security.to_vec(),
+                    |value| security_requirements(Some(value), schemes),
+                ),
+            });
+        }
+    }
+
+    Ok(operations)
+}
+
+fn collect_parameters(
+    root: &Value,
+    values: Option<&Vec<Value>>,
+    source_path: &str,
+    input: &OpenApiSpecInput,
+) -> OpenApiDocsResult<Vec<ParameterDoc>> {
+    let mut parameters = Vec::new();
+    for parameter in values.into_iter().flatten() {
+        let resolved = resolve_node(root, parameter, source_path, input)?;
+        let Some(object) = resolved.as_object() else {
+            continue;
+        };
+        let schema = object
+            .get("schema")
+            .map(|schema| schema_label(root, schema, source_path, input))
+            .transpose()?
+            .unwrap_or_else(|| "-".to_string());
+        parameters.push(ParameterDoc {
+            name: string_field(object, "name").unwrap_or_default().to_string(),
+            location: string_field(object, "in").unwrap_or_default().to_string(),
+            required: object.get("required").and_then(Value::as_bool).unwrap_or(false),
+            schema,
+            description: string_field(object, "description").unwrap_or_default().to_string(),
+            example: object.get("example").map(example_value),
+        });
+    }
+    Ok(parameters)
+}
+
+fn collect_request_body(
+    root: &Value,
+    value: Option<&Value>,
+    source_path: &str,
+    input: &OpenApiSpecInput,
+) -> OpenApiDocsResult<Option<RequestBodyDoc>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let resolved = resolve_node(root, value, source_path, input)?;
+    let Some(object) = resolved.as_object() else {
+        return Ok(None);
+    };
+    Ok(Some(RequestBodyDoc {
+        required: object.get("required").and_then(Value::as_bool).unwrap_or(false),
+        description: string_field(object, "description").unwrap_or_default().to_string(),
+        content: collect_content(root, object.get("content"), source_path, input)?,
+    }))
+}
+
+fn collect_responses(
+    root: &Value,
+    value: Option<&Value>,
+    source_path: &str,
+    input: &OpenApiSpecInput,
+) -> OpenApiDocsResult<Vec<ResponseDoc>> {
+    let mut responses = Vec::new();
+    for (status, response) in sorted_child_values(value) {
+        let resolved = resolve_node(root, response, source_path, input)?;
+        let Some(object) = resolved.as_object() else {
+            continue;
+        };
+        responses.push(ResponseDoc {
+            status: status.to_string(),
+            description: string_field(object, "description").unwrap_or_default().to_string(),
+            content: collect_content(root, object.get("content"), source_path, input)?,
+        });
+    }
+    Ok(responses)
+}
+
+fn collect_content(
+    root: &Value,
+    value: Option<&Value>,
+    source_path: &str,
+    input: &OpenApiSpecInput,
+) -> OpenApiDocsResult<Vec<MediaTypeDoc>> {
+    let mut content = Vec::new();
+    for (media_type, media) in sorted_child_objects(value) {
+        let schema = media
+            .get("schema")
+            .map(|schema| schema_label(root, schema, source_path, input))
+            .transpose()?
+            .unwrap_or_else(|| "-".to_string());
+        content.push(MediaTypeDoc {
+            media_type: media_type.to_string(),
+            schema,
+            examples: collect_examples(root, media, source_path, input)?,
+        });
+    }
+    Ok(content)
+}
+
+fn collect_examples(
+    root: &Value,
+    media: &Map<String, Value>,
+    source_path: &str,
+    input: &OpenApiSpecInput,
+) -> OpenApiDocsResult<Vec<ExampleDoc>> {
+    let mut examples = Vec::new();
+    if let Some(value) = media.get("example") {
+        examples.push(ExampleDoc { name: "example".to_string(), value: example_value(value) });
+    }
+    for (name, example) in sorted_child_values(media.get("examples")) {
+        let resolved = resolve_node(root, example, source_path, input)?;
+        let value = resolved.get("value").unwrap_or(&resolved);
+        examples.push(ExampleDoc { name: name.to_string(), value: example_value(value) });
+    }
+    Ok(examples)
+}
+
+fn collect_schemas(
+    root: &Value,
+    source_path: &str,
+    input: &OpenApiSpecInput,
+) -> OpenApiDocsResult<Vec<SchemaDoc>> {
+    let mut schemas = Vec::new();
+    for (name, schema) in sorted_child_values(root.pointer("/components/schemas")) {
+        let resolved = resolve_node(root, schema, source_path, input)?;
+        let object = resolved.as_object();
+        schemas.push(SchemaDoc {
+            name: name.to_string(),
+            schema: schema_label(root, schema, source_path, input)?,
+            description: object
+                .and_then(|schema| object_string(schema, "description"))
+                .unwrap_or_default()
+                .to_string(),
+            required: object.map_or_else(Vec::new, |schema| string_array(schema.get("required"))),
+            properties: collect_schema_properties(root, &resolved, source_path, input)?,
+        });
+    }
+    Ok(schemas)
+}
+
+fn collect_schema_properties(
+    root: &Value,
+    schema: &Value,
+    source_path: &str,
+    input: &OpenApiSpecInput,
+) -> OpenApiDocsResult<Vec<SchemaPropertyDoc>> {
+    let Some(schema_object) = schema.as_object() else {
+        return Ok(Vec::new());
+    };
+    let required = string_array(schema_object.get("required")).into_iter().collect::<BTreeSet<_>>();
+    let mut properties = Vec::new();
+    for (name, property) in sorted_child_values(schema_object.get("properties")) {
+        let property_object = property.as_object();
+        properties.push(SchemaPropertyDoc {
+            name: name.to_string(),
+            schema: schema_label(root, property, source_path, input)?,
+            required: required.contains(name),
+            description: property_object
+                .and_then(|property| object_string(property, "description"))
+                .unwrap_or_default()
+                .to_string(),
+        });
+    }
+    Ok(properties)
+}
+
+fn collect_security_schemes(
+    root: &Value,
+    source_path: &str,
+    input: &OpenApiSpecInput,
+) -> OpenApiDocsResult<BTreeMap<String, SecurityScheme>> {
+    let mut schemes = BTreeMap::new();
+    for (name, scheme) in sorted_child_values(root.pointer("/components/securitySchemes")) {
+        let resolved = resolve_node(root, scheme, source_path, input)?;
+        let Some(object) = resolved.as_object() else {
+            continue;
+        };
+        schemes.insert(
+            name.to_string(),
+            SecurityScheme {
+                kind: string_field(object, "type").unwrap_or("security").to_string(),
+                description: string_field(object, "description").unwrap_or_default().to_string(),
+            },
+        );
+    }
+    Ok(schemes)
+}
+
+fn security_requirements(
+    value: Option<&Value>,
+    schemes: &BTreeMap<String, SecurityScheme>,
+) -> Vec<SecurityRequirementDoc> {
+    let mut requirements = Vec::new();
+    for requirement in value.and_then(Value::as_array).into_iter().flatten() {
+        for (name, scopes) in sorted_child_values(Some(requirement)) {
+            let scheme = schemes.get(name).cloned().unwrap_or_default();
+            requirements.push(SecurityRequirementDoc {
+                name: name.to_string(),
+                kind: scheme.kind,
+                scopes: string_array(Some(scopes)),
+                description: scheme.description,
+            });
+        }
+    }
+    requirements
+}

--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -183,6 +183,9 @@ export declare function generateI18nModule(dictDir: string, config: JsI18NRuntim
  */
 export declare function generateOgImageSvg(data: JsOgImageData, config?: JsOgImageConfig | undefined | null): string
 
+/** Generates static OpenAPI reference Markdown pages from local JSON/YAML files. */
+export declare function generateOpenApiDocs(inputs: Array<JsOpenApiDocsInput>, options?: JsOpenApiDocsOptions | undefined | null): JsGeneratedOpenApiDocs
+
 /** Generates the client-side search runtime module. */
 export declare function generateSearchModule(optionsJson: string, indexPath: string): string
 
@@ -968,6 +971,12 @@ export interface JsFrameworkComponentIsland {
   content?: string
 }
 
+/** Generated OpenAPI Markdown pages and navigation metadata. */
+export interface JsGeneratedOpenApiDocs {
+  pages: Record<string, string>
+  nav: Array<JsDocsNavItem>
+}
+
 /** One unique git author returned by `getGitContributors`. */
 export interface JsGitContributor {
   /** Author name from `%an`. */
@@ -1415,6 +1424,19 @@ export interface JsOgImageData {
   siteName?: string
   /** Author name. */
   author?: string
+}
+
+/** One local OpenAPI file consumed by the generated docs pipeline. */
+export interface JsOpenApiDocsInput {
+  path: string
+  name?: string
+  failOnUnresolvedRefs?: boolean
+}
+
+/** Options shared by all OpenAPI docs inputs. */
+export interface JsOpenApiDocsOptions {
+  root?: string
+  basePath?: string
 }
 
 /** Per-page frontmatter chrome flags. */

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -191,6 +191,7 @@ module.exports.generateDocsNavCode = binding.generateDocsNavCode;
 module.exports.collectDocsSourceFiles = binding.collectDocsSourceFiles;
 module.exports.generateDocsDataJson = binding.generateDocsDataJson;
 module.exports.generateDocsMarkdown = binding.generateDocsMarkdown;
+module.exports.generateOpenApiDocs = binding.generateOpenApiDocs;
 module.exports.writeGeneratedDocs = binding.writeGeneratedDocs;
 module.exports.buildCollectionManifest = binding.buildCollectionManifest;
 module.exports.mergeHighlightedCodeBlocks = binding.mergeHighlightedCodeBlocks;

--- a/crates/ox_content_napi/src/docs_bindings.rs
+++ b/crates/ox_content_napi/src/docs_bindings.rs
@@ -1,20 +1,22 @@
 // BTreeMap keeps JavaScript-facing docs output deterministic.
 use std::collections::{BTreeMap, HashMap};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use ox_content_docs::{
-    DocExtractor, DocsNavMetadataOptions, build_export_graph, extract_docs_from_directories,
-    extract_docs_from_entry_points, generate_docs_data_json, generate_markdown, generate_nav_code,
-    generate_nav_metadata, generate_nav_metadata_from_docs_with_options, normalize_doc_items,
+    DocExtractor, DocsNavMetadataOptions, OpenApiDocsOptions, OpenApiSpecInput, build_export_graph,
+    extract_docs_from_directories, extract_docs_from_entry_points, generate_docs_data_json,
+    generate_markdown, generate_nav_code, generate_nav_metadata,
+    generate_nav_metadata_from_docs_with_options, generate_openapi_docs, normalize_doc_items,
     write_docs_output,
 };
 
 use crate::{
     JsDocEntry, JsDocsMarkdownModule, JsDocsMarkdownOptions, JsDocsNavItem, JsDocsNavOptions,
     JsDocsOutputOptions, JsEntryPointDocsOptions, JsEntryPointSpec, JsEntrypointDocsModule,
-    JsExportGraph, JsExtractedDocsModule, JsGraphOptions, JsSourceDocItem,
+    JsExportGraph, JsExtractedDocsModule, JsGeneratedOpenApiDocs, JsGraphOptions,
+    JsOpenApiDocsInput, JsOpenApiDocsOptions, JsSourceDocItem,
 };
 
 mod graph;
@@ -229,6 +231,34 @@ pub fn generate_docs_data_json_napi(
         &generated_at,
     )
     .map_err(|error| Error::from_reason(error.to_string()))
+}
+
+/// Generates static OpenAPI reference Markdown pages from local JSON/YAML files.
+#[napi(js_name = "generateOpenApiDocs")]
+#[allow(clippy::disallowed_types, clippy::implicit_hasher)]
+pub fn generate_openapi_docs_napi(
+    inputs: Vec<JsOpenApiDocsInput>,
+    options: Option<JsOpenApiDocsOptions>,
+) -> Result<JsGeneratedOpenApiDocs> {
+    let options = options.unwrap_or_default();
+    let inputs = inputs
+        .into_iter()
+        .map(|input| OpenApiSpecInput {
+            path: PathBuf::from(input.path),
+            name: input.name,
+            fail_on_unresolved_refs: input.fail_on_unresolved_refs.unwrap_or(true),
+        })
+        .collect::<Vec<_>>();
+    let generated = generate_openapi_docs(
+        &inputs,
+        &OpenApiDocsOptions { root: options.root.map(PathBuf::from), base_path: options.base_path },
+    )
+    .map_err(|error| Error::from_reason(error.to_string()))?;
+
+    Ok(JsGeneratedOpenApiDocs {
+        pages: generated.pages.into_iter().collect(),
+        nav: generated.nav_items.into_iter().map(map_docs_nav_item).collect(),
+    })
 }
 
 /// Writes generated API documentation files and native sidecars.

--- a/crates/ox_content_napi/src/docs_openapi_types.rs
+++ b/crates/ox_content_napi/src/docs_openapi_types.rs
@@ -1,0 +1,31 @@
+use std::collections::HashMap;
+
+use napi_derive::napi;
+
+use crate::JsDocsNavItem;
+
+/// One local OpenAPI file consumed by the generated docs pipeline.
+#[napi(object)]
+#[derive(Clone, Default)]
+pub struct JsOpenApiDocsInput {
+    pub path: String,
+    pub name: Option<String>,
+    pub fail_on_unresolved_refs: Option<bool>,
+}
+
+/// Options shared by all OpenAPI docs inputs.
+#[napi(object)]
+#[derive(Clone, Default)]
+pub struct JsOpenApiDocsOptions {
+    pub root: Option<String>,
+    pub base_path: Option<String>,
+}
+
+/// Generated OpenAPI Markdown pages and navigation metadata.
+#[napi(object)]
+#[derive(Clone, Default)]
+#[allow(clippy::disallowed_types)]
+pub struct JsGeneratedOpenApiDocs {
+    pub pages: HashMap<String, String>,
+    pub nav: Vec<JsDocsNavItem>,
+}

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -18,6 +18,7 @@ mod collection_bindings;
 mod docs_bindings;
 mod docs_graph_types;
 mod docs_markdown_types;
+mod docs_openapi_types;
 mod docs_source_types;
 mod ffi;
 mod framework_codegen;
@@ -44,10 +45,12 @@ pub use docs_bindings::{
     build_export_graph_napi, collect_docs_source_files, extract_docs_from_directories_napi,
     extract_docs_from_entry_points_napi, extract_file_doc_entries, extract_file_docs,
     generate_docs_data_json_napi, generate_docs_markdown, generate_docs_nav_code,
-    generate_docs_nav_metadata, generate_docs_nav_metadata_from_docs_napi, write_generated_docs,
+    generate_docs_nav_metadata, generate_docs_nav_metadata_from_docs_napi,
+    generate_openapi_docs_napi, write_generated_docs,
 };
 pub use docs_graph_types::*;
 pub use docs_markdown_types::*;
+pub use docs_openapi_types::*;
 pub use docs_source_types::*;
 pub use framework_codegen::*;
 pub use highlight_bindings::*;

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -187,6 +187,9 @@ export declare function generateI18nModule(dictDir: string, config: JsI18NRuntim
  */
 export declare function generateOgImageSvg(data: JsOgImageData, config?: JsOgImageConfig | undefined | null): string
 
+/** Generates static OpenAPI reference Markdown pages from local JSON/YAML files. */
+export declare function generateOpenApiDocs(inputs: Array<JsOpenApiDocsInput>, options?: JsOpenApiDocsOptions | undefined | null): JsGeneratedOpenApiDocs
+
 /** Generates the client-side search runtime module. */
 export declare function generateSearchModule(optionsJson: string, indexPath: string): string
 
@@ -972,6 +975,12 @@ export interface JsFrameworkComponentIsland {
   content?: string
 }
 
+/** Generated OpenAPI Markdown pages and navigation metadata. */
+export interface JsGeneratedOpenApiDocs {
+  pages: Record<string, string>
+  nav: Array<JsDocsNavItem>
+}
+
 /** One unique git author returned by `getGitContributors`. */
 export interface JsGitContributor {
   /** Author name from `%an`. */
@@ -1419,6 +1428,19 @@ export interface JsOgImageData {
   siteName?: string
   /** Author name. */
   author?: string
+}
+
+/** One local OpenAPI file consumed by the generated docs pipeline. */
+export interface JsOpenApiDocsInput {
+  path: string
+  name?: string
+  failOnUnresolvedRefs?: boolean
+}
+
+/** Options shared by all OpenAPI docs inputs. */
+export interface JsOpenApiDocsOptions {
+  root?: string
+  basePath?: string
 }
 
 /** Per-page frontmatter chrome flags. */

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
@@ -195,6 +195,7 @@ module.exports.generateDocsNavCode = binding.generateDocsNavCode;
 module.exports.collectDocsSourceFiles = binding.collectDocsSourceFiles;
 module.exports.generateDocsDataJson = binding.generateDocsDataJson;
 module.exports.generateDocsMarkdown = binding.generateDocsMarkdown;
+module.exports.generateOpenApiDocs = binding.generateOpenApiDocs;
 module.exports.writeGeneratedDocs = binding.writeGeneratedDocs;
 module.exports.buildCollectionManifest = binding.buildCollectionManifest;
 module.exports.mergeHighlightedCodeBlocks = binding.mergeHighlightedCodeBlocks;

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
@@ -195,6 +195,7 @@ module.exports.generateDocsNavCode = binding.generateDocsNavCode;
 module.exports.collectDocsSourceFiles = binding.collectDocsSourceFiles;
 module.exports.generateDocsDataJson = binding.generateDocsDataJson;
 module.exports.generateDocsMarkdown = binding.generateDocsMarkdown;
+module.exports.generateOpenApiDocs = binding.generateOpenApiDocs;
 module.exports.writeGeneratedDocs = binding.writeGeneratedDocs;
 module.exports.buildCollectionManifest = binding.buildCollectionManifest;
 module.exports.mergeHighlightedCodeBlocks = binding.mergeHighlightedCodeBlocks;

--- a/npm/vite-plugin-ox-content/src/docs.test.ts
+++ b/npm/vite-plugin-ox-content/src/docs.test.ts
@@ -2,7 +2,13 @@ import { afterEach, describe, expect, it } from "vite-plus/test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { extractDocs, generateMarkdown, resolveDocsOptions, writeDocs } from "./docs";
+import {
+  extractDocs,
+  generateMarkdown,
+  generateOpenApiDocs,
+  resolveDocsOptions,
+  writeDocs,
+} from "./docs";
 import type { ExtractedDocs } from "./types";
 
 const tempDirs: string[] = [];
@@ -250,6 +256,79 @@ describe("writeDocs", () => {
 
     const nav = await fs.readFile(path.join(outDir, "nav.ts"), "utf-8");
     expect(nav).toMatchSnapshot();
+  });
+});
+
+describe("resolveDocsOptions", () => {
+  it("normalizes OpenAPI docs shorthand and shared defaults", () => {
+    expect(
+      resolveDocsOptions({
+        basePath: "/reference",
+        openapi: {
+          src: ["./openapi.yaml", { path: "./billing.json", name: "Billing" }],
+          failOnUnresolvedRefs: false,
+        },
+      })?.openapi,
+    ).toEqual({
+      src: [
+        { path: "./openapi.yaml", failOnUnresolvedRefs: false },
+        { path: "./billing.json", name: "Billing", failOnUnresolvedRefs: false },
+      ],
+      basePath: "/reference",
+    });
+  });
+});
+
+describe("generateOpenApiDocs", () => {
+  it("renders local OpenAPI pages and sidebar metadata", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-openapi-"));
+    tempDirs.push(root);
+
+    await fs.writeFile(
+      path.join(root, "openapi.yaml"),
+      `openapi: 3.1.0
+info:
+  title: Pet API
+  version: 1.0.0
+paths:
+  /pets/{id}:
+    get:
+      operationId: getPet
+      summary: Get a pet
+      tags: [Pets]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: string
+`,
+      "utf-8",
+    );
+
+    const options = resolveDocsOptions({
+      basePath: "/reference",
+      openapi: "openapi.yaml",
+    })!;
+    const generated = generateOpenApiDocs(options, root);
+
+    expect(generated.pages["openapi/pet-api/index.md"]).toContain("Get a pet");
+    expect(generated.pages["openapi/pet-api/getpet.md"]).toContain("## Responses");
+    expect(generated.pages["openapi/pet-api/schemas.md"]).toContain("## Pet");
+    expect(generated.nav[0]).toMatchObject({
+      title: "Pet API",
+      path: "/reference/openapi/pet-api",
+    });
   });
 });
 

--- a/npm/vite-plugin-ox-content/src/docs.ts
+++ b/npm/vite-plugin-ox-content/src/docs.ts
@@ -57,6 +57,11 @@ import type {
   DocEntry,
   ResolvedDocsEntryPoint,
   DocsOptions,
+  DocsNavigationItem,
+  GeneratedOpenApiDocs,
+  OpenApiDocsSource,
+  ResolvedOpenApiDocsInput,
+  ResolvedOpenApiDocsOptions,
 } from "./types";
 import { importNapiModule, importNapiModuleSync } from "./napi";
 
@@ -72,6 +77,8 @@ const DEFAULT_DOCS_INCLUDE = [
   "**/*.cts",
   "**/*.cjs",
 ];
+
+const DEFAULT_OPENAPI_NAV_BASE_PATH = "/api";
 
 /**
  * Extracts JSDoc documentation from source files in specified directories.
@@ -257,6 +264,39 @@ export function generateMarkdown(
 }
 
 /**
+ * Generates Markdown documentation from local OpenAPI 3.0/3.1 files.
+ */
+export function generateOpenApiDocs(
+  options: ResolvedDocsOptions,
+  root = process.cwd(),
+): GeneratedOpenApiDocs {
+  if (!options.openapi) {
+    return { pages: {}, nav: [] };
+  }
+
+  const napi = importNapiModuleSync();
+  const generateOpenApiDocs = (
+    napi as {
+      generateOpenApiDocs?: (
+        inputs: ResolvedOpenApiDocsInput[],
+        options?: { root?: string; basePath?: string },
+      ) => GeneratedOpenApiDocs;
+    }
+  ).generateOpenApiDocs;
+
+  if (typeof generateOpenApiDocs !== "function") {
+    throw new Error(
+      "[ox-content] generateOpenApiDocs is not available from @ox-content/napi. Please rebuild the NAPI package.",
+    );
+  }
+
+  return generateOpenApiDocs(options.openapi.src, {
+    root,
+    basePath: options.openapi.basePath ?? options.basePath ?? DEFAULT_OPENAPI_NAV_BASE_PATH,
+  });
+}
+
+/**
  * Writes generated documentation to the output directory.
  */
 export async function writeDocs(
@@ -264,6 +304,7 @@ export async function writeDocs(
   outDir: string,
   extractedDocs?: ExtractedDocs[],
   options?: ResolvedDocsOptions,
+  extraNav: DocsNavigationItem[] = [],
 ): Promise<void> {
   const napi = importNapiModuleSync();
 
@@ -273,12 +314,22 @@ export async function writeDocs(
     );
   }
 
+  let generateNav = options?.generateNav ?? false;
+  let docsToWrite = docs;
+  if (generateNav && extraNav.length > 0) {
+    docsToWrite = {
+      ...docs,
+      "nav.ts": generateCombinedNavCode(napi, extractedDocs, options, extraNav),
+    };
+    generateNav = false;
+  }
+
   napi.writeGeneratedDocs(
-    docs,
+    docsToWrite,
     outDir,
     extractedDocs ? toRustDocsModules(extractedDocs) : undefined,
     {
-      generateNav: options?.generateNav ?? false,
+      generateNav,
       groupBy: options?.groupBy ?? "file",
       generatedAt: existingGeneratedAt(outDir) ?? new Date().toISOString(),
       basePath: options?.basePath,
@@ -290,6 +341,64 @@ export async function writeDocs(
       singleEntryRoot: options?.singleEntryRoot,
     },
   );
+}
+
+function generateCombinedNavCode(
+  napi: unknown,
+  extractedDocs: ExtractedDocs[] | undefined,
+  options: ResolvedDocsOptions | undefined,
+  extraNav: DocsNavigationItem[],
+): string {
+  const nav = [...generateSourceDocsNav(napi, extractedDocs, options), ...extraNav];
+  const generateDocsNavCode = (
+    napi as {
+      generateDocsNavCode?: (nav: DocsNavigationItem[], exportName?: string) => string;
+    }
+  ).generateDocsNavCode;
+  if (typeof generateDocsNavCode !== "function") {
+    throw new Error("[ox-content] generateDocsNavCode is not available from @ox-content/napi.");
+  }
+  return generateDocsNavCode(nav, "apiNav");
+}
+
+function generateSourceDocsNav(
+  napi: unknown,
+  extractedDocs: ExtractedDocs[] | undefined,
+  options: ResolvedDocsOptions | undefined,
+): DocsNavigationItem[] {
+  if (!extractedDocs?.length || !options || options.groupBy !== "file") {
+    return [];
+  }
+  const generateDocsNavMetadataFromDocs = (
+    napi as {
+      generateDocsNavMetadataFromDocs?: (
+        docs: ReturnType<typeof toRustDocsModules>,
+        options: {
+          basePath?: string;
+          pathStrategy: ResolvedDocsOptions["pathStrategy"];
+          groupOrder?: string[];
+          sort?: string[];
+          sortEntryPoints: boolean;
+          kindSortOrder?: string[];
+          singleEntryRoot: ResolvedDocsOptions["singleEntryRoot"];
+        },
+      ) => DocsNavigationItem[];
+    }
+  ).generateDocsNavMetadataFromDocs;
+  if (typeof generateDocsNavMetadataFromDocs !== "function") {
+    throw new Error(
+      "[ox-content] generateDocsNavMetadataFromDocs is not available from @ox-content/napi.",
+    );
+  }
+  return generateDocsNavMetadataFromDocs(toRustDocsModules(extractedDocs), {
+    basePath: options.basePath,
+    pathStrategy: options.pathStrategy,
+    groupOrder: options.groupOrder,
+    sort: options.sort,
+    sortEntryPoints: options.sortEntryPoints,
+    kindSortOrder: options.kindSortOrder,
+    singleEntryRoot: options.singleEntryRoot,
+  });
 }
 
 /** Keep `docs.json`'s timestamp stable across regenerations of the same tree. */
@@ -366,6 +475,7 @@ export function resolveDocsOptions(
     entryPoints: opts.entryPoints?.map((entryPoint) =>
       typeof entryPoint === "string" ? { path: entryPoint } : entryPoint,
     ),
+    openapi: resolveOpenApiDocsOptions(opts.openapi, opts.basePath),
     format: opts.format ?? "markdown",
     private: opts.private ?? false,
     internal: opts.internal ?? false,
@@ -394,4 +504,60 @@ export function resolveDocsOptions(
     singleEntryRoot: opts.singleEntryRoot ?? "preserve",
     generateNav: opts.generateNav ?? true,
   };
+}
+
+function resolveOpenApiDocsOptions(
+  input: DocsOptions["openapi"],
+  basePath: string | undefined,
+): ResolvedOpenApiDocsOptions | false {
+  if (!input || input === false) {
+    return false;
+  }
+
+  const config = isOpenApiSource(input) || Array.isArray(input) ? { src: input } : input;
+  const defaultFailOnUnresolvedRefs = config.failOnUnresolvedRefs ?? true;
+  const sources = toArray(config.src).map((source) =>
+    resolveOpenApiDocsInput(source, defaultFailOnUnresolvedRefs),
+  );
+
+  if (sources.length === 0) {
+    return false;
+  }
+
+  return {
+    src: sources,
+    basePath: config.basePath ?? basePath,
+  };
+}
+
+function resolveOpenApiDocsInput(
+  source: OpenApiDocsSource,
+  defaultFailOnUnresolvedRefs: boolean,
+): ResolvedOpenApiDocsInput {
+  if (typeof source === "string") {
+    return { path: source, failOnUnresolvedRefs: defaultFailOnUnresolvedRefs };
+  }
+
+  return {
+    path: source.path,
+    name: source.name,
+    failOnUnresolvedRefs: source.failOnUnresolvedRefs ?? defaultFailOnUnresolvedRefs,
+  };
+}
+
+function isOpenApiSource(
+  input: DocsOptions["openapi"],
+): input is OpenApiDocsSource | OpenApiDocsSource[] {
+  return (
+    typeof input === "string" ||
+    Array.isArray(input) ||
+    (typeof input === "object" && input !== null && "path" in input)
+  );
+}
+
+function toArray<T>(value: T | T[] | undefined): T[] {
+  if (value === undefined) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
 }

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -10,7 +10,7 @@ import type { Plugin, ViteDevServer, ResolvedConfig } from "vite";
 import "./virtual";
 import { createMarkdownEnvironment } from "./environment";
 import { transformMarkdown } from "./transform";
-import { extractDocs, generateMarkdown, writeDocs } from "./docs";
+import { extractDocs, generateMarkdown, generateOpenApiDocs, writeDocs } from "./docs";
 import { buildSsg } from "./ssg";
 import { notFoundSearchExcludeIds } from "./not-found";
 import { BlogFeedError } from "./blog";
@@ -95,6 +95,13 @@ export type {
   MarkdownDisplayFormat,
   DocsOptions,
   ResolvedDocsOptions,
+  OpenApiDocsSource,
+  OpenApiDocsInput,
+  OpenApiDocsOptions,
+  ResolvedOpenApiDocsInput,
+  ResolvedOpenApiDocsOptions,
+  DocsNavigationItem,
+  GeneratedOpenApiDocs,
   DocEntry,
   ParamDoc,
   ReturnDoc,
@@ -236,9 +243,10 @@ async function regenerateDocs(resolvedOptions: ResolvedOptions, root: string): P
   const srcDirs = docsOptions.src.map((src) => path.resolve(root, src));
   const outDir = path.resolve(root, docsOptions.out);
   const extracted = await extractDocs(srcDirs, docsOptions);
-  const generated = generateMarkdown(extracted, docsOptions);
+  const openapi = generateOpenApiDocs(docsOptions, root);
+  const generated = { ...generateMarkdown(extracted, docsOptions), ...openapi.pages };
 
-  await writeDocs(generated, outDir, extracted, docsOptions);
+  await writeDocs(generated, outDir, extracted, docsOptions, openapi.nav);
 
   return Object.keys(generated).length;
 }
@@ -804,7 +812,13 @@ export {
   type RunDocsTestsOptions,
   type WrittenDocsTestFile,
 } from "./docs-tests";
-export { extractDocs, generateMarkdown, writeDocs, resolveDocsOptions } from "./docs";
+export {
+  extractDocs,
+  generateMarkdown,
+  generateOpenApiDocs,
+  writeDocs,
+  resolveDocsOptions,
+} from "./docs";
 export { lintMarkdown, lintMarkdownAsync } from "./lint";
 export { lintMarkdownFile, lintMarkdownFiles, shouldLintMarkdownFile } from "./lint-files";
 export type {

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -3711,6 +3711,16 @@ export interface DocsOptions {
   entryPoints?: DocsEntryPoint[];
 
   /**
+   * Local OpenAPI 3.0/3.1 JSON or YAML files to render as static REST API docs.
+   *
+   * Generated pages are written under `out/openapi/<spec>/` and use the same
+   * Markdown, stale-file cleanup, SSG, and search pipeline as source docs.
+   *
+   * @default false
+   */
+  openapi?: OpenApiDocsSource | OpenApiDocsSource[] | OpenApiDocsOptions | false;
+
+  /**
    * Output format.
    *
    * `markdown` is the primary supported format. `json` and `html` are reserved
@@ -3924,6 +3934,7 @@ export interface ResolvedDocsOptions {
   include: string[];
   exclude: string[];
   entryPoints?: ResolvedDocsEntryPoint[];
+  openapi: ResolvedOpenApiDocsOptions | false;
   format: "markdown" | "json" | "html";
   private: boolean;
   internal: boolean;
@@ -3951,6 +3962,55 @@ export interface ResolvedDocsOptions {
   kindSortOrder?: string[];
   singleEntryRoot: "preserve" | "flatten";
   generateNav: boolean;
+}
+
+/** OpenAPI docs shorthand accepted by `docs.openapi`. */
+export type OpenApiDocsSource = string | OpenApiDocsInput;
+
+/** One local OpenAPI file consumed by generated REST API docs. */
+export interface OpenApiDocsInput {
+  /** JSON or YAML file path, resolved from the Vite project root. */
+  path: string;
+  /** Optional display name. Defaults to `info.title` or the file name. */
+  name?: string;
+  /** Fail on unresolved or remote `$ref` values. Defaults to `true`. */
+  failOnUnresolvedRefs?: boolean;
+}
+
+/** Object form for configuring generated OpenAPI docs. */
+export interface OpenApiDocsOptions {
+  /** Local OpenAPI files to render. */
+  src?: OpenApiDocsSource | OpenApiDocsSource[];
+  /** Route prefix used by generated OpenAPI nav metadata. Defaults to `basePath` or `/api`. */
+  basePath?: string;
+  /** Default unresolved `$ref` policy for sources. Defaults to `true`. */
+  failOnUnresolvedRefs?: boolean;
+}
+
+/** Resolved local OpenAPI file input. */
+export interface ResolvedOpenApiDocsInput {
+  path: string;
+  name?: string;
+  failOnUnresolvedRefs: boolean;
+}
+
+/** Resolved generated OpenAPI docs options. */
+export interface ResolvedOpenApiDocsOptions {
+  src: ResolvedOpenApiDocsInput[];
+  basePath?: string;
+}
+
+/** Navigation item emitted for generated docs sidebars. */
+export interface DocsNavigationItem {
+  title: string;
+  path: string;
+  children?: DocsNavigationItem[];
+}
+
+/** Generated OpenAPI Markdown pages and sidebar metadata. */
+export interface GeneratedOpenApiDocs {
+  pages: Record<string, string>;
+  nav: DocsNavigationItem[];
 }
 
 /**


### PR DESCRIPTION
Closes #945.

## Summary
- add a Rust OpenAPI 3.0/3.1 reference generator for local JSON/YAML files
- expose the generator through NAPI and @ox-content/vite-plugin docs options
- merge generated OpenAPI pages into docs output and sidebar nav metadata
- validate refs, local path safety, duplicate operation slugs, examples, security, schemas, and TS option normalization

## Validation
- node scripts/check-file-lines.ts
- git diff --check HEAD~1..HEAD
- vp run workspace:fmt:check
- vp run check:ts
- vp exec --filter @ox-content/vite-plugin -- vp test src/docs.test.ts
- INSTA_WORKSPACE_ROOT=$PWD cargo test -p ox_content_docs openapi
- cargo test -p ox_content_napi generate_openapi_docs --no-default-features
- vp exec --filter @ox-content/vite-plugin -- vp run build

## Local broad-test note
- INSTA_WORKSPACE_ROOT=$PWD vp run test still fails in existing ox_content_lsp snapshot tests because the local insta snapshot path is doubled under crates/ox_content_lsp/crates/ox_content_lsp. The same pattern was reproduced outside the OpenAPI code path; focused package gates above pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790340734&installation_model_id=422833&pr_number=1018&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1018&signature=7c81c57eadf64fc3da028aaed1be3b93048ffed044e0d422c9354d4db19d6cb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->