### PR TITLE
feat(code-play): run Rust Go and Python examples

### DIFF
--- a/docs/content/examples/code-play.md
+++ b/docs/content/examples/code-play.md
@@ -6,7 +6,10 @@ description: Opt-in on-demand sample execution with stdio, stderr, config, prove
 # Code Play
 
 This page uses `@ox-content/code-play` with **JavaScript** and **TypeScript**
-enabled. Other languages stay ordinary fences until a site opts them in.
+enabled. Other languages stay ordinary fences until a site opts them in. The
+standalone `examples/code-play` app also opts into Rust and Go, and renders
+Python with an explicit remote executor when `OX_CODE_PLAY_PYTHON_ENDPOINT` is
+set.
 Routes without a `play` fence stay ordinary docs pages and do not load
 `ox-code-play.js`.
 
@@ -27,6 +30,9 @@ export default {
       languages: {
         javascript: true,
         typescript: { execute: true, typecheck: true },
+        rust: true,
+        go: true,
+        python: { endpoint: "https://piston.example/api/v2/piston" },
       },
       ui: "default",
       viewers: { config: true, stdio: true, stderr: true, provenance: true, timing: true },
@@ -119,9 +125,36 @@ renders no chrome — use `createCodePlay()` from your own UI.
 
 ## Remote languages
 
-Python, Rust, Go, and the rest of the catalog are registered but not enabled
-on this page. Give Rust/Go a playground endpoint, or give Python a
-Piston-compatible `endpoint`, before marking those fences `play`.
+Rust and Go use typed playground adapters. During `vite dev`, their browser
+payloads use the Vite dev proxy by default; production builds embed
+`endpoints.rust` and `endpoints.go`. Python uses the generic remote adapter and
+needs a Piston-compatible `languages.python.endpoint`.
+
+````md
+```rust play typecheck play-title="Rust playground"
+fn main() {
+    println!("ok");
+}
+```
+
+```go play typecheck play-title="Go playground" play-withVet=false
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("ok")
+}
+```
+
+```python play play-title="Python via Piston"
+print("ok")
+```
+````
+
+If Python is enabled without an endpoint, **Run** reports
+`status: "unsupported"` and explains that a configured HTTP executor is
+required. Transport and CORS failures report `status: "offline"`.
 
 See [@ox-content/code-play](../packages/code-play.md) and the
 [roadmap](../code-play-roadmap.md).

--- a/docs/content/packages/code-play.md
+++ b/docs/content/packages/code-play.md
@@ -11,8 +11,10 @@ nothing until you list languages.
 
 The [docs example](../examples/code-play.md) on this site and the standalone
 [`examples/code-play`](https://github.com/ubugeeei-prod/ox-content/tree/main/examples/code-play)
-app enable JavaScript and TypeScript only. Rust, Go, and remote languages stay
-off unless you opt in.
+app demonstrate the browser UI. The docs site keeps JavaScript and TypeScript
+enabled; the standalone app also enables Rust and Go, and renders Python with
+an explicit Piston-compatible endpoint when one is configured. Rust, Go, and
+remote languages stay off unless you opt in.
 
 ## Install
 
@@ -29,6 +31,9 @@ export default {
       languages: {
         typescript: { execute: true, typecheck: true },
         javascript: true,
+        rust: true,
+        go: true,
+        python: { endpoint: "https://piston.example/api/v2/piston" },
       },
       ui: "default",
       viewers: { config: true, stdio: true, stderr: true, provenance: true, timing: true },
@@ -77,6 +82,20 @@ fn main() {
     println!("ok");
 }
 ```
+
+```go play typecheck play-title="Go vet off" play-withVet=false
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("ok")
+}
+```
+
+```python play play-title="Python via Piston"
+print("ok")
+```
 ````
 
 `play-title` labels the widget. `play-compact` / `play-headless` override
@@ -84,7 +103,8 @@ the UI preset for one sample, `play-timeout=2500` overrides the timeout, and
 `play-viewers=stdio,stderr,-timing` toggles viewers. `play-<config-key>=...`
 sets one language config value for that sample, so TypeScript can use
 `play-strict=false`, Rust can use `play-edition=2021`, and Go can use
-`play-withVet=false`.
+`play-withVet=false`. Python and other remote languages need their
+`languages.<id>.endpoint` set at plugin configuration time.
 
 HTML / MDX form:
 
@@ -197,6 +217,18 @@ Rust and Go on a published page call `endpoints.rust` / `endpoints.go`
 directly from the browser. Official playgrounds may reject that as CORS;
 keep the Vite proxy for local docs, or point `endpoints` at an executor you
 control.
+
+During `vite dev`, Code Play payloads use `/__ox-code-play/rust` and
+`/__ox-code-play/go` by default when `proxy` is enabled. Explicit
+`endpoints.rust` and `endpoints.go` values are preserved. Production builds
+embed the configured endpoints instead, so static hosts do not depend on the
+dev middleware.
+
+Python has no bundled public executor. Configure a Piston-compatible
+`languages.python.endpoint` that you operate or trust. If Python is enabled
+without an endpoint, the widget still renders, but **Run** returns
+`status: "unsupported"` with an endpoint diagnostic instead of silently doing
+nothing.
 
 ## Security
 

--- a/examples/code-play/README.md
+++ b/examples/code-play/README.md
@@ -1,7 +1,7 @@
 # Code Play example
 
 Minimal Vite + Ox Content site that opts into `@ox-content/code-play` for
-JavaScript and TypeScript only.
+JavaScript, TypeScript, Rust, Go, and Python.
 
 From the repository root:
 
@@ -9,7 +9,14 @@ From the repository root:
 corepack pnpm --filter ./examples/code-play dev
 ```
 
-Then open the printed local URL. Click **Run** on a `play` fence.
+Then open the printed local URL. Click **Run** on a `play` fence. Rust and Go
+use the Vite dev proxy for their official playground requests during `dev`.
+Python renders as Code Play, but **Run** reports `unsupported` until you point
+it at a Piston-compatible executor:
+
+```bash
+OX_CODE_PLAY_PYTHON_ENDPOINT=https://your-piston.example/api/v2/piston corepack pnpm --filter ./examples/code-play dev
+```
 
 ```bash
 corepack pnpm --filter ./examples/code-play build
@@ -21,4 +28,5 @@ routes with `play` fences load the runtime.
 
 The plugin never executes samples during Markdown transform or SSG. Readers
 trigger **Run** in the browser. TypeScript **Typecheck** needs the Vite dev
-proxy or a reachable `endpoints.typecheck`.
+proxy or a reachable `endpoints.typecheck`. Python source is sent to the
+configured `OX_CODE_PLAY_PYTHON_ENDPOINT`; set only an executor you trust.

--- a/examples/code-play/content/index.md
+++ b/examples/code-play/content/index.md
@@ -5,9 +5,11 @@ description: Minimal Vite site that runs documentation samples on demand.
 
 # Code Play example
 
-This site enables **JavaScript** and **TypeScript** only. Mark a fence with
-`play`. **Typecheck** shows during `vite dev`, or on a published page if you
-set `endpoints.typecheck`.
+This site enables **JavaScript**, **TypeScript**, **Rust**, **Go**, and
+**Python**. Mark a fence with `play`. **Typecheck** shows for TypeScript during
+`vite dev`, or on a published page if you set `endpoints.typecheck`. Rust and
+Go use official playground adapters; Python uses a Piston-compatible endpoint
+when `OX_CODE_PLAY_PYTHON_ENDPOINT` is set.
 
 See the [plain page](./plain.md) for a route with no Code Play runtime.
 
@@ -24,6 +26,26 @@ console.log(label);
 
 ```js play play-title="JavaScript sum"
 console.log(2 + 40);
+```
+
+```rust play typecheck play-title="Rust playground" play-mode=release
+fn main() {
+    println!("hello from Rust Code Play");
+}
+```
+
+```go play typecheck play-title="Go playground" play-withVet=false
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("hello from Go Code Play")
+}
+```
+
+```python play play-title="Python remote executor"
+print("hello from Python Code Play")
 ```
 
 See [@ox-content/code-play](https://github.com/ubugeeei-prod/ox-content/blob/main/docs/content/packages/code-play.md)

--- a/examples/code-play/vite.config.ts
+++ b/examples/code-play/vite.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vite-plus";
 import { oxContent } from "@ox-content/vite-plugin";
 import { codePlay } from "@ox-content/code-play";
 
+const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env;
+const pythonEndpoint = env?.OX_CODE_PLAY_PYTHON_ENDPOINT;
+
 export default defineConfig({
   plugins: [
     oxContent({
@@ -13,6 +16,9 @@ export default defineConfig({
       languages: {
         javascript: true,
         typescript: { execute: true, typecheck: true },
+        rust: true,
+        go: true,
+        python: pythonEndpoint ? { endpoint: pythonEndpoint } : true,
       },
       srcDir: "content",
       outDir: "dist",

--- a/npm/ox-content-code-play/src/adapters.test.ts
+++ b/npm/ox-content-code-play/src/adapters.test.ts
@@ -114,6 +114,43 @@ describe("language adapters", () => {
     expect(sh.stdio[0]?.text).toBe("1\n");
   });
 
+  it("runs Python through an explicit Piston-compatible endpoint", async () => {
+    const transport = createMemoryTransport((request) => {
+      expect(request.url).toBe("https://exec.example/api/v2/piston/execute");
+      expect(request.method).toBe("POST");
+      const body = JSON.parse(request.body ?? "{}") as {
+        language: string;
+        version: string;
+        files: Array<{ content: string }>;
+      };
+      expect(body).toEqual({
+        language: "python",
+        version: "*",
+        files: [{ content: "print('py ok')" }],
+      });
+      return {
+        ok: true,
+        status: 200,
+        text: JSON.stringify({ run: { stdout: "py ok\n", stderr: "", code: 0 } }),
+      };
+    });
+    const play = createCodePlay({
+      languages: { python: { endpoint: "https://exec.example/api/v2/piston" } },
+      transport,
+    });
+
+    const result = await play.createSession({ language: "py", code: "print('py ok')" }).run();
+
+    expect(result.status).toBe("ok");
+    expect(result.stdout).toBe("py ok\n");
+    expect(result.stderr).toBe("");
+    expect(result.provenance.execute).toEqual({
+      host: "exec.example",
+      runtime: "python",
+      sandbox: "piston",
+    });
+  });
+
   it("builds framework preview documents instead of executing host UI code", async () => {
     const play = createCodePlay({ languages: { vue: true, react: true } });
     const result = await play

--- a/npm/ox-content-code-play/src/config.ts
+++ b/npm/ox-content-code-play/src/config.ts
@@ -36,6 +36,12 @@ export const DEFAULT_ENDPOINTS: PlaygroundEndpoints = {
   go: "https://play.golang.org/compile",
 };
 
+/** Vite dev middleware only. Rust browser runs use this proxy during `vite dev`. */
+export const DEV_RUST_PATH = "/__ox-code-play/rust";
+
+/** Vite dev middleware only. Go browser runs use this proxy during `vite dev`. */
+export const DEV_GO_PATH = "/__ox-code-play/go";
+
 /** Vite dev middleware only. Not present in production SSG output. */
 export const DEV_TYPECHECK_PATH = "/__ox-code-play/typecheck";
 

--- a/npm/ox-content-code-play/src/plugin.test.ts
+++ b/npm/ox-content-code-play/src/plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { DEV_TYPECHECK_PATH } from "./config";
+import { DEV_GO_PATH, DEV_RUST_PATH, DEV_TYPECHECK_PATH } from "./config";
 import { decodePayload } from "./payload";
 import { codePlay } from "./plugin";
 
@@ -45,6 +45,69 @@ describe("codePlay vite plugin", () => {
     const payload = payloadFromTransform(plugin, "```python play\nprint(1)\n```\n");
     expect(payload.endpoint).toBe("https://exec.example/api/v2/piston");
     expect(payload.capabilities.execute).toBe(true);
+  });
+
+  it("rewrites opted-in Rust, Go, and Python play fences on the same page", () => {
+    const plugin = codePlay({
+      languages: {
+        rust: true,
+        go: true,
+        python: { endpoint: "https://exec.example/api/v2/piston" },
+      },
+    });
+    resolveCommand(plugin, "build");
+    const transform = hookFn(plugin.transform) as (source: string, id: string) => string | null;
+    const rewritten = transform(
+      [
+        '```rust play typecheck play-title="Rust"',
+        "fn main() {}",
+        "```",
+        '```go play typecheck play-title="Go"',
+        "package main",
+        "func main() {}",
+        "```",
+        '```python play play-title="Python"',
+        "print(1)",
+        "```",
+      ].join("\n"),
+      "page.md",
+    );
+    const payloads = [...(rewritten ?? "").matchAll(/<!--ox-code-play:([A-Za-z0-9+/=]+)-->/g)].map(
+      (match) => decodePayload(match[1] ?? ""),
+    );
+
+    expect(payloads.map((payload) => payload.language)).toEqual(["rust", "go", "python"]);
+    expect(payloads.map((payload) => payload.capabilities.execute)).toEqual([true, true, true]);
+    expect(payloads.map((payload) => payload.capabilities.typecheck)).toEqual([true, true, false]);
+    expect(payloads[2]?.endpoint).toBe("https://exec.example/api/v2/piston");
+  });
+
+  it("uses Vite dev proxy endpoints for Rust and Go browser payloads", () => {
+    const plugin = codePlay({ languages: { rust: true, go: true } });
+    resolveCommand(plugin, "serve");
+
+    const rust = payloadFromTransform(plugin, "```rust play\nfn main() {}\n```\n");
+    const go = payloadFromTransform(plugin, "```go play\npackage main\nfunc main() {}\n```\n");
+
+    expect(rust.endpoints?.rust).toBe(DEV_RUST_PATH);
+    expect(rust.endpoints?.go).toBe(DEV_GO_PATH);
+    expect(go.endpoints?.rust).toBe(DEV_RUST_PATH);
+    expect(go.endpoints?.go).toBe(DEV_GO_PATH);
+  });
+
+  it("keeps explicit Rust and Go endpoints out of the dev proxy payload rewrite", () => {
+    const plugin = codePlay({
+      languages: { rust: true, go: true },
+      endpoints: {
+        rust: "https://rust.example/execute",
+        go: "https://go.example/compile",
+      },
+    });
+    resolveCommand(plugin, "serve");
+
+    const rust = payloadFromTransform(plugin, "```rust play\nfn main() {}\n```\n");
+    expect(rust.endpoints?.rust).toBe("https://rust.example/execute");
+    expect(rust.endpoints?.go).toBe("https://go.example/compile");
   });
 
   it("embeds per-sample authoring options in payloads", () => {

--- a/npm/ox-content-code-play/src/plugin.ts
+++ b/npm/ox-content-code-play/src/plugin.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import type { Plugin, ViteDevServer } from "vite";
 import { resolveLanguage } from "./catalog";
 import {
+  DEV_GO_PATH,
+  DEV_RUST_PATH,
   DEV_TYPECHECK_PATH,
   resolveCodePlayOptions,
   type RawCodePlayOptions,
@@ -30,6 +32,7 @@ const MARKDOWN_RE = /\.(?:md|markdown|mdx)(?:$|\?)/i;
 export function codePlay(options: CodePlayPluginOptions = {}): Plugin {
   const resolved = resolveCodePlayOptions(options);
   const explicitTypecheck = options.endpoints?.typecheck;
+  const proxyTargets = { rust: resolved.endpoints.rust, go: resolved.endpoints.go };
   let base = resolved.base;
   let command: "build" | "serve" = "serve";
   let outDir = resolved.outDir;
@@ -56,12 +59,14 @@ export function codePlay(options: CodePlayPluginOptions = {}): Plugin {
       root = config.root;
       base = resolved.base === "/" ? normalizeBase(config.base) : resolved.base;
       outDir = resolved.outDir ?? config.build.outDir;
-      if (explicitTypecheck === undefined) {
-        if (command === "serve" && resolved.proxy) {
-          resolved.endpoints.typecheck = DEV_TYPECHECK_PATH;
-        } else {
-          delete resolved.endpoints.typecheck;
-        }
+      if (command === "serve" && resolved.proxy) {
+        resolved.endpoints.rust = options.endpoints?.rust ?? DEV_RUST_PATH;
+        resolved.endpoints.go = options.endpoints?.go ?? DEV_GO_PATH;
+      }
+      if (explicitTypecheck === undefined && command === "serve" && resolved.proxy) {
+        resolved.endpoints.typecheck = DEV_TYPECHECK_PATH;
+      } else if (explicitTypecheck === undefined) {
+        delete resolved.endpoints.typecheck;
       }
     },
 
@@ -103,7 +108,7 @@ export function codePlay(options: CodePlayPluginOptions = {}): Plugin {
 
     configureServer(server) {
       if (resolved.proxy) {
-        mountProxies(server, resolved.endpoints.rust, resolved.endpoints.go);
+        mountProxies(server, proxyTargets.rust, proxyTargets.go);
       }
       server.middlewares.use(async (req, res, next) => {
         const urlPath = req.url?.split("?")[0] ?? "";

--- a/npm/vite-plugin-ox-content/test/vrt/code-play.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/code-play.spec.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import { bundleBrowserClient } from "../../../ox-content-code-play/src/bundle-browser";
 import { resolveCodePlayOptions } from "../../../ox-content-code-play/src/config";
 import { enhancePlayHtml } from "../../../ox-content-code-play/src/html";
@@ -137,3 +137,195 @@ test("Cancel aborts an in-flight sandbox run and re-enables Run", async ({ page 
     await rm(outDir, { recursive: true, force: true });
   }
 });
+
+test("hydrates Rust, Go, and Python runtime widgets and runs them on demand", async ({ page }) => {
+  const outDir = await mkdtemp(path.join(tmpdir(), "ox-code-play-vrt-runtimes-"));
+  try {
+    await bundleBrowserClient(outDir);
+    const client = await readFile(path.join(outDir, "browser.mjs"), "utf8");
+    const options = resolveCodePlayOptions({
+      languages: {
+        rust: true,
+        go: true,
+        python: { endpoint: "https://exec.example/api/v2/piston" },
+      },
+    });
+    const rustCode = `fn main() {\n    println!("rust ok");\n}`;
+    const goCode = `package main\nimport "fmt"\nfunc main() { fmt.Println("go ok") }`;
+    const pythonCode = `print("python ok")`;
+
+    await page.route("https://play.rust-lang.org/execute", async (route) => {
+      if (route.request().method() === "OPTIONS") {
+        await route.fulfill({ status: 204, headers: corsHeaders() });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        headers: { ...corsHeaders(), "content-type": "application/json" },
+        body: JSON.stringify({ success: true, stdout: "rust ok\n", stderr: "" }),
+      });
+    });
+    await page.route("https://play.golang.org/compile", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { ...corsHeaders(), "content-type": "application/json" },
+        body: JSON.stringify({ Events: [{ Kind: "stdout", Message: "go ok\n" }] }),
+      });
+    });
+    await page.route("https://exec.example/api/v2/piston/execute", async (route) => {
+      if (route.request().method() === "OPTIONS") {
+        await route.fulfill({ status: 204, headers: corsHeaders() });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        headers: { ...corsHeaders(), "content-type": "application/json" },
+        body: JSON.stringify({ run: { stdout: "python ok\n", stderr: "", code: 0 } }),
+      });
+    });
+
+    const html = [
+      renderWidget("rust", rustCode, "Rust success", options),
+      renderWidget("go", goCode, "Go success", options),
+      renderWidget("python", pythonCode, "Python success", options),
+    ].join("\n");
+    await page.setContent(
+      `<!doctype html><html><head><meta charset="utf-8"></head><body>${html}<script type="module">${client}</script></body></html>`,
+      { waitUntil: "domcontentloaded" },
+    );
+
+    await runWidget(page, "Rust success", "rust ok");
+    await runWidget(page, "Go success", "go ok");
+    await runWidget(page, "Python success", "python ok");
+    await expect(page.getByRole("region", { name: /Rust success/ })).toContainText(
+      "Rust Playground",
+    );
+    await expect(page.getByRole("region", { name: /Go success/ })).toContainText("Go Playground");
+    await expect(page.getByRole("region", { name: /Python success/ })).toContainText(
+      "Piston-compatible",
+    );
+  } finally {
+    await rm(outDir, { recursive: true, force: true });
+  }
+});
+
+test("surfaces runtime errors and unsupported remote executors in hydrated widgets", async ({
+  page,
+}) => {
+  const outDir = await mkdtemp(path.join(tmpdir(), "ox-code-play-vrt-runtimes-error-"));
+  try {
+    await bundleBrowserClient(outDir);
+    const client = await readFile(path.join(outDir, "browser.mjs"), "utf8");
+    const options = resolveCodePlayOptions({ languages: { go: true, python: true } });
+    await page.route("https://play.golang.org/compile", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { ...corsHeaders(), "content-type": "application/json" },
+        body: JSON.stringify({ Errors: "prog.go:3:1: undefined: missing\n" }),
+      });
+    });
+    const html = [
+      renderWidget(
+        "go",
+        `package main\nfunc main() {\n    missing()\n}`,
+        "Go compile error",
+        options,
+      ),
+      renderWidget("python", `print("needs endpoint")`, "Python unsupported", options),
+    ].join("\n");
+    await page.setContent(
+      `<!doctype html><html><head><meta charset="utf-8"></head><body>${html}<script type="module">${client}</script></body></html>`,
+      { waitUntil: "domcontentloaded" },
+    );
+
+    const go = page.getByRole("region", { name: /Go compile error/ });
+    await go.getByRole("button", { name: /Run/ }).click();
+    await expect(go.locator("[data-ox-status]")).toHaveText("Error");
+    await expect(go.locator(".ox-code-play__diag--error").first()).toContainText(
+      "undefined: missing",
+    );
+
+    const python = page.getByRole("region", { name: /Python unsupported/ });
+    await expect(python).toContainText("Endpoint missing");
+    await python.getByRole("button", { name: /Run/ }).click();
+    await expect(python.locator("[data-ox-status]")).toHaveText("Unsupported");
+    await expect(python.locator(".ox-code-play__diag--error").first()).toContainText(
+      /Python execution needs a configured HTTP executor/,
+    );
+  } finally {
+    await rm(outDir, { recursive: true, force: true });
+  }
+});
+
+test("surfaces Rust playground transport failures as offline in the browser", async ({ page }) => {
+  const outDir = await mkdtemp(path.join(tmpdir(), "ox-code-play-vrt-runtimes-offline-"));
+  try {
+    await bundleBrowserClient(outDir);
+    const client = await readFile(path.join(outDir, "browser.mjs"), "utf8");
+    const options = resolveCodePlayOptions({ languages: { rust: true } });
+    await page.route("https://play.rust-lang.org/execute", async (route) => {
+      await route.abort("failed");
+    });
+    const html = renderWidget("rust", `fn main() {}`, "Rust offline", options);
+    await page.setContent(
+      `<!doctype html><html><head><meta charset="utf-8"></head><body>${html}<script type="module">${client}</script></body></html>`,
+      { waitUntil: "domcontentloaded" },
+    );
+
+    const rust = page.getByRole("region", { name: /Rust offline/ });
+    await rust.getByRole("button", { name: /Run/ }).click();
+    await expect(rust.locator("[data-ox-status]")).toHaveText("Offline");
+    await expect(rust.locator(".ox-code-play__diag--error").first()).toContainText(
+      /CORS|unreachable/,
+    );
+  } finally {
+    await rm(outDir, { recursive: true, force: true });
+  }
+});
+
+function renderWidget(
+  language: string,
+  code: string,
+  title: string,
+  options: ReturnType<typeof resolveCodePlayOptions>,
+): string {
+  const payload = encodePayload(
+    payloadFromFence(
+      {
+        language,
+        meta: `play play-title="${title}"`,
+        code,
+        raw: "",
+        start: 0,
+        end: 0,
+        typecheck: false,
+        title,
+        config: {},
+      },
+      options,
+    ),
+  );
+  const escapedCode = code.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+  return enhancePlayHtml(`<pre><code class="language-${language}">${escapedCode}</code></pre>`, {
+    decodePayload,
+    encodePayload,
+    matchFences: [{ language, code, payload }],
+  });
+}
+
+async function runWidget(page: Page, title: string, output: string): Promise<void> {
+  const widget = page.getByRole("region", { name: new RegExp(title) });
+  await widget.getByRole("button", { name: /Run/ }).click();
+  await expect(widget.locator("[data-ox-status]")).toHaveText("Done");
+  await expect(widget.locator(".ox-code-play__stdio-text")).toContainText(output, {
+    timeout: 10_000,
+  });
+}
+
+function corsHeaders(): Record<string, string> {
+  return {
+    "access-control-allow-origin": "*",
+    "access-control-allow-methods": "POST, OPTIONS",
+    "access-control-allow-headers": "content-type",
+  };
+}


### PR DESCRIPTION
## Summary
- route Rust and Go browser payloads through the Vite dev proxy by default during `vite dev`, while preserving explicit endpoints and production endpoints
- extend the standalone Code Play example and package docs with Rust, Go, and Python runtime examples; Python remains an explicit Piston-compatible remote executor
- add adapter, plugin, and browser coverage for Rust/Go/Python success, error, offline, unsupported, and no-runtime plain-page behavior

Closes #916

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @ox-content/code-play test`
- `corepack pnpm --filter @ox-content/code-play typecheck`
- `corepack pnpm --filter @ox-content/code-play build`
- `corepack pnpm --filter @ox-content/napi build`
- `corepack pnpm --filter @ox-content/vite-plugin build`
- `corepack pnpm --dir npm/vite-plugin-ox-content exec playwright test test/vrt/code-play.spec.ts`
- `corepack pnpm --filter ./examples/code-play build`
- `OX_CODE_PLAY_PYTHON_ENDPOINT=https://exec.example/api/v2/piston corepack pnpm --filter ./examples/code-play build` plus decoded Python payload endpoint assertion
- plain-page runtime assertion: `examples/code-play/dist/plain/index.html` has no `data-ox-code-play` and no `ox-code-play.js` script tag
- `corepack pnpm exec vpr fmt:check`
- `node scripts/check-file-lines.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790342106&installation_model_id=422833&pr_number=1020&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1020&signature=d2add4ef9c4de3dee42fb210f77dc7faa0e1d04a43f204a60481a637f79c6187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Rust and Go execution support to the Code Play example.
  * Added optional Python execution through a configurable Piston-compatible endpoint.
  * Added runnable Rust, Go, and Python examples.
  * Documented development proxy behavior, production endpoints, and execution statuses.

* **Bug Fixes**
  * Improved reporting for unsupported Python execution and offline transport or CORS failures.

* **Tests**
  * Added coverage for multi-language execution, compilation errors, missing endpoints, and connectivity failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->