### PR TITLE
feat(images): add static image galleries

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -1099,6 +1099,34 @@ export interface JsI18NRuntimeLocale {
   dir?: string
 }
 
+/** Opt-in static `::: gallery` image groups. */
+export interface JsImageGalleryOptions {
+  /**
+   * Enable static image gallery blocks.
+   *
+   * Default: `false`.
+   */
+  enabled?: boolean
+  /**
+   * Add `loading="lazy"` to images inside galleries.
+   *
+   * Default: follows `images.lazy`, or `true` when `images` is disabled.
+   */
+  lazy?: boolean
+  /**
+   * Validation mode for images with empty alt text.
+   *
+   * Default: `"error"`.
+   */
+  missingAlt?: string
+  /**
+   * Validation mode for galleries without image items.
+   *
+   * Default: `"error"`.
+   */
+  empty?: string
+}
+
 /** Opt-in figures, captions, and lazy images. */
 export interface JsImageOptions {
   /**
@@ -2460,6 +2488,12 @@ export interface JsTransformOptions {
    * Default: disabled.
    */
   images?: JsImageOptions
+  /**
+   * Opt-in static `::: gallery` image groups.
+   *
+   * Default: disabled.
+   */
+  imageGalleries?: JsImageGalleryOptions
   /**
    * Opt-in `::: card` / `::: link-card` / `::: card-grid` blocks.
    *

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -1103,6 +1103,34 @@ export interface JsI18NRuntimeLocale {
   dir?: string
 }
 
+/** Opt-in static `::: gallery` image groups. */
+export interface JsImageGalleryOptions {
+  /**
+   * Enable static image gallery blocks.
+   *
+   * Default: `false`.
+   */
+  enabled?: boolean
+  /**
+   * Add `loading="lazy"` to images inside galleries.
+   *
+   * Default: follows `images.lazy`, or `true` when `images` is disabled.
+   */
+  lazy?: boolean
+  /**
+   * Validation mode for images with empty alt text.
+   *
+   * Default: `"error"`.
+   */
+  missingAlt?: string
+  /**
+   * Validation mode for galleries without image items.
+   *
+   * Default: `"error"`.
+   */
+  empty?: string
+}
+
 /** Opt-in figures, captions, and lazy images. */
 export interface JsImageOptions {
   /**
@@ -2464,6 +2492,12 @@ export interface JsTransformOptions {
    * Default: disabled.
    */
   images?: JsImageOptions
+  /**
+   * Opt-in static `::: gallery` image groups.
+   *
+   * Default: disabled.
+   */
+  imageGalleries?: JsImageGalleryOptions
   /**
    * Opt-in `::: card` / `::: link-card` / `::: card-grid` blocks.
    *

--- a/crates/ox_content_napi/src/transform_bindings.rs
+++ b/crates/ox_content_napi/src/transform_bindings.rs
@@ -38,8 +38,8 @@ pub use embed_types::{JsPmOptions, JsPmTransformResult, JsTabsTransformResult, J
 pub use feature_options::{
     JsAttrsOptions, JsCodeBlockLintOptions, JsCodeImportOptions, JsContainerOptions,
     JsContainerTypeOptions, JsDocsTestOptions, JsEditThisPageOptions, JsEmojiShortcodeOptions,
-    JsImageOptions, JsIncludeOptions, JsMediaEmbedsOptions, JsNotByAiOptions, JsSanitizeOptions,
-    JsWikiLinkOptions,
+    JsImageGalleryOptions, JsImageOptions, JsIncludeOptions, JsMediaEmbedsOptions,
+    JsNotByAiOptions, JsSanitizeOptions, JsWikiLinkOptions,
 };
 pub use file_tree_options::JsFileTreeOptions;
 pub use keyboard_keys_options::JsKeyboardKeysOptions;

--- a/crates/ox_content_napi/src/transform_bindings/feature_options.rs
+++ b/crates/ox_content_napi/src/transform_bindings/feature_options.rs
@@ -7,9 +7,11 @@ use ox_content_transform::{
     WikiLinkOptions,
 };
 
+mod image_gallery_options;
 mod image_options;
 mod media_embeds_options;
 mod not_by_ai_options;
+pub use image_gallery_options::JsImageGalleryOptions;
 pub use image_options::JsImageOptions;
 pub use media_embeds_options::JsMediaEmbedsOptions;
 pub use not_by_ai_options::JsNotByAiOptions;

--- a/crates/ox_content_napi/src/transform_bindings/feature_options/image_gallery_options.rs
+++ b/crates/ox_content_napi/src/transform_bindings/feature_options/image_gallery_options.rs
@@ -1,0 +1,38 @@
+use napi_derive::napi;
+use ox_content_transform::ImageGalleryOptions;
+
+/// Opt-in static `::: gallery` image groups.
+#[napi(object)]
+#[derive(Default, Clone)]
+pub struct JsImageGalleryOptions {
+    /// Enable static image gallery blocks.
+    ///
+    /// Default: `false`.
+    pub enabled: Option<bool>,
+
+    /// Add `loading="lazy"` to images inside galleries.
+    ///
+    /// Default: follows `images.lazy`, or `true` when `images` is disabled.
+    pub lazy: Option<bool>,
+
+    /// Validation mode for images with empty alt text.
+    ///
+    /// Default: `"error"`.
+    pub missing_alt: Option<String>,
+
+    /// Validation mode for galleries without image items.
+    ///
+    /// Default: `"error"`.
+    pub empty: Option<String>,
+}
+
+impl From<JsImageGalleryOptions> for ImageGalleryOptions {
+    fn from(value: JsImageGalleryOptions) -> Self {
+        Self {
+            enabled: value.enabled,
+            lazy: value.lazy,
+            missing_alt: value.missing_alt,
+            empty: value.empty,
+        }
+    }
+}

--- a/crates/ox_content_napi/src/transform_bindings/transform_options.rs
+++ b/crates/ox_content_napi/src/transform_bindings/transform_options.rs
@@ -5,9 +5,9 @@ use ox_content_transform::{MathOptions, TransformOptions};
 use super::{
     JsAbbreviationsOptions, JsAttrsOptions, JsBadgeOptions, JsCardOptions, JsCodeGroupOptions,
     JsCodeImportOptions, JsContainerOptions, JsDataTableOptions, JsDefinitionListOptions,
-    JsEditThisPageOptions, JsEmojiShortcodeOptions, JsFileTreeOptions, JsImageOptions,
-    JsIncludeOptions, JsKeyboardKeysOptions, JsMagicLinkOptions, JsMathOptions, JsNotByAiOptions,
-    JsPartialsOptions, JsSanitizeOptions, JsStepsOptions, JsWikiLinkOptions,
+    JsEditThisPageOptions, JsEmojiShortcodeOptions, JsFileTreeOptions, JsImageGalleryOptions,
+    JsImageOptions, JsIncludeOptions, JsKeyboardKeysOptions, JsMagicLinkOptions, JsMathOptions,
+    JsNotByAiOptions, JsPartialsOptions, JsSanitizeOptions, JsStepsOptions, JsWikiLinkOptions,
 };
 
 /// Transform options for JavaScript.
@@ -234,6 +234,11 @@ pub struct JsTransformOptions {
     /// Default: disabled.
     pub images: Option<JsImageOptions>,
 
+    /// Opt-in static `::: gallery` image groups.
+    ///
+    /// Default: disabled.
+    pub image_galleries: Option<JsImageGalleryOptions>,
+
     /// Opt-in `::: card` / `::: link-card` / `::: card-grid` blocks.
     ///
     /// Default: disabled.
@@ -298,6 +303,7 @@ impl From<JsTransformOptions> for TransformOptions {
             definition_lists: value.definition_lists.map(Into::into),
             magic_links: value.magic_links.map(Into::into),
             images: value.images.map(Into::into),
+            image_galleries: value.image_galleries.map(Into::into),
             cards: value.cards.map(Into::into),
             math: match value.math {
                 Some(Either::A(enabled)) => Some(MathOptions { enabled: Some(enabled) }),

--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -248,6 +248,9 @@ const CONTRIBUTORS_CSS: &str = include_str!("html/contributors.css");
 const FILE_TREE_CSS: &str =
     concat!(include_str!("html/file_tree.css"), include_str!("html/data_tables.css"));
 
+/// CSS for opt-in static image galleries.
+const IMAGE_GALLERY_CSS: &str = include_str!("html/image_gallery.css");
+
 /// CSS styles for opt-in `{kbd:...}` keyboard keys.
 const KBD_CSS: &str = include_str!("plugins/kbd.css");
 

--- a/crates/ox_content_ssg/src/html/image_gallery.css
+++ b/crates/ox_content_ssg/src/html/image_gallery.css
@@ -1,0 +1,35 @@
+.content .ox-image-gallery {
+  margin: 1.5rem 0;
+}
+.content .ox-image-gallery__caption {
+  margin-bottom: 0.75rem;
+  color: var(--octc-color-text);
+  font-weight: 600;
+}
+.content .ox-image-gallery__items {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(12rem, 100%), 1fr));
+  gap: 0.875rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.content .ox-image-gallery__item {
+  min-width: 0;
+}
+.content .ox-image-gallery__figure {
+  margin: 0;
+}
+.content .ox-image-gallery__figure img {
+  display: block;
+  width: 100%;
+  height: auto;
+  margin: 0;
+  border-radius: 4px;
+}
+.content .ox-image-gallery__item-caption {
+  margin-top: 0.45rem;
+  color: var(--octc-color-text-muted);
+  font-size: 0.875rem;
+  line-height: 1.45;
+}

--- a/crates/ox_content_ssg/src/html/render_inner.rs
+++ b/crates/ox_content_ssg/src/html/render_inner.rs
@@ -28,9 +28,9 @@ use super::utils::{
     page_content_contains_any, wrap_css_section,
 };
 use super::{
-    CONTRIBUTORS_CSS, ENTRY_CSS, FILE_TREE_CSS, GITHUB_CSS, ISLAND_CSS, MERMAID_CSS, NavGroup,
-    OGP_CSS, PageData, PageTemplate, SOCIAL_CSS, SOCIAL_TWEET_FULL_CSS, SSG_CSS, SsgConfig,
-    TABS_CSS, YOUTUBE_CSS,
+    CONTRIBUTORS_CSS, ENTRY_CSS, FILE_TREE_CSS, GITHUB_CSS, IMAGE_GALLERY_CSS, ISLAND_CSS,
+    MERMAID_CSS, NavGroup, OGP_CSS, PageData, PageTemplate, SOCIAL_CSS, SOCIAL_TWEET_FULL_CSS,
+    SSG_CSS, SsgConfig, TABS_CSS, YOUTUBE_CSS,
 };
 
 pub(super) struct GeneratedPage {
@@ -131,6 +131,9 @@ pub(super) fn generate_html_inner(
     }
     if page_content_contains_any(&page_data.content, &["ox-file-tree", "ox-data-table"]) {
         css_sections.push(wrap_css_section("file-tree", FILE_TREE_CSS));
+    }
+    if page_content_contains_any(&page_data.content, &["ox-image-gallery"]) {
+        css_sections.push(wrap_css_section("image-gallery", IMAGE_GALLERY_CSS));
     }
     push_not_by_ai_css(&mut css_sections, &page_data.content);
     push_content_plugin_css(&mut css_sections, &page_data.content);

--- a/crates/ox_content_ssg/src/html/tests.rs
+++ b/crates/ox_content_ssg/src/html/tests.rs
@@ -22,6 +22,7 @@ fn snapshot_text(value: &str) -> String {
 mod abbr;
 mod aside;
 mod contributors;
+mod image_gallery;
 mod lazy_widgets;
 mod mobile_css;
 mod mpa_navigation;
@@ -75,6 +76,7 @@ fn default_theme_surfaces_stay_flat() {
         super::SSG_CSS.as_str(),
         super::CONTRIBUTORS_CSS,
         super::FILE_TREE_CSS,
+        super::IMAGE_GALLERY_CSS,
         super::not_by_ai::NOT_BY_AI_CSS,
         super::KBD_CSS,
         super::ABBR_CSS,

--- a/crates/ox_content_ssg/src/html/tests/image_gallery.rs
+++ b/crates/ox_content_ssg/src/html/tests/image_gallery.rs
@@ -1,0 +1,18 @@
+use super::super::generate_html;
+use super::rendering::{config, page};
+
+#[test]
+fn includes_css_when_gallery_markup_is_present() {
+    let page_data = page(
+        "Gallery",
+        None,
+        r#"<figure class="ox-image-gallery"><ul class="ox-image-gallery__items"></ul></figure>"#,
+        vec![],
+        None,
+        "gallery",
+    );
+    let html = generate_html(&page_data, &[], &config("Test Site", "/", None));
+
+    assert!(html.contains("ox-content:css:image-gallery:start"), "{html}");
+    assert!(html.contains(".content .ox-image-gallery__items"), "{html}");
+}

--- a/crates/ox_content_ssg/src/html/tests/rendering.rs
+++ b/crates/ox_content_ssg/src/html/tests/rendering.rs
@@ -2,7 +2,7 @@ use super::super::nav::generate_nav_html;
 use super::super::utils::{format_last_updated, generate_toc_html, html_locale_attrs};
 use super::super::*;
 
-fn page(
+pub(super) fn page(
     title: &str,
     description: Option<&str>,
     content: &str,
@@ -29,7 +29,7 @@ fn page(
     }
 }
 
-fn config(site_name: &str, base: &str, locale: Option<&str>) -> SsgConfig {
+pub(super) fn config(site_name: &str, base: &str, locale: Option<&str>) -> SsgConfig {
     SsgConfig {
         site_name: site_name.to_string(),
         base: base.to_string(),

--- a/crates/ox_content_transform/src/features.rs
+++ b/crates/ox_content_transform/src/features.rs
@@ -22,6 +22,7 @@ mod emoji;
 mod emoji_shortcodes;
 mod escape;
 mod file_tree;
+mod image_galleries;
 mod images;
 mod includes;
 mod keyboard_keys;
@@ -48,6 +49,7 @@ use edit::append_edit_this_page;
 use emoji_shortcodes::replace_emoji_shortcodes;
 pub(super) use escape::{escape_html_attr, escape_html_text};
 use file_tree::ResolvedFileTreeOptions;
+use image_galleries::ResolvedImageGalleryOptions;
 use images::ResolvedImageOptions;
 use includes::ResolvedIncludeOptions;
 use magic::ResolvedMagicLinks;
@@ -78,6 +80,7 @@ pub struct TransformFeatureOptions {
     abbreviations: Option<abbreviations::ResolvedAbbreviations>,
     magic_links: Option<ResolvedMagicLinks>,
     images: Option<ResolvedImageOptions>,
+    image_galleries: Option<ResolvedImageGalleryOptions>,
     math: bool,
     attributes: bool,
     edit_this_page: Option<ResolvedEditThisPageOptions>,
@@ -122,24 +125,17 @@ impl TransformFeatureOptions {
         let cards = cards::resolve(options.cards.as_ref());
         let steps = steps::resolve(options.steps.as_ref());
         let code_groups = code_groups::resolve(options.code_groups.as_ref());
+        let images = images::resolve(options.images.as_ref(), attributes);
+        let image_galleries =
+            image_galleries::resolve(options.image_galleries.as_ref(), attributes, images.as_ref());
         let mut containers = containers::resolve(options.containers.as_ref());
-        if (cards.is_some() || steps.is_some() || code_groups.is_some())
-            && let Some(containers) = containers.as_mut()
-        {
-            if cards.is_some() {
-                for name in cards::reserved_type_names() {
-                    containers.types.remove(*name);
-                }
-            }
-            if steps.is_some() {
-                containers.types.remove("steps");
-            }
-            if code_groups.is_some() {
-                for name in code_groups::reserved_type_names() {
-                    containers.types.remove(*name);
-                }
-            }
-        }
+        containers::remove_reserved_type_names(
+            &mut containers,
+            cards.as_ref().map(|_| cards::reserved_type_names()),
+            steps.is_some(),
+            code_groups.as_ref().map(|_| code_groups::reserved_type_names()),
+            image_galleries.is_some(),
+        );
         let includes = includes::resolve(options.includes.as_ref(), source_path);
         let partials = partials::resolve(options.partials.as_ref(), source_path);
         let file_tree = file_tree::resolve(options.file_tree.as_ref());
@@ -150,7 +146,6 @@ impl TransformFeatureOptions {
         let keyboard_keys = keyboard_keys::resolve(options.keyboard_keys.as_ref());
         let abbreviations = abbreviations::resolve(options.abbreviations.as_ref());
         let magic_links = magic::resolve(options.magic_links.as_ref());
-        let images = images::resolve(options.images.as_ref(), attributes);
         let math = math::resolve(options.math.as_ref());
         let edit_this_page = resolve_edit_this_page(
             options.edit_this_page.as_ref(),
@@ -176,6 +171,7 @@ impl TransformFeatureOptions {
             abbreviations,
             magic_links,
             images,
+            image_galleries,
             math,
             attributes,
             edit_this_page,
@@ -201,6 +197,7 @@ impl TransformFeatureOptions {
             || self.abbreviations.is_some()
             || self.magic_links.is_some()
             || self.images.is_some()
+            || self.image_galleries.is_some()
             || self.math
     }
 
@@ -264,6 +261,9 @@ pub fn preprocess_markdown<'a>(
     }
 
     if current.contains(":::") {
+        if let Some(galleries) = &options.image_galleries {
+            current = Cow::Owned(image_galleries::transform(&current, galleries, &mut errors));
+        }
         if options.cards.is_some() {
             current = Cow::Owned(cards::transform(&current));
         }

--- a/crates/ox_content_transform/src/features/containers.rs
+++ b/crates/ox_content_transform/src/features/containers.rs
@@ -87,6 +87,29 @@ pub(super) fn resolve(options: Option<&ContainerOptions>) -> Option<ResolvedCont
     Some(ResolvedContainerOptions { types })
 }
 
+pub(super) fn remove_reserved_type_names(
+    options: &mut Option<ResolvedContainerOptions>,
+    cards: Option<&[&str]>,
+    steps: bool,
+    code_groups: Option<&[&str]>,
+    galleries: bool,
+) {
+    let Some(options) = options.as_mut() else {
+        return;
+    };
+    for names in [cards, code_groups].into_iter().flatten() {
+        for name in names {
+            options.types.remove(*name);
+        }
+    }
+    if steps {
+        options.types.remove("steps");
+    }
+    if galleries {
+        options.types.remove("gallery");
+    }
+}
+
 pub(super) fn transform(source: &str, options: &ResolvedContainerOptions) -> String {
     let mut out = String::with_capacity(source.len() + 64);
     let mut lines = source.split_inclusive('\n').peekable();

--- a/crates/ox_content_transform/src/features/image_galleries.rs
+++ b/crates/ox_content_transform/src/features/image_galleries.rs
@@ -1,0 +1,306 @@
+//! Opt-in `::: gallery` image groups.
+//!
+//! Disabled by default. Enabled galleries render static HTML and reuse the
+//! Markdown image parser so URL sanitization, captions, dimensions, and attrs
+//! stay aligned with the image feature.
+
+use crate::ImageGalleryOptions;
+
+use super::images::{self, ParsedImage, ResolvedImageOptions};
+use super::segments::{is_closing_fence, is_indented_code_line, parse_opening_fence};
+
+mod html;
+#[cfg(test)]
+mod tests;
+
+use html::emit_gallery;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ReportMode {
+    Ignore,
+    Warn,
+    Error,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct ResolvedImageGalleryOptions {
+    image: ResolvedImageOptions,
+    missing_alt: ReportMode,
+    empty: ReportMode,
+}
+
+struct GalleryOpen {
+    colon_count: usize,
+    caption: Option<String>,
+}
+
+struct GalleryItem<'a> {
+    image: ParsedImage<'a>,
+}
+
+pub(super) fn resolve(
+    options: Option<&ImageGalleryOptions>,
+    attrs: bool,
+    images: Option<&ResolvedImageOptions>,
+) -> Option<ResolvedImageGalleryOptions> {
+    let options = options?;
+    if options.enabled == Some(false) {
+        return None;
+    }
+    let lazy = options.lazy.unwrap_or_else(|| images.is_none_or(|image| image.lazy));
+    Some(ResolvedImageGalleryOptions {
+        image: ResolvedImageOptions { lazy, attrs },
+        missing_alt: report_mode(options.missing_alt.as_deref(), ReportMode::Error),
+        empty: report_mode(options.empty.as_deref(), ReportMode::Error),
+    })
+}
+
+pub(super) fn transform(
+    source: &str,
+    options: &ResolvedImageGalleryOptions,
+    errors: &mut Vec<String>,
+) -> String {
+    if !source.contains(":::") || !source.contains("gallery") {
+        return source.to_string();
+    }
+    rewrite(source, options, errors)
+}
+
+fn rewrite(
+    source: &str,
+    options: &ResolvedImageGalleryOptions,
+    errors: &mut Vec<String>,
+) -> String {
+    let mut out = String::with_capacity(source.len());
+    let mut in_fence = false;
+    let mut fence_char = b'\0';
+    let mut fence_len = 0usize;
+    let mut lines = source.split_inclusive('\n');
+
+    while let Some(line_with_end) = lines.next() {
+        let (line, ending) = split_ending(line_with_end);
+
+        if in_fence {
+            out.push_str(line);
+            out.push_str(ending);
+            if is_closing_fence(line, fence_char, fence_len) {
+                in_fence = false;
+            }
+            continue;
+        }
+
+        if let Some(open) = parse_opening_fence(line) {
+            in_fence = true;
+            fence_char = open.fence_char;
+            fence_len = open.fence_len;
+            out.push_str(line);
+            out.push_str(ending);
+            continue;
+        }
+
+        let Some(open) = parse_gallery_open(line) else {
+            out.push_str(line);
+            out.push_str(ending);
+            continue;
+        };
+
+        let mut body = String::new();
+        let mut close = None;
+        for inner in lines.by_ref() {
+            let (inner_line, inner_end) = split_ending(inner);
+            if is_gallery_close(inner_line, open.colon_count) {
+                close = Some((inner_line, inner_end));
+                break;
+            }
+            body.push_str(inner_line);
+            body.push_str(inner_end);
+        }
+
+        let mut original = String::with_capacity(line_with_end.len() + body.len() + 8);
+        original.push_str(line);
+        original.push_str(ending);
+        original.push_str(&body);
+        if let Some((close_line, close_end)) = close {
+            original.push_str(close_line);
+            original.push_str(close_end);
+        } else {
+            errors.push("Image gallery block is missing a closing ::: fence.".to_string());
+            out.push_str(&original);
+            continue;
+        }
+
+        match render_gallery(open.caption.as_deref(), &body, options) {
+            Ok((html, diagnostics)) => {
+                errors.extend(diagnostics);
+                out.push_str(&html);
+            }
+            Err(diagnostics) => {
+                errors.extend(diagnostics);
+                out.push_str(&original);
+            }
+        }
+    }
+
+    out
+}
+
+fn render_gallery(
+    caption: Option<&str>,
+    body: &str,
+    options: &ResolvedImageGalleryOptions,
+) -> Result<(String, Vec<String>), Vec<String>> {
+    let mut diagnostics = Vec::new();
+    let mut items = Vec::new();
+
+    for (index, line) in body.lines().enumerate() {
+        let Some(candidate) = normalize_item_line(line) else {
+            continue;
+        };
+        let Some(image) = images::parse_image(candidate, &options.image) else {
+            diagnostics.push(format!("Image gallery item {} must be a Markdown image.", index + 1));
+            return Err(diagnostics);
+        };
+        if !candidate[image.end..].trim().is_empty() {
+            diagnostics.push(format!(
+                "Image gallery item {} has unsupported trailing content.",
+                index + 1
+            ));
+            return Err(diagnostics);
+        }
+        if image.alt.trim().is_empty() {
+            let message = format!("Image gallery item {} is missing alt text.", index + 1);
+            match options.missing_alt {
+                ReportMode::Ignore => {}
+                ReportMode::Warn => diagnostics.push(message),
+                ReportMode::Error => {
+                    diagnostics.push(message);
+                    return Err(diagnostics);
+                }
+            }
+        }
+        items.push(GalleryItem { image });
+    }
+
+    if items.is_empty() {
+        let diagnostics = match options.empty {
+            ReportMode::Ignore => Vec::new(),
+            ReportMode::Warn | ReportMode::Error => {
+                vec!["Image gallery is empty. Add at least one Markdown image.".to_string()]
+            }
+        };
+        return Err(diagnostics);
+    }
+
+    let mut html = String::new();
+    emit_gallery(&mut html, caption, &items, &options.image);
+    Ok((html, diagnostics))
+}
+
+fn normalize_item_line(line: &str) -> Option<&str> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Some(rest) = trimmed.strip_prefix("- ").or_else(|| trimmed.strip_prefix("* ")) {
+        return Some(rest.trim_start());
+    }
+    if let Some(rest) = strip_ordered_marker(trimmed) {
+        return Some(rest.trim_start());
+    }
+    Some(trimmed)
+}
+
+fn strip_ordered_marker(value: &str) -> Option<&str> {
+    let dot = value.find('.')?;
+    if dot == 0 || !value[..dot].bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    value[dot + 1..].starts_with(char::is_whitespace).then_some(&value[dot + 1..])
+}
+
+fn parse_gallery_open(line: &str) -> Option<GalleryOpen> {
+    if is_indented_code_line(line) {
+        return None;
+    }
+    let trimmed = line.trim_start();
+    let colon_count = trimmed.bytes().take_while(|byte| *byte == b':').count();
+    if colon_count < 3 {
+        return None;
+    }
+    let rest = trimmed[colon_count..].trim();
+    let mut parts = rest.splitn(2, char::is_whitespace);
+    if parts.next()? != "gallery" {
+        return None;
+    }
+    Some(GalleryOpen { colon_count, caption: parse_caption(parts.next().unwrap_or_default()) })
+}
+
+fn parse_caption(meta: &str) -> Option<String> {
+    let meta = meta.trim();
+    if meta.is_empty() {
+        return None;
+    }
+    let mut rest = meta;
+    while let Some(eq) = rest.find('=') {
+        let key = rest[..eq].trim();
+        rest = rest[eq + 1..].trim_start();
+        let (value, next) = parse_meta_value(rest);
+        if matches!(key, "title" | "caption") && !value.is_empty() {
+            return Some(value);
+        }
+        rest = next.trim_start();
+    }
+    Some(unquote(meta).to_string()).filter(|value| !value.is_empty())
+}
+
+fn parse_meta_value(rest: &str) -> (String, &str) {
+    let bytes = rest.as_bytes();
+    let Some(first) = bytes.first() else {
+        return (String::new(), rest);
+    };
+    if *first == b'"' || *first == b'\'' {
+        let quote = *first;
+        if let Some(rel) = rest[1..].find(quote as char) {
+            return (rest[1..1 + rel].to_string(), &rest[2 + rel..]);
+        }
+        return (rest[1..].to_string(), "");
+    }
+    let end = rest.find(char::is_whitespace).unwrap_or(rest.len());
+    (rest[..end].to_string(), &rest[end..])
+}
+
+fn unquote(value: &str) -> &str {
+    let bytes = value.as_bytes();
+    if bytes.len() >= 2
+        && matches!(bytes.first(), Some(b'"' | b'\''))
+        && bytes.first() == bytes.last()
+    {
+        &value[1..value.len() - 1]
+    } else {
+        value
+    }
+}
+
+fn is_gallery_close(line: &str, colon_count: usize) -> bool {
+    let trimmed = line.trim();
+    trimmed.len() >= colon_count && trimmed.bytes().all(|byte| byte == b':')
+}
+
+fn report_mode(value: Option<&str>, fallback: ReportMode) -> ReportMode {
+    match value.map(str::trim) {
+        Some("ignore") => ReportMode::Ignore,
+        Some("warn") => ReportMode::Warn,
+        Some("error") => ReportMode::Error,
+        _ => fallback,
+    }
+}
+
+fn split_ending(line_with_end: &str) -> (&str, &str) {
+    if let Some(line) = line_with_end.strip_suffix("\r\n") {
+        (line, "\n")
+    } else if let Some(line) = line_with_end.strip_suffix('\n') {
+        (line, "\n")
+    } else {
+        (line_with_end.strip_suffix('\r').unwrap_or(line_with_end), "")
+    }
+}

--- a/crates/ox_content_transform/src/features/image_galleries/html.rs
+++ b/crates/ox_content_transform/src/features/image_galleries/html.rs
@@ -1,0 +1,70 @@
+use super::super::images::{self, ParsedImage, ResolvedImageOptions};
+use super::GalleryItem;
+use crate::features::attr_tokens::{ParsedAttrs, write_attrs_except};
+use crate::features::{escape_html_attr, escape_html_text};
+
+pub(super) fn emit_gallery(
+    out: &mut String,
+    caption: Option<&str>,
+    items: &[GalleryItem<'_>],
+    image_options: &ResolvedImageOptions,
+) {
+    out.push_str("<figure class=\"ox-image-gallery\"");
+    if caption.is_none() {
+        out.push_str(" role=\"group\" aria-label=\"Image gallery\"");
+    }
+    out.push_str(">\n");
+    if let Some(caption) = caption.filter(|value| !value.trim().is_empty()) {
+        out.push_str("<figcaption class=\"ox-image-gallery__caption\">");
+        escape_html_text(caption, out);
+        out.push_str("</figcaption>\n");
+    }
+    out.push_str("<ul class=\"ox-image-gallery__items\">\n");
+    for item in items {
+        out.push_str(
+            "<li class=\"ox-image-gallery__item\"><figure class=\"ox-image-gallery__figure\">",
+        );
+        emit_img(out, &item.image, image_options);
+        if let Some(caption) = item.image.caption {
+            out.push_str("<figcaption class=\"ox-image-gallery__item-caption\">");
+            let caption = images::unescape_markdown(caption);
+            escape_html_text(&caption, out);
+            out.push_str("</figcaption>");
+        }
+        out.push_str("</figure></li>\n");
+    }
+    out.push_str("</ul>\n</figure>\n");
+}
+
+fn emit_img(out: &mut String, image: &ParsedImage<'_>, options: &ResolvedImageOptions) {
+    out.push_str("<img");
+    if let Some(src) = image.src {
+        out.push_str(" src=\"");
+        escape_html_attr(src, out);
+        out.push('"');
+    }
+    out.push_str(" alt=\"");
+    escape_html_attr(image.alt, out);
+    out.push('"');
+    if let Some(attrs) = &image.attrs {
+        write_image_attrs(out, attrs);
+    }
+    if options.lazy {
+        out.push_str(" loading=\"lazy\"");
+    }
+    if let Some(width) = image.width.as_deref() {
+        out.push_str(" width=\"");
+        out.push_str(width);
+        out.push('"');
+    }
+    if let Some(height) = image.height.as_deref() {
+        out.push_str(" height=\"");
+        out.push_str(height);
+        out.push('"');
+    }
+    out.push('>');
+}
+
+fn write_image_attrs(out: &mut String, attrs: &ParsedAttrs) {
+    write_attrs_except(out, attrs, &["src", "alt", "loading", "width", "height"]);
+}

--- a/crates/ox_content_transform/src/features/image_galleries/snapshots/ox_content_transform__features__image_galleries__tests__preprocess_snapshot_html.snap
+++ b/crates/ox_content_transform/src/features/image_galleries/snapshots/ox_content_transform__features__image_galleries__tests__preprocess_snapshot_html.snap
@@ -1,0 +1,11 @@
+---
+source: crates/ox_content_transform/src/features/image_galleries/tests.rs
+expression: source
+---
+<figure class="ox-image-gallery">
+<figcaption class="ox-image-gallery__caption">Screenshots</figcaption>
+<ul class="ox-image-gallery__items">
+<li class="ox-image-gallery__item"><figure class="ox-image-gallery__figure"><img src="/one.png" alt="One" loading="lazy"><figcaption class="ox-image-gallery__item-caption">First</figcaption></figure></li>
+<li class="ox-image-gallery__item"><figure class="ox-image-gallery__figure"><img src="/two.png" alt="Two" loading="lazy"></figure></li>
+</ul>
+</figure>

--- a/crates/ox_content_transform/src/features/image_galleries/tests.rs
+++ b/crates/ox_content_transform/src/features/image_galleries/tests.rs
@@ -1,0 +1,233 @@
+use super::{ReportMode, resolve, transform};
+use crate::transformer::MarkdownTransformer;
+use crate::{
+    AttrsOptions, ContainerOptions, ContainerTypeOptions, ImageGalleryOptions, TransformOptions,
+};
+
+fn gallery_options(missing_alt: Option<&str>, empty: Option<&str>) -> TransformOptions {
+    TransformOptions {
+        gfm: Some(true),
+        image_galleries: Some(ImageGalleryOptions {
+            enabled: Some(true),
+            lazy: None,
+            missing_alt: missing_alt.map(ToString::to_string),
+            empty: empty.map(ToString::to_string),
+        }),
+        ..Default::default()
+    }
+}
+
+fn html(source: &str, options: TransformOptions) -> crate::TransformResult {
+    MarkdownTransformer::from_options(&options).transform(source)
+}
+
+#[test]
+fn resolve_is_none_when_omitted_or_false() {
+    assert!(resolve(None, false, None).is_none());
+    assert!(
+        resolve(
+            Some(&ImageGalleryOptions { enabled: Some(false), ..Default::default() }),
+            false,
+            None,
+        )
+        .is_none()
+    );
+}
+
+#[test]
+fn resolve_defaults_to_strict_accessibility() {
+    let resolved =
+        resolve(Some(&ImageGalleryOptions { enabled: None, ..Default::default() }), false, None)
+            .expect("enabled");
+    assert!(resolved.image.lazy);
+    assert_eq!(resolved.missing_alt, ReportMode::Error);
+    assert_eq!(resolved.empty, ReportMode::Error);
+}
+
+#[test]
+fn inherits_lazy_default_from_images_option() {
+    let images = super::super::images::ResolvedImageOptions { lazy: false, attrs: false };
+    let resolved = resolve(
+        Some(&ImageGalleryOptions { enabled: None, ..Default::default() }),
+        false,
+        Some(&images),
+    )
+    .expect("enabled");
+    assert!(!resolved.image.lazy);
+}
+
+#[test]
+fn disabled_by_default() {
+    let source = "::: gallery\n![Alt](/x.png \"Caption\")\n:::\n";
+    let result = html(source, TransformOptions::default());
+    assert!(result.errors.is_empty(), "{:?}", result.errors);
+    assert!(!result.html.contains("ox-image-gallery"), "{html}", html = result.html);
+    assert!(result.html.contains("gallery"), "{html}", html = result.html);
+}
+
+#[test]
+fn enabled_gallery_renders_static_semantic_html() {
+    let result = html(
+        "::: gallery title=\"Launch shots\"\n- ![Stage](/stage.png \"Keynote\")\n- ![Booth](https://example.com/booth.jpg)\n:::\n",
+        gallery_options(None, None),
+    );
+    assert!(result.errors.is_empty(), "{:?}", result.errors);
+    assert!(
+        result.html.contains(r#"<figure class="ox-image-gallery">"#),
+        "{html}",
+        html = result.html
+    );
+    assert!(
+        result
+            .html
+            .contains(r#"<figcaption class="ox-image-gallery__caption">Launch shots</figcaption>"#),
+        "{html}",
+        html = result.html
+    );
+    assert!(
+        result.html.contains(r#"<ul class="ox-image-gallery__items">"#),
+        "{html}",
+        html = result.html
+    );
+    assert!(
+        result.html.contains(r#"<li class="ox-image-gallery__item">"#),
+        "{html}",
+        html = result.html
+    );
+    assert!(
+        result.html.contains(r#"<img src="/stage.png" alt="Stage" loading="lazy">"#),
+        "{html}",
+        html = result.html
+    );
+    assert!(
+        result
+            .html
+            .contains(r#"<figcaption class="ox-image-gallery__item-caption">Keynote</figcaption>"#),
+        "{html}",
+        html = result.html
+    );
+    assert!(
+        result
+            .html
+            .contains(r#"<img src="https://example.com/booth.jpg" alt="Booth" loading="lazy">"#),
+        "{html}",
+        html = result.html
+    );
+    assert!(!result.html.contains("```"), "{html}", html = result.html);
+}
+
+#[test]
+fn attrs_dimensions_and_eager_images_compose() {
+    let mut options = gallery_options(None, None);
+    options.attributes = Some(AttrsOptions { enabled: Some(true) });
+    options.image_galleries.as_mut().unwrap().lazy = Some(false);
+    let result = html(
+        "::: gallery\n![Wide](./wide.png){.hero width=640 height=360 data-kind=wide}\n:::\n",
+        options,
+    );
+    assert!(result.errors.is_empty(), "{:?}", result.errors);
+    assert!(result.html.contains(r#"<img src="./wide.png" alt="Wide" class="hero" data-kind="wide" width="640" height="360">"#), "{html}", html = result.html);
+    assert!(!result.html.contains("loading="), "{html}", html = result.html);
+    assert!(!result.html.contains("{.hero"), "{html}", html = result.html);
+}
+
+#[test]
+fn missing_alt_error_preserves_gallery_source() {
+    let result = html("::: gallery\n![](/x.png)\n:::\n", gallery_options(None, None));
+    assert_eq!(result.errors.len(), 1, "{:?}", result.errors);
+    assert!(result.errors[0].contains("missing alt text"), "{:?}", result.errors);
+    assert!(!result.html.contains("ox-image-gallery"), "{html}", html = result.html);
+    assert!(result.html.contains("gallery"), "{html}", html = result.html);
+}
+
+#[test]
+fn missing_alt_warn_renders_and_reports_diagnostic() {
+    let result = html("::: gallery\n![](/x.png)\n:::\n", gallery_options(Some("warn"), None));
+    assert_eq!(result.errors.len(), 1, "{:?}", result.errors);
+    assert!(
+        result.html.contains(r#"<img src="/x.png" alt="" loading="lazy">"#),
+        "{html}",
+        html = result.html
+    );
+}
+
+#[test]
+fn empty_gallery_is_diagnostic_and_not_rewritten() {
+    let result = html("::: gallery\n\n:::\n", gallery_options(None, None));
+    assert_eq!(result.errors.len(), 1, "{:?}", result.errors);
+    assert!(result.errors[0].contains("empty"), "{:?}", result.errors);
+    assert!(!result.html.contains("ox-image-gallery"), "{html}", html = result.html);
+}
+
+#[test]
+fn malformed_item_is_actionable() {
+    let result = html("::: gallery\nnot an image\n:::\n", gallery_options(None, None));
+    assert_eq!(result.errors.len(), 1, "{:?}", result.errors);
+    assert!(result.errors[0].contains("Markdown image"), "{:?}", result.errors);
+    assert!(!result.html.contains("ox-image-gallery"), "{html}", html = result.html);
+}
+
+#[test]
+fn skips_fenced_and_indented_gallery_markers() {
+    let fenced =
+        html("````md\n::: gallery\n![Alt](/x.png)\n:::\n````\n", gallery_options(None, None));
+    assert!(!fenced.html.contains("ox-image-gallery"), "{html}", html = fenced.html);
+
+    let indented =
+        html("    ::: gallery\n    ![Alt](/x.png)\n    :::\n", gallery_options(None, None));
+    assert!(!indented.html.contains("ox-image-gallery"), "{html}", html = indented.html);
+}
+
+#[test]
+fn unsafe_sources_are_sanitized_like_images() {
+    let result =
+        html("::: gallery\n![Alt](javascript:alert(1))\n:::\n", gallery_options(None, None));
+    assert!(result.errors.is_empty(), "{:?}", result.errors);
+    assert!(
+        result.html.contains(r#"<img alt="Alt" loading="lazy">"#),
+        "{html}",
+        html = result.html
+    );
+    assert!(!result.html.contains("javascript:"), "{html}", html = result.html);
+}
+
+#[test]
+fn gallery_precedes_custom_container_with_same_name() {
+    let mut types = rustc_hash::FxHashMap::default();
+    types.insert(
+        "gallery".to_string(),
+        ContainerTypeOptions { title: Some("Container".to_string()), tag: None },
+    );
+    let result = html(
+        "::: gallery\n![Alt](/x.png)\n:::\n",
+        TransformOptions {
+            gfm: Some(true),
+            containers: Some(ContainerOptions { enabled: Some(true), types: Some(types) }),
+            image_galleries: Some(ImageGalleryOptions {
+                enabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    );
+    assert!(result.html.contains("ox-image-gallery"), "{html}", html = result.html);
+    assert!(!result.html.contains("ox-container--gallery"), "{html}", html = result.html);
+}
+
+#[test]
+fn preprocess_snapshot_html() {
+    let resolved = resolve(
+        Some(&ImageGalleryOptions { enabled: Some(true), ..Default::default() }),
+        false,
+        None,
+    )
+    .expect("enabled");
+    let mut errors = Vec::new();
+    let source = transform(
+        "::: gallery \"Screenshots\"\n![One](/one.png \"First\")\n![Two](/two.png)\n:::\n",
+        &resolved,
+        &mut errors,
+    );
+    assert!(errors.is_empty(), "{errors:?}");
+    insta::assert_snapshot!(source);
+}

--- a/crates/ox_content_transform/src/features/images.rs
+++ b/crates/ox_content_transform/src/features/images.rs
@@ -62,14 +62,14 @@ pub(super) fn replace_images(segment: &str, options: &ResolvedImageOptions, out:
     out.push_str(&segment[cursor..]);
 }
 
-struct ParsedImage<'a> {
-    alt: &'a str,
-    src: Option<&'a str>,
-    caption: Option<&'a str>,
-    attrs: Option<ParsedAttrs>,
-    width: Option<String>,
-    height: Option<String>,
-    end: usize,
+pub(super) struct ParsedImage<'a> {
+    pub(super) alt: &'a str,
+    pub(super) src: Option<&'a str>,
+    pub(super) caption: Option<&'a str>,
+    pub(super) attrs: Option<ParsedAttrs>,
+    pub(super) width: Option<String>,
+    pub(super) height: Option<String>,
+    pub(super) end: usize,
 }
 
 #[derive(Default)]
@@ -84,7 +84,10 @@ fn is_indented_code_segment(segment: &str) -> bool {
     segment.starts_with('\t') || segment.starts_with("    ")
 }
 
-fn parse_image<'a>(input: &'a str, options: &ResolvedImageOptions) -> Option<ParsedImage<'a>> {
+pub(super) fn parse_image<'a>(
+    input: &'a str,
+    options: &ResolvedImageOptions,
+) -> Option<ParsedImage<'a>> {
     let rest = input.strip_prefix("![")?;
     let (alt, after_alt) = split_balanced(rest, b'[', b']')?;
     let after_alt = after_alt.strip_prefix('(')?;
@@ -290,7 +293,7 @@ fn emit_image(out: &mut String, options: &ResolvedImageOptions, image: &ParsedIm
     }
 }
 
-fn unescape_markdown(value: &str) -> String {
+pub(super) fn unescape_markdown(value: &str) -> String {
     let mut out = String::with_capacity(value.len());
     let mut chars = value.chars();
     while let Some(ch) = chars.next() {

--- a/crates/ox_content_transform/src/options.rs
+++ b/crates/ox_content_transform/src/options.rs
@@ -56,6 +56,8 @@ pub struct TransformOptions {
     pub magic_links: Option<MagicLinkOptions>,
     /// Opt-in figures, captions, and lazy images. Disabled when omitted.
     pub images: Option<ImageOptions>,
+    /// Opt-in static `::: gallery` image groups. Disabled when omitted.
+    pub image_galleries: Option<ImageGalleryOptions>,
     /// Opt-in `::: card` / `::: link-card` / `::: card-grid` blocks. Disabled when omitted.
     pub cards: Option<CardOptions>,
     /// Opt-in `file-tree` fences. Disabled when omitted.
@@ -122,6 +124,14 @@ pub struct MagicLinkImageOverride {
 pub struct ImageOptions {
     pub enabled: Option<bool>,
     pub lazy: Option<bool>,
+}
+
+#[derive(Clone, Default)]
+pub struct ImageGalleryOptions {
+    pub enabled: Option<bool>,
+    pub lazy: Option<bool>,
+    pub missing_alt: Option<String>,
+    pub empty: Option<String>,
 }
 
 #[derive(Clone, Default)]

--- a/npm/vite-plugin-ox-content/src/collections.ts
+++ b/npm/vite-plugin-ox-content/src/collections.ts
@@ -2,6 +2,7 @@ import * as path from "node:path";
 import { applyCollectionRoutes } from "./apply-permalinks";
 import { toJsDataTableOptions } from "./data-table-options";
 import { toJsFileTreeOptions } from "./file-tree-options";
+import { toJsImageGalleryOptions } from "./image-gallery-options";
 import { toJsPartialsOptions } from "./partials-options";
 import { generateCollectionsModule } from "./collections-runtime";
 import { importNapiModule } from "./napi";
@@ -68,6 +69,12 @@ type NativeTransformOptions = {
     types?: Record<string, { title?: string; tag?: string }>;
   };
   images?: { enabled?: boolean; lazy?: boolean };
+  imageGalleries?: {
+    enabled?: boolean;
+    lazy?: boolean;
+    missingAlt?: "error" | "warn" | "ignore";
+    empty?: "error" | "warn" | "ignore";
+  };
   cjkEmphasis?: boolean;
   codeImports?: { enabled?: boolean; rootDir?: string };
   includes?: { enabled?: boolean; rootDir?: string };
@@ -272,6 +279,7 @@ function createNativeTransformOptions(options: ResolvedOptions): NativeTransform
           lazy: options.images.lazy,
         }
       : undefined,
+    imageGalleries: toJsImageGalleryOptions(options.imageGalleries, options.images),
     cjkEmphasis: options.cjkEmphasis ?? false,
     codeImports: options.codeImports?.enabled
       ? {

--- a/npm/vite-plugin-ox-content/src/image-galleries.transform.test.ts
+++ b/npm/vite-plugin-ox-content/src/image-galleries.transform.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createDocsResolvedOptions } from "../test/fixtures/docs-fixture";
+import { transformMarkdown } from "./transform";
+import type { ResolvedOptions } from "./types";
+
+describe("image gallery transform", () => {
+  it("leaves gallery source literal unless opted in", async () => {
+    const markdown = [
+      '::: gallery title="Screenshots"',
+      '- ![Hero](/hero.png "Hero view")',
+      "- ![Chart](https://example.com/chart.png)",
+      ":::",
+      "",
+    ].join("\n");
+
+    const defaultResult = await transformMarkdown(
+      markdown,
+      "docs/galleries.md",
+      createResolvedOptions(),
+    );
+    expect(defaultResult.html).not.toContain("ox-image-gallery");
+    expect(defaultResult.html).toContain("gallery");
+
+    const enabledResult = await transformMarkdown(
+      markdown,
+      "docs/galleries.md",
+      createResolvedOptions({
+        imageGalleries: { enabled: true, missingAlt: "error", empty: "error" },
+      }),
+    );
+    expect(enabledResult.html).toContain('<figure class="ox-image-gallery">');
+    expect(enabledResult.html).toContain(
+      '<figcaption class="ox-image-gallery__caption">Screenshots</figcaption>',
+    );
+    expect(enabledResult.html).toContain('<img src="/hero.png" alt="Hero" loading="lazy">');
+    expect(enabledResult.html).toContain(
+      '<figcaption class="ox-image-gallery__item-caption">Hero view</figcaption>',
+    );
+    expect(enabledResult.html).toContain(
+      '<img src="https://example.com/chart.png" alt="Chart" loading="lazy">',
+    );
+    expect(enabledResult.html).not.toContain("<script");
+  });
+
+  it("reports strict missing-alt diagnostics without rewriting the block", async () => {
+    const { result, warnings } = await captureTransformWarnings(() =>
+      transformMarkdown(
+        "::: gallery\n![](/x.png)\n:::\n",
+        "docs/galleries.md",
+        createResolvedOptions({
+          imageGalleries: { enabled: true, missingAlt: "error", empty: "error" },
+        }),
+      ),
+    );
+    expect(flattenWarnings(warnings)).toContain("missing alt text");
+    expect(result.html).not.toContain("ox-image-gallery");
+    expect(result.html).toContain("gallery");
+  });
+
+  it("can warn for missing alt text and still render", async () => {
+    const { result, warnings } = await captureTransformWarnings(() =>
+      transformMarkdown(
+        "::: gallery\n![](/x.png)\n:::\n",
+        "docs/galleries.md",
+        createResolvedOptions({
+          imageGalleries: { enabled: true, missingAlt: "warn", empty: "error" },
+        }),
+      ),
+    );
+    expect(flattenWarnings(warnings)).toContain("missing alt text");
+    expect(result.html).toContain('<img src="/x.png" alt="" loading="lazy">');
+  });
+
+  it("composes image attrs, dimensions, and eager loading", async () => {
+    const result = await transformMarkdown(
+      "::: gallery\n![Wide](./wide.png){.hero width=640 height=360 data-kind=wide}\n:::\n",
+      "docs/galleries.md",
+      createResolvedOptions({
+        attrs: { enabled: true },
+        images: { enabled: true, lazy: false },
+        imageGalleries: { enabled: true, missingAlt: "error", empty: "error" },
+      }),
+    );
+    expect(result.html).toContain(
+      '<img src="./wide.png" alt="Wide" class="hero" data-kind="wide" width="640" height="360">',
+    );
+    expect(result.html).not.toContain("loading=");
+    expect(result.html).not.toContain("{.hero");
+  });
+});
+
+function createResolvedOptions(overrides: Partial<ResolvedOptions> = {}): ResolvedOptions {
+  return createDocsResolvedOptions({ highlight: false, ...overrides });
+}
+
+async function captureTransformWarnings<T>(
+  run: () => Promise<T>,
+): Promise<{ result: T; warnings: unknown[][] }> {
+  const warnings: unknown[][] = [];
+  const original = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+  try {
+    return { result: await run(), warnings };
+  } finally {
+    console.warn = original;
+  }
+}
+
+function flattenWarnings(warnings: unknown[][]): string {
+  return warnings.flatMap((args) => args.map(String)).join("\n");
+}

--- a/npm/vite-plugin-ox-content/src/image-gallery-options.test.ts
+++ b/npm/vite-plugin-ox-content/src/image-gallery-options.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vite-plus/test";
+import { resolveImageGalleryOptions, toJsImageGalleryOptions } from "./image-gallery-options";
+
+describe("resolveImageGalleryOptions", () => {
+  it("keeps galleries disabled when omitted or explicitly false", () => {
+    expect(resolveImageGalleryOptions(undefined)).toEqual({
+      enabled: false,
+      lazy: true,
+      missingAlt: "error",
+      empty: "error",
+    });
+    expect(resolveImageGalleryOptions(false)).toEqual({
+      enabled: false,
+      lazy: true,
+      missingAlt: "error",
+      empty: "error",
+    });
+    expect(resolveImageGalleryOptions({ enabled: false })).toEqual({
+      enabled: false,
+      lazy: true,
+      missingAlt: "error",
+      empty: "error",
+    });
+  });
+
+  it("enables strict gallery diagnostics from true or object options", () => {
+    expect(resolveImageGalleryOptions(true)).toEqual({
+      enabled: true,
+      missingAlt: "error",
+      empty: "error",
+    });
+    expect(resolveImageGalleryOptions({})).toEqual({
+      enabled: true,
+      lazy: undefined,
+      missingAlt: "error",
+      empty: "error",
+    });
+  });
+
+  it("normalizes diagnostic modes and keeps an explicit lazy override", () => {
+    expect(
+      resolveImageGalleryOptions({
+        lazy: false,
+        missingAlt: "warn",
+        empty: "ignore",
+      }),
+    ).toEqual({
+      enabled: true,
+      lazy: false,
+      missingAlt: "warn",
+      empty: "ignore",
+    });
+    expect(
+      resolveImageGalleryOptions({ missingAlt: "off" as never, empty: "bad" as never }),
+    ).toEqual({
+      enabled: true,
+      lazy: undefined,
+      missingAlt: "error",
+      empty: "error",
+    });
+  });
+});
+
+describe("toJsImageGalleryOptions", () => {
+  it("omits disabled galleries from native transform options", () => {
+    expect(
+      toJsImageGalleryOptions(resolveImageGalleryOptions(false), { enabled: true, lazy: true }),
+    ).toBeUndefined();
+  });
+
+  it("inherits lazy loading from resolved image options", () => {
+    expect(
+      toJsImageGalleryOptions(resolveImageGalleryOptions(true), { enabled: true, lazy: false }),
+    ).toEqual({
+      enabled: true,
+      lazy: false,
+      missingAlt: "error",
+      empty: "error",
+    });
+  });
+
+  it("uses explicit gallery lazy and diagnostic modes", () => {
+    expect(
+      toJsImageGalleryOptions(
+        resolveImageGalleryOptions({ lazy: false, missingAlt: "warn", empty: "ignore" }),
+        { enabled: true, lazy: true },
+      ),
+    ).toEqual({
+      enabled: true,
+      lazy: false,
+      missingAlt: "warn",
+      empty: "ignore",
+    });
+  });
+});

--- a/npm/vite-plugin-ox-content/src/image-gallery-options.ts
+++ b/npm/vite-plugin-ox-content/src/image-gallery-options.ts
@@ -1,0 +1,48 @@
+import type { OxContentOptions, ResolvedImageGalleryOptions, ResolvedOptions } from "./types";
+
+type JsImageGalleryOptions = {
+  enabled: true;
+  lazy?: boolean;
+  missingAlt: "error" | "warn" | "ignore";
+  empty: "error" | "warn" | "ignore";
+};
+
+const disabled: ResolvedImageGalleryOptions = {
+  enabled: false,
+  lazy: true,
+  missingAlt: "error",
+  empty: "error",
+};
+
+export function resolveImageGalleryOptions(
+  options: OxContentOptions["imageGalleries"],
+): ResolvedImageGalleryOptions {
+  if (!options) return { ...disabled };
+  if (options === true) {
+    return { enabled: true, missingAlt: "error", empty: "error" };
+  }
+  if (options.enabled === false) return { ...disabled };
+  return {
+    enabled: options.enabled ?? true,
+    lazy: options.lazy,
+    missingAlt: reportMode(options.missingAlt),
+    empty: reportMode(options.empty),
+  };
+}
+
+export function toJsImageGalleryOptions(
+  options: ResolvedOptions["imageGalleries"] | undefined,
+  images: ResolvedOptions["images"] | undefined,
+): JsImageGalleryOptions | undefined {
+  if (!options?.enabled) return undefined;
+  return {
+    enabled: true,
+    lazy: options.lazy ?? images?.lazy ?? true,
+    missingAlt: options.missingAlt,
+    empty: options.empty,
+  };
+}
+
+function reportMode(value: unknown): "error" | "warn" | "ignore" {
+  return value === "warn" || value === "ignore" ? value : "error";
+}

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -59,6 +59,8 @@ export type {
   ResolvedContainerOptions,
   ImageOptions,
   ResolvedImageOptions,
+  ImageGalleryOptions,
+  ResolvedImageGalleryOptions,
   ResourcesOptions,
   ResolvedResourcesOptions,
   CodeImportOptions,
@@ -661,6 +663,7 @@ export { resolveStepsOptions } from "./step-options";
 export { resolveCodeGroupOptions } from "./code-group-options";
 export { resolveFileTreeOptions } from "./file-tree-options";
 export { resolveDataTableOptions } from "./data-table-options";
+export { resolveImageGalleryOptions } from "./image-gallery-options";
 export { resolveHeadingPermalinksOptions } from "./heading-permalinks-options";
 export { resolveTypedHoverOptions } from "./typed-hover";
 

--- a/npm/vite-plugin-ox-content/src/public-exports.test.ts
+++ b/npm/vite-plugin-ox-content/src/public-exports.test.ts
@@ -44,6 +44,7 @@ describe("public export surface", () => {
       "resolveTaxonomiesOptions",
       "resolveVersionsOptions",
       "resolveResourcesOptions",
+      "resolveImageGalleryOptions",
       "resolveTeamOptions",
       "resolveSiteMapsOptions",
       "resolveMarkdownSourceOptions",

--- a/npm/vite-plugin-ox-content/src/resolve-options.ts
+++ b/npm/vite-plugin-ox-content/src/resolve-options.ts
@@ -9,6 +9,7 @@ import { resolveFileTreeOptions } from "./file-tree-options";
 import { resolveIconsOptions } from "./icons";
 import { resolveHeadingPermalinksOptions } from "./heading-permalinks-options";
 import { resolveI18nOptions } from "./i18n";
+import { resolveImageGalleryOptions } from "./image-gallery-options";
 import { resolveIncludeOptions } from "./include-options";
 import { resolvePartialsOptions } from "./partials-options";
 import { resolveAbbreviationsOptions } from "./abbreviations-options";
@@ -78,6 +79,7 @@ export function resolveOptions(options: OxContentOptions): ResolvedOptions {
     magicLinks: resolveMagicLinkOptions(options.magicLinks),
     containers: resolveContainerOptions(options.containers),
     images: resolveImageOptions(options.images),
+    imageGalleries: resolveImageGalleryOptions(options.imageGalleries),
     codeImports: resolveCodeImportOptions(options.codeImports),
     includes: resolveIncludeOptions(options.includes),
     partials: resolvePartialsOptions(options.partials),
@@ -158,7 +160,6 @@ function resolveTwitterEmbedOptions(
   if (options === true) return {};
   return options;
 }
-
 function resolvePmOptions(
   options: boolean | BuiltinPmOptions | undefined,
 ): BuiltinPmOptions | false {
@@ -189,7 +190,6 @@ export function resolveMathOptions(options: OxContentOptions["math"]): ResolvedO
   if (options === true) return { enabled: true };
   return { enabled: options.enabled ?? true };
 }
-
 function resolveAttrsOptions(options: OxContentOptions["attrs"]): ResolvedOptions["attrs"] {
   if (!options) return { enabled: false };
   if (options === true) return { enabled: true };

--- a/npm/vite-plugin-ox-content/src/resources.test.ts
+++ b/npm/vite-plugin-ox-content/src/resources.test.ts
@@ -197,6 +197,33 @@ describe("buildSsg resources", () => {
     expect(pngSize(copied)).toEqual({ width: 8, height: 8 });
   });
 
+  it("copies images referenced from opt-in galleries", async () => {
+    const root = await makeSite({
+      "guide.md": [
+        "# Guide",
+        "",
+        '::: gallery title="Screenshots"',
+        '![Hero](./hero.png?width=4 "Hero view")',
+        ":::",
+        "",
+      ].join("\n"),
+      "hero.png": samplePng(8, 8),
+    });
+    const result = await buildSsg(
+      {
+        ...enabledOptions(resolveResourcesOptions(true)),
+        imageGalleries: { enabled: true, missingAlt: "error", empty: "error" },
+      },
+      root,
+    );
+    expect(result.errors).toEqual([]);
+
+    const html = await fs.readFile(pageHtml(root, "guide"), "utf8");
+    expect(html).toContain('class="ox-image-gallery"');
+    expect(html).toMatch(/src="hero\.[a-f0-9]{12}\.png"/);
+    expect(result.files.some((file) => /hero\.[a-f0-9]{12}\.png$/.test(file))).toBe(true);
+  });
+
   it("resizes, crops, and converts format at build time", async () => {
     const root = await makeSite({
       "guide.md": [

--- a/npm/vite-plugin-ox-content/src/transform.ts
+++ b/npm/vite-plugin-ox-content/src/transform.ts
@@ -51,6 +51,7 @@ import { applyTypedHover } from "./typed-hover";
 import { resolveMdxForFilePath } from "./markdown";
 import { toJsDataTableOptions } from "./data-table-options";
 import { toJsFileTreeOptions } from "./file-tree-options";
+import { toJsImageGalleryOptions } from "./image-gallery-options";
 import { toJsPartialsOptions } from "./partials-options";
 
 /**
@@ -332,6 +333,12 @@ interface JsTransformOptions {
   images?: {
     enabled?: boolean;
     lazy?: boolean;
+  };
+  imageGalleries?: {
+    enabled?: boolean;
+    lazy?: boolean;
+    missingAlt?: "error" | "warn" | "ignore";
+    empty?: "error" | "warn" | "ignore";
   };
 
   cjkEmphasis?: boolean;
@@ -684,6 +691,7 @@ export async function transformMarkdown(
           lazy: options.images.lazy,
         }
       : undefined,
+    imageGalleries: toJsImageGalleryOptions(options.imageGalleries, options.images),
     cjkEmphasis: options.cjkEmphasis ?? false,
     codeImports: options.codeImports?.enabled
       ? {

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -1783,6 +1783,18 @@ export interface OxContentOptions {
   images?: boolean | ImageOptions;
 
   /**
+   * Opt-in static `::: gallery` image groups.
+   *
+   * Each non-empty line inside the block must be a Markdown image, optionally
+   * as a list item. Image titles become item captions, and the block title or
+   * caption metadata becomes the gallery caption. Passing `true` or `{}`
+   * enables strict empty-gallery and missing-alt diagnostics.
+   *
+   * @default false
+   */
+  imageGalleries?: boolean | ImageGalleryOptions;
+
+  /**
    * Opt-in page-bundle resources and build-time image processing.
    *
    * Off by default. `true` or `{}` treats each page directory as a bundle:
@@ -2133,6 +2145,10 @@ export interface ResolvedOptions {
   magicLinks?: ResolvedMagicLinkOptions;
   containers: ResolvedContainerOptions;
   images: ResolvedImageOptions;
+  /**
+   * Present after `resolveOptions`. Omitted in hand-built fixtures means off.
+   */
+  imageGalleries?: ResolvedImageGalleryOptions;
   codeImports: ResolvedCodeImportOptions;
   includes: ResolvedIncludeOptions;
   /**
@@ -2541,6 +2557,49 @@ export interface ImageOptions {
 export interface ResolvedImageOptions {
   enabled: boolean;
   lazy: boolean;
+}
+
+/**
+ * Options for opt-in static image galleries.
+ */
+export interface ImageGalleryOptions {
+  /**
+   * Enable `::: gallery` blocks.
+   *
+   * @default true when the options object is supplied.
+   */
+  enabled?: boolean;
+
+  /**
+   * Add `loading="lazy"` to gallery images.
+   *
+   * @default follows `images.lazy`, or true when `images` is disabled.
+   */
+  lazy?: boolean;
+
+  /**
+   * Diagnostics for image items without alt text.
+   *
+   * @default "error"
+   */
+  missingAlt?: "error" | "warn" | "ignore";
+
+  /**
+   * Diagnostics for galleries without image items.
+   *
+   * @default "error"
+   */
+  empty?: "error" | "warn" | "ignore";
+}
+
+/**
+ * Resolved image gallery transform options.
+ */
+export interface ResolvedImageGalleryOptions {
+  enabled: boolean;
+  lazy?: boolean;
+  missingAlt: "error" | "warn" | "ignore";
+  empty: "error" | "warn" | "ignore";
 }
 
 /**


### PR DESCRIPTION
Closes #947.

## Summary
- add opt-in ::: gallery blocks that render static semantic gallery markup
- reuse image parsing/sanitization/attrs/dimensions and resource processing
- expose Vite/NAPI options plus SSG gallery CSS

## Validation
- cargo test -p ox_content_transform image_galleries
- cargo test -p ox_content_ssg image_gallery
- cargo test -p ox_content_napi transform_bindings --no-default-features
- cargo test -p ox_content_napi javascript_wrapper --no-default-features
- vp exec --filter @ox-content/vite-plugin -- vp test src/image-gallery-options.test.ts src/image-galleries.transform.test.ts src/resources.test.ts src/public-exports.test.ts
- vp run fmt:check
- node scripts/check-file-lines.ts
- cargo clippy -p ox_content_transform -p ox_content_ssg -p ox_content_napi --all-targets -- -D warnings
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790343122&installation_model_id=422833&pr_number=1022&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1022&signature=c639c97fc642857998c0c07ec1e0ebe258cfc73969b698f909df5a369abd6006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->