### PR TITLE
feat(markdown): add static timeline blocks

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -2224,6 +2224,40 @@ export interface JsThemeLayout {
   maxContentWidth?: string
 }
 
+/** Opt-in static `::: timeline` milestone lists. */
+export interface JsTimelineOptions {
+  /**
+   * Enable static timeline blocks.
+   *
+   * Default: `false`.
+   */
+  enabled?: boolean
+  /**
+   * Render timelines as ordered lists unless a block overrides it.
+   *
+   * Default: `true`.
+   */
+  ordered?: boolean
+  /**
+   * Validation mode for malformed dates.
+   *
+   * Default: `"error"`.
+   */
+  invalidDate?: string
+  /**
+   * Validation mode for unsupported item metadata.
+   *
+   * Default: `"error"`.
+   */
+  unknownMeta?: string
+  /**
+   * Validation mode for timeline blocks without items.
+   *
+   * Default: `"error"`.
+   */
+  empty?: string
+}
+
 /**
  * Transform options for JavaScript.
  *
@@ -2494,6 +2528,12 @@ export interface JsTransformOptions {
    * Default: disabled.
    */
   imageGalleries?: JsImageGalleryOptions
+  /**
+   * Opt-in static `::: timeline` milestone lists.
+   *
+   * Default: disabled.
+   */
+  timelines?: JsTimelineOptions
   /**
    * Opt-in `::: card` / `::: link-card` / `::: card-grid` blocks.
    *

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -2228,6 +2228,40 @@ export interface JsThemeLayout {
   maxContentWidth?: string
 }
 
+/** Opt-in static `::: timeline` milestone lists. */
+export interface JsTimelineOptions {
+  /**
+   * Enable static timeline blocks.
+   *
+   * Default: `false`.
+   */
+  enabled?: boolean
+  /**
+   * Render timelines as ordered lists unless a block overrides it.
+   *
+   * Default: `true`.
+   */
+  ordered?: boolean
+  /**
+   * Validation mode for malformed dates.
+   *
+   * Default: `"error"`.
+   */
+  invalidDate?: string
+  /**
+   * Validation mode for unsupported item metadata.
+   *
+   * Default: `"error"`.
+   */
+  unknownMeta?: string
+  /**
+   * Validation mode for timeline blocks without items.
+   *
+   * Default: `"error"`.
+   */
+  empty?: string
+}
+
 /**
  * Transform options for JavaScript.
  *
@@ -2498,6 +2532,12 @@ export interface JsTransformOptions {
    * Default: disabled.
    */
   imageGalleries?: JsImageGalleryOptions
+  /**
+   * Opt-in static `::: timeline` milestone lists.
+   *
+   * Default: disabled.
+   */
+  timelines?: JsTimelineOptions
   /**
    * Opt-in `::: card` / `::: link-card` / `::: card-grid` blocks.
    *

--- a/crates/ox_content_napi/src/transform_bindings.rs
+++ b/crates/ox_content_napi/src/transform_bindings.rs
@@ -39,7 +39,7 @@ pub use feature_options::{
     JsAttrsOptions, JsCodeBlockLintOptions, JsCodeImportOptions, JsContainerOptions,
     JsContainerTypeOptions, JsDocsTestOptions, JsEditThisPageOptions, JsEmojiShortcodeOptions,
     JsImageGalleryOptions, JsImageOptions, JsIncludeOptions, JsMediaEmbedsOptions,
-    JsNotByAiOptions, JsSanitizeOptions, JsWikiLinkOptions,
+    JsNotByAiOptions, JsSanitizeOptions, JsTimelineOptions, JsWikiLinkOptions,
 };
 pub use file_tree_options::JsFileTreeOptions;
 pub use keyboard_keys_options::JsKeyboardKeysOptions;

--- a/crates/ox_content_napi/src/transform_bindings/feature_options.rs
+++ b/crates/ox_content_napi/src/transform_bindings/feature_options.rs
@@ -11,10 +11,12 @@ mod image_gallery_options;
 mod image_options;
 mod media_embeds_options;
 mod not_by_ai_options;
+mod timeline_options;
 pub use image_gallery_options::JsImageGalleryOptions;
 pub use image_options::JsImageOptions;
 pub use media_embeds_options::JsMediaEmbedsOptions;
 pub use not_by_ai_options::JsNotByAiOptions;
+pub use timeline_options::JsTimelineOptions;
 
 /// Wiki-link transform options.
 #[napi(object)]

--- a/crates/ox_content_napi/src/transform_bindings/feature_options/timeline_options.rs
+++ b/crates/ox_content_napi/src/transform_bindings/feature_options/timeline_options.rs
@@ -1,0 +1,44 @@
+use napi_derive::napi;
+use ox_content_transform::TimelineOptions;
+
+/// Opt-in static `::: timeline` milestone lists.
+#[napi(object)]
+#[derive(Default, Clone)]
+pub struct JsTimelineOptions {
+    /// Enable static timeline blocks.
+    ///
+    /// Default: `false`.
+    pub enabled: Option<bool>,
+
+    /// Render timelines as ordered lists unless a block overrides it.
+    ///
+    /// Default: `true`.
+    pub ordered: Option<bool>,
+
+    /// Validation mode for malformed dates.
+    ///
+    /// Default: `"error"`.
+    pub invalid_date: Option<String>,
+
+    /// Validation mode for unsupported item metadata.
+    ///
+    /// Default: `"error"`.
+    pub unknown_meta: Option<String>,
+
+    /// Validation mode for timeline blocks without items.
+    ///
+    /// Default: `"error"`.
+    pub empty: Option<String>,
+}
+
+impl From<JsTimelineOptions> for TimelineOptions {
+    fn from(value: JsTimelineOptions) -> Self {
+        Self {
+            enabled: value.enabled,
+            ordered: value.ordered,
+            invalid_date: value.invalid_date,
+            unknown_meta: value.unknown_meta,
+            empty: value.empty,
+        }
+    }
+}

--- a/crates/ox_content_napi/src/transform_bindings/transform_options.rs
+++ b/crates/ox_content_napi/src/transform_bindings/transform_options.rs
@@ -7,7 +7,8 @@ use super::{
     JsCodeImportOptions, JsContainerOptions, JsDataTableOptions, JsDefinitionListOptions,
     JsEditThisPageOptions, JsEmojiShortcodeOptions, JsFileTreeOptions, JsImageGalleryOptions,
     JsImageOptions, JsIncludeOptions, JsKeyboardKeysOptions, JsMagicLinkOptions, JsMathOptions,
-    JsNotByAiOptions, JsPartialsOptions, JsSanitizeOptions, JsStepsOptions, JsWikiLinkOptions,
+    JsNotByAiOptions, JsPartialsOptions, JsSanitizeOptions, JsStepsOptions, JsTimelineOptions,
+    JsWikiLinkOptions,
 };
 
 /// Transform options for JavaScript.
@@ -239,6 +240,11 @@ pub struct JsTransformOptions {
     /// Default: disabled.
     pub image_galleries: Option<JsImageGalleryOptions>,
 
+    /// Opt-in static `::: timeline` milestone lists.
+    ///
+    /// Default: disabled.
+    pub timelines: Option<JsTimelineOptions>,
+
     /// Opt-in `::: card` / `::: link-card` / `::: card-grid` blocks.
     ///
     /// Default: disabled.
@@ -304,6 +310,7 @@ impl From<JsTransformOptions> for TransformOptions {
             magic_links: value.magic_links.map(Into::into),
             images: value.images.map(Into::into),
             image_galleries: value.image_galleries.map(Into::into),
+            timelines: value.timelines.map(Into::into),
             cards: value.cards.map(Into::into),
             math: match value.math {
                 Some(Either::A(enabled)) => Some(MathOptions { enabled: Some(enabled) }),

--- a/crates/ox_content_search/src/markdown/tests.rs
+++ b/crates/ox_content_search/src/markdown/tests.rs
@@ -75,6 +75,31 @@ fn explicit_mdx_setting_overrides_the_source_extension() {
 }
 
 #[test]
+fn timeline_markdown_items_stay_searchable_in_source_order() {
+    let root = std::env::temp_dir().join(format!("ox-search-timeline-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    write_tree(
+        &root,
+        &[(
+            "releases.md",
+            "# Releases\n\n::: timeline\n- 2026-08-26 RC cut\n  Nested migration notes.\n- 2026-09 GA window\n:::\n",
+        )],
+    );
+
+    let body = body(&build_search_index_from_directory_with_options(
+        root.to_str().unwrap(),
+        "/",
+        &[".md".to_string()],
+        None,
+    ));
+    let rc = body.find("RC cut").expect("timeline title indexed");
+    let nested = body.find("Nested migration notes").expect("nested body indexed");
+    let ga = body.find("GA window").expect("later item indexed");
+    assert!(rc < nested && nested < ga, "{body:?}");
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
 fn off_indexes_every_page() {
     let root = std::env::temp_dir().join(format!("ox-search-drafts-off-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&root);

--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -254,6 +254,9 @@ const FILE_TREE_CSS: &str =
 /// CSS for opt-in static image galleries.
 const IMAGE_GALLERY_CSS: &str = include_str!("html/image_gallery.css");
 
+/// CSS for opt-in static timelines.
+const TIMELINE_CSS: &str = include_str!("html/timeline.css");
+
 /// CSS styles for opt-in `{kbd:...}` keyboard keys.
 const KBD_CSS: &str = include_str!("plugins/kbd.css");
 

--- a/crates/ox_content_ssg/src/html/render_inner.rs
+++ b/crates/ox_content_ssg/src/html/render_inner.rs
@@ -30,7 +30,7 @@ use super::utils::{
 use super::{
     CONTRIBUTORS_CSS, ENTRY_CSS, FILE_TREE_CSS, GITHUB_CSS, IMAGE_GALLERY_CSS, ISLAND_CSS,
     MERMAID_CSS, NavGroup, OGP_CSS, PageData, PageTemplate, SOCIAL_CSS, SOCIAL_TWEET_FULL_CSS,
-    SSG_CSS, SsgConfig, TABS_CSS, YOUTUBE_CSS,
+    SSG_CSS, SsgConfig, TABS_CSS, TIMELINE_CSS, YOUTUBE_CSS,
 };
 
 pub(super) struct GeneratedPage {
@@ -135,6 +135,9 @@ pub(super) fn generate_html_inner(
     }
     if page_content_contains_any(&page_data.content, &["ox-image-gallery"]) {
         css_sections.push(wrap_css_section("image-gallery", IMAGE_GALLERY_CSS));
+    }
+    if page_content_contains_any(&page_data.content, &["ox-timeline"]) {
+        css_sections.push(wrap_css_section("timeline", TIMELINE_CSS));
     }
     push_not_by_ai_css(&mut css_sections, &page_data.content);
     push_content_plugin_css(&mut css_sections, &page_data.content);

--- a/crates/ox_content_ssg/src/html/tests.rs
+++ b/crates/ox_content_ssg/src/html/tests.rs
@@ -31,6 +31,7 @@ mod rendering;
 mod social;
 mod theme;
 mod theme_quality;
+mod timeline;
 
 #[test]
 fn search_keydown_ignores_ime_composition() {
@@ -77,6 +78,7 @@ fn default_theme_surfaces_stay_flat() {
         super::CONTRIBUTORS_CSS,
         super::FILE_TREE_CSS,
         super::IMAGE_GALLERY_CSS,
+        super::TIMELINE_CSS,
         super::not_by_ai::NOT_BY_AI_CSS,
         super::KBD_CSS,
         super::ABBR_CSS,

--- a/crates/ox_content_ssg/src/html/tests/timeline.rs
+++ b/crates/ox_content_ssg/src/html/tests/timeline.rs
@@ -1,0 +1,19 @@
+use super::super::generate_html;
+use super::rendering::{config, page};
+
+#[test]
+fn includes_css_when_timeline_markup_is_present() {
+    let page_data = page(
+        "Timeline",
+        None,
+        r#"<section class="ox-timeline"><ol class="ox-timeline__items"></ol></section>"#,
+        vec![],
+        None,
+        "timeline",
+    );
+    let html = generate_html(&page_data, &[], &config("Test Site", "/", None));
+
+    assert!(html.contains("ox-content:css:timeline:start"), "{html}");
+    assert!(html.contains(".content .ox-timeline__item"), "{html}");
+    assert!(html.contains("@media (max-width: 640px)"), "{html}");
+}

--- a/crates/ox_content_ssg/src/html/timeline.css
+++ b/crates/ox_content_ssg/src/html/timeline.css
@@ -1,0 +1,86 @@
+.content .ox-timeline {
+  margin: 1.75rem 0;
+}
+.content .ox-timeline__caption {
+  margin-bottom: 0.75rem;
+  color: var(--octc-color-text);
+  font-weight: 600;
+}
+.content .ox-timeline__items {
+  display: grid;
+  gap: 0.95rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.content .ox-timeline__item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1rem minmax(0, 1fr);
+  column-gap: 0.75rem;
+  min-width: 0;
+}
+.content .ox-timeline__item:not(:last-child)::after {
+  content: "";
+  position: absolute;
+  top: 1.4rem;
+  bottom: -0.9rem;
+  left: 0.3125rem;
+  border-left: 1px solid var(--octc-color-border);
+}
+.content .ox-timeline__marker {
+  width: 0.625rem;
+  height: 0.625rem;
+  margin-top: 0.5rem;
+  border: 2px solid var(--octc-color-primary);
+  border-radius: 999px;
+  background: var(--octc-color-bg);
+}
+.content .ox-timeline__content {
+  min-width: 0;
+}
+.content .ox-timeline__content > :first-child {
+  margin-top: 0;
+}
+.content .ox-timeline__content > :last-child {
+  margin-bottom: 0;
+}
+.content .ox-timeline__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.5rem;
+  align-items: center;
+  color: var(--octc-color-text-muted);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+.content .ox-timeline__date {
+  color: var(--octc-color-text);
+  font-variant-numeric: tabular-nums;
+}
+.content .ox-timeline__date--invalid {
+  color: var(--octc-color-text-muted);
+}
+.content .ox-timeline__label,
+.content .ox-timeline__status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.35rem;
+  padding: 0 0.35rem;
+  border: 1px solid var(--octc-color-border);
+  border-radius: 4px;
+}
+.content .ox-timeline__title {
+  margin: 0.15rem 0 0.35rem;
+  color: var(--octc-color-text);
+  font-weight: 600;
+}
+@media (max-width: 640px) {
+  .content .ox-timeline__items {
+    gap: 0.85rem;
+  }
+  .content .ox-timeline__item {
+    grid-template-columns: 0.875rem minmax(0, 1fr);
+    column-gap: 0.625rem;
+  }
+}

--- a/crates/ox_content_transform/src/features.rs
+++ b/crates/ox_content_transform/src/features.rs
@@ -1,10 +1,8 @@
 #![allow(clippy::redundant_pub_crate)]
-
+use crate::TransformOptions;
 use rustc_hash::FxHashMap;
 use std::borrow::Cow;
 use std::path::PathBuf;
-
-use crate::TransformOptions;
 
 mod abbreviations;
 mod attr_tokens;
@@ -33,8 +31,8 @@ mod option_resolve;
 mod partials;
 mod segments;
 mod steps;
+mod timelines;
 mod wiki;
-
 use attributes::transform_attribute_syntax;
 use cards::ResolvedCardOptions;
 pub use code_blocks::{
@@ -81,11 +79,11 @@ pub struct TransformFeatureOptions {
     magic_links: Option<ResolvedMagicLinks>,
     images: Option<ResolvedImageOptions>,
     image_galleries: Option<ResolvedImageGalleryOptions>,
+    timelines: Option<timelines::ResolvedTimelineOptions>,
     math: bool,
     attributes: bool,
     edit_this_page: Option<ResolvedEditThisPageOptions>,
 }
-
 #[derive(Clone)]
 struct ResolvedWikiLinkOptions {
     base_url: String,
@@ -128,6 +126,7 @@ impl TransformFeatureOptions {
         let images = images::resolve(options.images.as_ref(), attributes);
         let image_galleries =
             image_galleries::resolve(options.image_galleries.as_ref(), attributes, images.as_ref());
+        let timelines = timelines::resolve(options.timelines.as_ref());
         let mut containers = containers::resolve(options.containers.as_ref());
         containers::remove_reserved_type_names(
             &mut containers,
@@ -135,6 +134,7 @@ impl TransformFeatureOptions {
             steps.is_some(),
             code_groups.as_ref().map(|_| code_groups::reserved_type_names()),
             image_galleries.is_some(),
+            timelines.is_some(),
         );
         let includes = includes::resolve(options.includes.as_ref(), source_path);
         let partials = partials::resolve(options.partials.as_ref(), source_path);
@@ -172,6 +172,7 @@ impl TransformFeatureOptions {
             magic_links,
             images,
             image_galleries,
+            timelines,
             math,
             attributes,
             edit_this_page,
@@ -198,6 +199,7 @@ impl TransformFeatureOptions {
             || self.magic_links.is_some()
             || self.images.is_some()
             || self.image_galleries.is_some()
+            || self.timelines.is_some()
             || self.math
     }
 
@@ -263,6 +265,9 @@ pub fn preprocess_markdown<'a>(
     if current.contains(":::") {
         if let Some(galleries) = &options.image_galleries {
             current = Cow::Owned(image_galleries::transform(&current, galleries, &mut errors));
+        }
+        if let Some(timelines) = &options.timelines {
+            current = Cow::Owned(timelines::transform(&current, timelines, &mut errors));
         }
         if options.cards.is_some() {
             current = Cow::Owned(cards::transform(&current));

--- a/crates/ox_content_transform/src/features/containers.rs
+++ b/crates/ox_content_transform/src/features/containers.rs
@@ -93,6 +93,7 @@ pub(super) fn remove_reserved_type_names(
     steps: bool,
     code_groups: Option<&[&str]>,
     galleries: bool,
+    timelines: bool,
 ) {
     let Some(options) = options.as_mut() else {
         return;
@@ -107,6 +108,9 @@ pub(super) fn remove_reserved_type_names(
     }
     if galleries {
         options.types.remove("gallery");
+    }
+    if timelines {
+        options.types.remove("timeline");
     }
 }
 

--- a/crates/ox_content_transform/src/features/timelines.rs
+++ b/crates/ox_content_transform/src/features/timelines.rs
@@ -1,0 +1,207 @@
+//! Opt-in static `::: timeline` milestone lists.
+//!
+//! Timeline blocks are disabled by default. When enabled, closed blocks are
+//! rewritten to semantic static HTML while nested item bodies stay Markdown so
+//! the normal renderer can keep headings, links, and emphasis searchable.
+
+use crate::TimelineOptions;
+
+mod date;
+mod html;
+mod meta;
+mod parse;
+#[cfg(test)]
+mod tests;
+
+use html::emit_timeline;
+use parse::{TimelineOpen, parse_timeline_items, parse_timeline_open};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ReportMode {
+    Ignore,
+    Warn,
+    Error,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct ResolvedTimelineOptions {
+    ordered: bool,
+    invalid_date: ReportMode,
+    unknown_meta: ReportMode,
+    empty: ReportMode,
+}
+
+pub(super) fn resolve(options: Option<&TimelineOptions>) -> Option<ResolvedTimelineOptions> {
+    let options = options?;
+    if options.enabled == Some(false) {
+        return None;
+    }
+    Some(ResolvedTimelineOptions {
+        ordered: options.ordered.unwrap_or(true),
+        invalid_date: report_mode(options.invalid_date.as_deref(), ReportMode::Error),
+        unknown_meta: report_mode(options.unknown_meta.as_deref(), ReportMode::Error),
+        empty: report_mode(options.empty.as_deref(), ReportMode::Error),
+    })
+}
+
+pub(super) fn transform(
+    source: &str,
+    options: &ResolvedTimelineOptions,
+    errors: &mut Vec<String>,
+) -> String {
+    if !source.contains(":::") || !source.contains("timeline") {
+        return source.to_string();
+    }
+    rewrite(source, options, errors)
+}
+
+fn rewrite(source: &str, options: &ResolvedTimelineOptions, errors: &mut Vec<String>) -> String {
+    let mut out = String::with_capacity(source.len());
+    let mut lines = source.split_inclusive('\n');
+    let mut in_fence = false;
+    let mut fence_char = b'\0';
+    let mut fence_len = 0usize;
+
+    while let Some(line_with_end) = lines.next() {
+        let (line, ending) = split_ending(line_with_end);
+
+        if in_fence {
+            out.push_str(line);
+            out.push_str(ending);
+            if super::segments::is_closing_fence(line, fence_char, fence_len) {
+                in_fence = false;
+            }
+            continue;
+        }
+
+        if let Some(open) = super::segments::parse_opening_fence(line) {
+            in_fence = true;
+            fence_char = open.fence_char;
+            fence_len = open.fence_len;
+            out.push_str(line);
+            out.push_str(ending);
+            continue;
+        }
+
+        let Some(open) = parse_timeline_open(line, options.ordered) else {
+            out.push_str(line);
+            out.push_str(ending);
+            continue;
+        };
+
+        let mut body = String::new();
+        let mut close = None;
+        for inner in lines.by_ref() {
+            let (inner_line, inner_end) = split_ending(inner);
+            if is_timeline_close(inner_line, open.indent, open.colon_count) {
+                close = Some((inner_line, inner_end));
+                break;
+            }
+            body.push_str(inner_line);
+            body.push_str(inner_end);
+        }
+
+        let original = original_block(line, ending, &body, close);
+        let Some((_, _)) = close else {
+            errors.push("Timeline block is missing a closing ::: fence.".to_string());
+            out.push_str(&original);
+            continue;
+        };
+
+        match render_timeline(&open, &body, options) {
+            Ok((html, diagnostics)) => {
+                errors.extend(diagnostics);
+                out.push_str(&html);
+            }
+            Err(diagnostics) => {
+                errors.extend(diagnostics);
+                out.push_str(&original);
+            }
+        }
+    }
+
+    out
+}
+
+fn render_timeline(
+    open: &TimelineOpen,
+    body: &str,
+    options: &ResolvedTimelineOptions,
+) -> Result<(String, Vec<String>), Vec<String>> {
+    let (items, mut diagnostics) = parse_timeline_items(body, options);
+    if items.is_empty()
+        && push_diagnostic(options.empty, "Timeline block is empty.".to_string(), &mut diagnostics)
+    {
+        return Err(diagnostics);
+    }
+    if diagnostics.iter().any(|message| message.starts_with("error:")) {
+        for message in &mut diagnostics {
+            if let Some(stripped) = message.strip_prefix("error:") {
+                *message = stripped.to_string();
+            }
+        }
+        return Err(diagnostics);
+    }
+    let mut out = String::new();
+    emit_timeline(&mut out, open.caption.as_deref(), open.ordered, &items);
+    Ok((out, diagnostics))
+}
+
+fn push_diagnostic(mode: ReportMode, message: String, diagnostics: &mut Vec<String>) -> bool {
+    match mode {
+        ReportMode::Ignore => false,
+        ReportMode::Warn => {
+            diagnostics.push(message);
+            false
+        }
+        ReportMode::Error => {
+            diagnostics.push(format!("error:{message}"));
+            true
+        }
+    }
+}
+
+fn original_block(line: &str, ending: &str, body: &str, close: Option<(&str, &str)>) -> String {
+    let mut original = String::with_capacity(line.len() + ending.len() + body.len() + 8);
+    original.push_str(line);
+    original.push_str(ending);
+    original.push_str(body);
+    if let Some((close_line, close_end)) = close {
+        original.push_str(close_line);
+        original.push_str(close_end);
+    }
+    original
+}
+
+fn is_timeline_close(line: &str, opener_indent: usize, colon_count: usize) -> bool {
+    let indent = line.len() - line.trim_start().len();
+    if indent > opener_indent {
+        return false;
+    }
+    let trimmed = line.trim_start();
+    let count = trimmed.bytes().take_while(|byte| *byte == b':').count();
+    count >= colon_count
+        && trimmed
+            .as_bytes()
+            .get(count..)
+            .is_none_or(|rest| rest.iter().all(u8::is_ascii_whitespace))
+}
+
+fn split_ending(line_with_end: &str) -> (&str, &str) {
+    if let Some(line) = line_with_end.strip_suffix("\r\n") {
+        (line, "\n")
+    } else if let Some(line) = line_with_end.strip_suffix('\n') {
+        (line, "\n")
+    } else {
+        (line_with_end.strip_suffix('\r').unwrap_or(line_with_end), "")
+    }
+}
+
+fn report_mode(value: Option<&str>, default: ReportMode) -> ReportMode {
+    match value.map(str::trim) {
+        Some("ignore") => ReportMode::Ignore,
+        Some("warn") => ReportMode::Warn,
+        Some("error") | None => default,
+        Some(_) => default,
+    }
+}

--- a/crates/ox_content_transform/src/features/timelines/date.rs
+++ b/crates/ox_content_transform/src/features/timelines/date.rs
@@ -1,0 +1,99 @@
+use super::parse::TimelineDate;
+use super::{ReportMode, ResolvedTimelineOptions};
+
+pub(super) fn parse_date_and_title<'a>(
+    value: &'a str,
+    line: usize,
+    options: &ResolvedTimelineOptions,
+    diagnostics: &mut Vec<String>,
+) -> (Option<TimelineDate>, &'a str) {
+    if let Some(rest) = value.strip_prefix('[')
+        && let Some(end) = rest.find(']')
+    {
+        let date = parse_date_token(&rest[..end], line, options, diagnostics);
+        return (date, rest[end + 1..].trim_start());
+    }
+    let Some((token, rest)) = split_first_token(value) else {
+        return (None, value);
+    };
+    if !is_date_candidate(token) {
+        return (None, value);
+    }
+    (parse_date_token(token, line, options, diagnostics), rest.trim_start())
+}
+
+fn parse_date_token(
+    token: &str,
+    line: usize,
+    options: &ResolvedTimelineOptions,
+    diagnostics: &mut Vec<String>,
+) -> Option<TimelineDate> {
+    if is_valid_date(token) {
+        return Some(TimelineDate { text: token.to_string(), datetime: Some(token.to_string()) });
+    }
+    let message = format!("Timeline item on line {line} has invalid date `{token}`.");
+    match options.invalid_date {
+        ReportMode::Ignore => None,
+        ReportMode::Warn => {
+            diagnostics.push(message);
+            Some(TimelineDate { text: token.to_string(), datetime: None })
+        }
+        ReportMode::Error => {
+            diagnostics.push(format!("error:{message}"));
+            Some(TimelineDate { text: token.to_string(), datetime: None })
+        }
+    }
+}
+
+fn split_first_token(value: &str) -> Option<(&str, &str)> {
+    let trimmed = value.trim_start();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let end = trimmed.find(char::is_whitespace).unwrap_or(trimmed.len());
+    Some((&trimmed[..end], &trimmed[end..]))
+}
+
+fn is_date_candidate(value: &str) -> bool {
+    value.len() >= 4 && value.chars().all(|ch| ch.is_ascii_digit() || ch == '-')
+}
+
+fn is_valid_date(value: &str) -> bool {
+    match value.len() {
+        4 => value.parse::<u16>().is_ok_and(|year| year > 0),
+        7 => parse_year_month(value).is_some(),
+        10 => {
+            let Some((year, month)) = parse_year_month(&value[..7]) else {
+                return false;
+            };
+            if value.as_bytes().get(7) != Some(&b'-') {
+                return false;
+            }
+            value[8..].parse::<u8>().is_ok_and(|day| day > 0 && day <= days_in_month(year, month))
+        }
+        _ => false,
+    }
+}
+
+fn parse_year_month(value: &str) -> Option<(u16, u8)> {
+    if value.as_bytes().get(4) != Some(&b'-') {
+        return None;
+    }
+    let year = value[..4].parse::<u16>().ok().filter(|year| *year > 0)?;
+    let month = value[5..].parse::<u8>().ok().filter(|month| (1..=12).contains(month))?;
+    Some((year, month))
+}
+
+fn days_in_month(year: u16, month: u8) -> u8 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+fn is_leap_year(year: u16) -> bool {
+    year.is_multiple_of(4) && !year.is_multiple_of(100) || year.is_multiple_of(400)
+}

--- a/crates/ox_content_transform/src/features/timelines/html.rs
+++ b/crates/ox_content_transform/src/features/timelines/html.rs
@@ -1,0 +1,96 @@
+use super::super::{escape_html_attr, escape_html_text};
+use super::parse::{TimelineDate, TimelineItem};
+
+pub(super) fn emit_timeline(
+    out: &mut String,
+    caption: Option<&str>,
+    ordered: bool,
+    items: &[TimelineItem],
+) {
+    out.push_str("<section class=\"ox-timeline\" aria-label=\"Timeline\">\n");
+    if let Some(caption) = caption.filter(|value| !value.trim().is_empty()) {
+        out.push_str("<p class=\"ox-timeline__caption\">");
+        escape_html_text(caption, out);
+        out.push_str("</p>\n");
+    }
+    let list = if ordered { "ol" } else { "ul" };
+    out.push('<');
+    out.push_str(list);
+    out.push_str(" class=\"ox-timeline__items\">\n");
+    for item in items {
+        emit_item(out, item);
+    }
+    out.push_str("</");
+    out.push_str(list);
+    out.push_str(">\n</section>\n");
+}
+
+fn emit_item(out: &mut String, item: &TimelineItem) {
+    out.push_str("<li class=\"ox-timeline__item\"");
+    if let Some(status) = item.status.as_deref() {
+        out.push_str(" data-status=\"");
+        escape_html_attr(status, out);
+        out.push('"');
+    }
+    out.push_str(">\n<div class=\"ox-timeline__marker\" aria-hidden=\"true\"></div>\n");
+    out.push_str("<div class=\"ox-timeline__content\">\n");
+    emit_meta(out, item);
+    if !item.title.is_empty() {
+        emit_title(out, item);
+    }
+    if !item.body.trim().is_empty() {
+        out.push('\n');
+        out.push_str(item.body.trim_end());
+        out.push('\n');
+    }
+    out.push_str("</div>\n</li>\n");
+}
+
+fn emit_meta(out: &mut String, item: &TimelineItem) {
+    if item.date.is_none() && item.label.is_none() && item.status.is_none() {
+        return;
+    }
+    out.push_str("<div class=\"ox-timeline__meta\">");
+    if let Some(date) = &item.date {
+        emit_date(out, date);
+    }
+    if let Some(label) = item.label.as_deref() {
+        out.push_str("<span class=\"ox-timeline__label\">");
+        escape_html_text(label, out);
+        out.push_str("</span>");
+    }
+    if let Some(status) = item.status.as_deref() {
+        out.push_str("<span class=\"ox-timeline__status\">");
+        escape_html_text(status, out);
+        out.push_str("</span>");
+    }
+    out.push_str("</div>\n");
+}
+
+fn emit_date(out: &mut String, date: &TimelineDate) {
+    if let Some(datetime) = date.datetime.as_deref() {
+        out.push_str("<time class=\"ox-timeline__date\" datetime=\"");
+        escape_html_attr(datetime, out);
+        out.push_str("\">");
+        escape_html_text(&date.text, out);
+        out.push_str("</time>");
+    } else {
+        out.push_str("<span class=\"ox-timeline__date ox-timeline__date--invalid\">");
+        escape_html_text(&date.text, out);
+        out.push_str("</span>");
+    }
+}
+
+fn emit_title(out: &mut String, item: &TimelineItem) {
+    out.push_str("<p class=\"ox-timeline__title\">");
+    if let Some(href) = item.href.as_deref() {
+        out.push_str("<a href=\"");
+        escape_html_attr(href, out);
+        out.push_str("\">");
+        escape_html_text(&item.title, out);
+        out.push_str("</a>");
+    } else {
+        escape_html_text(&item.title, out);
+    }
+    out.push_str("</p>\n");
+}

--- a/crates/ox_content_transform/src/features/timelines/meta.rs
+++ b/crates/ox_content_transform/src/features/timelines/meta.rs
@@ -1,0 +1,115 @@
+use super::{ReportMode, ResolvedTimelineOptions};
+
+#[derive(Default)]
+pub(super) struct ItemMeta {
+    pub(super) label: Option<String>,
+    pub(super) status: Option<String>,
+    pub(super) href: Option<String>,
+}
+
+pub(super) fn parse_item_meta(
+    source: &str,
+    line: usize,
+    options: &ResolvedTimelineOptions,
+    diagnostics: &mut Vec<String>,
+    meta: &mut ItemMeta,
+) {
+    for token in split_meta_tokens(source) {
+        let Some((key, value)) = token.split_once('=') else {
+            push_unknown_meta(line, &token, options, diagnostics);
+            continue;
+        };
+        let value = unquote(value).to_string();
+        match key {
+            "label" => meta.label = Some(value),
+            "status" if is_safe_token(&value) => meta.status = Some(value),
+            "status" => push_unknown_meta(line, &format!("status={value}"), options, diagnostics),
+            "href" if is_safe_href(&value) => meta.href = Some(value),
+            "href" => push_unknown_meta(line, "href", options, diagnostics),
+            _ => push_unknown_meta(line, key, options, diagnostics),
+        }
+    }
+}
+
+pub(super) fn push_diagnostic(mode: ReportMode, message: String, diagnostics: &mut Vec<String>) {
+    match mode {
+        ReportMode::Ignore => {}
+        ReportMode::Warn => diagnostics.push(message),
+        ReportMode::Error => diagnostics.push(format!("error:{message}")),
+    }
+}
+
+pub(super) fn strip_trailing_meta(value: &str) -> (&str, Option<&str>) {
+    let trimmed = value.trim_end();
+    if !trimmed.ends_with('}') {
+        return (trimmed, None);
+    }
+    let Some(start) = trimmed.rfind('{') else {
+        return (trimmed, None);
+    };
+    (trimmed[..start].trim_end(), Some(trimmed[start + 1..trimmed.len() - 1].trim()))
+}
+
+pub(super) fn split_meta_tokens(value: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut token = String::new();
+    let mut quote = None;
+    for ch in value.chars() {
+        if quote == Some(ch) {
+            quote = None;
+            token.push(ch);
+            continue;
+        }
+        if quote.is_none() && (ch == '"' || ch == '\'') {
+            quote = Some(ch);
+            token.push(ch);
+            continue;
+        }
+        if quote.is_none() && ch.is_whitespace() {
+            if !token.is_empty() {
+                tokens.push(std::mem::take(&mut token));
+            }
+            continue;
+        }
+        token.push(ch);
+    }
+    if !token.is_empty() {
+        tokens.push(token);
+    }
+    tokens
+}
+
+pub(super) fn unquote(value: &str) -> &str {
+    value
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .or_else(|| value.strip_prefix('\'').and_then(|value| value.strip_suffix('\'')))
+        .unwrap_or(value)
+}
+
+fn push_unknown_meta(
+    line: usize,
+    key: &str,
+    options: &ResolvedTimelineOptions,
+    diagnostics: &mut Vec<String>,
+) {
+    push_diagnostic(
+        options.unknown_meta,
+        format!("Timeline item on line {line} has unsupported metadata `{key}`."),
+        diagnostics,
+    );
+}
+
+fn is_safe_token(value: &str) -> bool {
+    !value.is_empty()
+        && value.chars().all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+}
+
+fn is_safe_href(value: &str) -> bool {
+    let lower = value.trim().to_ascii_lowercase();
+    !lower.is_empty()
+        && !lower.starts_with("javascript:")
+        && !lower.starts_with("data:")
+        && !lower.starts_with("vbscript:")
+        && !lower.starts_with("//")
+}

--- a/crates/ox_content_transform/src/features/timelines/parse.rs
+++ b/crates/ox_content_transform/src/features/timelines/parse.rs
@@ -1,0 +1,192 @@
+use super::ResolvedTimelineOptions;
+use super::date::parse_date_and_title;
+use super::meta::{
+    ItemMeta, parse_item_meta, push_diagnostic, split_meta_tokens, strip_trailing_meta, unquote,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct TimelineOpen {
+    pub(super) indent: usize,
+    pub(super) colon_count: usize,
+    pub(super) caption: Option<String>,
+    pub(super) ordered: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct TimelineDate {
+    pub(super) text: String,
+    pub(super) datetime: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct TimelineItem {
+    pub(super) date: Option<TimelineDate>,
+    pub(super) title: String,
+    pub(super) label: Option<String>,
+    pub(super) status: Option<String>,
+    pub(super) href: Option<String>,
+    pub(super) body: String,
+}
+
+struct RawItem {
+    line: usize,
+    header: String,
+    body: String,
+}
+
+struct ItemMarker<'a> {
+    indent: usize,
+    rest: &'a str,
+}
+
+pub(super) fn parse_timeline_open(line: &str, default_ordered: bool) -> Option<TimelineOpen> {
+    if super::super::segments::is_indented_code_line(line) {
+        return None;
+    }
+    let indent = line.len() - line.trim_start().len();
+    let trimmed = line.trim_start();
+    let colon_count = trimmed.bytes().take_while(|byte| *byte == b':').count();
+    if colon_count < 3 {
+        return None;
+    }
+    let mut parts = trimmed[colon_count..].trim_start().splitn(2, char::is_whitespace);
+    if parts.next()? != "timeline" {
+        return None;
+    }
+    let meta = parts.next().unwrap_or_default().trim();
+    let (caption, ordered) = parse_open_meta(meta, default_ordered);
+    Some(TimelineOpen { indent, colon_count, caption, ordered })
+}
+
+pub(super) fn parse_timeline_items(
+    body: &str,
+    options: &ResolvedTimelineOptions,
+) -> (Vec<TimelineItem>, Vec<String>) {
+    let mut diagnostics = Vec::new();
+    let mut items = Vec::new();
+    let mut current: Option<RawItem> = None;
+    let mut item_indent = 0usize;
+
+    for (index, line_with_end) in body.split_inclusive('\n').enumerate() {
+        let (line, ending) = split_ending(line_with_end);
+        if let Some(marker) = parse_item_marker(line) {
+            if let Some(item) = current.take() {
+                push_parsed_item(item, options, &mut items, &mut diagnostics);
+            }
+            item_indent = marker.indent;
+            current = Some(RawItem {
+                line: index + 1,
+                header: marker.rest.trim().to_string(),
+                body: String::new(),
+            });
+            continue;
+        }
+        if let Some(item) = current.as_mut() {
+            item.body.push_str(strip_item_indent(line, item_indent));
+            item.body.push_str(ending);
+        } else if !line.trim().is_empty() {
+            push_diagnostic(
+                options.unknown_meta,
+                format!("Timeline line {} must start with a list item.", index + 1),
+                &mut diagnostics,
+            );
+        }
+    }
+
+    if let Some(item) = current.take() {
+        push_parsed_item(item, options, &mut items, &mut diagnostics);
+    }
+    (items, diagnostics)
+}
+
+fn push_parsed_item(
+    raw: RawItem,
+    options: &ResolvedTimelineOptions,
+    items: &mut Vec<TimelineItem>,
+    diagnostics: &mut Vec<String>,
+) {
+    let (header, meta_source) = strip_trailing_meta(&raw.header);
+    let mut meta = ItemMeta::default();
+    if let Some(source) = meta_source {
+        parse_item_meta(source, raw.line, options, diagnostics, &mut meta);
+    }
+    let (date, title) = parse_date_and_title(header.trim(), raw.line, options, diagnostics);
+    items.push(TimelineItem {
+        date,
+        title: title.trim().to_string(),
+        label: meta.label,
+        status: meta.status,
+        href: meta.href,
+        body: raw.body.trim_end().to_string(),
+    });
+}
+
+fn parse_open_meta(meta: &str, default_ordered: bool) -> (Option<String>, bool) {
+    if meta.is_empty() {
+        return (None, default_ordered);
+    }
+    let mut caption = None;
+    let mut ordered = default_ordered;
+    for token in split_meta_tokens(meta) {
+        if token == "unordered" || token == "ul" {
+            ordered = false;
+            continue;
+        }
+        if token == "ordered" || token == "ol" {
+            ordered = true;
+            continue;
+        }
+        let Some((key, value)) = token.split_once('=') else {
+            caption.get_or_insert_with(|| unquote(&token).to_string());
+            continue;
+        };
+        match key {
+            "caption" | "title" => caption = Some(unquote(value).to_string()),
+            "ordered" => ordered = value != "false",
+            _ => {}
+        }
+    }
+    (caption, ordered)
+}
+
+fn parse_item_marker(line: &str) -> Option<ItemMarker<'_>> {
+    let bytes = line.as_bytes();
+    let mut indent = 0usize;
+    while indent < bytes.len() && indent < 4 && bytes[indent] == b' ' {
+        indent += 1;
+    }
+    if indent >= 4 {
+        return None;
+    }
+    let rest = &line[indent..];
+    if let Some(rest) = rest.strip_prefix("- ").or_else(|| rest.strip_prefix("* ")) {
+        return Some(ItemMarker { indent, rest });
+    }
+    let digits = rest.bytes().take_while(u8::is_ascii_digit).count();
+    if digits > 0
+        && rest.as_bytes().get(digits) == Some(&b'.')
+        && rest[digits + 1..].starts_with(' ')
+    {
+        return Some(ItemMarker { indent, rest: &rest[digits + 2..] });
+    }
+    None
+}
+
+fn strip_item_indent(line: &str, item_indent: usize) -> &str {
+    let bytes = line.as_bytes();
+    let mut indent = 0usize;
+    while indent < bytes.len() && indent < item_indent + 2 && bytes[indent] == b' ' {
+        indent += 1;
+    }
+    &line[indent..]
+}
+
+fn split_ending(line_with_end: &str) -> (&str, &str) {
+    if let Some(line) = line_with_end.strip_suffix("\r\n") {
+        (line, "\n")
+    } else if let Some(line) = line_with_end.strip_suffix('\n') {
+        (line, "\n")
+    } else {
+        (line_with_end.strip_suffix('\r').unwrap_or(line_with_end), "")
+    }
+}

--- a/crates/ox_content_transform/src/features/timelines/snapshots/ox_content_transform__features__timelines__tests__preprocess_snapshot_html.snap
+++ b/crates/ox_content_transform/src/features/timelines/snapshots/ox_content_transform__features__timelines__tests__preprocess_snapshot_html.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ox_content_transform/src/features/timelines/tests.rs
+expression: source
+---
+<section class="ox-timeline" aria-label="Timeline">
+<p class="ox-timeline__caption">Roadmap</p>
+<ol class="ox-timeline__items">
+<li class="ox-timeline__item" data-status="done">
+<div class="ox-timeline__marker" aria-hidden="true"></div>
+<div class="ox-timeline__content">
+<div class="ox-timeline__meta"><time class="ox-timeline__date" datetime="2026-08-26">2026-08-26</time><span class="ox-timeline__status">done</span></div>
+<p class="ox-timeline__title">Start</p>
+</div>
+</li>
+<li class="ox-timeline__item">
+<div class="ox-timeline__marker" aria-hidden="true"></div>
+<div class="ox-timeline__content">
+<div class="ox-timeline__meta"><time class="ox-timeline__date" datetime="2026-09">2026-09</time></div>
+<p class="ox-timeline__title">Next</p>
+</div>
+</li>
+</ol>
+</section>

--- a/crates/ox_content_transform/src/features/timelines/tests.rs
+++ b/crates/ox_content_transform/src/features/timelines/tests.rs
@@ -1,0 +1,192 @@
+use super::{ReportMode, resolve, transform};
+use crate::transformer::MarkdownTransformer;
+use crate::{ContainerOptions, ContainerTypeOptions, TimelineOptions, TransformOptions};
+
+fn timeline_options(overrides: TimelineOptions) -> TransformOptions {
+    TransformOptions {
+        gfm: Some(true),
+        timelines: Some(TimelineOptions { enabled: Some(true), ..overrides }),
+        ..Default::default()
+    }
+}
+
+fn html(source: &str, options: TransformOptions) -> crate::TransformResult {
+    MarkdownTransformer::from_options(&options).transform(source)
+}
+
+#[test]
+fn resolve_is_none_when_omitted_or_disabled() {
+    assert!(resolve(None).is_none());
+    assert!(
+        resolve(Some(&TimelineOptions { enabled: Some(false), ..Default::default() })).is_none()
+    );
+}
+
+#[test]
+fn resolve_defaults_to_ordered_strict_diagnostics() {
+    let resolved =
+        resolve(Some(&TimelineOptions { enabled: None, ..Default::default() })).expect("enabled");
+    assert!(resolved.ordered);
+    assert_eq!(resolved.invalid_date, ReportMode::Error);
+    assert_eq!(resolved.unknown_meta, ReportMode::Error);
+    assert_eq!(resolved.empty, ReportMode::Error);
+}
+
+#[test]
+fn disabled_by_default_keeps_timeline_literal() {
+    let result = html("::: timeline\n- 2026-08-26 Release\n:::\n", TransformOptions::default());
+    assert!(result.errors.is_empty(), "{:?}", result.errors);
+    assert!(!result.html.contains("ox-timeline"), "{html}", html = result.html);
+    assert!(result.html.contains("timeline"), "{html}", html = result.html);
+}
+
+#[test]
+fn renders_semantic_static_timeline() {
+    let result = html(
+        "::: timeline title=\"Release history\"\n- 2026-08-26 RC cut {status=done label=\"RC\" href=\"/releases/rc\"}\n  Shipped **candidate** builds.\n- [2026-09] GA window {status=planned}\n:::\n",
+        timeline_options(TimelineOptions::default()),
+    );
+    assert!(result.errors.is_empty(), "{:?}", result.errors);
+    assert!(
+        result.html.contains(r#"<section class="ox-timeline" aria-label="Timeline">"#),
+        "{html}",
+        html = result.html
+    );
+    assert!(
+        result.html.contains(r#"<ol class="ox-timeline__items">"#),
+        "{html}",
+        html = result.html
+    );
+    assert!(
+        result
+            .html
+            .contains(r#"<time class="ox-timeline__date" datetime="2026-08-26">2026-08-26</time>"#),
+        "{html}",
+        html = result.html
+    );
+    assert!(result.html.contains(r#"data-status="done""#), "{html}", html = result.html);
+    assert!(
+        result.html.contains(r#"<span class="ox-timeline__label">RC</span>"#),
+        "{html}",
+        html = result.html
+    );
+    assert!(
+        result.html.contains(r#"<a href="/releases/rc">RC cut</a>"#),
+        "{html}",
+        html = result.html
+    );
+    assert!(result.html.contains("<strong>candidate</strong>"), "{html}", html = result.html);
+    assert!(!result.html.contains("<script"), "{html}", html = result.html);
+}
+
+#[test]
+fn opener_can_select_unordered_list() {
+    let result = html(
+        "::: timeline ordered=false\n- 2026-08-26 Done\n:::\n",
+        timeline_options(TimelineOptions::default()),
+    );
+    assert!(result.errors.is_empty(), "{:?}", result.errors);
+    assert!(
+        result.html.contains(r#"<ul class="ox-timeline__items">"#),
+        "{html}",
+        html = result.html
+    );
+}
+
+#[test]
+fn invalid_date_errors_preserve_source() {
+    let result = html(
+        "::: timeline\n- 2026-02-31 Impossible\n:::\n",
+        timeline_options(TimelineOptions::default()),
+    );
+    assert_eq!(result.errors.len(), 1, "{:?}", result.errors);
+    assert!(result.errors[0].contains("invalid date"), "{:?}", result.errors);
+    assert!(!result.html.contains("ox-timeline"), "{html}", html = result.html);
+    assert!(result.html.contains("timeline"), "{html}", html = result.html);
+}
+
+#[test]
+fn invalid_date_can_warn_and_render_without_datetime() {
+    let result = html(
+        "::: timeline\n- 2026-02-31 Impossible\n:::\n",
+        timeline_options(TimelineOptions {
+            invalid_date: Some("warn".to_string()),
+            ..Default::default()
+        }),
+    );
+    assert_eq!(result.errors.len(), 1, "{:?}", result.errors);
+    assert!(
+        result.html.contains(
+            r#"<span class="ox-timeline__date ox-timeline__date--invalid">2026-02-31</span>"#
+        ),
+        "{html}",
+        html = result.html
+    );
+}
+
+#[test]
+fn unknown_metadata_is_actionable() {
+    let result = html(
+        "::: timeline\n- 2026-08-26 Release {mood=happy}\n:::\n",
+        timeline_options(TimelineOptions::default()),
+    );
+    assert_eq!(result.errors.len(), 1, "{:?}", result.errors);
+    assert!(result.errors[0].contains("unsupported metadata"), "{:?}", result.errors);
+    assert!(!result.html.contains("ox-timeline"), "{html}", html = result.html);
+}
+
+#[test]
+fn empty_timeline_is_diagnostic() {
+    let result = html("::: timeline\n\n:::\n", timeline_options(TimelineOptions::default()));
+    assert_eq!(result.errors.len(), 1, "{:?}", result.errors);
+    assert!(result.errors[0].contains("empty"), "{:?}", result.errors);
+}
+
+#[test]
+fn skips_fenced_and_indented_timeline_markers() {
+    let fenced = html(
+        "```md\n::: timeline\n- 2026-08-26 Release\n:::\n```\n",
+        timeline_options(TimelineOptions::default()),
+    );
+    assert!(!fenced.html.contains("ox-timeline"), "{html}", html = fenced.html);
+
+    let indented = html(
+        "    ::: timeline\n    - 2026-08-26 Release\n    :::\n",
+        timeline_options(TimelineOptions::default()),
+    );
+    assert!(!indented.html.contains("ox-timeline"), "{html}", html = indented.html);
+}
+
+#[test]
+fn timeline_precedes_custom_container_with_same_name() {
+    let mut types = rustc_hash::FxHashMap::default();
+    types.insert(
+        "timeline".to_string(),
+        ContainerTypeOptions { title: Some("Container".to_string()), tag: None },
+    );
+    let result = html(
+        "::: timeline\n- 2026-08-26 Release\n:::\n",
+        TransformOptions {
+            gfm: Some(true),
+            containers: Some(ContainerOptions { enabled: Some(true), types: Some(types) }),
+            timelines: Some(TimelineOptions { enabled: Some(true), ..Default::default() }),
+            ..Default::default()
+        },
+    );
+    assert!(result.html.contains("ox-timeline"), "{html}", html = result.html);
+    assert!(!result.html.contains("ox-container--timeline"), "{html}", html = result.html);
+}
+
+#[test]
+fn preprocess_snapshot_html() {
+    let resolved = resolve(Some(&TimelineOptions { enabled: Some(true), ..Default::default() }))
+        .expect("enabled");
+    let mut errors = Vec::new();
+    let source = transform(
+        "::: timeline \"Roadmap\"\n- 2026-08-26 Start {status=done}\n- 2026-09 Next\n:::\n",
+        &resolved,
+        &mut errors,
+    );
+    assert!(errors.is_empty(), "{errors:?}");
+    insta::assert_snapshot!(source);
+}

--- a/crates/ox_content_transform/src/options.rs
+++ b/crates/ox_content_transform/src/options.rs
@@ -58,6 +58,8 @@ pub struct TransformOptions {
     pub images: Option<ImageOptions>,
     /// Opt-in static `::: gallery` image groups. Disabled when omitted.
     pub image_galleries: Option<ImageGalleryOptions>,
+    /// Opt-in static `::: timeline` milestone lists. Disabled when omitted.
+    pub timelines: Option<TimelineOptions>,
     /// Opt-in `::: card` / `::: link-card` / `::: card-grid` blocks. Disabled when omitted.
     pub cards: Option<CardOptions>,
     /// Opt-in `file-tree` fences. Disabled when omitted.
@@ -131,6 +133,15 @@ pub struct ImageGalleryOptions {
     pub enabled: Option<bool>,
     pub lazy: Option<bool>,
     pub missing_alt: Option<String>,
+    pub empty: Option<String>,
+}
+
+#[derive(Clone, Default)]
+pub struct TimelineOptions {
+    pub enabled: Option<bool>,
+    pub ordered: Option<bool>,
+    pub invalid_date: Option<String>,
+    pub unknown_meta: Option<String>,
     pub empty: Option<String>,
 }
 

--- a/npm/vite-plugin-ox-content/src/collections.ts
+++ b/npm/vite-plugin-ox-content/src/collections.ts
@@ -4,6 +4,7 @@ import { toJsDataTableOptions } from "./data-table-options";
 import { toJsFileTreeOptions } from "./file-tree-options";
 import { toJsImageGalleryOptions } from "./image-gallery-options";
 import { toJsPartialsOptions } from "./partials-options";
+import { toJsTimelineOptions } from "./timeline-options";
 import { generateCollectionsModule } from "./collections-runtime";
 import { importNapiModule } from "./napi";
 import type {
@@ -73,6 +74,13 @@ type NativeTransformOptions = {
     enabled?: boolean;
     lazy?: boolean;
     missingAlt?: "error" | "warn" | "ignore";
+    empty?: "error" | "warn" | "ignore";
+  };
+  timelines?: {
+    enabled?: boolean;
+    ordered?: boolean;
+    invalidDate?: "error" | "warn" | "ignore";
+    unknownMeta?: "error" | "warn" | "ignore";
     empty?: "error" | "warn" | "ignore";
   };
   cjkEmphasis?: boolean;
@@ -280,6 +288,7 @@ function createNativeTransformOptions(options: ResolvedOptions): NativeTransform
         }
       : undefined,
     imageGalleries: toJsImageGalleryOptions(options.imageGalleries, options.images),
+    timelines: toJsTimelineOptions(options.timelines),
     cjkEmphasis: options.cjkEmphasis ?? false,
     codeImports: options.codeImports?.enabled
       ? {

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -61,6 +61,8 @@ export type {
   ResolvedImageOptions,
   ImageGalleryOptions,
   ResolvedImageGalleryOptions,
+  TimelineOptions,
+  ResolvedTimelineOptions,
   ResourcesOptions,
   ResolvedResourcesOptions,
   CodeImportOptions,
@@ -664,6 +666,7 @@ export { resolveCodeGroupOptions } from "./code-group-options";
 export { resolveFileTreeOptions } from "./file-tree-options";
 export { resolveDataTableOptions } from "./data-table-options";
 export { resolveImageGalleryOptions } from "./image-gallery-options";
+export { resolveTimelineOptions } from "./timeline-options";
 export { resolveHeadingPermalinksOptions } from "./heading-permalinks-options";
 export { resolveTypedHoverOptions } from "./typed-hover";
 

--- a/npm/vite-plugin-ox-content/src/public-exports.test.ts
+++ b/npm/vite-plugin-ox-content/src/public-exports.test.ts
@@ -45,6 +45,7 @@ describe("public export surface", () => {
       "resolveVersionsOptions",
       "resolveResourcesOptions",
       "resolveImageGalleryOptions",
+      "resolveTimelineOptions",
       "resolveTeamOptions",
       "resolveSiteMapsOptions",
       "resolveMarkdownSourceOptions",

--- a/npm/vite-plugin-ox-content/src/resolve-options.ts
+++ b/npm/vite-plugin-ox-content/src/resolve-options.ts
@@ -16,7 +16,6 @@ import { resolveAbbreviationsOptions } from "./abbreviations-options";
 import { resolveMagicLinkOptions } from "./magic-link-options";
 import { resolveDefinitionListOptions } from "./definition-list-options";
 import { resolveNotByAiOptions } from "./not-by-ai-options";
-export { resolveNotByAiOptions } from "./not-by-ai-options";
 import { normalizeMarkdownExtensions } from "./markdown";
 import { resolveOgImageOptions } from "./og-image";
 import { resolveCascadeOptions, resolvePermalinksOptions } from "./permalinks";
@@ -31,6 +30,7 @@ import { resolveSiteMapsOptions } from "./site-maps";
 import { resolveSsgOptions } from "./ssg";
 import { resolveStepsOptions } from "./step-options";
 import { resolveTaxonomiesOptions } from "./taxonomies";
+import { resolveTimelineOptions } from "./timeline-options";
 import { resolveTypedHoverOptions } from "./typed-hover";
 import type { BuiltinPmOptions, OxContentOptions, ResolvedOptions } from "./types";
 import { resolveVersionsOptions } from "./versions";
@@ -79,6 +79,7 @@ export function resolveOptions(options: OxContentOptions): ResolvedOptions {
     containers: resolveContainerOptions(options.containers),
     images: resolveImageOptions(options.images),
     imageGalleries: resolveImageGalleryOptions(options.imageGalleries),
+    timelines: resolveTimelineOptions(options.timelines),
     codeImports: resolveCodeImportOptions(options.codeImports),
     includes: resolveIncludeOptions(options.includes),
     partials: resolvePartialsOptions(options.partials),
@@ -111,7 +112,6 @@ export function resolveOptions(options: OxContentOptions): ResolvedOptions {
     i18n: resolveI18nOptions(options.i18n),
   };
 }
-
 export function resolveBuiltinEmbedOptions(
   options: OxContentOptions["embeds"],
 ): ResolvedOptions["embeds"] {
@@ -341,7 +341,6 @@ function resolveCodeAnnotationsOptions(
       defaultLineNumbers: false,
     };
   }
-
   return {
     enabled: true,
     notation: options.notation ?? "attribute",

--- a/npm/vite-plugin-ox-content/src/timeline-options.test.ts
+++ b/npm/vite-plugin-ox-content/src/timeline-options.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vite-plus/test";
+import { resolveTimelineOptions, toJsTimelineOptions } from "./timeline-options";
+
+describe("resolveTimelineOptions", () => {
+  it("keeps timelines disabled when omitted or explicitly false", () => {
+    expect(resolveTimelineOptions(undefined)).toEqual({
+      enabled: false,
+      ordered: true,
+      invalidDate: "error",
+      unknownMeta: "error",
+      empty: "error",
+    });
+    expect(resolveTimelineOptions(false)).toEqual({
+      enabled: false,
+      ordered: true,
+      invalidDate: "error",
+      unknownMeta: "error",
+      empty: "error",
+    });
+    expect(resolveTimelineOptions({ enabled: false })).toEqual({
+      enabled: false,
+      ordered: true,
+      invalidDate: "error",
+      unknownMeta: "error",
+      empty: "error",
+    });
+  });
+
+  it("enables strict timeline diagnostics from true or object options", () => {
+    expect(resolveTimelineOptions(true)).toEqual({
+      enabled: true,
+      ordered: true,
+      invalidDate: "error",
+      unknownMeta: "error",
+      empty: "error",
+    });
+    expect(resolveTimelineOptions({})).toEqual({
+      enabled: true,
+      ordered: true,
+      invalidDate: "error",
+      unknownMeta: "error",
+      empty: "error",
+    });
+  });
+
+  it("normalizes diagnostic modes and keeps ordering overrides", () => {
+    expect(
+      resolveTimelineOptions({
+        ordered: false,
+        invalidDate: "warn",
+        unknownMeta: "ignore",
+        empty: "warn",
+      }),
+    ).toEqual({
+      enabled: true,
+      ordered: false,
+      invalidDate: "warn",
+      unknownMeta: "ignore",
+      empty: "warn",
+    });
+    expect(
+      resolveTimelineOptions({ invalidDate: "off" as never, unknownMeta: "bad" as never }),
+    ).toEqual({
+      enabled: true,
+      ordered: true,
+      invalidDate: "error",
+      unknownMeta: "error",
+      empty: "error",
+    });
+  });
+});
+
+describe("toJsTimelineOptions", () => {
+  it("omits disabled timelines from native transform options", () => {
+    expect(toJsTimelineOptions(resolveTimelineOptions(false))).toBeUndefined();
+  });
+
+  it("passes native timeline options with camel-case diagnostics", () => {
+    expect(
+      toJsTimelineOptions(
+        resolveTimelineOptions({
+          ordered: false,
+          invalidDate: "warn",
+          unknownMeta: "ignore",
+          empty: "warn",
+        }),
+      ),
+    ).toEqual({
+      enabled: true,
+      ordered: false,
+      invalidDate: "warn",
+      unknownMeta: "ignore",
+      empty: "warn",
+    });
+  });
+});

--- a/npm/vite-plugin-ox-content/src/timeline-options.ts
+++ b/npm/vite-plugin-ox-content/src/timeline-options.ts
@@ -1,0 +1,59 @@
+import type { OxContentOptions, ResolvedOptions, ResolvedTimelineOptions } from "./types";
+
+type ReportMode = "error" | "warn" | "ignore";
+
+type JsTimelineOptions = {
+  enabled: true;
+  ordered: boolean;
+  invalidDate: ReportMode;
+  unknownMeta: ReportMode;
+  empty: ReportMode;
+};
+
+const disabled: ResolvedTimelineOptions = {
+  enabled: false,
+  ordered: true,
+  invalidDate: "error",
+  unknownMeta: "error",
+  empty: "error",
+};
+
+export function resolveTimelineOptions(
+  options: OxContentOptions["timelines"],
+): ResolvedTimelineOptions {
+  if (!options) return { ...disabled };
+  if (options === true) {
+    return {
+      enabled: true,
+      ordered: true,
+      invalidDate: "error",
+      unknownMeta: "error",
+      empty: "error",
+    };
+  }
+  if (options.enabled === false) return { ...disabled };
+  return {
+    enabled: options.enabled ?? true,
+    ordered: options.ordered ?? true,
+    invalidDate: reportMode(options.invalidDate),
+    unknownMeta: reportMode(options.unknownMeta),
+    empty: reportMode(options.empty),
+  };
+}
+
+export function toJsTimelineOptions(
+  options: ResolvedOptions["timelines"] | undefined,
+): JsTimelineOptions | undefined {
+  if (!options?.enabled) return undefined;
+  return {
+    enabled: true,
+    ordered: options.ordered,
+    invalidDate: options.invalidDate,
+    unknownMeta: options.unknownMeta,
+    empty: options.empty,
+  };
+}
+
+function reportMode(value: unknown): ReportMode {
+  return value === "warn" || value === "ignore" ? value : "error";
+}

--- a/npm/vite-plugin-ox-content/src/timelines.transform.test.ts
+++ b/npm/vite-plugin-ox-content/src/timelines.transform.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createDocsResolvedOptions } from "../test/fixtures/docs-fixture";
+import { transformMarkdown } from "./transform";
+import type { ResolvedOptions } from "./types";
+
+describe("timeline transform", () => {
+  it("leaves timeline source literal unless opted in", async () => {
+    const markdown = [
+      '::: timeline title="Release history"',
+      '- 2026-08-26 RC cut {status=done label="RC" href="/releases/rc"}',
+      "  Shipped **candidate** builds.",
+      "- [2026-09] GA window {status=planned}",
+      "- Follow-up hardening {label=Next}",
+      ":::",
+      "",
+    ].join("\n");
+
+    const defaultResult = await transformMarkdown(
+      markdown,
+      "docs/releases.md",
+      createResolvedOptions(),
+    );
+    expect(defaultResult.html).not.toContain("ox-timeline");
+    expect(defaultResult.html).toContain("timeline");
+
+    const enabledResult = await transformMarkdown(
+      markdown,
+      "docs/releases.md",
+      createResolvedOptions({
+        timelines: {
+          enabled: true,
+          ordered: true,
+          invalidDate: "error",
+          unknownMeta: "error",
+          empty: "error",
+        },
+      }),
+    );
+    expect(enabledResult.html).toContain('<section class="ox-timeline" aria-label="Timeline">');
+    expect(enabledResult.html).toContain('<ol class="ox-timeline__items">');
+    expect(enabledResult.html).toContain(
+      '<time class="ox-timeline__date" datetime="2026-08-26">2026-08-26</time>',
+    );
+    expect(enabledResult.html).toContain('data-status="done"');
+    expect(enabledResult.html).toContain('<span class="ox-timeline__label">RC</span>');
+    expect(enabledResult.html).toContain('<span class="ox-timeline__label">Next</span>');
+    expect(enabledResult.html).toContain('<a href="/releases/rc">RC cut</a>');
+    expect(enabledResult.html).toContain("<strong>candidate</strong>");
+    expect(enabledResult.html).not.toContain("<script");
+  });
+
+  it("reports malformed dates without rewriting the block", async () => {
+    const { result, warnings } = await captureTransformWarnings(() =>
+      transformMarkdown(
+        "::: timeline\n- 2026-02-31 Impossible\n:::\n",
+        "docs/releases.md",
+        createResolvedOptions({
+          timelines: {
+            enabled: true,
+            ordered: true,
+            invalidDate: "error",
+            unknownMeta: "error",
+            empty: "error",
+          },
+        }),
+      ),
+    );
+    expect(flattenWarnings(warnings)).toContain("invalid date");
+    expect(result.html).not.toContain("ox-timeline");
+    expect(result.html).toContain("timeline");
+  });
+
+  it("can warn for malformed dates and still render without datetime", async () => {
+    const { result, warnings } = await captureTransformWarnings(() =>
+      transformMarkdown(
+        "::: timeline\n- 2026-02-31 Impossible\n:::\n",
+        "docs/releases.md",
+        createResolvedOptions({
+          timelines: {
+            enabled: true,
+            ordered: true,
+            invalidDate: "warn",
+            unknownMeta: "error",
+            empty: "error",
+          },
+        }),
+      ),
+    );
+    expect(flattenWarnings(warnings)).toContain("invalid date");
+    expect(result.html).toContain(
+      '<span class="ox-timeline__date ox-timeline__date--invalid">2026-02-31</span>',
+    );
+  });
+
+  it("keeps nested markdown, containers, and code-fence markers in item bodies", async () => {
+    const result = await transformMarkdown(
+      [
+        "::: timeline",
+        "- 2026-08-26 Authoring polish",
+        "  ::: tip",
+        "  Nested **container** copy.",
+        "  :::",
+        "  ",
+        "  ```md",
+        "  ::: timeline",
+        "  ```",
+        ":::",
+        "",
+      ].join("\n"),
+      "docs/releases.md",
+      createResolvedOptions({
+        containers: { enabled: true, types: {} },
+        timelines: {
+          enabled: true,
+          ordered: true,
+          invalidDate: "error",
+          unknownMeta: "error",
+          empty: "error",
+        },
+      }),
+    );
+    expect(result.html).toContain("ox-timeline__content");
+    expect(result.html).toContain("ox-container--tip");
+    expect(result.html).toContain("<strong>container</strong>");
+    expect(result.html).toContain("::: timeline");
+    expect(result.html).toContain("<code");
+  });
+});
+
+function createResolvedOptions(overrides: Partial<ResolvedOptions> = {}): ResolvedOptions {
+  return createDocsResolvedOptions({ highlight: false, ...overrides });
+}
+
+async function captureTransformWarnings<T>(
+  run: () => Promise<T>,
+): Promise<{ result: T; warnings: unknown[][] }> {
+  const warnings: unknown[][] = [];
+  const original = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+  try {
+    return { result: await run(), warnings };
+  } finally {
+    console.warn = original;
+  }
+}
+
+function flattenWarnings(warnings: unknown[][]): string {
+  return warnings.flatMap((args) => args.map(String)).join("\n");
+}

--- a/npm/vite-plugin-ox-content/src/transform.ts
+++ b/npm/vite-plugin-ox-content/src/transform.ts
@@ -53,6 +53,7 @@ import { toJsDataTableOptions } from "./data-table-options";
 import { toJsFileTreeOptions } from "./file-tree-options";
 import { toJsImageGalleryOptions } from "./image-gallery-options";
 import { toJsPartialsOptions } from "./partials-options";
+import { toJsTimelineOptions } from "./timeline-options";
 
 /**
  * NAPI bindings for Rust-based Markdown processing.
@@ -338,6 +339,13 @@ interface JsTransformOptions {
     enabled?: boolean;
     lazy?: boolean;
     missingAlt?: "error" | "warn" | "ignore";
+    empty?: "error" | "warn" | "ignore";
+  };
+  timelines?: {
+    enabled?: boolean;
+    ordered?: boolean;
+    invalidDate?: "error" | "warn" | "ignore";
+    unknownMeta?: "error" | "warn" | "ignore";
     empty?: "error" | "warn" | "ignore";
   };
 
@@ -692,6 +700,7 @@ export async function transformMarkdown(
         }
       : undefined,
     imageGalleries: toJsImageGalleryOptions(options.imageGalleries, options.images),
+    timelines: toJsTimelineOptions(options.timelines),
     cjkEmphasis: options.cjkEmphasis ?? false,
     codeImports: options.codeImports?.enabled
       ? {

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -1795,6 +1795,17 @@ export interface OxContentOptions {
   imageGalleries?: boolean | ImageGalleryOptions;
 
   /**
+   * Opt-in static `::: timeline` milestone lists.
+   *
+   * Timeline blocks render dated or undated milestones from Markdown-only
+   * `::: timeline` blocks. Items can carry `status`, `label`, and `href`
+   * metadata while nested Markdown stays searchable and static.
+   *
+   * @default false
+   */
+  timelines?: boolean | TimelineOptions;
+
+  /**
    * Opt-in page-bundle resources and build-time image processing.
    *
    * Off by default. `true` or `{}` treats each page directory as a bundle:
@@ -2149,6 +2160,10 @@ export interface ResolvedOptions {
    * Present after `resolveOptions`. Omitted in hand-built fixtures means off.
    */
   imageGalleries?: ResolvedImageGalleryOptions;
+  /**
+   * Present after `resolveOptions`. Omitted in hand-built fixtures means off.
+   */
+  timelines?: ResolvedTimelineOptions;
   codeImports: ResolvedCodeImportOptions;
   includes: ResolvedIncludeOptions;
   /**
@@ -2607,6 +2622,57 @@ export interface ResolvedImageGalleryOptions {
   enabled: boolean;
   lazy?: boolean;
   missingAlt: "error" | "warn" | "ignore";
+  empty: "error" | "warn" | "ignore";
+}
+
+/**
+ * Options for opt-in static timelines.
+ */
+export interface TimelineOptions {
+  /**
+   * Enable `::: timeline` blocks.
+   *
+   * @default true when the options object is supplied.
+   */
+  enabled?: boolean;
+
+  /**
+   * Render timelines as ordered lists unless a block overrides it.
+   *
+   * @default true
+   */
+  ordered?: boolean;
+
+  /**
+   * Diagnostics for malformed `YYYY`, `YYYY-MM`, or `YYYY-MM-DD` item dates.
+   *
+   * @default "error"
+   */
+  invalidDate?: "error" | "warn" | "ignore";
+
+  /**
+   * Diagnostics for unsupported item metadata.
+   *
+   * @default "error"
+   */
+  unknownMeta?: "error" | "warn" | "ignore";
+
+  /**
+   * Diagnostics for timeline blocks without items.
+   *
+   * @default "error"
+   */
+  empty?: "error" | "warn" | "ignore";
+}
+
+/**
+ * Resolved timeline transform options.
+ */
+export interface ResolvedTimelineOptions {
+  enabled: boolean;
+  ordered: boolean;
+  invalidDate: "error" | "warn" | "ignore";
+  unknownMeta: "error" | "warn" | "ignore";
   empty: "error" | "warn" | "ignore";
 }
 

--- a/npm/vite-plugin-ox-content/test/fixtures/docs-fixture.ts
+++ b/npm/vite-plugin-ox-content/test/fixtures/docs-fixture.ts
@@ -147,6 +147,13 @@ export function createDocsResolvedOptions(
     definitionLists: { enabled: false },
     containers: { enabled: false, types: {} },
     images: { enabled: false, lazy: true },
+    timelines: {
+      enabled: false,
+      ordered: true,
+      invalidDate: "error",
+      unknownMeta: "error",
+      empty: "error",
+    },
     codeImports: { enabled: false },
     includes: { enabled: false },
     partials: { enabled: false, root: "_partials", missing: "literal" },


### PR DESCRIPTION
## Summary
- add an opt-in timeline markdown feature with strict/warn/ignore diagnostics
- render semantic static timeline HTML and SSG CSS only when timeline markup is present
- expose timelines through NAPI and the Vite plugin, with search/source-order coverage

Closes #948

## Tests
- cargo test -p ox_content_transform timelines
- cargo test -p ox_content_ssg timeline
- cargo test -p ox_content_search timeline
- cargo test -p ox_content_napi transform_bindings --no-default-features
- cargo test -p ox_content_napi javascript_wrapper --no-default-features
- cargo clippy -p ox_content_transform -p ox_content_ssg -p ox_content_napi -p ox_content_search --all-targets -- -D warnings
- vp exec --filter @ox-content/napi -- vp run build:debug
- vp exec --filter @ox-content/vite-plugin -- vp test src/timeline-options.test.ts src/timelines.transform.test.ts src/public-exports.test.ts src/search.test.ts
- vp run fmt:check
- node scripts/check-file-lines.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790345109&installation_model_id=422833&pr_number=1024&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1024&signature=7535fc0a610dc6623a2ac1001bf3279e940377f717882785d5b342c200702d42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->