### PR TITLE
feat(code-play): add project sandbox payloads

### DIFF
--- a/docs/content/code-play-roadmap.md
+++ b/docs/content/code-play-roadmap.md
@@ -91,6 +91,15 @@ execute and framework previews, third-party playgrounds, endpoint trust,
 production typecheck / CORS, and the "no local shell" guarantee in
 SECURITY.md and the package guide.
 
+### 7. `feat(code-play): project-level sandbox provider adapters`
+
+Tracked in #873. Project examples add provider metadata adapters, multi-file
+payloads, safe Markdown-relative file collection, and fallback links while
+leaving ordinary single-file snippets on the existing local execution paths.
+StackBlitz, CodeSandbox, WebContainer, and external links are represented as
+payload metadata first; provider runtime scripts stay out of pages unless a
+later adapter runtime explicitly opts in.
+
 ## Out of Scope
 
 - Making Code Play a built-in `@ox-content/vite-plugin` option.

--- a/docs/content/ja/packages/code-play.md
+++ b/docs/content/ja/packages/code-play.md
@@ -93,6 +93,23 @@ HTML / MDX 形式:
 </CodePlay>
 ```
 
+プロジェクト単位の例は、サンプルごとに `play-project` または `project` で明示します。
+現在のフェンスは主たる実行スニペットのままにし、project metadata としてファイル名、
+provider、外部 fallback link を追加します。
+
+````md
+```ts play play-project=stackblitz play-file=src/main.ts play-entry=src/main.ts play-files=package.json,src/App.tsx play-project-url=https://stackblitz.com/edit/example
+console.log("project");
+```
+````
+
+`play-file` は現在のフェンスをプロジェクト内のどのファイルとして扱うかを指定します。
+`play-files` は追加ファイルのカンマ区切りリストで、Markdown source file からの相対パスとして
+解決され、`srcDir` の内側に制限されます。provider metadata adapter は
+`stackblitz`、`codesandbox`、`webcontainer`、`external` に対応しています。
+Code Play は provider script を読み込みません。安全な `http(s)` URL があるとき、
+生成された widget は project metadata と **Open** fallback link を描画します。
+
 ## Headless API
 
 ```ts
@@ -210,6 +227,10 @@ dev ミドルウェアが不要なら `proxy: false` にしてください。
   プライバシーポリシーが適用されます。
 - Piston 互換の `languages.<id>.endpoint` はその言語のソースを受け取ります。
   信頼できる HTTPS エンドポイントだけを、埋め込み認証情報なしで設定してください。
+- Project sandbox payload は、現在のフェンスと `play-files` の信頼済み source を埋め込みます。
+  追加ファイルは Markdown source root 配下の相対パスだけを受け付けます。symlink の実パスも
+  埋め込み前に検査され、存在しないファイルや大きすぎるファイルは widget warning になります。
+  provider URL は認証情報なしの `http(s)` に制限されます。
 
 ## 初回公開
 

--- a/docs/content/packages/code-play.md
+++ b/docs/content/packages/code-play.md
@@ -114,6 +114,23 @@ HTML / MDX form:
 </CodePlay>
 ```
 
+Project-level examples opt in per sample with `play-project` or `project`.
+The current fence stays the primary executable snippet, while project metadata
+adds file names, provider choice, and an external fallback link:
+
+````md
+```ts play play-project=stackblitz play-file=src/main.ts play-entry=src/main.ts play-files=package.json,src/App.tsx play-project-url=https://stackblitz.com/edit/example
+console.log("project");
+```
+````
+
+`play-file` names the current fence inside the project. `play-files` is a
+comma-separated list of extra files, resolved relative to the Markdown source
+file and confined to `srcDir`. Supported provider metadata adapters are
+`stackblitz`, `codesandbox`, `webcontainer`, and `external`. Code Play does
+not load provider scripts; the generated widget renders project metadata and
+an **Open** fallback link when a safe `http(s)` URL is supplied.
+
 ## Headless API
 
 ```ts
@@ -249,6 +266,11 @@ ship. Do not mark visitor-supplied or unreviewed snippets as `play`.
 - A Piston-compatible `languages.<id>.endpoint` receives source for that
   language. Only set HTTPS endpoints you trust, without embedded
   credentials.
+- Project sandbox payloads embed trusted source for the current fence and any
+  `play-files` entries. Extra files must be relative paths under the Markdown
+  source root; symlink real paths are checked before embedding, missing or
+  oversized files become widget warnings, and provider URLs are limited to
+  `http(s)` without credentials.
 
 ## First publish
 

--- a/npm/ox-content-code-play/README.md
+++ b/npm/ox-content-code-play/README.md
@@ -57,6 +57,19 @@ sample. The MDX-style `<CodePlay>` tag accepts `title`, `ui`, `timeout`,
 </CodePlay>
 ```
 
+Project-level examples stay opt-in per sample:
+
+````md
+```ts play play-project=stackblitz play-file=src/main.ts play-entry=src/main.ts play-files=package.json,src/App.tsx play-project-url=https://stackblitz.com/edit/example
+console.log("project");
+```
+````
+
+`play-file` names the current fence inside the project, `play-files` lists
+extra files relative to the Markdown source file, and `play-project-url`
+provides the external fallback link. Providers are metadata adapters; no
+StackBlitz, CodeSandbox, or WebContainer script is loaded by Code Play.
+
 ## Headless API
 
 ```ts
@@ -95,6 +108,9 @@ visitor-supplied snippets as `play`.
   The Vite `/__ox-code-play/*` proxy is **dev-only**.
 - Other languages need a Piston-compatible `endpoint` you trust.
 - `sh` never spawns a local shell.
+- Project sandboxes include trusted source in the static payload. `play-files`
+  are read only from relative paths inside the configured Markdown source root,
+  with symlink real paths checked before embedding.
 
 ## Example
 

--- a/npm/ox-content-code-play/src/authoring.ts
+++ b/npm/ox-content-code-play/src/authoring.ts
@@ -7,6 +7,16 @@ export interface ParsedPlayOptions {
   ui?: CodePlayPreset;
   viewers?: Partial<ViewerFlags>;
   timeoutMs?: number;
+  project?: ParsedProjectOptions;
+}
+
+export interface ParsedProjectOptions {
+  provider: string;
+  entry?: string;
+  file?: string;
+  files: string[];
+  openUrl?: string;
+  fallbackUrl?: string;
 }
 
 export function parsePlayMeta(meta: string): ParsedPlayOptions {
@@ -54,6 +64,9 @@ export function parseCodePlayAttributes(attrs: string): ParsedPlayOptions {
     }
     if (name === "viewers") {
       options.viewers = parseViewers(value);
+      continue;
+    }
+    if (applyProjectAttribute(options, name, value)) {
       continue;
     }
     if (name.startsWith("config-")) {
@@ -134,6 +147,9 @@ function applyPlayOption(options: ParsedPlayOptions, rawName: string, value: str
     options.viewers = parseViewers(value);
     return;
   }
+  if (applyProjectMeta(options, rawName, value)) {
+    return;
+  }
   const configKey =
     name.startsWith("play-config:") || name.startsWith("play-config.")
       ? rawName.slice("play-config:".length)
@@ -143,6 +159,71 @@ function applyPlayOption(options: ParsedPlayOptions, rawName: string, value: str
   if (configKey) {
     options.config[configKey] = coerceOptionValue(value);
   }
+}
+
+function applyProjectMeta(options: ParsedPlayOptions, rawName: string, value: string): boolean {
+  const name = rawName.toLowerCase();
+  switch (name) {
+    case "play-project":
+    case "play-sandbox":
+    case "play-provider":
+      ensureProject(options, value);
+      return true;
+    case "play-entry":
+      ensureProject(options).entry = value;
+      return true;
+    case "play-file":
+      ensureProject(options).file = value;
+      return true;
+    case "play-files":
+      ensureProject(options).files.push(...splitList(value));
+      return true;
+    case "play-project-url":
+    case "play-open-url":
+      ensureProject(options).openUrl = value;
+      return true;
+    case "play-fallback-url":
+      ensureProject(options).fallbackUrl = value;
+      return true;
+    default:
+      return false;
+  }
+}
+
+function applyProjectAttribute(options: ParsedPlayOptions, name: string, value: string): boolean {
+  switch (name) {
+    case "project":
+    case "sandbox":
+    case "provider":
+      ensureProject(options, value);
+      return true;
+    case "entry":
+      ensureProject(options).entry = value;
+      return true;
+    case "file":
+      ensureProject(options).file = value;
+      return true;
+    case "files":
+      ensureProject(options).files.push(...splitList(value));
+      return true;
+    case "project-url":
+    case "open-url":
+      ensureProject(options).openUrl = value;
+      return true;
+    case "fallback-url":
+      ensureProject(options).fallbackUrl = value;
+      return true;
+    default:
+      return false;
+  }
+}
+
+function ensureProject(options: ParsedPlayOptions, provider = "external"): ParsedProjectOptions {
+  options.project ??= { provider, files: [] };
+  if (provider && options.project.provider === "external") {
+    options.project.provider = provider;
+  }
+  return options.project;
 }
 
 function readTokenPair(token: string): { name: string; value: string } | undefined {
@@ -192,6 +273,13 @@ function parseViewers(value: string): Partial<ViewerFlags> | undefined {
     }
   }
   return Object.keys(viewers).length > 0 ? viewers : undefined;
+}
+
+function splitList(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
 }
 
 function coerceOptionValue(value: string): string | number | boolean {

--- a/npm/ox-content-code-play/src/html.ts
+++ b/npm/ox-content-code-play/src/html.ts
@@ -3,6 +3,7 @@ import { DEFAULT_ENDPOINTS, DEFAULT_VIEWERS } from "./config";
 import { decodeHtml, escapeAttribute } from "./escape";
 import { parseCodePlayAttributes } from "./markdown";
 import { payloadTypecheckEnabled } from "./payload-factory";
+import { projectSandboxFromPayloadInput } from "./project-sandbox";
 import type { PlaygroundEndpoints, PlayPayload } from "./types";
 
 const COMMENT_PATTERN = /<!--ox-code-play:([A-Za-z0-9+/=]+)-->\s*(<pre\b[\s\S]*?<\/pre>)/gi;
@@ -67,7 +68,7 @@ function upgradeCodePlayTags(html: string, options: HtmlEnhanceOptions): string 
     const definition = resolveLanguage(language);
     const endpoints = options.endpoints ?? DEFAULT_ENDPOINTS;
     const playOptions = parseCodePlayAttributes(attrs);
-    const payload = options.encodePayload({
+    const payloadValue: PlayPayload = {
       language: definition?.id ?? language,
       code,
       title: playOptions.title,
@@ -80,7 +81,17 @@ function upgradeCodePlayTags(html: string, options: HtmlEnhanceOptions): string 
       ui: playOptions.ui ?? "default",
       timeoutMs: playOptions.timeoutMs ?? 10_000,
       endpoints,
+    };
+    const project = projectSandboxFromPayloadInput({
+      language: payloadValue.language,
+      code,
+      definition,
+      project: playOptions.project,
     });
+    if (project) {
+      payloadValue.project = project;
+    }
+    const payload = options.encodePayload(payloadValue);
     return wrapWidget(
       payload,
       `<pre><code class="language-${escapeAttribute(language)}">${body}</code></pre>`,

--- a/npm/ox-content-code-play/src/hydrate.ts
+++ b/npm/ox-content-code-play/src/hydrate.ts
@@ -88,6 +88,7 @@ function bindWidget(element: HTMLElement, payload: PlayPayload, client: CodePlay
     language: payload.language,
     code: payload.code,
     config: payload.config,
+    project: payload.project,
   });
   const runButton = element.querySelector<HTMLButtonElement>('[data-ox-action="run"]');
   const checkButton = element.querySelector<HTMLButtonElement>('[data-ox-action="typecheck"]');

--- a/npm/ox-content-code-play/src/index.ts
+++ b/npm/ox-content-code-play/src/index.ts
@@ -24,7 +24,13 @@ export {
   runningRunActionState,
   runPlayAction,
 } from "./hydrate-action";
-export { renderPlayUi, renderRunStatusText } from "./ui";
+export { renderPlayUi, renderProjectSandboxHtml, renderRunStatusText } from "./ui";
+export {
+  PROJECT_SANDBOX_ADAPTERS,
+  normalizeProjectPath,
+  projectSandboxFromPayloadInput,
+  projectSandboxProviderLabel,
+} from "./project-sandbox";
 export {
   renderConfigHtml,
   renderDiagnosticsHtml,
@@ -47,6 +53,12 @@ export type {
   LanguageEnable,
   PlayPayload,
   Provenance,
+  ProjectSandbox,
+  ProjectSandboxAdapter,
+  ProjectSandboxAdapterInput,
+  ProjectSandboxFile,
+  ProjectSandboxProvider,
+  ProjectSandboxTarget,
   RunAction,
   RunActionPhase,
   RunActionState,

--- a/npm/ox-content-code-play/src/markdown.test.ts
+++ b/npm/ox-content-code-play/src/markdown.test.ts
@@ -47,6 +47,39 @@ describe("markdown and viewers", () => {
     expect(stripPlayMeta(fence?.meta ?? "")).toBe('annotate="highlight:1"');
   });
 
+  it("parses project sandbox authoring without leaking project keys into config", () => {
+    const source = [
+      '```ts play play-project=stackblitz play-entry=src/main.ts play-file=src/main.ts play-files=package.json,src/App.tsx play-project-url=https://stackblitz.com/edit/ox-content annotate="highlight:1"',
+      "console.log('project');",
+      "```",
+    ].join("\n");
+    const fence = parsePlayFences(source)[0];
+    expect(fence?.project).toEqual({
+      provider: "stackblitz",
+      entry: "src/main.ts",
+      file: "src/main.ts",
+      files: ["package.json", "src/App.tsx"],
+      openUrl: "https://stackblitz.com/edit/ox-content",
+    });
+    expect(fence?.config).toEqual({});
+    expect(stripPlayMeta(fence?.meta ?? "")).toBe('annotate="highlight:1"');
+
+    const payload = payloadFromFence(
+      fence!,
+      resolveCodePlayOptions({ languages: { typescript: true } }),
+    );
+    expect(payload.project).toMatchObject({
+      provider: "stackblitz",
+      label: "StackBlitz",
+      target: "browser",
+      entry: "src/main.ts",
+      openUrl: "https://stackblitz.com/edit/ox-content",
+    });
+    expect(payload.project?.files).toEqual([
+      { path: "src/main.ts", code: "console.log('project');" },
+    ]);
+  });
+
   it("rewrites play fences to comments and parses CodePlay tags", () => {
     const options = resolveCodePlayOptions({ languages: { typescript: true } });
     const rewritten = rewritePlayFences("```ts play\nconst n = 1;\n```", (fence) =>
@@ -70,6 +103,16 @@ describe("markdown and viewers", () => {
       ui: "compact",
       timeoutMs: 3000,
       config: { strict: false, withVet: false },
+    });
+    const projectTags = parseCodePlayTags(
+      `<CodePlay lang="ts" project="codesandbox" entry="src/main.ts" file="src/main.ts" files="package.json,src/App.tsx" project-url="https://codesandbox.io/p/sandbox/demo">\nconst n = 1\n</CodePlay>`,
+    );
+    expect(projectTags[0]?.project).toMatchObject({
+      provider: "codesandbox",
+      entry: "src/main.ts",
+      file: "src/main.ts",
+      files: ["package.json", "src/App.tsx"],
+      openUrl: "https://codesandbox.io/p/sandbox/demo",
     });
   });
 

--- a/npm/ox-content-code-play/src/markdown.ts
+++ b/npm/ox-content-code-play/src/markdown.ts
@@ -5,6 +5,7 @@ import {
   splitPlayInfo,
 } from "./authoring";
 import type { CodePlayPreset, ViewerFlags } from "./types";
+import type { ParsedProjectOptions } from "./authoring";
 
 export { parseCodePlayAttributes, parsePlayMeta, type ParsedPlayOptions } from "./authoring";
 
@@ -21,6 +22,7 @@ export interface PlayFence {
   ui?: CodePlayPreset;
   viewers?: Partial<ViewerFlags>;
   timeoutMs?: number;
+  project?: ParsedProjectOptions;
 }
 
 export interface ParsedFence {
@@ -106,6 +108,7 @@ export function parsePlayFences(source: string): PlayFence[] {
         ui: options.ui,
         viewers: options.viewers,
         timeoutMs: options.timeoutMs,
+        project: options.project,
       };
     });
 }
@@ -171,6 +174,7 @@ export function parseCodePlayTags(source: string): PlayFence[] {
       ui: options.ui,
       viewers: options.viewers,
       timeoutMs: options.timeoutMs,
+      project: options.project,
     });
   }
   return tags;

--- a/npm/ox-content-code-play/src/payload-factory.ts
+++ b/npm/ox-content-code-play/src/payload-factory.ts
@@ -1,9 +1,24 @@
 import { resolveLanguage } from "./catalog";
 import type { ResolvedCodePlayOptions } from "./config";
 import type { PlayFence } from "./markdown";
-import type { LanguageDefinition, PlayPayload, PlaygroundEndpoints } from "./types";
+import { projectSandboxFromPayloadInput } from "./project-sandbox";
+import type {
+  LanguageDefinition,
+  PlayPayload,
+  PlaygroundEndpoints,
+  ProjectSandboxFile,
+} from "./types";
 
-export function payloadFromFence(fence: PlayFence, options: ResolvedCodePlayOptions): PlayPayload {
+export interface PayloadFromFenceContext {
+  files?: ProjectSandboxFile[];
+  warnings?: string[];
+}
+
+export function payloadFromFence(
+  fence: PlayFence,
+  options: ResolvedCodePlayOptions,
+  context: PayloadFromFenceContext = {},
+): PlayPayload {
   const definition = resolveLanguage(fence.language);
   const enabled = definition ? options.languages.get(definition.id) : undefined;
   const payload: PlayPayload = {
@@ -27,6 +42,17 @@ export function payloadFromFence(fence: PlayFence, options: ResolvedCodePlayOpti
   };
   if (enabled?.endpoint) {
     payload.endpoint = enabled.endpoint;
+  }
+  const project = projectSandboxFromPayloadInput({
+    language: payload.language,
+    code: payload.code,
+    definition,
+    project: fence.project,
+    files: context.files,
+    warnings: context.warnings,
+  });
+  if (project) {
+    payload.project = project;
   }
   return payload;
 }

--- a/npm/ox-content-code-play/src/plugin-paths.ts
+++ b/npm/ox-content-code-play/src/plugin-paths.ts
@@ -1,0 +1,69 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import type { ResolvedCodePlayOptions } from "./config";
+
+export const MARKDOWN_RE = /\.(?:md|markdown|mdx)(?:$|\?)/i;
+
+export function cleanMarkdownPath(id: string, root: string): string | undefined {
+  const file = id.split("?")[0];
+  if (!file || file.startsWith("\0")) {
+    return undefined;
+  }
+  return path.isAbsolute(file) ? file : path.resolve(root, file);
+}
+
+export function guessHtmlPath(file: string, srcDir: string, outDir: string): string | undefined {
+  const relative = path.relative(srcDir, file).replace(/\.(?:md|markdown|mdx)$/i, "");
+  const candidates = [
+    path.join(outDir, `${relative}.html`),
+    path.join(outDir, relative, "index.html"),
+  ];
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+export function normalizeBase(base: string): string {
+  if (!base || base === "/") {
+    return "/";
+  }
+  return base.endsWith("/") ? base : `${base}/`;
+}
+
+export function sourceRoot(root: string, resolved: ResolvedCodePlayOptions): string {
+  return path.resolve(root, resolved.srcDir ?? "docs");
+}
+
+export function urlToMarkdown(
+  urlPath: string,
+  root: string,
+  srcDir: string,
+  base: string,
+): string | undefined {
+  let relative = urlPath;
+  if (base !== "/" && relative.startsWith(base)) {
+    relative = relative.slice(base.length);
+  }
+  relative = relative.replace(/^\//, "").replace(/\.html$/, "");
+  if (!relative || relative.includes("..")) {
+    return undefined;
+  }
+  const candidates = [
+    path.resolve(root, srcDir, `${relative}.md`),
+    path.resolve(root, srcDir, relative, "index.md"),
+  ];
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+export function walkFiles(dir: string): string[] {
+  const entries = readdirSync(dir);
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      files.push(...walkFiles(full));
+    } else {
+      files.push(full);
+    }
+  }
+  return files;
+}

--- a/npm/ox-content-code-play/src/plugin.test.ts
+++ b/npm/ox-content-code-play/src/plugin.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vite-plus/test";
 import { DEV_GO_PATH, DEV_RUST_PATH, DEV_TYPECHECK_PATH } from "./config";
 import { decodePayload } from "./payload";
@@ -123,6 +126,76 @@ describe("codePlay vite plugin", () => {
     expect(payload.config.strict).toBe(false);
   });
 
+  it("collects project sandbox files from the Markdown source root", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "ox-code-play-project-"));
+    try {
+      mkdirSync(path.join(root, "content", "src"), { recursive: true });
+      const documentPath = path.join(root, "content", "guide.md");
+      writeFileSync(path.join(root, "content", "package.json"), '{"scripts":{"dev":"vite"}}\n');
+      writeFileSync(path.join(root, "content", "src", "App.tsx"), "export function App() {}\n");
+
+      const plugin = codePlay({ languages: { typescript: true }, srcDir: "content" });
+      resolveCommand(plugin, "build", root);
+      const payload = payloadFromTransform(
+        plugin,
+        [
+          "```ts play play-project=stackblitz play-file=src/main.ts play-entry=src/main.ts play-files=package.json,src/App.tsx play-project-url=https://stackblitz.com/edit/ox-content",
+          'console.log("project");',
+          "```",
+        ].join("\n"),
+        documentPath,
+      );
+
+      expect(payload.project).toMatchObject({
+        provider: "stackblitz",
+        label: "StackBlitz",
+        target: "browser",
+        entry: "src/main.ts",
+      });
+      expect(payload.project?.files.map((file) => file.path)).toEqual([
+        "src/main.ts",
+        "package.json",
+        "src/App.tsx",
+      ]);
+      expect(payload.project?.files[1]?.code).toBe('{"scripts":{"dev":"vite"}}\n');
+      expect(payload.project?.warnings).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("drops unsafe project files and provider URLs from payloads", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "ox-code-play-project-unsafe-"));
+    try {
+      mkdirSync(path.join(root, "content", "src"), { recursive: true });
+      const documentPath = path.join(root, "content", "guide.md");
+      writeFileSync(path.join(root, "content", "src", "safe.ts"), "export const safe = true;\n");
+
+      const plugin = codePlay({ languages: { typescript: true }, srcDir: "content" });
+      resolveCommand(plugin, "build", root);
+      const payload = payloadFromTransform(
+        plugin,
+        [
+          "```ts play play-project=stackblitz play-file=src/main.ts play-files=../secret.ts,missing.ts,src/safe.ts play-project-url=https://example.com/not-stackblitz",
+          'console.log("project");',
+          "```",
+        ].join("\n"),
+        documentPath,
+      );
+
+      expect(payload.project?.openUrl).toBeUndefined();
+      expect(payload.project?.files.map((file) => file.path)).toEqual([
+        "src/main.ts",
+        "src/safe.ts",
+      ]);
+      expect(payload.project?.warnings?.join("\n")).toMatch(/unsafe project file path/);
+      expect(payload.project?.warnings?.join("\n")).toMatch(/missing project file/);
+      expect(payload.project?.warnings?.join("\n")).toMatch(/unexpected host/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("does not request a browser client asset until a play fence is transformed", async () => {
     const plugin = codePlay({ languages: { javascript: true } });
     resolveCommand(plugin, "build");
@@ -156,19 +229,23 @@ describe("codePlay vite plugin", () => {
   });
 });
 
-function resolveCommand(plugin: { configResolved?: unknown }, command: "build" | "serve"): void {
+function resolveCommand(
+  plugin: { configResolved?: unknown },
+  command: "build" | "serve",
+  root = "/",
+): void {
   hookFn(plugin.configResolved)({
     command,
-    root: "/",
+    root,
     base: "/",
     build: { outDir: "dist" },
   } as never);
 }
 
-function payloadFromTransform(plugin: { transform?: unknown }, code: string) {
+function payloadFromTransform(plugin: { transform?: unknown }, code: string, id = "page.md") {
   const rewritten = (hookFn(plugin.transform) as (source: string, id: string) => string | null)(
     code,
-    "page.md",
+    id,
   );
   const match =
     typeof rewritten === "string" ? /<!--ox-code-play:([A-Za-z0-9+/=]+)-->/.exec(rewritten) : null;

--- a/npm/ox-content-code-play/src/plugin.ts
+++ b/npm/ox-content-code-play/src/plugin.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from "node:fs/promises";
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import type { Plugin, ViteDevServer } from "vite";
 import { resolveLanguage } from "./catalog";
@@ -12,9 +12,19 @@ import {
   type ResolvedCodePlayOptions,
 } from "./config";
 import { enhanceGeneratedModule, enhancePlayHtml, type HtmlEnhanceOptions } from "./html";
-import { parseCodePlayTags, parsePlayFences, rewritePlayFences } from "./markdown";
+import { parseCodePlayTags, parsePlayFences, rewritePlayFences, type PlayFence } from "./markdown";
 import { decodePayload, encodePayload } from "./payload";
-import { payloadFromFence } from "./payload-factory";
+import { payloadFromFence, type PayloadFromFenceContext } from "./payload-factory";
+import { collectProjectFiles } from "./project-files";
+import {
+  MARKDOWN_RE,
+  cleanMarkdownPath,
+  guessHtmlPath,
+  normalizeBase,
+  sourceRoot,
+  urlToMarkdown,
+  walkFiles,
+} from "./plugin-paths";
 import {
   assertBrowserClientSource,
   resolveClientFile,
@@ -27,7 +37,6 @@ export type CodePlayPluginOptions = RawCodePlayOptions;
 
 const VIRTUAL_ID = "virtual:ox-content/code-play";
 const RESOLVED_VIRTUAL = `\0${VIRTUAL_ID}`;
-const MARKDOWN_RE = /\.(?:md|markdown|mdx)(?:$|\?)/i;
 
 export function codePlay(options: CodePlayPluginOptions = {}): Plugin {
   const resolved = resolveCodePlayOptions(options);
@@ -97,7 +106,13 @@ export function codePlay(options: CodePlayPluginOptions = {}): Plugin {
         if (!definition || !resolved.languages.has(definition.id)) {
           return null;
         }
-        return encodePayload(payloadFromFence(fence, resolved));
+        return encodePayload(
+          payloadFromFence(
+            fence,
+            resolved,
+            projectContextForFence(fence, cleanMarkdownPath(id, root), sourceRoot(root, resolved)),
+          ),
+        );
       });
       if (rewritten === code) {
         return null;
@@ -220,6 +235,7 @@ function enhanceHtmlForUrl(
     return undefined;
   }
   const source = readFileSync(markdownPath, "utf8");
+  const srcRoot = sourceRoot(root, resolved);
   const fences = [...parsePlayFences(source), ...parseCodePlayTags(source)].filter((fence) => {
     const definition = resolveLanguage(fence.language);
     return Boolean(definition && resolved.languages.has(definition.id));
@@ -233,31 +249,12 @@ function enhanceHtmlForUrl(
       fences.map((fence) => ({
         language: fence.language,
         code: fence.code,
-        payload: encodePayload(payloadFromFence(fence, resolved)),
+        payload: encodePayload(
+          payloadFromFence(fence, resolved, projectContextForFence(fence, markdownPath, srcRoot)),
+        ),
       })),
     ),
   );
-}
-
-function urlToMarkdown(
-  urlPath: string,
-  root: string,
-  srcDir: string,
-  base: string,
-): string | undefined {
-  let relative = urlPath;
-  if (base !== "/" && relative.startsWith(base)) {
-    relative = relative.slice(base.length);
-  }
-  relative = relative.replace(/^\//, "").replace(/\.html$/, "");
-  if (!relative || relative.includes("..")) {
-    return undefined;
-  }
-  const candidates = [
-    path.resolve(root, srcDir, `${relative}.md`),
-    path.resolve(root, srcDir, relative, "index.md"),
-  ];
-  return candidates.find((candidate) => existsSync(candidate));
 }
 
 function mountProxies(server: ViteDevServer, rustUrl: string, goUrl: string): void {
@@ -304,7 +301,9 @@ async function enhanceWrittenPages(
         fences.map((fence) => ({
           language: fence.language,
           code: fence.code,
-          payload: encodePayload(payloadFromFence(fence, resolved)),
+          payload: encodePayload(
+            payloadFromFence(fence, resolved, projectContextForFence(fence, file, srcDir)),
+          ),
         })),
       ),
     );
@@ -316,35 +315,18 @@ async function enhanceWrittenPages(
   return enhancedAny;
 }
 
-function guessHtmlPath(file: string, srcDir: string, outDir: string): string | undefined {
-  const relative = path.relative(srcDir, file).replace(/\.(?:md|markdown|mdx)$/i, "");
-  const candidates = [
-    path.join(outDir, `${relative}.html`),
-    path.join(outDir, relative, "index.html"),
-  ];
-  return candidates.find((candidate) => existsSync(candidate));
-}
-
-function walkFiles(dir: string): string[] {
-  const entries = readdirSync(dir);
-  const files: string[] = [];
-  for (const entry of entries) {
-    const full = path.join(dir, entry);
-    const stat = statSync(full);
-    if (stat.isDirectory()) {
-      files.push(...walkFiles(full));
-    } else {
-      files.push(full);
-    }
+function projectContextForFence(
+  fence: Pick<PlayFence, "project">,
+  documentPath: string | undefined,
+  srcRoot: string,
+): PayloadFromFenceContext {
+  if (!fence.project) {
+    return {};
   }
-  return files;
-}
-
-function normalizeBase(base: string): string {
-  if (!base || base === "/") {
-    return "/";
-  }
-  return base.endsWith("/") ? base : `${base}/`;
+  return collectProjectFiles(fence.project, {
+    documentPath,
+    sourceRoot: srcRoot,
+  });
 }
 
 export type { CodePlayPluginOptions as CodePlayOptions };

--- a/npm/ox-content-code-play/src/project-files.ts
+++ b/npm/ox-content-code-play/src/project-files.ts
@@ -1,0 +1,86 @@
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import path from "node:path";
+import type { ParsedProjectOptions } from "./authoring";
+import { normalizeProjectPath } from "./project-sandbox";
+import type { ProjectSandboxFile } from "./types";
+
+export interface ProjectFileCollectionContext {
+  documentPath?: string;
+  sourceRoot?: string;
+  maxFiles?: number;
+  maxBytes?: number;
+}
+
+export interface ProjectFileCollection {
+  files: ProjectSandboxFile[];
+  warnings: string[];
+}
+
+const DEFAULT_MAX_FILES = 32;
+const DEFAULT_MAX_BYTES = 256 * 1024;
+
+export function collectProjectFiles(
+  project: ParsedProjectOptions | undefined,
+  context: ProjectFileCollectionContext = {},
+): ProjectFileCollection {
+  const warnings: string[] = [];
+  if (!project?.files.length) {
+    return { files: [], warnings };
+  }
+  if (!context.documentPath) {
+    warnings.push("Skipped project files because the Markdown source path is unavailable.");
+    return { files: [], warnings };
+  }
+
+  const documentDir = path.dirname(context.documentPath);
+  const sourceRoot = path.resolve(context.sourceRoot ?? documentDir);
+  const realSourceRoot = realpathIfExists(sourceRoot) ?? sourceRoot;
+  const files: ProjectSandboxFile[] = [];
+  for (const requested of project.files) {
+    if (files.length >= (context.maxFiles ?? DEFAULT_MAX_FILES)) {
+      warnings.push(`Skipped project file after ${files.length} files: ${requested}`);
+      continue;
+    }
+    const safePath = normalizeProjectPath(requested, warnings);
+    if (!safePath) {
+      continue;
+    }
+    const absolute = path.resolve(documentDir, safePath);
+    if (!pathInside(absolute, sourceRoot)) {
+      warnings.push(`Skipped project file outside source root: ${safePath}`);
+      continue;
+    }
+    const realAbsolute = realpathIfExists(absolute);
+    if (!realAbsolute) {
+      warnings.push(`Skipped missing project file: ${safePath}`);
+      continue;
+    }
+    if (!pathInside(realAbsolute, realSourceRoot)) {
+      warnings.push(`Skipped project file outside real source root: ${safePath}`);
+      continue;
+    }
+    const stat = statSync(realAbsolute);
+    if (!stat.isFile()) {
+      warnings.push(`Skipped non-file project path: ${safePath}`);
+      continue;
+    }
+    if (stat.size > (context.maxBytes ?? DEFAULT_MAX_BYTES)) {
+      warnings.push(`Skipped large project file: ${safePath}`);
+      continue;
+    }
+    files.push({ path: safePath, code: readFileSync(realAbsolute, "utf8") });
+  }
+  return { files, warnings };
+}
+
+function realpathIfExists(file: string): string | undefined {
+  if (!existsSync(file)) {
+    return undefined;
+  }
+  return realpathSync(file);
+}
+
+function pathInside(file: string, root: string): boolean {
+  const relative = path.relative(root, file);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}

--- a/npm/ox-content-code-play/src/project-sandbox.ts
+++ b/npm/ox-content-code-play/src/project-sandbox.ts
@@ -1,0 +1,232 @@
+import type { ParsedProjectOptions } from "./authoring";
+import type {
+  LanguageDefinition,
+  ProjectSandbox,
+  ProjectSandboxAdapter,
+  ProjectSandboxFile,
+  ProjectSandboxProvider,
+  ProjectSandboxTarget,
+} from "./types";
+
+export interface ProjectSandboxPayloadInput {
+  language: string;
+  code: string;
+  definition?: LanguageDefinition;
+  project?: ParsedProjectOptions;
+  files?: ProjectSandboxFile[];
+  warnings?: string[];
+}
+
+export const PROJECT_SANDBOX_ADAPTERS: Record<ProjectSandboxProvider, ProjectSandboxAdapter> = {
+  stackblitz: adapter("stackblitz", "StackBlitz", "browser"),
+  codesandbox: adapter("codesandbox", "CodeSandbox", "browser"),
+  webcontainer: adapter("webcontainer", "WebContainer", "node"),
+  external: adapter("external", "External sandbox", "external"),
+};
+
+export function projectSandboxFromPayloadInput(
+  input: ProjectSandboxPayloadInput,
+): ProjectSandbox | undefined {
+  if (!input.project) {
+    return undefined;
+  }
+  const warnings = [...(input.warnings ?? [])];
+  const adapter = resolveProjectSandboxAdapter(input.project.provider, warnings);
+  const sourceFile = normalizeProjectPath(input.project.file, warnings, "source file");
+  const entry = normalizeProjectPath(input.project.entry, warnings, "entry path");
+  const primary = {
+    path: sourceFile ?? entry ?? defaultProjectFile(input.language, input.definition),
+    code: input.code,
+  };
+  const files = mergeProjectFiles([primary, ...(input.files ?? [])]);
+  const openUrl = safeProjectUrl(input.project.openUrl, adapter.provider, warnings);
+  const fallbackUrl = safeProjectUrl(input.project.fallbackUrl, adapter.provider, warnings);
+  return adapter.resolve({
+    provider: input.project.provider,
+    entry: entry ?? primary.path,
+    files,
+    openUrl,
+    fallbackUrl,
+    warnings,
+  });
+}
+
+export function normalizeProjectPath(
+  value: string | undefined,
+  warnings: string[] = [],
+  label = "file path",
+): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const normalized = trimmed.replace(/^\.\//, "");
+  if (
+    normalized.startsWith("/") ||
+    normalized.includes("\\") ||
+    normalized.includes("\0") ||
+    normalized.split("/").some((part) => part === "" || part === "." || part === "..") ||
+    /^[a-z]+:/i.test(normalized)
+  ) {
+    warnings.push(`Skipped unsafe project ${label}: ${trimmed}`);
+    return undefined;
+  }
+  if (normalized.length > 256) {
+    warnings.push(`Skipped long project ${label}: ${trimmed}`);
+    return undefined;
+  }
+  return normalized;
+}
+
+export function projectSandboxProviderLabel(provider: ProjectSandboxProvider): string {
+  return PROJECT_SANDBOX_ADAPTERS[provider].label;
+}
+
+function adapter(
+  provider: ProjectSandboxProvider,
+  label: string,
+  target: ProjectSandboxTarget,
+): ProjectSandboxAdapter {
+  return {
+    provider,
+    label,
+    target,
+    resolve(input) {
+      return compactProjectSandbox({
+        provider,
+        label,
+        target,
+        entry: input.entry,
+        files: input.files,
+        openUrl: input.openUrl,
+        fallbackUrl: input.fallbackUrl,
+        warnings: input.warnings,
+      });
+    },
+  };
+}
+
+function defaultProjectFile(language: string, definition: LanguageDefinition | undefined): string {
+  if (definition?.framework === "vue") {
+    return "src/App.vue";
+  }
+  if (definition?.framework === "react" || definition?.framework === "solid") {
+    return "src/App.tsx";
+  }
+  if (definition?.framework === "svelte") {
+    return "src/App.svelte";
+  }
+  switch (language) {
+    case "javascript":
+      return "index.js";
+    case "typescript":
+      return "index.ts";
+    case "go":
+      return "main.go";
+    case "rust":
+      return "src/main.rs";
+    default:
+      return "snippet.txt";
+  }
+}
+
+function resolveProjectSandboxAdapter(
+  rawProvider: string,
+  warnings: string[],
+): ProjectSandboxAdapter {
+  const provider = rawProvider.trim().toLowerCase();
+  switch (provider) {
+    case "stackblitz":
+    case "stack-blitz":
+    case "sb":
+      return PROJECT_SANDBOX_ADAPTERS.stackblitz;
+    case "codesandbox":
+    case "code-sandbox":
+    case "csb":
+      return PROJECT_SANDBOX_ADAPTERS.codesandbox;
+    case "webcontainer":
+    case "web-container":
+      return PROJECT_SANDBOX_ADAPTERS.webcontainer;
+    case "external":
+    case "":
+      return PROJECT_SANDBOX_ADAPTERS.external;
+    default:
+      warnings.push(`Unknown project sandbox provider: ${rawProvider}`);
+      return PROJECT_SANDBOX_ADAPTERS.external;
+  }
+}
+
+function mergeProjectFiles(files: ProjectSandboxFile[]): ProjectSandboxFile[] {
+  const merged = new Map<string, ProjectSandboxFile>();
+  for (const file of files) {
+    merged.set(file.path, file);
+  }
+  return [...merged.values()];
+}
+
+function safeProjectUrl(
+  value: string | undefined,
+  provider: ProjectSandboxProvider,
+  warnings: string[],
+): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    warnings.push(`Skipped invalid project URL: ${value}`);
+    return undefined;
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    warnings.push(`Skipped non-http project URL: ${value}`);
+    return undefined;
+  }
+  if (url.username || url.password) {
+    warnings.push(`Skipped project URL with credentials: ${url.origin}`);
+    return undefined;
+  }
+  if (!providerAllowsHost(provider, url.hostname)) {
+    warnings.push(`Skipped ${provider} project URL on unexpected host: ${url.hostname}`);
+    return undefined;
+  }
+  return url.href;
+}
+
+function providerAllowsHost(provider: ProjectSandboxProvider, host: string): boolean {
+  if (provider === "external") {
+    return true;
+  }
+  const normalized = host.toLowerCase();
+  const allowed: Record<Exclude<ProjectSandboxProvider, "external">, string[]> = {
+    stackblitz: ["stackblitz.com"],
+    codesandbox: ["codesandbox.io", "csb.app"],
+    webcontainer: ["webcontainers.io", "webcontainer.io"],
+  };
+  return allowed[provider].some(
+    (suffix) => normalized === suffix || normalized.endsWith(`.${suffix}`),
+  );
+}
+
+function compactProjectSandbox(project: ProjectSandbox): ProjectSandbox {
+  const next: ProjectSandbox = {
+    provider: project.provider,
+    label: project.label,
+    target: project.target,
+    files: project.files,
+  };
+  if (project.entry) {
+    next.entry = project.entry;
+  }
+  if (project.openUrl) {
+    next.openUrl = project.openUrl;
+  }
+  if (project.fallbackUrl) {
+    next.fallbackUrl = project.fallbackUrl;
+  }
+  if (project.warnings?.length) {
+    next.warnings = project.warnings;
+  }
+  return next;
+}

--- a/npm/ox-content-code-play/src/session.ts
+++ b/npm/ox-content-code-play/src/session.ts
@@ -7,6 +7,7 @@ import type {
   AdapterRequest,
   CodePlayTransport,
   PlaygroundEndpoints,
+  ProjectSandbox,
   ResolvedLanguageEnable,
   RunResult,
   SessionEventMap,
@@ -38,6 +39,7 @@ export class CodePlaySession {
   private readonly timeoutMs: number;
   private readonly transport: CodePlayTransport;
   private readonly endpoints: PlaygroundEndpoints;
+  private readonly project: ProjectSandbox | undefined;
   private readonly loadTypeScript?: () => Promise<TypeScriptLike | undefined>;
   private readonly listeners = new Map<SessionEventName, Set<Listener<unknown>>>();
   private abort: AbortController | undefined;
@@ -50,6 +52,7 @@ export class CodePlaySession {
     this.timeoutMs = input.timeoutMs;
     this.transport = input.transport;
     this.endpoints = input.endpoints;
+    this.project = input.project;
     this.loadTypeScript = input.loadTypeScript;
   }
 
@@ -94,6 +97,7 @@ export class CodePlaySession {
       transport: this.transport,
       loadTypeScript: this.loadTypeScript,
       endpoints: this.endpoints,
+      project: this.project,
       signal,
     };
     try {
@@ -133,5 +137,6 @@ export interface SessionConstructorInput extends SessionInput {
   timeoutMs: number;
   transport: CodePlayTransport;
   endpoints: PlaygroundEndpoints;
+  project?: ProjectSandbox;
   loadTypeScript?: () => Promise<TypeScriptLike | undefined>;
 }

--- a/npm/ox-content-code-play/src/styles.ts
+++ b/npm/ox-content-code-play/src/styles.ts
@@ -98,6 +98,64 @@ export const CODE_PLAY_STYLES = `
 .ox-code-play__runtime-chip--ok strong { color: var(--octc-color-primary, var(--octc-accent, #4f46e5)); }
 .ox-code-play__runtime-chip--warn strong { color: var(--octc-warning, #b54708); }
 .ox-code-play__runtime-chip--muted strong { opacity: 0.72; }
+.ox-code-play__project {
+  display: inline-flex;
+  flex: 1 1 18rem;
+  min-width: min(100%, 16rem);
+  gap: 0.45rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-left: auto;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--octc-color-border, color-mix(in srgb, currentColor 14%, transparent));
+  border-radius: 6px;
+  background: var(--octc-color-bg, Canvas);
+}
+.ox-code-play__project-main,
+.ox-code-play__project-entry {
+  display: inline-grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+.ox-code-play__project-main { flex: 1 1 8.5rem; }
+.ox-code-play__project-entry { flex: 999 1 9rem; }
+.ox-code-play__project-main span,
+.ox-code-play__project-entry span {
+  font: 600 0.62rem/1.1 ui-sans-serif, system-ui, sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.62;
+}
+.ox-code-play__project-main strong,
+.ox-code-play__project-entry strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font: 650 0.78rem/1.2 ui-sans-serif, system-ui, sans-serif;
+}
+.ox-code-play__project-files,
+.ox-code-play__project-warning,
+.ox-code-play__project-link {
+  flex: 0 0 auto;
+  border-radius: 6px;
+  padding: 0.18rem 0.45rem;
+  font: 650 0.68rem/1.25 ui-sans-serif, system-ui, sans-serif;
+}
+.ox-code-play__project-files {
+  background: color-mix(in srgb, var(--octc-color-text, CanvasText) 8%, transparent);
+}
+.ox-code-play__project-warning {
+  color: var(--octc-warning, #b54708);
+  background: color-mix(in srgb, var(--octc-warning, #b54708) 12%, transparent);
+}
+.ox-code-play__project-link {
+  color: var(--octc-color-primary, var(--octc-accent, #4f46e5));
+  background: color-mix(in srgb, var(--octc-color-primary, var(--octc-accent, #4f46e5)) 12%, transparent);
+  text-decoration: none;
+}
+.ox-code-play__project-link:focus-visible {
+  outline: 2px solid var(--octc-color-primary, var(--octc-accent, #4f46e5));
+  outline-offset: 2px;
+}
 .ox-code-play .ox-code { margin: 0; }
 .ox-code-play__source pre { margin: 0; border: 0; border-radius: 0; }
 .ox-code-play__tabs {

--- a/npm/ox-content-code-play/src/types.ts
+++ b/npm/ox-content-code-play/src/types.ts
@@ -176,10 +176,47 @@ export interface ViewerFlags {
 
 export type CodePlayPreset = "default" | "compact" | "headless";
 
+export type ProjectSandboxProvider = "stackblitz" | "codesandbox" | "webcontainer" | "external";
+
+export type ProjectSandboxTarget = "browser" | "node" | "external";
+
+export interface ProjectSandboxFile {
+  path: string;
+  code: string;
+}
+
+export interface ProjectSandbox {
+  provider: ProjectSandboxProvider;
+  label: string;
+  target: ProjectSandboxTarget;
+  entry?: string;
+  files: ProjectSandboxFile[];
+  openUrl?: string;
+  fallbackUrl?: string;
+  warnings?: string[];
+}
+
+export interface ProjectSandboxAdapterInput {
+  provider: string;
+  entry?: string;
+  files: ProjectSandboxFile[];
+  openUrl?: string;
+  fallbackUrl?: string;
+  warnings?: string[];
+}
+
+export interface ProjectSandboxAdapter {
+  provider: ProjectSandboxProvider;
+  label: string;
+  target: ProjectSandboxTarget;
+  resolve(input: ProjectSandboxAdapterInput): ProjectSandbox;
+}
+
 export interface SessionInput {
   language: string;
   code: string;
   config?: Record<string, unknown>;
+  project?: ProjectSandbox;
 }
 
 export interface PlayPayload {
@@ -194,6 +231,7 @@ export interface PlayPayload {
   ui: CodePlayPreset;
   timeoutMs: number;
   endpoints?: PlaygroundEndpoints;
+  project?: ProjectSandbox;
 }
 
 export interface TypeScriptLike {
@@ -244,6 +282,7 @@ export interface AdapterRequest {
   transport: CodePlayTransport;
   loadTypeScript?: () => Promise<TypeScriptLike | undefined>;
   endpoints: PlaygroundEndpoints;
+  project?: ProjectSandbox;
   signal?: AbortSignal;
 }
 

--- a/npm/ox-content-code-play/src/ui.ts
+++ b/npm/ox-content-code-play/src/ui.ts
@@ -1,10 +1,11 @@
 import { resolveLanguage } from "./catalog";
-import { escapeHtml } from "./escape";
+import { escapeAttribute, escapeHtml } from "./escape";
 import { idleRunActionState } from "./hydrate-action";
 import type {
   CodePlayPreset,
   LanguageDefinition,
   PlayPayload,
+  ProjectSandbox,
   RunActionState,
   RunResult,
 } from "./types";
@@ -96,7 +97,7 @@ function renderRuntimeStrip(
     runtimeChip("Executor", executor.label, executor.kind),
     runtimeChip("Checks", checks, payload.capabilities.typecheck ? "ok" : "muted"),
   ].join("");
-  return `<div class="ox-code-play__runtime" aria-label="Code Play runtime">${chips}</div>`;
+  return `<div class="ox-code-play__runtime" aria-label="Code Play runtime">${chips}${renderProjectSandboxHtml(payload.project)}</div>`;
 }
 
 function runtimeLabel(
@@ -138,6 +139,32 @@ function executorLabel(
 
 function runtimeChip(label: string, value: string, kind: "ok" | "warn" | "muted"): string {
   return `<span class="ox-code-play__runtime-chip ox-code-play__runtime-chip--${kind}"><span>${escapeHtml(label)}</span><strong>${escapeHtml(value)}</strong></span>`;
+}
+
+export function renderProjectSandboxHtml(project: ProjectSandbox | undefined): string {
+  if (!project) {
+    return "";
+  }
+  const fileCount = `${project.files.length} ${project.files.length === 1 ? "file" : "files"}`;
+  const target =
+    project.target === "browser"
+      ? "Browser project"
+      : project.target === "node"
+        ? "Node-like project"
+        : "External project";
+  const url = project.openUrl ?? project.fallbackUrl;
+  const warnings = project.warnings?.length
+    ? `<span class="ox-code-play__project-warning" title="${escapeAttribute(project.warnings.join("\n"))}">Warnings</span>`
+    : "";
+  const link = url
+    ? `<a class="ox-code-play__project-link" href="${escapeAttribute(url)}" target="_blank" rel="noopener noreferrer">Open</a>`
+    : "";
+  return `<span class="ox-code-play__project" data-ox-project-provider="${escapeAttribute(project.provider)}">
+    <span class="ox-code-play__project-main"><span>${escapeHtml(project.label)}</span><strong>${escapeHtml(target)}</strong></span>
+    ${project.entry ? `<span class="ox-code-play__project-entry"><span>Entry</span><strong>${escapeHtml(project.entry)}</strong></span>` : ""}
+    <span class="ox-code-play__project-files">${escapeHtml(fileCount)}</span>
+    ${warnings}${link}
+  </span>`;
 }
 
 function renderTabs(state: UiState, panel: string): string {

--- a/npm/ox-content-code-play/src/viewers.test.ts
+++ b/npm/ox-content-code-play/src/viewers.test.ts
@@ -127,6 +127,31 @@ describe("stderr UI flags", () => {
     expect(ready).toContain("On demand");
   });
 
+  it("renders project sandbox metadata and fallback links", () => {
+    const html = renderPlayUi({
+      payload: payload({
+        project: {
+          provider: "stackblitz",
+          label: "StackBlitz",
+          target: "browser",
+          entry: "src/main.ts",
+          files: [
+            { path: "src/main.ts", code: "console.log(1)" },
+            { path: "package.json", code: "{}" },
+          ],
+          openUrl: "https://stackblitz.com/edit/demo",
+          warnings: ["Skipped missing project file: src/missing.ts"],
+        },
+      }),
+    });
+    expect(html).toContain('data-ox-project-provider="stackblitz"');
+    expect(html).toContain("Browser project");
+    expect(html).toContain("src/main.ts");
+    expect(html).toContain("2 files");
+    expect(html).toContain('href="https://stackblitz.com/edit/demo"');
+    expect(html).toContain("Warnings");
+  });
+
   it("omits the stderr tab and panel when viewers.stderr is false", () => {
     const html = renderPlayUi({
       payload: payload({ viewers: { ...DEFAULT_VIEWERS, stderr: false } }),

--- a/npm/vite-plugin-ox-content/test/vrt/code-play-helpers.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/code-play-helpers.ts
@@ -1,0 +1,59 @@
+import { expect, type Page } from "@playwright/test";
+import { resolveCodePlayOptions } from "../../../ox-content-code-play/src/config";
+import { enhancePlayHtml } from "../../../ox-content-code-play/src/html";
+import { decodePayload, encodePayload } from "../../../ox-content-code-play/src/payload";
+import { payloadFromFence } from "../../../ox-content-code-play/src/payload-factory";
+
+export function renderWidget(
+  language: string,
+  code: string,
+  title: string,
+  options: ReturnType<typeof resolveCodePlayOptions>,
+): string {
+  const payload = encodePayload(
+    payloadFromFence(
+      {
+        language,
+        meta: `play play-title="${title}"`,
+        code,
+        raw: "",
+        start: 0,
+        end: 0,
+        typecheck: false,
+        title,
+        config: {},
+      },
+      options,
+    ),
+  );
+  const escapedCode = code.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+  return enhancePlayHtml(`<pre><code class="language-${language}">${escapedCode}</code></pre>`, {
+    decodePayload,
+    encodePayload,
+    matchFences: [{ language, code, payload }],
+  });
+}
+
+export async function runWidget(page: Page, title: string, output: string): Promise<void> {
+  const widget = page.getByRole("region", { name: new RegExp(title) });
+  await widget.getByRole("button", { name: /Run/ }).click();
+  await expect(widget.locator("[data-ox-status]")).toHaveText("Done");
+  await expect(widget.locator(".ox-code-play__stdio-text")).toContainText(output, {
+    timeout: 10_000,
+  });
+}
+
+export function corsHeaders(): Record<string, string> {
+  return {
+    "access-control-allow-origin": "*",
+    "access-control-allow-methods": "POST, OPTIONS",
+    "access-control-allow-headers": "content-type",
+  };
+}
+
+export async function fitsViewport(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const doc = document.documentElement;
+    return doc.scrollWidth <= doc.clientWidth + 1;
+  });
+}

--- a/npm/vite-plugin-ox-content/test/vrt/code-play.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/code-play.spec.ts
@@ -1,12 +1,14 @@
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { bundleBrowserClient } from "../../../ox-content-code-play/src/bundle-browser";
 import { resolveCodePlayOptions } from "../../../ox-content-code-play/src/config";
 import { enhancePlayHtml } from "../../../ox-content-code-play/src/html";
+import { parsePlayFences } from "../../../ox-content-code-play/src/markdown";
 import { decodePayload, encodePayload } from "../../../ox-content-code-play/src/payload";
 import { payloadFromFence } from "../../../ox-content-code-play/src/payload-factory";
+import { corsHeaders, fitsViewport, renderWidget, runWidget } from "./code-play-helpers";
 
 test("hydrates written SSG HTML and runs JavaScript in the browser sandbox", async ({ page }) => {
   const outDir = await mkdtemp(path.join(tmpdir(), "ox-code-play-vrt-"));
@@ -283,49 +285,53 @@ test("surfaces Rust playground transport failures as offline in the browser", as
   }
 });
 
-function renderWidget(
-  language: string,
-  code: string,
-  title: string,
-  options: ReturnType<typeof resolveCodePlayOptions>,
-): string {
-  const payload = encodePayload(
-    payloadFromFence(
-      {
-        language,
-        meta: `play play-title="${title}"`,
-        code,
-        raw: "",
-        start: 0,
-        end: 0,
-        typecheck: false,
-        title,
-        config: {},
-      },
-      options,
-    ),
-  );
-  const escapedCode = code.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
-  return enhancePlayHtml(`<pre><code class="language-${language}">${escapedCode}</code></pre>`, {
-    decodePayload,
-    encodePayload,
-    matchFences: [{ language, code, payload }],
-  });
-}
+test("renders project sandbox fallback links on mobile without provider scripts", async ({
+  page,
+}) => {
+  const outDir = await mkdtemp(path.join(tmpdir(), "ox-code-play-vrt-project-"));
+  try {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await bundleBrowserClient(outDir);
+    const client = await readFile(path.join(outDir, "browser.mjs"), "utf8");
+    const options = resolveCodePlayOptions({ languages: { typescript: true } });
+    const source = [
+      '```ts play play-title="Project demo" play-project=stackblitz play-file=src/main.ts play-entry=src/main.ts play-project-url=https://stackblitz.com/edit/ox-content-project',
+      'console.log("project");',
+      "```",
+    ].join("\n");
+    const fence = parsePlayFences(source)[0];
+    if (!fence) {
+      throw new Error("expected a project Code Play fence");
+    }
+    const payload = encodePayload(
+      payloadFromFence(fence, options, {
+        files: [{ path: "package.json", code: '{"scripts":{"dev":"vite"}}\n' }],
+      }),
+    );
+    const widget = enhancePlayHtml(`<pre><code class="language-ts">${fence.code}</code></pre>`, {
+      decodePayload,
+      encodePayload,
+      matchFences: [{ language: "ts", code: fence.code, payload }],
+    });
 
-async function runWidget(page: Page, title: string, output: string): Promise<void> {
-  const widget = page.getByRole("region", { name: new RegExp(title) });
-  await widget.getByRole("button", { name: /Run/ }).click();
-  await expect(widget.locator("[data-ox-status]")).toHaveText("Done");
-  await expect(widget.locator(".ox-code-play__stdio-text")).toContainText(output, {
-    timeout: 10_000,
-  });
-}
+    await page.setContent(
+      `<!doctype html><html><head><meta charset="utf-8"></head><body>${widget}<script type="module">${client}</script></body></html>`,
+      { waitUntil: "domcontentloaded" },
+    );
 
-function corsHeaders(): Record<string, string> {
-  return {
-    "access-control-allow-origin": "*",
-    "access-control-allow-methods": "POST, OPTIONS",
-    "access-control-allow-headers": "content-type",
-  };
-}
+    const project = page.getByRole("region", { name: /Project demo/ });
+    await expect(project.locator(".ox-code-play__project")).toBeVisible();
+    await expect(project).toContainText("StackBlitz");
+    await expect(project).toContainText("2 files");
+    await expect(project.getByRole("link", { name: "Open" })).toHaveAttribute(
+      "href",
+      "https://stackblitz.com/edit/ox-content-project",
+    );
+    await expect(page.locator('script[src*="stackblitz"], iframe[src*="stackblitz"]')).toHaveCount(
+      0,
+    );
+    expect(await fitsViewport(page)).toBe(true);
+  } finally {
+    await rm(outDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add project sandbox metadata to Code Play authoring, payloads, hydration, and runtime adapter inputs
- collect safe project files from Markdown-relative globs without executing provider scripts
- render provider/fallback project controls in the widget and document the new authoring surface

## Validation
- vp check --fix npm/ox-content-code-play/src/plugin.ts npm/ox-content-code-play/src/plugin-paths.ts npm/vite-plugin-ox-content/test/vrt/code-play.spec.ts npm/vite-plugin-ox-content/test/vrt/code-play-helpers.ts
- node scripts/check-file-lines.ts
- corepack pnpm --filter @ox-content/code-play exec tsgo --noEmit
- corepack pnpm --filter @ox-content/code-play exec vpr test src/markdown.test.ts src/plugin.test.ts src/viewers.test.ts
- corepack pnpm --filter @ox-content/code-play run build
- corepack pnpm --filter @ox-content/vite-plugin exec playwright test test/vrt/code-play.spec.ts
- vp run check:ts (passes; existing repo-wide warnings only)
- vp run build:docs (passes; existing docs transform warning for ja/built-in/./options.json remains)

Closes #873
Refs #856
Refs #851

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790356680&installation_model_id=422833&pr_number=1026&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1026&signature=5b1456b3bbeb3c8a4755d4b789f30d624eb6d3ca089b5bb68f9810402c08b30e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->