### PR TITLE
refactor(core): resolve page routes through native ssg

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -1654,6 +1654,16 @@ export interface JsResolvedModule {
   exports: Array<JsPublicExport>
 }
 
+/** One page after cascade and optional permalink / slug rewriting. */
+export interface JsResolvedSsgRoutePage {
+  /** Source path relative to the content root. */
+  source: string
+  /** Resolved URL path. */
+  urlPath: string
+  /** Frontmatter after cascade fills. */
+  frontmatter: Record<string, unknown>
+}
+
 /** HTML sanitizer options. */
 export interface JsSanitizeOptions {
   /**
@@ -2018,6 +2028,24 @@ export interface JsSsgPageData {
   canonical?: string
   /** Companion `.md` URL when copy-as-markdown chrome is on. */
   markdownSource?: string
+}
+
+/** Resolved page routes plus collision and rejection diagnostics. */
+export interface JsSsgPageRouteOutput {
+  /** Pages that still have a unique URL. */
+  pages: Array<JsResolvedSsgRoutePage>
+  /** Human-readable collision and rejection messages. */
+  errors: Array<string>
+}
+
+/** One page considered for cascade and permalink resolution. */
+export interface JsSsgRoutePageInput {
+  /** Source path relative to the content root. */
+  source: string
+  /** File-tree URL before permalink or slug rewriting. */
+  fileUrl: string
+  /** Parsed frontmatter object. */
+  frontmatter: Record<string, unknown>
 }
 
 /** Resolved SSG output and public route paths. */
@@ -2793,6 +2821,9 @@ export declare function renderSsgSectionIndex(title: string, items: Array<JsSect
 
 /** Resolves manual SSG navigation groups. */
 export declare function resolveSsgNavigationGroups(navigation: Array<JsSsgNavigationGroup>, base: string, extension: string): Array<JsSsgNavGroup>
+
+/** Resolves permalink / slug routes and `_index` frontmatter cascade. */
+export declare function resolveSsgPageRoutes(pages: Array<JsSsgRoutePageInput>, permalinksEnabled: boolean, cascadeEnabled: boolean): JsSsgPageRouteOutput
 
 /** Resolves all output and public route paths for an SSG page. */
 export declare function resolveSsgRoutePaths(inputPath: string, srcDir: string, outDir: string, base: string, extension: string, siteUrl?: string | undefined | null): JsSsgRoutePaths

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -221,6 +221,7 @@ module.exports.nativeHighlightLanguages = binding.nativeHighlightLanguages;
 module.exports.generateSsgBarePage = binding.generateSsgBarePage;
 module.exports.getGitLastUpdated = binding.getGitLastUpdated;
 module.exports.getGitContributors = binding.getGitContributors;
+module.exports.resolveSsgPageRoutes = binding.resolveSsgPageRoutes;
 module.exports.resolveSsgRoutePaths = binding.resolveSsgRoutePaths;
 module.exports.getSsgOutputPath = binding.getSsgOutputPath;
 module.exports.getSsgUrlPath = binding.getSsgUrlPath;

--- a/crates/ox_content_napi/src/ssg_bindings.rs
+++ b/crates/ox_content_napi/src/ssg_bindings.rs
@@ -11,6 +11,8 @@ mod git;
 pub use git::*;
 mod head;
 pub use head::render_head;
+mod page_routes;
+pub use page_routes::*;
 mod section_index;
 pub use section_index::*;
 

--- a/crates/ox_content_napi/src/ssg_bindings/page_routes.rs
+++ b/crates/ox_content_napi/src/ssg_bindings/page_routes.rs
@@ -1,0 +1,110 @@
+use napi_derive::napi;
+use serde_json::{Map, Value};
+
+/// One page considered for cascade and permalink resolution.
+#[napi(object)]
+pub struct JsSsgRoutePageInput {
+    /// Source path relative to the content root.
+    pub source: String,
+    /// File-tree URL before permalink or slug rewriting.
+    pub file_url: String,
+    /// Parsed frontmatter object.
+    #[napi(ts_type = "Record<string, unknown>")]
+    pub frontmatter: Value,
+}
+
+/// One page after cascade and optional permalink / slug rewriting.
+#[napi(object)]
+pub struct JsResolvedSsgRoutePage {
+    /// Source path relative to the content root.
+    pub source: String,
+    /// Resolved URL path.
+    pub url_path: String,
+    /// Frontmatter after cascade fills.
+    #[napi(ts_type = "Record<string, unknown>")]
+    pub frontmatter: Value,
+}
+
+/// Resolved page routes plus collision and rejection diagnostics.
+#[napi(object)]
+pub struct JsSsgPageRouteOutput {
+    /// Pages that still have a unique URL.
+    pub pages: Vec<JsResolvedSsgRoutePage>,
+    /// Human-readable collision and rejection messages.
+    pub errors: Vec<String>,
+}
+
+/// Resolves permalink / slug routes and `_index` frontmatter cascade.
+#[napi(js_name = "resolveSsgPageRoutes")]
+pub fn resolve_ssg_page_routes(
+    pages: Vec<JsSsgRoutePageInput>,
+    permalinks_enabled: bool,
+    cascade_enabled: bool,
+) -> JsSsgPageRouteOutput {
+    let pages = pages.into_iter().map(convert_page).collect::<Vec<_>>();
+    let output = ox_content_ssg::resolve_page_routes(
+        &pages,
+        &ox_content_ssg::PermalinksOptions { enabled: permalinks_enabled },
+        &ox_content_ssg::CascadeOptions { enabled: cascade_enabled },
+    );
+
+    JsSsgPageRouteOutput {
+        pages: output
+            .pages
+            .into_iter()
+            .map(|page| JsResolvedSsgRoutePage {
+                source: page.source,
+                url_path: page.url_path,
+                frontmatter: Value::Object(page.frontmatter),
+            })
+            .collect(),
+        errors: output.errors,
+    }
+}
+
+fn convert_page(page: JsSsgRoutePageInput) -> ox_content_ssg::RoutePage {
+    ox_content_ssg::RoutePage {
+        source: page.source,
+        file_url: page.file_url,
+        frontmatter: object_frontmatter(page.frontmatter),
+    }
+}
+
+fn object_frontmatter(value: Value) -> Map<String, Value> {
+    match value {
+        Value::Object(map) => map,
+        _ => Map::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_routes_through_native_ssg() {
+        let output = resolve_ssg_page_routes(
+            vec![
+                page("guide/_index.md", "guide/_index", serde_json::json!({ "section": "Guide" })),
+                page("guide/intro.md", "guide/intro", serde_json::json!({ "permalink": "/start" })),
+                page("guide/child.md", "guide/child", serde_json::json!({ "slug": "hello" })),
+            ],
+            true,
+            true,
+        );
+
+        assert_eq!(output.pages.len(), 3);
+        assert_eq!(output.pages[1].url_path, "start");
+        assert_eq!(output.pages[2].url_path, "guide/hello");
+        assert_eq!(output.pages[2].frontmatter["section"], "Guide");
+        assert!(output.errors.is_empty());
+    }
+
+    fn page(source: &str, file_url: &str, frontmatter: Value) -> JsSsgRoutePageInput {
+        JsSsgRoutePageInput {
+            source: source.to_string(),
+            file_url: file_url.to_string(),
+            frontmatter,
+        }
+    }
+}

--- a/crates/ox_content_napi/src/tests/runtime_features.rs
+++ b/crates/ox_content_napi/src/tests/runtime_features.rs
@@ -89,6 +89,7 @@ fn javascript_wrapper_and_declarations_cover_expected_exports() {
         "renderHead",
         "renderSsgSectionIndex",
         "resolveSsgNavigationGroups",
+        "resolveSsgPageRoutes",
         "resolveSsgRoutePaths",
         "sanitizeHtml",
         "searchIndex",

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -1658,6 +1658,16 @@ export interface JsResolvedModule {
   exports: Array<JsPublicExport>
 }
 
+/** One page after cascade and optional permalink / slug rewriting. */
+export interface JsResolvedSsgRoutePage {
+  /** Source path relative to the content root. */
+  source: string
+  /** Resolved URL path. */
+  urlPath: string
+  /** Frontmatter after cascade fills. */
+  frontmatter: Record<string, unknown>
+}
+
 /** HTML sanitizer options. */
 export interface JsSanitizeOptions {
   /**
@@ -2022,6 +2032,24 @@ export interface JsSsgPageData {
   canonical?: string
   /** Companion `.md` URL when copy-as-markdown chrome is on. */
   markdownSource?: string
+}
+
+/** Resolved page routes plus collision and rejection diagnostics. */
+export interface JsSsgPageRouteOutput {
+  /** Pages that still have a unique URL. */
+  pages: Array<JsResolvedSsgRoutePage>
+  /** Human-readable collision and rejection messages. */
+  errors: Array<string>
+}
+
+/** One page considered for cascade and permalink resolution. */
+export interface JsSsgRoutePageInput {
+  /** Source path relative to the content root. */
+  source: string
+  /** File-tree URL before permalink or slug rewriting. */
+  fileUrl: string
+  /** Parsed frontmatter object. */
+  frontmatter: Record<string, unknown>
 }
 
 /** Resolved SSG output and public route paths. */
@@ -2797,6 +2825,9 @@ export declare function renderSsgSectionIndex(title: string, items: Array<JsSect
 
 /** Resolves manual SSG navigation groups. */
 export declare function resolveSsgNavigationGroups(navigation: Array<JsSsgNavigationGroup>, base: string, extension: string): Array<JsSsgNavGroup>
+
+/** Resolves permalink / slug routes and `_index` frontmatter cascade. */
+export declare function resolveSsgPageRoutes(pages: Array<JsSsgRoutePageInput>, permalinksEnabled: boolean, cascadeEnabled: boolean): JsSsgPageRouteOutput
 
 /** Resolves all output and public route paths for an SSG page. */
 export declare function resolveSsgRoutePaths(inputPath: string, srcDir: string, outDir: string, base: string, extension: string, siteUrl?: string | undefined | null): JsSsgRoutePaths

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
@@ -71,6 +71,7 @@ renderFrameworkComponentCode
 renderHead
 renderSsgSectionIndex
 resolveSsgNavigationGroups
+resolveSsgPageRoutes
 resolveSsgRoutePaths
 sanitizeHtml
 searchIndex

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
@@ -225,6 +225,7 @@ module.exports.nativeHighlightLanguages = binding.nativeHighlightLanguages;
 module.exports.generateSsgBarePage = binding.generateSsgBarePage;
 module.exports.getGitLastUpdated = binding.getGitLastUpdated;
 module.exports.getGitContributors = binding.getGitContributors;
+module.exports.resolveSsgPageRoutes = binding.resolveSsgPageRoutes;
 module.exports.resolveSsgRoutePaths = binding.resolveSsgRoutePaths;
 module.exports.getSsgOutputPath = binding.getSsgOutputPath;
 module.exports.getSsgUrlPath = binding.getSsgUrlPath;

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
@@ -225,6 +225,7 @@ module.exports.nativeHighlightLanguages = binding.nativeHighlightLanguages;
 module.exports.generateSsgBarePage = binding.generateSsgBarePage;
 module.exports.getGitLastUpdated = binding.getGitLastUpdated;
 module.exports.getGitContributors = binding.getGitContributors;
+module.exports.resolveSsgPageRoutes = binding.resolveSsgPageRoutes;
 module.exports.resolveSsgRoutePaths = binding.resolveSsgRoutePaths;
 module.exports.getSsgOutputPath = binding.getSsgOutputPath;
 module.exports.getSsgUrlPath = binding.getSsgUrlPath;

--- a/npm/vite-plugin-ox-content/src/permalinks.ts
+++ b/npm/vite-plugin-ox-content/src/permalinks.ts
@@ -5,14 +5,13 @@
  * applies those URLs during SSG and collection manifest builds.
  */
 
+import { importNapiModuleSync } from "./napi";
 import type {
   CascadeOptions,
   PermalinksOptions,
   ResolvedCascadeOptions,
   ResolvedPermalinksOptions,
 } from "./types";
-
-const RESERVED_CASCADE_KEYS = new Set(["permalink", "slug"]);
 
 /** One page considered for cascade and permalink resolution. */
 export interface RoutePageInput {
@@ -59,37 +58,15 @@ export function resolvePageRoutes(input: {
   permalinks?: ResolvedPermalinksOptions | null;
   cascade?: ResolvedCascadeOptions | null;
 }): RouteResolveOutput {
-  const cascaded = applyCascade(input.pages, input.cascade);
-  if (!input.permalinks?.enabled) {
-    return {
-      pages: cascaded.map((page) => ({
-        source: page.source,
-        urlPath: normalizeUrlPath(page.fileUrl),
-        frontmatter: page.frontmatter,
-      })),
-      errors: [],
-    };
-  }
-
-  const pages: ResolvedRoutePage[] = [];
-  const errors: string[] = [];
-  const claimed = new Map<string, string>();
-  for (const page of cascaded) {
-    const { urlPath, error } = resolveOne(page);
-    if (error) {
-      errors.push(error);
-    }
-    const owner = claimed.get(urlPath);
-    if (owner) {
-      errors.push(
-        `[ox-content] URL collision at "${urlPath}": ${owner} kept, ${page.source} skipped`,
-      );
-      continue;
-    }
-    claimed.set(urlPath, page.source);
-    pages.push({ source: page.source, urlPath, frontmatter: page.frontmatter });
-  }
-  return { pages, errors };
+  return importNapiModuleSync().resolveSsgPageRoutes(
+    input.pages.map((page) => ({
+      source: page.source,
+      fileUrl: page.fileUrl,
+      frontmatter: page.frontmatter,
+    })),
+    input.permalinks?.enabled === true,
+    input.cascade?.enabled === true,
+  );
 }
 
 /** Escapes a value for use in an HTML attribute. */
@@ -125,139 +102,10 @@ function resolveFlag(value: boolean | { enabled?: boolean } | undefined): { enab
   return { enabled: value.enabled !== false };
 }
 
-function applyCascade(
-  pages: readonly RoutePageInput[],
-  options?: ResolvedCascadeOptions | null,
-): RoutePageInput[] {
-  if (!options?.enabled) {
-    return pages.map((page) => ({ ...page, frontmatter: { ...page.frontmatter } }));
-  }
-  const indexes = new Map<string, Record<string, unknown>>();
-  for (const page of pages) {
-    const source = normalizeSeparators(page.source);
-    if (isIndexFile(source)) {
-      indexes.set(directoryOf(source), { ...page.frontmatter });
-    }
-  }
-  return pages.map((page) => {
-    const source = normalizeSeparators(page.source);
-    const frontmatter = { ...page.frontmatter };
-    for (const dir of ancestorDirs(source)) {
-      const defaults = indexes.get(dir);
-      if (!defaults || (isIndexFile(source) && directoryOf(source) === dir)) {
-        continue;
-      }
-      for (const [key, value] of Object.entries(defaults)) {
-        if (!RESERVED_CASCADE_KEYS.has(key) && !(key in frontmatter)) {
-          frontmatter[key] = value;
-        }
-      }
-    }
-    return { ...page, frontmatter };
-  });
-}
-
-function resolveOne(page: RoutePageInput): { urlPath: string; error?: string } {
-  const fileUrl = normalizeUrlPath(page.fileUrl);
-  const permalink = readString(page.frontmatter.permalink);
-  if (permalink !== undefined) {
-    const url = isSafePermalink(permalink) ? normalizeUrlPath(permalink) : undefined;
-    return url
-      ? { urlPath: url }
-      : {
-          urlPath: fileUrl,
-          error: `[ox-content] rejected permalink ${JSON.stringify(permalink)} on ${page.source} (path escape); using the file-tree URL`,
-        };
-  }
-  const slug = readString(page.frontmatter.slug);
-  if (slug !== undefined) {
-    const url = rewriteSlug(fileUrl, slug);
-    return url
-      ? { urlPath: url }
-      : {
-          urlPath: fileUrl,
-          error: `[ox-content] rejected slug ${JSON.stringify(slug)} on ${page.source} (path escape); using the file-tree URL`,
-        };
-  }
-  return { urlPath: fileUrl };
-}
-
-function rewriteSlug(fileUrl: string, slug: string): string | undefined {
-  const trimmed = slug.trim();
-  if (trimmed.includes("/") || !isSafePermalink(trimmed)) {
-    return undefined;
-  }
-  const normalized = normalizeUrlPath(trimmed);
-  if (normalized === "/") {
-    return undefined;
-  }
-  if (fileUrl === "/") {
-    return normalized;
-  }
-  const segments = fileUrl.split("/").filter(Boolean);
-  segments.pop();
-  segments.push(normalized);
-  return segments.join("/");
-}
-
-function isSafePermalink(value: string): boolean {
-  const trimmed = value.trim();
-  if (!trimmed || /[\n\r\0]/u.test(trimmed) || trimmed.includes("\\") || trimmed.startsWith("//")) {
-    return false;
-  }
-  if (/^[A-Za-z]:/u.test(trimmed)) {
-    return false;
-  }
-  const lower = trimmed.toLowerCase();
-  if (
-    lower.includes("javascript:") ||
-    lower.includes("data:") ||
-    lower.includes("vbscript:") ||
-    lower.includes("file:") ||
-    lower.includes("://")
-  ) {
-    return false;
-  }
-  return pathSegments(trimmed).every((segment) => segment !== ".." && segment !== ".");
-}
-
 function pathSegments(value: string): string[] {
   return value
     .trim()
     .replace(/^\/+|\/+$/gu, "")
     .split("/")
     .filter(Boolean);
-}
-
-function readString(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
-}
-
-function normalizeSeparators(value: string): string {
-  return value.replaceAll("\\", "/");
-}
-
-function isIndexFile(source: string): boolean {
-  const name = source.split("/").pop() ?? source;
-  const stem = name.includes(".") ? name.slice(0, name.lastIndexOf(".")) : name;
-  return stem.toLowerCase() === "_index";
-}
-
-function directoryOf(source: string): string {
-  const index = source.lastIndexOf("/");
-  return index === -1 ? "" : source.slice(0, index);
-}
-
-function ancestorDirs(source: string): string[] {
-  const dir = directoryOf(source);
-  const dirs = [""];
-  if (!dir) {
-    return dirs;
-  }
-  let acc = "";
-  for (const segment of dir.split("/")) {
-    acc = acc ? `${acc}/${segment}` : segment;
-    dirs.push(acc);
-  }
-  return dirs;
 }


### PR DESCRIPTION
## Summary
- expose native SSG page-route resolution through NAPI
- route Vite plugin permalink/cascade resolution through the Rust API
- keep existing permalink tests as JS parity coverage

Refs #902.

## Validation
- node scripts/check-file-lines.ts
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p ox_content_napi
- cargo test -p ox_content_ssg permalink
- corepack pnpm --filter @ox-content/vite-plugin exec vp check --fix src/permalinks.ts src/permalinks.test.ts
- corepack pnpm --filter @ox-content/vite-plugin exec vp test src/permalinks.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790360867&installation_model_id=422833&pr_number=1028&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1028&signature=7bd219a799406b49d343a598f2ba20f5fc2b208016defaabaa0219c4b7b1ad9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->