### PR TITLE
refactor(core): parse markdown source frontmatter natively

### DIFF
--- a/npm/vite-plugin-ox-content/src/markdown-source-frontmatter.test.ts
+++ b/npm/vite-plugin-ox-content/src/markdown-source-frontmatter.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vite-plus/test";
+import { parseSourceFrontmatter } from "./markdown-source";
+
+describe("markdown source frontmatter", () => {
+  it("uses the native frontmatter parser for companion routing", () => {
+    expect(
+      parseSourceFrontmatter(
+        "---\ntitle: Guide\ntags:\n  - docs\nmeta:\n  draft: false\n---\n# Guide\n",
+      ),
+    ).toEqual({
+      title: "Guide",
+      tags: ["docs"],
+      meta: { draft: false },
+    });
+  });
+
+  it("keeps malformed frontmatter on the native empty-object path", () => {
+    expect(parseSourceFrontmatter("---\ntitle: [broken\n---\n# Guide\n")).toEqual({});
+  });
+});

--- a/npm/vite-plugin-ox-content/src/markdown-source.ts
+++ b/npm/vite-plugin-ox-content/src/markdown-source.ts
@@ -227,35 +227,7 @@ export function resolveMarkdownSourceRequest(
 
 /** Frontmatter keys only — not a Markdown parse. */
 export function parseSourceFrontmatter(source: string): Record<string, unknown> {
-  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!match?.[1]) {
-    return {};
-  }
-  const result: Record<string, unknown> = {};
-  for (const line of match[1].split("\n")) {
-    const kv = line.match(/^([A-Za-z_][\w-]*)\s*:\s*(.*)$/);
-    if (!kv) {
-      continue;
-    }
-    result[kv[1]] = parseFrontmatterScalar(kv[2].trim());
-  }
-  return result;
-}
-
-function parseFrontmatterScalar(value: string): unknown {
-  if (value === "true") {
-    return true;
-  }
-  if (value === "false") {
-    return false;
-  }
-  if (
-    (value.startsWith('"') && value.endsWith('"')) ||
-    (value.startsWith("'") && value.endsWith("'"))
-  ) {
-    return value.slice(1, -1);
-  }
-  return value;
+  return importNapiModuleSync().prepareSource(source, { frontmatter: true }).frontmatter;
 }
 
 function companionRelativePath(urlPath: string): string | undefined {


### PR DESCRIPTION
## Summary
- use the native prepared-source parser for markdown source companion frontmatter
- remove the simplified TypeScript frontmatter scanner
- add parity coverage for nested YAML and malformed frontmatter

Refs #902.

## Validation
- node scripts/check-file-lines.ts
- corepack pnpm --filter @ox-content/vite-plugin exec vp check --fix src/markdown-source.ts src/markdown-source-frontmatter.test.ts
- corepack pnpm --filter @ox-content/vite-plugin exec vp test src/markdown-source-frontmatter.test.ts src/markdown-source.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790360993&installation_model_id=422833&pr_number=1029&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1029&signature=40ab271b7322a388b2af2160be9639b39f8d0a231594cc88264f6d4a94a99d6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->