### PR TITLE
fix(styles): harden social component theme resets

### DIFF
--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html.snap
@@ -1152,6 +1152,7 @@ a:hover {
 .content .ox-magic-link__image {
   width: 1em;
   height: 1em;
+  margin: 0;
   border-radius: 999px;
   object-fit: cover;
   flex: 0 0 auto;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__generate_html_without_toc_omits_outline.snap
@@ -1149,6 +1149,7 @@ a:hover {
 .content .ox-magic-link__image {
   width: 1em;
   height: 1em;
+  margin: 0;
   border-radius: 999px;
   object-fit: cover;
   flex: 0 0 auto;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__rendering__html_locale_attrs_use_current_locale_and_direction.snap
@@ -1149,6 +1149,7 @@ a:hover {
 .content .ox-magic-link__image {
   width: 1em;
   height: 1em;
+  margin: 0;
   border-radius: 999px;
   object-fit: cover;
   flex: 0 0 auto;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_custom_social_link.snap
@@ -1149,6 +1149,7 @@ a:hover {
 .content .ox-magic-link__image {
   width: 1em;
   height: 1em;
+  margin: 0;
   border-radius: 999px;
   object-fit: cover;
   flex: 0 0 auto;

--- a/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
+++ b/crates/ox_content_ssg/src/html/tests/snapshots/ox_content_ssg__html__tests__theme__generate_html_with_theme.snap
@@ -1149,6 +1149,7 @@ a:hover {
 .content .ox-magic-link__image {
   width: 1em;
   height: 1em;
+  margin: 0;
   border-radius: 999px;
   object-fit: cover;
   flex: 0 0 auto;

--- a/crates/ox_content_ssg/src/plugins/magic-links.css
+++ b/crates/ox_content_ssg/src/plugins/magic-links.css
@@ -22,6 +22,7 @@
 .content .ox-magic-link__image {
   width: 1em;
   height: 1em;
+  margin: 0;
   border-radius: 999px;
   object-fit: cover;
   flex: 0 0 auto;

--- a/crates/ox_content_ssg/src/plugins/social-tweet-full.css
+++ b/crates/ox_content_ssg/src/plugins/social-tweet-full.css
@@ -80,7 +80,8 @@
   background: var(--ox-tweet-bg);
 }
 
-[data-theme="dark"] .ox-tweet--full {
+[data-theme="dark"] .ox-tweet--full,
+.dark .ox-tweet--full {
   --ox-tweet-border: 1px solid rgb(66, 83, 100);
   --ox-tweet-font-color: rgb(247, 249, 249);
   --ox-tweet-font-color-secondary: rgb(139, 152, 165);
@@ -93,7 +94,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .ox-tweet--full {
+  :root:not([data-theme="light"]):not(.light) .ox-tweet--full {
     --ox-tweet-border: 1px solid rgb(66, 83, 100);
     --ox-tweet-font-color: rgb(247, 249, 249);
     --ox-tweet-font-color-secondary: rgb(139, 152, 165);

--- a/docs/content/credits.md
+++ b/docs/content/credits.md
@@ -49,6 +49,9 @@ Contribution summary:
   output and Markdown companions were mounted under the prefix.
 - Requested programmatic feed item sources for the ryoppippi.com JSON-backed
   media feed migration.
+- Reported prose typography stylesheet interactions with rich magic-link
+  avatars during the ryoppippi.com migration.
+- Requested class-based dark-mode support for Twitter/X full-card styles.
 
 ## Third-party attribution
 

--- a/docs/content/ja/credits.md
+++ b/docs/content/ja/credits.md
@@ -46,6 +46,9 @@ Markdown 属性とリッチなソーシャル埋め込みの見た目の同等�
   生成 feed の item URL から prefix が抜けていた問題を報告しました。
 - ryoppippi.com の JSON-backed media feed 移行のために、programmatic feed item
   source を要望しました。
+- ryoppippi.com の移行中に、rich magic link の avatar と prose typography
+  stylesheet の相互作用を報告しました。
+- Twitter / X full card style の class ベース dark mode 対応を要望しました。
 
 ## 第三者の帰属
 

--- a/npm/vite-plugin-ox-content/test/vrt/magic-link.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/magic-link.spec.ts
@@ -1,7 +1,14 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import { expect, test } from "@playwright/test";
 import { generateHtmlPage } from "../../src/ssg";
 import { transformMarkdown } from "../../src/transform";
 import { createDocsResolvedOptions } from "../fixtures/docs-fixture";
+
+const MAGIC_LINK_CSS = path.join(
+  import.meta.dirname,
+  "../../../../crates/ox_content_ssg/src/plugins/magic-links.css",
+);
 
 test("magic links stay compact inside mobile prose", async ({ page }) => {
   const result = await transformMarkdown(
@@ -43,6 +50,12 @@ test("magic links stay compact inside mobile prose", async ({ page }) => {
 
   await page.setViewportSize({ width: 390, height: 844 });
   await page.setContent(html, { waitUntil: "load" });
+  await page.addStyleTag({ content: await readFile(MAGIC_LINK_CSS, "utf8") });
+  await page.addStyleTag({ content: ".prose img { margin-block: 2em; }" });
+  await page
+    .locator(".content")
+    .first()
+    .evaluate((content) => content.classList.add("prose"));
 
   const metrics = await page
     .locator(".ox-magic-link")
@@ -57,12 +70,15 @@ test("magic links stay compact inside mobile prose", async ({ page }) => {
         throw new Error("Missing magic-link details");
       }
       const linkStyle = getComputedStyle(link);
+      const imageStyle = getComputedStyle(image);
       const imageRect = image.getBoundingClientRect();
       const iconRect = externalIcon.getBoundingClientRect();
       const linkRect = link.getBoundingClientRect();
       return {
         borderRadius: Number.parseFloat(linkStyle.borderRadius),
         iconWidth: iconRect.width,
+        imageMarginBlockEnd: imageStyle.marginBlockEnd,
+        imageMarginBlockStart: imageStyle.marginBlockStart,
         imageWidth: imageRect.width,
         linkHeight: linkRect.height,
       };
@@ -70,6 +86,8 @@ test("magic links stay compact inside mobile prose", async ({ page }) => {
 
   expect(metrics.linkHeight).toBeLessThanOrEqual(32);
   expect(metrics.borderRadius).toBeLessThan(12);
+  expect(metrics.imageMarginBlockStart).toBe("0px");
+  expect(metrics.imageMarginBlockEnd).toBe("0px");
   expect(metrics.imageWidth).toBeLessThanOrEqual(18);
   expect(metrics.iconWidth).toBeLessThanOrEqual(12);
 });

--- a/npm/vite-plugin-ox-content/test/vrt/twitter-full-theme.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/twitter-full-theme.spec.ts
@@ -1,0 +1,87 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+const TWITTER_FULL_CSS = path.join(
+  import.meta.dirname,
+  "../../../../crates/ox_content_ssg/src/plugins/social-tweet-full.css",
+);
+
+test.describe("Twitter full-card themes", () => {
+  test("uses explicit class dark tokens on a light OS", async ({ page }) => {
+    await page.emulateMedia({ colorScheme: "light" });
+    await renderCard(page, { className: "dark" });
+
+    await expect(cardColors(page)).resolves.toEqual({
+      background: "rgb(21, 32, 43)",
+      color: "rgb(247, 249, 249)",
+    });
+  });
+
+  test("keeps data-theme dark tokens", async ({ page }) => {
+    await page.emulateMedia({ colorScheme: "light" });
+    await renderCard(page, { dataTheme: "dark" });
+
+    await expect(cardColors(page)).resolves.toEqual({
+      background: "rgb(21, 32, 43)",
+      color: "rgb(247, 249, 249)",
+    });
+  });
+
+  test("uses OS dark fallback without an explicit light theme", async ({ page }) => {
+    await page.emulateMedia({ colorScheme: "dark" });
+    await renderCard(page);
+
+    await expect(cardColors(page)).resolves.toEqual({
+      background: "rgb(21, 32, 43)",
+      color: "rgb(247, 249, 249)",
+    });
+  });
+
+  test("lets explicit light themes override a dark OS", async ({ page }) => {
+    await page.emulateMedia({ colorScheme: "dark" });
+
+    for (const attrs of [{ className: "light" }, { dataTheme: "light" }] as const) {
+      await renderCard(page, attrs);
+      await expect(cardColors(page)).resolves.toEqual({
+        background: "rgb(255, 255, 255)",
+        color: "rgb(15, 20, 25)",
+      });
+    }
+  });
+});
+
+async function renderCard(
+  page: Page,
+  attrs: { className?: string; dataTheme?: "dark" | "light" } = {},
+): Promise<void> {
+  const css = await readFile(TWITTER_FULL_CSS, "utf8");
+  const htmlClass = attrs.className ? ` class="${attrs.className}"` : "";
+  const dataTheme = attrs.dataTheme ? ` data-theme="${attrs.dataTheme}"` : "";
+  await page.setContent(
+    `<!doctype html>
+<html${htmlClass}${dataTheme}>
+  <head>
+    <meta charset="utf-8">
+    <style>${css}</style>
+  </head>
+  <body>
+    <figure class="ox-tweet ox-tweet--fetched ox-tweet--full">
+      <p class="ox-tweet__body">Theme probe</p>
+    </figure>
+  </body>
+</html>`,
+    { waitUntil: "load" },
+  );
+}
+
+async function cardColors(page: Page): Promise<{ background: string; color: string }> {
+  return page.locator(".ox-tweet--full").evaluate((card) => {
+    const style = getComputedStyle(card);
+    return {
+      background: style.backgroundColor,
+      color: style.color,
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- reset rich magic-link avatar margins so prose image rules cannot inflate inline chips
- support class-based dark and light theme handling for Twitter/X full cards
- add ryoppippi credit notes for the reported production migration gaps

Closes #1030.
Closes #1031.

## Tests
- node scripts/check-file-lines.ts
- corepack pnpm --filter @ox-content/vite-plugin exec vp check --fix test/vrt/magic-link.spec.ts test/vrt/twitter-full-theme.spec.ts src/published-styles.test.ts src/plugins/twitter-full.test.ts src/plugins/twitter/parity.test.ts
- corepack pnpm --filter @ox-content/vite-plugin exec vp test src/published-styles.test.ts src/plugins/twitter-full.test.ts src/plugins/twitter/parity.test.ts
- corepack pnpm --filter @ox-content/vite-plugin exec playwright test test/vrt/magic-link.spec.ts test/vrt/twitter-full-theme.spec.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790362333&installation_model_id=422833&pr_number=1040&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1040&signature=7552e67c377990ad3abab50ba7cdf898b0f8e89f6c8340e6ee322e0758c4d6b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->