### PR TITLE
fix(ssg): skip output writes on dev server close

### DIFF
--- a/docs/content/credits.md
+++ b/docs/content/credits.md
@@ -41,6 +41,8 @@ Contribution summary:
   migration.
 - Reported the need for host-only redirect output without redundant HTML
   fallback pages during the ryoppippi.com migration.
+- Reported that closing Vite middleware servers could repeat production SSG
+  output writes during the ryoppippi.com migration.
 - The opt-in `<NotByAI />` authorship badge was requested and first shipped
   in production during the ryoppippi.com Ox Content migration.
 

--- a/docs/content/ja/credits.md
+++ b/docs/content/ja/credits.md
@@ -38,6 +38,8 @@ Markdown 属性とリッチなソーシャル埋め込みの見た目の同等�
   要望しました。
 - ryoppippi.com の移行中に、余分な HTML フォールバックページを出さない
   ホスト用リダイレクト出力を要望しました。
+- ryoppippi.com の移行中に、Vite middleware server を閉じると本番 SSG 出力が
+  繰り返されることを報告しました。
 - オプトインの `<NotByAI />` 執筆開示バッジは、ryoppippi.com の Ox Content
   移行で要望され、本番実装として先に入った機能です。
 

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -440,8 +440,14 @@ function createSsgPlugin(
   getRoot: () => string,
   ssgDevCache: ReturnType<typeof createDevServerCache>,
 ): Plugin {
+  let command: "build" | "serve" | undefined;
+
   return {
     name: "ox-content:ssg",
+
+    config(_config, env) {
+      command = env.command;
+    },
 
     configureServer(devServer) {
       const ssgOptions = resolvedOptions.ssg;
@@ -473,7 +479,7 @@ function createSsgPlugin(
 
     async closeBundle() {
       const ssgOptions = resolvedOptions.ssg;
-      if (!ssgOptions.enabled) {
+      if (command !== "build" || !ssgOptions.enabled) {
         return;
       }
 

--- a/npm/vite-plugin-ox-content/src/ssg-dev-close.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg-dev-close.test.ts
@@ -1,0 +1,126 @@
+import * as fs from "node:fs/promises";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { build as viteBuild, createServer, type InlineConfig, type ViteDevServer } from "vite";
+import { oxContent } from ".";
+
+const tempDirs: string[] = [];
+const activeServers: ViteDevServer[] = [];
+const activeListeners: http.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(activeListeners.splice(0).map((server) => closeHttpServer(server)));
+  await Promise.all(activeServers.splice(0).map((server) => server.close().catch(() => {})));
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("SSG dev server close", () => {
+  it("does not write SSG output when middleware servers close", async () => {
+    const root = await createProject("ox-content-ssg-middleware-close-");
+    const first = await trackDevServer(createSsgDevServer(root));
+    const second = await trackDevServer(createSsgDevServer(root));
+
+    await first.close();
+    await second.close();
+
+    await expectMissing(path.join(root, "site"));
+  });
+
+  it("keeps the development SSG middleware available", async () => {
+    const root = await createProject("ox-content-ssg-middleware-serve-");
+    const server = await trackDevServer(createSsgDevServer(root));
+    const listener = await listen(server);
+
+    const response = await fetch(`http://127.0.0.1:${listener.port}/`);
+    const html = await response.text();
+    await server.close();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain("<h1");
+    expect(html).toContain("Hello from SSG");
+    await expectMissing(path.join(root, "site"));
+  });
+
+  it("still writes SSG output during a production build", async () => {
+    const root = await createProject("ox-content-ssg-production-build-");
+
+    await viteBuild({
+      ...viteConfig(root),
+      build: {
+        outDir: "client",
+        emptyOutDir: false,
+      },
+    });
+
+    const html = await fs.readFile(path.join(root, "site", "index.html"), "utf8");
+    expect(html).toContain("Hello from SSG");
+  });
+});
+
+async function createProject(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(root);
+
+  await fs.mkdir(path.join(root, "content"), { recursive: true });
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(path.join(root, "content", "index.md"), "# Hello from SSG\n\nDev page.\n");
+  await fs.writeFile(
+    path.join(root, "index.html"),
+    '<div id="app"></div><script type="module" src="/src/main.js"></script>\n',
+  );
+  await fs.writeFile(
+    path.join(root, "src", "main.js"),
+    'document.querySelector("#app").textContent = "client";\n',
+  );
+  return root;
+}
+
+function viteConfig(root: string): InlineConfig {
+  return {
+    root,
+    configFile: false,
+    logLevel: "silent",
+    appType: "custom",
+    plugins: oxContent({
+      srcDir: "content",
+      outDir: "site",
+      ssg: true,
+      search: false,
+      ogViewer: false,
+    }),
+  };
+}
+
+function createSsgDevServer(root: string): Promise<ViteDevServer> {
+  return createServer({
+    ...viteConfig(root),
+    server: { middlewareMode: true },
+  });
+}
+
+async function trackDevServer(serverPromise: Promise<ViteDevServer>): Promise<ViteDevServer> {
+  const server = await serverPromise;
+  activeServers.push(server);
+  return server;
+}
+
+async function listen(server: ViteDevServer): Promise<{ port: number }> {
+  const listener = http.createServer(server.middlewares);
+  activeListeners.push(listener);
+  await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
+  const address = listener.address() as AddressInfo;
+  return { port: address.port };
+}
+
+function closeHttpServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+async function expectMissing(filePath: string): Promise<void> {
+  await expect(fs.access(filePath)).rejects.toThrow();
+}


### PR DESCRIPTION
## Summary

- guard the SSG `closeBundle` hook so only build-command plugin instances write outputs
- cover middleware server close, dev middleware serving, and production build output
- credit the production migration report

Closes #1033.

## Tests

- `corepack pnpm --filter @ox-content/vite-plugin exec vp check --fix src/index.ts src/ssg-dev-close.test.ts`
- `corepack pnpm --filter @ox-content/vite-plugin exec vp test src/ssg-dev-close.test.ts`
- `node scripts/check-file-lines.ts`
- `git diff --check`
- `corepack pnpm --filter @ox-content/vite-plugin exec vp test src/ssg-dev-close.test.ts src/ssg.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790363499&installation_model_id=422833&pr_number=1042&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1042&signature=74ecfda2f98c8585b7674f76e91fbe37c6132af3b6951ae8c6703626291b4485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented development server shutdowns from repeatedly writing production SSG output.
  * Ensured SSG output is generated during production builds while development middleware continues serving rendered pages without creating build files.

* **Tests**
  * Added coverage for development-server shutdowns, middleware responses, cleanup, and production SSG generation.

* **Documentation**
  * Added contribution credits in English and Japanese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->