### PR TITLE
fix(feeds): apply route prefix to item URLs

### DIFF
--- a/docs/content/credits.md
+++ b/docs/content/credits.md
@@ -41,6 +41,8 @@ Contribution summary:
   migration.
 - The opt-in `<NotByAI />` authorship badge was requested and first shipped
   in production during the ryoppippi.com Ox Content migration.
+- Reported that generated feed item URLs missed `ssg.routePrefix` while page
+  output and Markdown companions were mounted under the prefix.
 
 ## Third-party attribution
 

--- a/docs/content/ja/credits.md
+++ b/docs/content/ja/credits.md
@@ -38,6 +38,8 @@ Markdown 属性とリッチなソーシャル埋め込みの見た目の同等�
   要望しました。
 - オプトインの `<NotByAI />` 執筆開示バッジは、ryoppippi.com の Ox Content
   移行で要望され、本番実装として先に入った機能です。
+- ページ出力と Markdown companion が `ssg.routePrefix` 配下に配置される一方、
+  生成 feed の item URL から prefix が抜けていた問題を報告しました。
 
 ## 第三者の帰属
 

--- a/npm/vite-plugin-ox-content/src/ssg.test.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.test.ts
@@ -19,6 +19,7 @@ import {
   shouldGenerateOgImages,
 } from "./ssg";
 import { applyContributorOptions, filterGitContributors, gravatarAvatar } from "./contributors";
+import { resolveFeedsOptions } from "./feeds";
 import type { ResolvedOptions } from "./types";
 import { createDocsResolvedOptions } from "../test/fixtures/docs-fixture";
 
@@ -583,6 +584,82 @@ describe("SSG routePrefix", () => {
       "utf8",
     );
     expect(html).toContain("/blog/first-post/");
+    expect(built.errors).toEqual([]);
+  });
+
+  it("applies routePrefix to feed item URLs without moving root feed files", async () => {
+    const root = await makeSite({
+      "my-post/index.md": "---\ntitle: My Post\ndate: 2026-08-26\n---\n# My Post\n",
+      "explicit/index.md":
+        "---\ntitle: Explicit\ndate: 2026-08-25\npermalink: /news/explicit\n---\n# Explicit\n",
+    });
+    const built = await buildSsg(
+      routePrefixOptions({
+        ssg: {
+          ...routePrefixOptions().ssg,
+          routePrefix: "/blog/",
+          markdownSource: { enabled: true, alternate: true, copy: true },
+        },
+        collections: {
+          enabled: true,
+          collections: {
+            blog: { name: "blog", source: ["*/index.md"], include: [] },
+          },
+        },
+        feeds: resolveFeedsOptions({
+          formats: ["rss", "atom", "json"],
+          collection: "blog",
+          path: "/",
+        }),
+        permalinks: { enabled: true },
+      }),
+      root,
+    );
+
+    expect(built.files).toEqual(
+      expect.arrayContaining([
+        path.join(root, "dist", "blog", "my-post", "index.html"),
+        path.join(root, "dist", "blog", "my-post.md"),
+        path.join(root, "dist", "news", "explicit", "index.html"),
+        path.join(root, "dist", "news", "explicit.md"),
+        path.join(root, "dist", "feed.xml"),
+        path.join(root, "dist", "atom.xml"),
+        path.join(root, "dist", "feed.json"),
+      ]),
+    );
+    await expect(fs.access(path.join(root, "dist", "blog", "feed.xml"))).rejects.toThrow();
+
+    const rss = await fs.readFile(path.join(root, "dist", "feed.xml"), "utf8");
+    expect(rss).toContain("<link>https://example.com/blog/my-post/</link>");
+    expect(rss).toContain("<guid>https://example.com/blog/my-post/</guid>");
+    expect(rss).toContain("<link>https://example.com/news/explicit/</link>");
+    expect(rss).not.toContain("https://example.com/my-post/");
+    expect(rss).not.toContain("https://example.com/blog/news/explicit/");
+
+    const atom = await fs.readFile(path.join(root, "dist", "atom.xml"), "utf8");
+    expect(atom).toContain('<link href="https://example.com/blog/my-post/"/>');
+    expect(atom).toContain("<id>https://example.com/blog/my-post/</id>");
+    expect(atom).toContain('<link href="https://example.com/news/explicit/"/>');
+
+    const jsonFeed = JSON.parse(
+      await fs.readFile(path.join(root, "dist", "feed.json"), "utf8"),
+    ) as {
+      feed_url: string;
+      items: Array<{ id: string; url: string }>;
+    };
+    expect(jsonFeed.feed_url).toBe("https://example.com/feed.json");
+    expect(jsonFeed.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "https://example.com/blog/my-post/",
+          url: "https://example.com/blog/my-post/",
+        }),
+        expect.objectContaining({
+          id: "https://example.com/news/explicit/",
+          url: "https://example.com/news/explicit/",
+        }),
+      ]),
+    );
     expect(built.errors).toEqual([]);
   });
 

--- a/npm/vite-plugin-ox-content/src/ssg.ts
+++ b/npm/vite-plugin-ox-content/src/ssg.ts
@@ -17,6 +17,7 @@ import { transformIslands, hasIslands } from "./island";
 import { importNapiModule, importNapiModuleSync } from "./napi";
 import { DEFAULT_MARKDOWN_EXTENSIONS } from "./markdown";
 import type {
+  CollectionEntry,
   ResolvedOptions,
   ResolvedA11y,
   ResolvedReaderChrome,
@@ -2074,9 +2075,7 @@ async function writeGeneratedPages(
     options: context.options.feeds,
     publishState: context.options.publishState,
     collectionNames: Object.keys(context.options.collections?.collections ?? {}),
-    collections: context.options.feeds?.enabled
-      ? (await buildCollectionManifest(context.root, context.options)).collections
-      : undefined,
+    collections: await buildFeedCollections(context, outputPages),
   });
   generatedFiles.push(...feeds.files);
   if (feeds.warning) {
@@ -2106,6 +2105,44 @@ function sitePathFromUrlPath(urlPath: string): string {
     return "/";
   }
   return urlPath.startsWith("/") ? urlPath : `/${urlPath}`;
+}
+
+async function buildFeedCollections(
+  context: BuildSsgContext,
+  outputPages: readonly PageProcessResult[],
+): Promise<Record<string, CollectionEntry[]> | undefined> {
+  if (!context.options.feeds?.enabled) {
+    return undefined;
+  }
+  const manifest = await buildCollectionManifest(context.root, context.options);
+  return applyFeedPageRoutes(manifest.collections, context, outputPages);
+}
+
+function applyFeedPageRoutes(
+  collections: Record<string, CollectionEntry[]>,
+  context: BuildSsgContext,
+  outputPages: readonly PageProcessResult[],
+): Record<string, CollectionEntry[]> {
+  const routeBySource = new Map<string, string>();
+  for (const page of outputPages) {
+    const route = sitePathFromUrlPath(page.routePaths.urlPath);
+    routeBySource.set(page.inputPath, route);
+    routeBySource.set(
+      path.relative(context.srcDir, page.inputPath).replaceAll(path.sep, "/"),
+      route,
+    );
+  }
+
+  const routed: Record<string, CollectionEntry[]> = {};
+  for (const [name, entries] of Object.entries(collections)) {
+    routed[name] = entries.map((entry) => {
+      const route =
+        routeBySource.get(entry.source) ??
+        routeBySource.get(path.resolve(context.srcDir, entry.source));
+      return route ? { ...entry, path: route } : entry;
+    });
+  }
+  return routed;
 }
 
 function sitemapPages(


### PR DESCRIPTION
## Summary
- route generated feed collection item URLs through the SSG page route map
- keep root feed output paths unchanged while preserving permalink overrides
- add a routePrefix regression test covering RSS, Atom, JSON Feed, and Markdown companions
- credit @ryoppippi for the report

Closes #1039.

## Validation
- corepack pnpm --filter @ox-content/vite-plugin exec vp check --fix src/ssg.ts src/ssg.test.ts
- corepack pnpm --filter @ox-content/vite-plugin exec vp test src/ssg.test.ts src/feeds.test.ts src/feeds-write.test.ts
- node scripts/check-file-lines.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790364076&installation_model_id=422833&pr_number=1043&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1043&signature=b6973559f287a9ce474245618f7607007974e90948b7cba5cc07f0c712544bc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed generated feed item URLs so they correctly include the configured route prefix.
  - Preserved custom permalink overrides without adding an incorrect prefix.
  - RSS, Atom, and JSON feed files continue to be generated at the output root.

- **Tests**
  - Added coverage confirming correct prefixed URLs across supported feed formats.

- **Documentation**
  - Credited the community report in English and Japanese release documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->