### PR TITLE
feat(feeds): accept programmatic item sources

### DIFF
--- a/docs/content/built-in/feeds.md
+++ b/docs/content/built-in/feeds.md
@@ -79,11 +79,53 @@ oxContent({
 });
 ```
 
+## Programmatic items
+
+A channel can set `items` instead of `collection` when the feed source is a JSON
+file, database result, or another curated build-time source. The resolver runs
+during SSG and may return a promise:
+
+```ts
+import media from "./src/contents/external-rss/media.json";
+
+oxContent({
+  feeds: {
+    media: {
+      formats: ["rss"],
+      path: "/works/media",
+      title: "Media | ryoppippi.com",
+      items: async () =>
+        media
+          .filter((item) => !item.playlist)
+          .map((item) => ({
+            title: item.title,
+            url: item.link,
+            id: `media:${item.link}`,
+            date: item.pubDate,
+            description: `${item.kind === "podcast" ? "Podcast" : "YouTube"} | ${item.title}`,
+            author: { name: "ryoppippi", url: "https://ryoppippi.com" },
+            language: item.lang,
+          })),
+    },
+  },
+  ssg: {
+    siteUrl: "https://ryoppippi.com",
+  },
+});
+```
+
+Set either `collection` or `items` on a channel. Supplying both is rejected.
+Programmatic items support `title`, `url` or `loc`, optional `id`, `date`,
+`description`, `content`, `author` / `authors`, `image`, `attachments`, and
+`language`. The RSS, Atom, and JSON Feed renderers emit the fields that each
+format supports.
+
 | Option        | Type                                        | Default                              |
 | ------------- | ------------------------------------------- | ------------------------------------ |
 | `feeds`       | `boolean` / one feed / named record / array | `false`                              |
 | `formats`     | `("rss" \| "atom" \| "json")[]`             | `["rss", "atom", "json"]`            |
 | `collection`  | `string`                                    | `content`, else the first collection |
+| `items`       | `FeedItemInput[]` / async resolver          | omitted                              |
 | `limit`       | `number`                                    | `20`                                 |
 | `path`        | `string`                                    | `/` (site root)                      |
 | `title`       | `string`                                    | SSG site name                        |

--- a/docs/content/credits.md
+++ b/docs/content/credits.md
@@ -47,6 +47,8 @@ Contribution summary:
   in production during the ryoppippi.com Ox Content migration.
 - Reported that generated feed item URLs missed `ssg.routePrefix` while page
   output and Markdown companions were mounted under the prefix.
+- Requested programmatic feed item sources for the ryoppippi.com JSON-backed
+  media feed migration.
 
 ## Third-party attribution
 

--- a/docs/content/ja/built-in/feeds.md
+++ b/docs/content/ja/built-in/feeds.md
@@ -74,11 +74,51 @@ oxContent({
 });
 ```
 
+## Programmatic items
+
+フィードの元データが JSON ファイル、database の結果、ビルド時に集めた curated データのときは、チャンネルに `collection` ではなく `items` を設定できます。resolver は SSG 中に実行され、promise を返せます。
+
+```ts
+import media from "./src/contents/external-rss/media.json";
+
+oxContent({
+  feeds: {
+    media: {
+      formats: ["rss"],
+      path: "/works/media",
+      title: "Media | ryoppippi.com",
+      items: async () =>
+        media
+          .filter((item) => !item.playlist)
+          .map((item) => ({
+            title: item.title,
+            url: item.link,
+            id: `media:${item.link}`,
+            date: item.pubDate,
+            description: `${item.kind === "podcast" ? "Podcast" : "YouTube"} | ${item.title}`,
+            author: { name: "ryoppippi", url: "https://ryoppippi.com" },
+            language: item.lang,
+          })),
+    },
+  },
+  ssg: {
+    siteUrl: "https://ryoppippi.com",
+  },
+});
+```
+
+1 つのチャンネルに `collection` と `items` を同時に書くことはできません。
+同時に指定すると reject されます。programmatic item は `title`、`url` または
+`loc`、任意の `id`、`date`、`description`、`content`、`author` /
+`authors`、`image`、`attachments`、`language` を受け取ります。RSS、Atom、
+JSON Feed の各 renderer は、その形式が対応する field を出力します。
+
 | オプション    | 型                                         | 既定                                  |
 | ------------- | ------------------------------------------ | ------------------------------------- |
 | `feeds`       | `boolean` / 単一フィード / 名前付き / 配列 | `false`                               |
 | `formats`     | `("rss" \| "atom" \| "json")[]`            | `["rss", "atom", "json"]`             |
 | `collection`  | `string`                                   | `content`、なければ最初のコレクション |
+| `items`       | `FeedItemInput[]` / async resolver         | 省略                                  |
 | `limit`       | `number`                                   | `20`                                  |
 | `path`        | `string`                                   | `/`（サイトルート）                   |
 | `title`       | `string`                                   | SSG のサイト名                        |

--- a/docs/content/ja/credits.md
+++ b/docs/content/ja/credits.md
@@ -44,6 +44,8 @@ Markdown 属性とリッチなソーシャル埋め込みの見た目の同等�
   移行で要望され、本番実装として先に入った機能です。
 - ページ出力と Markdown companion が `ssg.routePrefix` 配下に配置される一方、
   生成 feed の item URL から prefix が抜けていた問題を報告しました。
+- ryoppippi.com の JSON-backed media feed 移行のために、programmatic feed item
+  source を要望しました。
 
 ## 第三者の帰属
 

--- a/npm/vite-plugin-ox-content/src/blog-feed-date.ts
+++ b/npm/vite-plugin-ox-content/src/blog-feed-date.ts
@@ -2,7 +2,8 @@
  * Publication dates from RSS / Atom items.
  */
 
-import { parseDate, type ParsedDate } from "./feed-format";
+import { parseDate } from "./feed-date";
+import type { ParsedDate } from "./feed-format";
 
 const MONTHS: Record<string, number> = {
   jan: 1,

--- a/npm/vite-plugin-ox-content/src/blog-posts.ts
+++ b/npm/vite-plugin-ox-content/src/blog-posts.ts
@@ -3,7 +3,7 @@
  */
 
 import * as path from "node:path";
-import { parseDate } from "./feed-format";
+import { parseDate } from "./feed-date";
 import { resolveBlogCollectionName } from "./blog-options";
 import { siteHref, type BlogSourcePage } from "./blog-html";
 import type { BlogAuthor, ResolvedBlogOptions, ResolvedCollectionsOptions } from "./types";

--- a/npm/vite-plugin-ox-content/src/feed-date.ts
+++ b/npm/vite-plugin-ox-content/src/feed-date.ts
@@ -1,0 +1,114 @@
+import type { ParsedDate } from "./feed-format";
+
+export function parseDate(value: string | undefined): ParsedDate | undefined {
+  if (!value) {
+    return undefined;
+  }
+  if (/^\d+$/.test(value)) {
+    const n = Number(value);
+    return unixToDate(value.length >= 13 ? Math.trunc(n / 1000) : n);
+  }
+  return parseCivilDate(value);
+}
+
+function parseCivilDate(value: string): ParsedDate | undefined {
+  if (value.length < 10 || value[4] !== "-" || value[7] !== "-") {
+    return undefined;
+  }
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(5, 7));
+  const day = Number(value.slice(8, 10));
+  let hour = 0;
+  let minute = 0;
+  let second = 0;
+  let offset = 0;
+  if (value.length > 10) {
+    const rest = value.slice(10);
+    const time = rest.startsWith("T") || rest.startsWith(" ") ? rest.slice(1) : "";
+    if (time.length < 8 || time[2] !== ":" || time[5] !== ":") {
+      return undefined;
+    }
+    hour = Number(time.slice(0, 2));
+    minute = Number(time.slice(3, 5));
+    second = Number(time.slice(6, 8));
+    const parsedOffset = parseOffset(timezoneSuffix(time));
+    if (parsedOffset == null) {
+      return undefined;
+    }
+    offset = parsedOffset;
+  }
+  const unix = civilToUnix(year, month, day, hour, minute, second);
+  return unix == null ? undefined : unixToDate(unix - offset);
+}
+
+function timezoneSuffix(rest: string): string {
+  const afterTime = rest.slice(8);
+  if (afterTime.startsWith(".")) {
+    const index = afterTime.search(/[Z+-]/);
+    return index === -1 ? "" : afterTime.slice(index);
+  }
+  return afterTime;
+}
+
+function parseOffset(tz: string): number | undefined {
+  if (!tz || tz === "Z") {
+    return 0;
+  }
+  if (tz.length < 6) {
+    return undefined;
+  }
+  const sign = tz[0] === "+" ? 1 : tz[0] === "-" ? -1 : 0;
+  if (!sign) {
+    return undefined;
+  }
+  return sign * (Number(tz.slice(1, 3)) * 3600 + Number(tz.slice(4, 6)) * 60);
+}
+
+function civilToUnix(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+): number | undefined {
+  if (month < 1 || month > 12 || day < 1 || day > 31 || hour > 23 || minute > 59 || second > 60) {
+    return undefined;
+  }
+  let y = year;
+  if (month <= 2) {
+    y -= 1;
+  }
+  const era = Math.trunc((y >= 0 ? y : y - 399) / 400);
+  const yoe = y - era * 400;
+  const shifted = month + (month > 2 ? -3 : 9);
+  const doy = Math.trunc((153 * shifted + 2) / 5) + day - 1;
+  const doe = yoe * 365 + Math.trunc(yoe / 4) - Math.trunc(yoe / 100) + doy;
+  const days = era * 146097 + doe - 719468;
+  return days * 86400 + hour * 3600 + minute * 60 + second;
+}
+
+function unixToDate(unix: number): ParsedDate | undefined {
+  const days = Math.floor(unix / 86400);
+  const tod = ((unix % 86400) + 86400) % 86400;
+  const z = days + 719468;
+  const era = Math.trunc((z >= 0 ? z : z - 146096) / 146097);
+  const doe = z - era * 146097;
+  const yoe = Math.trunc(
+    (doe - Math.trunc(doe / 1460) + Math.trunc(doe / 36524) - Math.trunc(doe / 146096)) / 365,
+  );
+  const year = yoe + era * 400;
+  const doy = doe - (365 * yoe + Math.trunc(yoe / 4) - Math.trunc(yoe / 100));
+  const mp = Math.trunc((5 * doy + 2) / 153);
+  const day = doy - Math.trunc((153 * mp + 2) / 5) + 1;
+  const month = mp < 10 ? mp + 3 : mp - 9;
+  return {
+    unix,
+    year: year + (month <= 2 ? 1 : 0),
+    month,
+    day,
+    hour: Math.trunc(tod / 3600),
+    minute: Math.trunc((tod % 3600) / 60),
+    second: tod % 60,
+  };
+}

--- a/npm/vite-plugin-ox-content/src/feed-format.ts
+++ b/npm/vite-plugin-ox-content/src/feed-format.ts
@@ -1,5 +1,7 @@
 /** RSS / Atom / JSON Feed string bodies used by `feeds.ts`. */
 
+import type { FeedItemAttachment, FeedItemAuthor } from "./types";
+
 export interface ParsedDate {
   unix: number;
   year: number;
@@ -21,12 +23,21 @@ export interface FeedDocument {
 export interface FeedEntry {
   title: string;
   description?: string;
+  content?: string;
   loc: string;
+  id?: string;
   date?: ParsedDate;
+  authors?: FeedItemAuthor[];
+  image?: string;
+  attachments?: FeedItemAttachment[];
+  language?: string;
 }
 
 export function generateRss(doc: FeedDocument, items: readonly FeedEntry[]): string {
-  let xml = '<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0">\n  <channel>\n    <title>';
+  const dc = items.some((item) => item.authors?.length || item.language)
+    ? ' xmlns:dc="http://purl.org/dc/elements/1.1/"'
+    : "";
+  let xml = `<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0"${dc}>\n  <channel>\n    <title>`;
   xml += escapeXml(doc.siteName);
   xml += "</title>\n    <link>";
   xml += escapeXml(doc.home);
@@ -38,17 +49,18 @@ export function generateRss(doc: FeedDocument, items: readonly FeedEntry[]): str
     xml += escapeXml(item.title);
     xml += "</title>\n      <link>";
     xml += escapeXml(item.loc);
-    xml += "</link>\n      <guid>";
-    xml += escapeXml(item.loc);
-    xml += "</guid>\n";
-    if (item.description) {
+    xml += "</link>\n";
+    xml += rssGuid(item);
+    const description = item.content ?? item.description;
+    if (description) {
       xml += "      <description>";
-      xml += escapeXml(item.description);
+      xml += escapeXml(description);
       xml += "</description>\n";
     }
     if (item.date) {
       xml += `      <pubDate>${formatRfc822(item.date)}</pubDate>\n`;
     }
+    xml += rssItemMeta(item);
     xml += "    </item>\n";
   }
   xml += "  </channel>\n</rss>\n";
@@ -73,17 +85,26 @@ export function generateAtom(doc: FeedDocument, items: readonly FeedEntry[]): st
     xml += "</subtitle>\n";
   }
   for (const item of items) {
-    xml += "  <entry>\n    <title>";
+    xml += `  <entry${item.language ? ` xml:lang="${escapeXml(item.language)}"` : ""}>\n    <title>`;
     xml += escapeXml(item.title);
     xml += '</title>\n    <link href="';
     xml += escapeXml(item.loc);
     xml += '"/>\n    <id>';
-    xml += escapeXml(item.loc);
+    xml += escapeXml(entryId(item));
     xml += `</id>\n    <updated>${item.date ? formatRfc3339(item.date) : updated}</updated>\n`;
     if (item.description) {
       xml += "    <summary>";
       xml += escapeXml(item.description);
       xml += "</summary>\n";
+    }
+    if (item.content) {
+      xml += `    <content type="text">${escapeXml(item.content)}</content>\n`;
+    }
+    for (const author of item.authors ?? []) {
+      xml += atomAuthor(author);
+    }
+    for (const attachment of item.attachments ?? []) {
+      xml += atomAttachment(attachment);
     }
     xml += "  </entry>\n";
   }
@@ -108,34 +129,28 @@ export function generateJson(doc: FeedDocument, items: readonly FeedEntry[]): st
       json += ",";
     }
     json += '\n    {\n      "id": ';
-    json += jsonString(item.loc);
+    json += jsonString(entryId(item));
     json += ',\n      "url": ';
     json += jsonString(item.loc);
     json += ',\n      "title": ';
     json += jsonString(item.title);
-    if (item.description) {
-      json += ',\n      "content_text": ';
+    if (item.description && item.content) {
+      json += ',\n      "summary": ';
       json += jsonString(item.description);
+    }
+    if (item.description || item.content) {
+      json += ',\n      "content_text": ';
+      json += jsonString(item.content ?? item.description);
     }
     if (item.date) {
       json += ',\n      "date_published": ';
       json += jsonString(formatRfc3339(item.date));
     }
+    json += jsonItemMeta(item);
     json += "\n    }";
   });
   json += "\n  ]\n}\n";
   return json;
-}
-
-export function parseDate(value: string | undefined): ParsedDate | undefined {
-  if (!value) {
-    return undefined;
-  }
-  if (/^\d+$/.test(value)) {
-    const n = Number(value);
-    return unixToDate(value.length >= 13 ? Math.trunc(n / 1000) : n);
-  }
-  return parseCivilDate(value);
 }
 
 function channelDescription(doc: FeedDocument): string {
@@ -217,106 +232,100 @@ function pad(value: number, width: number): string {
   return String(value).padStart(width, "0");
 }
 
-function parseCivilDate(value: string): ParsedDate | undefined {
-  if (value.length < 10 || value[4] !== "-" || value[7] !== "-") {
-    return undefined;
-  }
-  const year = Number(value.slice(0, 4));
-  const month = Number(value.slice(5, 7));
-  const day = Number(value.slice(8, 10));
-  let hour = 0;
-  let minute = 0;
-  let second = 0;
-  let offset = 0;
-  if (value.length > 10) {
-    const rest = value.slice(10);
-    const time = rest.startsWith("T") || rest.startsWith(" ") ? rest.slice(1) : "";
-    if (time.length < 8 || time[2] !== ":" || time[5] !== ":") {
-      return undefined;
-    }
-    hour = Number(time.slice(0, 2));
-    minute = Number(time.slice(3, 5));
-    second = Number(time.slice(6, 8));
-    const parsedOffset = parseOffset(timezoneSuffix(time));
-    if (parsedOffset == null) {
-      return undefined;
-    }
-    offset = parsedOffset;
-  }
-  const unix = civilToUnix(year, month, day, hour, minute, second);
-  return unix == null ? undefined : unixToDate(unix - offset);
+function entryId(item: FeedEntry): string {
+  return item.id ?? item.loc;
 }
 
-function timezoneSuffix(rest: string): string {
-  const afterTime = rest.slice(8);
-  if (afterTime.startsWith(".")) {
-    const index = afterTime.search(/[Z+-]/);
-    return index === -1 ? "" : afterTime.slice(index);
-  }
-  return afterTime;
+function rssGuid(item: FeedEntry): string {
+  const id = entryId(item);
+  const attr = id === item.loc ? "" : ' isPermaLink="false"';
+  return `      <guid${attr}>${escapeXml(id)}</guid>\n`;
 }
 
-function parseOffset(tz: string): number | undefined {
-  if (!tz || tz === "Z") {
-    return 0;
+function rssItemMeta(item: FeedEntry): string {
+  let xml = "";
+  for (const author of item.authors ?? []) {
+    xml += `      <dc:creator>${escapeXml(author.name)}</dc:creator>\n`;
   }
-  if (tz.length < 6) {
-    return undefined;
+  if (item.language) {
+    xml += `      <dc:language>${escapeXml(item.language)}</dc:language>\n`;
   }
-  const sign = tz[0] === "+" ? 1 : tz[0] === "-" ? -1 : 0;
-  if (!sign) {
-    return undefined;
+  for (const attachment of item.attachments ?? []) {
+    xml += rssEnclosure(attachment);
   }
-  return sign * (Number(tz.slice(1, 3)) * 3600 + Number(tz.slice(4, 6)) * 60);
+  return xml;
 }
 
-function civilToUnix(
-  year: number,
-  month: number,
-  day: number,
-  hour: number,
-  minute: number,
-  second: number,
-): number | undefined {
-  if (month < 1 || month > 12 || day < 1 || day > 31 || hour > 23 || minute > 59 || second > 60) {
-    return undefined;
-  }
-  let y = year;
-  if (month <= 2) {
-    y -= 1;
-  }
-  const era = Math.trunc((y >= 0 ? y : y - 399) / 400);
-  const yoe = y - era * 400;
-  const shifted = month + (month > 2 ? -3 : 9);
-  const doy = Math.trunc((153 * shifted + 2) / 5) + day - 1;
-  const doe = yoe * 365 + Math.trunc(yoe / 4) - Math.trunc(yoe / 100) + doy;
-  const days = era * 146097 + doe - 719468;
-  return days * 86400 + hour * 3600 + minute * 60 + second;
+function rssEnclosure(attachment: FeedItemAttachment): string {
+  return `      <enclosure${xmlAttrs([
+    ["url", attachment.url],
+    ["type", attachment.mimeType],
+    ["length", attachment.sizeInBytes],
+  ])}/>\n`;
 }
 
-function unixToDate(unix: number): ParsedDate | undefined {
-  const days = Math.floor(unix / 86400);
-  const tod = ((unix % 86400) + 86400) % 86400;
-  const z = days + 719468;
-  const era = Math.trunc((z >= 0 ? z : z - 146096) / 146097);
-  const doe = z - era * 146097;
-  const yoe = Math.trunc(
-    (doe - Math.trunc(doe / 1460) + Math.trunc(doe / 36524) - Math.trunc(doe / 146096)) / 365,
-  );
-  const year = yoe + era * 400;
-  const doy = doe - (365 * yoe + Math.trunc(yoe / 4) - Math.trunc(yoe / 100));
-  const mp = Math.trunc((5 * doy + 2) / 153);
-  const day = doy - Math.trunc((153 * mp + 2) / 5) + 1;
-  const month = mp < 10 ? mp + 3 : mp - 9;
-  return {
-    unix,
-    year: year + (month <= 2 ? 1 : 0),
-    month,
-    day,
-    hour: Math.trunc(tod / 3600),
-    minute: Math.trunc((tod % 3600) / 60),
-    second: tod % 60,
-  };
+function atomAuthor(author: FeedItemAuthor): string {
+  const uri = author.url ? `\n      <uri>${escapeXml(author.url)}</uri>` : "";
+  return `    <author>\n      <name>${escapeXml(author.name)}</name>${uri}\n    </author>\n`;
+}
+
+function atomAttachment(attachment: FeedItemAttachment): string {
+  return `    <link${xmlAttrs([
+    ["rel", "enclosure"],
+    ["href", attachment.url],
+    ["type", attachment.mimeType],
+    ["length", attachment.sizeInBytes],
+    ["title", attachment.title],
+  ])}/>\n`;
+}
+
+function xmlAttrs(attrs: Array<[string, string | number | undefined]>): string {
+  return attrs
+    .flatMap(([key, value]) => (value == null ? [] : [` ${key}="${escapeXml(String(value))}"`]))
+    .join("");
+}
+
+function jsonItemMeta(item: FeedEntry): string {
+  let json = "";
+  if (item.authors?.length) {
+    json += ',\n      "authors": [';
+    json += item.authors.map(jsonAuthor).join(", ");
+    json += "]";
+  }
+  if (item.image) {
+    json += ',\n      "image": ';
+    json += jsonString(item.image);
+  }
+  if (item.language) {
+    json += ',\n      "language": ';
+    json += jsonString(item.language);
+  }
+  if (item.attachments?.length) {
+    json += ',\n      "attachments": [';
+    json += item.attachments.map(jsonAttachment).join(", ");
+    json += "]";
+  }
+  return json;
+}
+
+function jsonAuthor(author: FeedItemAuthor): string {
+  const url = author.url ? `, "url": ${jsonString(author.url)}` : "";
+  return `{\n        "name": ${jsonString(author.name)}${url}\n      }`;
+}
+
+function jsonAttachment(attachment: FeedItemAttachment): string {
+  const fields = [
+    `"url": ${jsonString(attachment.url)}`,
+    attachment.mimeType ? `"mime_type": ${jsonString(attachment.mimeType)}` : "",
+    attachment.title ? `"title": ${jsonString(attachment.title)}` : "",
+    numberJsonField("size_in_bytes", attachment.sizeInBytes),
+    numberJsonField("duration_in_seconds", attachment.durationInSeconds),
+  ].filter(Boolean);
+  return `{\n        ${fields.join(",\n        ")}\n      }`;
+}
+
+function numberJsonField(name: string, value: number | undefined): string {
+  return value == null ? "" : `"${name}": ${String(value)}`;
 }
 
 function weekdayUtc(year: number, month: number, day: number): number {

--- a/npm/vite-plugin-ox-content/src/feeds-items.ts
+++ b/npm/vite-plugin-ox-content/src/feeds-items.ts
@@ -1,15 +1,23 @@
-import { parseDate } from "./feed-format";
+import { parseDate } from "./feed-date";
 import type { FeedEntry } from "./feed-format";
 import { homePageUrl } from "./feeds-output";
 import { classifyPublishState } from "./publish-state";
-import type { ResolvedPublishStateOptions } from "./types";
-import type { FeedItemInput, FeedsRenderInput } from "./feeds";
+import type {
+  FeedItemAttachment,
+  FeedItemAuthor,
+  FeedItemInput,
+  ResolvedPublishStateOptions,
+} from "./types";
+import type { FeedsRenderInput } from "./feeds";
 
 const DEFAULT_LIMIT = 20;
 
 function rawItems(input: FeedsRenderInput): readonly FeedItemInput[] {
   if (input.items) {
     return input.items;
+  }
+  if (Array.isArray(input.options?.items)) {
+    return input.options.items;
   }
   const names = input.collectionNames ?? Object.keys(input.collections ?? {});
   const name = resolveFeedCollectionName(input.options?.collection, names);
@@ -71,14 +79,28 @@ function isExcludedFromFeed(
 }
 
 function normalizeItem(item: FeedItemInput, input: FeedsRenderInput): FeedEntry {
+  const description = stringField(item.description ?? item.frontmatter?.description);
+  const content = stringField(item.content ?? item.frontmatter?.content);
+  const loc = stringField(item.loc) ?? stringField(item.url) ?? itemLoc(input, item);
+  const id = usesProgrammaticItems(input) ? stringField(item.id) : undefined;
   return {
-    title: item.title ?? "",
-    description: typeof item.description === "string" ? item.description : undefined,
-    loc: item.loc || itemLoc(input, item),
+    title: stringField(item.title) ?? "",
+    description,
+    content,
+    loc,
+    id: id ?? loc,
     date:
       parseDate(dateField(item.date ?? item.frontmatter?.date)) ??
       parseDate(dateField(item.lastUpdated ?? item.frontmatter?.lastUpdated)),
+    authors: authorsField(item),
+    image: stringField(item.image ?? item.frontmatter?.image),
+    attachments: attachmentsField(item.attachments ?? item.frontmatter?.attachments),
+    language: stringField(item.language ?? item.frontmatter?.language),
   };
+}
+
+function usesProgrammaticItems(input: FeedsRenderInput): boolean {
+  return input.items !== undefined || Array.isArray(input.options?.items);
 }
 
 function itemLoc(input: FeedsRenderInput, item: FeedItemInput): string {
@@ -98,4 +120,72 @@ function dateField(value: unknown): string | undefined {
     return value.toISOString();
   }
   return undefined;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function authorsField(item: FeedItemInput): FeedItemAuthor[] | undefined {
+  const values: unknown[] = [];
+  values.push(item.author ?? item.frontmatter?.author);
+  const authors = item.authors ?? item.frontmatter?.authors;
+  if (Array.isArray(authors)) {
+    values.push(...authors);
+  } else {
+    values.push(authors);
+  }
+  const normalized = values.flatMap((value) => {
+    const author = normalizeAuthor(value);
+    return author ? [author] : [];
+  });
+  return normalized.length ? normalized : undefined;
+}
+
+function normalizeAuthor(value: unknown): FeedItemAuthor | undefined {
+  const name = typeof value === "string" ? value : isRecord(value) ? value.name : undefined;
+  if (typeof name !== "string" || !name.trim()) {
+    return undefined;
+  }
+  const url = isRecord(value) ? stringField(value.url) : undefined;
+  return { name: name.trim(), ...(url ? { url } : {}) };
+}
+
+function attachmentsField(value: unknown): FeedItemAttachment[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const attachments = value.flatMap((item) => {
+    if (!isRecord(item)) {
+      return [];
+    }
+    const url = stringField(item.url);
+    if (!url) {
+      return [];
+    }
+    return [
+      {
+        url,
+        ...copyString(item, "mimeType"),
+        ...copyString(item, "title"),
+        ...copyNumber(item, "sizeInBytes"),
+        ...copyNumber(item, "durationInSeconds"),
+      },
+    ];
+  });
+  return attachments.length ? attachments : undefined;
+}
+
+function copyString(record: Record<string, unknown>, key: string): Record<string, string> {
+  const value = stringField(record[key]);
+  return value ? { [key]: value } : {};
+}
+
+function copyNumber(record: Record<string, unknown>, key: string): Record<string, number> {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? { [key]: value } : {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value);
 }

--- a/npm/vite-plugin-ox-content/src/feeds-named.test.ts
+++ b/npm/vite-plugin-ox-content/src/feeds-named.test.ts
@@ -102,6 +102,25 @@ describe("resolveFeedsOptions named feeds", () => {
     expect(resolved.feeds?.[0]?.title).toBe("Blog");
     expect(resolved.feeds?.[1]?.language).toBe("ja");
   });
+
+  it("rejects channels that set both collection and items", () => {
+    expect(() =>
+      resolveFeedsOptions({
+        formats: ["rss"],
+        collection: "blog",
+        items: [],
+      }),
+    ).toThrow("cannot set both collection and items");
+    expect(() =>
+      resolveFeedsOptions({
+        media: {
+          formats: ["rss"],
+          collection: "media",
+          items: [],
+        },
+      }),
+    ).toThrow('"media"');
+  });
 });
 
 describe("generateFeeds channel metadata", () => {

--- a/npm/vite-plugin-ox-content/src/feeds-programmatic.test.ts
+++ b/npm/vite-plugin-ox-content/src/feeds-programmatic.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createDocsResolvedOptions } from "../test/fixtures/docs-fixture";
+import { resolveFeedsOptions } from "./feeds";
+import { buildSsg } from "./ssg";
+import type { FeedItemsResolveContext } from "./types";
+
+type MediaItem = {
+  title: string;
+  link: string;
+  pubDate: string;
+  lang: string;
+  kind?: "podcast" | "video";
+  playlist?: boolean;
+};
+
+const mediaJson: MediaItem[] = [
+  {
+    title: "Guest appearance",
+    link: "https://media.example.com/episode",
+    pubDate: "2026-08-01",
+    lang: "ja",
+    kind: "podcast",
+  },
+  {
+    title: "Playlist rollup",
+    link: "https://media.example.com/playlist",
+    pubDate: "2026-08-02",
+    lang: "ja",
+    kind: "video",
+    playlist: true,
+  },
+];
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("programmatic feeds", () => {
+  it("writes async JSON-backed media items during SSG", async () => {
+    const root = await makeSite();
+    let context: FeedItemsResolveContext | undefined;
+
+    const result = await buildSsg(
+      createDocsResolvedOptions({
+        feeds: resolveFeedsOptions({
+          media: {
+            formats: ["rss", "atom", "json"],
+            path: "/works/media",
+            title: "Media | ryoppippi.com",
+            language: "ja",
+            items: async (input) => {
+              context = input;
+              return mediaJson
+                .filter((item) => !item.playlist)
+                .map((item) => ({
+                  title: item.title,
+                  url: item.link,
+                  id: `media:${item.link}`,
+                  date: item.pubDate,
+                  description: `${item.kind === "podcast" ? "Podcast" : "YouTube"} | ${item.title}`,
+                  content: `Curated external media entry for ${item.title}.`,
+                  author: { name: "ryoppippi", url: "https://ryoppippi.com" },
+                  image: "https://media.example.com/cover.png",
+                  attachments: [
+                    {
+                      url: "https://media.example.com/episode.mp3",
+                      mimeType: "audio/mpeg",
+                      title: "Episode audio",
+                      sizeInBytes: 12345,
+                      durationInSeconds: 600,
+                    },
+                  ],
+                  language: item.lang,
+                }));
+            },
+          },
+        }),
+        ssg: {
+          ...createDocsResolvedOptions().ssg,
+          bare: true,
+          siteUrl: "https://ryoppippi.example",
+        },
+      }),
+      root,
+    );
+
+    expect(context).toMatchObject({ name: "media", path: "/works/media", base: "/" });
+    expect(result.files).toEqual(
+      expect.arrayContaining([
+        path.join(root, "dist", "works", "media", "feed.xml"),
+        path.join(root, "dist", "works", "media", "atom.xml"),
+        path.join(root, "dist", "works", "media", "feed.json"),
+      ]),
+    );
+
+    const rss = await fs.readFile(path.join(root, "dist", "works", "media", "feed.xml"), "utf8");
+    expect(rss).toContain("<title>Guest appearance</title>");
+    expect(rss).toContain(
+      '<guid isPermaLink="false">media:https://media.example.com/episode</guid>',
+    );
+    expect(rss).toContain("<dc:creator>ryoppippi</dc:creator>");
+    expect(rss).toContain('<enclosure url="https://media.example.com/episode.mp3"');
+    expect(rss).not.toContain("Playlist rollup");
+
+    const atom = await fs.readFile(path.join(root, "dist", "works", "media", "atom.xml"), "utf8");
+    expect(atom).toContain('<entry xml:lang="ja">');
+    expect(atom).toContain("<id>media:https://media.example.com/episode</id>");
+    expect(atom).toContain(
+      '<content type="text">Curated external media entry for Guest appearance.</content>',
+    );
+    expect(atom).toContain('<link rel="enclosure" href="https://media.example.com/episode.mp3"');
+
+    const json = JSON.parse(
+      await fs.readFile(path.join(root, "dist", "works", "media", "feed.json"), "utf8"),
+    ) as {
+      items: Array<{
+        id: string;
+        url: string;
+        summary: string;
+        content_text: string;
+        authors: Array<{ name: string; url: string }>;
+        image: string;
+        attachments: Array<{ url: string; mime_type: string; duration_in_seconds: number }>;
+        language: string;
+      }>;
+    };
+    expect(json.items).toEqual([
+      expect.objectContaining({
+        id: "media:https://media.example.com/episode",
+        url: "https://media.example.com/episode",
+        summary: "Podcast | Guest appearance",
+        content_text: "Curated external media entry for Guest appearance.",
+        authors: [{ name: "ryoppippi", url: "https://ryoppippi.com" }],
+        image: "https://media.example.com/cover.png",
+        language: "ja",
+      }),
+    ]);
+    expect(json.items[0]?.attachments[0]).toMatchObject({
+      url: "https://media.example.com/episode.mp3",
+      mime_type: "audio/mpeg",
+      duration_in_seconds: 600,
+    });
+    expect(result.errors).toEqual([]);
+  });
+});
+
+async function makeSite(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "ox-content-programmatic-feeds-"));
+  tempDirs.push(root);
+  const file = path.join(root, "content", "index.md");
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, "---\ntitle: Home\n---\n# Home\n", "utf8");
+  return root;
+}

--- a/npm/vite-plugin-ox-content/src/feeds.ts
+++ b/npm/vite-plugin-ox-content/src/feeds.ts
@@ -21,6 +21,8 @@ import { publishedItems } from "./feeds-items";
 import type {
   FeedChannelOptions,
   FeedFormat,
+  FeedItemInput,
+  FeedItemsResolveContext,
   FeedsOptions,
   ResolvedFeedChannel,
   ResolvedFeedsOptions,
@@ -33,6 +35,7 @@ const DEFAULT_PATH = "/";
 const CHANNEL_KEYS = new Set([
   "formats",
   "collection",
+  "items",
   "limit",
   "path",
   "title",
@@ -43,18 +46,7 @@ const CHANNEL_KEYS = new Set([
   "copyright",
 ]);
 
-/** One collection entry considered for a feed. */
-export interface FeedItemInput {
-  title?: string;
-  description?: string;
-  path?: string;
-  loc?: string;
-  date?: unknown;
-  lastUpdated?: unknown;
-  draft?: unknown;
-  unlisted?: unknown;
-  frontmatter?: Record<string, unknown>;
-}
+export type { FeedItemAttachment, FeedItemAuthor, FeedItemInput, FeedItemsSource } from "./types";
 
 /** Inputs for rendering feed bodies. */
 export interface FeedsRenderInput {
@@ -171,7 +163,12 @@ export async function writeFeedFiles(
 
   const files: string[] = [];
   for (const channel of channels) {
-    const generated = generateFeeds({ ...input, options: { enabled: true, ...channel } });
+    const channelItems = await resolveChannelItems(channel, input);
+    const generatedInput = channelItems === undefined ? input : { ...input, items: channelItems };
+    const generated = generateFeeds({
+      ...generatedInput,
+      options: { enabled: true, ...channel },
+    });
     if (generated.warning) {
       return { files: [], warning: generated.warning };
     }
@@ -198,6 +195,11 @@ export async function writeFeedFiles(
 }
 
 function resolveChannel(value: FeedChannelOptions, name?: string): ResolvedFeedChannel {
+  if (value.collection && value.items != null) {
+    throw new Error(
+      `[ox-content] feeds channel ${feedChannelName(name)} cannot set both collection and items`,
+    );
+  }
   const channel: ResolvedFeedChannel = {
     formats: normalizeFormats(value.formats),
     limit: value.limit ?? DEFAULT_LIMIT,
@@ -205,6 +207,9 @@ function resolveChannel(value: FeedChannelOptions, name?: string): ResolvedFeedC
   };
   if (value.collection) {
     channel.collection = value.collection;
+  }
+  if (value.items != null) {
+    channel.items = value.items;
   }
   if (name) {
     channel.name = name;
@@ -255,6 +260,46 @@ function normalizeFormats(formats: readonly FeedFormat[] | undefined): FeedForma
     }
   }
   return resolved;
+}
+
+async function resolveChannelItems(
+  channel: ResolvedFeedChannel,
+  input: WriteFeedFilesInput,
+): Promise<readonly FeedItemInput[] | undefined> {
+  const source = channel.items;
+  if (source == null) {
+    return undefined;
+  }
+  if (Array.isArray(source)) {
+    return source;
+  }
+  const items = await source(feedItemsContext(channel, input));
+  if (Array.isArray(items)) {
+    return items;
+  }
+  throw new Error(
+    `[ox-content] feeds channel ${feedChannelName(channel.name)} items must return an array`,
+  );
+}
+
+function feedItemsContext(
+  channel: ResolvedFeedChannel,
+  input: WriteFeedFilesInput,
+): FeedItemsResolveContext {
+  return {
+    name: channel.name,
+    formats: channel.formats,
+    path: channel.path,
+    siteUrl: input.siteUrl,
+    siteName: input.siteName,
+    siteDescription: input.siteDescription,
+    base: input.base,
+    outDir: input.outDir,
+  };
+}
+
+function feedChannelName(name: string | undefined): string {
+  return name ? JSON.stringify(name) : "default";
 }
 
 function feedDocument(input: FeedsRenderInput): FeedDocument {

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -147,6 +147,12 @@ export type {
   ResolvedBlogFeedSource,
   ResolvedBlogOptions,
   FeedFormat,
+  FeedItemAuthor,
+  FeedItemAuthorInput,
+  FeedItemAttachment,
+  FeedItemInput,
+  FeedItemsResolveContext,
+  FeedItemsSource,
   FeedChannelOptions,
   FeedsOptions,
   ResolvedFeedChannel,
@@ -876,7 +882,8 @@ export {
 } from "./publish-state";
 export { resolvePermalinksOptions, resolveCascadeOptions } from "./permalinks";
 export { resolveRedirectsOptions } from "./redirects";
-export { resolveFeedsOptions } from "./feeds";
+export { generateFeeds, resolveFeedsOptions } from "./feeds";
+export type { FeedsRenderInput, FeedsRenderResult, WriteFeedFilesInput } from "./feeds";
 export {
   BlogFeedError,
   resolveBlogOptions,

--- a/npm/vite-plugin-ox-content/src/public-exports.test.ts
+++ b/npm/vite-plugin-ox-content/src/public-exports.test.ts
@@ -21,6 +21,7 @@ describe("public export surface", () => {
       "extractDocs",
       "extractDocsTests",
       "generateCollectionsVirtualModule",
+      "generateFeeds",
       "generateMarkdown",
       "isMarkdownFilePath",
       "oxContent",

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -1124,6 +1124,61 @@ export interface ResolvedRedirectsOptions {
  */
 export type FeedFormat = "rss" | "atom" | "json";
 
+/** One feed item author accepted by programmatic feeds. */
+export interface FeedItemAuthor {
+  name: string;
+  url?: string;
+}
+
+export type FeedItemAuthorInput = string | FeedItemAuthor;
+
+/** One JSON Feed / enclosure attachment accepted by programmatic feeds. */
+export interface FeedItemAttachment {
+  url: string;
+  mimeType?: string;
+  title?: string;
+  sizeInBytes?: number;
+  durationInSeconds?: number;
+}
+
+/** One collection or programmatic item considered for a generated feed. */
+export interface FeedItemInput {
+  title?: string;
+  description?: string;
+  content?: string;
+  path?: string;
+  loc?: string;
+  url?: string;
+  id?: string;
+  date?: unknown;
+  lastUpdated?: unknown;
+  draft?: unknown;
+  unlisted?: unknown;
+  author?: FeedItemAuthorInput;
+  authors?: readonly FeedItemAuthorInput[];
+  image?: string;
+  attachments?: readonly FeedItemAttachment[];
+  language?: string;
+  frontmatter?: Record<string, unknown>;
+}
+
+export interface FeedItemsResolveContext {
+  name?: string;
+  formats: readonly FeedFormat[];
+  path: string;
+  siteUrl?: string;
+  siteName?: string;
+  siteDescription?: string;
+  base: string;
+  outDir?: string;
+}
+
+export type FeedItemsSource =
+  | readonly FeedItemInput[]
+  | ((
+      context: FeedItemsResolveContext,
+    ) => readonly FeedItemInput[] | Promise<readonly FeedItemInput[]>);
+
 /**
  * One feed's formats, source, output path, and channel metadata.
  */
@@ -1139,6 +1194,12 @@ export interface FeedChannelOptions {
    * configured collection when `content` is absent.
    */
   collection?: string;
+
+  /**
+   * Programmatic items for this channel. A channel may set either
+   * `collection` or `items`, not both.
+   */
+  items?: FeedItemsSource;
 
   /**
    * Maximum number of published items, newest first.
@@ -1189,6 +1250,7 @@ export interface ResolvedFeedChannel {
   name?: string;
   formats: readonly FeedFormat[];
   collection?: string;
+  items?: FeedItemsSource;
   limit: number;
   path: string;
   title?: string;


### PR DESCRIPTION
## Summary
- add async programmatic item sources for feed channels during SSG
- render shared item metadata across RSS, Atom, and JSON Feed outputs
- keep collection feed GUIDs tied to final URLs while allowing explicit programmatic item ids
- document JSON-backed media feed usage and credit @ryoppippi

Closes #1038.

## Validation
- corepack pnpm --filter @ox-content/vite-plugin exec vp check --fix src/feeds.ts src/feeds-items.ts src/feed-format.ts src/feed-date.ts src/feeds-named.test.ts src/feeds-programmatic.test.ts src/index.ts src/public-exports.test.ts src/types.ts src/blog-posts.ts src/blog-feed-date.ts
- corepack pnpm --filter @ox-content/vite-plugin exec vp test src/feeds.test.ts src/feeds-named.test.ts src/feeds-write.test.ts src/feeds-programmatic.test.ts src/public-exports.test.ts src/ssg-output.test.ts src/blog-feeds.test.ts src/blog-feed-date.test.ts src/blog-ssg-feeds.test.ts src/blog-ssg.test.ts src/ssg.test.ts
- node scripts/check-file-lines.ts
- git diff --check
- vp run test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790365417&installation_model_id=422833&pr_number=1044&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1044&signature=f0bd09abf47b2745ce061c2f6a4132629b7ecbe326c585caa99bcc6a5760e949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->