### PR TITLE
fix(svelte): hydrate server-rendered islands

### DIFF
--- a/docs/content/ja/mdx.md
+++ b/docs/content/ja/mdx.md
@@ -129,10 +129,11 @@ specifier はそのファイルのディレクトリから解決されます。�
 
 グローバルな `components` マップは、ローカル import を書かないページ向けの
 後方互換フォールバックのままです。フレームワークプラグインは任意で
-`renderIsland(name, props, filePath)` フックを渡し、transform 時に island の
-内側 HTML を差し替えられます。そのフックはアダプタ側に置きます。コア
-レンダラーは `react-dom/server`、`svelte/server`、`solid-js/web` を
-import しません。
+`renderIsland(name, props, filePath, slotHtml)` フックを渡し、transform 時に
+island の内側 HTML を差し替えられます。アダプタがサーバーで描画した HTML は
+server-rendered として印が付き、クライアント runtime は重複した subtree を
+mount せず hydrate できます。そのフックはアダプタ側に置きます。コア
+レンダラーは `react-dom/server`、`svelte/server`、`solid-js/web` を import しません。
 
 ## Markdown でコンポーネントを書く
 
@@ -299,7 +300,9 @@ Props は JSX 風の構文です。次の形を認識します。
 各コンポーネントは生成 HTML の island ラッパーになります。ブロックレベルの
 コンポーネントは `<div data-ox-island="Name" …>`、インラインは
 `<span data-ox-island="Name" …>` です。対応するフレームワークランタイムが、
-クライアントで本物のコンポーネントをその要素へマウントします。
+クライアントで本物のコンポーネントをその要素へマウントします。アダプタが
+すでにサーバーでコンポーネント HTML を描画している場合、island wrapper には
+`data-ox-ssr="true"` が付き、対応 runtime は既存 DOM を hydrate できます。
 
 ハイドレーションのタイミングはロード戦略で制御します
 （[`@ox-content/islands`](./packages/vite-plugin-ox-content.md) を見てください）。

--- a/docs/content/mdx.md
+++ b/docs/content/mdx.md
@@ -128,9 +128,11 @@ component file invalidates the Markdown module through Vite HMR.
 
 The global `components` map remains the backwards-compatible fallback for pages
 that do not declare a local import. Framework plugins may also pass an optional
-`renderIsland(name, props, filePath)` hook to replace island inner HTML at
-transform time. That hook lives on the adapter; the core renderer does not
-import `react-dom/server`, `svelte/server`, or `solid-js/web`.
+`renderIsland(name, props, filePath, slotHtml)` hook to replace island inner HTML
+at transform time. Adapter-rendered HTML is marked as server-rendered so the
+client runtime can hydrate it instead of mounting a duplicate subtree. That hook
+lives on the adapter; the core renderer does not import `react-dom/server`,
+`svelte/server`, or `solid-js/web`.
 
 ## Authoring components in Markdown
 
@@ -303,7 +305,9 @@ the payload.
 Each component becomes an island wrapper in the generated HTML — a block-level
 component renders as a `<div data-ox-island="Name" …>` and an inline one as a
 `<span data-ox-island="Name" …>`. The matching framework runtime mounts the real
-component into that element on the client.
+component into that element on the client. When an adapter has already rendered
+the component HTML on the server, the island wrapper carries `data-ox-ssr="true"`
+so compatible runtimes can hydrate the existing DOM instead.
 
 Hydration timing is controlled by a load strategy (see
 [`@ox-content/islands`](./packages/vite-plugin-ox-content.md)):

--- a/docs/content/packages/vite-plugin-ox-content-svelte.md
+++ b/docs/content/packages/vite-plugin-ox-content-svelte.md
@@ -95,8 +95,10 @@ import GtvChart from './gtv-chart/GtvChart.svelte'
 <GtvChart title="ok" />
 ```
 
-Optional `renderIsland(name, props, filePath)` can replace island inner HTML
-at transform time. The hook belongs on the Svelte adapter; `@ox-content/vite-plugin`
+Optional `renderIsland(name, props, filePath, slotHtml)` can replace island
+inner HTML at transform time. Server-rendered islands are marked and adopted
+with Svelte 5 `hydrate()` on the client, while islands without SSR markup keep
+using `mount()`. The hook belongs on the Svelte adapter; `@ox-content/vite-plugin`
 does not import `svelte/server`.
 
 ## Example Component (Svelte 5 Runes)

--- a/npm/ox-content-islands/src/runtime.ts
+++ b/npm/ox-content-islands/src/runtime.ts
@@ -49,6 +49,7 @@ function parseIslandConfig(element: HTMLElement): IslandConfig {
     load,
     mediaQuery,
     props,
+    ssr: element.dataset.oxSsr === "true",
   };
 }
 

--- a/npm/ox-content-islands/src/types.ts
+++ b/npm/ox-content-islands/src/types.ts
@@ -28,6 +28,8 @@ export interface IslandConfig {
   mediaQuery?: string;
   /** Component props (JSON serialized in data-ox-props) */
   props: Record<string, unknown>;
+  /** Whether the island wrapper already contains server-rendered component HTML. */
+  ssr?: boolean;
 }
 
 /**

--- a/npm/vite-plugin-ox-content-svelte/package.json
+++ b/npm/vite-plugin-ox-content-svelte/package.json
@@ -46,6 +46,7 @@
     "@sveltejs/vite-plugin-svelte": "catalog:",
     "@types/node": "catalog:",
     "@typescript/native-preview": "catalog:",
+    "playwright": "^1.62.1",
     "svelte": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",

--- a/npm/vite-plugin-ox-content-svelte/src/__snapshots__/transform.test.ts.snap
+++ b/npm/vite-plugin-ox-content-svelte/src/__snapshots__/transform.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`transformMarkdownWithSvelte > discovers nested, expression, and fragment islands from the MDX AST 1`] = `
 "import 'svelte/internal/disclose-version';
 import * as $ from 'svelte/internal/client';
-import { createRawSnippet, onMount, mount, unmount } from 'svelte';
+import { createRawSnippet, hydrate, mount, onMount, unmount } from 'svelte';
 import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
 import Callout from '../src/components/Callout.svelte';
 import Badge from '../src/components/Badge.svelte';
@@ -34,7 +34,8 @@ export default function Nested_mdx($$anchor, $$props) {
 				componentProps.children = createRawSnippet(() => ({ render: () => \`<div>\${islandContent}</div>\` }));
 			}
 
-			const instance = mount(Component, { target: element, props: componentProps });
+			const attach = element.dataset.oxSsr === 'true' ? hydrate : mount;
+			const instance = attach(Component, { target: element, props: componentProps });
 
 			mounted.push(instance);
 
@@ -66,7 +67,7 @@ export const frontmatter = {};"
 exports[`transformMarkdownWithSvelte > discovers nested, expression, and fragment islands from the MDX AST 2`] = `
 "import 'svelte/internal/disclose-version';
 import * as $ from 'svelte/internal/client';
-import { createRawSnippet, onMount, mount, unmount } from 'svelte';
+import { createRawSnippet, hydrate, mount, onMount, unmount } from 'svelte';
 import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
 import Alert from '../src/components/Alert.svelte';
 
@@ -96,7 +97,8 @@ export default function Expr_mdx($$anchor, $$props) {
 				componentProps.children = createRawSnippet(() => ({ render: () => \`<div>\${islandContent}</div>\` }));
 			}
 
-			const instance = mount(Component, { target: element, props: componentProps });
+			const attach = element.dataset.oxSsr === 'true' ? hydrate : mount;
+			const instance = attach(Component, { target: element, props: componentProps });
 
 			mounted.push(instance);
 
@@ -128,7 +130,7 @@ export const frontmatter = {};"
 exports[`transformMarkdownWithSvelte > discovers nested, expression, and fragment islands from the MDX AST 3`] = `
 "import 'svelte/internal/disclose-version';
 import * as $ from 'svelte/internal/client';
-import { createRawSnippet, onMount, mount, unmount } from 'svelte';
+import { createRawSnippet, hydrate, mount, onMount, unmount } from 'svelte';
 import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
 import Alert from '../src/components/Alert.svelte';
 
@@ -158,7 +160,8 @@ export default function Fragment_mdx($$anchor, $$props) {
 				componentProps.children = createRawSnippet(() => ({ render: () => \`<div>\${islandContent}</div>\` }));
 			}
 
-			const instance = mount(Component, { target: element, props: componentProps });
+			const attach = element.dataset.oxSsr === 'true' ? hydrate : mount;
+			const instance = attach(Component, { target: element, props: componentProps });
 
 			mounted.push(instance);
 
@@ -213,7 +216,7 @@ export const frontmatter = {};"
 exports[`transformMarkdownWithSvelte > turns registered components into islands and leaves fenced tags literal 1`] = `
 "import 'svelte/internal/disclose-version';
 import * as $ from 'svelte/internal/client';
-import { createRawSnippet, onMount, mount, unmount } from 'svelte';
+import { createRawSnippet, hydrate, mount, onMount, unmount } from 'svelte';
 import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
 import Alert from '../src/components/Alert.svelte';
 
@@ -243,7 +246,8 @@ export default function Svelte_md($$anchor, $$props) {
 				componentProps.children = createRawSnippet(() => ({ render: () => \`<div>\${islandContent}</div>\` }));
 			}
 
-			const instance = mount(Component, { target: element, props: componentProps });
+			const attach = element.dataset.oxSsr === 'true' ? hydrate : mount;
+			const instance = attach(Component, { target: element, props: componentProps });
 
 			mounted.push(instance);
 

--- a/npm/vite-plugin-ox-content-svelte/src/hydration.test.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/hydration.test.ts
@@ -1,0 +1,249 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { svelte as sveltePlugin } from "@sveltejs/vite-plugin-svelte";
+import { compile } from "svelte/compiler";
+import { render } from "svelte/server";
+import { createServer, type ViteDevServer } from "vite";
+import { chromium, type Browser } from "playwright";
+import { describe, expect, it } from "vite-plus/test";
+import { transformMarkdownWithSvelte } from "./transform";
+import type { Component } from "svelte";
+import type { ResolvedSvelteOptions } from "./types";
+
+declare global {
+  interface Window {
+    __destroy: () => void | Promise<void>;
+    __pageHydrated?: boolean;
+  }
+}
+
+const DIRNAME = path.dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = path.resolve(DIRNAME, "..");
+const ISLANDS_ENTRY = path.resolve(DIRNAME, "../../ox-content-islands/src/index.ts");
+const ISLANDS_ROOT = path.resolve(DIRNAME, "../../ox-content-islands");
+
+describe("Svelte island hydration", () => {
+  it("hydrates server-rendered MDX islands without duplicating markup", async () => {
+    const root = await mkdtemp(path.join(PACKAGE_ROOT, ".tmp-hydration-"));
+    let browser: Browser | undefined;
+    let server: ViteDevServer | undefined;
+
+    try {
+      await mkdir(path.join(root, "docs"), { recursive: true });
+      await writeFile(path.join(root, "docs", "Counter.svelte"), COUNTER_SVELTE);
+      const serverCounterPath = path.join(root, "docs", "Counter.server.mjs");
+      await writeFile(
+        serverCounterPath,
+        compile(COUNTER_SVELTE, {
+          filename: "Counter.svelte",
+          generate: "server",
+          runes: true,
+        }).js.code,
+      );
+      const serverCounter = (await import(
+        `${pathToFileURL(serverCounterPath).href}?t=${Date.now()}`
+      )) as { default: Component<Record<string, unknown>> };
+
+      server = await createServer({
+        root,
+        appType: "mpa",
+        logLevel: "silent",
+        plugins: [sveltePlugin()],
+        resolve: {
+          alias: {
+            "@ox-content/islands": ISLANDS_ENTRY,
+          },
+        },
+        server: {
+          host: "127.0.0.1",
+          port: 0,
+          strictPort: false,
+          fs: {
+            allow: [root, PACKAGE_ROOT, ISLANDS_ROOT],
+          },
+        },
+      });
+      await server.listen();
+
+      const markdown = [
+        "import Counter from './Counter.svelte'",
+        "",
+        '<Counter initial={1} label="Clicks">',
+        "  <strong>ready</strong>",
+        "</Counter>",
+      ].join("\n");
+      const documentPath = path.join(root, "docs", "page.mdx");
+      const options = createOptions({
+        components: {},
+        root,
+        renderIsland: async (_name, props, _filePath, slotHtml) => {
+          const componentProps = { ...props };
+          if (slotHtml?.trim()) {
+            componentProps.children = (renderer: { push(html: string): void }) => {
+              renderer.push(`<div>${slotHtml}</div>`);
+            };
+          }
+          return render(serverCounter.default, { props: componentProps }).html;
+        },
+      });
+
+      const ssrResult = await transformMarkdownWithSvelte(markdown, documentPath, {
+        ...options,
+        ssr: true,
+      });
+      const clientResult = await transformMarkdownWithSvelte(markdown, documentPath, {
+        ...options,
+        ssr: false,
+      });
+      expect(ssrResult.code).toContain('data-ox-ssr=\\"true\\"');
+      expect(clientResult.code).toContain("element.dataset.oxSsr === 'true' ? hydrate : mount");
+
+      await writeFile(path.join(root, "docs", "page-server.mjs"), ssrResult.code);
+      await writeFile(path.join(root, "docs", "page-client.mjs"), clientResult.code);
+      await writeFile(
+        path.join(root, "docs", "entry.js"),
+        [
+          "import Page from './page-client.mjs';",
+          "import { hydrate, unmount } from 'svelte';",
+          "const instance = hydrate(Page, { target: document.getElementById('app') });",
+          "window.__destroy = () => unmount(instance);",
+          "window.__pageHydrated = true;",
+        ].join("\n"),
+      );
+
+      const pageModule = (await server.ssrLoadModule("/docs/page-server.mjs")) as {
+        default: Component<Record<string, unknown>>;
+      };
+      const pageHtml = render(pageModule.default).html;
+      expect(pageHtml).toContain('data-testid="counter"');
+      expect(pageHtml).toContain('data-testid="slot"');
+      expect(countOccurrences(pageHtml, 'data-testid="counter"')).toBe(1);
+      await writeFile(
+        path.join(root, "docs", "index.html"),
+        [
+          "<!doctype html><html><body>",
+          `<div id="app">${pageHtml}</div>`,
+          '<script type="module" src="/docs/entry.js"></script>',
+          "</body></html>",
+        ].join(""),
+      );
+
+      browser = await chromium.launch({
+        channel: process.env.CI ? "chrome" : undefined,
+        headless: true,
+      });
+      const page = await browser.newPage();
+      const browserDiagnostics: string[] = [];
+      page.on("console", (message) => {
+        browserDiagnostics.push(`${message.type()}: ${message.text()}`);
+      });
+      page.on("pageerror", (error) => {
+        browserDiagnostics.push(`pageerror: ${error.message}`);
+      });
+      const response = await page.goto(`${serverUrl(server)}/docs/index.html`);
+      expect(response?.status()).toBe(200);
+      await page.waitForFunction(() => window.__pageHydrated === true);
+      await page.waitForFunction(() => {
+        const island = document.querySelector("[data-ox-island]");
+        return island?.getAttribute("data-ox-hydrated") === "true";
+      });
+      await page.waitForFunction(
+        () => document.querySelectorAll('[data-testid="counter"]').length === 1,
+      );
+      await page.waitForFunction(
+        () => document.querySelectorAll('[data-testid="slot"]').length === 1,
+      );
+      await page.locator('[data-testid="counter"]').waitFor({ state: "attached" });
+      await page.locator('[data-testid="slot"]').waitFor({ state: "attached" });
+
+      const counterCount = await page.locator('[data-testid="counter"]').count();
+      if (counterCount !== 1) {
+        throw new Error(
+          [
+            `Expected one hydrated counter, received ${counterCount}.`,
+            `Console: ${browserDiagnostics.join("\n")}`,
+            `HTML: ${await page.content()}`,
+          ].join("\n"),
+        );
+      }
+      const islandState = await page.locator("[data-ox-island]").evaluate((element) => ({
+        innerHTML: element.innerHTML,
+        oxContent: (element as HTMLElement).dataset.oxContent,
+      }));
+      expect(islandState.oxContent).toContain("<p><strong>ready</strong></p>");
+      expect(islandState.innerHTML).toContain('data-testid="slot"');
+      expect(await page.locator('[data-testid="slot"]').count()).toBe(1);
+      expect(await page.locator('[data-ox-island][data-ox-ssr="true"]').count()).toBe(1);
+      expect(await page.locator('[data-ox-island][data-ox-hydrated="true"]').count()).toBe(1);
+      expect(await page.locator('[data-testid="button"]').textContent()).toBe("Clicks: 1");
+      await page.locator('[data-testid="button"]').click();
+      await page.waitForFunction(
+        () => document.querySelector('[data-testid="button"]')?.textContent === "Clicks: 2",
+      );
+
+      await page.evaluate(() => window.__destroy());
+      await page.waitForFunction(() => document.querySelector("#app")?.childElementCount === 0);
+    } finally {
+      await browser?.close();
+      await server?.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps non-SSR islands on the mount path", async () => {
+    const result = await transformMarkdownWithSvelte(
+      "import Counter from './Counter.svelte'\n\n<Counter initial={1} />\n",
+      "/repo/docs/page.mdx",
+      createOptions({ components: {} }),
+    );
+
+    expect(result.code).toContain("element.dataset.oxSsr === 'true' ? hydrate : mount");
+    expect(result.code).not.toContain('data-ox-ssr="true"');
+  });
+});
+
+function createOptions(overrides: Partial<ResolvedSvelteOptions> = {}): ResolvedSvelteOptions {
+  return {
+    srcDir: "docs",
+    outDir: "dist",
+    base: "/",
+    extensions: [".md", ".markdown", ".mdx"],
+    gfm: true,
+    autolinks: true,
+    frontmatter: true,
+    toc: true,
+    tocMaxDepth: 3,
+    codeAnnotations: { enabled: false, metaKey: "annotate" },
+    components: { Counter: "./docs/Counter.svelte" },
+    runes: true,
+    embeds: { github: false, openGraph: false },
+    root: "/repo",
+    mdxDocumentProps: false,
+    ...overrides,
+  } as ResolvedSvelteOptions;
+}
+
+function serverUrl(server: ViteDevServer): string {
+  const url = server.resolvedUrls?.local[0];
+  if (!url) throw new Error("Vite server did not expose a local URL.");
+  return url.replace(/\/$/, "");
+}
+
+function countOccurrences(value: string, needle: string): number {
+  return value.split(needle).length - 1;
+}
+
+const COUNTER_SVELTE = `
+<script>
+  let { initial = 0, label = 'Clicks', children } = $props();
+  let count = $state(initial);
+</script>
+
+<section data-testid="counter">
+  <button data-testid="button" onclick={() => count += 1}>{label}: {count}</button>
+  {#if children}
+    <div data-testid="slot">{@render children()}</div>
+  {/if}
+</section>
+`;

--- a/npm/vite-plugin-ox-content-svelte/src/transform.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/transform.ts
@@ -1040,7 +1040,7 @@ function generateSvelteModule(
 
   return `
 <script>
-  import { createRawSnippet, onMount, mount, unmount } from 'svelte';
+  import { createRawSnippet, hydrate, mount, onMount, unmount } from 'svelte';
   import { initIslands, readIslandSlotHtml } from '@ox-content/islands';
   ${imports}
 
@@ -1070,7 +1070,8 @@ ${componentMap}
         }));
       }
 
-      const instance = mount(Component, { target: element, props: componentProps });
+      const attach = element.dataset.oxSsr === 'true' ? hydrate : mount;
+      const instance = attach(Component, { target: element, props: componentProps });
       mounted.push(instance);
 
       return () => unmount(instance);

--- a/npm/vite-plugin-ox-content-svelte/src/types.ts
+++ b/npm/vite-plugin-ox-content-svelte/src/types.ts
@@ -110,6 +110,7 @@ export interface SvelteIntegrationOptions extends OxContentOptions {
 
   /**
    * Optional adapter hook that replaces island inner HTML at transform time.
+   * The fourth argument receives the original slot HTML, when present.
    * The core renderer stays framework-neutral; do not import a framework SSR
    * runtime from `@ox-content/vite-plugin`.
    */

--- a/npm/vite-plugin-ox-content/src/island-ssr.test.ts
+++ b/npm/vite-plugin-ox-content/src/island-ssr.test.ts
@@ -6,18 +6,23 @@ describe("applyIslandSsrHtml", () => {
     const html = [
       '<div class="ox-island" data-ox-island="GtvChart" data-ox-props="{&quot;props&quot;:{&quot;title&quot;:&quot;ok&quot;}}">',
       '<script type="application/json">{"props":{"title":"ok"}}</script>',
+      "<p>Original slot</p>",
       "</div>",
     ].join("");
 
     const rendered = await applyIslandSsrHtml(
       html,
-      (name, props, filePath) =>
-        `<span class="ssr">${name}:${String(props.title)}:${filePath}</span>`,
+      (name, props, filePath, slotHtml) =>
+        `<span class="ssr">${name}:${String(props.title)}:${filePath}:${slotHtml}</span>`,
       "/repo/docs/guide.mdx",
     );
 
-    expect(rendered).toContain('<span class="ssr">GtvChart:ok:/repo/docs/guide.mdx</span>');
+    expect(rendered).toContain(
+      '<span class="ssr">GtvChart:ok:/repo/docs/guide.mdx:<p>Original slot</p></span>',
+    );
     expect(rendered).toContain('data-ox-island="GtvChart"');
+    expect(rendered).toContain('data-ox-ssr="true"');
+    expect(rendered).toContain("data-ox-content='&lt;p&gt;Original slot&lt;/p&gt;'");
     expect(rendered).toContain('<script type="application/json">');
     expect(rendered).not.toContain("svelte/server");
     expect(rendered).not.toContain("react-dom/server");

--- a/npm/vite-plugin-ox-content/src/island-ssr.ts
+++ b/npm/vite-plugin-ox-content/src/island-ssr.ts
@@ -2,14 +2,16 @@
  * Optional adapter-side island SSR.
  *
  * Framework plugins may supply `renderIsland` to replace island inner HTML at
- * transform time. This helper stays framework-neutral and does not import a
- * framework SSR runtime.
+ * transform time. The hook receives the original slot HTML so adapters can pass
+ * children into their SSR runtime. This helper stays framework-neutral and does
+ * not import a framework SSR runtime.
  */
 
 export type RenderIslandFn = (
   name: string,
   props: Record<string, unknown>,
   filePath: string,
+  slotHtml?: string,
 ) => string | Promise<string>;
 
 const RUST_PAYLOAD_KEYS = new Set(["props", "expressions", "spreads"]);
@@ -32,10 +34,19 @@ export async function applyIslandSsrHtml(
     const inner = output.slice(island.innerStart, island.closeStart);
     const scriptMatch = inner.match(PAYLOAD_SCRIPT);
     const script = scriptMatch?.[0] ?? "";
+    const slotHtml = inner.slice(script.length);
     const props = parseIslandProps(island.propsAttr, script);
-    const ssrHtml = await renderIsland(island.name, props, filePath);
+    const ssrHtml = await renderIsland(island.name, props, filePath, slotHtml);
+    const openTag = markIslandServerRendered(
+      output.slice(island.openStart, island.openEnd),
+      slotHtml,
+    );
     output =
-      output.slice(0, island.innerStart) + script + ssrHtml + output.slice(island.closeStart);
+      output.slice(0, island.openStart) +
+      openTag +
+      script +
+      ssrHtml +
+      output.slice(island.closeStart);
   }
 
   return output;
@@ -43,6 +54,8 @@ export async function applyIslandSsrHtml(
 
 interface IslandRange {
   name: string;
+  openStart: number;
+  openEnd: number;
   innerStart: number;
   closeStart: number;
   propsAttr?: string;
@@ -60,6 +73,8 @@ function findIslandRanges(html: string): IslandRange[] {
     const closeStart = findMatchingClose(html, innerStart, tag);
     ranges.push({
       name,
+      openStart: match.index,
+      openEnd: innerStart,
       innerStart,
       closeStart,
       propsAttr: matchAttr(match[2] ?? "", "data-ox-props"),
@@ -106,6 +121,27 @@ function indexOfTagOpen(html: string, openNeedle: string, from: number): number 
 function matchAttr(attrs: string, name: string): string | undefined {
   const match = new RegExp(`\\b${name}="([^"]*)"`, "i").exec(attrs);
   return match?.[1] === undefined ? undefined : decodeHtmlAttr(match[1]);
+}
+
+function markIslandServerRendered(openTag: string, slotHtml: string): string {
+  const attrs = hasAttr(openTag, "data-ox-ssr") ? [] : ['data-ox-ssr="true"'];
+  if (slotHtml.trim() && !hasAttr(openTag, "data-ox-content")) {
+    attrs.push(`data-ox-content='${escapeSingleQuotedAttr(slotHtml)}'`);
+  }
+  if (attrs.length === 0) return openTag;
+  return openTag.replace(/>$/, ` ${attrs.join(" ")}>`);
+}
+
+function hasAttr(openTag: string, name: string): boolean {
+  return new RegExp(`\\s${name}(?:\\s*=|\\s|>|$)`, "i").test(openTag);
+}
+
+function escapeSingleQuotedAttr(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("'", "&#39;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
 }
 
 function parseIslandProps(propsAttr: string | undefined, script: string): Record<string, unknown> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,8 +257,6 @@ importers:
         specifier: ^3.8.6
         version: 3.8.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.2.0)
 
-  crates/ox_content_wasm/pkg: {}
-
   deploy: {}
 
   docs:
@@ -2269,6 +2267,9 @@ importers:
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260707.2
+      playwright:
+        specifier: ^1.62.1
+        version: 1.62.1
       svelte:
         specifier: 'catalog:'
         version: 5.56.10
@@ -2335,7 +2336,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: 4.1.11
-        version: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
+        version: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11))(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
       vscode-languageclient:
         specifier: ^10.1.0
         version: 10.1.0
@@ -12009,12 +12010,12 @@ snapshots:
       vite: '@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)'
       vue: 3.5.41(typescript@7.0.2)
 
-  '@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.11)':
+  '@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.3(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.11)
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
+      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11))(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -12025,15 +12026,15 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.3(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11)
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
+      '@vitest/browser': 4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11))(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.11)':
+  '@vitest/browser@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))':
     dependencies:
       '@blazediff/core': 1.9.1
       '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
@@ -12042,7 +12043,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11))(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -12050,7 +12051,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11)':
+  '@vitest/browser@4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))':
     dependencies:
       '@blazediff/core': 1.9.1
       '@vitest/mocker': 4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
@@ -12059,7 +12060,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11))(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -16244,8 +16245,8 @@ snapshots:
     dependencies:
       '@oxc-project/types': 0.143.0
       '@oxlint/plugins': 1.73.0
-      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.11)
-      '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.11)
+      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))
+      '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
@@ -16257,7 +16258,7 @@ snapshots:
       oxfmt: 0.62.0(svelte@5.56.10)(vite-plus@0.2.9(@types/node@26.2.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(jiti@1.21.7)(svelte@5.56.10)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
       oxlint: 1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@26.2.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(jiti@1.21.7)(svelte@5.56.10)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
       oxlint-tsgolint: 7.0.2001
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.9
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.9
@@ -16302,7 +16303,7 @@ snapshots:
     dependencies:
       '@oxc-project/types': 0.143.0
       '@oxlint/plugins': 1.73.0
-      '@vitest/browser': 4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11)
+      '@vitest/browser': 4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)))
       '@vitest/browser-preview': 4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11)
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
@@ -16315,7 +16316,7 @@ snapshots:
       oxfmt: 0.62.0(svelte@5.56.10)(vite-plus@0.2.9(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(svelte@5.56.10)(terser@5.49.0)(typescript@7.0.2)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(yaml@2.9.0))
       oxlint: 1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(svelte@5.56.10)(terser@5.49.0)(typescript@7.0.2)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(yaml@2.9.0))
       oxlint-tsgolint: 7.0.2001
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11))(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.9
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.9
@@ -16432,7 +16433,7 @@ snapshots:
       - unrun
       - yaml
 
-  vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)):
+  vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))
@@ -16456,11 +16457,11 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.2.0
-      '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.11)
+      '@vitest/browser-preview': 4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)):
+  vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.11))(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@8.0.14(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.0)(yaml@2.9.0))


### PR DESCRIPTION
## Summary

- mark adapter-rendered MDX islands as SSR output while preserving their original slot HTML for client hydration
- switch the Svelte island runtime path to `hydrate()` only for server-rendered islands and keep non-SSR islands on `mount()`
- add a Playwright-backed Svelte fixture that proves SSR markup is adopted without duplicate counters or slots

Closes #1052

## Verification

- `vp install --frozen-lockfile --prefer-offline`
- `corepack pnpm --filter @ox-content/vite-plugin-svelte exec vp test`
- `corepack pnpm --filter @ox-content/vite-plugin exec vp test src/island-ssr.test.ts`
- `corepack pnpm --filter @ox-content/islands exec vp test`
- `corepack pnpm --filter @ox-content/vite-plugin-svelte exec vp check --fix`
- `corepack pnpm --filter @ox-content/vite-plugin exec vp check --fix src/island-ssr.ts src/island-ssr.test.ts`
- `corepack pnpm --filter @ox-content/islands exec vp check --fix`
- `corepack pnpm --filter @ox-content/vite-plugin-svelte exec vp pack`
- `corepack pnpm --filter @ox-content/islands exec vp pack`
- `corepack pnpm --filter @ox-content/vite-plugin exec vp pack`
- `node scripts/check-file-lines.ts`
- `git diff --check`

## Credits

Thanks @ryoppippi for the report and repro direction.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790381446&installation_model_id=422833&pr_number=1056&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1056&signature=50f85ffa816b427b77b906678c0e8b4508eb41aa1766293909bb038e44340d56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-rendered islands now hydrate existing HTML without creating duplicate content.
  * Island rendering preserves and passes through original slot content.
  * Islands without server-rendered HTML continue using standard mounting behavior.

* **Documentation**
  * Updated guides to explain server-rendered island hydration, slot content, and the optional rendering parameter.

* **Tests**
  * Added coverage for server rendering, hydration, slot content, interactivity, and non-server-rendered islands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->