### PR TITLE
fix(embeds): repair Open Graph card metadata and drop the favicon beacon

### DIFF
--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -167,6 +167,17 @@ Unreachable pages fall back to a plain link card. Requests to localhost,
 private IP ranges, and non-HTTP(S) schemes are rejected, so Markdown content
 cannot probe the network the build runs in.
 
+Card text is decoded from the page's own markup, so an `og:title` written as
+`Tips &amp; Tricks` renders as `Tips & Tricks`. An `og:image` is resolved
+against the page it was declared on — absolute, protocol-relative, and
+document-relative forms all work — and is dropped when it resolves somewhere
+the fetcher would refuse to go.
+
+The favicon comes from the target page's own `<link rel="icon">`, falling back
+to `/favicon.ico` on that origin. No third-party favicon service is contacted,
+so rendering a card never tells an outside host which links a documentation
+page carries.
+
 ## Package Manager Tabs
 
 `embeds.pm` expands one npm-style command into an accessible tab group for

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -143,6 +143,10 @@ GitHub issue、pull request、commit、discussion、gist の URL も、同じ
 
 届かないページはプレーンなリンクカードに落ちます。localhost、プライベート IP 範囲、HTTP(S) 以外のスキームへのリクエストは拒否するので、Markdown 本文がビルド環境のネットワークを探れません。
 
+カードのテキストはページ自身のマークアップからデコードするので、`Tips &amp; Tricks` と書かれた `og:title` は `Tips & Tricks` として描画されます。`og:image` は宣言元のページを基準に解決し（絶対・プロトコル相対・文書相対のいずれの形式も動きます）、フェッチャーが拒否する先へ解決された場合は破棄します。
+
+favicon は対象ページ自身の `<link rel="icon">` から取り、無ければその origin の `/favicon.ico` へフォールバックします。サードパーティの favicon サービスへは接続しないので、カードを描画してもドキュメントページのリンク先が外部ホストへ伝わりません。
+
 ## パッケージマネージャタブ
 
 `embeds.pm` は 1 つの npm 風コマンドを、npm、pnpm、yarn、bun、vp（Vite+）向けのアクセシブルなタブグループへ展開します。

--- a/npm/vite-plugin-ox-content/src/plugins/ogp-parse.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/ogp-parse.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vite-plus/test";
+import { parseOgpFromHtml } from "./ogp/parse";
+
+const PAGE = "https://example.com/posts/one";
+
+function meta(...tags: string[]): string {
+  return `<html><head>${tags.join("")}</head></html>`;
+}
+
+describe("Open Graph metadata parsing", () => {
+  it("decodes character references in text metadata", () => {
+    const data = parseOgpFromHtml(
+      meta(
+        `<meta property="og:title" content="Tips &amp; Tricks &#39;25">`,
+        `<meta property="og:description" content="Caf&eacute; &lt;b&gt; &#x2014; done">`,
+        `<meta property="og:site_name" content="A &amp; B">`,
+      ),
+      PAGE,
+    );
+
+    expect(data.title).toBe("Tips & Tricks '25");
+    expect(data.description).toBe("Café <b> — done");
+    expect(data.siteName).toBe("A & B");
+  });
+
+  it("decodes character references in the plain title tag", () => {
+    const data = parseOgpFromHtml(meta(`<title>Ruby &amp; Rails</title>`), PAGE);
+    expect(data.title).toBe("Ruby & Rails");
+  });
+
+  it("resolves a protocol-relative image against the page URL", () => {
+    const data = parseOgpFromHtml(
+      meta(`<meta property="og:image" content="//cdn.example.net/card.png">`),
+      PAGE,
+    );
+    expect(data.image).toBe("https://cdn.example.net/card.png");
+  });
+
+  it("resolves a root-relative image against the page origin", () => {
+    const data = parseOgpFromHtml(
+      meta(`<meta property="og:image" content="/static/card.png">`),
+      PAGE,
+    );
+    expect(data.image).toBe("https://example.com/static/card.png");
+  });
+
+  it("resolves a path-relative image against the page directory", () => {
+    const data = parseOgpFromHtml(meta(`<meta property="og:image" content="card.png">`), PAGE);
+    expect(data.image).toBe("https://example.com/posts/card.png");
+  });
+
+  it("decodes ampersands inside an image query string", () => {
+    const data = parseOgpFromHtml(
+      meta(`<meta property="og:image" content="https://cdn.example.net/c.png?w=1&amp;h=2">`),
+      PAGE,
+    );
+    expect(data.image).toBe("https://cdn.example.net/c.png?w=1&h=2");
+  });
+
+  it("drops an image the fetcher would refuse to load", () => {
+    for (const hostile of ["javascript:alert(1)", "http://127.0.0.1/card.png", "data:,x"]) {
+      const data = parseOgpFromHtml(meta(`<meta property="og:image" content="${hostile}">`), PAGE);
+      expect(data.image, hostile).toBeUndefined();
+    }
+  });
+
+  it("takes the favicon from the page instead of a third-party lookup service", () => {
+    const declared = parseOgpFromHtml(meta(`<link rel="icon" href="/assets/icon.svg">`), PAGE);
+    expect(declared.favicon).toBe("https://example.com/assets/icon.svg");
+
+    const fallback = parseOgpFromHtml(meta(`<title>No icon</title>`), PAGE);
+    expect(fallback.favicon).toBe("https://example.com/favicon.ico");
+
+    for (const data of [declared, fallback]) {
+      expect(data.favicon).not.toContain("google.com");
+    }
+  });
+
+  it("falls back to the host name when the page names no title", () => {
+    const data = parseOgpFromHtml(meta(""), PAGE);
+    expect(data.title).toBe("example.com");
+  });
+});

--- a/npm/vite-plugin-ox-content/src/plugins/ogp.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/ogp.ts
@@ -7,6 +7,7 @@
 
 export { clearOgpCache } from "./ogp/cache";
 export { fetchOgpData } from "./ogp/fetch";
+export { decodeHtmlEntities, parseOgpFromHtml } from "./ogp/parse";
 export { collectOgpUrls, prefetchOgpData, transformOgp } from "./ogp/transform";
 export { resolveOgpOptions } from "./ogp/types";
 export type { OgpData, OgpOptions, ResolvedOgpOptions } from "./ogp/types";

--- a/npm/vite-plugin-ox-content/src/plugins/ogp/fetch.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/ogp/fetch.ts
@@ -1,7 +1,8 @@
 import { readDiskOgp, readMemoryOgp, writeDiskOgp, writeMemoryOgp } from "./cache";
 import type { OgpData, OgpOptions, ResolvedOgpOptions } from "./types";
 import { resolveOgpOptions } from "./types";
-import { extractDomain, getFaviconUrl, isSafeOgpUrl, normalizeOgpUrl, ogpCacheKey } from "./url";
+import { parseOgpFromHtml } from "./parse";
+import { isSafeOgpUrl, normalizeOgpUrl, ogpCacheKey } from "./url";
 
 const inflight = new Map<string, Promise<OgpData | null>>();
 
@@ -75,56 +76,4 @@ async function requestOgpData(url: string, options: ResolvedOgpOptions): Promise
     }
     return null;
   }
-}
-
-export function parseOgpFromHtml(html: string, url: string): OgpData {
-  const result: OgpData = {
-    url,
-    title: "",
-  };
-
-  const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i);
-  const ogTitleMatch =
-    html.match(/<meta[^>]*property=["']og:title["'][^>]*content=["']([^"']+)["']/i) ||
-    html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']og:title["']/i);
-
-  result.title = ogTitleMatch?.[1] || titleMatch?.[1] || extractDomain(url);
-
-  const descMatch =
-    html.match(/<meta[^>]*property=["']og:description["'][^>]*content=["']([^"']+)["']/i) ||
-    html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']og:description["']/i) ||
-    html.match(/<meta[^>]*name=["']description["'][^>]*content=["']([^"']+)["']/i) ||
-    html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*name=["']description["']/i);
-
-  if (descMatch) {
-    result.description = descMatch[1];
-  }
-
-  const imageMatch =
-    html.match(/<meta[^>]*property=["']og:image["'][^>]*content=["']([^"']+)["']/i) ||
-    html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']og:image["']/i);
-
-  if (imageMatch) {
-    let imageUrl = imageMatch[1];
-    if (imageUrl.startsWith("/")) {
-      try {
-        const urlObj = new URL(url);
-        imageUrl = `${urlObj.protocol}//${urlObj.host}${imageUrl}`;
-      } catch {
-        // Keep as is
-      }
-    }
-    result.image = imageUrl;
-  }
-
-  const siteNameMatch =
-    html.match(/<meta[^>]*property=["']og:site_name["'][^>]*content=["']([^"']+)["']/i) ||
-    html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']og:site_name["']/i);
-
-  if (siteNameMatch) {
-    result.siteName = siteNameMatch[1];
-  }
-
-  result.favicon = getFaviconUrl(url);
-  return result;
 }

--- a/npm/vite-plugin-ox-content/src/plugins/ogp/parse.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/ogp/parse.ts
@@ -1,0 +1,139 @@
+import type { OgpData } from "./types";
+import { extractDomain, isSafeOgpUrl } from "./url";
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+  eacute: "é",
+  copy: "©",
+  reg: "®",
+  trade: "™",
+  hellip: "…",
+  mdash: "—",
+  ndash: "–",
+  lsquo: "‘",
+  rsquo: "’",
+  ldquo: "“",
+  rdquo: "”",
+};
+
+/**
+ * Expand the character references that show up in `<meta>` content.
+ *
+ * Metadata is markup, so an `og:title` of `Tips & Tricks` reaches us as
+ * `Tips &amp; Tricks`. Rendering that verbatim puts the raw entity on the card,
+ * and it is the renderer's job — not the author's — to escape the text again.
+ */
+export function decodeHtmlEntities(value: string): string {
+  if (!value.includes("&")) return value;
+
+  return value.replace(/&(#[0-9]+|#[xX][0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);/g, (match, body) => {
+    if (body.startsWith("#")) {
+      const code =
+        body[1] === "x" || body[1] === "X"
+          ? Number.parseInt(body.slice(2), 16)
+          : Number.parseInt(body.slice(1), 10);
+      if (!Number.isInteger(code) || code <= 0 || code > 0x10ffff) return match;
+      try {
+        return String.fromCodePoint(code);
+      } catch {
+        return match;
+      }
+    }
+    return NAMED_ENTITIES[body.toLowerCase()] ?? match;
+  });
+}
+
+/**
+ * Resolve a URL taken from page metadata against the page it came from.
+ *
+ * Open Graph lets a site write `og:image` as an absolute URL, a
+ * protocol-relative one, or a path relative to the document. Only the first
+ * form is usable as-is: the other two have to be resolved against the source
+ * page, not against whatever docs page ends up embedding the card.
+ */
+export function resolveMetaUrl(value: string, pageUrl: string): string | undefined {
+  const decoded = decodeHtmlEntities(value).trim();
+  if (decoded === "") return undefined;
+
+  let resolved: string;
+  try {
+    resolved = new URL(decoded, pageUrl).href;
+  } catch {
+    return undefined;
+  }
+
+  return isSafeOgpUrl(resolved) ? resolved : undefined;
+}
+
+function metaContent(
+  html: string,
+  attribute: "property" | "name",
+  key: string,
+): string | undefined {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match =
+    html.match(
+      new RegExp(`<meta[^>]*${attribute}=["']${escaped}["'][^>]*content=["']([^"']*)["']`, "i"),
+    ) ??
+    html.match(
+      new RegExp(`<meta[^>]*content=["']([^"']*)["'][^>]*${attribute}=["']${escaped}["']`, "i"),
+    );
+
+  const value = match?.[1] && decodeHtmlEntities(match[1]).trim();
+  return value ? value : undefined;
+}
+
+function declaredIcon(html: string, pageUrl: string): string | undefined {
+  const match =
+    html.match(/<link[^>]*rel=["'](?:shortcut )?icon["'][^>]*href=["']([^"']+)["']/i) ??
+    html.match(/<link[^>]*href=["']([^"']+)["'][^>]*rel=["'](?:shortcut )?icon["']/i);
+  return match ? resolveMetaUrl(match[1], pageUrl) : undefined;
+}
+
+/**
+ * The site's own icon, never a third-party favicon lookup service.
+ *
+ * Routing every card through an external service would tell that service which
+ * outbound links each documentation page carries, for every reader, and would
+ * make cards depend on a host the build never chose.
+ */
+function faviconUrl(html: string, pageUrl: string): string | undefined {
+  return declaredIcon(html, pageUrl) ?? resolveMetaUrl("/favicon.ico", pageUrl);
+}
+
+export function parseOgpFromHtml(html: string, url: string): OgpData {
+  const titleTag = html.match(/<title[^>]*>([^<]*)<\/title>/i)?.[1];
+  const result: OgpData = {
+    url,
+    title:
+      metaContent(html, "property", "og:title") ??
+      (titleTag && decodeHtmlEntities(titleTag).trim()) ??
+      extractDomain(url),
+  };
+  if (result.title === "") {
+    result.title = extractDomain(url);
+  }
+
+  const description =
+    metaContent(html, "property", "og:description") ?? metaContent(html, "name", "description");
+  if (description) result.description = description;
+
+  const image =
+    html.match(/<meta[^>]*property=["']og:image["'][^>]*content=["']([^"']+)["']/i)?.[1] ??
+    html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']og:image["']/i)?.[1];
+  const resolvedImage = image && resolveMetaUrl(image, url);
+  if (resolvedImage) result.image = resolvedImage;
+
+  const siteName = metaContent(html, "property", "og:site_name");
+  if (siteName) result.siteName = siteName;
+
+  const favicon = faviconUrl(html, url);
+  if (favicon) result.favicon = favicon;
+
+  return result;
+}

--- a/npm/vite-plugin-ox-content/src/plugins/ogp/url.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/ogp/url.ts
@@ -45,14 +45,6 @@ export function extractDomain(url: string): string {
   }
 }
 
-export function getFaviconUrl(url: string): string {
-  try {
-    return `https://www.google.com/s2/favicons?domain=${new URL(url).hostname}&sz=32`;
-  } catch {
-    return "";
-  }
-}
-
 /**
  * Normalize a URL for cache keys: lowercase host, drop default ports and
  * fragments, and strip a trailing slash that is not the root path.


### PR DESCRIPTION
## Summary
- expand character references in `og:title`, `og:description`, `og:site_name`, and the plain `<title>`, so `Tips &amp; Tricks` stops rendering as literal entity text
- resolve `og:image` against the page it was declared on, fixing protocol-relative (`//cdn.example.net/x.png`, previously mangled into `https://example.com//cdn.example.net/x.png`) and document-relative forms
- run `og:image` through the same URL policy the fetcher uses, which the card href already had but the image did not
- take the favicon from the target page`s own `<link rel="icon">`, falling back to `/favicon.ico` on that origin, instead of a third-party lookup service
- move metadata parsing out of the network layer into `ogp/parse.ts`
- document the decode, resolve, and privacy behavior in English and Japanese

The favicon change is the privacy one: every rendered card used to make the
reader`s browser call an external service with the linked domain, which told
that service which outbound links each documentation page carries, and made
cards depend on a host the build never chose.

## Verification
- cd npm/vite-plugin-ox-content && vp test run src/plugins/ogp-parse.test.ts src/plugins/ogp.test.ts
- cd npm/vite-plugin-ox-content && vp test run
- vp run check:ts
- node scripts/check-file-lines.ts

Each defect was reproduced against the old parser before the fix; the new
`ogp-parse.test.ts` pins all four.

Refs #874
Refs #861

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790399121&installation_model_id=422833&pr_number=1061&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1061&signature=0d2e733fca6d62e27e4b98698c8d68d7edf24a1cec7cfc780fdb7b0eba0382a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Open Graph cards now decode HTML entities in titles and descriptions.
  * Relative and protocol-relative images are resolved against the source page, while unsafe destinations are excluded.
  * Favicons are read from the source page, with a same-origin `/favicon.ico` fallback.
* **Documentation**
  * Updated English and Japanese embed guides to explain Open Graph image, text, and favicon handling.
* **Tests**
  * Added coverage for metadata decoding, URL resolution, safety checks, and favicon fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->