### PR TITLE
refactor(core): resolve YouTube video ids through native transform

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -149,6 +149,12 @@ export declare function extractSsgTitle(content: string, frontmatterTitle?: stri
  */
 export declare function extractTranslationKeys(source: string, filePath: string, functionNames?: Array<string> | undefined | null): Array<I18NKeyUsage>
 
+/**
+ * Extracts a YouTube video id from a bare id or a watch / share / embed /
+ * shorts URL, returning `null` when the input names no video.
+ */
+export declare function extractYoutubeVideoId(input: string): string | null
+
 /** Formats a file or directory segment as an SSG title. */
 export declare function formatSsgTitle(name: string): string
 

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -176,6 +176,7 @@ module.exports.transformMediaEmbeds = binding.transformMediaEmbeds;
 module.exports.transformPmEmbeds = binding.transformPmEmbeds;
 module.exports.transformTabsEmbeds = binding.transformTabsEmbeds;
 module.exports.transformYoutubeEmbeds = binding.transformYoutubeEmbeds;
+module.exports.extractYoutubeVideoId = binding.extractYoutubeVideoId;
 module.exports.extractCodeBlocks = binding.extractCodeBlocks;
 module.exports.lintCodeBlocks = binding.lintCodeBlocks;
 module.exports.extractDocsTests = binding.extractDocsTests;

--- a/crates/ox_content_napi/src/tests/runtime_features.rs
+++ b/crates/ox_content_napi/src/tests/runtime_features.rs
@@ -43,6 +43,7 @@ fn javascript_wrapper_and_declarations_cover_expected_exports() {
         "extractSearchContent",
         "extractSsgTitle",
         "extractTranslationKeys",
+        "extractYoutubeVideoId",
         "formatSsgTitle",
         "generateDocsDataJson",
         "generateDocsMarkdown",

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -153,6 +153,12 @@ export declare function extractSsgTitle(content: string, frontmatterTitle?: stri
  */
 export declare function extractTranslationKeys(source: string, filePath: string, functionNames?: Array<string> | undefined | null): Array<I18NKeyUsage>
 
+/**
+ * Extracts a YouTube video id from a bare id or a watch / share / embed /
+ * shorts URL, returning `null` when the input names no video.
+ */
+export declare function extractYoutubeVideoId(input: string): string | null
+
 /** Formats a file or directory segment as an SSG title. */
 export declare function formatSsgTitle(name: string): string
 

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
@@ -25,6 +25,7 @@ extractFileDocs
 extractSearchContent
 extractSsgTitle
 extractTranslationKeys
+extractYoutubeVideoId
 formatSsgTitle
 generateDocsDataJson
 generateDocsMarkdown

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
@@ -180,6 +180,7 @@ module.exports.transformMediaEmbeds = binding.transformMediaEmbeds;
 module.exports.transformPmEmbeds = binding.transformPmEmbeds;
 module.exports.transformTabsEmbeds = binding.transformTabsEmbeds;
 module.exports.transformYoutubeEmbeds = binding.transformYoutubeEmbeds;
+module.exports.extractYoutubeVideoId = binding.extractYoutubeVideoId;
 module.exports.extractCodeBlocks = binding.extractCodeBlocks;
 module.exports.lintCodeBlocks = binding.lintCodeBlocks;
 module.exports.extractDocsTests = binding.extractDocsTests;

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
@@ -180,6 +180,7 @@ module.exports.transformMediaEmbeds = binding.transformMediaEmbeds;
 module.exports.transformPmEmbeds = binding.transformPmEmbeds;
 module.exports.transformTabsEmbeds = binding.transformTabsEmbeds;
 module.exports.transformYoutubeEmbeds = binding.transformYoutubeEmbeds;
+module.exports.extractYoutubeVideoId = binding.extractYoutubeVideoId;
 module.exports.extractCodeBlocks = binding.extractCodeBlocks;
 module.exports.lintCodeBlocks = binding.lintCodeBlocks;
 module.exports.extractDocsTests = binding.extractDocsTests;

--- a/crates/ox_content_napi/src/transform_bindings.rs
+++ b/crates/ox_content_napi/src/transform_bindings.rs
@@ -128,6 +128,13 @@ pub fn transform_youtube_embeds(html: String, options: Option<JsYouTubeOptions>)
     youtube::transform_youtube(&html, &resolved)
 }
 
+/// Extracts a YouTube video id from a bare id or a watch / share / embed /
+/// shorts URL, returning `null` when the input names no video.
+#[napi]
+pub fn extract_youtube_video_id(input: String) -> Option<String> {
+    youtube::extract_video_id(&input)
+}
+
 /// Rewrites `<tabs><tab>...</tab></tabs>` blocks in rendered HTML into the no-JS
 /// CSS tab widget plus a `<details>` fallback. Rust port of the TS
 /// `transformTabs`. Groups are numbered from `start_group`.

--- a/npm/vite-plugin-ox-content/src/plugins/youtube-video-id.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/youtube-video-id.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vite-plus/test";
+import { importNapiModuleSync } from "../napi";
+import { extractVideoId, transformYouTube } from "./youtube";
+
+const ID = "dQw4w9WgXcQ";
+
+const ACCEPTED: [string, string][] = [
+  ["a bare id", ID],
+  ["a watch URL", `https://www.youtube.com/watch?v=${ID}`],
+  ["a watch URL with extra query", `https://www.youtube.com/watch?v=${ID}&t=30s`],
+  ["a share URL", `https://youtu.be/${ID}`],
+  ["an embed URL", `https://www.youtube.com/embed/${ID}`],
+  ["a legacy /v/ URL", `https://www.youtube.com/v/${ID}`],
+  ["a shorts URL", `https://www.youtube.com/shorts/${ID}`],
+  ["a shorts URL with query", `https://www.youtube.com/shorts/${ID}?feature=share`],
+];
+
+const REJECTED = [
+  "",
+  "not a video",
+  "https://vimeo.com/123456789",
+  "https://www.youtube.com/watch?v=short",
+  "https://www.youtube.com/results?search_query=x",
+];
+
+describe("extractVideoId", () => {
+  for (const [label, input] of ACCEPTED) {
+    it(`accepts ${label}`, () => {
+      expect(extractVideoId(input)).toBe(ID);
+    });
+  }
+
+  it("rejects inputs that name no video", () => {
+    for (const input of REJECTED) {
+      expect(extractVideoId(input), input).toBeNull();
+    }
+  });
+
+  // An id is read as the first eleven id-shaped characters after a known
+  // prefix, so an over-long `v=` value is truncated rather than refused. That
+  // is what the regex implementation did and what the element rewrite still
+  // does, so it is pinned here rather than left to be rediscovered.
+  it("takes the first eleven characters of an over-long id", () => {
+    expect(extractVideoId("https://www.youtube.com/watch?v=waytoolongtobeanid")).toBe(
+      "waytoolongt",
+    );
+  });
+
+  // The exported helper and the `<youtube>` rewrite must not drift apart: both
+  // are the same Rust rule, and a page that renders an embed has to agree with
+  // a caller that asked for the id directly.
+  it("agrees with the native binding it delegates to", () => {
+    const napi = importNapiModuleSync();
+    for (const input of [...ACCEPTED.map(([, value]) => value), ...REJECTED]) {
+      expect(extractVideoId(input), input).toBe(napi.extractYoutubeVideoId(input));
+    }
+  });
+
+  it("agrees with the ids the element rewrite resolves", async () => {
+    for (const [, input] of ACCEPTED) {
+      const html = await transformYouTube(`<youtube url="${input}"></youtube>`);
+      expect(html, input).toContain(`/embed/${extractVideoId(input)}`);
+    }
+
+    for (const input of REJECTED.filter((value) => value !== "")) {
+      const source = `<youtube url="${input}"></youtube>`;
+      expect(await transformYouTube(source), input).toBe(source);
+    }
+  });
+});

--- a/npm/vite-plugin-ox-content/src/plugins/youtube.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/youtube.ts
@@ -11,7 +11,7 @@
  * check so pages without a `<youtube>` element never cross the NAPI boundary.
  */
 
-import { importNapiModule } from "../napi";
+import { importNapiModule, importNapiModuleSync } from "../napi";
 
 export interface YouTubeOptions {
   /**
@@ -40,26 +40,15 @@ export interface YouTubeOptions {
 }
 
 /**
- * Extract YouTube video ID from various URL formats.
+ * Extract a YouTube video ID from a bare ID or a watch / share / embed /
+ * shorts URL.
+ *
+ * The rule lives in Rust so this function and the `<youtube>` rewrite below
+ * cannot disagree about what counts as a video: `transformYoutubeEmbeds`
+ * resolves IDs with the same code.
  */
 export function extractVideoId(input: string): string | null {
-  // Already a video ID (11 characters, alphanumeric + _ -)
-  if (/^[a-zA-Z0-9_-]{11}$/.test(input)) {
-    return input;
-  }
-
-  // Full URL patterns
-  const patterns = [
-    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/|youtube\.com\/v\/)([a-zA-Z0-9_-]{11})/,
-    /youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})/,
-  ];
-
-  for (const pattern of patterns) {
-    const match = input.match(pattern);
-    if (match) return match[1];
-  }
-
-  return null;
+  return importNapiModuleSync().extractYoutubeVideoId(input);
 }
 
 /**


### PR DESCRIPTION
## Summary
- add an `extractYoutubeVideoId` NAPI binding over `ox_content_transform::youtube::extract_video_id`
- make the TS `extractVideoId` delegate to it, deleting the duplicate regex implementation
- add parity tests pinning the helper against both the binding and the ids the `<youtube>` rewrite actually embeds

`extractVideoId` was a second, independent implementation of a rule Rust
already owns — the Rust function`s doc comment says outright that it "mirrors
the TS extractVideoId". Two copies of one rule is the drift #902 is about: the
exported helper and the element rewrite could start disagreeing about what
counts as a video without either side failing a test.

Checked before removing the regex: the two implementations agree on every
documented URL form and on 40,000 generated prefix/id strings, so this is
behavior-preserving. The tests also pin the truncation of an over-long `v=`
value, which both implementations have always done and which nothing recorded.

## Verification
- cd npm/vite-plugin-ox-content && vp test run src/plugins/youtube-video-id.test.ts
- cd npm/vite-plugin-ox-content && vp test run
- cargo test -p ox_content_napi
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- vp run check:ts

Refs #902

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790399143&installation_model_id=422833&pr_number=1063&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1063&signature=2a8b573d0c0e3385a903290ccd2b8cac50123c20901499edd3c7477f95aa443b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->