### PR TITLE
refactor(embeds): drive media embeds from a provider registry

### DIFF
--- a/crates/ox_content_transform/src/media_embeds.rs
+++ b/crates/ox_content_transform/src/media_embeds.rs
@@ -4,6 +4,9 @@ mod native;
 mod package_cards;
 mod playground_cards;
 mod provider_cards;
+mod registry;
+#[cfg(test)]
+mod registry_tests;
 mod render;
 mod speaker_deck;
 #[cfg(test)]
@@ -12,20 +15,8 @@ mod video_cards;
 
 use crate::{MediaEmbedsOptions, html_scan::find_ci};
 
-use apple_music::render_apple_music;
 use html::{ComponentElement, find_component, find_pascal_component};
-use native::{render_audio, render_video};
-use package_cards::{render_crates_io, render_docker_hub, render_npm_package, render_pypi};
-use playground_cards::{render_codepen, render_jsfiddle, render_observable};
-use provider_cards::{
-    render_discord, render_facebook, render_fediverse, render_google_maps, render_instagram,
-    render_mastodon, render_misskey, render_mixi2, render_qiita, render_threads, render_zenn,
-};
-use render::{
-    render_bluesky, render_spotify, render_stackblitz, render_tweet, render_webcontainer,
-};
-use speaker_deck::render_speaker_deck;
-use video_cards::{render_twitch, render_vimeo};
+use registry::{PROVIDERS, Provider, Tag};
 
 pub fn transform_media_embeds(html: &str, options: Option<&MediaEmbedsOptions>) -> String {
     let Some(options) = options else {
@@ -36,162 +27,42 @@ pub fn transform_media_embeds(html: &str, options: Option<&MediaEmbedsOptions>) 
     }
 
     let mut current = html.to_string();
-    if options.spotify.unwrap_or(false) && contains_ci(&current, "<spotify") {
-        current = transform_component(&current, "spotify", render_spotify);
-    }
-    if options.apple_music.unwrap_or(false) && contains_ci(&current, "<applemusic") {
-        current = transform_component(&current, "applemusic", render_apple_music);
-    }
-    if options.speaker_deck.unwrap_or(false) && contains_ci(&current, "<speakerdeck") {
-        current = transform_component(&current, "speakerdeck", render_speaker_deck);
-    }
-    if options.audio.unwrap_or(false) && current.contains("<Audio") {
-        current = transform_pascal_component(&current, "Audio", render_audio);
-    }
-    if options.video.unwrap_or(false) && current.contains("<Video") {
-        current = transform_pascal_component(&current, "Video", render_video);
-    }
-    if options.stack_blitz.unwrap_or(false) && contains_ci(&current, "<stackblitz") {
-        current = transform_component(&current, "stackblitz", render_stackblitz);
-    }
-    if options.twitter.unwrap_or(false)
-        && (contains_ci(&current, "<tweet") || contains_ci(&current, "<xpost"))
-    {
-        current = transform_component(&current, "tweet", render_tweet);
-        current = transform_component(&current, "xpost", render_tweet);
-    }
-    if options.bluesky.unwrap_or(false) && contains_ci(&current, "<bluesky") {
-        current = transform_component(&current, "bluesky", render_bluesky);
-    }
-    if options.google_maps.unwrap_or(false) && contains_ci(&current, "<googlemaps") {
-        current = transform_component(&current, "googlemaps", render_google_maps);
-    }
-    if options.qiita.unwrap_or(false) && contains_ci(&current, "<qiita") {
-        current = transform_component(&current, "qiita", render_qiita);
-    }
-    if options.zenn.unwrap_or(false) && contains_ci(&current, "<zenn") {
-        current = transform_component(&current, "zenn", render_zenn);
-    }
-    if options.package_registry.unwrap_or(false) {
-        if contains_ci(&current, "<npmpackage") {
-            current = transform_component(&current, "npmpackage", render_npm_package);
+    for provider in PROVIDERS {
+        if (provider.enabled)(options) && provider.appears_in(&current) {
+            current = rewrite_components(&current, provider);
         }
-        if contains_ci(&current, "<cratesio") {
-            current = transform_component(&current, "cratesio", render_crates_io);
-        }
-        if contains_ci(&current, "<pypi") {
-            current = transform_component(&current, "pypi", render_pypi);
-        }
-        if contains_ci(&current, "<dockerhub") {
-            current = transform_component(&current, "dockerhub", render_docker_hub);
-        }
-    }
-    if options.playgrounds.unwrap_or(false) {
-        if contains_ci(&current, "<codepen") {
-            current = transform_component(&current, "codepen", render_codepen);
-        }
-        if contains_ci(&current, "<jsfiddle") {
-            current = transform_component(&current, "jsfiddle", render_jsfiddle);
-        }
-        if contains_ci(&current, "<observable") {
-            current = transform_component(&current, "observable", render_observable);
-        }
-    }
-    if options.vimeo.unwrap_or(false) && contains_ci(&current, "<vimeo") {
-        current = transform_component(&current, "vimeo", render_vimeo);
-    }
-    if options.twitch.unwrap_or(false) && contains_ci(&current, "<twitch") {
-        current = transform_component(&current, "twitch", render_twitch);
-    }
-    if options.discord.unwrap_or(false) && contains_ci(&current, "<discord") {
-        current = transform_component(&current, "discord", render_discord);
-    }
-    if options.fediverse.unwrap_or(false) {
-        if contains_ci(&current, "<fediverse") {
-            current = transform_component(&current, "fediverse", render_fediverse);
-        }
-        if contains_ci(&current, "<mastodon") {
-            current = transform_component(&current, "mastodon", render_mastodon);
-        }
-        if contains_ci(&current, "<misskey") {
-            current = transform_component(&current, "misskey", render_misskey);
-        }
-        if contains_ci(&current, "<mixi2") {
-            current = transform_component(&current, "mixi2", render_mixi2);
-        }
-    }
-    if options.facebook.unwrap_or(false) && contains_ci(&current, "<facebook") {
-        current = transform_component(&current, "facebook", render_facebook);
-    }
-    if options.threads.unwrap_or(false) && contains_ci(&current, "<threads") {
-        current = transform_component(&current, "threads", render_threads);
-    }
-    if options.instagram.unwrap_or(false) && contains_ci(&current, "<instagram") {
-        current = transform_component(&current, "instagram", render_instagram);
-    }
-    if options.web_container.unwrap_or(false) && contains_ci(&current, "<webcontainer") {
-        current = transform_component(&current, "webcontainer", render_webcontainer);
     }
     current
 }
 
 fn has_enabled_embed(options: &MediaEmbedsOptions) -> bool {
-    options.spotify.unwrap_or(false)
-        || options.apple_music.unwrap_or(false)
-        || options.speaker_deck.unwrap_or(false)
-        || options.audio.unwrap_or(false)
-        || options.video.unwrap_or(false)
-        || options.stack_blitz.unwrap_or(false)
-        || options.twitter.unwrap_or(false)
-        || options.bluesky.unwrap_or(false)
-        || options.google_maps.unwrap_or(false)
-        || options.qiita.unwrap_or(false)
-        || options.zenn.unwrap_or(false)
-        || options.package_registry.unwrap_or(false)
-        || options.playgrounds.unwrap_or(false)
-        || options.vimeo.unwrap_or(false)
-        || options.twitch.unwrap_or(false)
-        || options.discord.unwrap_or(false)
-        || options.fediverse.unwrap_or(false)
-        || options.facebook.unwrap_or(false)
-        || options.threads.unwrap_or(false)
-        || options.instagram.unwrap_or(false)
-        || options.web_container.unwrap_or(false)
+    PROVIDERS.iter().any(|provider| (provider.enabled)(options))
 }
 
-fn contains_ci(html: &str, needle: &str) -> bool {
-    find_ci(html, 0, needle).is_some()
+impl Provider {
+    /// Cheap pre-scan so a document without the tag never pays for a rewrite.
+    fn appears_in(&self, html: &str) -> bool {
+        match self.tag {
+            Tag::AnyCase => find_ci(html, 0, &format!("<{}", self.name)).is_some(),
+            Tag::Pascal => html.contains(&format!("<{}", self.name)),
+        }
+    }
 }
 
-fn transform_pascal_component(
-    html: &str,
-    name: &str,
-    render: fn(&ComponentElement<'_>) -> Option<String>,
-) -> String {
-    rewrite_components(html, name, render, find_pascal_component)
-}
+fn rewrite_components(html: &str, provider: &Provider) -> String {
+    let find: for<'a> fn(&'a str, usize, &str, &str) -> Option<ComponentElement<'a>> =
+        match provider.tag {
+            Tag::AnyCase => find_component,
+            Tag::Pascal => find_pascal_component,
+        };
 
-fn transform_component(
-    html: &str,
-    name: &str,
-    render: fn(&ComponentElement<'_>) -> Option<String>,
-) -> String {
-    rewrite_components(html, name, render, find_component)
-}
-
-fn rewrite_components(
-    html: &str,
-    name: &str,
-    render: fn(&ComponentElement<'_>) -> Option<String>,
-    find: for<'a> fn(&'a str, usize, &str, &str) -> Option<ComponentElement<'a>>,
-) -> String {
     let mut out = String::with_capacity(html.len());
     let mut cursor = 0usize;
-    let open = format!("<{name}");
+    let open = format!("<{}", provider.name);
 
-    while let Some(element) = find(html, cursor, &open, name) {
+    while let Some(element) = find(html, cursor, &open, provider.name) {
         out.push_str(&html[cursor..element.span.0]);
-        if let Some(rendered) = render(&element) {
+        if let Some(rendered) = (provider.render)(&element) {
             out.push_str(&rendered);
         } else {
             out.push_str(&html[element.span.0..element.span.1]);

--- a/crates/ox_content_transform/src/media_embeds/registry.rs
+++ b/crates/ox_content_transform/src/media_embeds/registry.rs
@@ -1,0 +1,198 @@
+//! The first-party embed provider table.
+//!
+//! Every provider is one row: the tag an author writes, how that tag is
+//! matched, the option that turns it on, and the renderer. Adding a provider
+//! means adding a row — not editing a dispatch chain and a separate
+//! "is anything enabled" predicate that has to be kept in step with it.
+
+use crate::MediaEmbedsOptions;
+
+use super::apple_music::render_apple_music;
+use super::html::ComponentElement;
+use super::native::{render_audio, render_video};
+use super::package_cards::{render_crates_io, render_docker_hub, render_npm_package, render_pypi};
+use super::playground_cards::{render_codepen, render_jsfiddle, render_observable};
+use super::provider_cards::{
+    render_discord, render_facebook, render_fediverse, render_google_maps, render_instagram,
+    render_mastodon, render_misskey, render_mixi2, render_qiita, render_threads, render_zenn,
+};
+use super::render::{
+    render_bluesky, render_spotify, render_stackblitz, render_tweet, render_webcontainer,
+};
+use super::speaker_deck::render_speaker_deck;
+use super::video_cards::{render_twitch, render_vimeo};
+
+/// How a provider's tag is spelled in the document.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum Tag {
+    /// Matched case-insensitively, so `<zenn>` and `<Zenn>` both resolve.
+    AnyCase,
+    /// Matched exactly, reserving the lowercase spelling for the HTML element
+    /// of the same name — `<audio>` stays a plain audio element, `<Audio>`
+    /// becomes the embed.
+    Pascal,
+}
+
+/// One first-party embed provider.
+pub(super) struct Provider {
+    pub(super) name: &'static str,
+    pub(super) tag: Tag,
+    pub(super) enabled: fn(&MediaEmbedsOptions) -> bool,
+    pub(super) render: fn(&ComponentElement<'_>) -> Option<String>,
+}
+
+fn on(value: Option<bool>) -> bool {
+    value.unwrap_or(false)
+}
+
+/// Providers in the order they rewrite a document.
+///
+/// The order is part of the contract: a document is rewritten once per row, so
+/// a renderer only ever sees markup the rows above it have already settled.
+pub(super) const PROVIDERS: &[Provider] = &[
+    Provider {
+        name: "spotify",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.spotify),
+        render: render_spotify,
+    },
+    Provider {
+        name: "applemusic",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.apple_music),
+        render: render_apple_music,
+    },
+    Provider {
+        name: "speakerdeck",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.speaker_deck),
+        render: render_speaker_deck,
+    },
+    Provider { name: "Audio", tag: Tag::Pascal, enabled: |o| on(o.audio), render: render_audio },
+    Provider { name: "Video", tag: Tag::Pascal, enabled: |o| on(o.video), render: render_video },
+    Provider {
+        name: "stackblitz",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.stack_blitz),
+        render: render_stackblitz,
+    },
+    Provider { name: "tweet", tag: Tag::AnyCase, enabled: |o| on(o.twitter), render: render_tweet },
+    Provider { name: "xpost", tag: Tag::AnyCase, enabled: |o| on(o.twitter), render: render_tweet },
+    Provider {
+        name: "bluesky",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.bluesky),
+        render: render_bluesky,
+    },
+    Provider {
+        name: "googlemaps",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.google_maps),
+        render: render_google_maps,
+    },
+    Provider { name: "qiita", tag: Tag::AnyCase, enabled: |o| on(o.qiita), render: render_qiita },
+    Provider { name: "zenn", tag: Tag::AnyCase, enabled: |o| on(o.zenn), render: render_zenn },
+    Provider {
+        name: "npmpackage",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.package_registry),
+        render: render_npm_package,
+    },
+    Provider {
+        name: "cratesio",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.package_registry),
+        render: render_crates_io,
+    },
+    Provider {
+        name: "pypi",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.package_registry),
+        render: render_pypi,
+    },
+    Provider {
+        name: "dockerhub",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.package_registry),
+        render: render_docker_hub,
+    },
+    Provider {
+        name: "codepen",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.playgrounds),
+        render: render_codepen,
+    },
+    Provider {
+        name: "jsfiddle",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.playgrounds),
+        render: render_jsfiddle,
+    },
+    Provider {
+        name: "observable",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.playgrounds),
+        render: render_observable,
+    },
+    Provider { name: "vimeo", tag: Tag::AnyCase, enabled: |o| on(o.vimeo), render: render_vimeo },
+    Provider {
+        name: "twitch",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.twitch),
+        render: render_twitch,
+    },
+    Provider {
+        name: "discord",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.discord),
+        render: render_discord,
+    },
+    Provider {
+        name: "fediverse",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.fediverse),
+        render: render_fediverse,
+    },
+    Provider {
+        name: "mastodon",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.fediverse),
+        render: render_mastodon,
+    },
+    Provider {
+        name: "misskey",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.fediverse),
+        render: render_misskey,
+    },
+    Provider {
+        name: "mixi2",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.fediverse),
+        render: render_mixi2,
+    },
+    Provider {
+        name: "facebook",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.facebook),
+        render: render_facebook,
+    },
+    Provider {
+        name: "threads",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.threads),
+        render: render_threads,
+    },
+    Provider {
+        name: "instagram",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.instagram),
+        render: render_instagram,
+    },
+    Provider {
+        name: "webcontainer",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.web_container),
+        render: render_webcontainer,
+    },
+];

--- a/crates/ox_content_transform/src/media_embeds/registry_tests.rs
+++ b/crates/ox_content_transform/src/media_embeds/registry_tests.rs
@@ -1,0 +1,86 @@
+//! Invariants of the provider table itself.
+//!
+//! A table trades a dispatch chain for rows, and the hazard it introduces is a
+//! mis-wired row — a provider pointing at the wrong option, so it turns on with
+//! an unrelated feature or never turns on at all. The compiler cannot catch
+//! that, so it is pinned here.
+
+use crate::MediaEmbedsOptions;
+
+use super::registry::PROVIDERS;
+use super::transform_media_embeds;
+
+/// Turns one option on, leaving the rest at their defaults.
+type SetOption = fn(&mut MediaEmbedsOptions);
+
+/// Every option a caller can set, paired with the name it is known by.
+const SETTERS: &[(&str, SetOption)] = &[
+    ("spotify", |o| o.spotify = Some(true)),
+    ("appleMusic", |o| o.apple_music = Some(true)),
+    ("speakerDeck", |o| o.speaker_deck = Some(true)),
+    ("audio", |o| o.audio = Some(true)),
+    ("video", |o| o.video = Some(true)),
+    ("stackBlitz", |o| o.stack_blitz = Some(true)),
+    ("twitter", |o| o.twitter = Some(true)),
+    ("bluesky", |o| o.bluesky = Some(true)),
+    ("googleMaps", |o| o.google_maps = Some(true)),
+    ("qiita", |o| o.qiita = Some(true)),
+    ("zenn", |o| o.zenn = Some(true)),
+    ("packageRegistry", |o| o.package_registry = Some(true)),
+    ("playgrounds", |o| o.playgrounds = Some(true)),
+    ("vimeo", |o| o.vimeo = Some(true)),
+    ("twitch", |o| o.twitch = Some(true)),
+    ("discord", |o| o.discord = Some(true)),
+    ("fediverse", |o| o.fediverse = Some(true)),
+    ("facebook", |o| o.facebook = Some(true)),
+    ("threads", |o| o.threads = Some(true)),
+    ("instagram", |o| o.instagram = Some(true)),
+    ("webContainer", |o| o.web_container = Some(true)),
+];
+
+fn enabled_by(set: SetOption) -> Vec<&'static str> {
+    let mut options = MediaEmbedsOptions::default();
+    set(&mut options);
+    PROVIDERS.iter().filter(|p| (p.enabled)(&options)).map(|p| p.name).collect()
+}
+
+#[test]
+fn each_option_gates_exactly_its_own_providers() {
+    let mut report = String::new();
+    for (name, set) in SETTERS {
+        report.push_str(name);
+        report.push_str(" -> ");
+        report.push_str(&enabled_by(*set).join(", "));
+        report.push('\n');
+    }
+    insta::assert_snapshot!(report);
+}
+
+#[test]
+fn every_provider_is_reachable_from_some_option() {
+    for provider in PROVIDERS {
+        let reachable = SETTERS.iter().any(|(_, set)| enabled_by(*set).contains(&provider.name));
+        assert!(reachable, "{} has no option that turns it on", provider.name);
+    }
+}
+
+#[test]
+fn provider_tags_are_unique() {
+    let mut seen: Vec<&str> = Vec::new();
+    for provider in PROVIDERS {
+        assert!(!seen.contains(&provider.name), "duplicate provider tag {}", provider.name);
+        seen.push(provider.name);
+    }
+}
+
+#[test]
+fn nothing_is_enabled_by_default() {
+    let options = MediaEmbedsOptions::default();
+    for provider in PROVIDERS {
+        assert!(!(provider.enabled)(&options), "{} is on by default", provider.name);
+    }
+
+    // And the whole transform is a no-op, tags left exactly as authored.
+    let source = r#"<Spotify url="https://open.spotify.com/track/abc123"></Spotify>"#;
+    assert_eq!(transform_media_embeds(source, Some(&options)), source);
+}

--- a/crates/ox_content_transform/src/media_embeds/snapshots/ox_content_transform__media_embeds__registry_tests__each_option_gates_exactly_its_own_providers.snap
+++ b/crates/ox_content_transform/src/media_embeds/snapshots/ox_content_transform__media_embeds__registry_tests__each_option_gates_exactly_its_own_providers.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ox_content_transform/src/media_embeds/registry_tests.rs
+expression: report
+---
+spotify -> spotify
+appleMusic -> applemusic
+speakerDeck -> speakerdeck
+audio -> Audio
+video -> Video
+stackBlitz -> stackblitz
+twitter -> tweet, xpost
+bluesky -> bluesky
+googleMaps -> googlemaps
+qiita -> qiita
+zenn -> zenn
+packageRegistry -> npmpackage, cratesio, pypi, dockerhub
+playgrounds -> codepen, jsfiddle, observable
+vimeo -> vimeo
+twitch -> twitch
+discord -> discord
+fediverse -> fediverse, mastodon, misskey, mixi2
+facebook -> facebook
+threads -> threads
+instagram -> instagram
+webContainer -> webcontainer


### PR DESCRIPTION
## Summary
- replace the twenty-one-arm dispatch chain with one declarative provider table
- derive `has_enabled_embed` from that table instead of restating every option
- add tests for the invariants a table can break and the compiler cannot catch

Adding a provider used to mean editing two hand-written lists that had to stay
in step: the dispatch chain of `if enabled && contains_ci(…)` arms, and a
separate `has_enabled_embed` predicate naming every option again. Nothing
checked they agreed. A row wired to the wrong option would surface only as a
provider that turns on with an unrelated feature, or never turns on at all.

Each provider is now one row — the tag an author writes, whether it is matched
case-insensitively or PascalCase-only (`<Audio>` vs the plain `<audio>`
element), the option that gates it, and the renderer. `media_embeds.rs` drops
from 204 lines to 75.

## Behavior is unchanged

Rewriting order is preserved, and every existing byte-exact HTML snapshot for
every provider passes untouched.

## The gating contract is now one artifact

`each_option_gates_exactly_its_own_providers` snapshots the whole mapping, so a
mis-wired row fails loudly and the contract is readable at a glance:

```
twitter         -> tweet, xpost
packageRegistry -> npmpackage, cratesio, pypi, dockerhub
playgrounds     -> codepen, jsfiddle, observable
fediverse       -> fediverse, mastodon, misskey, mixi2
```

Alongside it: every row is reachable from some option, tags are unique, and
nothing is enabled by default.

## Verification
- cargo test -p ox_content_transform  (496 passed)
- cargo clippy -p ox_content_transform --all-targets -- -D warnings
- cargo fmt --all -- --check
- node scripts/check-file-lines.ts

Refs #874
Refs #861

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790401205&installation_model_id=422833&pr_number=1066&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1066&signature=5be9db2087d0d0dda602a464d9f3d5a29b74a59244c868c3fd4128cdd5e24d52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->