### PR TITLE
fix(feeds): parse feed dates through the native parser

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -1583,6 +1583,31 @@ export interface JsPagerOverride {
 }
 
 /**
+ * A feed date after parsing: the instant, its civil parts in UTC, and the two
+ * serializations the feed formats ask for.
+ */
+export interface JsParsedFeedDate {
+  /** Seconds since the Unix epoch. */
+  unix: number
+  /** Civil year in UTC. */
+  year: number
+  /** Civil month, 1-12. */
+  month: number
+  /** Civil day of month, 1-31. */
+  day: number
+  /** Hour, 0-23. */
+  hour: number
+  /** Minute, 0-59. */
+  minute: number
+  /** Second, 0-60. */
+  second: number
+  /** `YYYY-MM-DDTHH:MM:SSZ`, as Atom and JSON Feed want it. */
+  rfc3339: string
+  /** `Day, DD Mon YYYY HH:MM:SS +0000`, as RSS wants it. */
+  rfc822: string
+}
+
+/**
  * Parser options for JavaScript.
  *
  * When `gfm` is `true`, omitted extension flags inherit the GFM profile.
@@ -2828,6 +2853,13 @@ export declare function parseAndRender(source: string, options?: JsParserOptions
 
 /** Parses Markdown and renders to HTML asynchronously (runs on worker thread). */
 export declare function parseAndRenderAsync(source: string, options?: JsParserOptions | undefined | null): Promise<unknown>
+
+/**
+ * Parses a feed date — an epoch seconds/milliseconds integer, or a civil
+ * date-time with an optional zone offset — returning `null` when the value
+ * names no instant.
+ */
+export declare function parseFeedDate(value?: string | undefined | null): JsParsedFeedDate | null
 
 /** Parses Markdown source into a raw mdast memory block for JavaScript-side deserialization. */
 export declare function parseMdastRaw(source: string, options?: JsParserOptions | undefined | null): Uint8Array

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -245,4 +245,5 @@ module.exports.checkI18nProject = binding.checkI18nProject;
 module.exports.extractTranslationKeys = binding.extractTranslationKeys;
 module.exports.renderFrameworkComponentCode = binding.renderFrameworkComponentCode;
 module.exports.renderSsgSectionIndex = binding.renderSsgSectionIndex;
+module.exports.parseFeedDate = binding.parseFeedDate;
 module.exports.escapeSvelteMarkup = binding.escapeSvelteMarkup;

--- a/crates/ox_content_napi/src/ssg_bindings.rs
+++ b/crates/ox_content_napi/src/ssg_bindings.rs
@@ -7,6 +7,8 @@ use crate::{
 };
 
 mod converters;
+mod feed_dates;
+pub use feed_dates::*;
 mod git;
 pub use git::*;
 mod head;

--- a/crates/ox_content_napi/src/ssg_bindings/feed_dates.rs
+++ b/crates/ox_content_napi/src/ssg_bindings/feed_dates.rs
@@ -1,0 +1,45 @@
+use napi_derive::napi;
+
+/// A feed date after parsing: the instant, its civil parts in UTC, and the two
+/// serializations the feed formats ask for.
+#[napi(object)]
+pub struct JsParsedFeedDate {
+    /// Seconds since the Unix epoch.
+    pub unix: i64,
+    /// Civil year in UTC.
+    pub year: i32,
+    /// Civil month, 1-12.
+    pub month: u32,
+    /// Civil day of month, 1-31.
+    pub day: u32,
+    /// Hour, 0-23.
+    pub hour: u32,
+    /// Minute, 0-59.
+    pub minute: u32,
+    /// Second, 0-60.
+    pub second: u32,
+    /// `YYYY-MM-DDTHH:MM:SSZ`, as Atom and JSON Feed want it.
+    pub rfc3339: String,
+    /// `Day, DD Mon YYYY HH:MM:SS +0000`, as RSS wants it.
+    pub rfc822: String,
+}
+
+/// Parses a feed date — an epoch seconds/milliseconds integer, or a civil
+/// date-time with an optional zone offset — returning `null` when the value
+/// names no instant.
+#[napi(js_name = "parseFeedDate")]
+pub fn parse_feed_date(value: Option<String>) -> Option<JsParsedFeedDate> {
+    let parsed = ox_content_ssg::parse_date(value.as_deref())?;
+    let (year, month, day, hour, minute, second) = parsed.parts();
+    Some(JsParsedFeedDate {
+        unix: parsed.unix(),
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        rfc3339: parsed.rfc3339(),
+        rfc822: parsed.rfc822(),
+    })
+}

--- a/crates/ox_content_napi/src/tests/runtime_features.rs
+++ b/crates/ox_content_napi/src/tests/runtime_features.rs
@@ -80,6 +80,7 @@ fn javascript_wrapper_and_declarations_cover_expected_exports() {
         "parse",
         "parseAndRender",
         "parseAndRenderAsync",
+        "parseFeedDate",
         "parseMdastRaw",
         "parseScopedSearchQuery",
         "parseTransferRaw",

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -1587,6 +1587,31 @@ export interface JsPagerOverride {
 }
 
 /**
+ * A feed date after parsing: the instant, its civil parts in UTC, and the two
+ * serializations the feed formats ask for.
+ */
+export interface JsParsedFeedDate {
+  /** Seconds since the Unix epoch. */
+  unix: number
+  /** Civil year in UTC. */
+  year: number
+  /** Civil month, 1-12. */
+  month: number
+  /** Civil day of month, 1-31. */
+  day: number
+  /** Hour, 0-23. */
+  hour: number
+  /** Minute, 0-59. */
+  minute: number
+  /** Second, 0-60. */
+  second: number
+  /** `YYYY-MM-DDTHH:MM:SSZ`, as Atom and JSON Feed want it. */
+  rfc3339: string
+  /** `Day, DD Mon YYYY HH:MM:SS +0000`, as RSS wants it. */
+  rfc822: string
+}
+
+/**
  * Parser options for JavaScript.
  *
  * When `gfm` is `true`, omitted extension flags inherit the GFM profile.
@@ -2832,6 +2857,13 @@ export declare function parseAndRender(source: string, options?: JsParserOptions
 
 /** Parses Markdown and renders to HTML asynchronously (runs on worker thread). */
 export declare function parseAndRenderAsync(source: string, options?: JsParserOptions | undefined | null): Promise<unknown>
+
+/**
+ * Parses a feed date — an epoch seconds/milliseconds integer, or a civil
+ * date-time with an optional zone offset — returning `null` when the value
+ * names no instant.
+ */
+export declare function parseFeedDate(value?: string | undefined | null): JsParsedFeedDate | null
 
 /** Parses Markdown source into a raw mdast memory block for JavaScript-side deserialization. */
 export declare function parseMdastRaw(source: string, options?: JsParserOptions | undefined | null): Uint8Array

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
@@ -62,6 +62,7 @@ normalizeVitePressFrontmatter
 parse
 parseAndRender
 parseAndRenderAsync
+parseFeedDate
 parseMdastRaw
 parseScopedSearchQuery
 parseTransferRaw

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
@@ -249,4 +249,5 @@ module.exports.checkI18nProject = binding.checkI18nProject;
 module.exports.extractTranslationKeys = binding.extractTranslationKeys;
 module.exports.renderFrameworkComponentCode = binding.renderFrameworkComponentCode;
 module.exports.renderSsgSectionIndex = binding.renderSsgSectionIndex;
+module.exports.parseFeedDate = binding.parseFeedDate;
 module.exports.escapeSvelteMarkup = binding.escapeSvelteMarkup;

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
@@ -249,4 +249,5 @@ module.exports.checkI18nProject = binding.checkI18nProject;
 module.exports.extractTranslationKeys = binding.extractTranslationKeys;
 module.exports.renderFrameworkComponentCode = binding.renderFrameworkComponentCode;
 module.exports.renderSsgSectionIndex = binding.renderSsgSectionIndex;
+module.exports.parseFeedDate = binding.parseFeedDate;
 module.exports.escapeSvelteMarkup = binding.escapeSvelteMarkup;

--- a/crates/ox_content_ssg/src/feeds.rs
+++ b/crates/ox_content_ssg/src/feeds.rs
@@ -2,7 +2,7 @@
 
 mod dates;
 
-use dates::parse_date;
+pub use dates::{ParsedDate, parse_date};
 
 const MISSING_SITE_URL: &str = "[ox-content] feeds is enabled but ssg.siteUrl is not set; RSS, Atom, and JSON feeds were not written";
 

--- a/crates/ox_content_ssg/src/feeds/dates.rs
+++ b/crates/ox_content_ssg/src/feeds/dates.rs
@@ -5,7 +5,7 @@ const MONTHS: [&str; 12] =
     ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
 #[derive(Clone, Copy)]
-pub(super) struct ParsedDate {
+pub struct ParsedDate {
     unix: i64,
     year: i32,
     month: u32,
@@ -16,18 +16,26 @@ pub(super) struct ParsedDate {
 }
 
 impl ParsedDate {
-    pub(super) fn unix(self) -> i64 {
+    /// Seconds since the Unix epoch.
+    pub fn unix(self) -> i64 {
         self.unix
     }
 
-    pub(super) fn rfc3339(self) -> String {
+    /// `YYYY-MM-DDTHH:MM:SSZ`, as Atom and JSON Feed want it.
+    pub fn rfc3339(self) -> String {
         format!(
             "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
             self.year, self.month, self.day, self.hour, self.minute, self.second
         )
     }
 
-    pub(super) fn rfc822(self) -> String {
+    /// `Day, DD Mon YYYY HH:MM:SS +0000`, as RSS wants it.
+    /// Civil date-time parts in UTC: year, month, day, hour, minute, second.
+    pub fn parts(self) -> (i32, u32, u32, u32, u32, u32) {
+        (self.year, self.month, self.day, self.hour, self.minute, self.second)
+    }
+
+    pub fn rfc822(self) -> String {
         format!(
             "{}, {:02} {} {:04} {:02}:{:02}:{:02} +0000",
             WEEKDAYS[weekday_utc(self.year, self.month, self.day)],
@@ -41,7 +49,7 @@ impl ParsedDate {
     }
 }
 
-pub(super) fn parse_date(value: Option<&str>) -> Option<ParsedDate> {
+pub fn parse_date(value: Option<&str>) -> Option<ParsedDate> {
     let value = value?.trim();
     if value.is_empty() {
         return None;

--- a/crates/ox_content_ssg/src/lib.rs
+++ b/crates/ox_content_ssg/src/lib.rs
@@ -91,7 +91,9 @@ mod vitepress;
 pub use assets::{
     ExternalizedAssets, GeneratedHtmlPage, SharedAsset, externalize_shared_page_assets,
 };
-pub use feeds::{FeedFormat, FeedItem, FeedsOptions, FeedsOutput, generate_feeds};
+pub use feeds::{
+    FeedFormat, FeedItem, FeedsOptions, FeedsOutput, ParsedDate, generate_feeds, parse_date,
+};
 pub use html::{
     A11y, BarePageData, Contributor, EntryPageConfig, FeatureConfig, GeneratedHtml, HeadAlternate,
     HeadDiagnostic, HeadInput, HeadJsonLd, HeadLink, HeadMeta, HeadValidation, HeaderNavItem,

--- a/npm/vite-plugin-ox-content/src/feed-date.test.ts
+++ b/npm/vite-plugin-ox-content/src/feed-date.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vite-plus/test";
+import { importNapiModuleSync } from "./napi";
+import { parseDate } from "./feed-date";
+
+const ACCEPTED: [string, string, number][] = [
+  ["a civil date", "2024-01-02", 1704153600],
+  ["a UTC date-time", "2024-01-02T03:04:05Z", 1704164645],
+  ["a positive offset", "2024-01-02T03:04:05+09:00", 1704132245],
+  ["a negative offset", "2024-01-02T03:04:05-05:30", 1704184445],
+  ["a space separator", "2024-01-02 03:04:05Z", 1704164645],
+  ["fractional seconds", "2024-01-02T03:04:05.123Z", 1704164645],
+  ["epoch seconds", "1700000000", 1700000000],
+  ["epoch milliseconds", "1700000000000", 1700000000],
+  ["a leap day", "2024-02-29T00:00:00Z", 1709164800],
+  ["a pre-epoch instant", "1969-12-31T23:59:59Z", -1],
+];
+
+const REJECTED = [
+  "",
+  "not a date",
+  "2024-13-02",
+  "2024-01-32",
+  "2024-01-02T24:00:00Z",
+  "2024-01-02X03:04:05Z",
+];
+
+describe("parseDate", () => {
+  for (const [label, input, unix] of ACCEPTED) {
+    it(`accepts ${label}`, () => {
+      expect(parseDate(input)?.unix).toBe(unix);
+    });
+  }
+
+  it("rejects values that name no instant", () => {
+    for (const input of REJECTED) {
+      expect(parseDate(input), input).toBeUndefined();
+    }
+    expect(parseDate(undefined)).toBeUndefined();
+  });
+
+  // Frontmatter dates arrive with whatever padding the author left, and two of
+  // the three call sites do not trim before asking. Dropping the date silently
+  // is how a post loses its position in a feed.
+  it("tolerates surrounding whitespace", () => {
+    expect(parseDate(" 2024-01-02T03:04:05Z ")?.unix).toBe(1704164645);
+    expect(parseDate("\t2024-01-02")?.unix).toBe(1704153600);
+  });
+
+  // A digit string past the safe-integer range is not a date anyone meant.
+  // Rounding it into a year in the billions and writing that to a feed is
+  // worse than refusing it.
+  it("refuses an epoch value it cannot represent exactly", () => {
+    expect(parseDate("99999999999999999999")).toBeUndefined();
+  });
+
+  it("agrees with the native parser it delegates to", () => {
+    const napi = importNapiModuleSync();
+    for (const input of [...ACCEPTED.map(([, value]) => value), ...REJECTED]) {
+      expect(parseDate(input)?.unix, input).toBe(napi.parseFeedDate(input)?.unix);
+    }
+  });
+});

--- a/npm/vite-plugin-ox-content/src/feed-date.ts
+++ b/npm/vite-plugin-ox-content/src/feed-date.ts
@@ -1,114 +1,25 @@
 import type { ParsedDate } from "./feed-format";
+import { importNapiModuleSync } from "./napi";
 
+/**
+ * Parse a feed date: epoch seconds, epoch milliseconds, or a civil date-time
+ * with an optional zone offset.
+ *
+ * The rule lives in Rust (`ox_content_ssg::parse_date`) so the feeds the Vite
+ * plugin writes and the ones the native SSG writes agree on what a date is.
+ */
 export function parseDate(value: string | undefined): ParsedDate | undefined {
-  if (!value) {
+  const parsed = importNapiModuleSync().parseFeedDate(value);
+  if (!parsed) {
     return undefined;
   }
-  if (/^\d+$/.test(value)) {
-    const n = Number(value);
-    return unixToDate(value.length >= 13 ? Math.trunc(n / 1000) : n);
-  }
-  return parseCivilDate(value);
-}
-
-function parseCivilDate(value: string): ParsedDate | undefined {
-  if (value.length < 10 || value[4] !== "-" || value[7] !== "-") {
-    return undefined;
-  }
-  const year = Number(value.slice(0, 4));
-  const month = Number(value.slice(5, 7));
-  const day = Number(value.slice(8, 10));
-  let hour = 0;
-  let minute = 0;
-  let second = 0;
-  let offset = 0;
-  if (value.length > 10) {
-    const rest = value.slice(10);
-    const time = rest.startsWith("T") || rest.startsWith(" ") ? rest.slice(1) : "";
-    if (time.length < 8 || time[2] !== ":" || time[5] !== ":") {
-      return undefined;
-    }
-    hour = Number(time.slice(0, 2));
-    minute = Number(time.slice(3, 5));
-    second = Number(time.slice(6, 8));
-    const parsedOffset = parseOffset(timezoneSuffix(time));
-    if (parsedOffset == null) {
-      return undefined;
-    }
-    offset = parsedOffset;
-  }
-  const unix = civilToUnix(year, month, day, hour, minute, second);
-  return unix == null ? undefined : unixToDate(unix - offset);
-}
-
-function timezoneSuffix(rest: string): string {
-  const afterTime = rest.slice(8);
-  if (afterTime.startsWith(".")) {
-    const index = afterTime.search(/[Z+-]/);
-    return index === -1 ? "" : afterTime.slice(index);
-  }
-  return afterTime;
-}
-
-function parseOffset(tz: string): number | undefined {
-  if (!tz || tz === "Z") {
-    return 0;
-  }
-  if (tz.length < 6) {
-    return undefined;
-  }
-  const sign = tz[0] === "+" ? 1 : tz[0] === "-" ? -1 : 0;
-  if (!sign) {
-    return undefined;
-  }
-  return sign * (Number(tz.slice(1, 3)) * 3600 + Number(tz.slice(4, 6)) * 60);
-}
-
-function civilToUnix(
-  year: number,
-  month: number,
-  day: number,
-  hour: number,
-  minute: number,
-  second: number,
-): number | undefined {
-  if (month < 1 || month > 12 || day < 1 || day > 31 || hour > 23 || minute > 59 || second > 60) {
-    return undefined;
-  }
-  let y = year;
-  if (month <= 2) {
-    y -= 1;
-  }
-  const era = Math.trunc((y >= 0 ? y : y - 399) / 400);
-  const yoe = y - era * 400;
-  const shifted = month + (month > 2 ? -3 : 9);
-  const doy = Math.trunc((153 * shifted + 2) / 5) + day - 1;
-  const doe = yoe * 365 + Math.trunc(yoe / 4) - Math.trunc(yoe / 100) + doy;
-  const days = era * 146097 + doe - 719468;
-  return days * 86400 + hour * 3600 + minute * 60 + second;
-}
-
-function unixToDate(unix: number): ParsedDate | undefined {
-  const days = Math.floor(unix / 86400);
-  const tod = ((unix % 86400) + 86400) % 86400;
-  const z = days + 719468;
-  const era = Math.trunc((z >= 0 ? z : z - 146096) / 146097);
-  const doe = z - era * 146097;
-  const yoe = Math.trunc(
-    (doe - Math.trunc(doe / 1460) + Math.trunc(doe / 36524) - Math.trunc(doe / 146096)) / 365,
-  );
-  const year = yoe + era * 400;
-  const doy = doe - (365 * yoe + Math.trunc(yoe / 4) - Math.trunc(yoe / 100));
-  const mp = Math.trunc((5 * doy + 2) / 153);
-  const day = doy - Math.trunc((153 * mp + 2) / 5) + 1;
-  const month = mp < 10 ? mp + 3 : mp - 9;
   return {
-    unix,
-    year: year + (month <= 2 ? 1 : 0),
-    month,
-    day,
-    hour: Math.trunc(tod / 3600),
-    minute: Math.trunc((tod % 3600) / 60),
-    second: tod % 60,
+    unix: parsed.unix,
+    year: parsed.year,
+    month: parsed.month,
+    day: parsed.day,
+    hour: parsed.hour,
+    minute: parsed.minute,
+    second: parsed.second,
   };
 }


### PR DESCRIPTION
## Summary
- delete the TypeScript date parser and delegate to `ox_content_ssg::parse_date` through a new `parseFeedDate` binding
- fix three date inputs the TypeScript port got wrong
- publish `ParsedDate`, `parse_date`, and a `parts()` accessor on `ox_content_ssg`

`feed-date.ts` was a hand-port of `ox_content_ssg::feeds::dates` — same
algorithm, same helper names (`parseCivilDate`/`parse_civil_date`,
`timezoneSuffix`/`timezone_suffix`, `civilToUnix`/`civil_to_unix`), maintained
twice. Comparing the two across a corpus of date shapes found three inputs
where they disagree, and on all three TypeScript is the wrong one.

## The three defects

| Input | TypeScript | Rust |
| --- | --- | --- |
| `" 2024-01-02T03:04:05Z "` | `undefined` | parses |
| `"\t2024-01-02"` | `undefined` | parses |
| `"99999999999999999999"` | year 3,168,875,820 | `undefined` |

The whitespace one is live. `parseFeedDate` trims before calling, but
`feeds-items.ts` and `blog-posts.ts` do not — so a `date:` frontmatter value
with any padding silently lost its date, and with it its position in the feed.

The numeric one is `Number` rounding a value past the safe-integer range into a
date in the year three billion. Writing that into a feed is worse than refusing
the value, which is what Rust does.

## Verification
- cargo test --workspace  (1918 passed)
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- cd npm/vite-plugin-ox-content && vp test run  (894 passed)
- vp run check:ts
- node scripts/check-file-lines.ts

`feed-date.test.ts` pins the accepted shapes, the rejected ones, all three
fixed cases, and agreement with the binding it delegates to.

Refs #902

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790401757&installation_model_id=422833&pr_number=1068&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1068&signature=70ef3a1f138f5b2cb81954acb37d9d8669e5324b1569befa20b9844619d819df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->