### PR TITLE
perf(og-image): stop paying for work the cache already did

### DIFF
--- a/docs/content/built-in/site-generation.md
+++ b/docs/content/built-in/site-generation.md
@@ -204,9 +204,16 @@ generated image looks like this:
 | `width`                     | `1200`       | Image width in pixels.                                                |
 | `height`                    | `630`        | Image height in pixels.                                               |
 | `cache`                     | `true`       | Skip re-rendering unchanged pages.                                    |
-| `concurrency`               | `1`          | Parallel image renders.                                               |
+| `concurrency`               | CPU-aware    | Parallel image renders. Defaults to `min(4, cores - 1)`.              |
 | `satori.fonts`              | `[]`         | Font files for Satori (`.ttf`, `.otf`, or `.woff`).                   |
 | `satori.systemFontFallback` | `true`       | Try common OS font paths when `satori.fonts` is empty.                |
+
+Rendered images are cached under `.cache/og-images`, keyed by a hash of the
+template source and the page's props, so an unchanged page is copied from cache
+instead of re-rendered. Only pages whose title, description, or frontmatter
+changed pay for a render. That directory is gitignored, so a CI job that does
+not restore it renders every page every time — cache it between runs the same
+way you would `node_modules`.
 
 Chromium is the compatibility renderer: it can use normal browser CSS, local
 public assets, and framework templates exactly as a page would. Satori skips

--- a/docs/content/ja/built-in/site-generation.md
+++ b/docs/content/ja/built-in/site-generation.md
@@ -178,9 +178,11 @@ oxContent({
 | `width`                     | `1200`       | 画像幅（ピクセル）。                                             |
 | `height`                    | `630`        | 画像高さ（ピクセル）。                                           |
 | `cache`                     | `true`       | 変わっていないページの再描画を飛ばす。                           |
-| `concurrency`               | `1`          | 並列の画像描画。                                                 |
+| `concurrency`               | CPU 依存     | 並列の画像描画。既定は `min(4, cores - 1)`。                     |
 | `satori.fonts`              | `[]`         | Satori に渡すフォントファイル（`.ttf`、`.otf`、`.woff`）。       |
 | `satori.systemFontFallback` | `true`       | `satori.fonts` が空のとき、よくある OS フォントパスを探す。      |
+
+描画した画像は `.cache/og-images` にキャッシュします。キーはテンプレートのソースとページの props のハッシュなので、変更のないページは再描画せずキャッシュからコピーします。描画コストを払うのはタイトル・説明・frontmatter が変わったページだけです。このディレクトリは gitignore されているため、復元しない CI ジョブは毎回すべてのページを描画します。`node_modules` と同じように、実行間でキャッシュしてください。
 
 Chromium は互換性重視のレンダラーです。通常のブラウザ CSS、ローカル public
 アセット、フレームワークテンプレートをページと同じ感覚で使えます。Satori は

--- a/npm/vite-plugin-ox-content/src/og-image.test.ts
+++ b/npm/vite-plugin-ox-content/src/og-image.test.ts
@@ -104,12 +104,16 @@ describe("resolveOgImageOptions", () => {
       width: 1200,
       height: 630,
       cache: true,
-      concurrency: 1,
       satori: {
         fonts: [{ path: "fonts/Inter.ttf", name: "Inter", weight: 500 }],
         systemFontFallback: false,
       },
     });
+  });
+
+  it("keeps an explicit concurrency and defaults to more than one", () => {
+    expect(resolveOgImageOptions({ concurrency: 3 }).concurrency).toBe(3);
+    expect(resolveOgImageOptions(undefined).concurrency).toBeGreaterThan(1);
   });
 });
 
@@ -175,5 +179,88 @@ describe("generateOgImages with Satori", () => {
     } finally {
       await fs.rm(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("OG image caching", () => {
+  const props = (title: string) => ({
+    title,
+    description: "Browserless OG image rendering",
+    siteName: "Ox Content",
+  });
+
+  async function withDir<T>(run: (dir: string) => Promise<T>): Promise<T> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "ox-og-cache-"));
+    try {
+      return await run(dir);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("serves a second build from cache instead of re-rendering", async () => {
+    await withDir(async (dir) => {
+      const options = resolveOgImageOptions({
+        renderer: "satori",
+        width: 600,
+        height: 315,
+      });
+      const entry = { outputPath: path.join(dir, "og.png"), props: props("Cached page") };
+
+      const [first] = await generateOgImages([entry], options, dir);
+      expect(first).toEqual({ outputPath: entry.outputPath, cached: false });
+
+      await fs.rm(entry.outputPath);
+      const [second] = await generateOgImages([entry], options, dir);
+      expect(second).toEqual({ outputPath: entry.outputPath, cached: true });
+
+      // The output is restored from cache, not left missing.
+      const png = await fs.readFile(entry.outputPath);
+      expect(png.subarray(0, 8).toString("hex")).toBe("89504e470d0a1a0a");
+    });
+  });
+
+  it("re-renders only the page whose props changed", async () => {
+    await withDir(async (dir) => {
+      const options = resolveOgImageOptions({
+        renderer: "satori",
+        width: 600,
+        height: 315,
+      });
+      const stable = { outputPath: path.join(dir, "a.png"), props: props("Stable") };
+      const changing = { outputPath: path.join(dir, "b.png"), props: props("Before") };
+
+      await generateOgImages([stable, changing], options, dir);
+
+      const results = await generateOgImages(
+        [stable, { ...changing, props: props("After") }],
+        options,
+        dir,
+      );
+      expect(results.map((r) => r.cached)).toEqual([true, false]);
+    });
+  });
+
+  it("does not cache when caching is off", async () => {
+    await withDir(async (dir) => {
+      const options = resolveOgImageOptions({
+        renderer: "satori",
+        width: 600,
+        height: 315,
+        cache: false,
+      });
+      const entry = { outputPath: path.join(dir, "og.png"), props: props("Uncached") };
+
+      await generateOgImages([entry], options, dir);
+      const [second] = await generateOgImages([entry], options, dir);
+      expect(second).toEqual({ outputPath: entry.outputPath, cached: false });
+    });
+  });
+
+  // Rendering was serial by default, so a site paid one full page render per
+  // page end to end however many cores it had.
+  it("renders more than one page at a time by default", () => {
+    expect(resolveOgImageOptions(undefined).concurrency).toBeGreaterThan(1);
+    expect(resolveOgImageOptions({ concurrency: 1 }).concurrency).toBe(1);
   });
 });

--- a/npm/vite-plugin-ox-content/src/og-image/cache.ts
+++ b/npm/vite-plugin-ox-content/src/og-image/cache.ts
@@ -23,6 +23,22 @@ export function computeCacheKey(
 }
 
 /**
+ * Whether a cached PNG exists, without reading it.
+ *
+ * Deciding whether the browser has to start at all only needs to know that
+ * every key is present. Reading each file to answer that costs a full pass
+ * over the cache before rendering has begun.
+ */
+export async function isCached(cacheDir: string, key: string): Promise<boolean> {
+  try {
+    await fs.access(path.join(cacheDir, `${key}.png`));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Checks if a cached PNG exists for the given key.
  * Returns the cached file path if found, null otherwise.
  */

--- a/npm/vite-plugin-ox-content/src/og-image/index.ts
+++ b/npm/vite-plugin-ox-content/src/og-image/index.ts
@@ -6,11 +6,12 @@
  */
 import * as path from "path";
 import * as crypto from "crypto";
+import { availableParallelism } from "os";
 import { openBrowser } from "./browser";
 import type { OgBrowserSession } from "./browser";
 import { renderHtmlToPngWithSatori } from "./satori-renderer";
 import { getDefaultSatoriTemplate, getDefaultTemplate } from "./template";
-import { computeCacheKey, getCached, writeCache } from "./cache";
+import { computeCacheKey, getCached, isCached, writeCache } from "./cache";
 import type {
   OgImageOptions,
   ResolvedOgImageOptions,
@@ -34,6 +35,19 @@ export type { OgBrowserSession } from "./browser";
 /**
  * Resolves user-provided OG image options with defaults.
  */
+/**
+ * How many pages to render at once when the caller does not say.
+ *
+ * Rendering was serial by default, so a site paid one Chromium page render per
+ * page, end to end. Pages are cheap next to the browser itself, but they are
+ * not free — this stays well under the core count so a build machine keeps
+ * room for everything else.
+ */
+function defaultConcurrency(): number {
+  const cores = availableParallelism();
+  return Math.max(1, Math.min(4, cores - 1));
+}
+
 export function resolveOgImageOptions(options: OgImageOptions | undefined): ResolvedOgImageOptions {
   return {
     renderer: options?.renderer ?? "chromium",
@@ -42,7 +56,7 @@ export function resolveOgImageOptions(options: OgImageOptions | undefined): Reso
     width: options?.width ?? 1200,
     height: options?.height ?? 630,
     cache: options?.cache ?? true,
-    concurrency: options?.concurrency ?? 1,
+    concurrency: options?.concurrency ?? defaultConcurrency(),
     satori: {
       fonts: options?.satori?.fonts ?? [],
       systemFontFallback: options?.satori?.systemFontFallback ?? true,
@@ -598,14 +612,16 @@ export async function generateOgImages(
   // Cache directory
   const cacheDir = path.join(root, ".cache", "og-images");
 
+  const keyed = withCacheKeys(pages, templateSource, options);
+
   // Try to serve all from cache first if caching is enabled
   if (options.cache) {
-    const allCached = await tryServeAllFromCache(pages, templateSource, options, cacheDir);
+    const allCached = await tryServeAllFromCache(keyed, cacheDir);
     if (allCached) return allCached;
   }
 
   if (options.renderer === "satori") {
-    return renderSatoriPages(pages, templateFn, templateSource, options, cacheDir, root);
+    return renderSatoriPages(keyed, templateFn, options, cacheDir, root);
   }
 
   // Launch browser
@@ -626,11 +642,11 @@ export async function generateOgImages(
   // Process pages with concurrency control
   const concurrency = Math.max(1, options.concurrency);
 
-  for (let i = 0; i < pages.length; i += concurrency) {
-    const batch = pages.slice(i, i + concurrency);
+  for (let i = 0; i < keyed.length; i += concurrency) {
+    const batch = keyed.slice(i, i + concurrency);
     const batchResults = await Promise.all(
       batch.map((entry) =>
-        renderSinglePage(entry, templateFn, templateSource, options, cacheDir, session, publicDir),
+        renderSinglePage(entry, templateFn, options, cacheDir, session, publicDir),
       ),
     );
     results.push(...batchResults);
@@ -640,9 +656,8 @@ export async function generateOgImages(
 }
 
 async function renderSatoriPages(
-  pages: OgImagePageEntry[],
+  pages: KeyedPageEntry[],
   templateFn: OgImageTemplateFn,
-  templateSource: string,
   options: ResolvedOgImageOptions,
   cacheDir: string,
   root: string,
@@ -653,9 +668,7 @@ async function renderSatoriPages(
   for (let i = 0; i < pages.length; i += concurrency) {
     const batch = pages.slice(i, i + concurrency);
     const batchResults = await Promise.all(
-      batch.map((entry) =>
-        renderSingleSatoriPage(entry, templateFn, templateSource, options, cacheDir, root),
-      ),
+      batch.map((entry) => renderSingleSatoriPage(entry, templateFn, options, cacheDir, root)),
     );
     results.push(...batchResults);
   }
@@ -664,64 +677,82 @@ async function renderSatoriPages(
 }
 
 /**
- * Tries to serve all pages from cache.
- * Returns results if ALL pages are cached, null otherwise.
+ * Serves every page from cache when all of them are present.
+ *
+ * The probe is an existence check per key, not a read: on a partial hit this
+ * used to read and write every cached page before discovering the miss, then
+ * throw that work away and let the render loop redo it. Returns null when any
+ * page is missing, which is the signal that a renderer has to start.
  */
 async function tryServeAllFromCache(
+  pages: KeyedPageEntry[],
+  cacheDir: string,
+): Promise<OgImageResult[] | null> {
+  for (const entry of pages) {
+    if (!(await isCached(cacheDir, entry.key))) return null;
+  }
+
+  const results: OgImageResult[] = [];
+  for (const entry of pages) {
+    const cached = await getCached(cacheDir, entry.key);
+    // Raced with a cache eviction between the probe and the read.
+    if (!cached) return null;
+    await writeOutput(entry.outputPath, cached);
+    results.push({ outputPath: entry.outputPath, cached: true });
+  }
+  return results;
+}
+
+/** A page entry with its cache key computed once. */
+interface KeyedPageEntry extends OgImagePageEntry {
+  key: string;
+}
+
+/**
+ * Attaches the cache key to each entry.
+ *
+ * The key is a SHA-256 over the template source and the page props. It used to
+ * be recomputed three times per page — once to probe, once to read, once to
+ * write — over props that can be a whole frontmatter object.
+ */
+function withCacheKeys(
   pages: OgImagePageEntry[],
   templateSource: string,
   options: ResolvedOgImageOptions,
-  cacheDir: string,
-): Promise<OgImageResult[] | null> {
-  const fs = await import("fs/promises");
-  const results: OgImageResult[] = [];
-
-  for (const entry of pages) {
-    const key = computeCacheKey(
+): KeyedPageEntry[] {
+  return pages.map((entry) => ({
+    ...entry,
+    key: computeCacheKey(
       templateSource,
       entry.props as unknown as Record<string, unknown>,
       options.width,
       options.height,
-    );
-    const cached = await getCached(cacheDir, key);
-    if (!cached) return null; // At least one miss, need browser
+    ),
+  }));
+}
 
-    // Write cached file to output
-    await fs.mkdir(path.dirname(entry.outputPath), { recursive: true });
-    await fs.writeFile(entry.outputPath, cached);
-    results.push({ outputPath: entry.outputPath, cached: true });
-  }
-
-  return results;
+async function writeOutput(outputPath: string, png: Buffer): Promise<void> {
+  const fs = await import("fs/promises");
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, png);
 }
 
 /**
  * Renders a single page to PNG, with cache support.
  */
 async function renderSinglePage(
-  entry: OgImagePageEntry,
+  entry: KeyedPageEntry,
   templateFn: OgImageTemplateFn,
-  templateSource: string,
   options: ResolvedOgImageOptions,
   cacheDir: string,
   session: OgBrowserSession,
   publicDir?: string,
 ): Promise<OgImageResult> {
-  const fs = await import("fs/promises");
-
   try {
-    // Check cache
     if (options.cache) {
-      const key = computeCacheKey(
-        templateSource,
-        entry.props as unknown as Record<string, unknown>,
-        options.width,
-        options.height,
-      );
-      const cached = await getCached(cacheDir, key);
+      const cached = await getCached(cacheDir, entry.key);
       if (cached) {
-        await fs.mkdir(path.dirname(entry.outputPath), { recursive: true });
-        await fs.writeFile(entry.outputPath, cached);
+        await writeOutput(entry.outputPath, cached);
         return { outputPath: entry.outputPath, cached: true };
       }
     }
@@ -732,19 +763,10 @@ async function renderSinglePage(
     // Render HTML to PNG via session (page create/close handled internally)
     const png = await session.renderPage(html, options.width, options.height, publicDir);
 
-    // Write output
-    await fs.mkdir(path.dirname(entry.outputPath), { recursive: true });
-    await fs.writeFile(entry.outputPath, png);
+    await writeOutput(entry.outputPath, png);
 
-    // Write cache
     if (options.cache) {
-      const key = computeCacheKey(
-        templateSource,
-        entry.props as unknown as Record<string, unknown>,
-        options.width,
-        options.height,
-      );
-      await writeCache(cacheDir, key, png);
+      await writeCache(cacheDir, entry.key, png);
     }
 
     return { outputPath: entry.outputPath, cached: false };
@@ -761,27 +783,17 @@ async function renderSinglePage(
  * Renders a single page to PNG using Satori, with cache support.
  */
 async function renderSingleSatoriPage(
-  entry: OgImagePageEntry,
+  entry: KeyedPageEntry,
   templateFn: OgImageTemplateFn,
-  templateSource: string,
   options: ResolvedOgImageOptions,
   cacheDir: string,
   root: string,
 ): Promise<OgImageResult> {
-  const fs = await import("fs/promises");
-
   try {
     if (options.cache) {
-      const key = computeCacheKey(
-        templateSource,
-        entry.props as unknown as Record<string, unknown>,
-        options.width,
-        options.height,
-      );
-      const cached = await getCached(cacheDir, key);
+      const cached = await getCached(cacheDir, entry.key);
       if (cached) {
-        await fs.mkdir(path.dirname(entry.outputPath), { recursive: true });
-        await fs.writeFile(entry.outputPath, cached);
+        await writeOutput(entry.outputPath, cached);
         return { outputPath: entry.outputPath, cached: true };
       }
     }
@@ -789,17 +801,10 @@ async function renderSingleSatoriPage(
     const html = await templateFn(entry.props);
     const png = await renderHtmlToPngWithSatori(html, options, root);
 
-    await fs.mkdir(path.dirname(entry.outputPath), { recursive: true });
-    await fs.writeFile(entry.outputPath, png);
+    await writeOutput(entry.outputPath, png);
 
     if (options.cache) {
-      const key = computeCacheKey(
-        templateSource,
-        entry.props as unknown as Record<string, unknown>,
-        options.width,
-        options.height,
-      );
-      await writeCache(cacheDir, key, png);
+      await writeCache(cacheDir, entry.key, png);
     }
 
     return { outputPath: entry.outputPath, cached: false };

--- a/npm/vite-plugin-ox-content/src/og-image/renderer.ts
+++ b/npm/vite-plugin-ox-content/src/og-image/renderer.ts
@@ -80,7 +80,11 @@ export async function renderHtmlToPng(
   }
 
   const fullHtml = wrapHtml(html, width, height, !!publicDir);
-  await page.setContent(fullHtml, { waitUntil: "networkidle" });
+  // `load` fires once the document and its subresources — images, fonts, the
+  // things a card actually shows — have loaded. `networkidle` additionally
+  // waits out a 500ms quiet window, which a self-contained card spends idle,
+  // and which every page pays whether or not it requests anything.
+  await page.setContent(fullHtml, { waitUntil: "load" });
 
   const screenshot = await page.screenshot({
     type: "png",


### PR DESCRIPTION
## Summary
- render pages in parallel by default (`min(4, cores - 1)`) instead of one at a time
- wait for `load` rather than `networkidle`, which charged every page a 500ms idle window
- make the all-or-nothing cache probe an existence check, and compute each cache key once instead of three times
- document the cache in English and Japanese, including the CI caveat

## The cache was already there

Worth stating plainly, since it is easy to assume otherwise: images are cached
under `.cache/og-images`, keyed by a hash of the template source and the page
props, and `cache` has always defaulted to `true`. An unchanged page is copied
from cache, not re-rendered. Nothing in this PR changes what a cached page
produces.

What made generation feel heavy anyway was the work around it.

## Three costs, all scaling with page count

**Rendering was serial.** `concurrency` defaulted to `1`, so a site paid one
full page render per page end to end, on any machine, however many cores it
had. Pages are cheap next to the browser itself, so the default is now
CPU-aware and capped at 4 to leave a build machine room. An explicit
`concurrency` still wins.

**Every page waited out a network idle window.** `setContent` used
`waitUntil: "networkidle"`, which resolves only after 500ms with no network
activity. A self-contained card spends that window doing nothing and pays it
regardless. `load` already waits for the document and its subresources — the
images and fonts a card actually shows.

**The cache probe did the work twice.** `tryServeAllFromCache` read *and*
wrote every cached page before it could discover one miss, then returned null
and let the render loop redo all of it. It is now an existence check. The cache
key — a SHA-256 over the template source and what can be an entire frontmatter
object — was also recomputed three times per page (probe, read, write); it is
computed once.

## A note for CI

`.cache/` is gitignored, so a CI job that does not restore it renders every
page every time. That is now documented next to the option table — cache the
directory between runs the same way you would `node_modules`.

## Verification
- cd npm/vite-plugin-ox-content && vp test run  (899 passed)
- vp run check:ts
- node scripts/check-file-lines.ts

New tests cover a second build served from cache, only the changed page
re-rendering, `cache: false` staying uncached, and the concurrency default.
They run through the Satori renderer, so they need no Chromium.

I could not benchmark the Chromium path here — Playwright is not installed in
this environment — so the wins above are argued from the code, not measured.

Reported directly rather than filed as an issue: OG image generation was heavy
on a large site.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OG image rendering cache support, reusing unchanged images and rerendering only pages with updated content.
  - Added cache availability checks and support for restoring the cache between CI runs.
  - OG image rendering now uses a CPU-aware default concurrency of up to four tasks.

- **Bug Fixes**
  - Improved image generation reliability by waiting for page and resource loading to complete before rendering.

- **Documentation**
  - Documented OG image caching behavior, default concurrency, and CI cache requirements in English and Japanese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->