### PR TITLE
docs(plans): audit TypeScript modules for Rust migration

### DIFF
--- a/.plans/060-typescript-rust-migration-audit.md
+++ b/.plans/060-typescript-rust-migration-audit.md
@@ -1,0 +1,101 @@
+# TypeScript → Rust migration audit
+
+Answers the audit bullet of #902, split out as #1073. The point is to replace
+"move core behavior to Rust where practical" with a list of named slices, each
+with a reason, so the migrations after this are scoped rather than
+opportunistic.
+
+## Method
+
+Every `.ts` file under `npm/vite-plugin-ox-content/src` that is not a test or a
+declaration file — 209 modules. Each was classified from its imports and the
+globals it touches:
+
+- **ui-runtime** — reaches browser globals, or is a template string of
+  JavaScript emitted into the page.
+- **framework-integration** — React / Vue / Svelte / Solid specific.
+- **platform-glue** — imports `vite` or Node built-ins, or is a plugin entry
+  point.
+- **core-behavior** — none of the above: data in, data out.
+
+Duplicates were found by matching each exported TypeScript function against
+public Rust `fn` names, camelCase to snake_case, then reading both sides. That
+match is a starting point, not a verdict: `lint.ts` looked like a duplicate of
+`ox_content_markdown_lint` and is not — it is TypeScript orchestration over
+that engine, reaching the binding through a `napiBinding` local rather than the
+`importNapiModule` helper the first pass looked for.
+
+## Where the code sits
+
+| Class                 | Modules | Already delegating to Rust |
+| --------------------- | ------- | -------------------------- |
+| core-behavior         | 124     | 13                         |
+| platform-glue         | 58      | 13                         |
+| ui-runtime            | 25      | 3                          |
+| framework-integration | 2       | 1                          |
+| **total**             | **209** | **30**                     |
+
+No module is unclassified.
+
+The number that matters is the first row: 111 modules are pure data-in /
+data-out and do not go through Rust. That is not 111 migrations — most are
+small option normalizers where a NAPI hop would cost more than the function —
+but it is where the duplicates live.
+
+## Duplicates found
+
+Both implementations exist; neither calls the other.
+
+| Rule               | TypeScript                                                           | Rust                                            | State                                    |
+| ------------------ | -------------------------------------------------------------------- | ----------------------------------------------- | ---------------------------------------- |
+| Feed generation    | `feeds.ts` → `generateFeeds`                                         | `ox_content_ssg::generate_feeds`                | drifted, TS ahead — #1074                |
+| Site maps          | `site-maps.ts` (293 lines) → `generateSiteMaps`                      | `ox_content_ssg::site_maps::generate_site_maps` | unverified                               |
+| Redirects          | `redirects.ts` (339 lines) → `generateRedirectHtml`, `normalizePath` | `ox_content_ssg::redirects`                     | unverified                               |
+| Feed date fallback | `blog-feed-date.ts` → `parseFeedDate`                                | `ox_content_ssg::parse_date`                    | partial: the RFC 822 fallback is TS-only |
+
+Two were already closed while writing this audit, and both had drifted before
+anyone noticed:
+
+- `extractVideoId` — #1063. The Rust doc comment said it "mirrors the TS
+  extractVideoId"; they agreed, and the copy was deleted.
+- The feed date parser — #1068. They did **not** agree. Three inputs differed,
+  TypeScript wrong on all three, one of them live.
+
+That is the argument for doing the rest: every duplicate examined so far had
+either drifted or was one edit away from it.
+
+## Ranked migrations
+
+1. **Feeds** — #1074. Largest surface, already drifted, and the drift runs
+   TS-ahead so the port adds features to Rust rather than moving them.
+2. **Site maps** — `generate_site_maps` exists and nothing calls it from the
+   plugin. Verify the two agree, then delegate. Small and self-contained.
+3. **Redirects** — same shape as site maps: a Rust implementation with no
+   caller. `generateRedirectHtml` emits markup, so drift here is user-visible.
+4. **Feed date RFC 822 fallback** — push the one remaining branch into
+   `ox_content_ssg::parse_date` so `blog-feed-date.ts` disappears too.
+
+None depends on another. Feeds is tracked as #1074; the other three are
+small enough to land directly rather than sit in the backlog.
+
+## Staying in TypeScript, deliberately
+
+- **Search runtimes** — `search/hosted-runtime.ts` and `search/local-runtime.ts`
+  are template strings of JavaScript emitted into the page. `parseSearchQuery`
+  and `search` appear duplicated against Rust and are not a migration
+  candidate: they run in the reader's browser. Sharing them would mean wasm in
+  the search box, which is a much larger trade than a search box justifies.
+- **Trivial helpers** — `escapeHtml`, `escapeXml`, `escapeAttribute`,
+  `isSafeDest`, `stripMarkdownExtension` and friends. Real duplicates, but each
+  is a few lines and crossing the NAPI boundary costs more than running it.
+  Duplication is the cheaper defect here.
+- **`lint.ts`** — already Rust-backed. The TypeScript around it normalizes
+  options and loads `cspell-lib` for opt-in standard dictionaries, which is a
+  JavaScript-ecosystem dependency.
+- **Option normalizers** — the bulk of the 111. They translate user config into
+  a resolved shape and are consumed immediately by TypeScript.
+
+## Note on measuring
+
+Nothing here reports what a migration costs. #1075 covers that; until it lands,
+a migration PR cannot show whether it grew the native artifact or the build.


### PR DESCRIPTION
## Summary
- classify all 209 modules under `npm/vite-plugin-ox-content/src` as core behavior, platform glue, UI runtime, or framework integration
- name every rule implemented in both languages, with both file paths
- rank the migrations worth doing, and record what stays in TypeScript on purpose

## Where the code sits

| Class | Modules | Already delegating to Rust |
| --- | --- | --- |
| core-behavior | 124 | 13 |
| platform-glue | 58 | 13 |
| ui-runtime | 25 | 3 |
| framework-integration | 2 | 1 |
| **total** | **209** | **30** |

No module is unclassified. 111 modules are pure data-in / data-out and do not
go through Rust — not 111 migrations, but that is where the duplicates live.

## Duplicates

| Rule | TypeScript | Rust | State |
| --- | --- | --- | --- |
| Feed generation | `feeds.ts` | `ox_content_ssg::generate_feeds` | drifted, TS ahead — #1074 |
| Site maps | `site-maps.ts` (293 lines) | `ox_content_ssg::site_maps` | unverified |
| Redirects | `redirects.ts` (339 lines) | `ox_content_ssg::redirects` | unverified |
| Feed date fallback | `blog-feed-date.ts` | `ox_content_ssg::parse_date` | partial, RFC 822 branch is TS-only |

Both duplicates closed while writing this had already drifted or were one edit
from it — #1063 agreed and the copy was deleted; #1068 did **not** agree, and
was wrong in three places, one of them live. That is the argument for the rest.

## What the match got wrong

Name-matching TypeScript exports against Rust `fn`s is a starting point, not a
verdict. `lint.ts` looked like a duplicate of `ox_content_markdown_lint` and is
not — it is TypeScript orchestration over that engine, reaching the binding
through a `napiBinding` local instead of the `importNapiModule` helper the
first pass searched for. The audit records that, and the corrected detection.

## Staying in TypeScript, deliberately

`search/hosted-runtime.ts` and `search/local-runtime.ts` are template strings
of JavaScript emitted into the page — `parseSearchQuery` and `search` look
duplicated and are not candidates, because they run in the reader's browser.
The escape helpers are real duplicates that are cheaper duplicated than
marshalled across NAPI.

## Verification
- vp run check:ts
- node scripts/check-file-lines.ts

Document only; no code changes.

Closes #1073

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790405460&installation_model_id=422833&pr_number=1078&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1078&signature=508074b0ce46f426865b10590e7b014d7dddee23626f488b420348c2cb4d6f07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a migration audit covering TypeScript source files and their Rust migration status.
  * Documented duplicate implementations, migration priorities, and areas intentionally remaining in TypeScript.
  * Included an inventory of 209 non-test, non-declaration source files and their classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->