### PR TITLE
fix(docs): repair the live embed examples on the embeds page

### DIFF
--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -45,6 +45,21 @@ Documented PascalCase tags such as `<Tweet>` and `<OgCard>` work in both `.md`
 and `.mdx`. A document-local import of the same name (`import Tweet from
 "./Tweet"`) overrides the built-in and stays an MDX island.
 
+### One tag, one line, in `.md`
+
+The examples below spread attributes over several lines for readability. That
+form needs MDX. In a plain `.md` file a tag has to open and close its `>` on the
+same line:
+
+```md
+<Bluesky url="https://bsky.app/profile/bsky.app/post/3l6oveex3ii2l" handle="bsky.app">…</Bluesky>
+```
+
+CommonMark only starts a raw HTML block when the opening tag finishes on the
+line it began on. A tag left open at the end of a line is prose, so its
+attributes render as text, its URLs turn into links, and the lone `>` line
+becomes a blockquote. Enable `mdx` to write the multi-line form.
+
 Disable every built-in embed with `embeds: false`, or configure embeds
 individually:
 
@@ -308,18 +323,7 @@ network request:
 </XPost>
 ```
 
-<XPost
-url="https://x.com/jack/status/20"
-displayName="jack"
-handle="jack"
-dateLabel="Mar 21, 2006"
-likes="2.4M"
-views="10M"
-
->
-
-just setting up my twttr
-</XPost>
+<XPost url="https://x.com/jack/status/20" displayName="jack" handle="jack" dateLabel="Mar 21, 2006" likes="2.4M" views="10M">just setting up my twttr</XPost>
 
 Use the object form to fetch the post body, author, avatar, photos, and video
 posters at build time and serve them from your own origin. Fetched cards include
@@ -434,21 +438,7 @@ request is needed at all:
 </Bluesky>
 ```
 
-<Bluesky
-url="https://bsky.app/profile/bsky.app/post/3l6oveex3ii2l"
-displayName="Bluesky"
-handle="bsky.app"
-avatar="https://bsky.app/static/apple-touch-icon.png"
-dateTime="2024-02-06T12:34:56Z"
-dateLabel="Feb 6, 2024"
-replies="1.2k"
-reposts="8.4k"
-likes="21k"
-
->
-
-👋 Bluesky is an open social network
-</Bluesky>
+<Bluesky url="https://bsky.app/profile/bsky.app/post/3l6oveex3ii2l" displayName="Bluesky" handle="bsky.app" avatar="https://bsky.app/static/apple-touch-icon.png" dateTime="2024-02-06T12:34:56Z" dateLabel="Feb 6, 2024" replies="1.2k" reposts="8.4k" likes="21k">👋 Bluesky is an open social network</Bluesky>
 
 ## Provider Cards
 
@@ -593,19 +583,20 @@ oEmbed metadata can be resolved, and a safe link card when fetch or parse
 fails:
 
 ```mdx
-<SpeakerDeck
-  url="https://speakerdeck.com/player/abcdef1234567890"
-  title="My Talk"
-  author="Jane Doe"
-/>
+<SpeakerDeck url="https://speakerdeck.com/jane/my-talk" title="My Talk" author="Jane Doe" />
 ```
 
-<SpeakerDeck url="https://speakerdeck.com/player/abcdef1234567890" title="My Talk" author="Jane Doe" />
+<SpeakerDeck url="https://speakerdeck.com/jane/my-talk" title="My Talk" author="Jane Doe" />
+
+The deck above does not exist, so the example shows the link-card fallback
+rather than a player.
 
 Share URLs on `speakerdeck.com/{user}/{slug}` fetch [oEmbed](https://oembed.com/)
 metadata at build time (`title`, `author_name`, player id, and thumbnail when
 present). Already-embedded `speakerdeck.com/player/{id}` URLs render without a
-network request. `javascript:` and `data:` URLs stay as authored markup.
+network request — including ids that do not exist, which embed the provider's
+own error page, so prefer a share URL in examples. `javascript:` and `data:`
+URLs stay as authored markup.
 
 When oEmbed fetch or player-id parse fails, the output is a fallback link card
 that still points at the original HTTPS Speaker Deck URL. The iframe is

--- a/docs/content/examples/speaker-deck-embed.md
+++ b/docs/content/examples/speaker-deck-embed.md
@@ -27,13 +27,13 @@ Resolved player URL (no network request):
 
 ```html
 <SpeakerDeck
-  url="https://speakerdeck.com/player/abcdef1234567890"
+  url="https://speakerdeck.com/jane/my-talk"
   title="My Talk"
   author="Jane Doe"
 ></SpeakerDeck>
 ```
 
-<SpeakerDeck url="https://speakerdeck.com/player/abcdef1234567890" title="My Talk" author="Jane Doe"></SpeakerDeck>
+<SpeakerDeck url="https://speakerdeck.com/jane/my-talk" title="My Talk" author="Jane Doe"></SpeakerDeck>
 
 Share URLs (`https://speakerdeck.com/{user}/{slug}`) fetch oEmbed metadata at
 build time and inject the player id, title, and author. `javascript:` and

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -39,6 +39,16 @@ description: Markdown 中の HTML 風タグで書く GitHub / OG カード、パ
 
 `<Tweet>` や `<OgCard>` のようなドキュメント上の PascalCase タグは `.md` と `.mdx` の両方で動きます。同じ名前のドキュメントローカル import（`import Tweet from "./Tweet"`）は組み込みより優先され、MDX island のまま残ります。
 
+### `.md` では 1 タグ 1 行
+
+以下の例は読みやすさのため属性を複数行に分けています。この形式には MDX が必要です。素の `.md` ファイルでは、タグの開始と `>` を同じ行に収める必要があります。
+
+```md
+<Bluesky url="https://bsky.app/profile/bsky.app/post/3l6oveex3ii2l" handle="bsky.app">…</Bluesky>
+```
+
+CommonMark が生の HTML ブロックを開始するのは、開始タグがその行の中で閉じている場合だけです。行末でタグが開いたままだと本文として扱われ、属性はテキストとして描画され、URL はリンクになり、`>` だけの行は引用ブロックになります。複数行で書きたい場合は `mdx` を有効にしてください。
+
 すべての組み込み埋め込みを切るときは `embeds: false`、個別に設定するときはオブジェクトです。
 
 ```ts
@@ -256,18 +266,7 @@ YouTube 埋め込みは SSG ビルドと dev preview で常に処理されます
 </XPost>
 ```
 
-<XPost
-url="https://x.com/jack/status/20"
-displayName="jack"
-handle="jack"
-dateLabel="Mar 21, 2006"
-likes="2.4M"
-views="10M"
-
->
-
-just setting up my twttr
-</XPost>
+<XPost url="https://x.com/jack/status/20" displayName="jack" handle="jack" dateLabel="Mar 21, 2006" likes="2.4M" views="10M">just setting up my twttr</XPost>
 
 オブジェクト形式を使うと、ビルド時に本文、著者、アバター、写真、動画ポスターを取り、自分のオリジンから配信します。取ってきたカードには、日時、元投稿リンク、利用可能な返信/リポスト/引用/いいね/表示数、引用投稿の入れ子カード、「Replying to @…」リンクも含まれます。`appearance: "full"` は sveltweet / react-tweet 形の静的カードです。
 
@@ -471,16 +470,14 @@ Twitch player URL は Twitch の embed 要件に合わせ、安全な `parent` d
 `embeds.speakerDeck` は、プレーヤー URL か oEmbed メタデータが解決できたとき遅延 iframe を描画し、取得や解析に失敗したときは安全なリンクカードに落とします。
 
 ```mdx
-<SpeakerDeck
-  url="https://speakerdeck.com/player/abcdef1234567890"
-  title="My Talk"
-  author="Jane Doe"
-/>
+<SpeakerDeck url="https://speakerdeck.com/jane/my-talk" title="My Talk" author="Jane Doe" />
 ```
 
-<SpeakerDeck url="https://speakerdeck.com/player/abcdef1234567890" title="My Talk" author="Jane Doe" />
+<SpeakerDeck url="https://speakerdeck.com/jane/my-talk" title="My Talk" author="Jane Doe" />
 
-`speakerdeck.com/{user}/{slug}` の共有 URL はビルド時に [oEmbed](https://oembed.com/) で `title` / `author_name` / プレーヤー ID / サムネイルを取ります。すでに埋め込み用の `speakerdeck.com/player/{id}` はネットワークなしで描画します。`javascript:` と `data:` URL は書いたまま残します。
+上のデッキは存在しないため、この例はプレーヤーではなくリンクカードのフォールバックを示しています。
+
+`speakerdeck.com/{user}/{slug}` の共有 URL はビルド時に [oEmbed](https://oembed.com/) で `title` / `author_name` / プレーヤー ID / サムネイルを取ります。存在しない ID でもプロバイダ自身のエラーページを埋め込んでしまうため、例では共有 URL を使ってください。すでに埋め込み用の `speakerdeck.com/player/{id}` はネットワークなしで描画します。`javascript:` と `data:` URL は書いたまま残します。
 
 oEmbed 取得やプレーヤー ID の解析に失敗したときは、元の HTTPS Speaker Deck URL を指すフォールバックリンクカードになります。iframe は遅延読み込みで、`sandbox` と `referrerpolicy="strict-origin-when-cross-origin"` を付けます。Content-Security-Policy を設定しているサイトでは `frame-src https://speakerdeck.com` が必要です。詳細は [Speaker Deck Embed](/examples/speaker-deck-embed.md) を見てください。
 

--- a/npm/vite-plugin-ox-content/src/__snapshots__/docs.snapshot.test.ts.snap
+++ b/npm/vite-plugin-ox-content/src/__snapshots__/docs.snapshot.test.ts.snap
@@ -506,12 +506,12 @@ export default {
 </code></pre>
 <p>Resolved player URL (no network request):</p>
 <pre><code class="language-html">&#x3C;SpeakerDeck
-  url="https://speakerdeck.com/player/abcdef1234567890"
+  url="https://speakerdeck.com/jane/my-talk"
   title="My Talk"
   author="Jane Doe"
 >&#x3C;/SpeakerDeck>
 </code></pre>
-<figure class="ox-speaker-deck"><iframe class="ox-speaker-deck" src="https://speakerdeck.com/player/abcdef1234567890" title="My Talk" width="100%" height="480" loading="lazy" allowfullscreen sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-presentation" referrerpolicy="strict-origin-when-cross-origin"></iframe><figcaption class="ox-speaker-deck__meta"><a href="https://speakerdeck.com/player/abcdef1234567890" target="_blank" rel="noopener noreferrer"><strong class="ox-speaker-deck__title">My Talk</strong><span class="ox-speaker-deck__author">Jane Doe</span></a></figcaption></figure>
+<a class="ox-speaker-deck ox-speaker-deck--fallback" href="https://speakerdeck.com/jane/my-talk" target="_blank" rel="noopener noreferrer"><span class="ox-speaker-deck__title">My Talk</span><span class="ox-speaker-deck__author">Jane Doe</span></a>
 <p>Share URLs (<code>https://speakerdeck.com/{user}/{slug}</code>) fetch oEmbed metadata at
 build time and inject the player id, title, and author. <code>javascript:</code> and
 <code>data:</code> URLs are rejected and stay as authored markup.</p>


### PR DESCRIPTION
## Summary
- flatten the live `<XPost>` and `<Bluesky>` examples to one line each, and explain why in a new section
- point the `<SpeakerDeck>` examples at a share URL instead of a non-existent player id
- English and Japanese

Three rendered examples on `built-in/embeds` were broken, in two different ways.

## Multi-line tags are prose in `.md` — #1079, #1080

`<XPost>` and `<Bluesky>` were written with attributes across several lines.
CommonMark only begins a raw HTML block when the opening tag finishes on the
line it started on, so those tags never became HTML:

```
<p>&lt;Bluesky\nurl=&quot;<a href="https://bsky.app/…">https://bsky.app/…</a>&quot;…</p>
<blockquote>\n</blockquote>
```

The attributes render as text, the URLs autolink, and the lone `>` line becomes
the empty blockquote visible in both screenshots. Confirmed by parsing the exact
source: multi-line escapes, single-line keeps the raw tag, and `mdx: true` keeps
it either way.

The live examples are now one line. The fenced examples keep the readable
multi-line form — that form is valid MDX — and a new "One tag, one line, in
`.md`" section says which is which, so a reader copying a fence knows what to
change.

## A placeholder id embedded the provider's 404 page — #1081

`<SpeakerDeck url="…/player/abcdef1234567890" />` renders its iframe with no
build-time request, so the id is only resolved by the reader's browser — which
loaded Speaker Deck's own "Sorry, the deck you are looking for can't be found."
page into the docs, unstyled.

The examples now use a share URL. That path renders the static link-card
fallback the surrounding prose already describes, with no remote load at all.
The prose notes the deck is a placeholder, and warns that a player id which does
not exist embeds the provider's error page.

## Verification
- parsed every live component tag on the three changed pages through `parseAndRender`: 23 tags, 0 escaped
- confirmed at the transform level that the share URL renders a static card while the player URL renders an iframe
- vp check

Docs-only; no code changes. I could not complete a full `vp run build:docs` —
the workspace debug build filled the disk — so the verification above is at the
parser and transform level rather than the built page.

Closes #1079
Closes #1080
Closes #1081