### PR TITLE
fix(embeds): theme the embed error colour and scale slide decks

### DIFF
--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -228,6 +228,7 @@ const OGP_CSS: &str = include_str!("plugins/ogp.css");
 /// CSS styles for social embeds (Twitter/X, Reddit, Bluesky, WebContainer, media iframes).
 const SOCIAL_CSS: &str = concat!(
     include_str!("plugins/social.css"),
+    include_str!("plugins/media-iframes.css"),
     include_str!("plugins/provider-cards.css"),
     include_str!("plugins/social-twitter-rich.css"),
     include_str!("plugins/reddit.css"),

--- a/crates/ox_content_ssg/src/plugins/github.css
+++ b/crates/ox_content_ssg/src/plugins/github.css
@@ -181,12 +181,12 @@
 
 /* Error state */
 .ox-github-card.error {
-  border-color: #f87171;
+  border-color: var(--octc-color-danger);
   background: transparent;
 }
 
 .ox-github-error {
-  color: #f87171;
+  color: var(--octc-color-danger);
   font-size: 0.875rem;
 }
 

--- a/crates/ox_content_ssg/src/plugins/island.css
+++ b/crates/ox_content_ssg/src/plugins/island.css
@@ -70,7 +70,7 @@ noscript .ox-island-fallback {
 
 /* Error state */
 [data-ox-island].ox-island-error {
-  border: 1px solid #f87171;
+  border: 1px solid var(--octc-color-danger);
   padding: 1rem;
   border-radius: 4px;
   background: rgba(248, 113, 113, 0.1);
@@ -79,7 +79,7 @@ noscript .ox-island-fallback {
 [data-ox-island].ox-island-error::after {
   content: attr(data-ox-error);
   display: block;
-  color: #f87171;
+  color: var(--octc-color-danger);
   font-size: 0.875rem;
 }
 

--- a/crates/ox_content_ssg/src/plugins/media-iframes.css
+++ b/crates/ox_content_ssg/src/plugins/media-iframes.css
@@ -1,0 +1,29 @@
+/* ox-content media iframes - Spotify, Apple Music, Speaker Deck, StackBlitz,
+   and the native audio/video players. */
+
+.ox-spotify,
+.ox-apple-music,
+.ox-speaker-deck,
+.ox-stackblitz,
+.ox-audio,
+.ox-video {
+  display: block;
+  width: 100%;
+  margin: 1.5rem 0;
+  border: 0;
+  border-radius: 12px;
+}
+
+.ox-stackblitz {
+  border: 1px solid color-mix(in srgb, var(--octc-color-border) 74%, transparent);
+  border-radius: 8px;
+}
+
+/* Slide decks are 4:3. The iframe is emitted with a fixed `height`, which
+   letterboxes the deck on any column narrower than the width that height
+   assumes — most of them, on a phone. The class is on the figure as well as the
+   iframe, so this has to name the iframe. */
+iframe.ox-speaker-deck {
+  height: auto;
+  aspect-ratio: 4 / 3;
+}

--- a/crates/ox_content_ssg/src/plugins/social.css
+++ b/crates/ox_content_ssg/src/plugins/social.css
@@ -327,31 +327,3 @@
   border: 0;
   border-radius: 0;
 }
-
-/* Media iframes */
-.ox-spotify,
-.ox-apple-music,
-.ox-speaker-deck,
-.ox-stackblitz,
-.ox-audio,
-.ox-video {
-  display: block;
-  width: 100%;
-  margin: 1.5rem 0;
-  border: 0;
-  border-radius: 12px;
-}
-
-.ox-stackblitz {
-  border: 1px solid color-mix(in srgb, var(--octc-color-border) 74%, transparent);
-  border-radius: 8px;
-}
-
-/* Slide decks are 4:3. The iframe is emitted with a fixed `height`, which
-   letterboxes the deck on any column narrower than the width that height
-   assumes — most of them, on a phone. The class is on the figure as well as the
-   iframe, so this has to name the iframe. */
-iframe.ox-speaker-deck {
-  height: auto;
-  aspect-ratio: 4 / 3;
-}

--- a/crates/ox_content_ssg/src/plugins/social.css
+++ b/crates/ox_content_ssg/src/plugins/social.css
@@ -346,3 +346,12 @@
   border: 1px solid color-mix(in srgb, var(--octc-color-border) 74%, transparent);
   border-radius: 8px;
 }
+
+/* Slide decks are 4:3. The iframe is emitted with a fixed `height`, which
+   letterboxes the deck on any column narrower than the width that height
+   assumes — most of them, on a phone. The class is on the figure as well as the
+   iframe, so this has to name the iframe. */
+iframe.ox-speaker-deck {
+  height: auto;
+  aspect-ratio: 4 / 3;
+}


### PR DESCRIPTION
## Summary
- error states in the GitHub card and island placeholder use `--octc-color-danger` instead of a literal red
- Speaker Deck iframes take their height from a 4:3 ratio instead of a fixed 480px
- measured ten providers at 320px: none overflow, so nothing else needed changing

## Theme tokens

`#f87171` was painted directly in `github.css` and `island.css`, so those error
states ignored whatever red the installed colour-scheme package chose. They now
use `--octc-color-danger` — the token callouts, containers, and badges already
route through. **The rendered red changes** from `#f87171` to the theme's danger
colour; that is the point, but it is a visual change.

GitHub's language dots keep their literal values deliberately. `#f1e05a` is
JavaScript's colour, not the theme's — tokenising those would say something
false about the repository being described.

## Slide decks

A Speaker Deck iframe is emitted with `height="480"`. Slides are 4:3, so any
column narrower than 640px letterboxed the deck: at 320px it reserved 480px of
height for 240px of slide. Measured before and after in a browser with the real
stylesheets — 480px → 240px at a 320px width.

## What did not need fixing

The issue expects several providers to overflow on mobile. Measured with the
real markup and the real stylesheets at a 320px viewport — Spotify, Apple Music,
Speaker Deck, StackBlitz, Qiita, npm, Google Maps, Vimeo, Tweet, Bluesky —
`scrollWidth` equals `clientWidth` for all ten. Nothing overflows.

The other fixed heights are correct as they stand: a Spotify player, an Apple
Music player, and a StackBlitz editor are fixed-height widgets, not aspect-bound
ones. Only slides have an inherent ratio.

## Verification
- cargo test -p ox_content_ssg  (258 passed)
- cargo clippy -p ox_content_ssg --all-targets -- -D warnings
- cargo fmt --all -- --check
- browser measurement of all ten providers at 320px, before and after

This does not close #1071 — the light/dark sweep across every colour-scheme
package is still open, and I sampled ten of the providers rather than all of
them.

Refs #1071

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790407493&installation_model_id=422833&pr_number=1091&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1091&signature=37337a446412da3373d6cbda4f8c5696c016922296bbdc1034983265d6753105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->