### PR TITLE
feat(bench): report native artifact size on migration PRs

### DIFF
--- a/.github/scripts/compare-pr-benchmark.mjs
+++ b/.github/scripts/compare-pr-benchmark.mjs
@@ -1,11 +1,20 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { appendFileSync, readFileSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const runnerTemp = requiredEnv("RUNNER_TEMP");
 const commentPath = join(runnerTemp, "benchmark-comment.md");
+
+// The artifact rows are optional: a run that skipped the native build has
+// nothing to compare, and a half-present pair would be worse than no section.
+const baseArtifacts = join(runnerTemp, "artifacts-base.json");
+const headArtifacts = join(runnerTemp, "artifacts-head.json");
+const artifactArgs =
+  existsSync(baseArtifacts) && existsSync(headArtifacts)
+    ? ["--base-artifacts", baseArtifacts, "--head-artifacts", headArtifacts]
+    : [];
 
 const status = run("node", [
   "benchmarks/bundle-size/compare-pr-benchmark.mjs",
@@ -17,6 +26,7 @@ const status = run("node", [
   join(runnerTemp, "bundle-base.json"),
   "--head-bundle",
   join(runnerTemp, "bundle-head.json"),
+  ...artifactArgs,
   "--output",
   commentPath,
   "--base-sha",

--- a/.github/scripts/run-pr-benchmark.mjs
+++ b/.github/scripts/run-pr-benchmark.mjs
@@ -20,6 +20,7 @@ for (const file of [
   "benchmarks/bundle-size/parse-benchmark.mjs",
   "benchmarks/bundle-size/parse-benchmark-bun.mjs",
   "benchmarks/bundle-size/measure.mjs",
+  "benchmarks/bundle-size/measure-artifacts.mjs",
   "benchmarks/native-competitors/Cargo.toml",
   "benchmarks/native-competitors/Cargo.lock",
   "benchmarks/native-competitors/src/main.rs",
@@ -54,6 +55,13 @@ if (options.skipBundle) {
   ]);
 }
 
+// Artifact sizes come after `build:npm`, so the native binding and the
+// published JavaScript both exist to measure. Optional: a caller that does not
+// ask for it simply gets no artifact section in the report.
+if (options.artifactsJson) {
+  run("node", ["benchmarks/bundle-size/measure-artifacts.mjs", "--json", options.artifactsJson]);
+}
+
 /**
  * @param {string[]} args
  * @returns {{
@@ -70,6 +78,7 @@ function parseOptions(args) {
     source: null,
     runtimeJson: null,
     bundleJson: null,
+    artifactsJson: null,
     runs: process.env.OX_CONTENT_BENCHMARK_RUNS || "5",
     skipRuntime: false,
     skipBundle: false,
@@ -87,6 +96,10 @@ function parseOptions(args) {
     }
     if (arg === "--bundle-json") {
       parsed.bundleJson = readOptionValue(args, ++index, "--bundle-json");
+      continue;
+    }
+    if (arg === "--artifacts-json") {
+      parsed.artifactsJson = readOptionValue(args, ++index, "--artifacts-json");
       continue;
     }
     if (arg === "--runs") {

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -109,7 +109,8 @@ jobs:
             --source "$GITHUB_WORKSPACE" \
             --runs "$OX_CONTENT_BENCHMARK_RUNS" \
             --runtime-json "$RUNNER_TEMP/benchmark-base.json" \
-            --bundle-json "$RUNNER_TEMP/bundle-base.json"
+            --bundle-json "$RUNNER_TEMP/bundle-base.json" \
+            --artifacts-json "$RUNNER_TEMP/artifacts-base.json"
 
       - name: Benchmark head
         working-directory: .benchmark/head
@@ -129,7 +130,8 @@ jobs:
             --source "$GITHUB_WORKSPACE" \
             --runs "$OX_CONTENT_BENCHMARK_RUNS" \
             --runtime-json "$RUNNER_TEMP/benchmark-head.json" \
-            --bundle-json "$RUNNER_TEMP/bundle-head.json"
+            --bundle-json "$RUNNER_TEMP/bundle-head.json" \
+            --artifacts-json "$RUNNER_TEMP/artifacts-head.json"
 
       - name: Compare benchmarks
         env:

--- a/benchmarks/bundle-size/artifact-size-report.test.ts
+++ b/benchmarks/bundle-size/artifact-size-report.test.ts
@@ -1,0 +1,91 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vite-plus/test";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const script = join(here, "compare-pr-benchmark.mjs");
+
+function artifacts(napiRaw: number, napiGzip: number, jsRaw: number, jsGzip: number) {
+  return {
+    targets: [
+      { name: "napi binding", present: true, files: 1, raw: napiRaw, gzipped: napiGzip },
+      { name: "wasm package", present: false, files: 0, raw: 0, gzipped: 0 },
+      { name: "vite-plugin js", present: true, files: 10, raw: jsRaw, gzipped: jsGzip },
+    ],
+  };
+}
+
+function render(base: unknown, head: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), "ox-artifact-report-"));
+  const runtime = join(dir, "runtime.json");
+  const basePath = join(dir, "base.json");
+  const headPath = join(dir, "head.json");
+  writeFileSync(runtime, JSON.stringify({ results: [] }));
+  writeFileSync(basePath, JSON.stringify(base));
+  writeFileSync(headPath, JSON.stringify(head));
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      script,
+      "--base",
+      runtime,
+      "--head",
+      runtime,
+      "--base-artifacts",
+      basePath,
+      "--head-artifacts",
+      headPath,
+    ],
+    { encoding: "utf8" },
+  );
+  expect(result.status, result.stderr).toBe(0);
+  return result.stdout;
+}
+
+describe("native artifact size report", () => {
+  it("shows the native binding growing and the JavaScript shrinking", () => {
+    const out = render(artifacts(1000, 500, 2000, 1000), artifacts(1100, 550, 1800, 900));
+
+    expect(out).toContain("### Native Artifacts");
+    expect(out).toMatch(/\| napi binding \|.*\+10\.00%.*\+10\.00% \|/);
+    expect(out).toMatch(/\| vite-plugin js \|.*-10\.00%.*-10\.00% \|/);
+  });
+
+  // A target that was never built and one that shrank to nothing are different
+  // facts. Reporting zero would read as a total win.
+  it("says an unbuilt artifact is unbuilt rather than zero bytes", () => {
+    const out = render(artifacts(1000, 500, 2000, 1000), artifacts(1000, 500, 2000, 1000));
+    expect(out).toMatch(/\| wasm package \| not built \| not built \| n\/a \|/);
+  });
+
+  it("requires the two artifact paths together", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ox-artifact-report-"));
+    const runtime = join(dir, "runtime.json");
+    const only = join(dir, "only.json");
+    writeFileSync(runtime, JSON.stringify({ results: [] }));
+    writeFileSync(only, JSON.stringify(artifacts(1, 1, 1, 1)));
+
+    const result = spawnSync(
+      process.execPath,
+      [script, "--base", runtime, "--head", runtime, "--base-artifacts", only],
+      { encoding: "utf8" },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("--base-artifacts and --head-artifacts must be used together");
+  });
+
+  it("omits the section entirely when no artifact data is given", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ox-artifact-report-"));
+    const runtime = join(dir, "runtime.json");
+    writeFileSync(runtime, JSON.stringify({ results: [] }));
+    const result = spawnSync(process.execPath, [script, "--base", runtime, "--head", runtime], {
+      encoding: "utf8",
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).not.toContain("### Native Artifacts");
+  });
+});

--- a/benchmarks/bundle-size/compare-pr-benchmark.mjs
+++ b/benchmarks/bundle-size/compare-pr-benchmark.mjs
@@ -53,6 +53,8 @@ function parseOptions(args) {
     headPath: null,
     baseBundlePath: null,
     headBundlePath: null,
+    baseArtifactsPath: null,
+    headArtifactsPath: null,
     outputPath: null,
     baseSha: null,
     headSha: null,
@@ -74,6 +76,14 @@ function parseOptions(args) {
     }
     if (arg === "--head-bundle") {
       parsed.headBundlePath = readOptionValue(args, ++index, "--head-bundle");
+      continue;
+    }
+    if (arg === "--base-artifacts") {
+      parsed.baseArtifactsPath = readOptionValue(args, ++index, "--base-artifacts");
+      continue;
+    }
+    if (arg === "--head-artifacts") {
+      parsed.headArtifactsPath = readOptionValue(args, ++index, "--head-artifacts");
       continue;
     }
     if (arg === "--output") {
@@ -102,6 +112,9 @@ function parseOptions(args) {
   if (Boolean(parsed.baseBundlePath) !== Boolean(parsed.headBundlePath)) {
     throw new Error("--base-bundle and --head-bundle must be used together");
   }
+  if (Boolean(parsed.baseArtifactsPath) !== Boolean(parsed.headArtifactsPath)) {
+    throw new Error("--base-artifacts and --head-artifacts must be used together");
+  }
 
   return parsed;
 }
@@ -123,19 +136,34 @@ Options:
   --head <path>      Head benchmark JSON
   --base-bundle <path> Base bundle size JSON
   --head-bundle <path> Head bundle size JSON
+  --base-artifacts <path>  Base native artifact size JSON
+  --head-artifacts <path>  Head native artifact size JSON
   --output <path>    Write the Markdown comment to a file
   --base-sha <sha>   Base commit SHA for the heading
   --head-sha <sha>   Head commit SHA for the heading
   -h, --help         Show this help message`);
 }
 
-function buildComment({ basePath, headPath, baseBundlePath, headBundlePath, baseSha, headSha }) {
+function buildComment({
+  basePath,
+  headPath,
+  baseBundlePath,
+  headBundlePath,
+  baseArtifactsPath,
+  headArtifactsPath,
+  baseSha,
+  headSha,
+}) {
   const base = readJson(basePath);
   const head = readJson(headPath);
   const runtimeRows = compareRuntimeReports(base, head);
   const bundleRows =
     baseBundlePath && headBundlePath
       ? compareBundleReports(readJson(baseBundlePath), readJson(headBundlePath))
+      : [];
+  const artifactRows =
+    baseArtifactsPath && headArtifactsPath
+      ? compareArtifactReports(readJson(baseArtifactsPath), readJson(headArtifactsPath))
       : [];
   const competitiveRows = collectCompetitiveRows(head);
   const environmentRows = collectEnvironmentRows(base, head);
@@ -237,6 +265,29 @@ function buildComment({ basePath, headPath, baseBundlePath, headBundlePath, base
     );
   }
 
+  if (baseArtifactsPath && headArtifactsPath) {
+    lines.push(
+      "### Native Artifacts",
+      "",
+      "| Artifact | Base raw | Head raw | Raw delta | Base gzip | Head gzip | Gzip delta |",
+      "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    );
+    if (artifactRows.length === 0) {
+      lines.push("| n/a | n/a | n/a | n/a | n/a | n/a | n/a |");
+    } else {
+      for (const row of artifactRows) {
+        lines.push(
+          `| ${row.name} | ${formatArtifactBytes(row.baseRaw, row.basePresent)} | ${formatArtifactBytes(row.headRaw, row.headPresent)} | ${formatDelta(row.rawDeltaPercent)} | ${formatArtifactBytes(row.baseGzipped, row.basePresent)} | ${formatArtifactBytes(row.headGzipped, row.headPresent)} | ${formatDelta(row.gzipDeltaPercent)} |`,
+        );
+      }
+    }
+    lines.push(
+      "",
+      "Moving a rule into Rust grows the native binding and shrinks the JavaScript beside it. Both rows are shown so a migration reports its cost, not only its win. An artifact that was not built reads `not built` rather than zero, so an unbuilt target cannot be mistaken for one that vanished. These rows are informational and gate nothing.",
+      "",
+    );
+  }
+
   lines.push(
     "### Regression Gate",
     "",
@@ -267,6 +318,42 @@ function buildComment({ basePath, headPath, baseBundlePath, headBundlePath, base
   }
 
   return lines.join("\n");
+}
+
+/**
+ * Pairs base and head artifact measurements by name.
+ *
+ * A target missing on one side yields no percentage: there is no honest delta
+ * between a built artifact and one that was never built.
+ */
+function compareArtifactReports(base, head) {
+  const baseByName = new Map((base?.targets ?? []).map((target) => [target.name, target]));
+  const rows = [];
+  for (const headTarget of head?.targets ?? []) {
+    const baseTarget = baseByName.get(headTarget.name);
+    const comparable = Boolean(baseTarget?.present) && Boolean(headTarget.present);
+    rows.push({
+      name: headTarget.name,
+      basePresent: Boolean(baseTarget?.present),
+      headPresent: Boolean(headTarget.present),
+      baseRaw: baseTarget?.raw ?? 0,
+      headRaw: headTarget.raw,
+      baseGzipped: baseTarget?.gzipped ?? 0,
+      headGzipped: headTarget.gzipped,
+      rawDeltaPercent: comparable ? percentDelta(baseTarget.raw, headTarget.raw) : null,
+      gzipDeltaPercent: comparable ? percentDelta(baseTarget.gzipped, headTarget.gzipped) : null,
+    });
+  }
+  return rows;
+}
+
+function percentDelta(base, head) {
+  if (!base) return null;
+  return ((head - base) / base) * 100;
+}
+
+function formatArtifactBytes(value, present) {
+  return present ? formatBytes(value) : "not built";
 }
 
 function readJson(path) {

--- a/benchmarks/bundle-size/measure-artifacts.mjs
+++ b/benchmarks/bundle-size/measure-artifacts.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Usage: node benchmarks/bundle-size/measure-artifacts.mjs [--json <path>]
+//
+// Records the size of the artifacts a Rust migration moves bytes between: the
+// native binding, the wasm package, and the JavaScript that ships beside them.
+// Moving a rule into Rust grows the first and shrinks the last, and #1075 asks
+// that a migration show both halves of that trade rather than only its wins.
+
+import { createRequire } from "node:module";
+import { readFileSync, existsSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { join, dirname, extname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const { gzipSizeSync } = require("gzip-size");
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(HERE, "..", "..");
+
+/** Artifacts a migration moves bytes between. */
+const TARGETS = [
+  { name: "napi binding", path: "crates/ox_content_napi", match: (f) => extname(f) === ".node" },
+  {
+    name: "wasm package",
+    path: "crates/ox_content_wasm/pkg",
+    match: (f) => extname(f) === ".wasm",
+  },
+  {
+    name: "vite-plugin js",
+    path: "npm/vite-plugin-ox-content/dist",
+    match: (f) => [".js", ".cjs", ".mjs"].includes(extname(f)),
+  },
+];
+
+/** Every matching file below `dir`, recursively. */
+function walk(dir, match, out = []) {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, match, out);
+    else if (match(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Raw and gzipped bytes for one target.
+ *
+ * A missing directory reports `present: false` rather than zero: a target that
+ * was never built and a target that shrank to nothing are different facts, and
+ * a zero would read as a spectacular win in the delta table.
+ */
+function measure(target) {
+  const dir = join(ROOT, target.path);
+  const files = walk(dir, target.match);
+  if (files.length === 0) {
+    return { name: target.name, present: false, files: 0, raw: 0, gzipped: 0 };
+  }
+  let raw = 0;
+  let gzipped = 0;
+  for (const file of files) {
+    const content = readFileSync(file);
+    raw += statSync(file).size;
+    gzipped += gzipSizeSync(content);
+  }
+  return { name: target.name, present: true, files: files.length, raw, gzipped };
+}
+
+const report = { targets: TARGETS.map(measure) };
+
+const jsonIndex = process.argv.indexOf("--json");
+const output = JSON.stringify(report, null, 2);
+if (jsonIndex !== -1 && process.argv[jsonIndex + 1]) {
+  writeFileSync(process.argv[jsonIndex + 1], `${output}\n`);
+  process.stdout.write(`Wrote artifact sizes to ${process.argv[jsonIndex + 1]}\n`);
+} else {
+  process.stdout.write(`${output}\n`);
+}


### PR DESCRIPTION
## Summary
- add `measure-artifacts.mjs`, recording raw and gzipped bytes for the napi binding, the wasm package, and the built vite-plugin JavaScript
- add a **Native Artifacts** section to the existing PR benchmark comment
- wire it through `run-pr-benchmark.mjs`, the compare wrapper, and `benchmark.yml`

Moving a rule from TypeScript into Rust grows the native binding and shrinks the
JavaScript beside it. Nothing measured either half, so a migration could report
its win and stay quiet about its cost.

```
| Artifact       | Base raw | Head raw | Raw delta | Base gzip | Head gzip | Gzip delta |
| napi binding   | 78.64 MB | 80.21 MB | +2.00%    | 14.02 MB  | 14.44 MB  | +3.00%     |
| wasm package   | not built| not built| n/a       | not built | not built | n/a        |
| vite-plugin js |  1.52 MB |  1.43 MB | -6.00%    | 390.7 KB  | 359.4 KB  | -8.00%     |
```

## `not built` is not zero

An artifact that was never built and one that shrank to nothing are different
facts, and a zero would read as a spectacular win in the delta column. Unbuilt
targets say so, and produce no percentage — there is no honest delta between a
built artifact and an absent one.

For the same reason the whole section is skipped unless *both* sides produced a
measurement, rather than comparing against a missing file. A run that skipped
the native build simply gets no section.

## Gates nothing

These rows inform, like the existing build-time deltas. Growing the native
binding is the expected outcome of a migration, so failing on it would be
wrong; the point is that the number appears without a maintainer asking.

## Verification
- cd benchmarks/bundle-size && vp test run artifact-size-report.test.ts  (4 passed)
- rendered the section against real measurements plus a simulated migration
- node --check on both changed CI scripts
- vp run check:ts
- node scripts/check-file-lines.ts

One thing to note: `compare-pr-benchmark.test.ts` and its siblings report
10 failures in this package. Those are **pre-existing on `main`** — I ran them
stashed and unstashed and the counts are identical (10 failed | 8 passed both
ways). This change adds 4 passing tests on top and does not touch them.

Refs #1075

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790408325&installation_model_id=422833&pr_number=1093&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1093&signature=ab09244928bd924f03556c0c20d5e803def0bf31d2ff1a4d247b0bc35674a827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->