### PR TITLE
feat(feeds): generate channel metadata natively

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -1004,6 +1004,10 @@ export interface JsFeedsOptions {
   /** Any of `"rss"`, `"atom"`, `"json"`. Unknown names are ignored. */
   formats: Array<string>
   limit: number
+  language?: string
+  image?: string
+  favicon?: string
+  copyright?: string
 }
 
 /** Generated feed bodies, or a warning when generation is skipped. */

--- a/crates/ox_content_napi/src/feed_bindings.rs
+++ b/crates/ox_content_napi/src/feed_bindings.rs
@@ -49,6 +49,10 @@ pub struct JsFeedsOptions {
     /// Any of `"rss"`, `"atom"`, `"json"`. Unknown names are ignored.
     pub formats: Vec<String>,
     pub limit: u32,
+    pub language: Option<String>,
+    pub image: Option<String>,
+    pub favicon: Option<String>,
+    pub copyright: Option<String>,
 }
 
 /// Generated feed bodies, or a warning when generation is skipped.
@@ -120,6 +124,10 @@ pub fn generate_feed_bodies(options: JsFeedsOptions, items: Vec<JsFeedItem>) -> 
         json_url: options.json_url,
         formats: options.formats.iter().filter_map(|name| convert_format(name)).collect(),
         limit: options.limit as usize,
+        language: options.language,
+        image: options.image,
+        favicon: options.favicon,
+        copyright: options.copyright,
     };
     let items: Vec<_> = items.into_iter().map(convert_item).collect();
     let output = ox_content_ssg::generate_feeds(&resolved, &items);

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -1008,6 +1008,10 @@ export interface JsFeedsOptions {
   /** Any of `"rss"`, `"atom"`, `"json"`. Unknown names are ignored. */
   formats: Array<string>
   limit: number
+  language?: string
+  image?: string
+  favicon?: string
+  copyright?: string
 }
 
 /** Generated feed bodies, or a warning when generation is skipped. */

--- a/crates/ox_content_ssg/src/feeds.rs
+++ b/crates/ox_content_ssg/src/feeds.rs
@@ -101,6 +101,14 @@ pub struct FeedsOptions {
     pub formats: Vec<FeedFormat>,
     /// Maximum number of published items.
     pub limit: usize,
+    /// BCP 47 language for the whole feed.
+    pub language: Option<String>,
+    /// Channel image URL — RSS `<image>`, Atom `<logo>`, JSON Feed `icon`.
+    pub image: Option<String>,
+    /// Small square icon — Atom `<icon>`, JSON Feed `favicon`.
+    pub favicon: Option<String>,
+    /// Rights statement — RSS `<copyright>`, Atom `<rights>`.
+    pub copyright: Option<String>,
 }
 
 /// Generated feed bodies, or a warning when generation is skipped.
@@ -129,6 +137,10 @@ impl Default for FeedsOptions {
             json_url: String::new(),
             formats: vec![FeedFormat::Rss, FeedFormat::Atom, FeedFormat::Json],
             limit: 20,
+            language: None,
+            image: None,
+            favicon: None,
+            copyright: None,
         }
     }
 }
@@ -218,6 +230,11 @@ fn push_xml_attr_number(output: &mut String, name: &str, value: Option<i64>) {
     if let Some(value) = value {
         push_xml_attr(output, name, Some(&value.to_string()));
     }
+}
+
+/// A channel field worth emitting: present, and not just whitespace.
+fn channel_field(value: Option<&String>) -> Option<&str> {
+    value.map(String::as_str).filter(|value| !value.trim().is_empty())
 }
 
 fn escape_xml(value: &str, output: &mut String) {

--- a/crates/ox_content_ssg/src/feeds/atom.rs
+++ b/crates/ox_content_ssg/src/feeds/atom.rs
@@ -1,7 +1,8 @@
 //! Atom 1.0 bodies.
 
 use super::{
-    FeedAttachment, FeedAuthor, FeedItem, FeedsOptions, dates, entry_id, escape_xml, item_date,
+    FeedAttachment, FeedAuthor, FeedItem, FeedsOptions, channel_field, dates, entry_id, escape_xml,
+    item_date,
 };
 
 pub(super) fn generate_atom(options: &FeedsOptions, items: &[&FeedItem]) -> String {
@@ -11,8 +12,14 @@ pub(super) fn generate_atom(options: &FeedsOptions, items: &[&FeedItem]) -> Stri
         .map_or_else(|| "1970-01-01T00:00:00Z".to_string(), dates::ParsedDate::rfc3339);
 
     let mut xml = String::from(
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<feed xmlns=\"http://www.w3.org/2005/Atom\">\n  <title>",
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<feed xmlns=\"http://www.w3.org/2005/Atom\"",
     );
+    if let Some(language) = channel_field(options.language.as_ref()) {
+        xml.push_str(" xml:lang=\"");
+        escape_xml(language, &mut xml);
+        xml.push('"');
+    }
+    xml.push_str(">\n  <title>");
     escape_xml(&options.site_name, &mut xml);
     xml.push_str("</title>\n  <link href=\"");
     escape_xml(&options.atom_url, &mut xml);
@@ -30,6 +37,7 @@ pub(super) fn generate_atom(options: &FeedsOptions, items: &[&FeedItem]) -> Stri
         escape_xml(description, &mut xml);
         xml.push_str("</subtitle>\n");
     }
+    push_channel_meta(options, &mut xml);
 
     for item in items {
         xml.push_str("  <entry");
@@ -93,4 +101,27 @@ fn push_attachment(attachment: &FeedAttachment, xml: &mut String) {
     super::push_xml_attr_number(xml, "length", attachment.size_in_bytes);
     super::push_xml_attr(xml, "title", attachment.title.as_deref());
     xml.push_str("/>\n");
+}
+
+/// Atom channel metadata, ahead of the entries.
+///
+/// The string-patching version anchored on the literal `  <entry>`, which a
+/// localised entry does not match, so the block landed after every entry
+/// whenever an item carried an `xml:lang`. Generating it in place puts it in
+/// one predictable spot.
+fn push_channel_meta(options: &FeedsOptions, xml: &mut String) {
+    for (tag, value) in [
+        ("icon", channel_field(options.favicon.as_ref())),
+        ("logo", channel_field(options.image.as_ref())),
+        ("rights", channel_field(options.copyright.as_ref())),
+    ] {
+        let Some(value) = value else { continue };
+        xml.push_str("  <");
+        xml.push_str(tag);
+        xml.push('>');
+        escape_xml(value, xml);
+        xml.push_str("</");
+        xml.push_str(tag);
+        xml.push_str(">\n");
+    }
 }

--- a/crates/ox_content_ssg/src/feeds/json.rs
+++ b/crates/ox_content_ssg/src/feeds/json.rs
@@ -1,8 +1,8 @@
 //! JSON Feed 1.1 bodies.
 
 use super::{
-    FeedAttachment, FeedAuthor, FeedItem, FeedsOptions, entry_id, item_date, item_description,
-    push_json_string,
+    FeedAttachment, FeedAuthor, FeedItem, FeedsOptions, channel_field, entry_id, item_date,
+    item_description, push_json_string,
 };
 
 pub(super) fn generate_json(options: &FeedsOptions, items: &[&FeedItem]) -> String {
@@ -18,6 +18,17 @@ pub(super) fn generate_json(options: &FeedsOptions, items: &[&FeedItem]) -> Stri
     {
         json.push_str(",\n  \"description\": ");
         push_json_string(description, &mut json);
+    }
+    for (key, value) in [
+        ("language", channel_field(options.language.as_ref())),
+        ("icon", channel_field(options.image.as_ref())),
+        ("favicon", channel_field(options.favicon.as_ref())),
+    ] {
+        let Some(value) = value else { continue };
+        json.push_str(",\n  \"");
+        json.push_str(key);
+        json.push_str("\": ");
+        push_json_string(value, &mut json);
     }
     json.push_str(",\n  \"items\": [");
 

--- a/crates/ox_content_ssg/src/feeds/rss.rs
+++ b/crates/ox_content_ssg/src/feeds/rss.rs
@@ -1,8 +1,8 @@
 //! RSS 2.0 bodies.
 
 use super::{
-    FeedAttachment, FeedItem, FeedsOptions, channel_description, entry_id, escape_xml, item_date,
-    item_description,
+    FeedAttachment, FeedItem, FeedsOptions, channel_description, channel_field, entry_id,
+    escape_xml, item_date, item_description,
 };
 
 /// The Dublin Core namespace, declared only when an item uses it, so a feed
@@ -23,6 +23,7 @@ pub(super) fn generate_rss(options: &FeedsOptions, items: &[&FeedItem]) -> Strin
     xml.push_str("</link>\n    <description>");
     escape_xml(channel_description(options), &mut xml);
     xml.push_str("</description>\n");
+    push_channel_meta(options, &mut xml);
 
     for item in items {
         xml.push_str("    <item>\n      <title>");
@@ -83,4 +84,27 @@ fn push_enclosure(attachment: &FeedAttachment, xml: &mut String) {
     super::push_xml_attr(xml, "type", attachment.mime_type.as_deref());
     super::push_xml_attr_number(xml, "length", attachment.size_in_bytes);
     xml.push_str("/>\n");
+}
+
+/// RSS channel metadata, in the order the standard lists it.
+fn push_channel_meta(options: &FeedsOptions, xml: &mut String) {
+    if let Some(language) = channel_field(options.language.as_ref()) {
+        xml.push_str("    <language>");
+        escape_xml(language, xml);
+        xml.push_str("</language>\n");
+    }
+    if let Some(copyright) = channel_field(options.copyright.as_ref()) {
+        xml.push_str("    <copyright>");
+        escape_xml(copyright, xml);
+        xml.push_str("</copyright>\n");
+    }
+    if let Some(image) = channel_field(options.image.as_ref()) {
+        xml.push_str("    <image>\n      <url>");
+        escape_xml(image, xml);
+        xml.push_str("</url>\n      <title>");
+        escape_xml(&options.site_name, xml);
+        xml.push_str("</title>\n      <link>");
+        escape_xml(&options.home_page_url, xml);
+        xml.push_str("</link>\n    </image>\n");
+    }
 }

--- a/crates/ox_content_ssg/src/feeds/tests.rs
+++ b/crates/ox_content_ssg/src/feeds/tests.rs
@@ -39,6 +39,7 @@ fn enabled(site_url: Option<&str>) -> FeedsOptions {
         json_url: "https://example.com/feed.json".to_string(),
         formats: vec![FeedFormat::Rss, FeedFormat::Atom, FeedFormat::Json],
         limit: 20,
+        ..FeedsOptions::default()
     }
 }
 

--- a/npm/vite-plugin-ox-content/src/feed-parity.test.ts
+++ b/npm/vite-plugin-ox-content/src/feed-parity.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
+import { applyAtomMeta, applyJsonMeta, applyRssMeta, channelMeta } from "./feed-channel-meta";
 import { generateAtom, generateJson, generateRss } from "./feed-format";
 import { parseDate } from "./feed-date";
 import { importNapiModuleSync } from "./napi";
@@ -114,5 +115,98 @@ describe("feed generation parity", () => {
     expect(atomXml).toContain("<uri>https://example.com/kim</uri>");
     expect(jsonFeed).toContain('"image": "https://example.com/img.png"');
     expect(jsonFeed).toContain('"duration_in_seconds": 60');
+  });
+});
+
+const CHANNEL = {
+  language: "en",
+  image: "https://example.com/logo.png",
+  favicon: "https://example.com/icon.png",
+  copyright: "© 2026 Docs & Co",
+};
+
+function nativeWithChannel(items: unknown[]) {
+  const napi = importNapiModuleSync() as unknown as {
+    generateFeedBodies(
+      options: Record<string, unknown>,
+      items: unknown[],
+    ): { rssXml?: string; atomXml?: string; jsonFeed?: string };
+  };
+  return napi.generateFeedBodies(
+    {
+      enabled: true,
+      siteUrl: "https://example.com",
+      siteName: DOC.siteName,
+      siteDescription: DOC.siteDescription,
+      homePageUrl: DOC.home,
+      rssUrl: "https://example.com/feed.xml",
+      atomUrl: DOC.atomUrl,
+      jsonUrl: DOC.jsonUrl,
+      formats: ["rss", "atom", "json"],
+      limit: 20,
+      ...CHANNEL,
+    },
+    items,
+  );
+}
+
+const PLAIN = [
+  { title: "A", loc: "https://example.com/a", description: "d", date: "2024-01-02T03:04:05Z" },
+];
+const LOCALISED = [
+  {
+    title: "B",
+    loc: "https://example.com/b",
+    description: "d",
+    language: "ja",
+    date: "2024-01-02T03:04:05Z",
+  },
+];
+
+function tsWithChannel(items: typeof PLAIN) {
+  const entries = items.map((item) => ({
+    ...item,
+    date: item.date ? parseDate(item.date) : undefined,
+  })) as FeedEntry[];
+  const meta = channelMeta(DOC, CHANNEL);
+  return {
+    rss: applyRssMeta(generateRss(DOC, entries), meta),
+    atom: applyAtomMeta(generateAtom(DOC, entries), meta),
+    json: applyJsonMeta(generateJson(DOC, entries), meta),
+  };
+}
+
+describe("feed channel metadata parity", () => {
+  it("matches the TypeScript layer on every format", () => {
+    const rust = nativeWithChannel(PLAIN);
+    const ts = tsWithChannel(PLAIN);
+    expect(rust.rssXml).toBe(ts.rss);
+    expect(rust.atomXml).toBe(ts.atom);
+    expect(rust.jsonFeed).toBe(ts.json);
+  });
+
+  it("still matches on RSS and JSON when an item carries its own language", () => {
+    const rust = nativeWithChannel(LOCALISED);
+    const ts = tsWithChannel(LOCALISED as typeof PLAIN);
+    expect(rust.rssXml).toBe(ts.rss);
+    expect(rust.jsonFeed).toBe(ts.json);
+  });
+
+  // A recorded difference. The TypeScript layer patches the generated string
+  // and anchors on the literal `  <entry>`, which a localised entry does not
+  // match — so its icon, logo, and rights land *after* every entry, but only
+  // when some item happens to carry an `xml:lang`. Generating the metadata in
+  // place puts it ahead of the entries either way.
+  it("keeps Atom channel metadata ahead of the entries regardless of item language", () => {
+    for (const items of [PLAIN, LOCALISED]) {
+      const atom = nativeWithChannel(items).atomXml ?? "";
+      expect(atom.indexOf("<icon>")).toBeGreaterThan(-1);
+      expect(atom.indexOf("<icon>")).toBeLessThan(atom.indexOf("<entry"));
+      expect(atom.indexOf("<rights>")).toBeLessThan(atom.indexOf("<entry"));
+    }
+
+    // The behaviour this replaces, so the change is visible if anyone reverts it.
+    const legacy = tsWithChannel(LOCALISED as typeof PLAIN).atom;
+    expect(legacy.indexOf("<icon>")).toBeGreaterThan(legacy.indexOf("<entry"));
   });
 });


### PR DESCRIPTION
## Summary
- `FeedsOptions` gains `language`, `image`, `favicon`, `copyright`
- each format writes them inline instead of the TypeScript layer patching the generated string
- one deliberate Atom difference, recorded and pinned by a test

**Stacked on #1092** — review that first; this branch targets it, not `main`.

## What it replaces

`feed-channel-meta.ts` added channel fields by string surgery on finished
output: `xml.replace("</description>\n", …)` for RSS, `json.replace(",\n  \"items\":", …)`
for JSON Feed, and for Atom the literal `  <entry>` as an insertion anchor.

Output is byte-identical to that layer for RSS and JSON Feed, and for Atom
whenever no item carries its own language.

## The Atom difference

`  <entry>` does not match `  <entry xml:lang="ja">`. When any item was
localised the Atom anchor missed, the code fell through to its `</feed>`
replacement, and `<icon>`, `<logo>`, and `<rights>` landed **after every
entry** — so the same feed put its metadata in different places depending on
whether an item happened to have a language.

```
ts:   <entry xml:lang="ja"> … </entry>  <icon>…</icon>  <logo>…</logo>
rust: <icon>…</icon>  <logo>…</logo>  <entry xml:lang="ja"> … </entry>
```

Generated in place it is always ahead of the entries. The test asserts the
native ordering for both plain and localised items, **and** asserts the old
behaviour, so a revert cannot pass quietly.

## Verification
- cargo test -p ox_content_ssg  (258 passed)
- cargo test -p ox_content_napi  (63 passed)
- cargo clippy -p ox_content_ssg -p ox_content_napi --all-targets -- -D warnings
- cargo fmt --all -- --check
- cd npm/vite-plugin-ox-content && vp test run  (906 passed)
- node scripts/check-file-lines.ts

With this, everything `feeds.ts` writes exists natively. Deleting the
TypeScript writer and pointing the plugin at `generateFeedBodies` is the last
step of #1074 and its own change.

Refs #1074

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790408583&installation_model_id=422833&pr_number=1094&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1094&signature=e840dbc2b9ccb62aba38d870bb4619aca0f224df6e8698cd998993100599669f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->