### PR TITLE
feat(embeds): report the tags a provider refused

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -846,6 +846,24 @@ export interface JsEditThisPageOptions {
   label?: string
 }
 
+/**
+ * Transform opt-in static media embed components in already-rendered HTML.
+ * One tag an enabled provider refused, and what the transform did instead.
+ */
+export interface JsEmbedDiagnostic {
+  /** Tag name as the provider registers it, for example `speakerdeck`. */
+  provider: string
+  /** The URL the tag carried, when it carried one worth naming. */
+  url?: string
+  /** 1-based line of the opening tag in the transformed HTML. */
+  line: number
+  /**
+   * `"linked"` when the tag became a plain link, `"kept"` when its markup
+   * was left as authored.
+   */
+  fallback: string
+}
+
 /** Emoji-shortcode transform options. */
 export interface JsEmojiShortcodeOptions {
   /**
@@ -1496,6 +1514,12 @@ export interface JsMediaEmbedsOptions {
    * Default: `false`.
    */
   video?: boolean
+}
+
+/** Rewritten HTML plus every tag an enabled provider refused. */
+export interface JsMediaEmbedsResult {
+  html: string
+  diagnostics: Array<JsEmbedDiagnostic>
 }
 
 /** Opt-in `<NotByAI />` authorship badge. */
@@ -2982,8 +3006,10 @@ export declare function transformAsync(source: string, options?: JsTransformOpti
  */
 export declare function transformMdastRaw(source: string, options?: JsTransformOptions | undefined | null): Uint8Array
 
-/** Transform opt-in static media embed components in already-rendered HTML. */
 export declare function transformMediaEmbeds(html: string, options?: JsMediaEmbedsOptions | undefined | null): string
+
+/** Rewrites embeds and reports the tags no provider would render. */
+export declare function transformMediaEmbedsWithDiagnostics(html: string, options?: JsMediaEmbedsOptions | undefined | null): JsMediaEmbedsResult
 
 /** Transforms mermaid code blocks in HTML to rendered SVG diagrams. */
 export declare function transformMermaid(html: string, mmdcPath: string): MermaidTransformResult

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -173,6 +173,7 @@ module.exports.transformAsync = binding.transformAsync;
 module.exports.transformMdastRaw = binding.transformMdastRaw;
 module.exports.sanitizeHtml = binding.sanitizeHtml;
 module.exports.transformMediaEmbeds = binding.transformMediaEmbeds;
+module.exports.transformMediaEmbedsWithDiagnostics = binding.transformMediaEmbedsWithDiagnostics;
 module.exports.transformPmEmbeds = binding.transformPmEmbeds;
 module.exports.transformTabsEmbeds = binding.transformTabsEmbeds;
 module.exports.transformYoutubeEmbeds = binding.transformYoutubeEmbeds;

--- a/crates/ox_content_napi/src/tests/runtime_features.rs
+++ b/crates/ox_content_napi/src/tests/runtime_features.rs
@@ -98,6 +98,7 @@ fn javascript_wrapper_and_declarations_cover_expected_exports() {
         "transform",
         "transformAsync",
         "transformMediaEmbeds",
+        "transformMediaEmbedsWithDiagnostics",
         "transformMdastRaw",
         "transformPmEmbeds",
         "transformTabsEmbeds",

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_declarations.snap
@@ -850,6 +850,24 @@ export interface JsEditThisPageOptions {
   label?: string
 }
 
+/**
+ * Transform opt-in static media embed components in already-rendered HTML.
+ * One tag an enabled provider refused, and what the transform did instead.
+ */
+export interface JsEmbedDiagnostic {
+  /** Tag name as the provider registers it, for example `speakerdeck`. */
+  provider: string
+  /** The URL the tag carried, when it carried one worth naming. */
+  url?: string
+  /** 1-based line of the opening tag in the transformed HTML. */
+  line: number
+  /**
+   * `"linked"` when the tag became a plain link, `"kept"` when its markup
+   * was left as authored.
+   */
+  fallback: string
+}
+
 /** Emoji-shortcode transform options. */
 export interface JsEmojiShortcodeOptions {
   /**
@@ -1500,6 +1518,12 @@ export interface JsMediaEmbedsOptions {
    * Default: `false`.
    */
   video?: boolean
+}
+
+/** Rewritten HTML plus every tag an enabled provider refused. */
+export interface JsMediaEmbedsResult {
+  html: string
+  diagnostics: Array<JsEmbedDiagnostic>
 }
 
 /** Opt-in `<NotByAI />` authorship badge. */
@@ -2986,8 +3010,10 @@ export declare function transformAsync(source: string, options?: JsTransformOpti
  */
 export declare function transformMdastRaw(source: string, options?: JsTransformOptions | undefined | null): Uint8Array
 
-/** Transform opt-in static media embed components in already-rendered HTML. */
 export declare function transformMediaEmbeds(html: string, options?: JsMediaEmbedsOptions | undefined | null): string
+
+/** Rewrites embeds and reports the tags no provider would render. */
+export declare function transformMediaEmbedsWithDiagnostics(html: string, options?: JsMediaEmbedsOptions | undefined | null): JsMediaEmbedsResult
 
 /** Transforms mermaid code blocks in HTML to rendered SVG diagrams. */
 export declare function transformMermaid(html: string, mmdcPath: string): MermaidTransformResult

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_expected_exports.snap
@@ -80,6 +80,7 @@ searchIndex
 transform
 transformAsync
 transformMediaEmbeds
+transformMediaEmbedsWithDiagnostics
 transformMdastRaw
 transformPmEmbeds
 transformTabsEmbeds

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_index_js.snap
@@ -177,6 +177,7 @@ module.exports.transformAsync = binding.transformAsync;
 module.exports.transformMdastRaw = binding.transformMdastRaw;
 module.exports.sanitizeHtml = binding.sanitizeHtml;
 module.exports.transformMediaEmbeds = binding.transformMediaEmbeds;
+module.exports.transformMediaEmbedsWithDiagnostics = binding.transformMediaEmbedsWithDiagnostics;
 module.exports.transformPmEmbeds = binding.transformPmEmbeds;
 module.exports.transformTabsEmbeds = binding.transformTabsEmbeds;
 module.exports.transformYoutubeEmbeds = binding.transformYoutubeEmbeds;

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
@@ -177,6 +177,7 @@ module.exports.transformAsync = binding.transformAsync;
 module.exports.transformMdastRaw = binding.transformMdastRaw;
 module.exports.sanitizeHtml = binding.sanitizeHtml;
 module.exports.transformMediaEmbeds = binding.transformMediaEmbeds;
+module.exports.transformMediaEmbedsWithDiagnostics = binding.transformMediaEmbedsWithDiagnostics;
 module.exports.transformPmEmbeds = binding.transformPmEmbeds;
 module.exports.transformTabsEmbeds = binding.transformTabsEmbeds;
 module.exports.transformYoutubeEmbeds = binding.transformYoutubeEmbeds;

--- a/crates/ox_content_napi/src/transform_bindings.rs
+++ b/crates/ox_content_napi/src/transform_bindings.rs
@@ -193,6 +193,53 @@ pub fn sanitize_html_binding(html: String, options: Option<JsSanitizeOptions>) -
 }
 
 /// Transform opt-in static media embed components in already-rendered HTML.
+/// One tag an enabled provider refused, and what the transform did instead.
+#[napi(object)]
+pub struct JsEmbedDiagnostic {
+    /// Tag name as the provider registers it, for example `speakerdeck`.
+    pub provider: String,
+    /// The URL the tag carried, when it carried one worth naming.
+    pub url: Option<String>,
+    /// 1-based line of the opening tag in the transformed HTML.
+    pub line: u32,
+    /// `"linked"` when the tag became a plain link, `"kept"` when its markup
+    /// was left as authored.
+    pub fallback: String,
+}
+
+/// Rewritten HTML plus every tag an enabled provider refused.
+#[napi(object)]
+pub struct JsMediaEmbedsResult {
+    pub html: String,
+    pub diagnostics: Vec<JsEmbedDiagnostic>,
+}
+
+/// Rewrites embeds and reports the tags no provider would render.
+#[napi(js_name = "transformMediaEmbedsWithDiagnostics")]
+pub fn transform_media_embeds_with_diagnostics(
+    html: String,
+    options: Option<JsMediaEmbedsOptions>,
+) -> JsMediaEmbedsResult {
+    let options = options.map(Into::into);
+    let (html, diagnostics) =
+        media_embeds::transform_media_embeds_with_diagnostics(&html, options.as_ref());
+    JsMediaEmbedsResult {
+        html,
+        diagnostics: diagnostics
+            .into_iter()
+            .map(|diagnostic| JsEmbedDiagnostic {
+                provider: diagnostic.provider,
+                url: diagnostic.url,
+                line: diagnostic.line,
+                fallback: match diagnostic.fallback {
+                    media_embeds::EmbedFallback::Linked => "linked".to_string(),
+                    media_embeds::EmbedFallback::Kept => "kept".to_string(),
+                },
+            })
+            .collect(),
+    }
+}
+
 #[napi(js_name = "transformMediaEmbeds")]
 pub fn transform_media_embeds(html: String, options: Option<JsMediaEmbedsOptions>) -> String {
     let options = options.map(Into::into);

--- a/crates/ox_content_transform/src/media_embeds.rs
+++ b/crates/ox_content_transform/src/media_embeds.rs
@@ -18,25 +18,65 @@ mod video_cards;
 
 use crate::{MediaEmbedsOptions, html_scan::find_ci};
 
-use fallback::render_fallback;
+use fallback::{fallback_url, render_fallback};
 use html::{ComponentElement, find_component, find_pascal_component};
 use registry::{PROVIDERS, Provider, Tag};
 
+/// Why an enabled provider did not render the tag it was given.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EmbedFallback {
+    /// The tag carried a link-safe URL, so it became a plain link.
+    Linked,
+    /// Nothing safe to link to, so the authored markup was left alone.
+    Kept,
+}
+
+/// One tag an enabled provider refused, and what happened to it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbedDiagnostic {
+    /// Tag name as the provider registers it, for example `speakerdeck`.
+    pub provider: String,
+    /// The URL the tag carried, when it carried one worth naming.
+    pub url: Option<String>,
+    /// 1-based line of the opening tag in the transformed HTML.
+    pub line: u32,
+    /// What the transform did instead.
+    pub fallback: EmbedFallback,
+}
+
 pub fn transform_media_embeds(html: &str, options: Option<&MediaEmbedsOptions>) -> String {
+    transform_media_embeds_with_diagnostics(html, options).0
+}
+
+/// The transform plus every tag an enabled provider refused.
+///
+/// A refusal is invisible in the output — the tag becomes a link, or stays as
+/// written — so without this a typo in a URL ships silently.
+pub fn transform_media_embeds_with_diagnostics(
+    html: &str,
+    options: Option<&MediaEmbedsOptions>,
+) -> (String, Vec<EmbedDiagnostic>) {
     let Some(options) = options else {
-        return html.to_string();
+        return (html.to_string(), Vec::new());
     };
     if !has_enabled_embed(options) || !html.contains('<') {
-        return html.to_string();
+        return (html.to_string(), Vec::new());
     }
 
     let mut current = html.to_string();
+    let mut diagnostics = Vec::new();
     for provider in PROVIDERS {
         if (provider.enabled)(options) && provider.appears_in(&current) {
-            current = rewrite_components(&current, provider);
+            current = rewrite_components(&current, provider, &mut diagnostics);
         }
     }
-    current
+    (current, diagnostics)
+}
+
+/// 1-based line of `offset` within `html`.
+fn line_of(html: &str, offset: usize) -> u32 {
+    let counted = html[..offset.min(html.len())].bytes().filter(|byte| *byte == b'\n').count();
+    u32::try_from(counted + 1).unwrap_or(u32::MAX)
 }
 
 fn has_enabled_embed(options: &MediaEmbedsOptions) -> bool {
@@ -53,7 +93,11 @@ impl Provider {
     }
 }
 
-fn rewrite_components(html: &str, provider: &Provider) -> String {
+fn rewrite_components(
+    html: &str,
+    provider: &Provider,
+    diagnostics: &mut Vec<EmbedDiagnostic>,
+) -> String {
     let find: for<'a> fn(&'a str, usize, &str, &str) -> Option<ComponentElement<'a>> =
         match provider.tag {
             Tag::AnyCase => find_component,
@@ -69,9 +113,21 @@ fn rewrite_components(html: &str, provider: &Provider) -> String {
         let original = &html[element.span.0..element.span.1];
         // An enabled provider that cannot resolve its input still owes the
         // reader the link. Only a tag with no safe URL keeps its markup.
-        match (provider.render)(&element).or_else(|| render_fallback(&element)) {
-            Some(rendered) => out.push_str(&rendered),
-            None => out.push_str(original),
+        if let Some(rendered) = (provider.render)(&element) {
+            out.push_str(&rendered);
+        } else {
+            let fallback = render_fallback(&element);
+            diagnostics.push(EmbedDiagnostic {
+                provider: provider.name.to_string(),
+                url: fallback_url(&element).map(str::to_string),
+                line: line_of(html, element.span.0),
+                fallback: if fallback.is_some() {
+                    EmbedFallback::Linked
+                } else {
+                    EmbedFallback::Kept
+                },
+            });
+            out.push_str(fallback.as_deref().unwrap_or(original));
         }
         cursor = element.span.1;
     }

--- a/crates/ox_content_transform/src/media_embeds/fallback.rs
+++ b/crates/ox_content_transform/src/media_embeds/fallback.rs
@@ -21,16 +21,24 @@ use super::html::{ComponentElement, attr};
 use super::provider_cards::{is_safe_https_url, provider_url};
 use super::render::{escape_attr, escape_text};
 
+/// The URL a refused tag can still be linked to, if any.
+///
+/// Shared with the diagnostic so a report names the same URL the reader ends
+/// up with, rather than one the transform decided against.
+pub(super) fn fallback_url<'a>(element: &'a ComponentElement<'_>) -> Option<&'a str> {
+    provider_url(element).or_else(|| {
+        attr(element, "url")
+            .or_else(|| attr(element, "href"))
+            .filter(|value| is_safe_https_url(value))
+    })
+}
+
 /// A plain link standing in for an embed that could not be resolved.
 ///
 /// Returns `None` when the tag carries no URL safe enough to link to, in which
 /// case the caller keeps the original markup — there is nothing better to say.
 pub(super) fn render_fallback(element: &ComponentElement<'_>) -> Option<String> {
-    let href = provider_url(element).or_else(|| {
-        attr(element, "url")
-            .or_else(|| attr(element, "href"))
-            .filter(|value| is_safe_https_url(value))
-    })?;
+    let href = fallback_url(element)?;
 
     let label = link_label(element, href);
 

--- a/crates/ox_content_transform/src/media_embeds/fallback_tests.rs
+++ b/crates/ox_content_transform/src/media_embeds/fallback_tests.rs
@@ -4,7 +4,7 @@
 //! link-safe URL degrades to a neutral link, and one that does not keeps its
 //! markup because there is nothing better to say.
 
-use super::transform_media_embeds;
+use super::{EmbedFallback, transform_media_embeds, transform_media_embeds_with_diagnostics};
 use crate::MediaEmbedsOptions;
 
 /// A rejected tag either degrades to a neutral link or keeps its markup,
@@ -155,4 +155,54 @@ fn a_disabled_provider_is_left_completely_alone() {
     let source = r#"<Qiita url="https://qiita.com/ubugeeei"></Qiita>"#;
     let rendered = transform_media_embeds(source, Some(&MediaEmbedsOptions::default()));
     assert_eq!(rendered, source);
+}
+
+#[test]
+fn a_refused_tag_is_reported_with_its_url_and_line() {
+    let options = MediaEmbedsOptions { qiita: Some(true), ..Default::default() };
+    let source = concat!(
+        "<p>intro</p>\n",
+        "<p>more</p>\n",
+        r#"<Qiita url="https://qiita.com/ubugeeei"></Qiita>"#,
+    );
+
+    let (_, diagnostics) = transform_media_embeds_with_diagnostics(source, Some(&options));
+
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+    let diagnostic = &diagnostics[0];
+    assert_eq!(diagnostic.provider, "qiita");
+    assert_eq!(diagnostic.url.as_deref(), Some("https://qiita.com/ubugeeei"));
+    assert_eq!(diagnostic.line, 3);
+    assert_eq!(diagnostic.fallback, EmbedFallback::Linked);
+}
+
+#[test]
+fn a_tag_with_no_safe_url_reports_that_its_markup_was_kept() {
+    let options = MediaEmbedsOptions { speaker_deck: Some(true), ..Default::default() };
+    let (html, diagnostics) = transform_media_embeds_with_diagnostics(
+        r#"<SpeakerDeck url="javascript:alert(1)"></SpeakerDeck>"#,
+        Some(&options),
+    );
+
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+    assert_eq!(diagnostics[0].fallback, EmbedFallback::Kept);
+    assert_eq!(diagnostics[0].url, None);
+    assert!(html.contains("<SpeakerDeck"), "{html}");
+}
+
+#[test]
+fn a_provider_that_resolves_reports_nothing() {
+    let options = MediaEmbedsOptions { qiita: Some(true), ..Default::default() };
+    let (_, diagnostics) = transform_media_embeds_with_diagnostics(
+        r#"<Qiita url="https://qiita.com/ubugeeei/items/abcdef123456"></Qiita>"#,
+        Some(&options),
+    );
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+
+    // And a disabled provider is not the transform's business to report.
+    let (_, none) = transform_media_embeds_with_diagnostics(
+        r#"<Qiita url="https://qiita.com/ubugeeei"></Qiita>"#,
+        Some(&MediaEmbedsOptions::default()),
+    );
+    assert!(none.is_empty(), "{none:?}");
 }

--- a/npm/vite-plugin-ox-content/src/plugins/media.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/media.ts
@@ -213,7 +213,7 @@ export async function transformMediaEmbeds(
   if (!hasMediaMarker(result)) return result;
 
   const mod = await importNapiModule();
-  return mod.transformMediaEmbeds(result, {
+  const transformed = mod.transformMediaEmbedsWithDiagnostics(result, {
     spotify: options.spotify,
     appleMusic: options.appleMusic,
     speakerDeck: options.speakerDeck,
@@ -236,6 +236,9 @@ export async function transformMediaEmbeds(
     instagram: options.instagram,
     webContainer: options.webContainer,
   });
+
+  reportRefusedEmbeds(transformed.diagnostics);
+  return transformed.html;
 }
 
 function hasEnabledMediaEmbed(options: MediaEmbedOptions): boolean {
@@ -271,4 +274,25 @@ function hasMediaMarker(html: string): boolean {
       html,
     ) || /<(Audio|Video)[\s/>]/.test(html)
   );
+}
+
+/**
+ * Warns about tags an enabled provider refused.
+ *
+ * A refusal is invisible in the output — the tag becomes a plain link, or stays
+ * as authored — so a mistyped URL would otherwise ship without a word.
+ */
+function reportRefusedEmbeds(
+  diagnostics: readonly { provider: string; url?: string | null; line: number; fallback: string }[],
+): void {
+  for (const diagnostic of diagnostics) {
+    const target = diagnostic.url ? ` for ${diagnostic.url}` : "";
+    const outcome =
+      diagnostic.fallback === "linked"
+        ? "rendered as a plain link instead"
+        : "left as authored markup; it carries no URL safe to link to";
+    console.warn(
+      `[ox-content:embeds] <${diagnostic.provider}> on line ${diagnostic.line} did not resolve${target}; ${outcome}.`,
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- `transform_media_embeds_with_diagnostics` returns the rewritten HTML plus one record per refused tag
- the Vite plugin warns for each, naming the provider, the URL, the line, and the outcome
- `transform_media_embeds` keeps its signature and delegates

**Stacked on #1082** — review that first; this branch targets it, not `main`.

## Why

An enabled provider that refuses a tag degrades it quietly: it becomes a plain
link, or stays as authored. Neither shows up in the build, so a mistyped URL
ships without a word.

```
[ox-content:embeds] <applemusic> on line 1 did not resolve for
https://music.apple.com.evil.com/us/album/folklore/1524801260;
rendered as a plain link instead.
```

That exact warning turned up in the Apple Music test while building this — the
mechanism reporting a real case rather than a contrived one.

## Detail worth naming

The URL in the report is the one the **fallback links to**, not the one the tag
carried. The two differ when a tag names something unsafe: the reader gets no
link, and a diagnostic quoting the rejected URL would point at a page the reader
never reaches. Both come from the same helper so they cannot drift.

The two outcomes are distinguished — `linked` when the reader still gets the
URL, `kept` when there was nothing safe to link to and the markup stands.

## Scope

This is the diagnostics bullet of #1069. Still open there: the four fetch-side
failure modes, which live in the TypeScript fetchers rather than this
transform.

## Verification
- cargo test -p ox_content_transform  (502 passed)
- cargo test -p ox_content_napi  (63 passed)
- cargo clippy -p ox_content_transform -p ox_content_napi --all-targets -- -D warnings
- cargo fmt --all -- --check
- cd npm/vite-plugin-ox-content && vp test run  (899 passed, against a freshly built binding)
- vp run check:ts
- node scripts/check-file-lines.ts

Refs #1069

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790409013&installation_model_id=422833&pr_number=1095&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1095&signature=f46463822b8814f2e168e68c5f01868585c829eec0f67bd1f14ec923bcb82293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->