### PR TITLE
feat(embeds): add CodeSandbox playground cards

### DIFF
--- a/crates/ox_content_transform/src/media_embeds/playground_cards.rs
+++ b/crates/ox_content_transform/src/media_embeds/playground_cards.rs
@@ -16,10 +16,15 @@ pub(super) fn render_observable(element: &ComponentElement<'_>) -> Option<String
     render_playground_card(element, Provider::Observable)
 }
 
+pub(super) fn render_code_sandbox(element: &ComponentElement<'_>) -> Option<String> {
+    render_playground_card(element, Provider::CodeSandbox)
+}
+
 enum Provider {
     CodePen,
     JsFiddle,
     Observable,
+    CodeSandbox,
 }
 
 struct PlaygroundReference {
@@ -65,6 +70,7 @@ fn playground_reference(input: &str, provider: Provider) -> Option<PlaygroundRef
         Provider::CodePen => codepen_reference(&parsed.host, &segments),
         Provider::JsFiddle => jsfiddle_reference(&parsed.host, &segments),
         Provider::Observable => observable_reference(&parsed.host, &segments),
+        Provider::CodeSandbox => code_sandbox_reference(&parsed.host, &segments),
     }
 }
 
@@ -113,6 +119,26 @@ fn observable_reference(host: &str, segments: &[&str]) -> Option<PlaygroundRefer
     Some(PlaygroundReference { modifier: "observable", network: "Observable", title, author })
 }
 
+/// CodeSandbox names a sandbox four ways: the classic `/s/{id}`, the newer
+/// `/p/sandbox/{id}` and `/p/devbox/{id}`, and the already-embedded
+/// `/embed/{id}`. None of them carries an author, unlike CodePen.
+fn code_sandbox_reference(host: &str, segments: &[&str]) -> Option<PlaygroundReference> {
+    if !host_in(host, &["codesandbox.io", "www.codesandbox.io"]) {
+        return None;
+    }
+    let slug = match segments {
+        ["s", slug] | ["embed", slug] => slug,
+        ["p", "sandbox" | "devbox", slug] => slug,
+        _ => return None,
+    };
+    Some(PlaygroundReference {
+        modifier: "codesandbox",
+        network: "CodeSandbox",
+        title: titleize(safe_segment(slug)?),
+        author: None,
+    })
+}
+
 fn is_playground_embed(input: &str, network: &str) -> bool {
     let Some(parsed) = parse_https_url(input) else {
         return false;
@@ -125,6 +151,10 @@ fn is_playground_embed(input: &str, network: &str) -> bool {
         }
         "Observable" => {
             host_in(&parsed.host, &["observablehq.com"]) && parsed.path.starts_with("/embed/")
+        }
+        "CodeSandbox" => {
+            host_in(&parsed.host, &["codesandbox.io", "www.codesandbox.io"])
+                && parsed.path.starts_with("/embed/")
         }
         _ => false,
     }

--- a/crates/ox_content_transform/src/media_embeds/registry.rs
+++ b/crates/ox_content_transform/src/media_embeds/registry.rs
@@ -11,7 +11,9 @@ use super::apple_music::render_apple_music;
 use super::html::ComponentElement;
 use super::native::{render_audio, render_video};
 use super::package_cards::{render_crates_io, render_docker_hub, render_npm_package, render_pypi};
-use super::playground_cards::{render_codepen, render_jsfiddle, render_observable};
+use super::playground_cards::{
+    render_code_sandbox, render_codepen, render_jsfiddle, render_observable,
+};
 use super::provider_cards::{
     render_discord, render_facebook, render_fediverse, render_google_maps, render_instagram,
     render_mastodon, render_misskey, render_mixi2, render_qiita, render_threads, render_zenn,
@@ -133,6 +135,12 @@ pub(super) const PROVIDERS: &[Provider] = &[
         tag: Tag::AnyCase,
         enabled: |o| on(o.playgrounds),
         render: render_observable,
+    },
+    Provider {
+        name: "codesandbox",
+        tag: Tag::AnyCase,
+        enabled: |o| on(o.playgrounds),
+        render: render_code_sandbox,
     },
     Provider { name: "vimeo", tag: Tag::AnyCase, enabled: |o| on(o.vimeo), render: render_vimeo },
     Provider {

--- a/crates/ox_content_transform/src/media_embeds/snapshots/ox_content_transform__media_embeds__registry_tests__each_option_gates_exactly_its_own_providers.snap
+++ b/crates/ox_content_transform/src/media_embeds/snapshots/ox_content_transform__media_embeds__registry_tests__each_option_gates_exactly_its_own_providers.snap
@@ -14,7 +14,7 @@ googleMaps -> googlemaps
 qiita -> qiita
 zenn -> zenn
 packageRegistry -> npmpackage, cratesio, pypi, dockerhub
-playgrounds -> codepen, jsfiddle, observable
+playgrounds -> codepen, jsfiddle, observable, codesandbox
 vimeo -> vimeo
 twitch -> twitch
 discord -> discord

--- a/crates/ox_content_transform/src/media_embeds/tests.rs
+++ b/crates/ox_content_transform/src/media_embeds/tests.rs
@@ -128,6 +128,41 @@ fn renders_playground_cards() {
 }
 
 #[test]
+fn renders_code_sandbox_cards_from_every_url_form() {
+    let options = MediaEmbedsOptions { playgrounds: Some(true), ..Default::default() };
+
+    // A sandbox is named four ways and they all mean the same sandbox.
+    for url in [
+        "https://codesandbox.io/s/vite-react-demo",
+        "https://codesandbox.io/p/sandbox/vite-react-demo",
+        "https://codesandbox.io/p/devbox/vite-react-demo",
+        "https://codesandbox.io/embed/vite-react-demo",
+    ] {
+        let html = transform_media_embeds(
+            &format!(r#"<CodeSandbox url="{url}"></CodeSandbox>"#),
+            Some(&options),
+        );
+        assert!(html.contains("ox-provider-card--codesandbox"), "{url}: {html}");
+        assert!(html.contains("CodeSandbox"), "{url}: {html}");
+        // The slug becomes the title, with separators read as spaces.
+        assert!(html.contains("vite react demo"), "{url}: {html}");
+    }
+
+    // Only an /embed/ URL is accepted as an iframe source.
+    let framed = transform_media_embeds(
+        r#"<CodeSandbox url="https://codesandbox.io/s/demo" embed="https://codesandbox.io/embed/demo"></CodeSandbox>"#,
+        Some(&options),
+    );
+    assert!(framed.contains("<iframe"), "{framed}");
+
+    let unframed = transform_media_embeds(
+        r#"<CodeSandbox url="https://codesandbox.io/s/demo" embed="https://evil.example/embed/demo"></CodeSandbox>"#,
+        Some(&options),
+    );
+    assert!(!unframed.contains("<iframe"), "{unframed}");
+}
+
+#[test]
 fn renders_video_provider_cards() {
     let enabled =
         MediaEmbedsOptions { vimeo: Some(true), twitch: Some(true), ..Default::default() };

--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -507,6 +507,7 @@ default. Authors can pass stable metadata with attributes such as `title`,
 <DockerHub url="https://hub.docker.com/_/nginx" />
 
 <CodePen url="https://codepen.io/ubugeeei/pen/abc123" />
+<CodeSandbox url="https://codesandbox.io/p/sandbox/vite-react-demo" />
 
 <JSFiddle url="https://jsfiddle.net/ubugeeei/abc123/2/" />
 
@@ -539,6 +540,12 @@ default. Authors can pass stable metadata with attributes such as `title`,
 | `cacheTTL` | `3600000` | Freshness window in milliseconds.                |
 | `iframe`   | `false`   | Add lazy playground/video iframe URLs.           |
 | `parent`   | `[]`      | Twitch iframe parent domain or domains.          |
+
+CodeSandbox accepts all four ways a sandbox is named — `/s/{id}`,
+`/p/sandbox/{id}`, `/p/devbox/{id}`, and `/embed/{id}`. Unlike the other
+playgrounds it fetches nothing: the card is built from the URL and whatever
+attributes you pass, so a deleted sandbox still renders a card pointing at it
+rather than failing the build.
 
 `<Fediverse>`, `<Mastodon>`, `<Misskey>`, and `<Mixi2>` share the
 `embeds.fediverse` option. Google Maps accepts an optional safe Google Maps

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -404,6 +404,7 @@ iframe URL は `{ iframe: true }` のときだけ追加されます。Twitch ifr
 <DockerHub url="https://hub.docker.com/_/nginx" />
 
 <CodePen url="https://codepen.io/ubugeeei/pen/abc123" />
+<CodeSandbox url="https://codesandbox.io/p/sandbox/vite-react-demo" />
 
 <JSFiddle url="https://jsfiddle.net/ubugeeei/abc123/2/" />
 
@@ -436,6 +437,8 @@ iframe URL は `{ iframe: true }` のときだけ追加されます。Twitch ifr
 | `cacheTTL` | `3600000` | キャッシュの鮮度期間（ミリ秒）。                      |
 | `iframe`   | `false`   | playground/video の lazy iframe URL を追加する。      |
 | `parent`   | `[]`      | Twitch iframe の parent domain。                      |
+
+CodeSandbox はサンドボックスの 4 つの URL 形式すべてを受け付けます（`/s/{id}`、`/p/sandbox/{id}`、`/p/devbox/{id}`、`/embed/{id}`）。他のプレイグラウンドと違いフェッチは行いません。カードは URL と渡した属性だけから組み立てるので、削除済みのサンドボックスでもビルドを失敗させず、そこを指すカードを描画します。
 
 `<Fediverse>`、`<Mastodon>`、`<Misskey>`、`<Mixi2>` は
 `embeds.fediverse` を共有します。Google Maps は安全な Google Maps `embed`


### PR DESCRIPTION
## Summary
- add `<CodeSandbox>` alongside the existing playground providers
- accept all four URL forms a sandbox is named by
- no new option: it joins `embeds.playgrounds`

CodePen, JSFiddle, Observable, and StackBlitz were all embeddable. CodeSandbox,
which sits squarely among them, was not — a gap #861 exists to close, one
focused PR per provider.

## The four URL forms

```
https://codesandbox.io/s/vite-react-demo
https://codesandbox.io/p/sandbox/vite-react-demo
https://codesandbox.io/p/devbox/vite-react-demo
https://codesandbox.io/embed/vite-react-demo
```

All four resolve to the same card. The slug becomes the title with separators
read as spaces; unlike CodePen, a CodeSandbox URL carries no author, so the card
does not invent one.

## It fetches nothing

The other playgrounds fetch oEmbed metadata at build time. This one does not:
the card is built from the URL and whatever attributes the author passes. A
deleted sandbox still renders a card pointing at it rather than failing a build,
and adding the provider adds no network surface — which is the static-first
default #861 asks for.

Only an `/embed/` URL on the CodeSandbox host is accepted as an iframe source; a
look-alike host passed as `embed` is ignored, and the test covers that.

## No new option

It is gated by the existing `embeds.playgrounds`, so a site that already opted
into playgrounds gets it with no config change. The registry gating snapshot
caught the new row on its first run:

```
-playgrounds -> codepen, jsfiddle, observable
+playgrounds -> codepen, jsfiddle, observable, codesandbox
```

## Verification
- cargo test -p ox_content_transform  (503 passed)
- cargo clippy -p ox_content_transform --all-targets -- -D warnings
- cargo fmt --all -- --check
- cd npm/vite-plugin-ox-content && vp test run  (907 passed, against a freshly built binding)
- vp run check:ts
- node scripts/check-file-lines.ts

The docs get the fenced listing and the prose note here. A live rendered example
belongs in the live-examples block that #1096 adds, so it goes there rather than
conflicting with that branch.

Refs #861

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790410322&installation_model_id=422833&pr_number=1098&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1098&signature=3c002b2e781fad95518f0490f5994d101f8b85caa5d6404abcb6d5f99f42da69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->