### PR TITLE
fix(nix): pin a Rust version the overlay actually has

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
         lib = pkgs.lib;
         nodejs = pkgs.nodejs_26;
         pnpm = pkgs.pnpm;
-        rustToolchain = pkgs.rust-bin.stable."1.98.0".default.override {
+        rustToolchain = pkgs.rust-bin.stable."1.95.0".default.override {
           extensions = [
             "clippy"
             "rust-src"


### PR DESCRIPTION
`flake.nix` asked for `rust-bin.stable."1.98.0"`. That version does not exist in the pinned rust-overlay — its newest stable is **1.95.0**, which is exactly the workspace MSRV. So `nix develop` failed outright:

```
error: attribute '1.98.0' missing
       at flake.nix:32:25
```

That is why CONTRIBUTING's documented setup path does not work, and why anyone without a system Rust ≥ 1.95 cannot build the crates at all.

## Scope

This fixes the **Rust pin only**. `nodejs_26` on the next line is stale in the same way — the pinned nixpkgs stops at `nodejs_25` while `package.json` requires `node >= 26` — so the dev shell still fails there:

```
error: attribute 'nodejs_26' missing
       Did you mean one of nodejs_20, nodejs_22, nodejs_24 or nodejs_25?
```

That one cannot be fixed by picking a different attribute; it needs a `nixpkgs` input update, which is a bigger change and a separate decision. Filing it rather than bundling it here.

## Verification

`1.95.0` is confirmed present in the pinned overlay — I enumerated `rust-bin.stable` and built the toolchain from it successfully:

```
cargo 1.95.0 (f2d3ce0bd 2026-03-21)
rustc 1.95.0 (59807616e 2026-04-14)
```

`nix develop` still stops at `nodejs_26`, as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790417249&installation_model_id=422833&pr_number=1107&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1107&signature=a480c16a6d49fcc58d58f829cf6e784c924eca1acc059a3226f57d54c5495ff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development environment to use Rust 1.95.0.
  * Preserved existing tooling, formatting support, linting, source components, and WebAssembly target support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->