### PR TITLE
refactor(cross-references): move the pass into Rust

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -344,6 +344,9 @@ export interface IncrementalMarkdownRenderResult {
   errors: Array<string>
 }
 
+/** Same-origin path check: leading `/`, not `//`, and no scheme. */
+export declare function isSafeRedirectDest(value: string): boolean
+
 /** Opt-in skip link and print styles. Presence of the object enables the feature. */
 export interface JsA11y {
   /** Override for the skip-link label. Empty / omitted uses "Skip to content". */
@@ -533,6 +536,49 @@ export interface JsContainerTypeOptions {
   title?: string
   /** `"details"` renders `<details>`/`<summary>`; anything else is a `<div>`. */
   tag?: string
+}
+
+/** One rule the document broke. */
+export interface JsCrossReferenceDiagnostic {
+  /** `"error"` or `"warn"`, as the options asked. */
+  policy: string
+  message: string
+}
+
+/** One numbered target the document defines. */
+export interface JsCrossReferenceEntry {
+  id: string
+  /** `"figure"`, `"table"`, or `"section"`. */
+  kind: string
+  number: string
+  label: string
+  text: string
+  href: string
+  title?: string
+}
+
+/** The word placed before each number, per kind. */
+export interface JsCrossReferenceLabels {
+  figure?: string
+  table?: string
+  section?: string
+}
+
+/** The annotated HTML, what it defined, and what it got wrong. */
+export interface JsCrossReferenceOutput {
+  html: string
+  references: Array<JsCrossReferenceEntry>
+  diagnostics: Array<JsCrossReferenceDiagnostic>
+}
+
+/** Switches and labels for the cross-reference pass. */
+export interface JsCrossReferencesOptions {
+  enabled: boolean
+  /** `"warn"` reports and carries on; anything else fails the build. */
+  missing?: string
+  duplicates?: string
+  mismatches?: string
+  labels?: JsCrossReferenceLabels
 }
 
 /** Opt-in static `csv-table` / `json-table` fences. */
@@ -1840,6 +1886,47 @@ export interface JsReaderChrome {
   backToTop?: boolean
 }
 
+/** One planned static HTML redirect. */
+export interface JsRedirectEntry {
+  from: string
+  to: string
+  html: string
+  relativePath: string
+}
+
+/** One entry of the config rewrite map, in author order. */
+export interface JsRedirectMapEntry {
+  from: string
+  to: string
+}
+
+/** One page that other paths can redirect to. */
+export interface JsRedirectPage {
+  dest: string
+  aliases?: Array<string>
+  redirect?: string
+}
+
+/** Switches and the config rewrite map. */
+export interface JsRedirectsOptions {
+  enabled: boolean
+  map: Array<JsRedirectMapEntry>
+  netlify: boolean
+  headers: boolean
+  json: boolean
+  allowExternal: boolean
+  html: boolean
+  base?: string
+}
+
+/** Planned redirect pages and optional host files. */
+export interface JsRedirectsOutput {
+  pages: Array<JsRedirectEntry>
+  netlify?: string
+  headers?: string
+  json?: string
+}
+
 /** Resolved source module. */
 export interface JsResolvedModule {
   path: string
@@ -2957,6 +3044,9 @@ export interface Mf2ValidateResult {
 /** Every language name and alias the native highlighter answers to. */
 export declare function nativeHighlightLanguages(): Array<string>
 
+/** Strips a trailing slash except for `/`. Unsafe values return `None`. */
+export declare function normalizeRedirectPath(value: string): string | null
+
 /** Normalizes VitePress-specific frontmatter into ox-content's entry-page shape. */
 export declare function normalizeVitePressFrontmatter(frontmatter: any): any
 
@@ -3002,6 +3092,9 @@ export declare function parseScopedSearchQuery(query: string): JsScopedSearchQue
  */
 export declare function parseTransferRaw(source: string, kind: string, options?: JsParserOptions | undefined | null): Uint8Array
 
+/** Plans redirect pages and host files without writing anything. */
+export declare function planRedirects(options: JsRedirectsOptions, pages: Array<JsRedirectPage>): JsRedirectsOutput
+
 /** Prepared Markdown source with parsed frontmatter. */
 export interface PreparedSourceResult {
   /** Markdown content after optional frontmatter removal. */
@@ -3036,6 +3129,9 @@ export declare function renderFrameworkComponentCode(html: string, target: strin
 
 /** Resolve Unhead-compatible page-head descriptors to HTML. */
 export declare function renderHead(inputJson: string): JsSsgHtmlResult
+
+/** Static HTML redirect body. `dest` is escaped; callers still validate it. */
+export declare function renderRedirectHtml(dest: string): string
 
 /** Render result containing the HTML output. */
 export interface RenderResult {
@@ -3092,6 +3188,9 @@ export declare function transform(source: string, options?: JsTransformOptions |
 
 /** Transforms Markdown source asynchronously (runs on worker thread). */
 export declare function transformAsync(source: string, options?: JsTransformOptions | undefined | null): Promise<unknown>
+
+/** Numbers headings, figures, and tables, and links `@id` references to them. */
+export declare function transformCrossReferences(html: string, options: JsCrossReferencesOptions): JsCrossReferenceOutput
 
 /**
  * Transforms Markdown into a raw mdast transfer buffer.

--- a/crates/ox_content_napi/index.js
+++ b/crates/ox_content_napi/index.js
@@ -248,5 +248,6 @@ module.exports.renderFrameworkComponentCode = binding.renderFrameworkComponentCo
 module.exports.renderSsgSectionIndex = binding.renderSsgSectionIndex;
 module.exports.parseFeedDate = binding.parseFeedDate;
 module.exports.generateFeedBodies = binding.generateFeedBodies;
+module.exports.transformCrossReferences = binding.transformCrossReferences;
 module.exports.generateSiteMapBodies = binding.generateSiteMapBodies;
 module.exports.escapeSvelteMarkup = binding.escapeSvelteMarkup;

--- a/crates/ox_content_napi/src/cross_reference_bindings.rs
+++ b/crates/ox_content_napi/src/cross_reference_bindings.rs
@@ -1,0 +1,116 @@
+use napi_derive::napi;
+use ox_content_transform::cross_references::{
+    CrossReferenceKind, CrossReferenceLabels, CrossReferencesOptions, FailureMode,
+    transform_cross_references,
+};
+
+/// The word placed before each number, per kind.
+#[napi(object)]
+pub struct JsCrossReferenceLabels {
+    pub figure: Option<String>,
+    pub table: Option<String>,
+    pub section: Option<String>,
+}
+
+/// Switches and labels for the cross-reference pass.
+#[napi(object)]
+pub struct JsCrossReferencesOptions {
+    pub enabled: bool,
+    /// `"warn"` reports and carries on; anything else fails the build.
+    pub missing: Option<String>,
+    pub duplicates: Option<String>,
+    pub mismatches: Option<String>,
+    pub labels: Option<JsCrossReferenceLabels>,
+}
+
+/// One numbered target the document defines.
+#[napi(object)]
+pub struct JsCrossReferenceEntry {
+    pub id: String,
+    /// `"figure"`, `"table"`, or `"section"`.
+    pub kind: String,
+    pub number: String,
+    pub label: String,
+    pub text: String,
+    pub href: String,
+    pub title: Option<String>,
+}
+
+/// One rule the document broke.
+#[napi(object)]
+pub struct JsCrossReferenceDiagnostic {
+    /// `"error"` or `"warn"`, as the options asked.
+    pub policy: String,
+    pub message: String,
+}
+
+/// The annotated HTML, what it defined, and what it got wrong.
+#[napi(object)]
+pub struct JsCrossReferenceOutput {
+    pub html: String,
+    pub references: Vec<JsCrossReferenceEntry>,
+    pub diagnostics: Vec<JsCrossReferenceDiagnostic>,
+}
+
+/// Numbers headings, figures, and tables, and links `@id` references to them.
+#[napi(js_name = "transformCrossReferences")]
+pub fn transform_cross_references_binding(
+    html: String,
+    options: JsCrossReferencesOptions,
+) -> JsCrossReferenceOutput {
+    let labels = options.labels.unwrap_or(JsCrossReferenceLabels {
+        figure: None,
+        table: None,
+        section: None,
+    });
+    let defaults = CrossReferenceLabels::default();
+    let resolved = CrossReferencesOptions {
+        enabled: options.enabled,
+        missing: failure_mode(options.missing.as_deref()),
+        duplicates: failure_mode(options.duplicates.as_deref()),
+        mismatches: failure_mode(options.mismatches.as_deref()),
+        labels: CrossReferenceLabels {
+            figure: labels.figure.unwrap_or(defaults.figure),
+            table: labels.table.unwrap_or(defaults.table),
+            section: labels.section.unwrap_or(defaults.section),
+        },
+    };
+
+    let output = transform_cross_references(&html, &resolved);
+    JsCrossReferenceOutput {
+        html: output.html,
+        references: output
+            .references
+            .into_iter()
+            .map(|entry| JsCrossReferenceEntry {
+                id: entry.id,
+                kind: kind_name(entry.kind),
+                number: entry.number,
+                label: entry.label,
+                text: entry.text,
+                href: entry.href,
+                title: entry.title,
+            })
+            .collect(),
+        diagnostics: output
+            .diagnostics
+            .into_iter()
+            .map(|diagnostic| JsCrossReferenceDiagnostic {
+                policy: match diagnostic.policy {
+                    FailureMode::Warn => "warn".to_string(),
+                    FailureMode::Error => "error".to_string(),
+                },
+                message: diagnostic.message,
+            })
+            .collect(),
+    }
+}
+
+/// Only `"warn"` softens a rule; every other value keeps it fatal.
+fn failure_mode(value: Option<&str>) -> FailureMode {
+    if value == Some("warn") { FailureMode::Warn } else { FailureMode::Error }
+}
+
+fn kind_name(kind: CrossReferenceKind) -> String {
+    kind.as_str().to_string()
+}

--- a/crates/ox_content_napi/src/lib.rs
+++ b/crates/ox_content_napi/src/lib.rs
@@ -15,6 +15,7 @@
 )]
 
 mod collection_bindings;
+mod cross_reference_bindings;
 mod docs_bindings;
 mod docs_graph_types;
 mod docs_markdown_types;
@@ -70,6 +71,7 @@ pub use og_image_bindings::*;
 pub use parse_bindings::*;
 pub use parser_options::JsParserOptions;
 pub use publish_state_bindings::*;
+pub use cross_reference_bindings::*;
 pub use redirect_bindings::*;
 pub use search_bindings::*;
 pub use site_map_bindings::*;

--- a/crates/ox_content_napi/src/tests/runtime_features.rs
+++ b/crates/ox_content_napi/src/tests/runtime_features.rs
@@ -99,6 +99,7 @@ fn javascript_wrapper_and_declarations_cover_expected_exports() {
         "searchIndex",
         "transform",
         "transformAsync",
+        "transformCrossReferences",
         "transformMediaEmbeds",
         "transformMediaEmbedsWithDiagnostics",
         "transformMdastRaw",

--- a/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
+++ b/crates/ox_content_napi/src/tests/snapshots/ox_content_napi__tests__runtime_features__javascript_wrapper_native_load_errors.snap
@@ -252,5 +252,6 @@ module.exports.renderFrameworkComponentCode = binding.renderFrameworkComponentCo
 module.exports.renderSsgSectionIndex = binding.renderSsgSectionIndex;
 module.exports.parseFeedDate = binding.parseFeedDate;
 module.exports.generateFeedBodies = binding.generateFeedBodies;
+module.exports.transformCrossReferences = binding.transformCrossReferences;
 module.exports.generateSiteMapBodies = binding.generateSiteMapBodies;
 module.exports.escapeSvelteMarkup = binding.escapeSvelteMarkup;

--- a/crates/ox_content_transform/src/cross_references/annotate.rs
+++ b/crates/ox_content_transform/src/cross_references/annotate.rs
@@ -1,0 +1,572 @@
+//! The three numbering passes: sections, figures, and tables.
+//!
+//! Each walks the HTML once, assigns the next number to every element carrying
+//! a trackable `id`, and writes the `data-ox-xref-*` attributes the reference
+//! pass and the stylesheet read.
+
+use super::html::{
+    append_attr, append_data_attrs, escape_url_fragment, expected_kind, is_word_byte, read_attr,
+    should_track_target, text_content,
+};
+use super::types::{
+    CrossReferenceDiagnostic, CrossReferenceEntry, CrossReferenceKind, CrossReferencesOptions,
+    FailureMode,
+};
+use crate::html_scan::find_ci;
+use std::fmt::Write as _;
+
+/// A target plus where it was found, so the caller can report in document order.
+pub(super) struct TrackedTarget {
+    pub entry: CrossReferenceEntry,
+    pub position: usize,
+}
+
+/// Everything the passes accumulate.
+pub(super) struct Registry {
+    /// Insertion-ordered so a duplicate can be detected without a second map.
+    pub targets: Vec<TrackedTarget>,
+    pub diagnostics: Vec<CrossReferenceDiagnostic>,
+}
+
+impl Registry {
+    pub(super) fn new() -> Self {
+        Self { targets: Vec::new(), diagnostics: Vec::new() }
+    }
+
+    pub(super) fn get(&self, id: &str) -> Option<&CrossReferenceEntry> {
+        self.targets.iter().find(|target| target.entry.id == id).map(|target| &target.entry)
+    }
+
+    fn register(&mut self, policy: FailureMode, target: TrackedTarget) {
+        if self.get(&target.entry.id).is_some() {
+            self.diagnostics.push(CrossReferenceDiagnostic {
+                policy,
+                message: format!("duplicate cross-reference target \"{}\"", target.entry.id),
+            });
+            return;
+        }
+        self.targets.push(target);
+    }
+}
+
+/// Numbers `<h1>`–`<h6>` hierarchically: `1`, `1.2`, `1.2.1`.
+pub(super) fn annotate_sections(
+    html: &str,
+    options: &CrossReferencesOptions,
+    registry: &mut Registry,
+) -> String {
+    let mut counters = [0usize; 6];
+    let mut out = String::with_capacity(html.len());
+    let mut cursor = 0usize;
+
+    while let Some(open) = find_heading(html, cursor) {
+        let depth = open.depth;
+        counters[depth - 1] += 1;
+        // A deeper level restarts once its parent moves on.
+        counters[depth..].fill(0);
+
+        out.push_str(&html[cursor..open.start]);
+        let attrs = &html[open.attrs_start..open.attrs_end];
+        let body = &html[open.body_start..open.body_end];
+
+        match read_attr(attrs, "id").filter(|id| should_track_target(id)) {
+            None => out.push_str(&html[open.start..open.end]),
+            Some(id) => {
+                let number = section_number(&counters, depth);
+                let text = format!("{} {}", options.labels.section, number);
+                registry.register(
+                    options.duplicates,
+                    TrackedTarget {
+                        entry: CrossReferenceEntry {
+                            href: format!("#{}", escape_url_fragment(&id)),
+                            id,
+                            kind: CrossReferenceKind::Section,
+                            number: number.clone(),
+                            label: options.labels.section.clone(),
+                            text: text.clone(),
+                            title: Some(text_content(body)),
+                        },
+                        position: open.start,
+                    },
+                );
+                let _ = write!(
+                    out,
+                    "<h{depth}{}>{body}</h{depth}>",
+                    append_data_attrs(attrs, CrossReferenceKind::Section, &number, &text)
+                );
+            }
+        }
+        cursor = open.end;
+    }
+    out.push_str(&html[cursor..]);
+    out
+}
+
+/// `1.2.1`, skipping levels that were never opened.
+///
+/// The empty-string case is a heading whose own counter is zero, which cannot
+/// happen here — it is incremented immediately above — but the original fell
+/// back to the raw counter, so this keeps that shape.
+fn section_number(counters: &[usize; 6], depth: usize) -> String {
+    let parts: Vec<String> =
+        counters[..depth].iter().filter(|value| **value != 0).map(usize::to_string).collect();
+    if parts.is_empty() { counters[depth - 1].to_string() } else { parts.join(".") }
+}
+
+struct Heading {
+    depth: usize,
+    start: usize,
+    end: usize,
+    attrs_start: usize,
+    attrs_end: usize,
+    body_start: usize,
+    body_end: usize,
+}
+
+/// `<hN …>…</hN>` with matching N, non-greedy body.
+fn find_heading(html: &str, from: usize) -> Option<Heading> {
+    let bytes = html.as_bytes();
+    let mut cursor = from;
+
+    while let Some(open) = memchr::memchr(b'<', &bytes[cursor..]).map(|rel| cursor + rel) {
+        cursor = open + 1;
+        let Some(marker) = bytes.get(open + 1) else { break };
+        if !marker.eq_ignore_ascii_case(&b'h') {
+            continue;
+        }
+        let Some(digit) = bytes.get(open + 2).copied() else { continue };
+        if !(b'1'..=b'6').contains(&digit) {
+            continue;
+        }
+        // `\b` after the digit.
+        if bytes.get(open + 3).is_some_and(|byte| is_word_byte(*byte)) {
+            continue;
+        }
+        let Some(attrs_end) = html[open + 3..].find('>').map(|rel| open + 3 + rel) else {
+            continue;
+        };
+        let close = format!("</h{}>", digit as char);
+        let Some(close_at) = find_ci(html, attrs_end + 1, &close) else {
+            continue;
+        };
+        return Some(Heading {
+            depth: usize::from(digit - b'0'),
+            start: open,
+            end: close_at + close.len(),
+            attrs_start: open + 3,
+            attrs_end,
+            body_start: attrs_end + 1,
+            body_end: close_at,
+        });
+    }
+    None
+}
+
+/// Numbers `<figure>` blocks and standalone `<img>` in one shared sequence.
+pub(super) fn annotate_figures_and_images(
+    html: &str,
+    options: &CrossReferencesOptions,
+    registry: &mut Registry,
+) -> String {
+    let mut count = 0usize;
+    let mut out = String::with_capacity(html.len());
+    let mut cursor = 0usize;
+
+    while let Some(block) = find_figure_or_image(html, cursor) {
+        out.push_str(&html[cursor..block.start()]);
+        match block {
+            FigureBlock::Figure { start, end, attrs_start, attrs_end, body_start, body_end } => {
+                let attrs = &html[attrs_start..attrs_end];
+                let body = &html[body_start..body_end];
+                let figure_id = read_attr(attrs, "id");
+                // A figure without its own id borrows the first image's.
+                let image = if figure_id.is_some() { None } else { find_first_image(body) };
+                let id = figure_id.clone().or_else(|| image.as_ref().map(|img| img.id.clone()));
+
+                match id.filter(|value| should_track_target(value)) {
+                    None => out.push_str(&html[start..end]),
+                    Some(id) => {
+                        count += 1;
+                        let number = count.to_string();
+                        let text = format!("{} {}", options.labels.figure, number);
+                        let title = figure_caption(body)
+                            .or_else(|| image.as_ref().and_then(|img| img.alt.clone()));
+                        registry.register(
+                            options.duplicates,
+                            TrackedTarget {
+                                entry: CrossReferenceEntry {
+                                    href: format!("#{}", escape_url_fragment(&id)),
+                                    id,
+                                    kind: CrossReferenceKind::Figure,
+                                    number: number.clone(),
+                                    label: options.labels.figure.clone(),
+                                    text: text.clone(),
+                                    title,
+                                },
+                                position: start,
+                            },
+                        );
+                        match (figure_id, image) {
+                            // The figure owns the id, so it takes the attributes.
+                            (Some(_), _) => {
+                                let _ = write!(
+                                    out,
+                                    "<figure{}>{body}</figure>",
+                                    append_data_attrs(
+                                        attrs,
+                                        CrossReferenceKind::Figure,
+                                        &number,
+                                        &text
+                                    )
+                                );
+                            }
+                            // Otherwise they go on the image that supplied it.
+                            (None, Some(image)) => {
+                                let _ = write!(
+                                    out,
+                                    "<figure{attrs}>{}<img{}>{}</figure>",
+                                    &body[..image.start],
+                                    append_data_attrs(
+                                        &image.attrs,
+                                        CrossReferenceKind::Figure,
+                                        &number,
+                                        &text
+                                    ),
+                                    &body[image.end..]
+                                );
+                            }
+                            (None, None) => out.push_str(&html[start..end]),
+                        }
+                    }
+                }
+                cursor = end;
+            }
+            FigureBlock::Image { start, end, attrs_start, attrs_end } => {
+                let attrs = &html[attrs_start..attrs_end];
+                // Already numbered as part of a figure on an earlier pass.
+                let claimed = read_attr(attrs, "data-ox-xref-kind").is_some();
+                let id = read_attr(attrs, "id").filter(|value| should_track_target(value));
+                match (claimed, id) {
+                    (false, Some(id)) => {
+                        count += 1;
+                        let number = count.to_string();
+                        let text = format!("{} {}", options.labels.figure, number);
+                        let title = read_attr(attrs, "alt");
+                        registry.register(
+                            options.duplicates,
+                            TrackedTarget {
+                                entry: CrossReferenceEntry {
+                                    href: format!("#{}", escape_url_fragment(&id)),
+                                    id,
+                                    kind: CrossReferenceKind::Figure,
+                                    number: number.clone(),
+                                    label: options.labels.figure.clone(),
+                                    text: text.clone(),
+                                    title,
+                                },
+                                position: start,
+                            },
+                        );
+                        let _ = write!(
+                            out,
+                            "<img{}>",
+                            append_data_attrs(attrs, CrossReferenceKind::Figure, &number, &text)
+                        );
+                    }
+                    _ => out.push_str(&html[start..end]),
+                }
+                cursor = end;
+            }
+        }
+    }
+    out.push_str(&html[cursor..]);
+    out
+}
+
+enum FigureBlock {
+    Figure {
+        start: usize,
+        end: usize,
+        attrs_start: usize,
+        attrs_end: usize,
+        body_start: usize,
+        body_end: usize,
+    },
+    Image {
+        start: usize,
+        end: usize,
+        attrs_start: usize,
+        attrs_end: usize,
+    },
+}
+
+impl FigureBlock {
+    fn start(&self) -> usize {
+        match self {
+            Self::Figure { start, .. } | Self::Image { start, .. } => *start,
+        }
+    }
+}
+
+/// Whichever of `<figure>` or `<img>` comes first — one alternation, as before.
+fn find_figure_or_image(html: &str, from: usize) -> Option<FigureBlock> {
+    let figure = find_tag(html, from, "figure").and_then(|open| {
+        find_ci(html, open.attrs_end + 1, "</figure>").map(|close| FigureBlock::Figure {
+            start: open.start,
+            end: close + "</figure>".len(),
+            attrs_start: open.attrs_start,
+            attrs_end: open.attrs_end,
+            body_start: open.attrs_end + 1,
+            body_end: close,
+        })
+    });
+    let image = find_tag(html, from, "img").map(|open| FigureBlock::Image {
+        start: open.start,
+        end: open.attrs_end + 1,
+        attrs_start: open.attrs_start,
+        attrs_end: open.attrs_end,
+    });
+
+    match (figure, image) {
+        (Some(figure), Some(image)) => {
+            Some(if figure.start() <= image.start() { figure } else { image })
+        }
+        (found, None) | (None, found) => found,
+    }
+}
+
+pub(super) struct OpenTag {
+    pub start: usize,
+    pub attrs_start: usize,
+    /// Offset of the `>`.
+    pub attrs_end: usize,
+}
+
+/// `<name\b[^>]*>` at or after `from`.
+pub(super) fn find_tag(html: &str, from: usize, name: &str) -> Option<OpenTag> {
+    let open = format!("<{name}");
+    let mut cursor = from;
+    while let Some(start) = find_ci(html, cursor, &open) {
+        cursor = start + 1;
+        let attrs_start = start + open.len();
+        if html.as_bytes().get(attrs_start).is_some_and(|byte| is_word_byte(*byte)) {
+            continue;
+        }
+        let Some(attrs_end) = html[attrs_start..].find('>').map(|rel| attrs_start + rel) else {
+            continue;
+        };
+        return Some(OpenTag { start, attrs_start, attrs_end });
+    }
+    None
+}
+
+struct FoundImage {
+    id: String,
+    attrs: String,
+    /// Offsets within the figure body.
+    start: usize,
+    end: usize,
+    alt: Option<String>,
+}
+
+/// The first `<img>` in the body, but only if it carries an `id`.
+fn find_first_image(body: &str) -> Option<FoundImage> {
+    let open = find_tag(body, 0, "img")?;
+    let attrs = &body[open.attrs_start..open.attrs_end];
+    let id = read_attr(attrs, "id")?;
+    Some(FoundImage {
+        id,
+        attrs: attrs.to_string(),
+        start: open.start,
+        end: open.attrs_end + 1,
+        alt: read_attr(attrs, "alt"),
+    })
+}
+
+fn figure_caption(body: &str) -> Option<String> {
+    let open = find_tag(body, 0, "figcaption")?;
+    let close = find_ci(body, open.attrs_end + 1, "</figcaption>")?;
+    Some(text_content(&body[open.attrs_end + 1..close]))
+}
+
+/// Numbers `<table>` elements that carry a trackable `id`.
+pub(super) fn annotate_tables(
+    html: &str,
+    options: &CrossReferencesOptions,
+    registry: &mut Registry,
+) -> String {
+    let mut count = 0usize;
+    let mut out = String::with_capacity(html.len());
+    let mut cursor = 0usize;
+
+    while let Some(open) = find_tag(html, cursor, "table") {
+        out.push_str(&html[cursor..open.start]);
+        let attrs = &html[open.attrs_start..open.attrs_end];
+        match read_attr(attrs, "id").filter(|id| should_track_target(id)) {
+            None => out.push_str(&html[open.start..=open.attrs_end]),
+            Some(id) => {
+                count += 1;
+                let number = count.to_string();
+                let text = format!("{} {}", options.labels.table, number);
+                registry.register(
+                    options.duplicates,
+                    TrackedTarget {
+                        entry: CrossReferenceEntry {
+                            href: format!("#{}", escape_url_fragment(&id)),
+                            id,
+                            kind: CrossReferenceKind::Table,
+                            number: number.clone(),
+                            label: options.labels.table.clone(),
+                            text: text.clone(),
+                            title: None,
+                        },
+                        position: open.start,
+                    },
+                );
+                let _ = write!(
+                    out,
+                    "<table{}>",
+                    append_data_attrs(attrs, CrossReferenceKind::Table, &number, &text)
+                );
+            }
+        }
+        cursor = open.attrs_end + 1;
+    }
+    out.push_str(&html[cursor..]);
+    out
+}
+
+/// Moves a `{#tbl-x}` label written after a table onto the table itself.
+///
+/// Markdown gives no way to put an attribute on a table, so the label is
+/// authored below it — either as a paragraph or as a trailing empty row — and
+/// lifted here before the numbering pass sees it.
+pub(super) fn apply_trailing_table_labels(html: &str) -> String {
+    lift_trailing_cell_labels(&lift_paragraph_labels(html))
+}
+
+fn lift_paragraph_labels(html: &str) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut cursor = 0usize;
+
+    while let Some(open) = find_tag(html, cursor, "table") {
+        let Some(close) = find_ci(html, open.attrs_end + 1, "</table>") else {
+            break;
+        };
+        let table_end = close + "</table>".len();
+        let Some((label, consumed_to)) = trailing_paragraph_label(html, table_end) else {
+            out.push_str(&html[cursor..table_end]);
+            cursor = table_end;
+            continue;
+        };
+        let attrs = &html[open.attrs_start..open.attrs_end];
+        if read_attr(attrs, "id").is_some() {
+            out.push_str(&html[cursor..table_end]);
+            cursor = table_end;
+            continue;
+        }
+        out.push_str(&html[cursor..open.start]);
+        let _ = write!(out, "<table{}>", append_attr(attrs, "id", &label));
+        out.push_str(&html[open.attrs_end + 1..table_end]);
+        cursor = consumed_to;
+    }
+    out.push_str(&html[cursor..]);
+    out
+}
+
+/// `\s*<p>{#id}</p>` immediately after the table.
+fn trailing_paragraph_label(html: &str, from: usize) -> Option<(String, usize)> {
+    let after_space = skip_whitespace(html, from);
+    let rest = &html[after_space..];
+    let body = rest.strip_prefix("<p>{#")?;
+    let end = body.find("}</p>")?;
+    let id = &body[..end];
+    if !is_label_identifier(id) {
+        return None;
+    }
+    Some((id.to_string(), after_space + rest.len() - body.len() + end + "}</p>".len()))
+}
+
+fn lift_trailing_cell_labels(html: &str) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut cursor = 0usize;
+
+    while let Some(open) = find_tag(html, cursor, "table") {
+        let Some(close) = find_ci(html, open.attrs_end + 1, "</table>") else {
+            break;
+        };
+        let table_end = close + "</table>".len();
+        let attrs = &html[open.attrs_start..open.attrs_end];
+        let body = &html[open.attrs_end + 1..close];
+
+        match read_attr(attrs, "id").is_none().then(|| trailing_cell_label(body)).flatten() {
+            None => out.push_str(&html[cursor..table_end]),
+            Some((id, next_body)) => {
+                out.push_str(&html[cursor..open.start]);
+                let _ = write!(out, "<table{}>{next_body}</table>", append_attr(attrs, "id", &id));
+            }
+        }
+        cursor = table_end;
+    }
+    out.push_str(&html[cursor..]);
+    out
+}
+
+/// A final row of empty cells whose first cell carries a table id.
+///
+/// Returns the id and the body with that row removed.
+fn trailing_cell_label(body: &str) -> Option<(String, String)> {
+    let trailing = body.trim_end();
+    let tbody_end = trailing.strip_suffix("</tbody>").map(str::trim_end);
+    let (scan, tail) = match tbody_end {
+        Some(rest) => (rest, &body[rest.trim_end().len()..]),
+        None => (trailing, &body[trailing.len()..]),
+    };
+    let row_start = scan.rfind("<tr>")?;
+    let row = &scan[row_start..];
+    if !row.trim_end().ends_with("</tr>") {
+        return None;
+    }
+    let (id, all_empty) = empty_row_id(row)?;
+    if !all_empty || expected_kind(&id) != Some(CrossReferenceKind::Table) {
+        return None;
+    }
+    Some((id, format!("{}{}", &scan[..row_start], tail)))
+}
+
+/// Reads the id off a row whose cells are all empty.
+fn empty_row_id(row: &str) -> Option<(String, bool)> {
+    let mut id = None;
+    let mut cursor = 0usize;
+    let mut all_empty = true;
+    let mut cells = 0usize;
+
+    while let Some(open) = find_tag(row, cursor, "td") {
+        let close = find_ci(row, open.attrs_end + 1, "</td>")?;
+        if !row[open.attrs_end + 1..close].trim().is_empty() {
+            all_empty = false;
+        }
+        if cells == 0 {
+            id = read_attr(&row[open.attrs_start..open.attrs_end], "id");
+        }
+        cells += 1;
+        cursor = close + "</td>".len();
+    }
+    id.filter(|_| cells > 0).map(|value| (value, all_empty))
+}
+
+fn skip_whitespace(html: &str, from: usize) -> usize {
+    let bytes = html.as_bytes();
+    let mut cursor = from;
+    while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+        cursor += 1;
+    }
+    cursor
+}
+
+/// `[A-Za-z][A-Za-z0-9_-]*`
+fn is_label_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    chars.next().is_some_and(|ch| ch.is_ascii_alphabetic())
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+}

--- a/crates/ox_content_transform/src/cross_references/html.rs
+++ b/crates/ox_content_transform/src/cross_references/html.rs
@@ -1,0 +1,242 @@
+//! Attribute and text helpers for the cross-reference pass.
+//!
+//! These reproduce the semantics of the regular expressions the TypeScript
+//! implementation used, including the parts that look accidental. Where a rule
+//! is surprising it is spelled out, because "the regex did that" stops being an
+//! answer once the regex is gone.
+
+use super::types::CrossReferenceKind;
+use crate::features::escape::{escape_html_attr, escape_html_text};
+
+/// `id` prefixes that name a kind. Anything else is not a cross-reference.
+pub(super) fn expected_kind(id: &str) -> Option<CrossReferenceKind> {
+    let prefix = id.split('-').next().unwrap_or("").to_ascii_lowercase();
+    match prefix.as_str() {
+        "fig" | "figure" => Some(CrossReferenceKind::Figure),
+        "tbl" | "table" => Some(CrossReferenceKind::Table),
+        "sec" | "section" => Some(CrossReferenceKind::Section),
+        _ => None,
+    }
+}
+
+pub(super) fn should_track_target(id: &str) -> bool {
+    expected_kind(id).is_some()
+}
+
+/// Reads one attribute out of a raw attribute string.
+///
+/// A bare attribute (`<img hidden>`) reads as an empty string, which is how the
+/// caller tells "absent" from "present and empty".
+pub(super) fn read_attr(attrs: &str, name: &str) -> Option<String> {
+    // The original tried the quoted form across the whole string before
+    // considering a bare attribute, so `id id="x"` reads as `x`, not as the
+    // empty string the leading bare `id` would give. Two passes, same order.
+    if let Some(value) = read_quoted_attr(attrs, name) {
+        return Some(value);
+    }
+    read_bare_attr(attrs, name).then(String::new)
+}
+
+fn read_quoted_attr(attrs: &str, name: &str) -> Option<String> {
+    let bytes = attrs.as_bytes();
+    let mut cursor = 0usize;
+    while let Some(found) = crate::html_scan::find_ci(attrs, cursor, name) {
+        cursor = found + 1;
+        if !preceded_by_boundary(bytes, found) {
+            continue;
+        }
+        let mut probe = found + name.len();
+        while probe < bytes.len() && bytes[probe].is_ascii_whitespace() {
+            probe += 1;
+        }
+        if probe >= bytes.len() || bytes[probe] != b'=' {
+            continue;
+        }
+        probe += 1;
+        while probe < bytes.len() && bytes[probe].is_ascii_whitespace() {
+            probe += 1;
+        }
+        if probe >= bytes.len() || (bytes[probe] != b'"' && bytes[probe] != b'\'') {
+            continue;
+        }
+        let quote = bytes[probe] as char;
+        let start = probe + 1;
+        if let Some(end) = attrs[start..].find(quote).map(|rel| start + rel) {
+            return Some(decode_html(&attrs[start..end]));
+        }
+    }
+    None
+}
+
+fn read_bare_attr(attrs: &str, name: &str) -> bool {
+    let bytes = attrs.as_bytes();
+    let mut cursor = 0usize;
+    while let Some(found) = crate::html_scan::find_ci(attrs, cursor, name) {
+        cursor = found + 1;
+        if !preceded_by_boundary(bytes, found) {
+            continue;
+        }
+        let after = found + name.len();
+        if after == bytes.len() || bytes[after].is_ascii_whitespace() {
+            return true;
+        }
+    }
+    false
+}
+
+/// `(?:^|\s)` — the name starts the string or follows whitespace.
+fn preceded_by_boundary(bytes: &[u8], at: usize) -> bool {
+    at == 0 || bytes[at - 1].is_ascii_whitespace()
+}
+
+/// Appends `name="value"` unless the attribute is already there.
+pub(super) fn append_attr(attrs: &str, name: &str, value: &str) -> String {
+    if read_attr(attrs, name).is_some() {
+        return attrs.to_string();
+    }
+    let mut out = String::with_capacity(attrs.len() + name.len() + value.len() + 4);
+    out.push_str(attrs);
+    out.push(' ');
+    out.push_str(name);
+    out.push_str("=\"");
+    escape_html_attr(value, &mut out);
+    out.push('"');
+    out
+}
+
+pub(super) fn append_data_attrs(
+    attrs: &str,
+    kind: CrossReferenceKind,
+    number: &str,
+    text: &str,
+) -> String {
+    let with_kind = append_attr(attrs, "data-ox-xref-kind", kind.as_str());
+    let with_number = append_attr(&with_kind, "data-ox-xref-number", number);
+    append_attr(&with_number, "data-ox-xref-label", text)
+}
+
+pub(super) fn escape_html(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    escape_html_text(value, &mut out);
+    out
+}
+
+pub(super) fn escape_attr(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    escape_html_attr(value, &mut out);
+    out
+}
+
+/// Percent-encodes for use as a URL fragment, matching `encodeURIComponent`.
+///
+/// The unreserved set is the one `encodeURIComponent` leaves alone:
+/// alphanumerics and `-_.!~*'()`.
+pub(super) fn escape_url_fragment(value: &str) -> String {
+    const UNRESERVED: &[u8] = b"-_.!~*'()";
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || UNRESERVED.contains(&byte) {
+            out.push(byte as char);
+        } else {
+            const HEX: &[u8; 16] = b"0123456789ABCDEF";
+            out.push('%');
+            out.push(HEX[usize::from(byte >> 4)] as char);
+            out.push(HEX[usize::from(byte & 0x0f)] as char);
+        }
+    }
+    out
+}
+
+/// Strips tags and collapses whitespace, the way a reader would read it.
+pub(super) fn text_content(html: &str) -> String {
+    let without_anchors = strip_header_anchors(html);
+    let mut stripped = String::with_capacity(without_anchors.len());
+    let bytes = without_anchors.as_bytes();
+    let mut cursor = 0usize;
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'<' {
+            // `<[^>]+>` needs at least one character before the `>`.
+            if let Some(rel) = without_anchors[cursor + 1..].find('>')
+                && rel > 0
+            {
+                cursor = cursor + 1 + rel + 1;
+                continue;
+            }
+        }
+        let ch_len = char_len(&without_anchors[cursor..]);
+        stripped.push_str(&without_anchors[cursor..cursor + ch_len]);
+        cursor += ch_len;
+    }
+    decode_html(&collapse_whitespace(&stripped))
+}
+
+/// Drops `<a class="header-anchor" …>…</a>`, which is chrome, not title text.
+fn strip_header_anchors(html: &str) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut cursor = 0usize;
+    while let Some(open) = crate::html_scan::find_ci(html, cursor, "<a") {
+        // `<a\b`: `<address` is not an anchor.
+        if html.as_bytes().get(open + 2).is_some_and(|byte| is_word_byte(*byte)) {
+            out.push_str(&html[cursor..open + 2]);
+            cursor = open + 2;
+            continue;
+        }
+        let Some(open_end) = html[open..].find('>').map(|rel| open + rel + 1) else {
+            break;
+        };
+        let attrs = &html[open + 2..open_end - 1];
+        if !is_header_anchor(attrs) {
+            out.push_str(&html[cursor..open + 2]);
+            cursor = open + 2;
+            continue;
+        }
+        let Some(close) = crate::html_scan::find_ci(html, open_end, "</a>") else {
+            break;
+        };
+        out.push_str(&html[cursor..open]);
+        cursor = close + 4;
+    }
+    out.push_str(&html[cursor..]);
+    out
+}
+
+fn is_header_anchor(attrs: &str) -> bool {
+    read_attr(attrs, "class").is_some_and(|value| value == "header-anchor")
+}
+
+fn collapse_whitespace(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut in_space = false;
+    for ch in value.chars() {
+        if ch.is_whitespace() {
+            in_space = true;
+            continue;
+        }
+        if in_space && !out.is_empty() {
+            out.push(' ');
+        }
+        in_space = false;
+        out.push(ch);
+    }
+    out
+}
+
+/// Undoes the five entities the writer emits. Order matters: `&amp;` last, so
+/// `&amp;lt;` comes back as `&lt;` rather than `<`.
+pub(super) fn decode_html(value: &str) -> String {
+    value
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
+}
+
+/// JavaScript's `\w`: ASCII letters, digits, and underscore.
+pub(super) fn is_word_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+pub(super) fn char_len(rest: &str) -> usize {
+    rest.chars().next().map_or(1, char::len_utf8)
+}

--- a/crates/ox_content_transform/src/cross_references/mod.rs
+++ b/crates/ox_content_transform/src/cross_references/mod.rs
@@ -1,0 +1,128 @@
+//! Numbered cross-references: `@fig-1`, `@tbl-2`, `@sec-intro`.
+//!
+//! The pass runs over rendered HTML. It numbers every heading, figure, and
+//! table that carries a recognisable `id`, records what it found, and rewrites
+//! `@id` in prose into a link carrying the assigned label.
+//!
+//! Diagnostics are returned, not raised. Which of them are fatal is the
+//! caller's policy, and this crate does not panic on document content.
+
+mod annotate;
+mod html;
+#[cfg(test)]
+mod tests;
+mod text;
+mod types;
+
+pub use types::{
+    CrossReferenceDiagnostic, CrossReferenceEntry, CrossReferenceKind, CrossReferenceLabels,
+    CrossReferenceOutput, CrossReferencesOptions, FailureMode,
+};
+
+use std::fmt::Write as _;
+
+use annotate::Registry;
+use html::{escape_attr, escape_html, expected_kind};
+use text::{find_text_references, transform_text, transform_text_outside_citation_groups};
+
+/// Numbers the document's targets and links every reference to them.
+pub fn transform_cross_references(
+    html: &str,
+    options: &CrossReferencesOptions,
+) -> CrossReferenceOutput {
+    if !options.enabled {
+        return CrossReferenceOutput {
+            html: html.to_string(),
+            references: Vec::new(),
+            diagnostics: Vec::new(),
+        };
+    }
+
+    let mut registry = Registry::new();
+    let mut next = annotate::annotate_sections(html, options, &mut registry);
+    next = annotate::annotate_figures_and_images(&next, options, &mut registry);
+    next = annotate::apply_trailing_table_labels(&next);
+    next = annotate::annotate_tables(&next, options, &mut registry);
+    next = replace_references(&next, options, &mut registry);
+
+    // Document order, not discovery order: figures are numbered after every
+    // section, but a reader sees them interleaved.
+    registry.targets.sort_by_key(|target| target.position);
+
+    CrossReferenceOutput {
+        html: next,
+        references: registry.targets.into_iter().map(|target| target.entry).collect(),
+        diagnostics: registry.diagnostics,
+    }
+}
+
+fn replace_references(
+    html: &str,
+    options: &CrossReferencesOptions,
+    registry: &mut Registry,
+) -> String {
+    let mut diagnostics = Vec::new();
+    let out = transform_text(html, |text| {
+        transform_text_outside_citation_groups(text, |segment| {
+            replace_reference_segment(segment, options, registry, &mut diagnostics)
+        })
+    });
+    registry.diagnostics.append(&mut diagnostics);
+    out
+}
+
+fn replace_reference_segment(
+    text: &str,
+    options: &CrossReferencesOptions,
+    registry: &Registry,
+    diagnostics: &mut Vec<CrossReferenceDiagnostic>,
+) -> String {
+    let references = find_text_references(text);
+    if references.is_empty() {
+        return text.to_string();
+    }
+
+    let mut out = String::with_capacity(text.len());
+    let mut cursor = 0usize;
+    for reference in references {
+        let id = &text[reference.id_start..reference.end];
+        let Some(expected) = expected_kind(id) else {
+            continue;
+        };
+
+        // Everything up to and including the prefix character is kept as-is.
+        out.push_str(&text[cursor..reference.start + reference.prefix_len]);
+        cursor = reference.start + reference.prefix_len;
+
+        let Some(target) = registry.get(id) else {
+            diagnostics.push(CrossReferenceDiagnostic {
+                policy: options.missing,
+                message: format!("missing cross-reference target \"{id}\""),
+            });
+            continue;
+        };
+        if target.kind != expected {
+            diagnostics.push(CrossReferenceDiagnostic {
+                policy: options.mismatches,
+                message: format!(
+                    "cross-reference \"{id}\" expects {} but found {}",
+                    expected.as_str(),
+                    target.kind.as_str()
+                ),
+            });
+            continue;
+        }
+
+        let kind = target.kind.as_str();
+        let _ = write!(
+            out,
+            "<a class=\"ox-xref ox-xref-{kind}\" href=\"{}\" data-ox-xref-id=\"{}\" data-ox-xref-kind=\"{kind}\">{}</a>",
+            target.href,
+            escape_attr(&target.id),
+            escape_html(&target.text)
+        );
+        cursor = reference.end;
+    }
+    out.push_str(&text[cursor..]);
+    out
+}

--- a/crates/ox_content_transform/src/cross_references/tests.rs
+++ b/crates/ox_content_transform/src/cross_references/tests.rs
@@ -1,0 +1,204 @@
+use super::*;
+
+fn options() -> CrossReferencesOptions {
+    CrossReferencesOptions { enabled: true, ..CrossReferencesOptions::default() }
+}
+
+fn warn_options() -> CrossReferencesOptions {
+    CrossReferencesOptions {
+        enabled: true,
+        missing: FailureMode::Warn,
+        duplicates: FailureMode::Warn,
+        mismatches: FailureMode::Warn,
+        ..CrossReferencesOptions::default()
+    }
+}
+
+#[test]
+fn disabled_returns_the_input_untouched() {
+    let html = "<h1 id=\"sec-a\">A</h1><p>@sec-a</p>";
+    let output = transform_cross_references(html, &CrossReferencesOptions::default());
+    assert_eq!(output.html, html);
+    assert!(output.references.is_empty());
+}
+
+#[test]
+fn sections_number_hierarchically() {
+    let html = "<h1 id=\"sec-a\">A</h1><h2 id=\"sec-b\">B</h2><h3 id=\"sec-c\">C</h3>";
+    let output = transform_cross_references(html, &options());
+    let numbers: Vec<&str> = output.references.iter().map(|entry| entry.number.as_str()).collect();
+    assert_eq!(numbers, vec!["1", "1.1", "1.1.1"]);
+}
+
+#[test]
+fn a_deeper_level_restarts_when_its_parent_moves_on() {
+    let html = "<h1 id=\"sec-a\">A</h1><h2 id=\"sec-b\">B</h2><h1 id=\"sec-c\">C</h1><h2 id=\"sec-d\">D</h2>";
+    let output = transform_cross_references(html, &options());
+    let numbers: Vec<&str> = output.references.iter().map(|entry| entry.number.as_str()).collect();
+    assert_eq!(numbers, vec!["1", "1.1", "2", "2.1"]);
+}
+
+#[test]
+fn a_figure_without_its_own_id_borrows_the_first_image() {
+    let html = "<figure><img id=\"fig-a\" src=\"a.png\" alt=\"Alt\"></figure>";
+    let output = transform_cross_references(html, &options());
+    assert_eq!(output.references.len(), 1);
+    assert_eq!(output.references[0].id, "fig-a");
+    // The attributes land on the image that supplied the id, not the figure.
+    assert!(output.html.contains("<img id=\"fig-a\""), "{}", output.html);
+    assert!(output.html.contains("data-ox-xref-number=\"1\""), "{}", output.html);
+    assert!(!output.html.contains("<figure data-ox"), "{}", output.html);
+}
+
+#[test]
+fn figures_and_images_share_one_sequence() {
+    let html = "<figure id=\"fig-a\"><img src=\"a.png\"></figure><img id=\"fig-b\" src=\"b.png\">";
+    let output = transform_cross_references(html, &options());
+    let numbers: Vec<&str> = output.references.iter().map(|entry| entry.number.as_str()).collect();
+    assert_eq!(numbers, vec!["1", "2"]);
+}
+
+#[test]
+fn reported_order_follows_the_offsets_each_pass_saw() {
+    // Not document order, though it is close enough to look like it. Each pass
+    // records offsets into the string *it* walked, and every pass rewrites the
+    // document, so the figure's offset is measured in a string already grown by
+    // the section attributes — placing it after both headings rather than
+    // between them. The TypeScript implementation did the same; this pins the
+    // behaviour rather than the intention.
+    let html = "<h1 id=\"sec-a\">A</h1><img id=\"fig-a\" src=\"a.png\"><h2 id=\"sec-b\">B</h2>";
+    let output = transform_cross_references(html, &options());
+    let ids: Vec<&str> = output.references.iter().map(|entry| entry.id.as_str()).collect();
+    assert_eq!(ids, vec!["sec-a", "sec-b", "fig-a"]);
+}
+
+#[test]
+fn a_trailing_paragraph_label_is_lifted_onto_the_table() {
+    let html = "<table><tbody><tr><td>x</td></tr></tbody></table>\n<p>{#tbl-a}</p>";
+    let output = transform_cross_references(html, &options());
+    assert_eq!(output.references.len(), 1);
+    assert_eq!(output.references[0].id, "tbl-a");
+    assert!(!output.html.contains("{#tbl-a}"), "{}", output.html);
+}
+
+#[test]
+fn a_trailing_empty_row_label_is_lifted_and_removed() {
+    let html =
+        "<table><tbody><tr><td>x</td></tr><tr><td id=\"tbl-a\"></td><td></td></tr></tbody></table>";
+    let output = transform_cross_references(html, &options());
+    assert_eq!(output.references.len(), 1);
+    assert_eq!(output.references[0].id, "tbl-a");
+    assert!(!output.html.contains("tbl-a\"></td>"), "{}", output.html);
+}
+
+#[test]
+fn a_reference_becomes_a_link() {
+    let html = "<h1 id=\"sec-a\">A</h1><p>See @sec-a.</p>";
+    let output = transform_cross_references(html, &options());
+    assert!(
+        output.html.contains("<a class=\"ox-xref ox-xref-section\" href=\"#sec-a\""),
+        "{}",
+        output.html
+    );
+    assert!(output.html.contains(">Section 1</a>"), "{}", output.html);
+}
+
+#[test]
+fn the_prefix_character_is_consumed_so_adjacent_references_do_not_both_match() {
+    let html = "<h1 id=\"sec-a\">A</h1><h2 id=\"sec-b\">B</h2><p>@sec-a@sec-b</p>";
+    let output = transform_cross_references(html, &options());
+    assert_eq!(output.html.matches("ox-xref-section\"").count(), 1, "{}", output.html);
+}
+
+#[test]
+fn an_identifier_ending_in_a_dash_is_not_a_reference() {
+    // `-` is not a word character, so the trailing boundary needs one after it.
+    let html = "<h1 id=\"sec-a\">A</h1><p>@sec- alone</p>";
+    let output = transform_cross_references(html, &warn_options());
+    assert!(output.html.contains("@sec- alone"), "{}", output.html);
+}
+
+#[test]
+fn verbatim_elements_are_left_alone() {
+    let html = "<h1 id=\"sec-a\">A</h1><p><code>@sec-a</code> @sec-a</p>";
+    let output = transform_cross_references(html, &options());
+    assert!(output.html.contains("<code>@sec-a</code>"), "{}", output.html);
+    assert_eq!(output.html.matches("ox-xref-section\"").count(), 1, "{}", output.html);
+}
+
+#[test]
+fn address_is_not_an_anchor() {
+    let html = "<h1 id=\"sec-a\">A</h1><address>@sec-a</address>";
+    let output = transform_cross_references(html, &options());
+    assert!(output.html.contains("ox-xref-section"), "{}", output.html);
+}
+
+#[test]
+fn citation_groups_belong_to_the_citation_pass() {
+    let html = "<h1 id=\"sec-a\">A</h1><p>[@smith2020] @sec-a</p>";
+    let output = transform_cross_references(html, &options());
+    assert!(output.html.contains("[@smith2020]"), "{}", output.html);
+    assert!(output.html.contains("ox-xref-section"), "{}", output.html);
+}
+
+#[test]
+fn a_missing_target_is_reported_not_raised() {
+    let output = transform_cross_references("<p>@fig-nope</p>", &options());
+    assert_eq!(output.diagnostics.len(), 1);
+    assert_eq!(output.diagnostics[0].policy, FailureMode::Error);
+    assert!(output.diagnostics[0].message.contains("missing"), "{output:?}");
+    // The text is left as written so the author can see what failed.
+    assert!(output.html.contains("@fig-nope"), "{}", output.html);
+}
+
+#[test]
+fn a_kind_mismatch_is_reported() {
+    let html = "<h1 id=\"fig-a\">A</h1><p>@fig-a</p>";
+    let output = transform_cross_references(html, &options());
+    assert!(
+        output.diagnostics.iter().any(|d| d.message.contains("expects figure but found section")),
+        "{output:?}"
+    );
+}
+
+#[test]
+fn a_duplicate_id_is_reported_and_the_first_wins() {
+    let html = "<h1 id=\"sec-a\">First</h1><h2 id=\"sec-a\">Second</h2>";
+    let output = transform_cross_references(html, &options());
+    assert_eq!(output.references.len(), 1);
+    assert_eq!(output.references[0].title.as_deref(), Some("First"));
+    assert!(output.diagnostics.iter().any(|d| d.message.contains("duplicate")), "{output:?}");
+}
+
+#[test]
+fn an_untracked_id_is_neither_numbered_nor_linked() {
+    let html = "<h1 id=\"intro\">A</h1><p>@intro</p>";
+    let output = transform_cross_references(html, &options());
+    assert!(output.references.is_empty());
+    assert!(output.html.contains("@intro"), "{}", output.html);
+    assert!(output.diagnostics.is_empty(), "{output:?}");
+}
+
+#[test]
+fn the_header_anchor_is_not_part_of_the_title() {
+    let html = "<h1 id=\"sec-a\">Alpha<a class=\"header-anchor\" href=\"#sec-a\">#</a></h1>";
+    let output = transform_cross_references(html, &options());
+    assert_eq!(output.references[0].title.as_deref(), Some("Alpha"));
+}
+
+#[test]
+fn an_already_annotated_image_keeps_its_number() {
+    let html = "<img id=\"fig-a\" data-ox-xref-kind=\"figure\" src=\"a.png\"><img id=\"fig-b\" src=\"b.png\">";
+    let output = transform_cross_references(html, &options());
+    // Only the second is numbered, and it starts the sequence.
+    assert_eq!(output.references.len(), 1);
+    assert_eq!(output.references[0].id, "fig-b");
+    assert_eq!(output.references[0].number, "1");
+}
+
+#[test]
+fn an_id_needing_escaping_is_percent_encoded_in_the_href() {
+    let html = "<h1 id=\"sec-a b\">A</h1>";
+    let output = transform_cross_references(html, &options());
+    assert_eq!(output.references[0].href, "#sec-a%20b");
+}

--- a/crates/ox_content_transform/src/cross_references/text.rs
+++ b/crates/ox_content_transform/src/cross_references/text.rs
@@ -1,0 +1,217 @@
+//! Deciding which parts of the HTML are prose that `@ref` may be rewritten in.
+//!
+//! Three nested exclusions, applied outside-in: HTML comments and verbatim
+//! elements are skipped whole, then tags are skipped within what remains, then
+//! citation groups (`[@smith2020]`) are left for the citation pass.
+
+use super::html::{char_len, is_word_byte};
+
+/// Elements whose contents are never prose.
+const PROTECTED_TAGS: [&str; 6] = ["pre", "code", "script", "style", "textarea", "a"];
+
+/// Runs `replacer` over every stretch of prose in `html`.
+pub(super) fn transform_text(html: &str, mut replacer: impl FnMut(&str) -> String) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut cursor = 0usize;
+
+    while let Some(region) = next_protected_region(html, cursor) {
+        out.push_str(&transform_text_outside_tags(&html[cursor..region.start], &mut replacer));
+        out.push_str(&html[region.start..region.end]);
+        cursor = region.end;
+    }
+    out.push_str(&transform_text_outside_tags(&html[cursor..], &mut replacer));
+    out
+}
+
+struct Region {
+    start: usize,
+    end: usize,
+}
+
+/// The next comment or verbatim element at or after `from`.
+///
+/// A verbatim element runs to its *first* matching close tag — the original
+/// pattern was lazy, so nesting is not tracked.
+fn next_protected_region(html: &str, from: usize) -> Option<Region> {
+    let mut best: Option<Region> = None;
+    let mut consider = |candidate: Region| {
+        if best.as_ref().is_none_or(|current| candidate.start < current.start) {
+            best = Some(candidate);
+        }
+    };
+
+    if let Some(start) = html[from..].find("<!--").map(|rel| from + rel) {
+        let end = html[start + 4..].find("-->").map_or(html.len(), |rel| start + 4 + rel + 3);
+        consider(Region { start, end });
+    }
+
+    for tag in PROTECTED_TAGS {
+        let open = format!("<{tag}");
+        let mut probe = from;
+        while let Some(start) = crate::html_scan::find_ci(html, probe, &open) {
+            probe = start + 1;
+            // `\b` after the tag name.
+            let after = start + open.len();
+            if html.as_bytes().get(after).is_some_and(|byte| is_word_byte(*byte)) {
+                continue;
+            }
+            let close = format!("</{tag}>");
+            let Some(close_at) = crate::html_scan::find_ci(html, after, &close) else {
+                break;
+            };
+            consider(Region { start, end: close_at + close.len() });
+            break;
+        }
+    }
+
+    best
+}
+
+/// Applies `replacer` to the non-tag parts of a stretch of HTML.
+///
+/// A "tag" is `<` … `>` with at least one character between, matching the
+/// original split pattern; a bare `<` is prose.
+fn transform_text_outside_tags(segment: &str, replacer: &mut impl FnMut(&str) -> String) -> String {
+    let mut out = String::with_capacity(segment.len());
+    let mut text_start = 0usize;
+    let mut cursor = 0usize;
+    let bytes = segment.as_bytes();
+
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'<'
+            && let Some(rel) = segment[cursor + 1..].find('>')
+            && rel > 0
+        {
+            let tag_end = cursor + 1 + rel + 1;
+            out.push_str(&replacer(&segment[text_start..cursor]));
+            out.push_str(&segment[cursor..tag_end]);
+            cursor = tag_end;
+            text_start = tag_end;
+            continue;
+        }
+        cursor += char_len(&segment[cursor..]);
+    }
+    out.push_str(&replacer(&segment[text_start..]));
+    out
+}
+
+/// Applies `replacer` to prose outside citation groups.
+///
+/// A citation group is `[…]` on one line whose body starts with `@` or `-@`.
+/// Those belong to the citation pass, which runs later over the same text.
+pub(super) fn transform_text_outside_citation_groups(
+    text: &str,
+    mut replacer: impl FnMut(&str) -> String,
+) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut cursor = 0usize;
+    let mut scan = 0usize;
+    let bytes = text.as_bytes();
+
+    while scan < bytes.len() {
+        if bytes[scan] != b'[' {
+            scan += char_len(&text[scan..]);
+            continue;
+        }
+        // `[^\]\n]+` — at least one character, no `]` or newline inside.
+        let Some(close) = text[scan + 1..].find([']', '\n']).map(|rel| scan + 1 + rel) else {
+            break;
+        };
+        if bytes[close] != b']' || close == scan + 1 {
+            scan += char_len(&text[scan..]);
+            continue;
+        }
+        let body = text[scan + 1..close].trim();
+        if !body.starts_with('@') && !body.starts_with("-@") {
+            // Not a citation group; the scan continues past this `[` only, so a
+            // later `[` inside the same span still gets its chance.
+            scan += 1;
+            continue;
+        }
+        out.push_str(&replacer(&text[cursor..scan]));
+        out.push_str(&text[scan..=close]);
+        cursor = close + 1;
+        scan = close + 1;
+    }
+    out.push_str(&replacer(&text[cursor..]));
+    out
+}
+
+/// One `@identifier` found in prose.
+pub(super) struct TextReference {
+    /// Byte range of the whole match, prefix character included.
+    pub start: usize,
+    pub end: usize,
+    /// The prefix character, or empty at the start of the segment.
+    pub prefix_len: usize,
+    pub id_start: usize,
+}
+
+/// Finds `@identifier` occurrences, matching `(^|[^\w@/[])@([A-Za-z][A-Za-z0-9_-]*)\b`.
+///
+/// The prefix character is part of the match and therefore consumed, so
+/// `@fig-1@fig-2` yields only the first — the second `@` sits where a prefix
+/// would have to be, and `@` is excluded from that class.
+pub(super) fn find_text_references(text: &str) -> Vec<TextReference> {
+    let bytes = text.as_bytes();
+    let mut found = Vec::new();
+    let mut cursor = 0usize;
+
+    while cursor < bytes.len() {
+        let Some(rel) = memchr::memchr(b'@', &bytes[cursor..]) else {
+            break;
+        };
+        let at = cursor + rel;
+        let prefix_len = if at == 0 {
+            0
+        } else {
+            let prefix_start = prev_char_start(text, at);
+            let prefix = bytes[prefix_start];
+            if is_word_byte(prefix) || prefix == b'@' || prefix == b'/' || prefix == b'[' {
+                cursor = at + 1;
+                continue;
+            }
+            at - prefix_start
+        };
+
+        let id_start = at + 1;
+        if !bytes.get(id_start).is_some_and(u8::is_ascii_alphabetic) {
+            cursor = at + 1;
+            continue;
+        }
+        let mut id_end = id_start;
+        while bytes
+            .get(id_end)
+            .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_' || *byte == b'-')
+        {
+            id_end += 1;
+        }
+        if !word_boundary_at(bytes, id_end) {
+            cursor = at + 1;
+            continue;
+        }
+
+        found.push(TextReference { start: at - prefix_len, end: id_end, prefix_len, id_start });
+        cursor = id_end;
+    }
+    found
+}
+
+/// `\b` between `at - 1` and `at`, using JavaScript's `\w`.
+///
+/// The identifier may end in `-`, which is not a word character, so the
+/// boundary then requires the *next* character to be one — `@fig-` before a
+/// space does not match, while `@fig-x` does.
+fn word_boundary_at(bytes: &[u8], at: usize) -> bool {
+    let before = at.checked_sub(1).is_some_and(|index| is_word_byte(bytes[index]));
+    let after = bytes.get(at).is_some_and(|byte| is_word_byte(*byte));
+    before != after
+}
+
+fn prev_char_start(text: &str, at: usize) -> usize {
+    let mut index = at - 1;
+    while !text.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}

--- a/crates/ox_content_transform/src/cross_references/types.rs
+++ b/crates/ox_content_transform/src/cross_references/types.rs
@@ -1,0 +1,104 @@
+/// What a cross-reference target is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CrossReferenceKind {
+    Figure,
+    Table,
+    Section,
+}
+
+impl CrossReferenceKind {
+    /// The slug used in `data-ox-xref-kind` and the `ox-xref-*` class.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Figure => "figure",
+            Self::Table => "table",
+            Self::Section => "section",
+        }
+    }
+}
+
+/// What to do when a document breaks one of the cross-reference rules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureMode {
+    /// Fail the build.
+    Error,
+    /// Report and carry on.
+    Warn,
+}
+
+/// The word placed before each number, per kind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrossReferenceLabels {
+    pub figure: String,
+    pub table: String,
+    pub section: String,
+}
+
+impl Default for CrossReferenceLabels {
+    fn default() -> Self {
+        Self {
+            figure: "Figure".to_string(),
+            table: "Table".to_string(),
+            section: "Section".to_string(),
+        }
+    }
+}
+
+/// Switches and labels for the cross-reference pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrossReferencesOptions {
+    pub enabled: bool,
+    /// A `@ref` with no target.
+    pub missing: FailureMode,
+    /// Two targets claiming the same id.
+    pub duplicates: FailureMode,
+    /// A `@fig-x` that resolves to a table, and the like.
+    pub mismatches: FailureMode,
+    pub labels: CrossReferenceLabels,
+}
+
+impl Default for CrossReferencesOptions {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            missing: FailureMode::Error,
+            duplicates: FailureMode::Error,
+            mismatches: FailureMode::Error,
+            labels: CrossReferenceLabels::default(),
+        }
+    }
+}
+
+/// One numbered target the document defines.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrossReferenceEntry {
+    pub id: String,
+    pub kind: CrossReferenceKind,
+    /// `1`, or `2.3` for a nested section.
+    pub number: String,
+    /// The label word on its own, for callers that re-compose the text.
+    pub label: String,
+    /// Label and number together, as written into the link.
+    pub text: String,
+    pub href: String,
+    /// Heading text, figure caption, or image `alt`, when there is one.
+    pub title: Option<String>,
+}
+
+/// One rule a document broke, and how the caller asked to be told.
+///
+/// Rust returns these rather than raising: the plugin decides which are fatal,
+/// and the panic-construct gate keeps this crate from deciding for it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrossReferenceDiagnostic {
+    pub policy: FailureMode,
+    pub message: String,
+}
+
+/// The annotated HTML, what it defined, and what it got wrong.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CrossReferenceOutput {
+    pub html: String,
+    pub references: Vec<CrossReferenceEntry>,
+    pub diagnostics: Vec<CrossReferenceDiagnostic>,
+}

--- a/crates/ox_content_transform/src/features.rs
+++ b/crates/ox_content_transform/src/features.rs
@@ -22,7 +22,7 @@ mod definition_lists;
 mod edit;
 mod emoji;
 mod emoji_shortcodes;
-mod escape;
+pub(crate) mod escape;
 mod file_tree;
 mod image_galleries;
 mod images;

--- a/crates/ox_content_transform/src/lib.rs
+++ b/crates/ox_content_transform/src/lib.rs
@@ -11,6 +11,7 @@
     )
 )]
 
+pub mod cross_references;
 pub mod features;
 pub mod highlight;
 pub(crate) mod html_scan;

--- a/npm/vite-plugin-ox-content/src/cross-reference-html.ts
+++ b/npm/vite-plugin-ox-content/src/cross-reference-html.ts
@@ -1,9 +1,15 @@
-import type { CrossReferenceKind } from "./cross-reference-types";
+/**
+ * The escaping and prose-scanning helpers the citation pass still needs.
+ *
+ * The cross-reference pass that used to share this file now runs in
+ * `ox_content_transform::cross_references`; what is left here is what
+ * `citations.ts` uses, and it goes the same way when that pass moves.
+ */
 
 const PROTECTED_TEXT_RE = /<!--[\s\S]*?-->|<(pre|code|script|style|textarea|a)\b[\s\S]*?<\/\1>/gi;
-const CITATION_LIKE_GROUP_RE = /\[([^\]\n]+)\]/g;
 const TAG_RE = /(<[^>]+>)/g;
 
+/** Runs `replacer` over every stretch of prose, skipping verbatim elements. */
 export function transformText(html: string, replacer: (text: string) => string): string {
   let output = "";
   let cursor = 0;
@@ -14,99 +20,6 @@ export function transformText(html: string, replacer: (text: string) => string):
     cursor = start + match[0].length;
   }
   return output + transformTextOutsideTags(html.slice(cursor), replacer);
-}
-
-export function transformTextOutsideCitationGroups(
-  text: string,
-  replacer: (text: string) => string,
-): string {
-  let output = "";
-  let cursor = 0;
-  for (const match of text.matchAll(CITATION_LIKE_GROUP_RE)) {
-    const start = match.index ?? 0;
-    const body = (match[1] ?? "").trim();
-    if (!body.startsWith("@") && !body.startsWith("-@")) continue;
-    output += replacer(text.slice(cursor, start));
-    output += match[0];
-    cursor = start + match[0].length;
-  }
-  return output + replacer(text.slice(cursor));
-}
-
-export function findFirstImageWithId(body: string): {
-  id: string;
-  attrs: string;
-  start: number;
-  end: number;
-  alt?: string;
-} | null {
-  const match = /<img\b([^>]*)>/i.exec(body);
-  if (!match) return null;
-  const attrs = match[1] ?? "";
-  const id = readAttr(attrs, "id");
-  if (!id) return null;
-  return {
-    id,
-    attrs,
-    start: match.index,
-    end: match.index + match[0].length,
-    alt: readAttr(attrs, "alt"),
-  };
-}
-
-export function figureCaption(body: string): string | undefined {
-  const match = /<figcaption\b[^>]*>([\s\S]*?)<\/figcaption>/i.exec(body);
-  return match ? textContent(match[1] ?? "") : undefined;
-}
-
-export function expectedKind(id: string): CrossReferenceKind | null {
-  const prefix = id.toLowerCase().split("-")[0];
-  if (prefix === "fig" || prefix === "figure") return "figure";
-  if (prefix === "tbl" || prefix === "table") return "table";
-  if (prefix === "sec" || prefix === "section") return "section";
-  return null;
-}
-
-export function shouldTrackTarget(id: string): boolean {
-  return expectedKind(id) !== null;
-}
-
-export function appendDataAttrs(
-  attrs: string,
-  kind: CrossReferenceKind,
-  number: string,
-  text: string,
-): string {
-  return appendAttr(
-    appendAttr(appendAttr(attrs, "data-ox-xref-kind", kind), "data-ox-xref-number", number),
-    "data-ox-xref-label",
-    text,
-  );
-}
-
-export function appendAttr(attrs: string, name: string, value: string): string {
-  if (readAttr(attrs, name) !== undefined) return attrs;
-  return `${attrs} ${name}="${escapeAttr(value)}"`;
-}
-
-export function readAttr(attrs: string, name: string): string | undefined {
-  const escapedName = escapeRegExp(name);
-  const quoted = new RegExp(`(?:^|\\s)${escapedName}\\s*=\\s*("([^"]*)"|'([^']*)')`, "i").exec(
-    attrs,
-  );
-  if (quoted) return decodeHtml(quoted[2] ?? quoted[3] ?? "");
-  const bare = new RegExp(`(?:^|\\s)${escapedName}(?:\\s|$)`, "i").exec(attrs);
-  return bare ? "" : undefined;
-}
-
-export function textContent(html: string): string {
-  return decodeHtml(
-    html
-      .replace(/<a\b[^>]*class=(["'])header-anchor\1[\s\S]*?<\/a>/gi, "")
-      .replace(/<[^>]+>/g, "")
-      .replace(/\s+/g, " ")
-      .trim(),
-  );
 }
 
 export function escapeHtml(value: string): string {
@@ -126,17 +39,4 @@ function transformTextOutsideTags(segment: string, replacer: (text: string) => s
     .split(TAG_RE)
     .map((part) => (part.startsWith("<") ? part : replacer(part)))
     .join("");
-}
-
-function decodeHtml(value: string): string {
-  return value
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&amp;/g, "&");
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/npm/vite-plugin-ox-content/src/cross-references-parity.test.ts
+++ b/npm/vite-plugin-ox-content/src/cross-references-parity.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vite-plus/test";
+import { transformCrossReferences } from "./cross-references";
+import { importNapiModuleSync } from "./napi";
+import type { CrossReferenceEntry } from "./cross-reference-types";
+
+/**
+ * `cross-references.ts` and `ox_content_transform::cross_references` both
+ * number a document's headings, figures, and tables and link `@id` to them.
+ * Before the TypeScript one is deleted, the two have to agree.
+ *
+ * The corpus targets the places where the port could silently diverge — the
+ * regular expressions the TypeScript used had semantics that are easy to
+ * approximate and hard to reproduce:
+ *
+ * - `\b` after an identifier that may end in `-`, which is not a word
+ *   character, so the boundary flips to requiring one after it
+ * - the prefix character being *consumed*, so `@fig-1@fig-2` yields one match
+ * - `readAttr` preferring a quoted attribute anywhere over a bare one earlier
+ * - `<a\b` not matching `<address`
+ * - lazy bodies, so a verbatim element ends at its first close tag
+ */
+interface NativeOutput {
+  html: string;
+  references: CrossReferenceEntry[];
+  diagnostics: { policy: string; message: string }[];
+}
+
+function native(html: string, options: Record<string, unknown>): NativeOutput {
+  const napi = importNapiModuleSync() as unknown as {
+    transformCrossReferences(html: string, options: Record<string, unknown>): NativeOutput;
+  };
+  return napi.transformCrossReferences(html, options);
+}
+
+const OPTIONS = {
+  enabled: true,
+  missing: "warn",
+  duplicates: "warn",
+  mismatches: "warn",
+  labels: { figure: "Figure", table: "Table", section: "Section" },
+} as const;
+
+const CASES: Record<string, string> = {
+  "nested section numbering":
+    '<h1 id="sec-a">Alpha</h1><h2 id="sec-b">Beta</h2><h3 id="sec-c">Gamma</h3>' +
+    '<h2 id="sec-d">Delta</h2><h1 id="sec-e">Epsilon</h1>',
+  "heading depth resets": '<h2 id="sec-a">A</h2><h1 id="sec-b">B</h1><h2 id="sec-c">C</h2>',
+  "figure with its own id":
+    '<figure id="fig-one"><img src="a.png" alt="Alt"><figcaption>Cap</figcaption></figure>',
+  "figure borrowing the image id": '<figure><img id="fig-two" src="b.png" alt="Second"></figure>',
+  "standalone image": '<img id="fig-three" src="c.png" alt="Third">',
+  "figure and image share one sequence":
+    '<figure id="fig-a"><img src="a.png"></figure><img id="fig-b" src="b.png">' +
+    '<figure><img id="fig-c" src="c.png"></figure>',
+  "table with id": '<table id="tbl-one"><tbody><tr><td>x</td></tr></tbody></table>',
+  "trailing paragraph label":
+    "<table><tbody><tr><td>x</td></tr></tbody></table>\n<p>{#tbl-lifted}</p>",
+  "trailing empty-cell label":
+    '<table><tbody><tr><td>x</td></tr><tr><td id="tbl-cell"></td><td></td></tr></tbody></table>',
+  "reference resolves": '<h1 id="sec-a">A</h1><p>See @sec-a for details.</p>',
+  "reference at segment start": '<h1 id="sec-a">A</h1><p>@sec-a leads.</p>',
+  "adjacent references consume the prefix":
+    '<h1 id="sec-a">A</h1><h2 id="sec-b">B</h2><p>@sec-a@sec-b</p>',
+  "identifier ending in a dash": '<h1 id="sec-a">A</h1><p>@sec- and @sec-a</p>',
+  "reference after a slash": '<h1 id="sec-a">A</h1><p>path/@sec-a</p>',
+  "reference after a bracket": '<h1 id="sec-a">A</h1><p>[@sec-a]</p>',
+  "citation group is left alone":
+    '<h1 id="sec-a">A</h1><p>[@smith2020] and @sec-a and [-@jones]</p>',
+  "bracket that is not a citation": '<h1 id="sec-a">A</h1><p>[note] @sec-a</p>',
+  "protected code span": '<h1 id="sec-a">A</h1><p><code>@sec-a</code> and @sec-a</p>',
+  "protected pre block": '<h1 id="sec-a">A</h1><pre>@sec-a</pre><p>@sec-a</p>',
+  "protected anchor": '<h1 id="sec-a">A</h1><p><a href="#x">@sec-a</a> @sec-a</p>',
+  "address is not an anchor": '<h1 id="sec-a">A</h1><address>@sec-a</address>',
+  "html comment": '<h1 id="sec-a">A</h1><!-- @sec-a --><p>@sec-a</p>',
+  "missing target": "<p>@fig-nope</p>",
+  "kind mismatch": '<h1 id="fig-a">A</h1><p>@fig-a</p>',
+  "duplicate ids": '<h1 id="sec-a">A</h1><h2 id="sec-a">B</h2>',
+  "untracked id is ignored": '<h1 id="intro">A</h1><p>@intro</p>',
+  "header anchor stripped from the title":
+    '<h1 id="sec-a">Alpha<a class="header-anchor" href="#sec-a">#</a></h1>',
+  "entities in a heading": '<h1 id="sec-a">A &amp; B &lt;C&gt;</h1><p>@sec-a</p>',
+  "quoted attribute wins over a bare one": '<h1 id id="sec-a">A</h1><p>@sec-a</p>',
+  "single-quoted attribute": "<h1 id='sec-a'>A</h1><p>@sec-a</p>",
+  "id needing url escaping": '<h1 id="sec-a b">A</h1><p>@sec-a</p>',
+  "already annotated image is skipped":
+    '<img id="fig-a" data-ox-xref-kind="figure" src="a.png"><img id="fig-b" src="b.png">',
+  "whitespace collapsing in a title": '<h1 id="sec-a">  A   \n  B  </h1>',
+  // Positions are recorded against whichever string that pass walked, and each
+  // pass rewrites the document, so a figure's offset is measured in a longer
+  // string than a section's. Both implementations inherit that; the corpus
+  // pins it rather than pretending it is document order.
+  "mixed sections and figures":
+    '<h1 id="sec-a">A</h1><img id="fig-a" src="a.png"><h2 id="sec-b">B</h2>',
+  "empty document": "",
+  "no references at all": "<p>Plain text with no markers.</p>",
+};
+
+describe("cross-reference parity", () => {
+  for (const [name, html] of Object.entries(CASES)) {
+    it(`matches the TypeScript implementation: ${name}`, () => {
+      const ts = transformCrossReferences(html, OPTIONS);
+      const rust = native(html, OPTIONS);
+      expect(rust.html).toBe(ts.html);
+      expect(rust.references).toEqual(ts.references);
+    });
+  }
+});

--- a/npm/vite-plugin-ox-content/src/cross-references.ts
+++ b/npm/vite-plugin-ox-content/src/cross-references.ts
@@ -1,19 +1,5 @@
 import type { OxContentOptions, ResolvedOptions } from "./types";
-import {
-  appendAttr,
-  appendDataAttrs,
-  escapeAttr,
-  escapeHtml,
-  escapeUrlFragment,
-  expectedKind,
-  figureCaption,
-  findFirstImageWithId,
-  readAttr,
-  shouldTrackTarget,
-  textContent,
-  transformText,
-  transformTextOutsideCitationGroups,
-} from "./cross-reference-html";
+import { importNapiModuleSync } from "./napi";
 import type {
   CrossReferenceEntry,
   CrossReferenceFailureMode,
@@ -29,10 +15,6 @@ export type {
   ResolvedCrossReferencesOptions,
 } from "./cross-reference-types";
 
-interface CrossReferenceTarget extends CrossReferenceEntry {
-  position: number;
-}
-
 interface CrossReferenceDiagnostic {
   policy: CrossReferenceFailureMode;
   message: string;
@@ -46,7 +28,6 @@ const disabled: ResolvedCrossReferencesOptions = {
   labels: { figure: "Figure", table: "Table", section: "Section" },
 };
 
-const TEXT_REFERENCE_RE = /(^|[^\w@/[])@([A-Za-z][A-Za-z0-9_-]*)\b/g;
 export function resolveCrossReferencesOptions(
   options: OxContentOptions["crossReferences"],
 ): ResolvedOptions["crossReferences"] {
@@ -71,257 +52,33 @@ export function transformCrossReferences(
 ): { html: string; references: CrossReferenceEntry[] } {
   if (!options?.enabled) return { html, references: [] };
 
-  const diagnostics: CrossReferenceDiagnostic[] = [];
-  const targets = new Map<string, CrossReferenceTarget>();
-  let nextHtml = annotateSections(html, options, targets, diagnostics);
-  nextHtml = annotateFiguresAndImages(nextHtml, options, targets, diagnostics);
-  nextHtml = applyTrailingTableLabels(nextHtml);
-  nextHtml = annotateTables(nextHtml, options, targets, diagnostics);
-  flushDiagnostics(diagnostics);
-
-  nextHtml = replaceReferences(nextHtml, options, targets, diagnostics);
-  flushDiagnostics(diagnostics);
-
-  return {
-    html: nextHtml,
-    references: [...targets.values()]
-      .sort((a, b) => a.position - b.position)
-      .map(({ position: _position, ...reference }) => reference),
-  };
-}
-
-function annotateSections(
-  html: string,
-  options: ResolvedCrossReferencesOptions,
-  targets: Map<string, CrossReferenceTarget>,
-  diagnostics: CrossReferenceDiagnostic[],
-): string {
-  const counters = [0, 0, 0, 0, 0, 0];
-  return html.replace(
-    /<h([1-6])\b([^>]*)>([\s\S]*?)<\/h\1>/gi,
-    (full: string, rawDepth: string, attrs: string, body: string, offset: number) => {
-      const depth = Number(rawDepth);
-      counters[depth - 1] += 1;
-      counters.fill(0, depth);
-      const id = readAttr(attrs, "id");
-      if (!id || !shouldTrackTarget(id)) return full;
-
-      const number = counters.slice(0, depth).filter(Boolean).join(".");
-      const text = `${options.labels.section} ${number || counters[depth - 1]}`;
-      registerTarget(targets, diagnostics, options.duplicates, {
-        id,
-        kind: "section",
-        number,
-        label: options.labels.section,
-        text,
-        href: `#${escapeUrlFragment(id)}`,
-        title: textContent(body),
-        position: offset,
-      });
-      return `<h${rawDepth}${appendDataAttrs(attrs, "section", number, text)}>${body}</h${rawDepth}>`;
-    },
-  );
-}
-
-function annotateFiguresAndImages(
-  html: string,
-  options: ResolvedCrossReferencesOptions,
-  targets: Map<string, CrossReferenceTarget>,
-  diagnostics: CrossReferenceDiagnostic[],
-): string {
-  let count = 0;
-  let output = "";
-  let cursor = 0;
-  const blockRe = /<figure\b([^>]*)>([\s\S]*?)<\/figure>|<img\b([^>]*)>/gi;
-  for (const match of html.matchAll(blockRe)) {
-    const offset = match.index ?? 0;
-    output += html.slice(cursor, offset);
-
-    if (match[1] !== undefined) {
-      const attrs = match[1] ?? "";
-      const body = match[2] ?? "";
-      const figureId = readAttr(attrs, "id");
-      const image = figureId ? null : findFirstImageWithId(body);
-      const id = figureId ?? image?.id;
-      if (!id || !shouldTrackTarget(id)) {
-        output += match[0];
-        cursor = offset + match[0].length;
-        continue;
-      }
-
-      count += 1;
-      const number = String(count);
-      const text = `${options.labels.figure} ${number}`;
-      registerTarget(targets, diagnostics, options.duplicates, {
-        id,
-        kind: "figure",
-        number,
-        label: options.labels.figure,
-        text,
-        href: `#${escapeUrlFragment(id)}`,
-        title: figureCaption(body) ?? image?.alt,
-        position: offset,
-      });
-
-      if (figureId) {
-        output += `<figure${appendDataAttrs(attrs, "figure", number, text)}>${body}</figure>`;
-        cursor = offset + match[0].length;
-        continue;
-      }
-      const nextImage = `<img${appendDataAttrs(image.attrs, "figure", number, text)}>`;
-      output += `<figure${attrs}>${body.slice(0, image.start)}${nextImage}${body.slice(image.end)}</figure>`;
-      cursor = offset + match[0].length;
-      continue;
-    }
-
-    const attrs = match[3] ?? "";
-    if (readAttr(attrs, "data-ox-xref-kind")) {
-      output += match[0];
-      cursor = offset + match[0].length;
-      continue;
-    }
-    const id = readAttr(attrs, "id");
-    if (!id || !shouldTrackTarget(id)) {
-      output += match[0];
-      cursor = offset + match[0].length;
-      continue;
-    }
-
-    count += 1;
-    const number = String(count);
-    const text = `${options.labels.figure} ${number}`;
-    registerTarget(targets, diagnostics, options.duplicates, {
-      id,
-      kind: "figure",
-      number,
-      label: options.labels.figure,
-      text,
-      href: `#${escapeUrlFragment(id)}`,
-      title: readAttr(attrs, "alt"),
-      position: offset,
-    });
-    output += `<img${appendDataAttrs(attrs, "figure", number, text)}>`;
-    cursor = offset + match[0].length;
-  }
-  return output + html.slice(cursor);
-}
-
-function annotateTables(
-  html: string,
-  options: ResolvedCrossReferencesOptions,
-  targets: Map<string, CrossReferenceTarget>,
-  diagnostics: CrossReferenceDiagnostic[],
-): string {
-  let count = 0;
-  return html.replace(/<table\b([^>]*)>/gi, (full: string, attrs: string, offset: number) => {
-    const id = readAttr(attrs, "id");
-    if (!id || !shouldTrackTarget(id)) return full;
-
-    count += 1;
-    const number = String(count);
-    const text = `${options.labels.table} ${number}`;
-    registerTarget(targets, diagnostics, options.duplicates, {
-      id,
-      kind: "table",
-      number,
-      label: options.labels.table,
-      text,
-      href: `#${escapeUrlFragment(id)}`,
-      position: offset,
-    });
-    return `<table${appendDataAttrs(attrs, "table", number, text)}>`;
+  // Numbering, annotation, and reference rewriting all happen in one native
+  // call. Rust returns diagnostics rather than raising, because which of them
+  // are fatal is this layer's policy, not the transform's.
+  const napi = importNapiModuleSync() as unknown as NativeCrossReferenceModule;
+  const output = napi.transformCrossReferences(html, {
+    enabled: true,
+    missing: options.missing,
+    duplicates: options.duplicates,
+    mismatches: options.mismatches,
+    labels: options.labels,
   });
+  flushDiagnostics(output.diagnostics);
+
+  return { html: output.html, references: output.references };
 }
 
-function applyTrailingTableLabels(html: string): string {
-  const liftedParagraphLabels = html.replace(
-    /(<table\b[^>]*>[\s\S]*?<\/table>)\s*<p>\{#([A-Za-z][A-Za-z0-9_-]*)\}<\/p>/gi,
-    (full: string, table: string, id: string) => {
-      const open = /^<table\b([^>]*)>/i.exec(table);
-      if (!open || readAttr(open[1] ?? "", "id")) return full;
-      const nextOpen = `<table${appendAttr(open[1] ?? "", "id", id)}>`;
-      return nextOpen + table.slice(open[0].length);
+interface NativeCrossReferenceModule {
+  transformCrossReferences(
+    html: string,
+    options: {
+      enabled: boolean;
+      missing: CrossReferenceFailureMode;
+      duplicates: CrossReferenceFailureMode;
+      mismatches: CrossReferenceFailureMode;
+      labels: { figure: string; table: string; section: string };
     },
-  );
-  return liftedParagraphLabels.replace(
-    /<table\b([^>]*)>([\s\S]*?)<\/table>/gi,
-    (full: string, attrs: string, body: string) => {
-      if (readAttr(attrs, "id")) return full;
-      const label = trailingTableCellLabel(body);
-      if (!label) return full;
-      return `<table${appendAttr(attrs, "id", label.id)}>${label.body}</table>`;
-    },
-  );
-}
-
-function trailingTableCellLabel(body: string): { id: string; body: string } | null {
-  const match =
-    /(\s*<tr>\s*<td\b([^>]*)>\s*<\/td>(?:\s*<td\b[^>]*>\s*<\/td>)*\s*<\/tr>)(\s*<\/tbody>\s*)$/i.exec(
-      body,
-    );
-  if (!match) return null;
-  const id = readAttr(match[2] ?? "", "id");
-  if (!id || expectedKind(id) !== "table") return null;
-  return {
-    id,
-    body: body.slice(0, match.index) + (match[3] ?? ""),
-  };
-}
-
-function replaceReferences(
-  html: string,
-  options: ResolvedCrossReferencesOptions,
-  targets: Map<string, CrossReferenceTarget>,
-  diagnostics: CrossReferenceDiagnostic[],
-): string {
-  return transformText(html, (text) => {
-    return transformTextOutsideCitationGroups(text, (segment) =>
-      replaceReferenceSegment(segment, options, targets, diagnostics),
-    );
-  });
-}
-
-function replaceReferenceSegment(
-  text: string,
-  options: ResolvedCrossReferencesOptions,
-  targets: Map<string, CrossReferenceTarget>,
-  diagnostics: CrossReferenceDiagnostic[],
-): string {
-  return text.replace(TEXT_REFERENCE_RE, (full, prefix: string, id: string) => {
-    const expected = expectedKind(id);
-    if (!expected) return full;
-
-    const target = targets.get(id);
-    if (!target) {
-      diagnostics.push({
-        policy: options.missing,
-        message: `missing cross-reference target "${id}"`,
-      });
-      return full;
-    }
-    if (target.kind !== expected) {
-      diagnostics.push({
-        policy: options.mismatches,
-        message: `cross-reference "${id}" expects ${expected} but found ${target.kind}`,
-      });
-      return full;
-    }
-
-    return `${prefix}<a class="ox-xref ox-xref-${target.kind}" href="${target.href}" data-ox-xref-id="${escapeAttr(target.id)}" data-ox-xref-kind="${target.kind}">${escapeHtml(target.text)}</a>`;
-  });
-}
-
-function registerTarget(
-  targets: Map<string, CrossReferenceTarget>,
-  diagnostics: CrossReferenceDiagnostic[],
-  policy: CrossReferenceFailureMode,
-  target: CrossReferenceTarget,
-): void {
-  if (targets.has(target.id)) {
-    diagnostics.push({ policy, message: `duplicate cross-reference target "${target.id}"` });
-    return;
-  }
-  targets.set(target.id, target);
+  ): { html: string; references: CrossReferenceEntry[]; diagnostics: CrossReferenceDiagnostic[] };
 }
 
 function flushDiagnostics(diagnostics: CrossReferenceDiagnostic[]): void {


### PR DESCRIPTION
> **Depends on [#1109](https://github.com/ubugeeei-prod/ox-content/pull/1109).** `main` is currently missing the redirect wrapper exports, so the NAPI wrapper test fails on every branch until that merges. This PR's own checks will go green once it lands and this is rebased.

## Why

`cross-references.ts` numbered every heading, figure, and table and rewrote `@id` into links — 695 lines of TypeScript touching no browser or Node API. Pure data-in / data-out.

It was also one of the **six module fields `@ox-content/unplugin` cannot emit**. `unplugin` exports `html`, `frontmatter`, `toc`; the Vite plugin exports those plus `imports`, `exports`, `components`, `crossReferences`, `citations`, `bibliography`. The feature was Vite-only for no reason other than where the code lived — moving it into the shared crate is what makes it reachable from every bundler.

## Faithfulness was the risk

The TypeScript leaned on regex semantics that are easy to approximate and hard to reproduce. Each is now spelled out where it is implemented:

- `\b` after an identifier that may end in `-` — not a word character, so the boundary flips to requiring one *after* it
- the prefix character being **consumed**, so `@fig-1@fig-2` yields one match, not two
- `readAttr` preferring a quoted attribute anywhere over an earlier bare one (`id id="x"` reads as `x`, not `""`)
- `<a\b` not matching `<address`
- lazy bodies, so a verbatim element ends at its *first* close tag

A **36-case parity corpus** compares the two implementations directly. To check the corpus can actually fail, I mutated the Rust by one character — numbering sections by two — and **23 of the 36 cases went red**.

One quirk is preserved rather than fixed: reported order follows the offsets each pass saw, and every pass rewrites the document, so a figure between two headings sorts *after* both. That is what the TypeScript did; the test says so explicitly rather than asserting the intention.

## Shape

- Diagnostics are **returned, not raised** — which of them are fatal is the plugin's policy, and this keeps the crate inside the panic-construct gate.
- Scanning is hand-rolled over `html_scan::find_ci`. The backreferences rule out the `regex` crate anyway, and this is the faster path.
- Output is built with `write!` into one buffer rather than `format!` per element.

## Numbers

- **343 fewer lines** of production TypeScript
- 22 Rust tests, 36 parity cases, 5 pre-existing TypeScript tests still passing
- `cross-reference-html.ts` trimmed to the four helpers `citations.ts` still needs — it goes entirely when that pass moves too

## Verification

`cargo test -p ox_content_transform` — 524 passed. `cargo clippy` clean. Package suite — 951 passed. NAPI binding rebuilt and confirmed newer than the sources before the TypeScript ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790418953&installation_model_id=422833&pr_number=1110&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1110&signature=d37c1ade0d7fd8981337f52a1890c924a99465ab2b76090177237d79ab3f8446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-reference processing for sections, figures, images, and tables.
  * Automatically numbers targets and converts `@id` references into links.
  * Added configurable labels and warning or error diagnostics for missing, duplicate, or mismatched references.
  * Exposed cross-reference transformation through the JavaScript and TypeScript APIs.
* **Bug Fixes**
  * Improved handling of escaped links, titles, table labels, protected content, citations, and HTML attributes.
* **Tests**
  * Added comprehensive coverage and parity checks for native and JavaScript behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->