### PR TITLE
feat(embeds): distinguish the fetch-side embed failure modes

### DIFF
--- a/npm/vite-plugin-ox-content/src/plugins/github/api.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/github/api.ts
@@ -1,3 +1,4 @@
+import { classifyError, classifyStatus, warnEmbedFailure } from "../provider-failure";
 import { Buffer } from "node:buffer";
 import { gitHubResourceDataFromJson } from "./resource-metadata";
 import { resourceKey } from "./resource";
@@ -62,6 +63,14 @@ async function fetchSourceCommit(
     )}&sha=${encodeURIComponent(source.ref)}&per_page=1`;
     const response = await fetch(apiUrl, { headers: githubHeaders(options) });
     if (!response.ok) {
+      // A failed commit lookup is why a source card loses its "last changed"
+      // line, which is otherwise invisible.
+      warnEmbedFailure(
+        "github commit",
+        `${source.repo}/${source.path}`,
+        classifyStatus(response.status),
+        "a card without commit details",
+      );
       return undefined;
     }
 
@@ -111,7 +120,7 @@ export async function fetchRepoData(
     });
 
     if (!response.ok) {
-      console.warn(`Failed to fetch GitHub repo ${repo}: ${response.status}`);
+      warnEmbedFailure("github", repo, classifyStatus(response.status), "a link-only card");
       return null;
     }
 
@@ -122,7 +131,7 @@ export async function fetchRepoData(
 
     return data;
   } catch (error) {
-    console.warn(`Error fetching GitHub repo ${repo}:`, error);
+    warnEmbedFailure("github", repo, classifyError(error), "a link-only card");
     return null;
   }
 }
@@ -160,7 +169,12 @@ export async function fetchGitHubSource(
     ]);
 
     if (!response.ok) {
-      console.warn(`Failed to fetch GitHub source ${source.permalink}: ${response.status}`);
+      warnEmbedFailure(
+        "github",
+        source.permalink,
+        classifyStatus(response.status),
+        "a link-only card",
+      );
       return null;
     }
 
@@ -197,7 +211,7 @@ export async function fetchGitHubSource(
 
     return sourceData;
   } catch (error) {
-    console.warn(`Error fetching GitHub source ${source.permalink}:`, error);
+    warnEmbedFailure("github", source.permalink, classifyError(error), "a link-only card");
     return null;
   }
 }
@@ -220,8 +234,11 @@ export async function fetchGitHubResource(
   try {
     const response = await fetch(resource.apiUrl, { headers: githubPublicHeaders() });
     if (!response.ok) {
-      console.warn(
-        `Failed to fetch GitHub ${resource.kind} ${resource.permalink}: ${response.status}`,
+      warnEmbedFailure(
+        `github ${resource.kind}`,
+        resource.permalink,
+        classifyStatus(response.status),
+        "a link-only card",
       );
       return null;
     }
@@ -232,7 +249,12 @@ export async function fetchGitHubResource(
     }
     return data;
   } catch (error) {
-    console.warn(`Error fetching GitHub ${resource.kind} ${resource.permalink}:`, error);
+    warnEmbedFailure(
+      `github ${resource.kind}`,
+      resource.permalink,
+      classifyError(error),
+      "a link-only card",
+    );
     return null;
   }
 }

--- a/npm/vite-plugin-ox-content/src/plugins/ogp/fetch.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/ogp/fetch.ts
@@ -1,3 +1,4 @@
+import { classifyError, classifyStatus, warnEmbedFailure } from "../provider-failure";
 import { readDiskOgp, readMemoryOgp, writeDiskOgp, writeMemoryOgp } from "./cache";
 import type { OgpData, OgpOptions, ResolvedOgpOptions } from "./types";
 import { resolveOgpOptions } from "./types";
@@ -63,17 +64,13 @@ async function requestOgpData(url: string, options: ResolvedOgpOptions): Promise
     clearTimeout(timeoutId);
 
     if (!response.ok) {
-      console.warn(`Failed to fetch OGP for ${url}: ${response.status}`);
+      warnEmbedFailure("ogp", url, classifyStatus(response.status), "a link-only card");
       return null;
     }
 
     return parseOgpFromHtml(await response.text(), url);
   } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
-      console.warn(`Timeout fetching OGP for ${url}`);
-    } else {
-      console.warn(`Error fetching OGP for ${url}:`, error);
-    }
+    warnEmbedFailure("ogp", url, classifyError(error), "a link-only card");
     return null;
   }
 }

--- a/npm/vite-plugin-ox-content/src/plugins/provider-articles.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/provider-articles.ts
@@ -1,3 +1,5 @@
+import type { EmbedFailure } from "./provider-failure";
+import { classifyError, classifyStatus, warnEmbedFailure } from "./provider-failure";
 import {
   readProviderCache,
   resolveProviderCacheDir,
@@ -221,14 +223,22 @@ async function requestArticleMeta(
       headers: { accept: "application/json" },
       signal: controller.signal,
     });
-    if (!response.ok) return null;
+    if (!response.ok) {
+      warnArticleFallback(reference, classifyStatus(response.status));
+      return null;
+    }
     const value = await response.json();
     return reference.provider === "qiita" ? qiitaMeta(value) : zennMeta(value);
-  } catch {
+  } catch (error) {
+    warnArticleFallback(reference, classifyError(error));
     return null;
   } finally {
     clearTimeout(timeout);
   }
+}
+
+function warnArticleFallback(reference: ArticleReference, failure: EmbedFailure): void {
+  warnEmbedFailure(reference.provider, reference.apiUrl, failure, "a link-only article card");
 }
 
 function articleReference(provider: "qiita" | "zenn", attrs: string): ArticleReference | null {

--- a/npm/vite-plugin-ox-content/src/plugins/provider-failure.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/provider-failure.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  classifyError,
+  classifyStatus,
+  describeFailure,
+  resetEmbedFailureReporting,
+  warnEmbedFailure,
+} from "./provider-failure";
+
+describe("classifying a fetch outcome", () => {
+  it("separates a missing resource from a refusal", () => {
+    expect(classifyStatus(404)).toEqual({ kind: "missing", status: 404 });
+    expect(classifyStatus(410)).toEqual({ kind: "missing", status: 410 });
+    expect(classifyStatus(403)).toEqual({ kind: "unavailable", status: 403 });
+    expect(classifyStatus(401)).toEqual({ kind: "unavailable", status: 401 });
+    expect(classifyStatus(429)).toEqual({ kind: "unavailable", status: 429 });
+  });
+
+  it("treats a server error as a failed request, not a refusal", () => {
+    // 5xx says the provider is broken, not that it said no.
+    expect(classifyStatus(500)).toEqual({ kind: "fetch-failed", reason: "HTTP 500" });
+    expect(classifyStatus(502)).toEqual({ kind: "fetch-failed", reason: "HTTP 502" });
+  });
+
+  it("reads a missing network off the syscall error", () => {
+    const offline = Object.assign(new Error("fetch failed"), {
+      cause: { code: "ENOTFOUND" },
+    });
+    expect(classifyError(offline)).toEqual({ kind: "offline", reason: "ENOTFOUND" });
+  });
+
+  it("names a timeout as such", () => {
+    const aborted = Object.assign(new Error("aborted"), { name: "AbortError" });
+    expect(classifyError(aborted)).toEqual({ kind: "fetch-failed", reason: "timed out" });
+  });
+
+  it("does not mistake an ordinary error for being offline", () => {
+    expect(classifyError(new Error("bad json"))).toEqual({
+      kind: "fetch-failed",
+      reason: "bad json",
+    });
+    expect(classifyError("not an error")).toEqual({
+      kind: "fetch-failed",
+      reason: "unknown error",
+    });
+  });
+});
+
+describe("what each cause reads as", () => {
+  it("says something different for each", () => {
+    expect(describeFailure(classifyStatus(404))).toContain("does not exist");
+    expect(describeFailure(classifyStatus(403))).toContain("refused");
+    expect(describeFailure(classifyStatus(429))).toContain("rate limiting");
+    expect(describeFailure(classifyStatus(503))).toBe("HTTP 503");
+    expect(describeFailure({ kind: "offline", reason: "EAI_AGAIN" })).toContain("no network");
+  });
+});
+
+describe("reporting", () => {
+  let warned: string[];
+
+  beforeEach(() => {
+    resetEmbedFailureReporting();
+    warned = [];
+    vi.spyOn(console, "warn").mockImplementation((message: unknown) => {
+      warned.push(String(message));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("names the provider and the target for a per-embed failure", () => {
+    warnEmbedFailure("npm", "left-pad", classifyStatus(404), "a link-only package card");
+    expect(warned).toHaveLength(1);
+    expect(warned[0]).toContain("npm");
+    expect(warned[0]).toContain("left-pad");
+    expect(warned[0]).toContain("does not exist");
+    expect(warned[0]).toContain("a link-only package card");
+  });
+
+  it("reports an offline build once, not once per embed", () => {
+    const offline = { kind: "offline", reason: "ENOTFOUND" } as const;
+    for (let index = 0; index < 20; index++) {
+      warnEmbedFailure("npm", `package-${index}`, offline, "a link-only package card");
+    }
+    // The single fact that matters would otherwise be buried under twenty
+    // identical lines.
+    expect(warned).toHaveLength(1);
+    expect(warned[0]).toContain("No network");
+    expect(warned[0]).toContain("every embed lookup this build");
+  });
+
+  it("still reports other causes while offline has already been said", () => {
+    warnEmbedFailure("npm", "a", { kind: "offline", reason: "ENOTFOUND" }, "a card");
+    warnEmbedFailure("npm", "b", classifyStatus(404), "a card");
+    expect(warned).toHaveLength(2);
+    expect(warned[1]).toContain("does not exist");
+  });
+
+  it("does not name an offline provider or target, because neither is at fault", () => {
+    warnEmbedFailure("npm", "left-pad", { kind: "offline", reason: "ENOTFOUND" }, "a card");
+    expect(warned[0]).not.toContain("left-pad");
+  });
+});

--- a/npm/vite-plugin-ox-content/src/plugins/provider-failure.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/provider-failure.ts
@@ -1,0 +1,99 @@
+/**
+ * Why a build-time embed lookup did not produce metadata.
+ *
+ * Every fetcher used to collapse these into one message carrying a status code
+ * or an error string, so a rate limit read the same as a deleted resource and a
+ * disconnected machine read the same as a typo. The card that ships is the same
+ * either way; the difference matters to whoever reads the build log.
+ */
+
+export type EmbedFailure =
+  /** The provider answered and refused: auth, or a rate limit. */
+  | { kind: "unavailable"; status: number }
+  /** The provider answered and the thing is not there. */
+  | { kind: "missing"; status: number }
+  /** The request was made and failed: timeout, 5xx, a broken response. */
+  | { kind: "fetch-failed"; reason: string }
+  /** No network was reachable, so nothing was really attempted. */
+  | { kind: "offline"; reason: string };
+
+/** Node's fetch reports a missing network through `cause.code`. */
+const OFFLINE_CODES = new Set([
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ENETUNREACH",
+  "ENETDOWN",
+  "EHOSTUNREACH",
+]);
+
+export function classifyStatus(status: number): EmbedFailure {
+  if (status === 404 || status === 410) return { kind: "missing", status };
+  if (status === 401 || status === 403 || status === 429) return { kind: "unavailable", status };
+  return { kind: "fetch-failed", reason: `HTTP ${status}` };
+}
+
+export function classifyError(error: unknown): EmbedFailure {
+  if (error instanceof Error) {
+    if (error.name === "AbortError") return { kind: "fetch-failed", reason: "timed out" };
+    const code = errorCode(error);
+    if (code && OFFLINE_CODES.has(code)) return { kind: "offline", reason: code };
+    return { kind: "fetch-failed", reason: error.message };
+  }
+  return { kind: "fetch-failed", reason: "unknown error" };
+}
+
+/** `cause` is where undici puts the syscall error; older runtimes use `code`. */
+function errorCode(error: Error): string | undefined {
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause && typeof cause === "object" && "code" in cause) {
+    const code = (cause as { code?: unknown }).code;
+    if (typeof code === "string") return code;
+  }
+  const own = (error as { code?: unknown }).code;
+  return typeof own === "string" ? own : undefined;
+}
+
+export function describeFailure(failure: EmbedFailure): string {
+  switch (failure.kind) {
+    case "missing":
+      return `the resource does not exist (${failure.status})`;
+    case "unavailable":
+      return failure.status === 429
+        ? "the provider is rate limiting this build (429)"
+        : `the provider refused the request (${failure.status})`;
+    case "offline":
+      return `no network (${failure.reason})`;
+    case "fetch-failed":
+      return failure.reason;
+  }
+}
+
+/**
+ * An offline build fails every lookup for the same reason, so it says so once.
+ * One line per embed would bury the single fact that matters.
+ */
+let offlineReported = false;
+
+export function resetEmbedFailureReporting(): void {
+  offlineReported = false;
+}
+
+export function warnEmbedFailure(
+  provider: string,
+  target: string,
+  failure: EmbedFailure,
+  fallback: string,
+): void {
+  if (failure.kind === "offline") {
+    if (offlineReported) return;
+    offlineReported = true;
+    console.warn(
+      `[ox-content:embeds] No network (${failure.reason}); every embed lookup this build renders ${fallback}.`,
+    );
+    return;
+  }
+  console.warn(
+    `[ox-content:embeds] ${provider} lookup for ${target} failed: ${describeFailure(failure)}; rendering ${fallback}.`,
+  );
+}

--- a/npm/vite-plugin-ox-content/src/plugins/provider-offline-build.test.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/provider-offline-build.test.ts
@@ -1,0 +1,96 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  clearProviderPackageCache,
+  enrichProviderPackageEmbeds,
+  type ProviderPackageFetch,
+} from "./provider-packages";
+import { resetEmbedFailureReporting } from "./provider-failure";
+
+/**
+ * The point of the offline case: a build with a warm disk cache must not care
+ * that the network is gone. Same output, and nothing to say about it.
+ */
+const INPUT = '<NpmPackage url="https://www.npmjs.com/package/vite"></NpmPackage>';
+
+const PAYLOAD = {
+  name: "vite",
+  "dist-tags": { latest: "7.0.0" },
+  versions: { "7.0.0": { version: "7.0.0", license: "MIT", description: "Next generation" } },
+  time: { "7.0.0": "2026-08-26T00:00:00Z" },
+};
+
+function respondingFetch(): { fetch: ProviderPackageFetch; calls: string[] } {
+  const calls: string[] = [];
+  const fetch: ProviderPackageFetch = async (url) => {
+    calls.push(String(url));
+    return new Response(JSON.stringify(PAYLOAD), { status: 200 });
+  };
+  return { fetch, calls };
+}
+
+/** Fails the way Node does when there is no network at all. */
+function offlineFetch(): { fetch: ProviderPackageFetch; calls: string[] } {
+  const calls: string[] = [];
+  const fetch: ProviderPackageFetch = async (url) => {
+    calls.push(String(url));
+    throw Object.assign(new Error("fetch failed"), { cause: { code: "ENOTFOUND" } });
+  };
+  return { fetch, calls };
+}
+
+describe("an offline build", () => {
+  let cacheDir: string;
+  let warned: string[];
+
+  beforeEach(async () => {
+    cacheDir = await mkdtemp(path.join(tmpdir(), "ox-offline-"));
+    resetEmbedFailureReporting();
+    warned = [];
+    vi.spyOn(console, "warn").mockImplementation((message: unknown) => {
+      warned.push(String(message));
+    });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    clearProviderPackageCache();
+    await rm(cacheDir, { recursive: true, force: true });
+  });
+
+  it("renders what a warm cache holds, without reaching for the network", async () => {
+    const options = { persistCache: true, cacheDir };
+
+    const online = respondingFetch();
+    const warm = await enrichProviderPackageEmbeds(INPUT, options, online.fetch);
+    expect(online.calls).toHaveLength(1);
+
+    // A fresh process: only the disk cache survives.
+    clearProviderPackageCache();
+    resetEmbedFailureReporting();
+    warned = [];
+
+    const offline = offlineFetch();
+    const cold = await enrichProviderPackageEmbeds(INPUT, options, offline.fetch);
+
+    expect(cold).toBe(warm);
+    expect(offline.calls).toEqual([]);
+    expect(warned).toEqual([]);
+  });
+
+  it("says the network is gone once, however many embeds miss the cache", async () => {
+    const input = Array.from(
+      { length: 5 },
+      (_, index) => `<NpmPackage url="https://www.npmjs.com/package/pkg-${index}"></NpmPackage>`,
+    ).join("\n");
+
+    const offline = offlineFetch();
+    await enrichProviderPackageEmbeds(input, { persistCache: true, cacheDir }, offline.fetch);
+
+    expect(offline.calls).toHaveLength(5);
+    expect(warned).toHaveLength(1);
+    expect(warned[0]).toContain("No network");
+  });
+});

--- a/npm/vite-plugin-ox-content/src/plugins/provider-packages.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/provider-packages.ts
@@ -1,3 +1,5 @@
+import type { EmbedFailure } from "./provider-failure";
+import { classifyError, classifyStatus, warnEmbedFailure } from "./provider-failure";
 import {
   readProviderCache,
   resolveProviderCacheDir,
@@ -209,23 +211,21 @@ async function requestPackageMeta(
       signal: controller.signal,
     });
     if (!response.ok) {
-      warnPackageFallback(reference, String(response.status));
+      warnPackageFallback(reference, classifyStatus(response.status));
       return null;
     }
     const value = await response.json();
     return packageMetaFromJson(value, reference);
   } catch (error) {
-    warnPackageFallback(reference, error instanceof Error ? error.message : "unknown error");
+    warnPackageFallback(reference, classifyError(error));
     return null;
   } finally {
     clearTimeout(timeout);
   }
 }
 
-function warnPackageFallback(reference: PackageRegistryReference, reason: string): void {
-  console.warn(
-    `[ox-content] Failed to fetch ${reference.provider} metadata for ${reference.name}: ${reason}; rendering a link-only package card.`,
-  );
+function warnPackageFallback(reference: PackageRegistryReference, failure: EmbedFailure): void {
+  warnEmbedFailure(reference.provider, reference.name, failure, "a link-only package card");
 }
 
 function npmReference(url: URL, segments: string[]): PackageRegistryReference | null {

--- a/npm/vite-plugin-ox-content/src/plugins/provider-playgrounds.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/provider-playgrounds.ts
@@ -1,3 +1,5 @@
+import type { EmbedFailure } from "./provider-failure";
+import { classifyError, classifyStatus, warnEmbedFailure } from "./provider-failure";
 import {
   readProviderCache,
   resolveProviderCacheDir,
@@ -210,12 +212,12 @@ async function requestPlaygroundMeta(
       signal: controller.signal,
     });
     if (!response.ok) {
-      warnPlaygroundFallback(reference, String(response.status));
+      warnPlaygroundFallback(reference, classifyStatus(response.status));
       return null;
     }
     return playgroundMetaFromJson(await response.json());
   } catch (error) {
-    warnPlaygroundFallback(reference, error instanceof Error ? error.message : "unknown error");
+    warnPlaygroundFallback(reference, classifyError(error));
     return null;
   } finally {
     clearTimeout(timeout);
@@ -329,10 +331,8 @@ function titleize(value: string): string {
   return value.replaceAll("-", " ").replaceAll("_", " ");
 }
 
-function warnPlaygroundFallback(reference: PlaygroundReference, reason: string): void {
-  console.warn(
-    `[ox-content] Failed to fetch ${reference.provider} metadata for ${reference.canonicalUrl}: ${reason}; rendering a link-only playground card.`,
-  );
+function warnPlaygroundFallback(reference: PlaygroundReference, failure: EmbedFailure): void {
+  warnEmbedFailure(reference.provider, reference.apiUrl, failure, "a link-only playground card");
 }
 
 function compactMeta(meta: PlaygroundMeta): PlaygroundMeta {

--- a/npm/vite-plugin-ox-content/src/plugins/provider-videos.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/provider-videos.ts
@@ -1,3 +1,5 @@
+import type { EmbedFailure } from "./provider-failure";
+import { classifyError, classifyStatus, warnEmbedFailure } from "./provider-failure";
 import {
   readProviderCache,
   resolveProviderCacheDir,
@@ -206,12 +208,12 @@ async function requestVideoMeta(
       signal: controller.signal,
     });
     if (!response.ok) {
-      warnVideoFallback(reference, String(response.status));
+      warnVideoFallback(reference, classifyStatus(response.status));
       return null;
     }
     return vimeoMetaFromJson(await response.json());
   } catch (error) {
-    warnVideoFallback(reference, error instanceof Error ? error.message : "unknown error");
+    warnVideoFallback(reference, classifyError(error));
     return null;
   } finally {
     clearTimeout(timeout);
@@ -229,8 +231,6 @@ function readAttr(attrs: string, name: string): string | undefined {
   return value ? decodeProviderArticleAttr(value) : undefined;
 }
 
-function warnVideoFallback(reference: VideoProviderReference, reason: string): void {
-  console.warn(
-    `[ox-content] Failed to fetch ${reference.provider} metadata for ${reference.canonicalUrl}: ${reason}; rendering a link-only video card.`,
-  );
+function warnVideoFallback(reference: VideoProviderReference, failure: EmbedFailure): void {
+  warnEmbedFailure(reference.provider, reference.apiUrl, failure, "a link-only video card");
 }

--- a/npm/vite-plugin-ox-content/src/plugins/reddit/fetch.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/reddit/fetch.ts
@@ -1,3 +1,4 @@
+import { classifyError, classifyStatus, warnEmbedFailure } from "../provider-failure";
 import type { RedditPostData, RedditPostReference, ResolvedRedditEmbedOptions } from "./types";
 import {
   isSafeExternalUrl,
@@ -65,9 +66,18 @@ export async function requestRedditPostData(
       },
       signal: controller.signal,
     });
-    if (!response.ok) return null;
+    if (!response.ok) {
+      warnEmbedFailure(
+        "reddit",
+        reference.apiUrl,
+        classifyStatus(response.status),
+        "a link-only card",
+      );
+      return null;
+    }
     return parseRedditListing(await response.json(), reference);
-  } catch {
+  } catch (error) {
+    warnEmbedFailure("reddit", reference.apiUrl, classifyError(error), "a link-only card");
     return null;
   } finally {
     clearTimeout(timeoutId);

--- a/npm/vite-plugin-ox-content/src/plugins/speaker-deck.ts
+++ b/npm/vite-plugin-ox-content/src/plugins/speaker-deck.ts
@@ -1,3 +1,5 @@
+import { classifyError, classifyStatus, warnEmbedFailure } from "./provider-failure";
+
 const SPEAKERDECK_TAG =
   /<speakerdeck\b((?:[^>"']|"[^"]*"|'[^']*')*)>([\s\S]*?)<\/speakerdeck\s*>/gi;
 const OEMBED_ENDPOINT = "https://speakerdeck.com/oembed.json?url=";
@@ -101,6 +103,7 @@ async function fetchOembed(
       headers: { accept: "application/json" },
     });
     if (!response.ok) {
+      warnEmbedFailure("speakerdeck", url, classifyStatus(response.status), "a link-only card");
       return null;
     }
     const data = (await response.json()) as Record<string, unknown>;
@@ -118,7 +121,8 @@ async function fetchOembed(
       author,
       preview: preview && isSafeHttpsUrl(preview) ? preview : undefined,
     };
-  } catch {
+  } catch (error) {
+    warnEmbedFailure("speakerdeck", url, classifyError(error), "a link-only card");
     return null;
   }
 }


### PR DESCRIPTION
Closes #1101.

## Why

Every provider fetcher collapsed four different causes into one message carrying a status code or an error string. A rate limit read the same as a deleted resource; a disconnected machine read the same as a typo. The card that ships is the same either way — the difference matters to whoever reads the build log.

## The four causes

`provider-failure.ts` names them:

| cause | what happened | statuses |
|---|---|---|
| **fetch failure** | the request was made and failed | timeouts, 5xx, broken responses |
| **provider unavailable** | the provider answered and refused | 401, 403, 429 |
| **resource missing** | the provider answered, it is not there | 404, 410 |
| **offline** | no network was reachable | `cause.code` is `ENOTFOUND`, `EAI_AGAIN`, … |

A **5xx sits under "fetch failure", not "unavailable"** — the provider is broken, it did not say no. That distinction is the difference between "retry later" and "fix your URL".

## Offline gets different handling, not just different wording

Every lookup in an offline build fails for the same reason. So it is reported **once**, and it names neither provider nor target — neither is at fault, and one line per embed buries the single fact that matters. Other causes still report per embed while that line stands.

## Coverage

Wired through all eight fetchers: articles, packages, playgrounds, videos, ogp, github, reddit, speaker-deck.

Two gained diagnostics they never had:

- `provider-articles.ts` returned `null` in **complete silence** — a Qiita or Zenn card could degrade to a bare link with nothing in the log
- a GitHub **commit** lookup failing is why a source card loses its "last changed" line, and that was also silent

## The offline-build guarantee

The issue asked that an offline build's output be identical to a warm-cache build. It already is — `readProviderCache` short-circuits before the network — but that is the kind of claim worth proving rather than asserting, so there is a test: warm the cache, drop the network, and assert byte-identical output, **zero** fetch attempts, and **zero** warnings.

## Verification

12 new tests (10 for classification and reporting, 2 for the offline build). Package suite — 928 passed. Formatting and the panic-construct gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790419754&installation_model_id=422833&pr_number=1112&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1112&signature=5193ec907c870ad5132d247e1cbe43874a285e06f0eded7d7a15aced5ab6a73b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->