### PR TITLE
chore: drop test sources from the language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,21 @@
 /**/docs/api/** linguist-generated=true
 /crates/ox_content_napi/index.d.ts linguist-generated=true
 
+# Test sources. `linguist-vendored` is the only marker that drops a path from
+# the language statistics without claiming it is documentation or generated;
+# these are neither, they are just not the implementation the stats are for.
+*.test.ts linguist-vendored=true
+*.test.tsx linguist-vendored=true
+*.spec.ts linguist-vendored=true
+/npm/**/test/** linguist-vendored=true
+
+# The Rust half of the same rule. Excluding only the TypeScript tests would
+# move the reported split by roughly eight points on its own, which is the
+# opposite of what a statistic is for.
+tests.rs linguist-vendored=true
+test.rs linguist-vendored=true
+/crates/**/tests/** linguist-vendored=true
+
 # Test snapshots and rendered VRT baselines.
 /npm/vite-plugin-ox-content/src/__snapshots__/** linguist-generated=true
 /npm/vite-plugin-ox-content/test/vrt/**/*-snapshots/** linguist-generated=true


### PR DESCRIPTION
`.gitattributes` already says its purpose: *"Keep GitHub language statistics focused on maintained source code."* It excludes docs, examples, benchmarks, generated artifacts, and snapshots. Test sources belong in the same bucket — 31k lines of TypeScript and 33k of Rust that describe the code rather than being it.

## Both languages, deliberately

The request was for `.test.ts`. Doing only that would have moved the reported split by roughly **eight points on its own**, which is the opposite of what a statistic is for — so the Rust half of the same rule is here too.

| | counted before | counted after |
|---|---:|---:|
| Rust | 122,259 | 89,592 (55%) |
| TypeScript | 103,288 | 72,075 (45%) |

55/45 is what the production code actually is. If you'd rather have only the TypeScript half, drop the second block.

## On the marker

`linguist-vendored` is the only attribute that removes a path from the statistics without claiming it is documentation or generated. These are neither, so the comment says so — otherwise it reads as a miscategorisation later.

Inline `#[cfg(test)]` modules stay counted; they cannot be addressed by path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790421831&installation_model_id=422833&pr_number=1114&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1114&signature=128332db5830e0114ab1392aa7a592180263565b239f935d707ca0bb495f322e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->