### PR TITLE
refactor(nix): move the flake to flake-parts and split it into nix/ modules

### DIFF
--- a/docs/content/development-setup.md
+++ b/docs/content/development-setup.md
@@ -94,7 +94,8 @@ vp run bench:bundle
 ```text
 ox-content/
 ├── Cargo.toml              # Workspace configuration
-├── flake.nix               # Nix dev shell (Node.js, workspace bootstrap, Rust, Vite+ wrapper)
+├── flake.nix               # Nix flake wiring (inputs, systems, module list)
+├── nix/                    # Nix modules: dev shell, vp wrapper, Blacksmith CLI
 ├── rust-toolchain.toml     # Rust channel, components, and targets for Nix and rustup alike
 ├── .node-version           # Node.js version for CI / setup-node compatibility
 ├── vite.config.ts          # Vite+ workspace task graph

--- a/docs/content/ja/development-setup.md
+++ b/docs/content/ja/development-setup.md
@@ -94,7 +94,8 @@ vp run bench:bundle
 ```text
 ox-content/
 ├── Cargo.toml              # Workspace configuration
-├── flake.nix               # Nix dev shell (Node.js, workspace bootstrap, Rust, Vite+ wrapper)
+├── flake.nix               # Nix flake wiring (inputs, systems, module list)
+├── nix/                    # Nix modules: dev shell, vp wrapper, Blacksmith CLI
 ├── rust-toolchain.toml     # Rust channel, components, and targets for Nix and rustup alike
 ├── .node-version           # Node.js version for CI / setup-node compatibility
 ├── vite.config.ts          # Vite+ workspace task graph

--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,20 @@
 {
   "nodes": {
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "lastModified": 1787559586,
+        "narHash": "sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9d0d87172c374f89da73c1cfe6d81ae62feac1f1",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -34,9 +34,24 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1785031560,
+        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
@@ -58,21 +73,6 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -21,59 +21,14 @@
 
       imports = [
         ./nix/blacksmith.nix
+        ./nix/dev-shell.nix
         ./nix/pkgs.nix
         ./nix/vp.nix
       ];
 
       perSystem =
+        { pkgs, ... }:
         {
-          config,
-          lib,
-          pkgs,
-          rustToolchain,
-          ...
-        }:
-        let
-          nodejs = pkgs.nodejs_26;
-          pnpm = pkgs.pnpm;
-        in
-        {
-          devShells.default = pkgs.mkShell {
-            packages = [
-              nodejs
-              pnpm
-              config.packages.vp
-              config.packages.blacksmith
-              rustToolchain
-              pkgs.wasm-pack
-              pkgs.wasm-bindgen-cli
-              pkgs.binaryen
-              pkgs.cargo-watch
-              pkgs.cargo-llvm-cov
-              pkgs.git
-              pkgs.gh
-              pkgs.jq
-              pkgs.pkg-config
-              pkgs.rsync
-            ]
-            ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.libiconv ];
-
-            RUST_BACKTRACE = "1";
-            RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
-
-            shellHook = ''
-              export OX_CONTENT_WORKSPACE_ROOT="$PWD"
-              export PATH="$OX_CONTENT_WORKSPACE_ROOT/node_modules/.bin:$PATH"
-              export PLAYWRIGHT_BROWSERS_PATH="$OX_CONTENT_WORKSPACE_ROOT/.cache/ms-playwright"
-              export PUPPETEER_CACHE_DIR="$OX_CONTENT_WORKSPACE_ROOT/.cache/puppeteer"
-
-              echo "Ox Content dev shell ready."
-              echo "Run: vp install"
-              echo "Then: vp run ready"
-              echo "Testbox: blacksmith auth login && vp run testbox:warmup"
-            '';
-          };
-
           formatter = pkgs.nixfmt;
         };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,6 @@
       systems = [
         "aarch64-darwin"
         "aarch64-linux"
-        "x86_64-darwin"
         "x86_64-linux"
       ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
   };
 
   outputs =
-    inputs@{ flake-parts, rust-overlay, ... }:
+    inputs@{ flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [
         "aarch64-darwin"
@@ -19,17 +19,21 @@
         "x86_64-linux"
       ];
 
+      imports = [
+        ./nix/pkgs.nix
+      ];
+
       perSystem =
         {
           lib,
           pkgs,
+          rustToolchain,
           system,
           ...
         }:
         let
           nodejs = pkgs.nodejs_26;
           pnpm = pkgs.pnpm;
-          rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
           workspaceVp = pkgs.writeShellApplication {
             name = "vp";
             runtimeInputs = [
@@ -137,11 +141,6 @@
             };
         in
         {
-          _module.args.pkgs = import inputs.nixpkgs {
-            inherit system;
-            overlays = [ rust-overlay.overlays.default ];
-          };
-
           devShells.default = pkgs.mkShell {
             packages = [
               nodejs

--- a/flake.nix
+++ b/flake.nix
@@ -3,177 +3,182 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
+    flake-parts.url = "github:hercules-ci/flake-parts";
     rust-overlay.url = "github:oxalica/rust-overlay";
 
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =
-    {
-      nixpkgs,
-      flake-utils,
-      rust-overlay,
-      ...
-    }:
-    let
-      overlays = [ rust-overlay.overlays.default ];
-    in
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = import nixpkgs {
-          inherit system overlays;
-        };
+    inputs@{ flake-parts, rust-overlay, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
 
-        lib = pkgs.lib;
-        nodejs = pkgs.nodejs_26;
-        pnpm = pkgs.pnpm;
-        rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
-        workspaceVp = pkgs.writeShellApplication {
-          name = "vp";
-          runtimeInputs = [
-            nodejs
-            pnpm
-          ];
-          text = ''
-            workspace_root="''${OX_CONTENT_WORKSPACE_ROOT:-$PWD}"
+      perSystem =
+        {
+          lib,
+          pkgs,
+          system,
+          ...
+        }:
+        let
+          nodejs = pkgs.nodejs_26;
+          pnpm = pkgs.pnpm;
+          rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+          workspaceVp = pkgs.writeShellApplication {
+            name = "vp";
+            runtimeInputs = [
+              nodejs
+              pnpm
+            ];
+            text = ''
+              workspace_root="''${OX_CONTENT_WORKSPACE_ROOT:-$PWD}"
 
-            if [ -x "$workspace_root/node_modules/.bin/vp" ]; then
-              exec "$workspace_root/node_modules/.bin/vp" "$@"
-            fi
+              if [ -x "$workspace_root/node_modules/.bin/vp" ]; then
+                exec "$workspace_root/node_modules/.bin/vp" "$@"
+              fi
 
-            if [ "$#" -gt 0 ] && [ "$1" = "install" ]; then
-              echo "Bootstrapping workspace dependencies with pnpm install --frozen-lockfile..." >&2
-              exec pnpm --dir "$workspace_root" install --frozen-lockfile
-            fi
+              if [ "$#" -gt 0 ] && [ "$1" = "install" ]; then
+                echo "Bootstrapping workspace dependencies with pnpm install --frozen-lockfile..." >&2
+                exec pnpm --dir "$workspace_root" install --frozen-lockfile
+              fi
 
-            cat >&2 <<'EOF'
-            Local vite-plus is not installed yet.
+              cat >&2 <<'EOF'
+              Local vite-plus is not installed yet.
 
-            Run this inside the Nix shell:
-              vp install
+              Run this inside the Nix shell:
+                vp install
 
-            Or bootstrap manually:
-              pnpm install --frozen-lockfile
-            EOF
-            exit 127
-          '';
-        };
-
-        # Blacksmith CLI (testbox: warm a remote CI box and run `vp test` /
-        # `vp lint` / `vp build` against the local working tree). The vendor only
-        # publishes a moving "latest" channel — there are no versioned URLs — so
-        # these hashes must be refreshed when the CLI updates:
-        #   for p in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
-        #     curl -fsSL "https://clireleases.blacksmith.sh/cli/latest/$p/blacksmith.sha256"
-        #   done
-        blacksmith =
-          let
-            selector = {
-              x86_64-linux = {
-                os = "linux";
-                arch = "amd64";
-                sha256 = "38f1c7aef1a36c87e40b9b50bc573ecdbbb785de46b2825e95cb9abafa359bdd";
-              };
-              aarch64-linux = {
-                os = "linux";
-                arch = "arm64";
-                sha256 = "f8705a89bda30c40aed542319165f48cee47e96fbd5e54ff95e079528c3c872e";
-              };
-              x86_64-darwin = {
-                os = "darwin";
-                arch = "amd64";
-                sha256 = "6210b98c2b8b7903479456277753dd0959ed34f0226e9d5c40021c97a246f4e1";
-              };
-              aarch64-darwin = {
-                os = "darwin";
-                arch = "arm64";
-                sha256 = "a3367ab4151b12a4ea771515c314a0d48b62294c0b671325d42731f2be973f66";
-              };
-            };
-            target = selector.${system} or (throw "blacksmith CLI: unsupported system ${system}");
-          in
-          pkgs.stdenvNoCC.mkDerivation {
-            pname = "blacksmith-cli";
-            version = "latest";
-
-            src = pkgs.fetchurl {
-              url = "https://clireleases.blacksmith.sh/cli/latest/${target.os}/${target.arch}/blacksmith";
-              sha256 = target.sha256;
-            };
-
-            dontUnpack = true;
-
-            nativeBuildInputs = [
-              pkgs.makeWrapper
-            ]
-            ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.autoPatchelfHook ];
-
-            installPhase = ''
-              runHook preInstall
-              install -Dm755 "$src" "$out/bin/blacksmith"
-              runHook postInstall
+              Or bootstrap manually:
+                pnpm install --frozen-lockfile
+              EOF
+              exit 127
             '';
-
-            # The CLI shells out to rsync (testbox file sync, required) and to gh
-            # (status reporting, optional) — bundle both so it works regardless of
-            # the caller's PATH.
-            postFixup = ''
-              wrapProgram "$out/bin/blacksmith" \
-                --prefix PATH : ${
-                  lib.makeBinPath [
-                    pkgs.rsync
-                    pkgs.gh
-                  ]
-                }
-            '';
-
-            meta = {
-              description = "Blacksmith CLI (testbox + CI tooling)";
-              homepage = "https://docs.blacksmith.sh/blacksmith-testbox/overview";
-              platforms = builtins.attrNames selector;
-            };
           };
-      in
-      {
-        devShells.default = pkgs.mkShell {
-          packages = [
-            nodejs
-            pnpm
-            workspaceVp
-            blacksmith
-            rustToolchain
-            pkgs.wasm-pack
-            pkgs.wasm-bindgen-cli
-            pkgs.binaryen
-            pkgs.cargo-watch
-            pkgs.cargo-llvm-cov
-            pkgs.git
-            pkgs.gh
-            pkgs.jq
-            pkgs.pkg-config
-            pkgs.rsync
-          ]
-          ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.libiconv ];
 
-          RUST_BACKTRACE = "1";
-          RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+          # Blacksmith CLI (testbox: warm a remote CI box and run `vp test` /
+          # `vp lint` / `vp build` against the local working tree). The vendor only
+          # publishes a moving "latest" channel — there are no versioned URLs — so
+          # these hashes must be refreshed when the CLI updates:
+          #   for p in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+          #     curl -fsSL "https://clireleases.blacksmith.sh/cli/latest/$p/blacksmith.sha256"
+          #   done
+          blacksmith =
+            let
+              selector = {
+                x86_64-linux = {
+                  os = "linux";
+                  arch = "amd64";
+                  sha256 = "38f1c7aef1a36c87e40b9b50bc573ecdbbb785de46b2825e95cb9abafa359bdd";
+                };
+                aarch64-linux = {
+                  os = "linux";
+                  arch = "arm64";
+                  sha256 = "f8705a89bda30c40aed542319165f48cee47e96fbd5e54ff95e079528c3c872e";
+                };
+                x86_64-darwin = {
+                  os = "darwin";
+                  arch = "amd64";
+                  sha256 = "6210b98c2b8b7903479456277753dd0959ed34f0226e9d5c40021c97a246f4e1";
+                };
+                aarch64-darwin = {
+                  os = "darwin";
+                  arch = "arm64";
+                  sha256 = "a3367ab4151b12a4ea771515c314a0d48b62294c0b671325d42731f2be973f66";
+                };
+              };
+              target = selector.${system} or (throw "blacksmith CLI: unsupported system ${system}");
+            in
+            pkgs.stdenvNoCC.mkDerivation {
+              pname = "blacksmith-cli";
+              version = "latest";
 
-          shellHook = ''
-            export OX_CONTENT_WORKSPACE_ROOT="$PWD"
-            export PATH="$OX_CONTENT_WORKSPACE_ROOT/node_modules/.bin:$PATH"
-            export PLAYWRIGHT_BROWSERS_PATH="$OX_CONTENT_WORKSPACE_ROOT/.cache/ms-playwright"
-            export PUPPETEER_CACHE_DIR="$OX_CONTENT_WORKSPACE_ROOT/.cache/puppeteer"
+              src = pkgs.fetchurl {
+                url = "https://clireleases.blacksmith.sh/cli/latest/${target.os}/${target.arch}/blacksmith";
+                sha256 = target.sha256;
+              };
 
-            echo "Ox Content dev shell ready."
-            echo "Run: vp install"
-            echo "Then: vp run ready"
-            echo "Testbox: blacksmith auth login && vp run testbox:warmup"
-          '';
+              dontUnpack = true;
+
+              nativeBuildInputs = [
+                pkgs.makeWrapper
+              ]
+              ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.autoPatchelfHook ];
+
+              installPhase = ''
+                runHook preInstall
+                install -Dm755 "$src" "$out/bin/blacksmith"
+                runHook postInstall
+              '';
+
+              # The CLI shells out to rsync (testbox file sync, required) and to gh
+              # (status reporting, optional) — bundle both so it works regardless of
+              # the caller's PATH.
+              postFixup = ''
+                wrapProgram "$out/bin/blacksmith" \
+                  --prefix PATH : ${
+                    lib.makeBinPath [
+                      pkgs.rsync
+                      pkgs.gh
+                    ]
+                  }
+              '';
+
+              meta = {
+                description = "Blacksmith CLI (testbox + CI tooling)";
+                homepage = "https://docs.blacksmith.sh/blacksmith-testbox/overview";
+                platforms = builtins.attrNames selector;
+              };
+            };
+        in
+        {
+          _module.args.pkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [ rust-overlay.overlays.default ];
+          };
+
+          devShells.default = pkgs.mkShell {
+            packages = [
+              nodejs
+              pnpm
+              workspaceVp
+              blacksmith
+              rustToolchain
+              pkgs.wasm-pack
+              pkgs.wasm-bindgen-cli
+              pkgs.binaryen
+              pkgs.cargo-watch
+              pkgs.cargo-llvm-cov
+              pkgs.git
+              pkgs.gh
+              pkgs.jq
+              pkgs.pkg-config
+              pkgs.rsync
+            ]
+            ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.libiconv ];
+
+            RUST_BACKTRACE = "1";
+            RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+
+            shellHook = ''
+              export OX_CONTENT_WORKSPACE_ROOT="$PWD"
+              export PATH="$OX_CONTENT_WORKSPACE_ROOT/node_modules/.bin:$PATH"
+              export PLAYWRIGHT_BROWSERS_PATH="$OX_CONTENT_WORKSPACE_ROOT/.cache/ms-playwright"
+              export PUPPETEER_CACHE_DIR="$OX_CONTENT_WORKSPACE_ROOT/.cache/puppeteer"
+
+              echo "Ox Content dev shell ready."
+              echo "Run: vp install"
+              echo "Then: vp run ready"
+              echo "Testbox: blacksmith auth login && vp run testbox:warmup"
+            '';
+          };
+
+          formatter = pkgs.nixfmt;
         };
-
-        formatter = pkgs.nixfmt;
-      }
-    );
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,10 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
-    rust-overlay.url = "github:oxalica/rust-overlay";
-
-    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/flake.nix
+++ b/flake.nix
@@ -20,15 +20,16 @@
       ];
 
       imports = [
+        ./nix/blacksmith.nix
         ./nix/pkgs.nix
       ];
 
       perSystem =
         {
+          config,
           lib,
           pkgs,
           rustToolchain,
-          system,
           ...
         }:
         let
@@ -64,81 +65,6 @@
               exit 127
             '';
           };
-
-          # Blacksmith CLI (testbox: warm a remote CI box and run `vp test` /
-          # `vp lint` / `vp build` against the local working tree). The vendor only
-          # publishes a moving "latest" channel — there are no versioned URLs — so
-          # these hashes must be refreshed when the CLI updates:
-          #   for p in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
-          #     curl -fsSL "https://clireleases.blacksmith.sh/cli/latest/$p/blacksmith.sha256"
-          #   done
-          blacksmith =
-            let
-              selector = {
-                x86_64-linux = {
-                  os = "linux";
-                  arch = "amd64";
-                  sha256 = "38f1c7aef1a36c87e40b9b50bc573ecdbbb785de46b2825e95cb9abafa359bdd";
-                };
-                aarch64-linux = {
-                  os = "linux";
-                  arch = "arm64";
-                  sha256 = "f8705a89bda30c40aed542319165f48cee47e96fbd5e54ff95e079528c3c872e";
-                };
-                x86_64-darwin = {
-                  os = "darwin";
-                  arch = "amd64";
-                  sha256 = "6210b98c2b8b7903479456277753dd0959ed34f0226e9d5c40021c97a246f4e1";
-                };
-                aarch64-darwin = {
-                  os = "darwin";
-                  arch = "arm64";
-                  sha256 = "a3367ab4151b12a4ea771515c314a0d48b62294c0b671325d42731f2be973f66";
-                };
-              };
-              target = selector.${system} or (throw "blacksmith CLI: unsupported system ${system}");
-            in
-            pkgs.stdenvNoCC.mkDerivation {
-              pname = "blacksmith-cli";
-              version = "latest";
-
-              src = pkgs.fetchurl {
-                url = "https://clireleases.blacksmith.sh/cli/latest/${target.os}/${target.arch}/blacksmith";
-                sha256 = target.sha256;
-              };
-
-              dontUnpack = true;
-
-              nativeBuildInputs = [
-                pkgs.makeWrapper
-              ]
-              ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.autoPatchelfHook ];
-
-              installPhase = ''
-                runHook preInstall
-                install -Dm755 "$src" "$out/bin/blacksmith"
-                runHook postInstall
-              '';
-
-              # The CLI shells out to rsync (testbox file sync, required) and to gh
-              # (status reporting, optional) — bundle both so it works regardless of
-              # the caller's PATH.
-              postFixup = ''
-                wrapProgram "$out/bin/blacksmith" \
-                  --prefix PATH : ${
-                    lib.makeBinPath [
-                      pkgs.rsync
-                      pkgs.gh
-                    ]
-                  }
-              '';
-
-              meta = {
-                description = "Blacksmith CLI (testbox + CI tooling)";
-                homepage = "https://docs.blacksmith.sh/blacksmith-testbox/overview";
-                platforms = builtins.attrNames selector;
-              };
-            };
         in
         {
           devShells.default = pkgs.mkShell {
@@ -146,7 +72,7 @@
               nodejs
               pnpm
               workspaceVp
-              blacksmith
+              config.packages.blacksmith
               rustToolchain
               pkgs.wasm-pack
               pkgs.wasm-bindgen-cli

--- a/flake.nix
+++ b/flake.nix
@@ -12,11 +12,7 @@
   outputs =
     inputs@{ flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [
-        "aarch64-darwin"
-        "aarch64-linux"
-        "x86_64-linux"
-      ];
+      systems = import ./nix/systems.nix;
 
       imports = [
         ./nix/blacksmith.nix

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
       imports = [
         ./nix/blacksmith.nix
         ./nix/pkgs.nix
+        ./nix/vp.nix
       ];
 
       perSystem =
@@ -35,43 +36,13 @@
         let
           nodejs = pkgs.nodejs_26;
           pnpm = pkgs.pnpm;
-          workspaceVp = pkgs.writeShellApplication {
-            name = "vp";
-            runtimeInputs = [
-              nodejs
-              pnpm
-            ];
-            text = ''
-              workspace_root="''${OX_CONTENT_WORKSPACE_ROOT:-$PWD}"
-
-              if [ -x "$workspace_root/node_modules/.bin/vp" ]; then
-                exec "$workspace_root/node_modules/.bin/vp" "$@"
-              fi
-
-              if [ "$#" -gt 0 ] && [ "$1" = "install" ]; then
-                echo "Bootstrapping workspace dependencies with pnpm install --frozen-lockfile..." >&2
-                exec pnpm --dir "$workspace_root" install --frozen-lockfile
-              fi
-
-              cat >&2 <<'EOF'
-              Local vite-plus is not installed yet.
-
-              Run this inside the Nix shell:
-                vp install
-
-              Or bootstrap manually:
-                pnpm install --frozen-lockfile
-              EOF
-              exit 127
-            '';
-          };
         in
         {
           devShells.default = pkgs.mkShell {
             packages = [
               nodejs
               pnpm
-              workspaceVp
+              config.packages.vp
               config.packages.blacksmith
               rustToolchain
               pkgs.wasm-pack

--- a/nix/blacksmith.nix
+++ b/nix/blacksmith.nix
@@ -20,22 +20,22 @@
             x86_64-linux = {
               os = "linux";
               arch = "amd64";
-              sha256 = "38f1c7aef1a36c87e40b9b50bc573ecdbbb785de46b2825e95cb9abafa359bdd";
+              sha256 = "7f60f3b9f8d4d7644d9743f5d962acb3b3dbf675f51676702e5f292e02060bca";
             };
             aarch64-linux = {
               os = "linux";
               arch = "arm64";
-              sha256 = "f8705a89bda30c40aed542319165f48cee47e96fbd5e54ff95e079528c3c872e";
+              sha256 = "04c8d261526e23c7791f05b8acec8f02b9d1fe67c35a1adcf28076627327270a";
             };
             x86_64-darwin = {
               os = "darwin";
               arch = "amd64";
-              sha256 = "6210b98c2b8b7903479456277753dd0959ed34f0226e9d5c40021c97a246f4e1";
+              sha256 = "47281f402ff223f85e5165ea9018cd0281a727f19c69af8121ae4b09658ad313";
             };
             aarch64-darwin = {
               os = "darwin";
               arch = "arm64";
-              sha256 = "a3367ab4151b12a4ea771515c314a0d48b62294c0b671325d42731f2be973f66";
+              sha256 = "607b0f4413e426574527446c7718ea32587d57b24a3ea0749e1ab4138a426584";
             };
           };
           target = selector.${system} or (throw "blacksmith CLI: unsupported system ${system}");

--- a/nix/blacksmith.nix
+++ b/nix/blacksmith.nix
@@ -1,0 +1,85 @@
+{
+  perSystem =
+    {
+      lib,
+      pkgs,
+      system,
+      ...
+    }:
+    {
+      # Blacksmith CLI (testbox: warm a remote CI box and run `vp test` /
+      # `vp lint` / `vp build` against the local working tree). The vendor only
+      # publishes a moving "latest" channel — there are no versioned URLs — so
+      # these hashes must be refreshed when the CLI updates:
+      #   for p in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+      #     curl -fsSL "https://clireleases.blacksmith.sh/cli/latest/$p/blacksmith.sha256"
+      #   done
+      packages.blacksmith =
+        let
+          selector = {
+            x86_64-linux = {
+              os = "linux";
+              arch = "amd64";
+              sha256 = "38f1c7aef1a36c87e40b9b50bc573ecdbbb785de46b2825e95cb9abafa359bdd";
+            };
+            aarch64-linux = {
+              os = "linux";
+              arch = "arm64";
+              sha256 = "f8705a89bda30c40aed542319165f48cee47e96fbd5e54ff95e079528c3c872e";
+            };
+            x86_64-darwin = {
+              os = "darwin";
+              arch = "amd64";
+              sha256 = "6210b98c2b8b7903479456277753dd0959ed34f0226e9d5c40021c97a246f4e1";
+            };
+            aarch64-darwin = {
+              os = "darwin";
+              arch = "arm64";
+              sha256 = "a3367ab4151b12a4ea771515c314a0d48b62294c0b671325d42731f2be973f66";
+            };
+          };
+          target = selector.${system} or (throw "blacksmith CLI: unsupported system ${system}");
+        in
+        pkgs.stdenvNoCC.mkDerivation {
+          pname = "blacksmith-cli";
+          version = "latest";
+
+          src = pkgs.fetchurl {
+            url = "https://clireleases.blacksmith.sh/cli/latest/${target.os}/${target.arch}/blacksmith";
+            sha256 = target.sha256;
+          };
+
+          dontUnpack = true;
+
+          nativeBuildInputs = [
+            pkgs.makeWrapper
+          ]
+          ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.autoPatchelfHook ];
+
+          installPhase = ''
+            runHook preInstall
+            install -Dm755 "$src" "$out/bin/blacksmith"
+            runHook postInstall
+          '';
+
+          # The CLI shells out to rsync (testbox file sync, required) and to gh
+          # (status reporting, optional) — bundle both so it works regardless of
+          # the caller's PATH.
+          postFixup = ''
+            wrapProgram "$out/bin/blacksmith" \
+              --prefix PATH : ${
+                lib.makeBinPath [
+                  pkgs.rsync
+                  pkgs.gh
+                ]
+              }
+          '';
+
+          meta = {
+            description = "Blacksmith CLI (testbox + CI tooling)";
+            homepage = "https://docs.blacksmith.sh/blacksmith-testbox/overview";
+            platforms = builtins.attrNames selector;
+          };
+        };
+    };
+}

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -1,0 +1,51 @@
+{
+  perSystem =
+    {
+      config,
+      lib,
+      pkgs,
+      rustToolchain,
+      ...
+    }:
+    let
+      nodejs = pkgs.nodejs_26;
+      pnpm = pkgs.pnpm;
+    in
+    {
+      devShells.default = pkgs.mkShell {
+        packages = [
+          nodejs
+          pnpm
+          config.packages.vp
+          config.packages.blacksmith
+          rustToolchain
+          pkgs.wasm-pack
+          pkgs.wasm-bindgen-cli
+          pkgs.binaryen
+          pkgs.cargo-watch
+          pkgs.cargo-llvm-cov
+          pkgs.git
+          pkgs.gh
+          pkgs.jq
+          pkgs.pkg-config
+          pkgs.rsync
+        ]
+        ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.libiconv ];
+
+        RUST_BACKTRACE = "1";
+        RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+
+        shellHook = ''
+          export OX_CONTENT_WORKSPACE_ROOT="$PWD"
+          export PATH="$OX_CONTENT_WORKSPACE_ROOT/node_modules/.bin:$PATH"
+          export PLAYWRIGHT_BROWSERS_PATH="$OX_CONTENT_WORKSPACE_ROOT/.cache/ms-playwright"
+          export PUPPETEER_CACHE_DIR="$OX_CONTENT_WORKSPACE_ROOT/.cache/puppeteer"
+
+          echo "Ox Content dev shell ready."
+          echo "Run: vp install"
+          echo "Then: vp run ready"
+          echo "Testbox: blacksmith auth login && vp run testbox:warmup"
+        '';
+      };
+    };
+}

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,0 +1,23 @@
+{ inputs, ... }:
+let
+  root = ./..;
+in
+{
+  perSystem =
+    { system, ... }:
+    let
+      pkgs = import inputs.nixpkgs {
+        inherit system;
+        overlays = [ inputs.rust-overlay.overlays.default ];
+      };
+    in
+    {
+      # Every module that needs a package set needs the same overlaid one, and
+      # every module that needs a compiler needs the one rust-toolchain.toml
+      # names. Both are resolved once here and handed out as module arguments.
+      _module.args = {
+        inherit pkgs;
+        rustToolchain = pkgs.rust-bin.fromRustupToolchainFile (root + /rust-toolchain.toml);
+      };
+    };
+}

--- a/nix/systems.nix
+++ b/nix/systems.nix
@@ -1,0 +1,10 @@
+# The systems this repository supports, shared by the flake's `systems` and by
+# `meta.platforms` on the packages, so the two cannot disagree about what is
+# buildable.
+#
+# x86_64-darwin is absent: nixpkgs 26.11 dropped it.
+[
+  "aarch64-darwin"
+  "aarch64-linux"
+  "x86_64-linux"
+]

--- a/nix/vp.nix
+++ b/nix/vp.nix
@@ -1,0 +1,40 @@
+{
+  perSystem =
+    { pkgs, ... }:
+    let
+      nodejs = pkgs.nodejs_26;
+      pnpm = pkgs.pnpm;
+    in
+    {
+      packages.vp = pkgs.writeShellApplication {
+        name = "vp";
+        runtimeInputs = [
+          nodejs
+          pnpm
+        ];
+        text = ''
+          workspace_root="''${OX_CONTENT_WORKSPACE_ROOT:-$PWD}"
+
+          if [ -x "$workspace_root/node_modules/.bin/vp" ]; then
+            exec "$workspace_root/node_modules/.bin/vp" "$@"
+          fi
+
+          if [ "$#" -gt 0 ] && [ "$1" = "install" ]; then
+            echo "Bootstrapping workspace dependencies with pnpm install --frozen-lockfile..." >&2
+            exec pnpm --dir "$workspace_root" install --frozen-lockfile
+          fi
+
+          cat >&2 <<'EOF'
+          Local vite-plus is not installed yet.
+
+          Run this inside the Nix shell:
+            vp install
+
+          Or bootstrap manually:
+            pnpm install --frozen-lockfile
+          EOF
+          exit 127
+        '';
+      };
+    };
+}


### PR DESCRIPTION
Follows #1115.

## Summary

`flake.nix` had grown to 200 lines holding three unrelated things — a shell-script wrapper, a vendored CLI, and the dev shell — because `flake-utils.eachDefaultSystem` wraps every output in one closure and offers no seam to split along. This moves the flake to flake-parts and gives each concern a module, matching the layout used in `ryoppippi/ccusage`.

Building the extracted CLI for the first time turned up a real bug: `nix develop` could not be built at all. See below.

## What changed

```
flake.nix              inputs, systems, module list, formatter
nix/pkgs.nix           the overlaid package set and the rust-toolchain.toml compiler, as module args
nix/blacksmith.nix     packages.blacksmith
nix/vp.nix             packages.vp
nix/dev-shell.nix      devShells.default
```

`flake-utils` and its `systems` input leave the lock; `flake-parts` and `nixpkgs-lib` enter it. nixpkgs and rust-overlay keep the revisions #1115 set — this PR does not move them.

The systems `eachDefaultSystem` expanded to are now written out, and they are the same four. `blacksmith` and `vp` become buildable outputs rather than internal `let` bindings.

## The dev shell was broken

`blacksmith` is on the dev shell's PATH, and the vendor publishes its CLI only on a moving `latest` channel, so the four pinned hashes go stale whenever it ships — which it has. Evaluation succeeded, which is why nobody noticed, but the fixed-output fetch failed for anyone who actually entered the shell:

```
error: hash mismatch in fixed-output derivation
  got: sha256-YHsPRBPkJldFJ0RsdxjqMlh9V7JKPqB0nhq0E4pCZYQ=
```

Making it `packages.blacksmith` is what surfaced it — `nix build .#blacksmith` is now something you can run, and the first run failed. All four hashes are refreshed from the vendor's own `blacksmith.sha256` files, using the command the comment above the table already documented.

## Testing

Each refactor step was checked against the derivation hash, which stayed at `d4hqcd9x0gj7ma7ih15lcsgw9bs12f0w-nix-shell.drv` through the flake-parts swap and all four extractions — the migration changes no output.

With the hashes fixed, `nix develop` builds and runs for the first time:

```
rustc 1.98.0 (88d9e12ae 2026-08-18)
cargo 1.98.0 (797e8a9bc 2026-08-05)
rust-analyzer 1.98.0 (88d9e12a 2026-08-18)
v26.7.0            # node
10.27.0            # pnpm
vp, blacksmith     # both on PATH
wasm32-unknown-unknown present
```

rust-analyzer reporting the same `1.98.0` and the same commit hash as rustc is the component change from #1115 doing its job.

`nix build .#vp` and `nix build .#blacksmith` both succeed. `nix flake show` lists `devShells`, `formatter` and `packages` across all four systems.

## Next

`package.nix` + `default.nix` + `nix/packages.nix` with crane, so the six workspace binaries are buildable from Nix — the rest of the ccusage shape. It needs `Cargo.lock` committed first, which is currently `.gitignore`d, so it follows as a separate PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790429034&installation_model_id=422833&pr_number=1116&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1116&signature=758059fb6f91367a3cfbdcb17dc118ff1e2bf646d7c6db73d9add8b56b0cc020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Nix-based development environment for supported Linux and macOS systems.
  - Added the `vp` command wrapper, including automatic dependency installation when needed.
  - Added integrated Blacksmith CLI support and related development tooling.
  - Improved modularity and consistency of the development environment across supported systems.

- **Documentation**
  - Updated the English and Japanese setup guides with the revised Nix configuration and module structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## x86_64-darwin

Writing the systems out also made a second latent failure visible. Nixpkgs 26.11 — which the lock refreshed onto in #1115 — has dropped x86_64-darwin, so naming that system throws:

```
error: Nixpkgs 26.11 has dropped support for x86_64-darwin.
```

Evaluating one system at a time hides it, which is why it went unnoticed; `nix flake show` and `nix flake check` walk every system and fail outright. `eachDefaultSystem` produced the same four systems before this branch, so this is not a regression from the migration — it is just the first commit in a position to fix it. The system is dropped; Intel Macs would need nixpkgs 26.05, a different pin than the rest of the flake tracks.

`nix flake show` now completes across the three remaining systems.


`nix/systems.nix` holds that list, so the flake's `systems` and `meta.platforms` on the packages import the same file rather than being maintained as two copies.
