### PR TITLE
feat(nix): build the workspace binaries with crane

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,8 @@
+{
+  craneLib,
+  pkgs,
+  root ? ./.,
+}:
+pkgs.callPackage ./package.nix {
+  inherit craneLib root;
+}

--- a/docs/content/development-setup.md
+++ b/docs/content/development-setup.md
@@ -95,7 +95,8 @@ vp run bench:bundle
 ox-content/
 ├── Cargo.toml              # Workspace configuration
 ├── flake.nix               # Nix flake wiring (inputs, systems, module list)
-├── nix/                    # Nix modules: dev shell, vp wrapper, Blacksmith CLI
+├── nix/                    # Nix modules: dev shell, packages, vp wrapper, Blacksmith CLI
+├── package.nix             # Nix build of the workspace binaries, via crane
 ├── rust-toolchain.toml     # Rust channel, components, and targets for Nix and rustup alike
 ├── .node-version           # Node.js version for CI / setup-node compatibility
 ├── vite.config.ts          # Vite+ workspace task graph

--- a/docs/content/ja/development-setup.md
+++ b/docs/content/ja/development-setup.md
@@ -95,7 +95,8 @@ vp run bench:bundle
 ox-content/
 ├── Cargo.toml              # Workspace configuration
 ├── flake.nix               # Nix flake wiring (inputs, systems, module list)
-├── nix/                    # Nix modules: dev shell, vp wrapper, Blacksmith CLI
+├── nix/                    # Nix modules: dev shell, packages, vp wrapper, Blacksmith CLI
+├── package.nix             # Nix build of the workspace binaries, via crane
 ├── rust-toolchain.toml     # Rust channel, components, and targets for Nix and rustup alike
 ├── .node-version           # Node.js version for CI / setup-node compatibility
 ├── vite.config.ts          # Vite+ workspace task graph

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1787326676,
+        "narHash": "sha256-lWhBbBvC05/xwivKBBiM2YNizpmgqCgyOIzomvRuwxs=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "692f7e9ef2ece8125b466f66f2af532b3edaed0d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -51,6 +66,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
+    crane.url = "github:ipetkov/crane";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -18,6 +19,7 @@
       imports = [
         ./nix/blacksmith.nix
         ./nix/dev-shell.nix
+        ./nix/packages.nix
         ./nix/pkgs.nix
         ./nix/vp.nix
       ];

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,0 +1,32 @@
+{ inputs, ... }:
+let
+  root = ./..;
+in
+{
+  perSystem =
+    {
+      lib,
+      pkgs,
+      rustToolchain,
+      ...
+    }:
+    let
+      # crane builds with the toolchain rust-toolchain.toml names, not the one
+      # nixpkgs happens to carry, so the package and the dev shell compile with
+      # the same rustc.
+      craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+      ox-content = import (root + /default.nix) { inherit craneLib pkgs root; };
+    in
+    {
+      packages = {
+        inherit ox-content;
+        default = ox-content;
+      };
+
+      apps = lib.genAttrs ox-content.passthru.binaries (name: {
+        type = "app";
+        program = lib.getExe' ox-content name;
+      });
+    };
+}

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -24,7 +24,7 @@ in
         default = ox-content;
       };
 
-      apps = lib.genAttrs ox-content.passthru.binaries (name: {
+      apps = lib.genAttrs (lib.attrNames ox-content.passthru.binaries) (name: {
         type = "app";
         program = lib.getExe' ox-content name;
       });

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,108 @@
+{
+  craneLib,
+  lib,
+  libiconv,
+  pkg-config,
+  root ? ./.,
+  stdenv,
+}:
+let
+  inherit (lib.importTOML (root + /Cargo.toml)) workspace;
+  inherit (workspace.package) version homepage license;
+
+  # The crates that produce binaries. `ox_content_napi` and `ox_content_wasm`
+  # are deliberately absent: one links against the Node headers napi-build
+  # expects and the other only makes sense for the wasm32 target, so neither
+  # builds as a host binary and neither is what `nix run` should hand you.
+  binCrates = [
+    "ox_content_i18n_cli"
+    "ox_content_i18n_lsp"
+    "ox_content_link_checker"
+    "ox_content_lsp"
+    "ox_content_mdc_checker"
+    "ox_content_profile_cli"
+  ];
+
+  # `cleanCargoSource` keeps only what Cargo itself reads, but a lot of this
+  # workspace is embedded at compile time with `include_str!`: tree-sitter
+  # highlight queries, the i18n runtime, the SSG's stylesheets and scripts, the
+  # HTML entity table, the not-by-ai badges. Two crates reach outside `crates/`
+  # as well, for a lint dictionary that ships with the Vite plugin and for a
+  # benchmark corpus. Filtered out, they fail the build during macro expansion
+  # rather than at link time, which is why the error names a file and not a
+  # symbol.
+  #
+  # `.snap` is deliberately not in the list. Insta snapshots are read only by
+  # tests, which `doCheck = false` skips, and there are several hundred of them.
+  crateAssetSuffixes = [
+    ".css"
+    ".html"
+    ".js"
+    ".json"
+    ".md"
+    ".scm"
+    ".svg"
+    ".ts"
+    ".txt"
+  ];
+
+  externalAssets = [
+    "/benchmarks/bundle-size/content/api.md"
+    "/npm/vite-plugin-ox-content/src/lint-dictionaries.json"
+  ];
+
+  src = lib.cleanSourceWith {
+    name = "ox-content-source";
+    src = lib.cleanSource root;
+    filter =
+      path: type:
+      craneLib.filterCargoSources path type
+      || (lib.hasInfix "/crates/" path && lib.any (suffix: lib.hasSuffix suffix path) crateAssetSuffixes)
+      || lib.any (asset: lib.hasSuffix asset path) externalAssets;
+  };
+
+  commonArgs = {
+    pname = "ox-content";
+    inherit version src;
+    strictDeps = true;
+
+    # The workspace's tests are driven by the Vite+ task graph (`vp run
+    # test:rust`), which knows about the fixtures and the corpora this
+    # derivation does not carry.
+    doCheck = false;
+
+    cargoExtraArgs = lib.concatMapStringsSep " " (crate: "-p ${crate}") binCrates;
+
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
+  };
+
+  # Built once from a manifest-only source tree and reused by every later
+  # build, so editing a crate does not rebuild oxc and its dependents.
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+in
+craneLib.buildPackage (
+  commonArgs
+  // {
+    inherit cargoArtifacts;
+
+    passthru = {
+      inherit binCrates cargoArtifacts commonArgs;
+      binaries = [
+        "ox-content-i18n"
+        "ox-content-i18n-lsp"
+        "ox-content-link-check"
+        "ox-content-lsp"
+        "ox-content-mdc-check"
+        "ox-content-profile"
+      ];
+    };
+
+    meta = {
+      description = "Ox Content language servers and command-line tools";
+      inherit homepage;
+      license = lib.getLicenseFromSpdxId license;
+      mainProgram = "ox-content-lsp";
+    };
+  }
+)

--- a/package.nix
+++ b/package.nix
@@ -10,18 +10,29 @@ let
   inherit (lib.importTOML (root + /Cargo.toml)) workspace;
   inherit (workspace.package) version homepage license;
 
-  # The crates that produce binaries. `ox_content_napi` and `ox_content_wasm`
-  # are deliberately absent: one links against the Node headers napi-build
-  # expects and the other only makes sense for the wasm32 target, so neither
-  # builds as a host binary and neither is what `nix run` should hand you.
-  binCrates = [
-    "ox_content_i18n_cli"
-    "ox_content_i18n_lsp"
-    "ox_content_link_checker"
-    "ox_content_lsp"
-    "ox_content_mdc_checker"
-    "ox_content_profile_cli"
-  ];
+  # Installed binary -> the crate that produces it. `ox_content_napi` and
+  # `ox_content_wasm` are deliberately absent: one links against the Node
+  # headers napi-build expects and the other only makes sense for the wasm32
+  # target, so neither builds as a host binary and neither is what `nix run`
+  # should hand you.
+  #
+  # One mapping rather than two parallel lists, because the build selects
+  # crates and `meta` describes binaries, and the pairing between them is what
+  # would rot if they were kept apart.
+  binaries = {
+    "ox-content-i18n" = "ox_content_i18n_cli";
+    "ox-content-i18n-lsp" = "ox_content_i18n_lsp";
+    "ox-content-link-check" = "ox_content_link_checker";
+    "ox-content-lsp" = "ox_content_lsp";
+    "ox-content-mdc-check" = "ox_content_mdc_checker";
+    "ox-content-profile" = "ox_content_profile_cli";
+  };
+
+  mainProgram = "ox-content-lsp";
+
+  # Every binary crate states its own description; none of them are restated
+  # here.
+  describe = crate: (lib.importTOML (root + "/crates/${crate}/Cargo.toml")).package.description;
 
   # `cleanCargoSource` keeps only what Cargo itself reads, but a lot of this
   # workspace is embedded at compile time with `include_str!`: tree-sitter
@@ -71,7 +82,7 @@ let
     # derivation does not carry.
     doCheck = false;
 
-    cargoExtraArgs = lib.concatMapStringsSep " " (crate: "-p ${crate}") binCrates;
+    cargoExtraArgs = lib.concatMapStringsSep " " (crate: "-p ${crate}") (lib.attrValues binaries);
 
     nativeBuildInputs = [ pkg-config ];
     buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
@@ -87,22 +98,24 @@ craneLib.buildPackage (
     inherit cargoArtifacts;
 
     passthru = {
-      inherit binCrates cargoArtifacts commonArgs;
-      binaries = [
-        "ox-content-i18n"
-        "ox-content-i18n-lsp"
-        "ox-content-link-check"
-        "ox-content-lsp"
-        "ox-content-mdc-check"
-        "ox-content-profile"
-      ];
+      inherit binaries cargoArtifacts commonArgs;
     };
 
     meta = {
-      description = "Ox Content language servers and command-line tools";
-      inherit homepage;
+      # The derivation carries six binaries, so `description` follows the main
+      # program and the others are listed rather than summarised into a phrase
+      # that no manifest says.
+      description = describe binaries.${mainProgram};
+      longDescription = ''
+        Ox Content's language servers and command-line tools:
+
+        ${lib.concatStringsSep "\n" (
+          lib.mapAttrsToList (name: crate: "  ${name} - ${describe crate}") binaries
+        )}
+      '';
+      inherit homepage mainProgram;
       license = lib.getLicenseFromSpdxId license;
-      mainProgram = "ox-content-lsp";
+      platforms = import (root + /nix/systems.nix);
     };
   }
 )


### PR DESCRIPTION
Stacked on #1116.

## Summary

The flake produced a dev shell and two vendored tools, but nothing that builds this repository's own code — there was no way to get `ox-content-lsp` onto a machine from Nix. This adds `package.nix`, `default.nix` and `nix/packages.nix`, completing the ccusage-shaped layout started in #1116.

Six binaries in one derivation, each also exposed as an app:

```
ox-content-i18n  ox-content-i18n-lsp  ox-content-link-check
ox-content-lsp   ox-content-mdc-check ox-content-profile
```

## Why crane

- **It accepts an arbitrary toolchain.** `(crane.mkLib pkgs).overrideToolchain` takes the compiler `rust-toolchain.toml` names, so the package and the dev shell compile with the same rustc. `rustPlatform.buildRustPackage` would use whichever rustc nixpkgs carries, reopening exactly the split #1115 added the toolchain file to close.
- **It separates the dependency build from the source build.** The oxc crates, napi and tower-lsp are most of the compile time here; `buildDepsOnly` means editing a crate in this workspace does not rebuild them.

## The source filter

`cleanCargoSource` is not enough. A lot of this workspace is embedded at compile time and Cargo's own view of the source drops all of it, so `include_str!` fails during macro expansion:

```
error: couldn't read `crates/ox_content_parser/src/parser/inline/entities.txt`: No such file or directory
error: couldn't read `crates/ox_content_i18n/src/../templates/i18n-runtime.js`: No such file or directory
```

The filter adds them back — under `crates/`, 34 `.css`, 8 `.js`, 7 `.html`, 6 `.md`, 5 `.txt`, 5 `.scm`, 2 `.svg`, 1 `.ts`, 1 `.json` — plus two paths outside it, named explicitly: the lint dictionary shipped with `vite-plugin-ox-content` and the profile CLI's benchmark corpus. The 428 `.snap` files are deliberately left out; only the tests read them.

## Not built here

`ox_content_napi` links against the Node headers napi-build expects, and `ox_content_wasm` only makes sense for the wasm32 target. Neither builds as a host binary and neither is what `nix run` should hand you; the npm packages wrapping them are built by the Vite+ task graph. Tests are left to `vp run test:rust`, which knows about fixtures and corpora this derivation does not carry.

## meta

Nothing in `meta` is written in Nix that a manifest already states, following the shape used in `yusukebe/ax`:

- `description` — read from the crate behind `mainProgram` (`ox_content_lsp`).
- `longDescription` — the six binaries, each with the description its own crate states.
- `homepage`, `license` — from the workspace `Cargo.toml`; the SPDX id resolves through `lib.getLicenseFromSpdxId`.
- `platforms` — `nix/systems.nix`, the same list the flake instantiates for. Claiming a platform the flake does not build is how x86_64-darwin survived nixpkgs dropping it.

The binaries and crates were two parallel lists and are now one mapping: the build selects crates, `meta` describes binaries, and the pairing between them is the part that rots while both lists stay individually correct.

`versionCheckHook` is not wired up, unlike `ax`: none of these six accept `--version`.

## Testing

Verified against the lockfile committed in #1118, on `main` at v3.0.0-alpha.12. `nix build .#default` succeeds and produces all six binaries, which run:

```
$ ox-content-link-check --version
error: unexpected argument '--version' found
```

— the real clap parser, from the built binary.

`nix flake check` passes. `nix flake show` lists all six apps.

On Darwin the binaries link `libiconv` from the store alongside `/usr/lib/libSystem.B.dylib`. That is correct for something consumed through Nix; ccusage rewrites that install name only because it ships its binary through npm to machines without a Nix store, which is not the case here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790429806&installation_model_id=422833&pr_number=1117&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1117&signature=ac8f719062d8e20b1da438e90e791e13a953e283d5c61175474999cf1d4bf864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Nix-based packaging for the workspace and its command-line binaries.
  * Added runnable Nix apps for the packaged tools.
  * Ensured the development shell and packages use the project’s configured Rust toolchain.

* **Documentation**
  * Updated English and Japanese development setup guides with the new packaging files and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->