### PR TITLE
ci: raise package build fanout

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,6 +15,7 @@ env:
   CARGO_TERM_COLOR: always
   OX_CONTENT_BENCHMARK_RUNNER: blacksmith-32vcpu-ubuntu-2404
   OX_CONTENT_BENCHMARK_RUNS: "5"
+  OX_CONTENT_VP_PACKAGE_BUILD_CONCURRENCY: "12"
 
 jobs:
   benchmark:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  OX_CONTENT_VP_PACKAGE_BUILD_CONCURRENCY: "12"
 
 jobs:
   rustfmt:

--- a/benchmarks/bundle-size/run-pr-benchmark.test.ts
+++ b/benchmarks/bundle-size/run-pr-benchmark.test.ts
@@ -3,6 +3,10 @@ import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vite-plus/test";
+import {
+  packageBuildConcurrencyEnvName,
+  packageBuildConcurrencyFlag,
+} from "../../scripts/package-build-concurrency";
 
 const script = resolve(".github/scripts/run-pr-benchmark.mjs");
 
@@ -40,5 +44,21 @@ describe("run-pr-benchmark", () => {
       skipped: true,
       results: [],
     });
+  });
+
+  it("keeps package benchmark builds at the default fanout locally", () => {
+    expect(packageBuildConcurrencyFlag({})).toBe("");
+  });
+
+  it("lets CI raise package benchmark build fanout", () => {
+    expect(packageBuildConcurrencyFlag({ [packageBuildConcurrencyEnvName]: "12" })).toBe(
+      " --concurrency-limit 12",
+    );
+  });
+
+  it("rejects invalid package benchmark build fanout", () => {
+    expect(() => packageBuildConcurrencyFlag({ [packageBuildConcurrencyEnvName]: "0" })).toThrow(
+      `${packageBuildConcurrencyEnvName} must be a positive integer`,
+    );
   });
 });

--- a/scripts/package-build-concurrency.ts
+++ b/scripts/package-build-concurrency.ts
@@ -1,0 +1,15 @@
+export const packageBuildConcurrencyEnvName = "OX_CONTENT_VP_PACKAGE_BUILD_CONCURRENCY";
+
+export function packageBuildConcurrencyFlag(env: NodeJS.ProcessEnv = process.env): string {
+  const value = env[packageBuildConcurrencyEnvName];
+  if (!value) {
+    return "";
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || String(parsed) !== value) {
+    throw new Error(`${packageBuildConcurrencyEnvName} must be a positive integer`);
+  }
+
+  return ` --concurrency-limit ${value}`;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { defineConfig } from "vite-plus";
+import { packageBuildConcurrencyFlag } from "./scripts/package-build-concurrency";
 
 const lifecycleEnvName = "OX_CONTENT_VP_LIFECYCLE";
 
@@ -113,7 +114,7 @@ export default defineConfig({
       // `./npm/**` (not `./npm/*`): the theme presets live one level deeper at
       // npm/theme/* and npm/theme-color/*, and publish.yml packs them straight
       // from this task's output — a single-star filter would ship them dist-less.
-      "build:npm": task("vp run --filter './npm/**' build", {
+      "build:npm": task(`vp run${packageBuildConcurrencyFlag()} --filter './npm/**' build`, {
         dependsOn: ["build:napi"],
       }),
       "build:docs": task("vp run --filter ./docs build", {


### PR DESCRIPTION
## Summary
- make the `build:npm` task honor `OX_CONTENT_VP_PACKAGE_BUILD_CONCURRENCY` while keeping local/default fanout unchanged
- set CI and PR benchmark workflows to 12-way package build fanout on the 32-vCPU runner
- cover the new fanout flag validation in the benchmark script tests

## Context
- #1123 Build completed successfully but took 12m21s; its long step was the `vp run build` body, not setup/browser install
- package build fanout previously stayed at Vite+'s default 4 even on the 32-vCPU CI runner

## Verification
- `vp install --frozen-lockfile --prefer-offline`
- `vp test benchmarks/bundle-size/run-pr-benchmark.test.ts benchmarks/bundle-size/pr-benchmark-scope.test.ts`
- `vp run check:ts` (0 errors; existing warnings only)
- `vp run fmt`
- `vp run check:file-lines`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790442927&installation_model_id=422833&pr_number=1125&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1125&signature=7c5df6244da3dd7690a9c14464f42bf1d277522f5f1c51c8b05f296e80144675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->