### PR TITLE
ci: split build job phases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,8 +337,17 @@ jobs:
           vp exec --filter @ox-content/vite-plugin -- playwright install --with-deps chromium
           vp exec --filter @ox-content/vite-plugin -- puppeteer browsers install chrome-headless-shell
 
-      - name: Build
-        run: vp run build
+      - name: Build packages for docs
+        run: vp run build:npm
+
+      - name: Build documentation site
+        run: vp run --ignore-depends-on build:docs
+
+      - name: Build playground
+        run: vp run --ignore-depends-on build:playground
+
+      - name: Build Rust documentation
+        run: vp run --ignore-depends-on doc:cargo
 
       - name: Check generated documentation links
         run: >-


### PR DESCRIPTION
## Summary
- split the CI Build job into package, docs, playground, and cargo-doc phases
- keep the required check name stable while exposing the slow phase in Actions
- avoid rerunning task dependencies after the package build phase with vp's dependency skip flag

## Verification
- git diff --check
- vp run check:file-lines

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790444018&installation_model_id=422833&pr_number=1126&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1126&signature=28339d696a17e7d7d83f96464a419a938b4f183382667203f817323a88e5b4e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the build validation process by separately checking the documentation site, playground, package builds, and Rust documentation.
  * Build failures are now easier to identify by area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->