### PR TITLE
ci: skip rust docs for neutral PRs

### DIFF
--- a/.github/scripts/detect-pr-preview-scope.mjs
+++ b/.github/scripts/detect-pr-preview-scope.mjs
@@ -24,11 +24,12 @@ const TEST_ONLY_PATTERNS = [
 
 const PREVIEW_NEUTRAL_PATTERNS = [
   /^\.github\/(?:ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)\//,
-  /^\.github\/scripts\/(?:detect-pr-benchmark-scope|run-pr-benchmark|compare-pr-benchmark)\.mjs$/,
+  /^\.github\/scripts\/(?:detect-pr-benchmark-scope|detect-rust-doc-scope|run-pr-benchmark|compare-pr-benchmark)\.mjs$/,
   /^\.github\/workflows\/(?!nightly\.yml$|publish\.yml$)/,
   /^benchmarks\//,
   /^docs\//,
   /^examples\//,
+  /^scripts\/(?:pr-preview-scope|rust-doc-scope)\.test\.ts$/,
   /^README\.md$/,
   /^CHANGELOG\.md$/,
   /^CHENGELOG\.md$/,

--- a/.github/scripts/detect-rust-doc-scope.mjs
+++ b/.github/scripts/detect-rust-doc-scope.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const RUST_DOC_PATTERNS = [
+  /^\.github\/workflows\/ci\.yml$/,
+  /^\.github\/scripts\/detect-rust-doc-scope\.mjs$/,
+  /^\.cargo\//,
+  /^crates\//,
+  /^Cargo\.(?:toml|lock)$/,
+  /^rust-toolchain(?:\.toml)?$/,
+  /^vite\.config\.ts$/,
+];
+
+const RUST_DOC_NEUTRAL_PATTERNS = [
+  /^\.github\/(?:ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)\//,
+  /^\.github\/scripts\/(?!(?:detect-rust-doc-scope)\.mjs$)[^/]+\.mjs$/,
+  /^\.github\/workflows\/(?!ci\.yml$)/,
+  /^benchmarks\//,
+  /^binding-packages\//,
+  /^docs\//,
+  /^editors\//,
+  /^examples\//,
+  /^npm\//,
+  /^scripts\//,
+  /^package\.json$/,
+  /^pnpm-lock\.yaml$/,
+  /^README\.md$/,
+  /^CHANGELOG\.md$/,
+  /^CHENGELOG\.md$/,
+  /^LICENSE$/,
+  /^AGENTS\.md$/,
+  /^\.node-version$/,
+  /\.(?:md|mdx|png|jpe?g|gif|webp|svg|avif)$/i,
+];
+
+const inputPath = process.argv[2];
+
+if (!inputPath || process.argv.includes("--help") || process.argv.includes("-h")) {
+  printUsage();
+  process.exit(inputPath ? 0 : 2);
+}
+
+const files = readFileSync(inputPath, "utf8")
+  .split(/\r?\n/)
+  .map((file) => file.trim())
+  .filter(Boolean);
+
+const rustDocs = files.some((file) => classifyFile(file));
+
+console.error(
+  `Rust documentation scope: rust_docs=${formatBoolean(rustDocs)} (${files.length} changed file${
+    files.length === 1 ? "" : "s"
+  })`,
+);
+console.log(`rust_docs=${formatBoolean(rustDocs)}`);
+
+/**
+ * @param {string} file
+ * @returns {boolean}
+ */
+function classifyFile(file) {
+  if (matchesAny(file, RUST_DOC_PATTERNS)) {
+    return true;
+  }
+  if (matchesAny(file, RUST_DOC_NEUTRAL_PATTERNS)) {
+    return false;
+  }
+
+  // Unknown paths stay conservative. New Rust-facing surfaces can opt out
+  // after they are deliberately classified.
+  return true;
+}
+
+/**
+ * @param {string} file
+ * @param {readonly RegExp[]} patterns
+ * @returns {boolean}
+ */
+function matchesAny(file, patterns) {
+  return patterns.some((pattern) => pattern.test(file));
+}
+
+/**
+ * @param {boolean} value
+ * @returns {"true" | "false"}
+ */
+function formatBoolean(value) {
+  return value ? "true" : "false";
+}
+
+function printUsage() {
+  console.log(`Usage: node .github/scripts/detect-rust-doc-scope.mjs <changed-files.txt>
+
+Writes GitHub Actions outputs:
+  rust_docs=true|false`);
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,8 +346,30 @@ jobs:
       - name: Build playground
         run: vp run --ignore-depends-on build:playground
 
+      - name: Detect Rust documentation scope
+        id: rust-docs
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REPOSITORY: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags --depth=1 "https://github.com/$BASE_REPOSITORY.git" "$BASE_SHA"
+          git diff --name-only "$BASE_SHA" "$GITHUB_SHA" > "$RUNNER_TEMP/rust-doc-changed-files.txt"
+          node .github/scripts/detect-rust-doc-scope.mjs "$RUNNER_TEMP/rust-doc-changed-files.txt" >> "$GITHUB_OUTPUT"
+
+          echo "Changed files:"
+          sed 's/^/  /' "$RUNNER_TEMP/rust-doc-changed-files.txt"
+
       - name: Build Rust documentation
+        if: github.event_name != 'pull_request' || steps.rust-docs.outputs.rust_docs == 'true'
         run: vp run --ignore-depends-on doc:cargo
+
+      - name: Skip Rust documentation
+        if: github.event_name == 'pull_request' && steps.rust-docs.outputs.rust_docs != 'true'
+        run: echo "No Rust/Cargo documentation inputs changed."
 
       - name: Check generated documentation links
         run: >-

--- a/scripts/pr-preview-scope.test.ts
+++ b/scripts/pr-preview-scope.test.ts
@@ -55,6 +55,16 @@ describe("detect-pr-preview-scope", () => {
     expect(parseOutputs(result.stdout)).toEqual({ preview: "false" });
   });
 
+  it("skips rust documentation scope helper edits", () => {
+    const result = runScope([
+      ".github/scripts/detect-rust-doc-scope.mjs",
+      "scripts/rust-doc-scope.test.ts",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ preview: "false" });
+  });
+
   it("falls back to preview builds for unclassified paths", () => {
     const result = runScope(["tools/new-publish-surface/file.ts"]);
 

--- a/scripts/rust-doc-scope.test.ts
+++ b/scripts/rust-doc-scope.test.ts
@@ -1,0 +1,82 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+
+const script = resolve(".github/scripts/detect-rust-doc-scope.mjs");
+
+describe("detect-rust-doc-scope", () => {
+  it("skips documentation and preview-only edits", () => {
+    const result = runScope([
+      "docs/content/built-in/embeds.md",
+      "npm/theme/swiss/src/style.css",
+      "examples/playground/src/App.tsx",
+      ".github/scripts/detect-pr-preview-scope.mjs",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ rust_docs: "false" });
+  });
+
+  it("runs rust docs for workspace crate edits", () => {
+    const result = runScope(["crates/ox_content_renderer/src/html.rs"]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ rust_docs: "true" });
+  });
+
+  it("runs rust docs for cargo graph and task definition edits", () => {
+    const result = runScope(["Cargo.lock", "vite.config.ts"]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ rust_docs: "true" });
+  });
+
+  it("runs rust docs for the CI hook and scope detector", () => {
+    const result = runScope([
+      ".github/workflows/ci.yml",
+      ".github/scripts/detect-rust-doc-scope.mjs",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ rust_docs: "true" });
+  });
+
+  it("skips non-workspace editor cargo edits", () => {
+    const result = runScope(["editors/zed/Cargo.toml"]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ rust_docs: "false" });
+  });
+
+  it("falls back to rust docs for unclassified paths", () => {
+    const result = runScope(["tools/new-rust-surface/file.rs"]);
+
+    expect(result.status).toBe(0);
+    expect(parseOutputs(result.stdout)).toEqual({ rust_docs: "true" });
+  });
+});
+
+function runScope(files: string[]) {
+  const dir = mkdtempSync(join(tmpdir(), "ox-rust-doc-scope-"));
+  const changedFilesPath = join(dir, "changed-files.txt");
+  writeFileSync(changedFilesPath, `${files.join("\n")}\n`);
+
+  return spawnSync(process.execPath, [script, changedFilesPath], {
+    encoding: "utf8",
+  });
+}
+
+function parseOutputs(stdout: string) {
+  return Object.fromEntries(
+    stdout
+      .trim()
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => {
+        const index = line.indexOf("=");
+        return [line.slice(0, index), line.slice(index + 1)];
+      }),
+  );
+}


### PR DESCRIPTION
## Summary
- add a conservative Rust documentation scope detector for PR changed files
- skip the expensive cargo doc phase when PRs only touch docs, examples, npm UI, benchmarks, or other neutral files
- keep CI/self/detect changes conservative so the Rust docs path still validates when its wiring changes

## Verification
- vp test scripts/rust-doc-scope.test.ts
- vp run check:file-lines
- vp run check:ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790445094&installation_model_id=422833&pr_number=1127&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1127&signature=30494e089e06ca1b4232d6b860b574254f2b5db211853fedde2b491cb2b33310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic detection of changes affecting Rust documentation.
  - Rust documentation builds now run when relevant Rust, Cargo, or CI configuration files change.
  - Documentation-only or unrelated edits can skip unnecessary Rust documentation builds.
  - Unclassified changes conservatively trigger documentation validation.

- **Tests**
  - Added coverage for documentation-scope detection across Rust, Cargo, CI, editor, and unrelated file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->