### PR TITLE
feat(theme): expose token CSS rendering for bare and custom hosts

### DIFF
--- a/docs/content/built-in/component-styles.md
+++ b/docs/content/built-in/component-styles.md
@@ -96,6 +96,11 @@ crate CSS into the app.
 `renderMarkdown()` and `createMarkdownProcessor()` follow the same rule: they
 return markup, and you import the official sheets for the features you enabled.
 
+`core.css` carries the default `--octc-*` palette. A host that wants a
+`@ox-content/theme-color-*` scheme instead — or only its `--octc-syntax-*` code
+colors, without the page palette and layout — renders the tokens itself with
+`renderThemeTokenCss()`. See [Theming](../theming.md).
+
 For responsive Markdown tables in a custom host, import only
 `styles/markdown-tables.css` when you already own body typography, prose width,
 links, blockquotes, and table cell styling. Use `core.css` only when you want

--- a/docs/content/ja/built-in/component-styles.md
+++ b/docs/content/ja/built-in/component-styles.md
@@ -97,6 +97,12 @@ crate の CSS をアプリにコピーしないでください。
 `renderMarkdown()` と `createMarkdownProcessor()` も同じです。返すのは
 マークアップで、有効にした機能の公式シートは自分で import します。
 
+`core.css` は既定の `--octc-*` パレットを持っています。代わりに
+`@ox-content/theme-color-*` のスキームを使いたいホストや、ページのパレットと
+レイアウトは自前のまま `--octc-syntax-*` のコードカラーだけ欲しいホストは、
+`renderThemeTokenCss()` でトークンを自分で描画します。
+[テーマ](../theming.md)を参照してください。
+
 独自ホストのレスポンシブな Markdown table では、body typography、prose 幅、
 リンク、blockquote、table cell style を host 側で持っているなら
 `styles/markdown-tables.css` だけを import してください。`core.css` は

--- a/docs/content/ja/theming.md
+++ b/docs/content/ja/theming.md
@@ -230,6 +230,37 @@ defineTheme({
 
 `darkColors` も `colors` と同じキー単位のフォールバックです。省略したキーは既定のダークパレットを継承します。
 
+## bare / 独自ホストでのテーマトークン
+
+`ssg.bare: true` と独自ホストは自分で document を組み立てるので、Ox Content はテーマのスタイルシートを出しません。`renderThemeTokenCss()` は組み込み SSG が書くはずだった `--octc-*` 宣言をそのまま返します。Vite プラグインも SSG も、ネイティブバインディングもファイルシステム API も引き込まないサブパスから import できます。
+
+```ts
+import { renderThemeTokenCss } from "@ox-content/vite-plugin/theme-tokens";
+import { kanagawa } from "@ox-content/theme-color-kanagawa";
+
+const css = renderThemeTokenCss(kanagawa);
+```
+
+組み込みハイライタは `var(--octc-syntax-*)` を参照するので、ページのパレット・タイポグラフィ・レイアウトは自前のまま、配色のコードカラーだけ borrow したいホストはトークン名で絞り込めます。名前は `--octc-` プレフィックスなしで渡ってきます。
+
+```ts
+const syntaxOnly = renderThemeTokenCss(kanagawa, {
+  include: (name) => name.startsWith("syntax-"),
+});
+```
+
+出力は上の「ダークモード」で説明した 3 つのセレクタ（`:root`、`[data-theme="dark"]`、明示的なライト選択が勝つ `prefers-color-scheme` フォールバック）を使います。組み込み SSG が呼ぶのと同じレンダラだからです。
+
+レイヤの合成は `resolveTheme()` と同じです。配列を渡せばスキンとカラースキームを重ねられ、各レイヤの `extends` チェーンはベースから順に平坦化されます。
+
+```ts
+import { pixel } from "@ox-content/theme-pixel";
+
+const css = renderThemeTokenCss([pixel, kanagawa]);
+```
+
+トークン名は小文字のケバブケースです。空や不正な名前は壊れたカスタムプロパティを出す代わりに throw し、値が空のトークンはスキップされます。プラグイン本体を既に import しているなら、この関数は低レベルの `tokensToCss(light, dark)` と並んでパッケージルートからも export されています。
+
 ## エントリページのモード
 
 既定テーマはランディングページのモードを 2 つ持っています。

--- a/docs/content/theming.md
+++ b/docs/content/theming.md
@@ -263,6 +263,51 @@ defineTheme({
 `darkColors` follows the same key-by-key fallback as `colors`: any key you leave
 out inherits the default dark palette.
 
+## Theme Tokens in a Bare or Custom Host
+
+`ssg.bare: true` and custom hosts render their own document, so Ox Content emits
+no theme stylesheet for them. `renderThemeTokenCss()` returns the same `--octc-*`
+declarations the built-in SSG would have written, from a subpath that pulls in
+neither the Vite plugin, the SSG, the native binding, nor a filesystem API:
+
+```ts
+import { renderThemeTokenCss } from "@ox-content/vite-plugin/theme-tokens";
+import { kanagawa } from "@ox-content/theme-color-kanagawa";
+
+const css = renderThemeTokenCss(kanagawa);
+```
+
+The built-in highlighter emits `var(--octc-syntax-*)` references, so a host that
+wants a scheme's code colors while keeping its own page palette, typography, and
+layout can select tokens by name. Names arrive without the `--octc-` prefix:
+
+```ts
+const syntaxOnly = renderThemeTokenCss(kanagawa, {
+  include: (name) => name.startsWith("syntax-"),
+});
+```
+
+The output uses the three selectors described under Dark Mode above — `:root`,
+`[data-theme="dark"]`, and the `prefers-color-scheme` fallback that an explicit
+light choice still overrides — because this is the renderer the built-in SSG
+itself calls.
+
+Layers compose exactly as `resolveTheme()` composes them: pass an array to stack
+a skin and a color scheme, and each layer's `extends` chain is flattened
+base-first.
+
+```ts
+import { pixel } from "@ox-content/theme-pixel";
+
+const css = renderThemeTokenCss([pixel, kanagawa]);
+```
+
+Token names are lowercase kebab-case. An empty or malformed name throws instead
+of emitting a broken custom property, and a token with an empty value is
+skipped. The function is also re-exported from the package root, next to the
+lower-level `tokensToCss(light, dark)`, when you are already importing the
+plugin.
+
 ## Entry Page Modes
 
 The default theme supports two landing page modes:

--- a/npm/vite-plugin-ox-content/package.json
+++ b/npm/vite-plugin-ox-content/package.json
@@ -48,6 +48,16 @@
         "default": "./dist/markdown-tables.cjs"
       }
     },
+    "./theme-tokens": {
+      "import": {
+        "types": "./dist/theme-tokens.d.mts",
+        "default": "./dist/theme-tokens.mjs"
+      },
+      "require": {
+        "types": "./dist/theme-tokens.d.cts",
+        "default": "./dist/theme-tokens.cjs"
+      }
+    },
     "./vitepress-migrate": {
       "import": "./dist/vitepress-cli.mjs",
       "types": "./dist/vitepress-cli.d.mts"
@@ -82,7 +92,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "vp pack && node scripts/build-standalone-markdown-tables.mjs && node scripts/copy-component-styles.mjs",
+    "build": "vp pack && node scripts/build-standalone-entries.mjs && node scripts/copy-component-styles.mjs",
     "build:styles": "node scripts/copy-component-styles.mjs",
     "dev": "vp pack --watch",
     "typecheck": "tsgo --noEmit",

--- a/npm/vite-plugin-ox-content/scripts/build-standalone-entries.mjs
+++ b/npm/vite-plugin-ox-content/scripts/build-standalone-entries.mjs
@@ -5,7 +5,6 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const packageRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
-const sourceFile = join(packageRoot, "src/markdown-tables.ts");
 const distDir = join(packageRoot, "dist");
 const tscBin = join(
   packageRoot,
@@ -13,21 +12,33 @@ const tscBin = join(
   process.platform === "win32" ? "tsc.cmd" : "tsc",
 );
 
-const forbiddenRuntimeImports =
-  /(?:\brequire\s*\(|\bfrom\s+["']|node:|@ox-content\/napi|@resvg|playwright|puppeteer|fsevents)/;
+/**
+ * Entries a browser, bare, or custom host imports without the plugin, the SSG,
+ * or Node. `vp pack` routes them through a shared runtime chunk that pulls in
+ * `node:fs`, so they are recompiled here as self-contained modules instead.
+ */
+const STANDALONE_ENTRIES = ["markdown-tables", "theme-tokens"];
+
+const forbiddenIdentifiers = /(?:node:|@ox-content\/napi|@resvg|playwright|puppeteer|fsevents)/;
+// Anchored to the start of a line so a documentation example inside a JSDoc
+// block is not mistaken for a real import statement.
+const forbiddenStatements = /^\s*(?:import\s|export\s[^\n]*\sfrom\s|[^\n]*\brequire\s*\()/m;
 
 await mkdir(distDir, { recursive: true });
-const tempRoot = await mkdtemp(join(tmpdir(), "ox-markdown-tables-"));
+const tempRoot = await mkdtemp(join(tmpdir(), "ox-standalone-entries-"));
 
 try {
-  await compileStandalone("ES2022", "esm", "mjs");
-  await compileStandalone("CommonJS", "cjs", "cjs");
+  for (const entry of STANDALONE_ENTRIES) {
+    await compileStandalone(entry, "ES2022", "esm", "mjs");
+    await compileStandalone(entry, "CommonJS", "cjs", "cjs");
+  }
 } finally {
   await rm(tempRoot, { recursive: true, force: true });
 }
 
-async function compileStandalone(module, directoryName, extension) {
-  const outDir = join(tempRoot, directoryName);
+async function compileStandalone(entry, module, directoryName, extension) {
+  const sourceFile = join(packageRoot, `src/${entry}.ts`);
+  const outDir = join(tempRoot, entry, directoryName);
   await runTsc([
     sourceFile,
     "--ignoreConfig",
@@ -49,18 +60,18 @@ async function compileStandalone(module, directoryName, extension) {
     "false",
   ]);
 
-  const jsFile = `markdown-tables.${extension}`;
+  const jsFile = `${entry}.${extension}`;
   const mapFile = `${jsFile}.map`;
-  const compiledJs = join(outDir, "markdown-tables.js");
-  const compiledMap = join(outDir, "markdown-tables.js.map");
+  const compiledJs = join(outDir, `${entry}.js`);
+  const compiledMap = join(outDir, `${entry}.js.map`);
   const outputJs = join(distDir, jsFile);
   const outputMap = join(distDir, mapFile);
 
   const js = (await readFile(compiledJs, "utf8")).replace(
-    "sourceMappingURL=markdown-tables.js.map",
+    `sourceMappingURL=${entry}.js.map`,
     `sourceMappingURL=${mapFile}`,
   );
-  if (forbiddenRuntimeImports.test(js)) {
+  if (forbiddenIdentifiers.test(js) || forbiddenStatements.test(js)) {
     throw new Error(`Refusing to publish ${jsFile}: server/runtime import found`);
   }
 

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -944,6 +944,8 @@ export {
   stripMarkdownExtension,
 } from "./markdown";
 export { defineTheme, defaultTheme, mergeThemes, resolveTheme } from "./theme";
+export { renderThemeTokenCss, tokensToCss } from "./theme-tokens";
+export type { RenderThemeTokenCssOptions, ThemeTokenSource } from "./theme-tokens";
 export {
   fromVitePressConfig,
   generateVitePressMigrationConfig,

--- a/npm/vite-plugin-ox-content/src/public-exports.test.ts
+++ b/npm/vite-plugin-ox-content/src/public-exports.test.ts
@@ -36,6 +36,8 @@ describe("public export surface", () => {
       "renderHtmlToReactCreateElement",
       "renderHtmlToVueH",
       "renderMarkdownStream",
+      "renderThemeTokenCss",
+      "tokensToCss",
       "resolveBudouxOptions",
       "resolveDocsOptions",
       "resolveI18nOptions",

--- a/npm/vite-plugin-ox-content/src/theme-tokens-packaging.test.ts
+++ b/npm/vite-plugin-ox-content/src/theme-tokens-packaging.test.ts
@@ -1,0 +1,83 @@
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vite-plus/test";
+import packageJson from "../package.json" with { type: "json" };
+
+const require = createRequire(import.meta.url);
+const packageRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+
+const SERVER_GRAPH = /node:|@ox-content\/napi|@resvg|playwright|puppeteer|fsevents|satori|cspell/;
+// Anchored to the start of a line so the JSDoc usage example is not mistaken
+// for a real import statement.
+const IMPORT_STATEMENT = /^\s*(?:import\s|export\s[^\n]*\sfrom\s|[^\n]*\brequire\s*\()/m;
+
+describe("theme token entry packaging", () => {
+  it("declares a build-tool-neutral package subpath", () => {
+    const exported = (packageJson.exports as Record<string, PackageConditionalExport>)[
+      "./theme-tokens"
+    ];
+    expect(exported).toBeDefined();
+    expect(exported.import.types).toBe("./dist/theme-tokens.d.mts");
+    expect(exported.import.default).toBe("./dist/theme-tokens.mjs");
+    expect(exported.require.types).toBe("./dist/theme-tokens.d.cts");
+    expect(exported.require.default).toBe("./dist/theme-tokens.cjs");
+
+    const entries: string[] = require("../vite.config.ts").default.pack.entry;
+    expect(entries).toContain("src/theme-tokens.ts");
+  });
+
+  it("keeps the source entry free of every import", () => {
+    const source = readFileSync(join(packageRoot, "src/theme-tokens.ts"), "utf8");
+
+    // A bare host imports this subpath without the Vite plugin, the SSG, the
+    // native binding, or a filesystem API — so the module has no imports at
+    // all, not merely no server-side ones. `ThemeConfig` is matched
+    // structurally by `ThemeTokenSource` instead of being imported.
+    expect(source).not.toMatch(IMPORT_STATEMENT);
+    expect(source).not.toMatch(SERVER_GRAPH);
+  });
+
+  it("compiles the subpath standalone instead of through the shared runtime chunk", () => {
+    // `vp pack` gives the CommonJS entry a shared runtime chunk that requires
+    // `node:fs`, which is exactly what a bare host must not load.
+    const script = readFileSync(join(packageRoot, "scripts/build-standalone-entries.mjs"), "utf8");
+
+    expect(script).toContain('const STANDALONE_ENTRIES = ["markdown-tables", "theme-tokens"];');
+    expect(packageJson.scripts.build).toContain("node scripts/build-standalone-entries.mjs");
+  });
+
+  it("guards the built subpath against server graph imports", () => {
+    const distFiles = ["dist/theme-tokens.mjs", "dist/theme-tokens.cjs", "dist/theme-tokens.d.cts"];
+    for (const distFile of distFiles) {
+      const absolutePath = join(packageRoot, distFile);
+      if (!existsSync(absolutePath)) {
+        continue;
+      }
+      const source = readFileSync(absolutePath, "utf8");
+      expect(source, distFile).not.toMatch(SERVER_GRAPH);
+      expect(source, distFile).not.toMatch(IMPORT_STATEMENT);
+    }
+  });
+
+  it("routes the built-in SSG through the same renderer the subpath publishes", () => {
+    const theme = readFileSync(join(packageRoot, "src/theme.ts"), "utf8");
+
+    // One implementation, so the `:root` / `[data-theme="dark"]` /
+    // `prefers-color-scheme` contract cannot drift between the two.
+    expect(theme).toContain('from "./theme-tokens"');
+    expect(theme).toContain("renderThemeTokenCss(theme)");
+  });
+});
+
+interface PackageConditionalExport {
+  import: {
+    types: string;
+    default: string;
+  };
+  require: {
+    types: string;
+    default: string;
+  };
+}

--- a/npm/vite-plugin-ox-content/src/theme-tokens.test.ts
+++ b/npm/vite-plugin-ox-content/src/theme-tokens.test.ts
@@ -1,0 +1,187 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { describe, expect, it } from "vite-plus/test";
+import { renderThemeTokenCss, tokensToCss, type ThemeTokenSource } from "./theme-tokens";
+import { resolveTheme, themeToNapi } from "./theme";
+
+const packageRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+
+describe("renderThemeTokenCss", () => {
+  it("emits the three selectors the SSG runtime switches between", () => {
+    const css = renderThemeTokenCss({
+      tokens: { "syntax-foreground": "#545464" },
+      darkTokens: { "syntax-foreground": "#dcd7ba" },
+    });
+
+    expect(css).toContain(":root {\n  --octc-syntax-foreground: #545464;\n}");
+    expect(css).toContain('[data-theme="dark"] {\n  --octc-syntax-foreground: #dcd7ba;\n}');
+    expect(css).toContain("@media (prefers-color-scheme: dark) {");
+    // Explicit light has to beat the operating-system dark preference, which is
+    // what the `:not()` in the media block encodes.
+    expect(css).toContain(':root:not([data-theme="light"]) {');
+    expect(css).not.toContain(":root:not([data-theme='dark'])");
+  });
+
+  it("omits the dark blocks when a theme has no dark tokens", () => {
+    const css = renderThemeTokenCss({ tokens: { "syntax-foreground": "#545464" } });
+
+    expect(css).toBe(":root {\n  --octc-syntax-foreground: #545464;\n}");
+    expect(css).not.toContain("prefers-color-scheme");
+  });
+
+  it("returns nothing for a theme that declares no tokens", () => {
+    expect(renderThemeTokenCss({})).toBe("");
+    expect(renderThemeTokenCss([])).toBe("");
+  });
+
+  it("keeps only the tokens the include predicate accepts", () => {
+    const css = renderThemeTokenCss(
+      {
+        tokens: { "syntax-token-keyword": "#b35b79", "surface-glass": "#e7dba0" },
+        darkTokens: { "syntax-token-keyword": "#957fb8", "surface-glass": "#2a2a37" },
+      },
+      { include: (name) => name.startsWith("syntax-") },
+    );
+
+    expect(css).toContain("--octc-syntax-token-keyword: #b35b79;");
+    expect(css).toContain("--octc-syntax-token-keyword: #957fb8;");
+    expect(css).not.toContain("surface-glass");
+  });
+
+  it("drops an excluded token together with the override a later layer would apply", () => {
+    const css = renderThemeTokenCss(
+      [{ tokens: { "surface-glass": "#base" } }, { tokens: { "surface-glass": "#override" } }],
+      { include: (name) => name !== "surface-glass" },
+    );
+
+    expect(css).toBe("");
+  });
+
+  it("composes layers left to right and flattens each extends chain base-first", () => {
+    const base: ThemeTokenSource = {
+      tokens: { "syntax-foreground": "#base", "syntax-background": "#base-bg" },
+    };
+    const skin: ThemeTokenSource = { extends: base, tokens: { "syntax-foreground": "#skin" } };
+    const scheme: ThemeTokenSource = { tokens: { "syntax-background": "#scheme-bg" } };
+
+    const css = renderThemeTokenCss([skin, scheme]);
+
+    expect(css).toContain("--octc-syntax-foreground: #skin;");
+    expect(css).toContain("--octc-syntax-background: #scheme-bg;");
+    expect(css).not.toContain("#base-bg");
+  });
+
+  it("does not hang on a theme whose extends chain forms a cycle", () => {
+    const a: ThemeTokenSource = { tokens: { "syntax-foreground": "#a" } };
+    const b: ThemeTokenSource = { extends: a, tokens: { "syntax-background": "#b" } };
+    a.extends = b;
+
+    expect(renderThemeTokenCss(b)).toContain("--octc-syntax-foreground: #a;");
+  });
+
+  it("skips tokens with an empty value instead of emitting a malformed declaration", () => {
+    const css = renderThemeTokenCss({
+      tokens: { "syntax-foreground": "", "syntax-background": "#e7dba0" },
+    });
+
+    expect(css).toBe(":root {\n  --octc-syntax-background: #e7dba0;\n}");
+  });
+
+  it("rejects token names that would break out of the declaration block", () => {
+    for (const name of ["", " ", "Syntax-Foreground", "syntax foreground", "syntax:bar", "a}b"]) {
+      expect(() => renderThemeTokenCss({ tokens: { [name]: "#000" } }), name).toThrow(
+        /Invalid theme token name/,
+      );
+    }
+  });
+
+  it("validates dark token names too", () => {
+    expect(() => renderThemeTokenCss({ darkTokens: { "--octc-nested": "#000" } })).toThrow(
+      /Invalid theme token name/,
+    );
+  });
+
+  it("renders the same declarations the built-in SSG emits for the same theme", () => {
+    const theme = {
+      name: "shared",
+      tokens: { "syntax-foreground": "#545464" },
+      darkTokens: { "syntax-foreground": "#dcd7ba" },
+    };
+
+    const ssgCss = themeToNapi(resolveTheme(theme)).css ?? "";
+
+    expect(ssgCss).toContain(renderThemeTokenCss(resolveTheme(theme)));
+  });
+
+  it("re-exports the renderer the theme layer builds on", () => {
+    expect(tokensToCss({ "syntax-foreground": "#545464" }, {})).toBe(
+      renderThemeTokenCss({ tokens: { "syntax-foreground": "#545464" } }),
+    );
+  });
+});
+
+describe("bare host consuming @ox-content/theme-color-kanagawa", () => {
+  // Loaded through a runtime URL rather than a static import: the theme package
+  // is a sibling workspace package, so importing its source by name would need
+  // its `dist/`, and importing it by path would pull a file outside this
+  // package's `rootDir` into the TypeScript program. The point of the fixture
+  // is that a published `ThemeConfig` flows through the public API unchanged.
+  async function loadKanagawa(): Promise<ThemeTokenSource> {
+    const source = join(packageRoot, "../theme-color/kanagawa/src/index.ts");
+    const module = (await import(pathToFileURL(source).href)) as {
+      kanagawa: ThemeTokenSource;
+    };
+    return module.kanagawa;
+  }
+
+  it("renders the official syntax palette without page colors or layout", async () => {
+    const kanagawa = await loadKanagawa();
+
+    const css = renderThemeTokenCss(kanagawa, {
+      include: (name) => name.startsWith("syntax-"),
+    });
+
+    expect(css).toContain("--octc-syntax-token-keyword: #b35b79;");
+    expect(css).toContain("--octc-syntax-token-keyword: #957fb8;");
+    expect(css).toContain("--octc-syntax-background: #e7dba0;");
+    expect(css).toContain("--octc-syntax-background: #16161d;");
+
+    // Nothing from the page palette, code-block chrome, or brand accents.
+    expect(css).not.toMatch(/--octc-(?!syntax-)/);
+    expect(css).not.toContain("surface-glass");
+    expect(css).not.toContain("color-code-line");
+  });
+
+  it("covers explicit light, explicit dark, and the operating-system fallback", async () => {
+    const kanagawa = await loadKanagawa();
+
+    const css = renderThemeTokenCss(kanagawa, {
+      include: (name) => name === "syntax-foreground",
+    });
+
+    expect(css).toBe(
+      [
+        ":root {",
+        "  --octc-syntax-foreground: #545464;",
+        "}",
+        '[data-theme="dark"] {',
+        "  --octc-syntax-foreground: #dcd7ba;",
+        "}",
+        "@media (prefers-color-scheme: dark) {",
+        '  :root:not([data-theme="light"]) {',
+        "    --octc-syntax-foreground: #dcd7ba;",
+        "  }",
+        "}",
+      ].join("\n"),
+    );
+  });
+
+  it("renders every token when no filter is passed", async () => {
+    const kanagawa = await loadKanagawa();
+
+    const css = renderThemeTokenCss(kanagawa);
+
+    expect(css).toContain("--octc-surface-glass:");
+    expect(css).toContain("--octc-syntax-token-keyword:");
+  });
+});

--- a/npm/vite-plugin-ox-content/src/theme-tokens.ts
+++ b/npm/vite-plugin-ox-content/src/theme-tokens.ts
@@ -14,6 +14,69 @@ const TOKEN_PREFIX = "--octc-";
 const TOKEN_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
 
 /**
+ * The token-bearing shape of a theme.
+ *
+ * Declared structurally instead of importing `ThemeConfig` so this module keeps
+ * an empty import graph: `@ox-content/vite-plugin/theme-tokens` has to be
+ * loadable by a bare (`ssg.bare: true`) or custom host that never pulls in the
+ * Vite plugin, the SSG, the native binding, or a filesystem API. Every
+ * `ThemeConfig` — including the published `@ox-content/theme-color-*` and
+ * `@ox-content/theme-*` packages — satisfies it.
+ */
+export interface ThemeTokenSource {
+  tokens?: ThemeTokens;
+  darkTokens?: ThemeTokens;
+  extends?: ThemeTokenSource;
+}
+
+/**
+ * Options for {@link renderThemeTokenCss}.
+ */
+export interface RenderThemeTokenCssOptions {
+  /**
+   * Keeps only the tokens whose name passes the predicate. Names arrive without
+   * the `--octc-` prefix, so `(name) => name.startsWith("syntax-")` reuses a
+   * color scheme's highlighter palette without adopting its page colors,
+   * typography, or layout policy.
+   *
+   * Filtering runs per layer, before merging, so a token a later layer would
+   * have overridden is dropped along with the override.
+   */
+  include?: (name: string) => boolean;
+}
+
+/**
+ * Renders a theme's `--octc-*` tokens as a standalone stylesheet.
+ *
+ * The built-in SSG emits these declarations itself, but `ssg.bare: true` and
+ * custom hosts render their own document — this is how they get the same
+ * tokens. The built-in highlighter emits `var(--octc-syntax-*)` references, so
+ * a bare host that wants only the highlighter palette can ask for it:
+ *
+ * ```ts
+ * import { renderThemeTokenCss } from "@ox-content/vite-plugin/theme-tokens";
+ * import { kanagawa } from "@ox-content/theme-color-kanagawa";
+ *
+ * const css = renderThemeTokenCss(kanagawa, {
+ *   include: (name) => name.startsWith("syntax-"),
+ * });
+ * ```
+ *
+ * Layers compose left to right and each layer's `extends` chain is flattened
+ * base-first, matching how `resolveTheme()` stacks a skin and a color scheme.
+ */
+export function renderThemeTokenCss(
+  theme: ThemeTokenSource | ThemeTokenSource[],
+  options: RenderThemeTokenCssOptions = {},
+): string {
+  const layers = (Array.isArray(theme) ? theme : [theme]).flatMap(expandExtendsChain);
+  return tokensToCss(
+    mergeTokens(layers, "tokens", options.include),
+    mergeTokens(layers, "darkTokens", options.include),
+  );
+}
+
+/**
  * Renders light and dark token records as the three selectors the SSG runtime
  * switches between: an explicit `[data-theme="dark"]` opt-in, the OS
  * `prefers-color-scheme` fallback, and the `:root` base.
@@ -57,4 +120,41 @@ function assertTokenName(name: string): string {
     );
   }
   return name;
+}
+
+function mergeTokens(
+  layers: ThemeTokenSource[],
+  field: "tokens" | "darkTokens",
+  include?: (name: string) => boolean,
+): ThemeTokens {
+  const merged: ThemeTokens = {};
+
+  for (const layer of layers) {
+    for (const [name, value] of Object.entries(layer[field] ?? {})) {
+      if (!include || include(name)) {
+        merged[name] = value;
+      }
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Flattens one layer's `extends` chain into base-first order, mirroring the
+ * SSG's own resolution. The `seen` guard keeps a theme that extends itself (or
+ * forms a cycle across two packages) from hanging the caller.
+ */
+function expandExtendsChain(theme: ThemeTokenSource): ThemeTokenSource[] {
+  const chain: ThemeTokenSource[] = [];
+  const seen = new Set<ThemeTokenSource>();
+  let current: ThemeTokenSource | undefined = theme;
+
+  while (current && !seen.has(current)) {
+    seen.add(current);
+    chain.unshift(current);
+    current = current.extends;
+  }
+
+  return chain;
 }

--- a/npm/vite-plugin-ox-content/src/theme.ts
+++ b/npm/vite-plugin-ox-content/src/theme.ts
@@ -17,13 +17,13 @@ import {
   withSelfHostedFontHead,
   type ThemeFontValue,
 } from "./theme-fonts";
-import { tokensToCss, type ThemeTokens } from "./theme-tokens";
+import { renderThemeTokenCss, type ThemeTokens } from "./theme-tokens";
 import { withSelfHostedIconHead } from "./icons";
 
 export type { HeaderNavItem, LocaleLabel, ThemeAnnouncement } from "./header-chrome";
 
 export type { ThemeFontValue, ThemeWebFont } from "./theme-fonts";
-export type { ThemeTokens } from "./theme-tokens";
+export type { ThemeTokens, ThemeTokenSource } from "./theme-tokens";
 
 /**
  * Theme color configuration.
@@ -633,7 +633,7 @@ export function themeToNapi(
  * land after the typed color variables the Rust renderer emits.
  */
 function themeCss(theme: ResolvedThemeConfig): string {
-  const tokenCss = tokensToCss(theme.tokens, theme.darkTokens);
+  const tokenCss = renderThemeTokenCss(theme);
   const namedCss = namedFontVarsCss(theme.fonts);
   const prefix = [tokenCss, namedCss].filter(Boolean).join("\n");
   if (!prefix) {

--- a/npm/vite-plugin-ox-content/vite.config.ts
+++ b/npm/vite-plugin-ox-content/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       "src/vitepress-cli.ts",
       "src/incremental-dom.ts",
       "src/markdown-tables.ts",
+      "src/theme-tokens.ts",
       // `jsxImportSource: "@ox-content/vite-plugin"` makes the JSX transform
       // emit imports of ./jsx-runtime and ./jsx-dev-runtime, so both need to
       // be real modules in dist/, not just symbols on the main entry.


### PR DESCRIPTION
Closes #1129

## Problem

`tokensToCss(light, dark)` lived in `src/theme-tokens.ts` but was never published, so the repro in the issue held:

```ts
import("@ox-content/vite-plugin").then((module) => "tokensToCss" in module);
// false
```

`ssg.bare: true` emits no theme stylesheet by design, and the built-in highlighter emits `var(--octc-syntax-*)` references — so a bare or custom host had no public way to render an official `ThemeConfig`'s token declarations, and [ryoppippi/ryoppippi.com#2112](https://github.com/ryoppippi/ryoppippi.com/pull/2112) had to maintain an adapter that recreated the explicit and system dark-mode selectors by hand.

## API

```ts
import { renderThemeTokenCss } from "@ox-content/vite-plugin/theme-tokens";
import { kanagawa } from "@ox-content/theme-color-kanagawa";

// Every token.
const css = renderThemeTokenCss(kanagawa);

// Or just the highlighter palette, without the page colors and layout.
const syntaxOnly = renderThemeTokenCss(kanagawa, {
  include: (name) => name.startsWith("syntax-"),
});

// Layers compose like resolveTheme(); each layer's `extends` chain flattens base-first.
const stacked = renderThemeTokenCss([pixel, kanagawa]);
```

Names reach `include` without the `--octc-` prefix. Filtering runs per layer before merging, so an excluded token is dropped along with the override a later layer would have applied. `tokensToCss(light, dark)` is published alongside it, and both are re-exported from the package root for hosts already importing the plugin — the issue's `"tokensToCss" in module` check now returns `true`.

## Keeping the subpath loadable by a bare host

`src/theme-tokens.ts` has **no imports at all**: `ThemeConfig` is matched structurally by a local `ThemeTokenSource` rather than imported from `./theme`.

That alone was not enough. `vp pack` gives the CommonJS entry a shared runtime chunk, so the first build produced:

```js
// dist/theme-tokens.cjs
require("./vitepress.cjs");   // → node:fs, node:crypto, node:module, node:path
```

`theme-tokens` therefore joins `markdown-tables` in the standalone `tsc` build. That script is generalized over a list of entries (renamed `build-standalone-markdown-tables.mjs` → `build-standalone-entries.mjs`), and its import guard is now anchored to statement positions so a JSDoc usage example is not mistaken for a real import. Verified on the built output: both `.mjs` and `.cjs` are self-contained, and the `.d.mts` / `.d.cts` reference nothing external.

## No drift with the built-in SSG

`themeCss()` in `theme.ts` now calls `renderThemeTokenCss()` rather than `tokensToCss()` directly, so the `:root` / `[data-theme="dark"]` / `prefers-color-scheme` contract has exactly one implementation. A test asserts the SSG's emitted theme CSS contains what the public API produces for the same theme.

## Verification

`vp run test:ts-unit` — 993 passed (20 new). New coverage:

- All three selectors, including that an explicit light choice still overrides the OS dark preference.
- Syntax-only filtering against the real `@ox-content/theme-color-kanagawa` definition, asserting no `--octc-` token outside `syntax-` survives.
- Exact expected output for the light / dark / OS-fallback triple.
- Layer composition, `extends` flattening, and a cycle guard.
- Empty and malformed token names throw instead of emitting a broken custom property; empty values are skipped.
- Packaging: the export map, the pack entry, the import-free source, the standalone build wiring, and the built dist files.

The kanagawa fixture loads the theme through a runtime URL rather than a static import — it is a sibling workspace package, so importing it by name would need its `dist/`, and by path would pull a file outside this package's `rootDir` into the TypeScript program. A comment in the test explains this.

## Docs

New "Theme Tokens in a Bare or Custom Host" section in `theming.md` (EN and JA), plus a pointer from the custom-hosts section of `component-styles.md` (EN and JA).

## Note

Token *names* are validated; token *values* are still emitted verbatim, as they were before this change. That is fine for build-time config authored by the site owner, but worth knowing now that the renderer is public API — say the word if you want value validation as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790485790&installation_model_id=422833&pr_number=1131&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1131&signature=2db35c541dbf3a4cf6f237ba2cba788f10f9593e040f8ab84d885c731d7424be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public API for rendering theme-token CSS in bare or custom hosts.
  * Supports filtering tokens, layered themes, light/dark modes, and system color-scheme fallbacks.
  * Added a dedicated package export for theme-token utilities, available for import or require.
  * Built-in theming now uses the shared theme-token renderer.

* **Documentation**
  * Added English and Japanese guidance for custom host theme-token rendering and configuration.

* **Tests**
  * Added coverage for rendering behavior, filtering, theme inheritance, validation, compatibility, and package distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->