### PR TITLE
ci: assign the maintainer on new issues and pull requests

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,55 @@
+name: Triage
+
+on:
+  issues:
+    types: [opened]
+  # `pull_request_target` so a pull request opened from a fork still runs with a
+  # write-scoped token. This workflow never checks out, builds, or runs anything
+  # from the pull request, which is what keeps that trigger safe here.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    types: [opened, ready_for_review]
+
+permissions: {}
+
+env:
+  MAINTAINER: ubugeeei
+
+jobs:
+  assign:
+    name: Assign the maintainer
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      # Issues and pull requests share the `issues` endpoint for assignment, so
+      # one call covers both event types. Re-assigning is a no-op, and a pull
+      # request that was opened as a draft is already assigned by then.
+      - name: Add assignee
+        if: github.event.action != 'ready_for_review'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          jq -n --arg login "$MAINTAINER" '{assignees: [$login]}' |
+            gh api "repos/$GH_REPO/issues/$NUMBER/assignees" --method POST --input - --silent
+
+      # CODEOWNERS already requests the maintainer's review, but only for the
+      # paths it lists. This covers the rest. GitHub rejects a review request
+      # naming the pull request's own author, so those are skipped rather than
+      # failed; the assignment above is what surfaces those pull requests.
+      - name: Request review
+        if: github.event_name == 'pull_request_target' && !github.event.pull_request.draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          if [ "$AUTHOR" = "$MAINTAINER" ]; then
+            echo "Pull request #$NUMBER was opened by $MAINTAINER; a review cannot be requested from the author."
+            exit 0
+          fi
+          jq -n --arg login "$MAINTAINER" '{reviewers: [$login]}' |
+            gh api "repos/$GH_REPO/pulls/$NUMBER/requested_reviewers" --method POST --input - --silent

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,7 @@ node scripts/check-panic-constructs.mjs
 - Use conventional commit messages such as `feat: add parser option`, `fix: preserve heading ids`, or `docs: clarify Vite setup`.
 - Keep pull requests scoped to one purpose and describe the user-visible behavior, implementation notes, and verification performed.
 - Link related issues when there are any.
+- New issues and pull requests are assigned to @ubugeeei automatically, and pull requests opened by anyone else also get a review request. The assignee marks who triages, not who is blocked.
 - Include screenshots or rendered output for UI, documentation, or visual regression changes when that helps review.
 - Do not mix unrelated formatting or cleanup with feature and bug-fix changes.
 


### PR DESCRIPTION
Requested: a bot that assigns @ubugeeei and requests their review when an issue or pull request is opened.

## What it does

A `Triage` workflow that, on `issues: opened` and `pull_request_target: opened`:

- assigns `@ubugeeei` (issues and pull requests share the `issues` assignees endpoint, so one call covers both)
- requests `@ubugeeei`'s review on pull requests opened by anyone else

## What was already covered, and what wasn't

`.github/CODEOWNERS` has `* @ubugeeei`, so review requests already happen for the paths it lists — but nothing assigns. Checked against recent history:

| PR | assignees | review requests | author |
| --- | --- | --- | --- |
| #1127 | — | — | ubugeeei |
| #1126 | — | — | ubugeeei |
| #1123 | — | kazupon | ubugeeei |

So assignment is the real gap.

## One limitation worth knowing

**GitHub cannot request a review from a pull request's own author.** #1123 shows it: `kazupon` was requested via CODEOWNERS, `ubugeeei` was not, because they opened it. Since most pull requests here are opened by @ubugeeei, the review-request half applies mainly to outside contributions; the assignment half applies to everything.

The workflow skips that case with a log line instead of failing the run.

## Verification

Both API calls were run against #1130 before shipping:

- assignment returned `["ubugeeei"]` and is idempotent on an already-assigned pull request
- the review request returned `Review cannot be requested from pull request author. (HTTP 422)` — GitHub's semantic check, not a malformed body, confirming the request shape is right

## Security notes

- `pull_request_target` so a fork's pull request still gets a write-scoped token. The workflow never checks out, builds, or runs anything from the pull request — the reason that trigger is safe here. Annotated with `zizmor: ignore[dangerous-triggers]` plus a comment explaining why.
- `permissions: {}` at the top level, with `issues: write` / `pull-requests: write` scoped to the one job.
- Every context value is passed through `env:` rather than interpolated into `run:`.

Because `pull_request_target` workflows run from the base branch, this one will not run on its own pull request — the first real exercise is the next issue or pull request opened after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New issues and pull requests are automatically assigned for triage.
  * Ready-for-review pull requests can trigger an automatic review request.

* **Documentation**
  * Added contribution guidance explaining the automated triage and review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->