### PR TITLE
ci: cut the Rust documentation build from ~12 minutes to ~15 seconds

### DIFF
--- a/scripts/cargo-doc.mjs
+++ b/scripts/cargo-doc.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+/**
+ * Builds the Rust API documentation.
+ *
+ * `target/doc` is discarded first. CI keeps `target/` on a Blacksmith sticky
+ * disk, so the previous run's documentation is still there, and rustdoc then
+ * re-merges its shared cross-crate index against everything already on disk.
+ * That merge is single-threaded and memory-hungry: measured on the real CI
+ * disk, `cargo doc --workspace --no-deps` took 9m09s at 102% CPU with a 10.7 GB
+ * peak RSS against an accumulated 252 MB / 34-crate `target/doc`, and 15s on the
+ * same disk with it removed. Compilation artifacts elsewhere in `target/` still
+ * come from the cache, so the warm-build win is kept.
+ */
+
+import { spawnSync } from "node:child_process";
+import { rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+for (const stale of ["doc", "doc.parts"]) {
+  rmSync(join(repoRoot, "target", stale), { recursive: true, force: true });
+}
+
+const result = spawnSync("cargo", ["doc", "--workspace", "--no-deps", ...process.argv.slice(2)], {
+  cwd: repoRoot,
+  stdio: "inherit",
+});
+
+if (result.error) {
+  throw result.error;
+}
+process.exit(result.status ?? 1);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -241,10 +241,13 @@ export default defineConfig({
         dependsOn: ["build:npm"],
       }),
 
-      "doc:cargo": task("cargo doc --workspace --no-deps", {
+      // Wrapped rather than bare `cargo doc`: the script drops the previous
+      // run's `target/doc` first, which is what keeps rustdoc's shared index
+      // merge from re-reading a sticky disk's worth of stale documentation.
+      "doc:cargo": task("node scripts/cargo-doc.mjs", {
         dependsOn: ["build:napi"],
       }),
-      "doc:cargo-open": uncachedTask("cargo doc --workspace --no-deps --open"),
+      "doc:cargo-open": uncachedTask("node scripts/cargo-doc.mjs --open"),
       clean: uncachedTask("cargo clean"),
       "napi-prepublish": uncachedTask("napi prepublish", {
         cwd: "crates/ox_content_napi",


### PR DESCRIPTION
## Where the time actually was

`Build` is the critical path of every CI run. Across three recent `main` runs it took 699s / 822s / 870s, while no other job exceeded 150s except the Windows NAPI smoke test (~280s).

Stepping into it, one step was 710s of the 870s:

| Step | Time |
| --- | --- |
| **Build Rust documentation** | **710s** |
| Build packages for docs | 68s |
| Build documentation site | 29s |
| Install browsers | 20s |
| everything else | < 15s each |

Meanwhile `cargo build --workspace` in the same job finished in 14.68s, so dependencies were fully cached.

## Diagnosis

`cargo doc --workspace --no-deps` takes **17s locally** and **709s in CI**. I measured rather than guessed, with a temporary experiment workflow:

| Setup | `cargo doc` |
| --- | --- |
| Local machine | 17s |
| Fresh sticky disk, cargo only | 14s |
| Fresh sticky disk, after `build:npm` | 10s |
| Fresh sticky disk, full `Build` job replica | 10s |
| **Real long-lived `ci-build` sticky disk** | **560s** |
| Real disk, after `rm -rf target/doc` | **15s** |

So it was not the machine, not `vp run`, and not the preceding build steps — a faithful replica of the whole `Build` job documented in 10s. It was that one long-lived disk.

And it was not disk performance either. On that disk:

- 10% full (55G of 590G), inodes 1% used
- writing 2000 small files took **0.02s** — same as local `/tmp`
- but `cargo doc` ran at **102% CPU for 9 minutes** with a **10.7 GB peak RSS**

Single-threaded, memory-hungry, I/O-idle. That is rustdoc's shared cross-crate index merge, running against the previous run's `target/doc`: **252 MB, 5019 files, 34 crate directories**, preserved by the sticky disk.

## Fix

Discard `target/doc` before documenting, via `scripts/cargo-doc.mjs` wired into the `doc:cargo` task. Compilation artifacts elsewhere in `target/` are untouched, so warm builds stay warm.

Verified on the same disk and commit: **560s → 15s**.

`deploy.yml` runs `vp run build`, so it picks this up through the same task — that step was 6m29s there.

A Node wrapper rather than `rm -rf && cargo doc` so it works on Windows, and so the reasoning lives next to the code.

## Duplicate runs

`Nightly release` had **no concurrency group**. On `fix/table-scrollable-focus-selector` I pushed three times:

| Workflow | Runs | Cancelled |
| --- | --- | --- |
| CI | 3 | 2 |
| Benchmark | 3 | 1 |
| **Nightly release** | **3** | **0** |

Each of those runs seven cross-platform NAPI release builds, so two full sets were built for commits nobody was waiting on. Added a concurrency group matching CI's (`cancel-in-progress` only for pull requests, so `main` previews still all publish). Same for the zizmor workflow.

`Nightly release`'s `preview-scope` gate is working correctly — I confirmed it skipped the NAPI matrix entirely on a workflow-only pull request.

## Expected result

`Build` should drop from ~870s to ~175s, making it comparable to the Windows NAPI smoke test rather than 3× everything else.

## Not included

`ci.yml`'s `Build` job and `deploy.yml`'s `build` job do the same work on every push to `main` (`build:npm` + `build:docs` + `build:playground` + `doc:cargo`), and `void-deploy.yml` builds the docs a third time. They run concurrently, so `ci.yml` is not gating the deploy — the overlap is pure duplication. Collapsing it means deciding which workflow owns the `main` gate, so I left it alone rather than changing that semantics unasked. Happy to follow up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790488448&installation_model_id=422833&pr_number=1133&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1133&signature=c0cdd1e1764334cda0d7ecb146a84edfd613b195c8cd48b42ae339accbd72550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->