### PR TITLE
fix(embeds): repair card presentation defects

### DIFF
--- a/crates/ox_content_ssg/src/html/reader_chrome.rs
+++ b/crates/ox_content_ssg/src/html/reader_chrome.rs
@@ -149,11 +149,51 @@ fn rewrite_anchor(html: &str) -> Option<(String, usize)> {
             }
             markup.push('>');
             markup.push_str(inner);
-            markup.push_str(EXTERNAL_ICON);
+            if !wraps_block_content(inner) {
+                markup.push_str(EXTERNAL_ICON);
+            }
             markup.push_str("</a>");
             Some((markup, tag_end + 1 + inner.len() + close_len))
         }
     }
+}
+
+/// Block-level tags an inline text link never contains.
+///
+/// Embed cards wrap their whole body in one anchor, so the marker would land
+/// as a stray last child: a full-width row under a `display: grid` provider
+/// card, and a lone glyph after the footer of a repository or link-preview
+/// card. Anchors around an avatar plus a name stay inline and keep theirs.
+const BLOCK_CONTENT_TAGS: [&str; 14] = [
+    "address",
+    "article",
+    "blockquote",
+    "div",
+    "footer",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "header",
+    "section",
+    "table",
+];
+
+fn wraps_block_content(inner: &str) -> bool {
+    let mut rest = inner;
+    while let Some(offset) = rest.find('<') {
+        let tag = &rest[offset..];
+        let name = tag_name(tag);
+        if !name.is_empty()
+            && BLOCK_CONTENT_TAGS.iter().any(|block| name.eq_ignore_ascii_case(block))
+        {
+            return true;
+        }
+        rest = &tag[1..];
+    }
+    false
 }
 
 fn split_anchor_inner(html: &str, tag_end: usize) -> Option<(&str, usize)> {

--- a/crates/ox_content_ssg/src/html/reader_chrome.rs
+++ b/crates/ox_content_ssg/src/html/reader_chrome.rs
@@ -46,7 +46,6 @@ const COPY_BUTTON: &str = concat!(
     "<span class=\"ox-copy-status\" data-ox-copy-status role=\"status\" ",
     "aria-live=\"polite\"></span>"
 );
-const EXTERNAL_ICON: &str = "<span class=\"ox-external-icon\" aria-hidden=\"true\"></span>";
 
 /// Rewrites article HTML. Fenced code is never treated as a link target.
 pub(super) fn apply_reader_chrome(html: &str, chrome: ReaderChrome) -> String {
@@ -149,51 +148,11 @@ fn rewrite_anchor(html: &str) -> Option<(String, usize)> {
             }
             markup.push('>');
             markup.push_str(inner);
-            if !wraps_block_content(inner) {
-                markup.push_str(EXTERNAL_ICON);
-            }
+            markup.push_str(external_marker::external_marker(inner));
             markup.push_str("</a>");
             Some((markup, tag_end + 1 + inner.len() + close_len))
         }
     }
-}
-
-/// Block-level tags an inline text link never contains.
-///
-/// Embed cards wrap their whole body in one anchor, so the marker would land
-/// as a stray last child: a full-width row under a `display: grid` provider
-/// card, and a lone glyph after the footer of a repository or link-preview
-/// card. Anchors around an avatar plus a name stay inline and keep theirs.
-const BLOCK_CONTENT_TAGS: [&str; 14] = [
-    "address",
-    "article",
-    "blockquote",
-    "div",
-    "footer",
-    "h1",
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6",
-    "header",
-    "section",
-    "table",
-];
-
-fn wraps_block_content(inner: &str) -> bool {
-    let mut rest = inner;
-    while let Some(offset) = rest.find('<') {
-        let tag = &rest[offset..];
-        let name = tag_name(tag);
-        if !name.is_empty()
-            && BLOCK_CONTENT_TAGS.iter().any(|block| name.eq_ignore_ascii_case(block))
-        {
-            return true;
-        }
-        rest = &tag[1..];
-    }
-    false
 }
 
 fn split_anchor_inner(html: &str, tag_end: usize) -> Option<(&str, usize)> {
@@ -386,5 +345,6 @@ fn decode_one_entity(ent: &str) -> Option<(char, usize)> {
     None
 }
 
+mod external_marker;
 #[cfg(test)]
 mod tests;

--- a/crates/ox_content_ssg/src/html/reader_chrome/external_marker.rs
+++ b/crates/ox_content_ssg/src/html/reader_chrome/external_marker.rs
@@ -1,0 +1,48 @@
+//! The outbound-link marker, and which anchors should carry one.
+
+use super::tag_name;
+
+const EXTERNAL_ICON: &str = "<span class=\"ox-external-icon\" aria-hidden=\"true\"></span>";
+
+/// The marker for an anchor, or nothing when the anchor wraps a whole card.
+pub(super) fn external_marker(inner: &str) -> &'static str {
+    if wraps_block_content(inner) { "" } else { EXTERNAL_ICON }
+}
+
+/// Block-level tags an inline text link never contains.
+///
+/// Embed cards wrap their whole body in one anchor, so the marker would land
+/// as a stray last child: a full-width row under a `display: grid` provider
+/// card, and a lone glyph after the footer of a repository or link-preview
+/// card. Anchors around an avatar plus a name stay inline and keep theirs.
+const BLOCK_CONTENT_TAGS: [&str; 14] = [
+    "address",
+    "article",
+    "blockquote",
+    "div",
+    "footer",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "header",
+    "section",
+    "table",
+];
+
+fn wraps_block_content(inner: &str) -> bool {
+    let mut rest = inner;
+    while let Some(offset) = rest.find('<') {
+        let tag = &rest[offset..];
+        let name = tag_name(tag);
+        if !name.is_empty()
+            && BLOCK_CONTENT_TAGS.iter().any(|block| name.eq_ignore_ascii_case(block))
+        {
+            return true;
+        }
+        rest = &tag[1..];
+    }
+    false
+}

--- a/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
+++ b/crates/ox_content_ssg/src/html/reader_chrome/tests.rs
@@ -339,3 +339,12 @@ fn entry_page_skips_back_to_top_when_enabled() {
     assert!(!html.contains(r#"<button type="button" class="ox-back-to-top""#), "{html}");
     assert!(!html_open_tag(&html).contains("data-ox-back-to-top"), "{}", html_open_tag(&html));
 }
+
+#[test]
+fn card_wrapping_anchors_skip_the_external_marker() {
+    let card = r#"<a href="https://a.test/p"><header>h</header><div>d</div></a>"#;
+    let inline = r#"<a href="https://a.test/d">docs</a>"#;
+    let html = apply_reader_chrome(&format!("{card}{inline}"), ReaderChrome::enabled());
+    assert_eq!(html.matches("ox-external-icon").count(), 1, "{html}");
+    assert!(html.contains("<div>d</div></a>"), "{html}");
+}

--- a/crates/ox_content_ssg/src/html/tests/social.rs
+++ b/crates/ox_content_ssg/src/html/tests/social.rs
@@ -122,3 +122,17 @@ fn full_tweet_css_keeps_rich_copy_and_replies_affordances() {
     assert!(SOCIAL_TWEET_FULL_CSS.contains(".ox-tweet--full .ox-tweet__replies-link:hover"));
     assert!(!SOCIAL_TWEET_FULL_CSS.contains("text-align: center"), "{SOCIAL_TWEET_FULL_CSS}");
 }
+
+#[test]
+fn fetched_tweet_cards_sit_level_with_bluesky_cards() {
+    let html = generate_html(
+        &page(r#"<figure class="ox-tweet ox-tweet--fetched"></figure>"#),
+        &[],
+        &config(),
+    );
+
+    // A fetched tweet is `<figure><header>…`, so the shared `.ox-tweet > a`
+    // padding never applies and the card would start flush at its top border.
+    assert!(html.contains(".ox-tweet--fetched {\n  padding: 1rem 0;\n}"), "{html}");
+    assert!(html.contains(".ox-tweet > a,\n.ox-bluesky > a {"), "{html}");
+}

--- a/crates/ox_content_ssg/src/plugins/social.css
+++ b/crates/ox_content_ssg/src/plugins/social.css
@@ -17,6 +17,13 @@
   color: var(--octc-color-text);
 }
 
+/* A fetched tweet renders `<figure><header>…` rather than wrapping its body in
+   one anchor, so the rule above never matches it. Pad the card itself to keep
+   it level with the Bluesky card. */
+.ox-tweet--fetched {
+  padding: 1rem 0;
+}
+
 .ox-tweet > a:hover,
 .ox-bluesky > a:hover {
   text-decoration: none;

--- a/crates/ox_content_transform/src/media_embeds/render.rs
+++ b/crates/ox_content_transform/src/media_embeds/render.rs
@@ -44,7 +44,7 @@ pub(super) fn render_bluesky(element: &ComponentElement<'_>) -> Option<String> {
 pub(super) fn render_webcontainer(element: &ComponentElement<'_>) -> Option<String> {
     let entry = attr(element, "entry").unwrap_or("index.html");
     let title = attr(element, "title").unwrap_or("WebContainer");
-    let source = element.body.trim();
+    let source = dedent_block(element.body);
     let command_count = source.lines().filter(|line| !line.trim().is_empty()).count();
     let mut html = String::new();
     html.push_str("<div class=\"ox-webcontainer\" data-entry=\"");
@@ -54,7 +54,7 @@ pub(super) fn render_webcontainer(element: &ComponentElement<'_>) -> Option<Stri
     html.push_str("</strong><code>");
     escape_text(entry, &mut html);
     html.push_str("</code></span><span class=\"ox-webcontainer__status\">Boots on interaction</span></div><div class=\"ox-webcontainer__preview\"><pre><code>");
-    escape_text(source, &mut html);
+    escape_text(&source, &mut html);
     html.push_str("</code></pre></div><div class=\"ox-webcontainer__meta\"><span>Entry <code>");
     escape_text(entry, &mut html);
     html.push_str("</code></span><span>");
@@ -66,6 +66,30 @@ pub(super) fn render_webcontainer(element: &ComponentElement<'_>) -> Option<Stri
     }
     html.push_str("</span><span>Static source bundle</span><span>Requires cross-origin isolation</span></div></div>");
     Some(html)
+}
+
+/// Removes the indentation the author used to nest the block under its tag.
+///
+/// `trim()` alone drops the leading whitespace of the first line only, so
+/// `<WebContainer>` bodies rendered with the first command flush left and every
+/// later one still indented. The common prefix is measured across the
+/// non-blank lines and removed from all of them.
+fn dedent_block(body: &str) -> String {
+    let lines: Vec<&str> = body.trim_matches(['\n', '\r']).lines().collect();
+    let indent = lines
+        .iter()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.len() - line.trim_start().len())
+        .min()
+        .unwrap_or(0);
+
+    lines
+        .iter()
+        .map(|line| if line.len() >= indent { &line[indent..] } else { line.trim_start() })
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim_end()
+        .to_string()
 }
 
 /// A Spotify embed URL plus the kind of thing it plays.

--- a/crates/ox_content_transform/src/media_embeds/tests.rs
+++ b/crates/ox_content_transform/src/media_embeds/tests.rs
@@ -304,3 +304,32 @@ fn accepts_https_and_relative_media_sources() {
         assert!(!is_safe_media_url(input), "{input}");
     }
 }
+
+#[test]
+fn webcontainer_commands_keep_their_relative_indentation() {
+    // The docs nest the block under the tag. Trimming the body alone unindents
+    // the first command and leaves every later one pushed right.
+    let html = transform_media_embeds(
+        r#"<WebContainer entry="index.html" title="Demo">
+  npm install
+  npm run dev
+</WebContainer>"#,
+        Some(&MediaEmbedsOptions { web_container: Some(true), ..Default::default() }),
+    );
+
+    assert!(html.contains("<code>npm install\nnpm run dev</code>"), "{html}");
+    assert!(html.contains("<span>2 commands</span>"), "{html}");
+}
+
+#[test]
+fn webcontainer_keeps_indentation_that_is_part_of_the_script() {
+    let html = transform_media_embeds(
+        r#"<WebContainer entry="index.html">
+  npm install
+    npm run build -- --watch
+</WebContainer>"#,
+        Some(&MediaEmbedsOptions { web_container: Some(true), ..Default::default() }),
+    );
+
+    assert!(html.contains("<code>npm install\n  npm run build -- --watch</code>"), "{html}");
+}


### PR DESCRIPTION
Three defects visible on the docs Embeds page, all verified against the live site before and after.

## 1. Stray external-link marker on every card

`apply_reader_chrome` appends the outbound marker as the anchor's last child. That is right for an inline text link — but embed cards wrap their entire body in one anchor. On a `display: grid` provider card the marker became a **full-width row of its own** under the footer; the same orphaned glyph appeared on GitHub, OGP, and Bluesky cards.

Fixed by skipping the marker when the anchor wraps block-level content. Checked against every `a.ox-external` on the live page:

| Anchor | Layout | Wraps block? | Marker |
| --- | --- | --- | --- |
| `ox-provider-card__main` ×5 | grid | yes | removed |
| `ox-github-card` | block | yes | removed |
| `ox-ogp-card` | flex | yes | removed |
| `ox-bluesky__card` | block | yes | removed |
| plain inline links ×4 | inline | no | kept |
| `ox-tweet__profile` | flex | no | kept |
| `ox-tweet__permalink`, `ox-tweet__source`, `ox-github-code-*`, `ox-speaker-deck` | — | no | kept |

Exactly the 8 card wrappers lose it; every genuine text link keeps it.

## 2. Ragged WebContainer commands

```mdx
<WebContainer entry="index.html" title="Demo">
  npm install
  npm run dev
</WebContainer>
```

rendered as:

```
npm install
  npm run dev
```

`element.body.trim()` removes the leading whitespace of the first line only. Now the common indent across non-blank lines is measured and stripped, which also preserves indentation that is genuinely part of the script (a wrapped or nested command stays nested).

The existing test wrote its commands unindented, which is why this was never caught — the new tests cover both the flat and the deliberately-nested case.

## 3. Tweet card flush against its top border

A fetched tweet renders `<figure><header>…` rather than wrapping its body in an anchor, so the shared `.ox-tweet > a, .ox-bluesky > a { padding: 1rem 0 }` never applied to it. Measured on the live page, distance from the card's top border to its first content:

| | before | after |
| --- | --- | --- |
| Bluesky card | 17px | 17px |
| Tweet card | **1px** | **17px** |

## Tests

- `card_wrapping_anchors_skip_the_external_marker` — one card anchor and one inline link, asserts exactly one marker
- `webcontainer_commands_keep_their_relative_indentation` / `..._keeps_indentation_that_is_part_of_the_script`
- `fetched_tweet_cards_sit_level_with_bluesky_cards`

`cargo test --workspace` all green (79 suites, 0 failures); `vp run test:ts-unit` 994 passing after a NAPI rebuild.

## Still open

This addresses the visible defects, not the broader "何の機能かわからん" point about the WebContainer and Provider Cards sections. The WebContainer placeholder still says "Boots on interaction" while being inert in the docs, because booting is the host's job — making that read honestly is a product decision I did not want to make unasked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790491304&installation_model_id=422833&pr_number=1134&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1134&signature=6197e2682f36b4e4dd807859db178725fcade7dac20d5a3b1b37566f44a2d2b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * External-link icons are no longer added to card-style links containing block content.
  * Fetched tweet cards now align vertically with Bluesky cards.
  * WebContainer command blocks now preserve intended relative indentation while removing unnecessary formatting whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->