### PR TITLE
fix(citations): stop reading Markdown link labels as citations

### DIFF
--- a/npm/vite-plugin-ox-content/src/citations-search.test.ts
+++ b/npm/vite-plugin-ox-content/src/citations-search.test.ts
@@ -1,0 +1,56 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { collectCitationSearchText, resolveCitationsOptions } from "./citations";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("citation search text", () => {
+  it("does not read a linked scoped package name as a citation", async () => {
+    // The search-index pass reads Markdown source, where a link label opening
+    // with `@` is indistinguishable from a citation group by that `@` alone.
+    // These failed the whole index with `malformed citation`, because a scoped
+    // package name carries a `/` that no citation key may contain.
+    const markdown = [
+      "- [@ox-content/vite-plugin](./packages/vite-plugin-ox-content.md)",
+      "- [@ox-content/napi](./packages/napi.md)",
+      "- [@ox-content/wasm](./packages/wasm.md)",
+      "- [@ox-content/napi][napi-ref]",
+      "",
+      "[napi-ref]: ./packages/napi.md",
+    ].join("\n");
+
+    await expect(collectCitationSearchText(markdown, await options([]))).resolves.toBe("");
+  });
+
+  it("still collects a real citation alongside linked package names", async () => {
+    const markdown = ["See [@ox-content/napi](./packages/napi.md) and the spec [@rfc9110]."].join(
+      "\n",
+    );
+
+    const text = await collectCitationSearchText(
+      markdown,
+      await options([{ id: "rfc9110", title: "HTTP Semantics" }]),
+    );
+
+    expect(text).toContain("HTTP Semantics");
+  });
+
+  it("still reports a citation group that is genuinely malformed", async () => {
+    await expect(collectCitationSearchText("Bad [@bad key].", await options([]))).rejects.toThrow(
+      'malformed citation "[@bad key]"',
+    );
+  });
+});
+
+async function options(items: Array<Record<string, unknown>>) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "ox-citation-search-"));
+  tempDirs.push(root);
+  await fs.writeFile(path.join(root, "refs.json"), JSON.stringify(items), "utf8");
+  return resolveCitationsOptions({ bibliography: ["refs.json"], rootDir: root });
+}

--- a/npm/vite-plugin-ox-content/src/citations.ts
+++ b/npm/vite-plugin-ox-content/src/citations.ts
@@ -192,11 +192,27 @@ function citationKeysFromMarkdown(
   for (const match of visibleMarkdown.matchAll(BRACKET_RE)) {
     const body = (match[1] ?? "").trim();
     if (!body.startsWith("@") && !body.startsWith("-@")) continue;
+    if (isLinkLabel(visibleMarkdown, match)) continue;
     const parsed = parseCitationGroup(body, options, diagnostics);
     if (!parsed) continue;
     keys.push(...parsed.map((citation) => citation.key));
   }
   return keys;
+}
+
+/**
+ * A bracketed span that a destination or reference immediately follows is a
+ * Markdown link label, not a citation group.
+ *
+ * The HTML pass never sees these — by then the label is inside an `<a>` and has
+ * no brackets left — but the search-index pass reads the Markdown source, where
+ * a linked scoped package name is indistinguishable from a citation by its
+ * opening `@` alone. `[@ox-content/vite-plugin](./packages/vite-plugin.md)`
+ * reported a malformed citation and failed the whole index.
+ */
+function isLinkLabel(markdown: string, match: RegExpMatchArray): boolean {
+  const end = (match.index ?? 0) + match[0].length;
+  return markdown[end] === "(" || markdown[end] === "[";
 }
 
 function stripMarkdownCitationProtectedText(markdown: string): string {


### PR DESCRIPTION
Fixes the search-index failure from your `vp build`:

```
[ox-content] Failed to build search index: Error: [ox-content]
malformed citation "[@ox-content/vite-plugin]"
malformed citation "[@ox-content/napi]"
malformed citation "[@ox-content/wasm]"
```

It also failed the versioned index (`Failed to write search index for 2.90.0`).

## Cause

None of those are citations. They are the labels of ordinary Markdown links:

```md
- [@ox-content/napi](./packages/napi.md)
```

The scanner treats any bracketed span opening with `@` as a citation group. A scoped package name carries a `/`, which `CITATION_KEY_RE` rightly rejects — so a perfectly normal link was reported as a malformed citation and failed the whole index.

The HTML pass never sees this: by then the label is inside an `<a>` and has no brackets left. Only the search-index pass reads the Markdown source, which is why the error surfaced there and nowhere else.

## Fix

Skip a bracketed span that a link destination `(` or reference `[` immediately follows — the same rule Pandoc uses to tell `[@key]` from `[text](url)`.

## Verification

- All 18 `[@ox-content/…]` occurrences in the docs are links; none are bare citations.
- Scanning **all 215 docs files** through `collectCitationSearchText` now reports **zero** malformed citations. The only two remaining errors are `missing citation key "rfc9110"` on the two citation docs pages, which is expected — I ran the scan with a deliberately empty bibliography.
- Reverting the one-line guard makes the new test fail with your error text verbatim, including all three keys.
- A genuinely malformed group such as `[@bad key]` still errors.

New `citations-search.test.ts` covers the inline-link form, the reference-link form (`[@key][ref]`), a real citation collected alongside a linked package name, and the still-malformed case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790491326&installation_model_id=422833&pr_number=1135&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1135&signature=138031c34ecd8c62d4299b7025cef7ff2adc647629db6295ad95473955823fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown indexing to ignore scoped package names used as link labels.
  * Prevented valid links from being mistaken for malformed citations.
  * Continued collecting genuine citations while still reporting truly malformed citation groups.

* **Tests**
  * Added coverage for linked package names, mixed links and citations, and malformed citation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->