### PR TITLE
ci: publish theme presets in parallel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -451,22 +451,52 @@ jobs:
           npm publish "$TARBALL" --provenance --access public --tag "$NPM_TAG"
 
       # Theme presets are many small, uniform packages, so they publish from a
-      # loop rather than ~40 near-identical steps. Same skip-if-published guard
-      # as every step above; a single failure still fails the job.
+      # loop rather than ~70 near-identical steps. Same skip-if-published guard
+      # as every step above.
+      #
+      # They fan out because each one spends nearly all of its time on three
+      # network round-trips (`npm view`, then pack, then publish) and none of
+      # them depend on each other — a preset's only link to the plugin is an
+      # optional peer, which imposes no publish order. Concurrency is kept
+      # modest so the registry is not hit with 70 publishes at once.
+      #
+      # Unlike the serial loop, one failure no longer stops the presets behind
+      # it: the rest still publish and the step fails at the end. Every publish
+      # is guarded by the same skip-if-published check, so re-running the
+      # release picks up exactly what is missing.
       - name: Publish theme presets
+        env:
+          PRESET_PUBLISH_CONCURRENCY: "8"
         run: |
+          cat > "$RUNNER_TEMP/publish-preset.sh" <<'SCRIPT'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          dir="$1"
+          PKG_NAME=$(node -p "require('$PWD/$dir/package.json').name")
+          PKG_VERSION=$(node -p "require('$PWD/$dir/package.json').version")
+          if npm view "${PKG_NAME}@${PKG_VERSION}" version >/dev/null 2>&1; then
+            echo "[${PKG_NAME}] skipping ${PKG_VERSION} (already published)"
+            exit 0
+          fi
+          TARBALL=$(cd "$dir" && vp exec -- pnpm pack --pack-destination "$RUNNER_TEMP" | tail -1)
+          npm publish "$TARBALL" --provenance --access public --tag "$NPM_TAG" 2>&1 |
+            sed "s|^|[${PKG_NAME}] |"
+          SCRIPT
+          chmod +x "$RUNNER_TEMP/publish-preset.sh"
+
           shopt -s nullglob
+          presets=()
           for dir in npm/theme/* npm/theme-color/*; do
-            [ -f "$dir/package.json" ] || continue
-            PKG_NAME=$(node -p "require('./$dir/package.json').name")
-            PKG_VERSION=$(node -p "require('./$dir/package.json').version")
-            if npm view "${PKG_NAME}@${PKG_VERSION}" version >/dev/null 2>&1; then
-              echo "Skipping ${PKG_NAME}@${PKG_VERSION} (already published)"
-              continue
-            fi
-            TARBALL=$(cd "$dir" && vp exec -- pnpm pack --pack-destination /tmp | tail -1)
-            npm publish "$TARBALL" --provenance --access public --tag "$NPM_TAG"
+            [ -f "$dir/package.json" ] && presets+=("$dir")
           done
+          if [ ${#presets[@]} -eq 0 ]; then
+            echo "::error::No theme presets found to publish"
+            exit 1
+          fi
+          echo "Publishing ${#presets[@]} theme presets, ${PRESET_PUBLISH_CONCURRENCY} at a time"
+
+          printf '%s\n' "${presets[@]}" |
+            xargs -r -P "$PRESET_PUBLISH_CONCURRENCY" -n 1 "$RUNNER_TEMP/publish-preset.sh"
 
       - name: Publish @ox-content/wasm
         working-directory: crates/ox_content_wasm/pkg


### PR DESCRIPTION
The theme presets published from a serial bash loop over **72 packages** (27 skins + 45 colour schemes), each spending nearly all of its time on three network round-trips: `npm view`, `pnpm pack`, then `npm publish` with provenance. The publish dominates at a couple of seconds apiece, so the step ran for minutes on work that is almost entirely waiting.

## Change

Fan the loop out with `xargs -P`, capped at 8. The presets are independent — a preset's only link to the plugin is an *optional* peer dependency, which imposes no publish order — so nothing required them to run one at a time. The cap keeps the registry from being hit with 72 publishes at once.

The per-package logic is unchanged, including the skip-if-published guard. Output is prefixed with the package name so parallel logs stay readable.

## Rehearsal

I can't exercise the publish path before merge, so I rehearsed the part that could actually go wrong under concurrency — `pnpm pack` contending on the store:

- 72 presets packed at 8-way in **5.4s wall** for 28.5s of CPU (657% utilization)
- 72 valid tarballs, zero failures, no store contention

Both shell layers (the step and the generated per-package script) pass `bash -n`.

## One behaviour change

A failure no longer stops the presets queued behind it — the rest still publish, and the step fails at the end. Every publish keeps the same skip-if-published guard, so re-running the release picks up exactly what is missing. That is already how the serial loop was meant to be recovered, and it now leaves less to redo.

## Risk

This is the release path and cannot be tested before merge. The change is confined to one step; if it misbehaves, reverting to the serial loop is a clean revert of this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790491327&installation_model_id=422833&pr_number=1136&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1136&signature=d47a05631d0393672e10627a2fc67817200e26bc63b04e149073a1ebb965b4c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->