### PR TITLE
fix(theme): stop the 404 page from marking every sidebar group active

### DIFF
--- a/crates/ox_content_ssg/src/html/nav.rs
+++ b/crates/ox_content_ssg/src/html/nav.rs
@@ -65,7 +65,12 @@ fn render_nav_list(
 fn render_nav_item(html: &mut String, item: &NavItem, current_path: &str, key_path: &str) {
     let href = safe_nav_href(&item.href);
     let title = escape_html(&item.title);
-    let active_class = if item.path == current_path { " active" } else { "" };
+    // A sidebar group with no `link` of its own has an empty path, and so
+    // does a page that is not part of the site's routes — the generated
+    // `404.html` above all. Matching those two on equality lit up every
+    // group header at once, so an entry without a route is never current.
+    let active_class =
+        if !item.path.is_empty() && item.path == current_path { " active" } else { "" };
     if item.children.is_empty() {
         push_fmt(
             html,

--- a/crates/ox_content_ssg/src/html/tests.rs
+++ b/crates/ox_content_ssg/src/html/tests.rs
@@ -27,6 +27,7 @@ mod image_gallery;
 mod lazy_widgets;
 mod mobile_css;
 mod mpa_navigation;
+mod nav_active;
 mod navigation_state;
 mod rendering;
 mod social;

--- a/crates/ox_content_ssg/src/html/tests/nav_active.rs
+++ b/crates/ox_content_ssg/src/html/tests/nav_active.rs
@@ -1,0 +1,54 @@
+//! Which sidebar entry a page marks as current.
+
+use super::super::nav::generate_nav_html;
+use super::super::{NavGroup, NavItem};
+
+#[test]
+fn test_generate_nav_html_marks_no_group_active_without_a_route() {
+    // `404.html` is generated with an empty url path, and a sidebar group
+    // without a link of its own has an empty path too.
+    let nav_groups = vec![NavGroup {
+        title: "Guide".to_string(),
+        collapsed: Some(false),
+        sticky_collapsed: None,
+        items: vec![
+            NavItem {
+                title: "Group".to_string(),
+                path: String::new(),
+                href: "#".to_string(),
+                collapsed: Some(false),
+                sticky_collapsed: None,
+                children: vec![NavItem {
+                    title: "Getting started".to_string(),
+                    path: "getting-started".to_string(),
+                    href: "/docs/getting-started/index.html".to_string(),
+                    children: vec![],
+                    collapsed: None,
+                    sticky_collapsed: None,
+                }],
+            },
+            NavItem {
+                title: "Reference".to_string(),
+                path: String::new(),
+                href: "#".to_string(),
+                collapsed: Some(false),
+                sticky_collapsed: None,
+                children: vec![NavItem {
+                    title: "API".to_string(),
+                    path: "api".to_string(),
+                    href: "/docs/api/index.html".to_string(),
+                    children: vec![],
+                    collapsed: None,
+                    sticky_collapsed: None,
+                }],
+            },
+        ],
+    }];
+
+    let not_found = generate_nav_html(&nav_groups, "");
+    assert!(!not_found.contains("active"), "{not_found}");
+
+    let page = generate_nav_html(&nav_groups, "api");
+    assert_eq!(page.matches(" active").count(), 1, "{page}");
+    assert!(page.contains(r#"class="nav-link active">API"#), "{page}");
+}

--- a/crates/ox_content_ssg/src/html/tests/rendering.rs
+++ b/crates/ox_content_ssg/src/html/tests/rendering.rs
@@ -179,6 +179,56 @@ fn test_generate_nav_html_with_nested_collapsed_items() {
 }
 
 #[test]
+fn test_generate_nav_html_marks_no_group_active_without_a_route() {
+    // `404.html` is generated with an empty url path, and a sidebar group
+    // without a link of its own has an empty path too.
+    let nav_groups = vec![NavGroup {
+        title: "Guide".to_string(),
+        collapsed: Some(false),
+        sticky_collapsed: None,
+        items: vec![
+            NavItem {
+                title: "Group".to_string(),
+                path: String::new(),
+                href: "#".to_string(),
+                collapsed: Some(false),
+                sticky_collapsed: None,
+                children: vec![NavItem {
+                    title: "Getting started".to_string(),
+                    path: "getting-started".to_string(),
+                    href: "/docs/getting-started/index.html".to_string(),
+                    children: vec![],
+                    collapsed: None,
+                    sticky_collapsed: None,
+                }],
+            },
+            NavItem {
+                title: "Reference".to_string(),
+                path: String::new(),
+                href: "#".to_string(),
+                collapsed: Some(false),
+                sticky_collapsed: None,
+                children: vec![NavItem {
+                    title: "API".to_string(),
+                    path: "api".to_string(),
+                    href: "/docs/api/index.html".to_string(),
+                    children: vec![],
+                    collapsed: None,
+                    sticky_collapsed: None,
+                }],
+            },
+        ],
+    }];
+
+    let not_found = generate_nav_html(&nav_groups, "");
+    assert!(!not_found.contains("active"), "{not_found}");
+
+    let page = generate_nav_html(&nav_groups, "api");
+    assert_eq!(page.matches(" active").count(), 1, "{page}");
+    assert!(page.contains(r#"class="nav-link active">API"#), "{page}");
+}
+
+#[test]
 fn test_nested_nav_css_keeps_disclosure_and_hierarchy_visible() {
     assert!(
         SSG_CSS.contains(".nav-details > .nav-summary"),

--- a/crates/ox_content_ssg/src/html/tests/rendering.rs
+++ b/crates/ox_content_ssg/src/html/tests/rendering.rs
@@ -179,56 +179,6 @@ fn test_generate_nav_html_with_nested_collapsed_items() {
 }
 
 #[test]
-fn test_generate_nav_html_marks_no_group_active_without_a_route() {
-    // `404.html` is generated with an empty url path, and a sidebar group
-    // without a link of its own has an empty path too.
-    let nav_groups = vec![NavGroup {
-        title: "Guide".to_string(),
-        collapsed: Some(false),
-        sticky_collapsed: None,
-        items: vec![
-            NavItem {
-                title: "Group".to_string(),
-                path: String::new(),
-                href: "#".to_string(),
-                collapsed: Some(false),
-                sticky_collapsed: None,
-                children: vec![NavItem {
-                    title: "Getting started".to_string(),
-                    path: "getting-started".to_string(),
-                    href: "/docs/getting-started/index.html".to_string(),
-                    children: vec![],
-                    collapsed: None,
-                    sticky_collapsed: None,
-                }],
-            },
-            NavItem {
-                title: "Reference".to_string(),
-                path: String::new(),
-                href: "#".to_string(),
-                collapsed: Some(false),
-                sticky_collapsed: None,
-                children: vec![NavItem {
-                    title: "API".to_string(),
-                    path: "api".to_string(),
-                    href: "/docs/api/index.html".to_string(),
-                    children: vec![],
-                    collapsed: None,
-                    sticky_collapsed: None,
-                }],
-            },
-        ],
-    }];
-
-    let not_found = generate_nav_html(&nav_groups, "");
-    assert!(!not_found.contains("active"), "{not_found}");
-
-    let page = generate_nav_html(&nav_groups, "api");
-    assert_eq!(page.matches(" active").count(), 1, "{page}");
-    assert!(page.contains(r#"class="nav-link active">API"#), "{page}");
-}
-
-#[test]
 fn test_nested_nav_css_keeps_disclosure_and_hierarchy_visible() {
     assert!(
         SSG_CSS.contains(".nav-details > .nav-summary"),


### PR DESCRIPTION
Closes #1139

## Problem

`404.html` is generated with an empty url path, and a sidebar group with no `link` of its own carries an empty path too. The active check is `item.path == current_path`, so every group header matched at once and the whole navigation lit up as if each of them were the current page:

```js
[...document.querySelectorAll(".sidebar .active")].map((e) => e.className);
// ["nav-link nav-link--summary active", "nav-link nav-link--summary active", ...]
```

## Change

An entry without a route is never the current page, so skip the active class when the item has no path. Pages with a route are unaffected — they still mark exactly one entry.

## Verification

- `cargo test -p ox_content_ssg` — 265 pass. The new test asserts no active entry for the empty path and exactly one for a real page; reverting the fix makes it fail.
- `cargo test --workspace`, `cargo clippy -p ox_content_ssg --all-targets`, `vp run test:vrt` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790500368&installation_model_id=422833&pr_number=1149&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1149&signature=14f2bc0d8a4dd11cabaedbdf020d1d5b19df94254165107db05dac09a15127b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->