### PR TITLE
fix(ssg): step the pager over sidebar group headers

### DIFF
--- a/crates/ox_content_ssg/src/html/pagination.rs
+++ b/crates/ox_content_ssg/src/html/pagination.rs
@@ -75,9 +75,15 @@ fn normalize_path(value: &str) -> &str {
     value.trim().trim_matches('/')
 }
 
+/// True when an entry points at a page of this site the pager can step to.
+///
+/// A sidebar group with no `link` of its own is still a nav item, and the
+/// theme gives it `href="#"` so the header can toggle the group. It is a
+/// heading, not a destination: stepping onto it left "Next" pointing at
+/// `#`, which goes nowhere. Its children are flattened either way.
 fn is_in_site_href(href: &str) -> bool {
     let trimmed = href.trim();
-    if trimmed.is_empty() {
+    if trimmed.is_empty() || trimmed.starts_with('#') {
         return false;
     }
     let lower = trimmed.to_ascii_lowercase();

--- a/crates/ox_content_ssg/src/html/pagination/tests.rs
+++ b/crates/ox_content_ssg/src/html/pagination/tests.rs
@@ -329,3 +329,62 @@ fn generate_bare_html_is_unchanged() {
     assert!(!html.contains("pager"));
     assert!(!html.contains("Previous"));
 }
+
+#[test]
+fn flatten_skips_group_headers_without_a_link() {
+    // A sidebar group nested inside another group becomes a nav item with
+    // `href="#"`. Stepping onto it left the pager pointing at `#`.
+    let nav = guide(vec![
+        nav_item("First", "first", "/docs/first/index.html"),
+        nav_item_with_children(
+            "Nested Group",
+            "",
+            "#",
+            vec![nav_item("Child", "group/child", "/docs/group/child/index.html")],
+        ),
+        nav_item("Last", "last", "/docs/last/index.html"),
+    ]);
+
+    let html = generate_html(&page("first"), &nav, &config(true));
+    let pager = pager_html(&html).expect("first page should emit a pager");
+
+    assert!(!pager.contains(r##"href="#""##), "{pager}");
+    assert!(!pager.contains("Nested Group"), "{pager}");
+    assert!(pager.contains(r#"href="/docs/group/child/index.html""#), "{pager}");
+    assert!(pager.contains("Child"), "{pager}");
+}
+
+#[test]
+fn group_headers_do_not_capture_pages_with_an_empty_path() {
+    // The header's own path is empty, and so is the normalized path of the
+    // site root, so the root page used to resolve its neighbors from the
+    // header's position in the sidebar instead of its own.
+    let nav = guide(vec![
+        nav_item_with_children(
+            "Nested Group",
+            "",
+            "#",
+            vec![nav_item("Child", "group/child", "/docs/group/child/index.html")],
+        ),
+        nav_item("Last", "last", "/docs/last/index.html"),
+    ]);
+
+    let html = generate_html(&page("/"), &nav, &config(true));
+
+    assert!(pager_html(&html).is_none(), "a page outside the sidebar has no neighbors: {html}");
+}
+
+#[test]
+fn flatten_skips_fragment_only_hrefs() {
+    let nav = guide(vec![
+        nav_item("Intro", "intro", "/docs/intro/index.html"),
+        nav_item("Anchor", "", "#section"),
+        nav_item("API", "api", "/docs/api/index.html"),
+    ]);
+
+    let html = generate_html(&page("intro"), &nav, &config(true));
+    let pager = pager_html(&html).expect("in-site neighbor should still emit a pager");
+
+    assert!(pager.contains(r#"href="/docs/api/index.html""#), "{pager}");
+    assert!(!pager.contains("Anchor"), "{pager}");
+}

--- a/crates/ox_content_ssg/src/html/pagination/tests.rs
+++ b/crates/ox_content_ssg/src/html/pagination/tests.rs
@@ -1,9 +1,11 @@
+mod flatten;
+
 use super::super::{
     EntryPageConfig, HeadValidation, NavGroup, NavItem, PageChromeFlags, PageData, PagerOverride,
     ReaderChrome, SsgConfig, generate_bare_html, generate_html,
 };
 
-fn nav_item(title: &str, path: &str, href: &str) -> NavItem {
+pub(super) fn nav_item(title: &str, path: &str, href: &str) -> NavItem {
     NavItem {
         title: title.to_string(),
         path: path.to_string(),
@@ -14,7 +16,12 @@ fn nav_item(title: &str, path: &str, href: &str) -> NavItem {
     }
 }
 
-fn nav_item_with_children(title: &str, path: &str, href: &str, children: Vec<NavItem>) -> NavItem {
+pub(super) fn nav_item_with_children(
+    title: &str,
+    path: &str,
+    href: &str,
+    children: Vec<NavItem>,
+) -> NavItem {
     NavItem {
         title: title.to_string(),
         path: path.to_string(),
@@ -25,7 +32,7 @@ fn nav_item_with_children(title: &str, path: &str, href: &str, children: Vec<Nav
     }
 }
 
-fn guide(items: Vec<NavItem>) -> Vec<NavGroup> {
+pub(super) fn guide(items: Vec<NavItem>) -> Vec<NavGroup> {
     vec![NavGroup { title: "Guide".to_string(), items, collapsed: None, sticky_collapsed: None }]
 }
 
@@ -37,7 +44,7 @@ fn linear_nav() -> Vec<NavGroup> {
     ])
 }
 
-fn page(path: &str) -> PageData {
+pub(super) fn page(path: &str) -> PageData {
     PageData {
         title: "Current".to_string(),
         description: None,
@@ -57,7 +64,7 @@ fn page(path: &str) -> PageData {
     }
 }
 
-fn config(pagination: bool) -> SsgConfig {
+pub(super) fn config(pagination: bool) -> SsgConfig {
     SsgConfig {
         site_name: "Docs".to_string(),
         base: "/docs/".to_string(),
@@ -79,7 +86,7 @@ fn config(pagination: bool) -> SsgConfig {
     }
 }
 
-fn pager_html(html: &str) -> Option<&str> {
+pub(super) fn pager_html(html: &str) -> Option<&str> {
     let start = html.find(r#"<nav class="pager""#)?;
     let rest = &html[start..];
     let end = rest.find("</nav>")?;
@@ -135,65 +142,6 @@ fn last_page_emits_prev_only() {
     assert!(pager.contains("Guide"), "{pager}");
     assert!(!pager.contains(r#"rel="next""#), "{pager}");
     assert!(!pager.contains("Next"), "{pager}");
-}
-
-#[test]
-fn nested_sidebar_children_flatten_depth_first() {
-    let nav = guide(vec![
-        nav_item_with_children(
-            "Parent",
-            "parent",
-            "/docs/parent/index.html",
-            vec![
-                nav_item("Child A", "parent/a", "/docs/parent/a/index.html"),
-                nav_item("Child B", "parent/b", "/docs/parent/b/index.html"),
-            ],
-        ),
-        nav_item("Sibling", "sibling", "/docs/sibling/index.html"),
-    ]);
-
-    let html = generate_html(&page("parent/a"), &nav, &config(true));
-    let pager = pager_html(&html).expect("nested child should emit a pager");
-
-    assert!(pager.contains(r#"href="/docs/parent/index.html""#), "{pager}");
-    assert!(pager.contains("Parent"), "{pager}");
-    assert!(pager.contains(r#"href="/docs/parent/b/index.html""#), "{pager}");
-    assert!(pager.contains("Child B"), "{pager}");
-    assert!(!pager.contains(r#"href="/docs/sibling/index.html""#), "{pager}");
-}
-
-#[test]
-fn flatten_skips_items_with_empty_href() {
-    let nav = guide(vec![
-        nav_item("Skipped", "skipped", ""),
-        nav_item("First", "first", "/docs/first/index.html"),
-        nav_item("Second", "second", "/docs/second/index.html"),
-    ]);
-
-    let html = generate_html(&page("first"), &nav, &config(true));
-    let pager = pager_html(&html).expect("real neighbors should still emit a pager");
-
-    assert!(!pager.contains(r#"rel="prev""#), "{pager}");
-    assert!(!pager.contains("Skipped"), "{pager}");
-    assert!(pager.contains(r#"href="/docs/second/index.html""#), "{pager}");
-    assert!(pager.contains("Second"), "{pager}");
-}
-
-#[test]
-fn flatten_skips_external_https_hrefs() {
-    let nav = guide(vec![
-        nav_item("Intro", "intro", "/docs/intro/index.html"),
-        nav_item("External", "external", "https://example.com/docs"),
-        nav_item("API", "api", "/docs/api/index.html"),
-    ]);
-
-    let html = generate_html(&page("intro"), &nav, &config(true));
-    let pager = pager_html(&html).expect("in-site neighbor should still emit a pager");
-
-    assert!(pager.contains(r#"href="/docs/api/index.html""#), "{pager}");
-    assert!(pager.contains("API"), "{pager}");
-    assert!(!pager.contains("https://example.com/docs"), "{pager}");
-    assert!(!pager.contains("External"), "{pager}");
 }
 
 #[test]
@@ -328,63 +276,4 @@ fn generate_bare_html_is_unchanged() {
     );
     assert!(!html.contains("pager"));
     assert!(!html.contains("Previous"));
-}
-
-#[test]
-fn flatten_skips_group_headers_without_a_link() {
-    // A sidebar group nested inside another group becomes a nav item with
-    // `href="#"`. Stepping onto it left the pager pointing at `#`.
-    let nav = guide(vec![
-        nav_item("First", "first", "/docs/first/index.html"),
-        nav_item_with_children(
-            "Nested Group",
-            "",
-            "#",
-            vec![nav_item("Child", "group/child", "/docs/group/child/index.html")],
-        ),
-        nav_item("Last", "last", "/docs/last/index.html"),
-    ]);
-
-    let html = generate_html(&page("first"), &nav, &config(true));
-    let pager = pager_html(&html).expect("first page should emit a pager");
-
-    assert!(!pager.contains(r##"href="#""##), "{pager}");
-    assert!(!pager.contains("Nested Group"), "{pager}");
-    assert!(pager.contains(r#"href="/docs/group/child/index.html""#), "{pager}");
-    assert!(pager.contains("Child"), "{pager}");
-}
-
-#[test]
-fn group_headers_do_not_capture_pages_with_an_empty_path() {
-    // The header's own path is empty, and so is the normalized path of the
-    // site root, so the root page used to resolve its neighbors from the
-    // header's position in the sidebar instead of its own.
-    let nav = guide(vec![
-        nav_item_with_children(
-            "Nested Group",
-            "",
-            "#",
-            vec![nav_item("Child", "group/child", "/docs/group/child/index.html")],
-        ),
-        nav_item("Last", "last", "/docs/last/index.html"),
-    ]);
-
-    let html = generate_html(&page("/"), &nav, &config(true));
-
-    assert!(pager_html(&html).is_none(), "a page outside the sidebar has no neighbors: {html}");
-}
-
-#[test]
-fn flatten_skips_fragment_only_hrefs() {
-    let nav = guide(vec![
-        nav_item("Intro", "intro", "/docs/intro/index.html"),
-        nav_item("Anchor", "", "#section"),
-        nav_item("API", "api", "/docs/api/index.html"),
-    ]);
-
-    let html = generate_html(&page("intro"), &nav, &config(true));
-    let pager = pager_html(&html).expect("in-site neighbor should still emit a pager");
-
-    assert!(pager.contains(r#"href="/docs/api/index.html""#), "{pager}");
-    assert!(!pager.contains("Anchor"), "{pager}");
 }

--- a/crates/ox_content_ssg/src/html/pagination/tests/flatten.rs
+++ b/crates/ox_content_ssg/src/html/pagination/tests/flatten.rs
@@ -1,0 +1,126 @@
+//! Which sidebar entries the pager will step onto.
+//!
+//! An entry has to name a page of this site. Empty, external, and
+//! fragment-only hrefs are all skipped, and a group header carries the last
+//! of those.
+
+use super::super::super::generate_html;
+use super::{config, guide, nav_item, nav_item_with_children, page, pager_html};
+
+#[test]
+fn nested_sidebar_children_flatten_depth_first() {
+    let nav = guide(vec![
+        nav_item_with_children(
+            "Parent",
+            "parent",
+            "/docs/parent/index.html",
+            vec![
+                nav_item("Child A", "parent/a", "/docs/parent/a/index.html"),
+                nav_item("Child B", "parent/b", "/docs/parent/b/index.html"),
+            ],
+        ),
+        nav_item("Sibling", "sibling", "/docs/sibling/index.html"),
+    ]);
+
+    let html = generate_html(&page("parent/a"), &nav, &config(true));
+    let pager = pager_html(&html).expect("nested child should emit a pager");
+
+    assert!(pager.contains(r#"href="/docs/parent/index.html""#), "{pager}");
+    assert!(pager.contains("Parent"), "{pager}");
+    assert!(pager.contains(r#"href="/docs/parent/b/index.html""#), "{pager}");
+    assert!(pager.contains("Child B"), "{pager}");
+    assert!(!pager.contains(r#"href="/docs/sibling/index.html""#), "{pager}");
+}
+
+#[test]
+fn flatten_skips_items_with_empty_href() {
+    let nav = guide(vec![
+        nav_item("Skipped", "skipped", ""),
+        nav_item("First", "first", "/docs/first/index.html"),
+        nav_item("Second", "second", "/docs/second/index.html"),
+    ]);
+
+    let html = generate_html(&page("first"), &nav, &config(true));
+    let pager = pager_html(&html).expect("real neighbors should still emit a pager");
+
+    assert!(!pager.contains(r#"rel="prev""#), "{pager}");
+    assert!(!pager.contains("Skipped"), "{pager}");
+    assert!(pager.contains(r#"href="/docs/second/index.html""#), "{pager}");
+    assert!(pager.contains("Second"), "{pager}");
+}
+
+#[test]
+fn flatten_skips_external_https_hrefs() {
+    let nav = guide(vec![
+        nav_item("Intro", "intro", "/docs/intro/index.html"),
+        nav_item("External", "external", "https://example.com/docs"),
+        nav_item("API", "api", "/docs/api/index.html"),
+    ]);
+
+    let html = generate_html(&page("intro"), &nav, &config(true));
+    let pager = pager_html(&html).expect("in-site neighbor should still emit a pager");
+
+    assert!(pager.contains(r#"href="/docs/api/index.html""#), "{pager}");
+    assert!(pager.contains("API"), "{pager}");
+    assert!(!pager.contains("https://example.com/docs"), "{pager}");
+    assert!(!pager.contains("External"), "{pager}");
+}
+
+#[test]
+fn flatten_skips_group_headers_without_a_link() {
+    // A sidebar group nested inside another group becomes a nav item with
+    // `href="#"`. Stepping onto it left the pager pointing at `#`.
+    let nav = guide(vec![
+        nav_item("First", "first", "/docs/first/index.html"),
+        nav_item_with_children(
+            "Nested Group",
+            "",
+            "#",
+            vec![nav_item("Child", "group/child", "/docs/group/child/index.html")],
+        ),
+        nav_item("Last", "last", "/docs/last/index.html"),
+    ]);
+
+    let html = generate_html(&page("first"), &nav, &config(true));
+    let pager = pager_html(&html).expect("first page should emit a pager");
+
+    assert!(!pager.contains(r##"href="#""##), "{pager}");
+    assert!(!pager.contains("Nested Group"), "{pager}");
+    assert!(pager.contains(r#"href="/docs/group/child/index.html""#), "{pager}");
+    assert!(pager.contains("Child"), "{pager}");
+}
+
+#[test]
+fn group_headers_do_not_capture_pages_with_an_empty_path() {
+    // The header's own path is empty, and so is the normalized path of the
+    // site root, so the root page used to resolve its neighbors from the
+    // header's position in the sidebar instead of its own.
+    let nav = guide(vec![
+        nav_item_with_children(
+            "Nested Group",
+            "",
+            "#",
+            vec![nav_item("Child", "group/child", "/docs/group/child/index.html")],
+        ),
+        nav_item("Last", "last", "/docs/last/index.html"),
+    ]);
+
+    let html = generate_html(&page("/"), &nav, &config(true));
+
+    assert!(pager_html(&html).is_none(), "a page outside the sidebar has no neighbors: {html}");
+}
+
+#[test]
+fn flatten_skips_fragment_only_hrefs() {
+    let nav = guide(vec![
+        nav_item("Intro", "intro", "/docs/intro/index.html"),
+        nav_item("Anchor", "", "#section"),
+        nav_item("API", "api", "/docs/api/index.html"),
+    ]);
+
+    let html = generate_html(&page("intro"), &nav, &config(true));
+    let pager = pager_html(&html).expect("in-site neighbor should still emit a pager");
+
+    assert!(pager.contains(r#"href="/docs/api/index.html""#), "{pager}");
+    assert!(!pager.contains("Anchor"), "{pager}");
+}


### PR DESCRIPTION
Reported in chat: prev/next misbehaves once the sidebar has groups.

## Problem

A sidebar group nested inside another group has no `link` of its own, so the theme gives it `href="#"` to make the header a toggle. The pager flattened it as an ordinary destination, so the page in front of a nested group got a **"Next" pointing at `#`**, which goes nowhere:

```html
<a class="pager-link pager-link--next" rel="next" href="#">
  <span class="pager-label">Next</span>
  <span class="pager-title">Nested Group</span>
</a>
```

The header's `path` is empty as well, and so is the normalized path of the site root, so a root page also matched the header and resolved its neighbors from the header's position in the sidebar rather than its own.

## Change

Skip fragment-only hrefs when flattening, alongside the empty and external ones already skipped. A group's children are still flattened, so the order through the sidebar is unchanged.

## Verification

- `cargo test -p ox_content_ssg` — 267 pass, three new: the nested-group case, the root-page case, and a fragment-only entry.
- `cargo test --workspace`, `cargo clippy -p ox_content_ssg --all-targets` — clean.

Same root cause as #1139 (a group header has neither a route nor a path), but a separate code path, so it is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790500379&installation_model_id=422833&pr_number=1150&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1150&signature=b52cce5adaf78569a7a9344e1b00366d794e89ea0198caee40e494a0f9027ba5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->