### PR TITLE
feat(ssg): build edit links for GitLab, Bitbucket, and Gitea

### DIFF
--- a/crates/ox_content_napi/index.d.ts
+++ b/crates/ox_content_napi/index.d.ts
@@ -900,6 +900,21 @@ export interface JsEditThisPageOptions {
    */
   srcDir?: string
   /**
+   * Forge whose edit-URL shape to use: `github`, `gitlab`, `bitbucket`,
+   * or `gitea`.
+   *
+   * Default: inferred from the `repo_url` host, falling back to
+   * `github`. An unrecognized value is inferred the same way.
+   */
+  provider?: string
+  /**
+   * Edit-URL template, which wins over `provider`. Understands
+   * `{repoUrl}`, `{branch}`, and `{path}`; other braces stay literal.
+   *
+   * Default: the pattern for the resolved provider.
+   */
+  urlPattern?: string
+  /**
    * Link label.
    *
    * Default: `"Edit this page"`.

--- a/crates/ox_content_napi/src/transform_bindings/feature_options.rs
+++ b/crates/ox_content_napi/src/transform_bindings/feature_options.rs
@@ -230,6 +230,19 @@ pub struct JsEditThisPageOptions {
     /// Default: none, which makes `root_dir` inert.
     pub src_dir: Option<String>,
 
+    /// Forge whose edit-URL shape to use: `github`, `gitlab`, `bitbucket`,
+    /// or `gitea`.
+    ///
+    /// Default: inferred from the `repo_url` host, falling back to
+    /// `github`. An unrecognized value is inferred the same way.
+    pub provider: Option<String>,
+
+    /// Edit-URL template, which wins over `provider`. Understands
+    /// `{repoUrl}`, `{branch}`, and `{path}`; other braces stay literal.
+    ///
+    /// Default: the pattern for the resolved provider.
+    pub url_pattern: Option<String>,
+
     /// Link label.
     ///
     /// Default: `"Edit this page"`.
@@ -244,6 +257,8 @@ impl From<JsEditThisPageOptions> for EditThisPageOptions {
             branch: value.branch,
             root_dir: value.root_dir,
             src_dir: value.src_dir,
+            provider: value.provider,
+            url_pattern: value.url_pattern,
             label: value.label,
         }
     }

--- a/crates/ox_content_transform/src/features.rs
+++ b/crates/ox_content_transform/src/features.rs
@@ -110,6 +110,8 @@ struct ResolvedEditThisPageOptions {
     src_dir: Option<PathBuf>,
     /// The build's working directory, resolved once per page.
     working_dir: PathBuf,
+    /// Edit-URL template for the forge the repository is hosted on.
+    url_pattern: String,
     source_path: String,
     label: String,
 }

--- a/crates/ox_content_transform/src/features/edit.rs
+++ b/crates/ox_content_transform/src/features/edit.rs
@@ -2,6 +2,10 @@ use std::path::{Path, PathBuf};
 
 use super::{ResolvedEditThisPageOptions, escape_html_attr, escape_html_text};
 
+pub(super) mod provider;
+
+use provider::render_pattern;
+
 pub(super) fn append_edit_this_page(html: &str, options: &ResolvedEditThisPageOptions) -> String {
     let href = edit_this_page_href(options);
     let mut out = String::with_capacity(html.len() + href.len() + options.label.len() + 96);
@@ -18,8 +22,12 @@ pub(super) fn append_edit_this_page(html: &str, options: &ResolvedEditThisPageOp
 }
 
 fn edit_this_page_href(options: &ResolvedEditThisPageOptions) -> String {
-    let path = page_path(options);
-    format!("{}/edit/{}/{}", options.repo_url, options.branch, percent_encode_path(&path))
+    render_pattern(
+        &options.url_pattern,
+        &options.repo_url,
+        &options.branch,
+        &percent_encode_path(&page_path(options)),
+    )
 }
 
 /// The page's path inside the repository.

--- a/crates/ox_content_transform/src/features/edit/provider.rs
+++ b/crates/ox_content_transform/src/features/edit/provider.rs
@@ -1,0 +1,103 @@
+//! Edit-URL shapes for the forges a documentation site is hosted on.
+//!
+//! Every forge exposes a web editor, and no two agree on the path. GitLab
+//! puts a `/-/` scope separator in front of it, Bitbucket edits through its
+//! source view, and Gitea and Forgejo use `_edit`. A site on any of them
+//! needs the right shape or the link 404s.
+
+/// Placeholders a pattern may use.
+const REPO_URL: &str = "{repoUrl}";
+const BRANCH: &str = "{branch}";
+const PATH: &str = "{path}";
+
+const GITHUB: &str = "{repoUrl}/edit/{branch}/{path}";
+const GITLAB: &str = "{repoUrl}/-/edit/{branch}/{path}";
+const BITBUCKET: &str = "{repoUrl}/src/{branch}/{path}?mode=edit";
+const GITEA: &str = "{repoUrl}/_edit/{branch}/{path}";
+
+/// The pattern to build edit URLs with.
+///
+/// An explicit pattern wins, then a named provider, then the shape implied
+/// by the repository host. GitHub is the fallback because it is the shape
+/// this option has always produced.
+pub(in crate::features) fn resolve_pattern(
+    url_pattern: Option<&str>,
+    provider: Option<&str>,
+    repo_url: &str,
+) -> String {
+    if let Some(pattern) = url_pattern.map(str::trim).filter(|pattern| !pattern.is_empty()) {
+        return pattern.to_string();
+    }
+    named_pattern(provider.map(str::trim).unwrap_or_default())
+        .unwrap_or_else(|| infer_pattern(repo_url))
+        .to_string()
+}
+
+fn named_pattern(provider: &str) -> Option<&'static str> {
+    match provider.to_ascii_lowercase().as_str() {
+        "github" => Some(GITHUB),
+        "gitlab" => Some(GITLAB),
+        "bitbucket" => Some(BITBUCKET),
+        "gitea" | "forgejo" => Some(GITEA),
+        _ => None,
+    }
+}
+
+/// The shape implied by the repository host.
+///
+/// Only the hosted services are recognized. A self-hosted instance keeps
+/// GitHub's shape unless `provider` or a pattern says otherwise, because
+/// its hostname says nothing about the software behind it.
+fn infer_pattern(repo_url: &str) -> &'static str {
+    let host = host_of(repo_url).to_ascii_lowercase();
+    let host = host.strip_prefix("www.").unwrap_or(&host);
+    match host {
+        "gitlab.com" => GITLAB,
+        "bitbucket.org" => BITBUCKET,
+        "codeberg.org" | "gitea.com" => GITEA,
+        _ => GITHUB,
+    }
+}
+
+fn host_of(repo_url: &str) -> &str {
+    let after_scheme = repo_url.split_once("://").map_or(repo_url, |(_, rest)| rest);
+    let authority = after_scheme.split(['/', '?', '#']).next().unwrap_or_default();
+    let host = authority.rsplit_once('@').map_or(authority, |(_, host)| host);
+    host.split(':').next().unwrap_or_default()
+}
+
+/// Fills `pattern` in, leaving unknown placeholders as written.
+pub(in crate::features) fn render_pattern(
+    pattern: &str,
+    repo_url: &str,
+    branch: &str,
+    path: &str,
+) -> String {
+    let mut out = String::with_capacity(pattern.len() + repo_url.len() + path.len());
+    let mut rest = pattern;
+    while let Some(open) = rest.find('{') {
+        out.push_str(&rest[..open]);
+        let tail = &rest[open..];
+        let replacement = if tail.starts_with(REPO_URL) {
+            Some((repo_url, REPO_URL.len()))
+        } else if tail.starts_with(BRANCH) {
+            Some((branch, BRANCH.len()))
+        } else if tail.starts_with(PATH) {
+            Some((path, PATH.len()))
+        } else {
+            None
+        };
+        if let Some((value, len)) = replacement {
+            out.push_str(value);
+            rest = &tail[len..];
+        } else {
+            out.push('{');
+            rest = &tail[1..];
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/ox_content_transform/src/features/edit/provider/tests.rs
+++ b/crates/ox_content_transform/src/features/edit/provider/tests.rs
@@ -1,0 +1,112 @@
+use super::{render_pattern, resolve_pattern};
+
+fn url(provider: Option<&str>, repo_url: &str) -> String {
+    render_pattern(&resolve_pattern(None, provider, repo_url), repo_url, "main", "docs/guide.md")
+}
+
+#[test]
+fn each_named_provider_has_its_own_shape() {
+    assert_eq!(
+        url(Some("github"), "https://github.com/owner/repo"),
+        "https://github.com/owner/repo/edit/main/docs/guide.md"
+    );
+    assert_eq!(
+        url(Some("gitlab"), "https://git.example.com/owner/repo"),
+        "https://git.example.com/owner/repo/-/edit/main/docs/guide.md"
+    );
+    assert_eq!(
+        url(Some("bitbucket"), "https://git.example.com/owner/repo"),
+        "https://git.example.com/owner/repo/src/main/docs/guide.md?mode=edit"
+    );
+    assert_eq!(
+        url(Some("gitea"), "https://git.example.com/owner/repo"),
+        "https://git.example.com/owner/repo/_edit/main/docs/guide.md"
+    );
+    assert_eq!(
+        url(Some("forgejo"), "https://git.example.com/o/r"),
+        url(Some("gitea"), "https://git.example.com/o/r")
+    );
+}
+
+#[test]
+fn a_named_provider_is_case_insensitive() {
+    assert_eq!(
+        url(Some("GitLab"), "https://github.com/owner/repo"),
+        "https://github.com/owner/repo/-/edit/main/docs/guide.md"
+    );
+}
+
+#[test]
+fn hosted_forges_are_inferred_from_the_repository_url() {
+    assert_eq!(
+        url(None, "https://gitlab.com/owner/repo"),
+        "https://gitlab.com/owner/repo/-/edit/main/docs/guide.md"
+    );
+    assert_eq!(
+        url(None, "https://bitbucket.org/owner/repo"),
+        "https://bitbucket.org/owner/repo/src/main/docs/guide.md?mode=edit"
+    );
+    assert_eq!(
+        url(None, "https://codeberg.org/owner/repo"),
+        "https://codeberg.org/owner/repo/_edit/main/docs/guide.md"
+    );
+}
+
+#[test]
+fn an_unknown_host_or_provider_keeps_the_github_shape() {
+    let expected = "https://git.example.com/owner/repo/edit/main/docs/guide.md";
+
+    assert_eq!(url(None, "https://git.example.com/owner/repo"), expected);
+    assert_eq!(url(Some("sourcehut"), "https://git.example.com/owner/repo"), expected);
+    assert_eq!(url(Some(""), "https://git.example.com/owner/repo"), expected);
+}
+
+#[test]
+fn inference_reads_the_host_and_not_the_rest_of_the_url() {
+    // A path or a userinfo section that merely mentions another forge must
+    // not change the shape.
+    assert_eq!(
+        url(None, "https://github.com/owner/gitlab.com"),
+        "https://github.com/owner/gitlab.com/edit/main/docs/guide.md"
+    );
+    assert_eq!(
+        url(None, "https://user@gitlab.com:8443/owner/repo"),
+        "https://user@gitlab.com:8443/owner/repo/-/edit/main/docs/guide.md"
+    );
+    assert_eq!(
+        url(None, "https://WWW.GitLab.com/owner/repo"),
+        "https://WWW.GitLab.com/owner/repo/-/edit/main/docs/guide.md"
+    );
+}
+
+#[test]
+fn an_explicit_pattern_wins_over_the_provider_and_the_host() {
+    let pattern = "{repoUrl}/ui/edit?ref={branch}&file={path}";
+    let resolved = resolve_pattern(Some(pattern), Some("gitlab"), "https://gitlab.com/o/r");
+
+    assert_eq!(
+        render_pattern(&resolved, "https://gitlab.com/o/r", "trunk", "docs/guide.md"),
+        "https://gitlab.com/o/r/ui/edit?ref=trunk&file=docs/guide.md"
+    );
+}
+
+#[test]
+fn a_blank_pattern_falls_back_to_the_provider() {
+    assert_eq!(
+        render_pattern(
+            &resolve_pattern(Some("   "), Some("gitlab"), "https://github.com/o/r"),
+            "https://github.com/o/r",
+            "main",
+            "docs/guide.md",
+        ),
+        "https://github.com/o/r/-/edit/main/docs/guide.md"
+    );
+}
+
+#[test]
+fn braces_that_are_not_placeholders_stay_literal() {
+    assert_eq!(
+        render_pattern("{repoUrl}/{unknown}/{{/{path}", "https://x/y", "main", "a.md"),
+        "https://x/y/{unknown}/{{/a.md"
+    );
+}

--- a/crates/ox_content_transform/src/features/edit/tests.rs
+++ b/crates/ox_content_transform/src/features/edit/tests.rs
@@ -12,6 +12,8 @@ fn options(root_dir: Option<&str>, src_dir: Option<&str>) -> EditThisPageOptions
         branch: Some("main".to_string()),
         root_dir: root_dir.map(ToOwned::to_owned),
         src_dir: src_dir.map(ToOwned::to_owned),
+        provider: None,
+        url_pattern: None,
         label: None,
     }
 }

--- a/crates/ox_content_transform/src/features/option_resolve.rs
+++ b/crates/ox_content_transform/src/features/option_resolve.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use crate::{AttrsOptions, EditThisPageOptions, EmojiShortcodeOptions, WikiLinkOptions};
 
+use super::edit::provider::resolve_pattern;
 use super::{ResolvedEditThisPageOptions, ResolvedEmojiShortcodeOptions, ResolvedWikiLinkOptions};
 
 pub(super) fn resolve_wiki_links(
@@ -58,8 +59,12 @@ pub(super) fn resolve_edit_this_page(
         .filter(|value| !value.is_empty() && *value != ".")
         .map(ToOwned::to_owned);
 
+    let url_pattern =
+        resolve_pattern(options.url_pattern.as_deref(), options.provider.as_deref(), &repo_url);
+
     Some(ResolvedEditThisPageOptions {
         repo_url,
+        url_pattern,
         root_dir,
         src_dir: options.src_dir.as_deref().filter(|value| !value.is_empty()).map(PathBuf::from),
         working_dir: working_directory(),

--- a/crates/ox_content_transform/src/options.rs
+++ b/crates/ox_content_transform/src/options.rs
@@ -262,6 +262,13 @@ pub struct EditThisPageOptions {
     /// by the user, so [`Self::root_dir`] can be joined with the page's
     /// path inside that root.
     pub src_dir: Option<String>,
+    /// Forge whose edit-URL shape to use: `github`, `gitlab`, `bitbucket`,
+    /// or `gitea`. Inferred from the [`Self::repo_url`] host when omitted,
+    /// and an unrecognized value is inferred the same way.
+    pub provider: Option<String>,
+    /// Edit-URL template, which wins over [`Self::provider`]. Understands
+    /// `{repoUrl}`, `{branch}`, and `{path}`; anything else is literal.
+    pub url_pattern: Option<String>,
     pub label: Option<String>,
 }
 

--- a/docs/content/built-in/site-generation.md
+++ b/docs/content/built-in/site-generation.md
@@ -301,6 +301,44 @@ oxContent({
 <a href="https://gitlab.example.com/owner/repo/edit/main/packages/site/docs/guide/nested.md"></a>
 ```
 
+### Other forges
+
+Every forge puts its web editor at a different path, so a link built for the
+wrong one 404s:
+
+| Provider    | Shape                                     |
+| ----------- | ----------------------------------------- |
+| `github`    | `<repoUrl>/edit/<branch>/<path>`          |
+| `gitlab`    | `<repoUrl>/-/edit/<branch>/<path>`        |
+| `bitbucket` | `<repoUrl>/src/<branch>/<path>?mode=edit` |
+| `gitea`     | `<repoUrl>/_edit/<branch>/<path>`         |
+
+`gitlab.com`, `bitbucket.org`, `codeberg.org`, and `gitea.com` are recognized
+from `repoUrl` and need no configuration. A self-hosted instance needs
+`provider`, because its hostname says nothing about the software behind it:
+
+```ts
+oxContent({
+  editThisPage: {
+    repoUrl: "https://git.example.com/owner/repo",
+    provider: "gitlab",
+  },
+});
+```
+
+`gitea` covers Forgejo, which kept the same path. For anything these miss,
+`urlPattern` replaces the shape outright — `{repoUrl}`, `{branch}`, and
+`{path}` are filled in and other braces are left alone:
+
+```ts
+oxContent({
+  editThisPage: {
+    repoUrl: "https://git.example.com/owner/repo",
+    urlPattern: "{repoUrl}/ui/edit?ref={branch}&file={path}",
+  },
+});
+```
+
 ## Collections
 
 Collections expose Markdown files as a lazily-loaded, queryable manifest —

--- a/docs/content/ja/built-in/site-generation.md
+++ b/docs/content/ja/built-in/site-generation.md
@@ -260,6 +260,39 @@ oxContent({
 <a href="https://gitlab.example.com/owner/repo/edit/main/packages/site/docs/guide/nested.md"></a>
 ```
 
+### 他のフォージ
+
+フォージごとにウェブエディタのパスが違うため、別のフォージ向けのリンクは 404 になります。
+
+| Provider    | 形                                        |
+| ----------- | ----------------------------------------- |
+| `github`    | `<repoUrl>/edit/<branch>/<path>`          |
+| `gitlab`    | `<repoUrl>/-/edit/<branch>/<path>`        |
+| `bitbucket` | `<repoUrl>/src/<branch>/<path>?mode=edit` |
+| `gitea`     | `<repoUrl>/_edit/<branch>/<path>`         |
+
+`gitlab.com`、`bitbucket.org`、`codeberg.org`、`gitea.com` は `repoUrl` から判別するので設定は要りません。自前でホストしている場合はホスト名からソフトウェアが分からないので `provider` を指定します。
+
+```ts
+oxContent({
+  editThisPage: {
+    repoUrl: "https://git.example.com/owner/repo",
+    provider: "gitlab",
+  },
+});
+```
+
+`gitea` は同じパスを引き継いだ Forgejo も含みます。どれにも当てはまらないときは `urlPattern` で形そのものを差し替えます。`{repoUrl}`、`{branch}`、`{path}` を埋め、それ以外の波括弧はそのまま残します。
+
+```ts
+oxContent({
+  editThisPage: {
+    repoUrl: "https://git.example.com/owner/repo",
+    urlPattern: "{repoUrl}/ui/edit?ref={branch}&file={path}",
+  },
+});
+```
+
 ## コレクション
 
 コレクションは Markdown ファイルを、遅延読み込み可能な問い合わせマニフェストとして出します。ブログ索引、変更履歴、「関連ページ」一覧に使えます。すべての Markdown を覆う既定の `content` コレクションは最初からあります。

--- a/npm/vite-plugin-ox-content/src/index.ts
+++ b/npm/vite-plugin-ox-content/src/index.ts
@@ -104,6 +104,7 @@ export type {
   SanitizeOptions,
   ResolvedSanitizeOptions,
   EditThisPageOptions,
+  EditThisPageProvider,
   ResolvedEditThisPageOptions,
   CodeBlockLintOptions,
   ResolvedCodeBlockLintOptions,

--- a/npm/vite-plugin-ox-content/src/resolve-options.ts
+++ b/npm/vite-plugin-ox-content/src/resolve-options.ts
@@ -211,6 +211,8 @@ function resolveEditThisPageOptions(
     repoUrl: options.repoUrl,
     branch: options.branch ?? "main",
     rootDir: options.rootDir,
+    provider: options.provider,
+    urlPattern: options.urlPattern,
     label: options.label ?? "Edit this page",
   };
 }

--- a/npm/vite-plugin-ox-content/src/transform.test.ts
+++ b/npm/vite-plugin-ox-content/src/transform.test.ts
@@ -166,6 +166,43 @@ describe("transformMarkdown", () => {
     }
   });
 
+  it("shapes edit links for the forge the repository is hosted on", async () => {
+    const page = resolve(repoRoot, "docs/content/guide.md");
+
+    const editHref = async (editThisPage: Record<string, unknown>): Promise<string | undefined> => {
+      const result = await transformMarkdown(
+        "# Guide\n",
+        page,
+        createResolvedOptions({
+          editThisPage: { enabled: true, branch: "main", rootDir: "docs", ...editThisPage },
+        }),
+        { sourcePath: page, srcDir: resolve(repoRoot, "docs") },
+      );
+      return /<a href="([^"]+)"/.exec(result.html.split("ox-edit-this-page")[1] ?? "")?.[1];
+    };
+
+    expect(await editHref({ repoUrl: "https://gitlab.com/owner/repo" })).toBe(
+      "https://gitlab.com/owner/repo/-/edit/main/docs/content/guide.md",
+    );
+    expect(
+      await editHref({ repoUrl: "https://git.example.com/owner/repo", provider: "gitlab" }),
+    ).toBe("https://git.example.com/owner/repo/-/edit/main/docs/content/guide.md");
+    expect(await editHref({ repoUrl: "https://bitbucket.org/owner/repo" })).toBe(
+      "https://bitbucket.org/owner/repo/src/main/docs/content/guide.md?mode=edit",
+    );
+    expect(
+      await editHref({
+        repoUrl: "https://git.example.com/owner/repo",
+        urlPattern: "{repoUrl}/ui/edit?ref={branch}&file={path}",
+      }),
+      // `&` is escaped for the attribute, as any other href would be.
+    ).toBe("https://git.example.com/owner/repo/ui/edit?ref=main&#x26;file=docs/content/guide.md");
+    // Unchanged for the shape this option has always produced.
+    expect(await editHref({ repoUrl: "https://github.com/owner/repo" })).toBe(
+      "https://github.com/owner/repo/edit/main/docs/content/guide.md",
+    );
+  });
+
   it("leaves {badge} markup literal unless opted in", async () => {
     const markdown = "{badge:tip}Beta{/badge}";
 

--- a/npm/vite-plugin-ox-content/src/transform.ts
+++ b/npm/vite-plugin-ox-content/src/transform.ts
@@ -416,6 +416,8 @@ interface JsTransformOptions {
     branch?: string;
     rootDir?: string;
     srcDir?: string;
+    provider?: string;
+    urlPattern?: string;
     label?: string;
   };
 
@@ -756,6 +758,8 @@ export async function transformMarkdown(
           // to be measured from the source root rather than from wherever
           // the build happens to run.
           srcDir: ssgOptions?.srcDir,
+          provider: options.editThisPage.provider,
+          urlPattern: options.editThisPage.urlPattern,
           label: options.editThisPage.label,
         }
       : undefined,

--- a/npm/vite-plugin-ox-content/src/types.ts
+++ b/npm/vite-plugin-ox-content/src/types.ts
@@ -3531,6 +3531,38 @@ export interface EditThisPageOptions {
   rootDir?: string;
 
   /**
+   * Forge whose edit-URL shape to use.
+   *
+   * Every forge exposes a web editor at a different path — GitLab puts a
+   * `/-/` scope separator in front of it, Bitbucket edits through its source
+   * view, Gitea and Forgejo use `_edit` — so a site on the wrong shape links
+   * to a 404.
+   *
+   * Inferred from the `repoUrl` host when omitted (`gitlab.com`,
+   * `bitbucket.org`, `codeberg.org`, `gitea.com`), falling back to
+   * `'github'`. Set it explicitly for a self-hosted instance, whose hostname
+   * says nothing about the software behind it.
+   *
+   * @default inferred from `repoUrl`
+   */
+  provider?: EditThisPageProvider;
+
+  /**
+   * Edit-URL template, for a forge or an instance the shapes above miss.
+   *
+   * Understands `{repoUrl}`, `{branch}`, and `{path}`; other braces are
+   * left as written. Takes precedence over `provider`.
+   *
+   * @example
+   * ```ts
+   * urlPattern: '{repoUrl}/ui/edit?ref={branch}&file={path}'
+   * ```
+   *
+   * @default the pattern for the resolved `provider`
+   */
+  urlPattern?: string;
+
+  /**
    * Link text rendered in the page footer.
    *
    * Keep this short; the default theme renders it as a compact footer action.
@@ -3541,6 +3573,13 @@ export interface EditThisPageOptions {
 }
 
 /**
+ * Forges with a known edit-URL shape.
+ *
+ * `'gitea'` covers Forgejo, which kept the same path.
+ */
+export type EditThisPageProvider = "github" | "gitlab" | "bitbucket" | "gitea";
+
+/**
  * Resolved edit-link transform options.
  */
 export interface ResolvedEditThisPageOptions {
@@ -3548,6 +3587,8 @@ export interface ResolvedEditThisPageOptions {
   repoUrl?: string;
   branch: string;
   rootDir?: string;
+  provider?: EditThisPageProvider;
+  urlPattern?: string;
   label: string;
 }
 


### PR DESCRIPTION
Closes #1145

> **Stacked on #1151** (`fix/edit-this-page-root-dir`). Retarget to `main` once that merges; the diff shown here is this change alone.

## Problem

`editThisPage` only ever produced GitHub's `<repoUrl>/edit/<branch>/<path>`. Every other forge puts its web editor somewhere else, so a site hosted anywhere else had to leave the feature off rather than ship links that 404.

## Change

The shape now comes from the forge:

| Provider | Shape |
|---|---|
| `github` | `<repoUrl>/edit/<branch>/<path>` |
| `gitlab` | `<repoUrl>/-/edit/<branch>/<path>` |
| `bitbucket` | `<repoUrl>/src/<branch>/<path>?mode=edit` |
| `gitea` | `<repoUrl>/_edit/<branch>/<path>` |

`gitlab.com`, `bitbucket.org`, `codeberg.org`, and `gitea.com` are recognized from `repoUrl` and need no configuration. A self-hosted instance sets `provider`, since its hostname says nothing about the software behind it. `urlPattern` replaces the shape outright for anything these miss, filling in `{repoUrl}`, `{branch}`, and `{path}` and leaving other braces alone.

```ts
editThisPage: {
  repoUrl: "https://git.example.com/owner/repo",
  provider: "gitlab",
}
```

`gitea` covers Forgejo, which kept the same path.

## Compatibility

Inference reads the host, not the rest of the URL, so a repository named `gitlab.com` on GitHub keeps GitHub's shape. An unrecognized provider falls back to inference, and GitHub remains the default — sites configured today generate the same links.

## Verification

- `cargo test -p ox_content_transform` — 558 pass, eight new: each named provider, casing, host inference, hosts that only mention another forge, the pattern override, and braces that are not placeholders.
- A TypeScript test drives the providers through `transformMarkdown`, including that GitHub's output is unchanged.
- `cargo test --workspace`, `cargo clippy`, `vp run test:ts` (999), `vp run check:ts` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790500407&installation_model_id=422833&pr_number=1152&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1152&signature=9e4c0b5ae536bf00277eac1e8bf9ade21f8a202f86c8dcb9a5352e4093fe6fa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->