### PR TITLE
fix(twitter): isolate full cards from host prose styles

### DIFF
--- a/crates/ox_content_ssg/src/html.rs
+++ b/crates/ox_content_ssg/src/html.rs
@@ -237,6 +237,9 @@ const SOCIAL_CSS: &str = concat!(
 
 /// CSS for opt-in full-fidelity Tweet cards (`.ox-tweet--full`).
 const SOCIAL_TWEET_FULL_CSS: &str = concat!(
+    // Isolation first: the component rules that follow win wherever they set
+    // a property, and this only covers the ones they leave to the host.
+    include_str!("plugins/social-tweet-full-isolation.css"),
     include_str!("plugins/social-tweet-full.css"),
     include_str!("plugins/social-tweet-full-media.css"),
 );

--- a/crates/ox_content_ssg/src/plugins/social-tweet-full-isolation.css
+++ b/crates/ox_content_ssg/src/plugins/social-tweet-full-isolation.css
@@ -1,0 +1,71 @@
+/*
+ * Host-prose isolation for full-fidelity Tweet cards.
+ *
+ * The full card replaces native elements — a `<figure>` root, `<img>`
+ * avatars and media, a `<blockquote>` for the quoted post — and an article
+ * stylesheet such as `@tailwindcss/typography` styles those by element. The
+ * component rules below the isolation block win wherever they set a
+ * property; this file covers the properties they never set, which is how a
+ * `.prose` article was adding image margins to avatars and quotation
+ * typography to the quoted post.
+ *
+ * Every selector doubles the root class (`.ox-tweet.ox-tweet--full`) so it
+ * outranks `.prose <element>` regardless of which stylesheet the host
+ * imports last. Generated quotes need a longer chain still: Tailwind writes
+ * them at `.prose blockquote p:first-of-type::before`.
+ */
+
+/*
+ * The card root is a `<figure>`, and the component sets its margin at one
+ * class of specificity — which `.prose figure` outranks. Restate it here
+ * through the same custom property, so a host that overrides the property
+ * still gets what it asked for.
+ */
+.ox-tweet.ox-tweet--full {
+  margin: var(--ox-tweet-container-margin);
+}
+
+.ox-tweet.ox-tweet--full :where(img, video, figure, picture, svg) {
+  margin: 0;
+}
+
+.ox-tweet.ox-tweet--full :where(p, ul, ol, li, dl, dd, dt, hr, h1, h2, h3, h4, h5, h6) {
+  margin: 0;
+  padding: 0;
+}
+
+.ox-tweet.ox-tweet--full :where(ul, ol) {
+  list-style: none;
+}
+
+.ox-tweet.ox-tweet--full :where(a) {
+  font-weight: inherit;
+  text-decoration: none;
+}
+
+.ox-tweet.ox-tweet--full :where(code, pre, kbd, samp) {
+  padding: 0;
+  font-size: inherit;
+  font-family: inherit;
+  background: none;
+}
+
+.ox-tweet.ox-tweet--full :where(code)::before,
+.ox-tweet.ox-tweet--full :where(code)::after {
+  content: none;
+}
+
+/* The quoted post is a `<blockquote>`, which prose styles the hardest. */
+.ox-tweet.ox-tweet--full .ox-tweet__quote {
+  font-style: normal;
+  font-weight: 400;
+  color: inherit;
+  quotes: none;
+}
+
+.ox-tweet.ox-tweet--full .ox-tweet__quote :where(p)::before,
+.ox-tweet.ox-tweet--full .ox-tweet__quote :where(p)::after,
+.ox-tweet.ox-tweet--full .ox-tweet__quote :where(p):first-of-type::before,
+.ox-tweet.ox-tweet--full .ox-tweet__quote :where(p):last-of-type::after {
+  content: none;
+}

--- a/docs/content/built-in/embeds.md
+++ b/docs/content/built-in/embeds.md
@@ -399,7 +399,12 @@ render `.ox-tweet--full`. The full-card chrome follows the MIT-licensed
 are in [Credits](../credits.md). See
 [Twitter/X Embed](../examples/twitter-embed.md) for details.
 Custom hosts import `@ox-content/vite-plugin/styles/social.css` and, for
-`appearance: "full"`, `styles/twitter-full.css`. See
+`appearance: "full"`, `styles/twitter-full.css`. Those two are enough inside
+an article: the full-card stylesheet neutralizes the element rules a prose
+stylesheet such as `@tailwindcss/typography` applies to what the card
+replaces — image margins on avatars and media, quotation typography and
+generated quote marks on the quoted post, figure spacing on the card itself
+— so no downstream `.prose .ox-tweet--full …` overrides are needed. See
 [Component styles](./component-styles.md).
 
 ## Reddit

--- a/docs/content/ja/built-in/embeds.md
+++ b/docs/content/ja/built-in/embeds.md
@@ -319,7 +319,7 @@ oxContent({
 
 ダウンロードしたメディアは自分のサイトから出すので、厳しい `img-src 'self'` CSP も動き続けます。動画とアニメーション GIF は、`downloadVideo` をオンにしない限り自前のポスターと Watch on X パーマリンクを使い、生成 HTML に `video.twimg.com` は出しません。削除済みや非公開の投稿は、ビルドを落とさずリンクのみのカードに落ちます。引用投稿が欠けていても、元の投稿カードは残します。フルカード用 CSS は `.ox-tweet--full` を描画するページにだけ載ります。フルカードのクロムは MIT ライセンスの [react-tweet](https://github.com/vercel/react-tweet) と [sveltweet](https://github.com/ryoppippi/sveltweet) の見た目の契約に従います。帰属は [クレジット](../credits.md) にあります。詳細は [Twitter/X Embed](/examples/twitter-embed.md) を見てください。
 独自ホストは `@ox-content/vite-plugin/styles/social.css` を、`appearance: "full"`
-なら `styles/twitter-full.css` も import します。[コンポーネント CSS](./component-styles.md) を見てください。
+なら `styles/twitter-full.css` も import します。記事の中に置く場合もこの2つで足ります。フルカードの CSS は、`@tailwindcss/typography` のような本文用スタイルシートが、カードの置き換えた要素に当てる規則を打ち消します。アバターやメディアへの画像マージン、引用投稿への引用符とその typography、カード自体への figure の余白などです。`.prose .ox-tweet--full …` のような上書きを下流で書く必要はありません。[コンポーネント CSS](./component-styles.md) を見てください。
 
 ## Reddit
 

--- a/npm/vite-plugin-ox-content/scripts/copy-component-styles.mjs
+++ b/npm/vite-plugin-ox-content/scripts/copy-component-styles.mjs
@@ -32,7 +32,11 @@ export const STYLE_ENTRIES = /** @type {const} */ ([
   },
   {
     name: "twitter-full.css",
-    sources: ["plugins/social-tweet-full.css", "plugins/social-tweet-full-media.css"],
+    sources: [
+      "plugins/social-tweet-full-isolation.css",
+      "plugins/social-tweet-full.css",
+      "plugins/social-tweet-full-media.css",
+    ],
   },
   { name: "ogp.css", sources: ["plugins/ogp.css"] },
   { name: "github.css", sources: ["plugins/github.css"] },

--- a/npm/vite-plugin-ox-content/src/published-styles.test.ts
+++ b/npm/vite-plugin-ox-content/src/published-styles.test.ts
@@ -39,7 +39,11 @@ const CRATE_SOURCES: Record<
     "plugins/social-twitter-rich.css",
     "plugins/reddit.css",
   ],
-  "twitter-full.css": ["plugins/social-tweet-full.css", "plugins/social-tweet-full-media.css"],
+  "twitter-full.css": [
+    "plugins/social-tweet-full-isolation.css",
+    "plugins/social-tweet-full.css",
+    "plugins/social-tweet-full-media.css",
+  ],
   "ogp.css": ["plugins/ogp.css"],
   "github.css": ["plugins/github.css"],
   "markdown-tables.css": ["plugins/markdown-tables.css"],

--- a/npm/vite-plugin-ox-content/test/vrt/twitter-full-prose.spec.ts
+++ b/npm/vite-plugin-ox-content/test/vrt/twitter-full-prose.spec.ts
@@ -1,0 +1,195 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+const SSG_PLUGINS = path.join(import.meta.dirname, "../../../../crates/ox_content_ssg/src/plugins");
+
+/** The published `twitter-full.css`, in the order the package concatenates it. */
+const TWITTER_FULL_SOURCES = [
+  "social-tweet-full-isolation.css",
+  "social-tweet-full.css",
+  "social-tweet-full-media.css",
+];
+
+/** The published `social.css` entry, trimmed to what a full card needs. */
+const SOCIAL_SOURCES = ["social.css"];
+
+/**
+ * The `@tailwindcss/typography` rules a full card lands in.
+ *
+ * Copied from the plugin's own output rather than paraphrased, so the test
+ * fails if the isolation stops covering what a real `.prose` article does.
+ */
+const PROSE_CSS = `
+.prose { color: #374151; max-width: 65ch; }
+.prose a { color: #111827; text-decoration: underline; font-weight: 500; }
+.prose strong { font-weight: 600; }
+.prose ol, .prose ul { margin-top: 1.25em; margin-bottom: 1.25em; padding-inline-start: 1.625em; }
+.prose ol { list-style-type: decimal; }
+.prose ul { list-style-type: disc; }
+.prose img { margin-top: 2em; margin-bottom: 2em; }
+.prose video { margin-top: 2em; margin-bottom: 2em; }
+.prose figure { margin-top: 2em; margin-bottom: 2em; }
+.prose figure > * { margin-top: 0; margin-bottom: 0; }
+.prose p { margin-top: 1.25em; margin-bottom: 1.25em; }
+.prose code { color: #111827; font-weight: 600; font-size: 0.875em; }
+.prose code::before { content: "\`"; }
+.prose code::after { content: "\`"; }
+.prose blockquote {
+  font-weight: 500;
+  font-style: italic;
+  color: #111827;
+  border-inline-start-width: 0.25rem;
+  border-inline-start-color: #e5e7eb;
+  quotes: "\\201C""\\201D""\\2018""\\2019";
+  margin-top: 1.6em;
+  margin-bottom: 1.6em;
+  padding-inline-start: 1em;
+}
+.prose blockquote p:first-of-type::before { content: open-quote; }
+.prose blockquote p:last-of-type::after { content: close-quote; }
+`;
+
+const CARD_HTML = `
+<figure class="ox-tweet ox-tweet--fetched ox-tweet--full">
+  <div class="ox-tweet__header">
+    <a class="ox-tweet__avatar-link" href="https://x.com/probe">
+      <img class="ox-tweet__avatar" src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" alt="" width="48" height="48">
+    </a>
+    <div class="ox-tweet__author">
+      <a class="ox-tweet__author-name" href="https://x.com/probe">Probe</a>
+      <div class="ox-tweet__author-meta"><span class="ox-tweet__author-handle">@probe</span></div>
+    </div>
+  </div>
+  <p class="ox-tweet__body">Body text with <code>code</code> in it.</p>
+  <div class="ox-tweet__media" data-count="1">
+    <img class="ox-tweet__media-item" src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" alt="">
+  </div>
+  <blockquote class="ox-tweet__quote">
+    <div class="ox-tweet__quote-header">
+      <img class="ox-tweet__avatar" src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" alt="" width="20" height="20">
+      <span class="ox-tweet__author-handle">@quoted</span>
+    </div>
+    <p class="ox-tweet__quote-body">Quoted post text.</p>
+  </blockquote>
+</figure>`;
+
+test.describe("Twitter full cards inside prose", () => {
+  for (const scheme of ["light", "dark"] as const) {
+    for (const width of [1280, 380]) {
+      test(`stays isolated from article prose rules (${scheme}, ${width}px)`, async ({ page }) => {
+        await page.setViewportSize({ width, height: 900 });
+        await page.emulateMedia({ colorScheme: scheme });
+        await renderInProse(page);
+
+        // Avatars keep the 48px header geometry rather than growing by the
+        // article's image margins.
+        await expect(margins(page, ".ox-tweet__header .ox-tweet__avatar")).resolves.toEqual({
+          top: "0px",
+          bottom: "0px",
+        });
+        await expect(margins(page, ".ox-tweet__quote .ox-tweet__avatar")).resolves.toEqual({
+          top: "0px",
+          bottom: "0px",
+        });
+        await expect(margins(page, ".ox-tweet__media-item")).resolves.toEqual({
+          top: "0px",
+          bottom: "0px",
+        });
+
+        // The quoted post keeps full-card typography, not article quotation
+        // styling, and gets no generated quotation marks.
+        const quote = await page.locator(".ox-tweet__quote").evaluate((node) => {
+          const style = getComputedStyle(node);
+          return { fontStyle: style.fontStyle, fontWeight: style.fontWeight, quotes: style.quotes };
+        });
+        expect(quote.fontStyle).toBe("normal");
+        expect(quote.fontWeight).toBe("400");
+        expect(quote.quotes).toBe("none");
+
+        for (const pseudo of ["::before", "::after"]) {
+          const content = await page
+            .locator(".ox-tweet__quote-body")
+            .evaluate((node, which) => getComputedStyle(node, which).content, pseudo);
+          expect(content).toBe("none");
+        }
+
+        // The card keeps its own outer margin rather than the article's
+        // figure spacing.
+        await expect(margins(page, ".ox-tweet--full")).resolves.toEqual({
+          top: "24px",
+          bottom: "24px",
+        });
+
+        // Body paragraphs and inline code do not pick up article spacing.
+        await expect(margins(page, ".ox-tweet__body")).resolves.toEqual({
+          top: "0px",
+          bottom: "0px",
+        });
+        const codeContent = await page
+          .locator(".ox-tweet__body code")
+          .evaluate((node) => getComputedStyle(node, "::before").content);
+        expect(codeContent).toBe("none");
+      });
+    }
+  }
+
+  test("keeps the 48px header geometry a prose article would inflate", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await renderInProse(page);
+
+    const header = await page.locator(".ox-tweet__header").evaluate((node) => {
+      const avatar = node.querySelector(".ox-tweet__avatar") as HTMLElement;
+      return {
+        header: node.getBoundingClientRect().height,
+        avatar: avatar.getBoundingClientRect().height,
+      };
+    });
+
+    expect(header.avatar).toBe(48);
+    // 48px avatar plus the card's own line-height, nowhere near the 108px a
+    // 30px-per-side prose image margin produced.
+    expect(header.header).toBeLessThanOrEqual(60);
+  });
+});
+
+async function renderInProse(page: Page): Promise<void> {
+  const componentCss = await concat([...SOCIAL_SOURCES, ...TWITTER_FULL_SOURCES]);
+  await page.setContent(
+    `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <style>${componentCss}</style>
+    <style>${PROSE_CSS}</style>
+  </head>
+  <body>
+    <article class="prose">
+      <p>Article prose before the card.</p>
+      ${CARD_HTML}
+      <p>Article prose after the card.</p>
+    </article>
+  </body>
+</html>`,
+    { waitUntil: "load" },
+  );
+}
+
+/** Host stylesheets last, which is the order that used to lose. */
+async function concat(files: string[]): Promise<string> {
+  const parts = await Promise.all(
+    files.map((file) => readFile(path.join(SSG_PLUGINS, file), "utf8")),
+  );
+  return parts.join("\n");
+}
+
+async function margins(page: Page, selector: string): Promise<{ top: string; bottom: string }> {
+  return page
+    .locator(selector)
+    .first()
+    .evaluate((node) => {
+      const style = getComputedStyle(node);
+      return { top: style.marginTop, bottom: style.marginBottom };
+    });
+}


### PR DESCRIPTION
Closes #1157

## Problem

The full card replaces native elements — a `<figure>` root, `<img>` avatars and media, a `<blockquote>` for the quoted post — and an article stylesheet such as `@tailwindcss/typography` styles those *by element*. The component rules only win where they set a property, so everything they left to the host came from the article:

| Measurement | alpha.14 in `.prose` | expected |
| --- | ---: | ---: |
| primary avatar margin | `30px 0 30px` | `0` |
| header height | `108px` | `60px` |
| card height | `1295.53px` | `1106.19px` |

and the quoted post rendered `font-style: italic`, `font-weight: 500`, with generated `“…”` around it.

## Change

An **isolation layer ahead of the component rules**, covering the properties they leave unset:

- margins on replaced media (`img`, `video`, `figure`, `picture`, `svg`) and on block elements
- list markers, link weight and underline
- inline-code padding, font, and its generated backticks
- the quoted post's font style, weight, color, `quotes`, and generated quotation marks

Every selector doubles the root class (`.ox-tweet.ox-tweet--full`) so it outranks `.prose <element>` whichever stylesheet the host imports last, and the component rules that follow still win wherever they have an opinion. Generated quotes need a longer chain, since Tailwind writes them at `.prose blockquote p:first-of-type::before`.

**One more gap of the same class:** the card's own outer margin. The component sets it at one class of specificity, which `.prose figure` outranks, so the card was taking article figure spacing. It is restated here through the same custom property, so a host overriding `--ox-tweet-container-margin` still gets what it asked for.

The semantic `<blockquote>` stays; only its presentation is isolated.

## Verification

`npm/vite-plugin-ox-content/test/vrt/twitter-full-prose.spec.ts` renders the card inside a `.prose` article carrying Tailwind Typography's own rules — copied from the plugin's output rather than paraphrased — with the host stylesheet imported **last**, which is the order that used to lose. Across light/dark and 1280px/380px it asserts:

- avatar margins (header and quote) and media margins are `0px`
- the avatar is 48px and the header stays at or under 60px
- the quoted post is `normal` / `400` / `quotes: none`
- neither `::before` nor `::after` produces content on the quote body or on inline code
- the card keeps its own `24px` outer margin

Removing the isolation file from the fixture's stylesheet list makes it fail on the avatar margins, so it pins the reported symptom.

- `vp run test:vrt` — 47 pass (42 before, 5 new)
- `cargo test --workspace`, `vp run test:ts` (1017), `vp run check:ts` — clean
- `published-styles.test.ts` covers the new source in the packed `twitter-full.css`

Everything from #922 — Copy link, replies CTA, timezone, static HTML, CSP, cache — is untouched.

Thanks @ryoppippi for the reproduction and the downstream measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/ox-content/pr/1159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790512997&installation_model_id=422833&pr_number=1159&repository=ubugeeei-prod%2Fox-content&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fox-content%2Fpull%2F1159&signature=04cbfafc550a674199407070e6df560ee8e0ed9ab60f9a491646f074d77f6b2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved full-fidelity Twitter/X cards embedded in article content.
  - Prevented surrounding prose styles from incorrectly changing card spacing, images, typography, links, code, quotes, and media.
  - Preserved consistent card layout across light and dark themes and desktop and mobile screen sizes.

- **Documentation**
  - Clarified the stylesheet imports required for full Twitter/X embeds.
  - Documented that additional article-specific CSS overrides are no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->